### PR TITLE
ci: cache buildkit image so buildx setup survives Docker Hub outages

### DIFF
--- a/.github/workflows/cache-warming-kurtosis-cl-images.yml
+++ b/.github/workflows/cache-warming-kurtosis-cl-images.yml
@@ -1,8 +1,9 @@
 name: Cache Warming — Kurtosis CL images
 
-# Populates the base-branch docker-cl-* image cache that test-kurtosis-assertoor.yml
-# restores. Its warm path is skipped on cache-warming runs, so PR / merge_group runs
-# otherwise never get this cache and pull every third-party image from Docker Hub.
+# Populates the base-branch docker-cl-* and docker-buildkit-* image caches that
+# test-kurtosis-assertoor.yml restores. Its warm path is skipped on cache-warming
+# runs, so PR / merge_group runs otherwise never get these caches and pull every
+# third-party image from Docker Hub.
 # GitHub cache scoping makes default-branch caches readable from every PR and merge
 # group, so warming on main/release is enough.
 #

--- a/.github/workflows/cache-warming-kurtosis-gloas-images.yml
+++ b/.github/workflows/cache-warming-kurtosis-gloas-images.yml
@@ -1,10 +1,11 @@
 name: Cache Warming — Kurtosis GLOAS images
 
-# Populates the base-branch docker-cl-* image cache that test-kurtosis-gloas.yml
-# restores. That workflow only saves the cache on non-PR events and has no push /
-# schedule trigger of its own, so without this its PR runs cold-pull every
-# third-party image from Docker Hub. GitHub cache scoping makes default-branch
-# caches readable from every PR, so warming on main/release is enough.
+# Populates the base-branch docker-cl-* and docker-buildkit-* image caches that
+# test-kurtosis-gloas.yml restores. That workflow only saves the caches on non-PR
+# events and has no push / schedule trigger of its own, so without this its PR
+# runs cold-pull every third-party image from Docker Hub. GitHub cache scoping
+# makes default-branch caches readable from every PR, so warming on main/release
+# is enough.
 #
 # Triggers:
 #   - push to a protected branch touching test-kurtosis-gloas.yml -> warm on a version bump

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -26,6 +26,10 @@ env:
   KURTOSIS_CURL_JQ_IMAGE: "badouralix/curl-jq:latest"
   KURTOSIS_TRAEFIK_IMAGE: "traefik:2.10.6"
   KURTOSIS_ALPINE_IMAGE: "alpine:3.17"
+  # BuildKit image booted by docker/setup-buildx-action (pinned via driver-opts).
+  # Cached and pre-loaded so buildx can fall back to the local copy when its
+  # Docker Hub pull fails.
+  BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
 
 on:
   workflow_dispatch:
@@ -70,16 +74,58 @@ jobs:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
+      - name: Restore cached buildkit image
+        id: cache-buildkit-image
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/docker-cache-buildkit
+          key: docker-buildkit-${{ env.BUILDKIT_IMAGE }}
+
+      - name: Load cached buildkit image into daemon
+        if: steps.cache-buildkit-image.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/docker-cache-buildkit/buildkit.tar
+
+      # Best-effort: buildx pulls the image itself during bootstrap; this step
+      # only seeds the cache that future runs fall back on.
+      - name: Pull buildkit image for cache
+        id: pull-buildkit-image
+        if: steps.cache-buildkit-image.outputs.cache-hit != 'true'
+        continue-on-error: true
+        run: |
+          pull() {
+            for n in 1 2 3; do
+              if docker pull "$1"; then return 0; fi
+              echo "docker pull $1 failed (attempt $n of 3)"
+              sleep $((10 * n))
+            done
+            return 1
+          }
+          pull "${BUILDKIT_IMAGE}"
+          mkdir -p /tmp/docker-cache-buildkit
+          docker save "${BUILDKIT_IMAGE}" -o /tmp/docker-cache-buildkit/buildkit.tar
+
+      - name: Save buildkit image to cache
+        if: steps.cache-buildkit-image.outputs.cache-hit != 'true' && steps.pull-buildkit-image.outcome == 'success' && github.event_name != 'pull_request'
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/docker-cache-buildkit
+          key: docker-buildkit-${{ env.BUILDKIT_IMAGE }}
+
       - name: Set up Docker Buildx
         id: buildx_setup
         continue-on-error: true
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=${{ env.BUILDKIT_IMAGE }}
 
-      # setup-buildx boots BuildKit by pulling moby/buildkit from Docker Hub;
-      # retry once so a transient registry failure doesn't fail the job.
+      # setup-buildx boots BuildKit by pulling the pinned image from Docker Hub,
+      # falling back to the pre-loaded local copy when the registry is down;
+      # retry once so a transient failure doesn't fail the job.
       - name: Retry Docker Buildx setup on transient failure
         if: steps.buildx_setup.outcome == 'failure'
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=${{ env.BUILDKIT_IMAGE }}
 
       - name: Build erigon Docker image (with BuildKit layer cache)
         id: build_erigon_image
@@ -119,10 +165,11 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # Warms the docker-cl-* cache on the default branch (where merge_group runs
-  # restore it) via a dedicated workflow on a paths filter + daily schedule —
-  # the cache only changes when the pinned image versions in this file change.
-  # lookup-only makes it a no-op when the cache already exists.
+  # Warms the docker-cl-* and docker-buildkit-* caches on the default branch
+  # (where merge_group runs restore them) via a dedicated workflow on a paths
+  # filter + daily schedule — the caches only change when the pinned image
+  # versions in this file change. lookup-only makes it a no-op when the cache
+  # already exists.
   warm-third-party-images:
     if: ${{ inputs.cl-images-only }}
     runs-on: ubuntu-latest
@@ -187,6 +234,36 @@ jobs:
         with:
           path: /tmp/docker-cache
           key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}
+
+      - name: Check whether buildkit image is already cached
+        id: cache-buildkit-image
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/docker-cache-buildkit
+          key: docker-buildkit-${{ env.BUILDKIT_IMAGE }}
+          lookup-only: true
+
+      - name: Pull buildkit image
+        if: steps.cache-buildkit-image.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/docker-cache-buildkit
+          pull() {
+            for n in 1 2 3; do
+              if docker pull "$1"; then return 0; fi
+              echo "docker pull $1 failed (attempt $n of 3)"
+              sleep $((10 * n))
+            done
+            return 1
+          }
+          pull "${BUILDKIT_IMAGE}"
+          docker save "${BUILDKIT_IMAGE}" -o /tmp/docker-cache-buildkit/buildkit.tar
+
+      - name: Save buildkit image to cache
+        if: steps.cache-buildkit-image.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/docker-cache-buildkit
+          key: docker-buildkit-${{ env.BUILDKIT_IMAGE }}
 
   assertoor_test:
     name: assertoor_${{ matrix.suite }}_${{ matrix.exec_mode }}_test

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -22,6 +22,10 @@ env:
   KURTOSIS_CURL_JQ_IMAGE: "badouralix/curl-jq:latest"
   KURTOSIS_TRAEFIK_IMAGE: "traefik:2.10.6"
   KURTOSIS_ALPINE_IMAGE: "alpine:3.17"
+  # BuildKit image booted by docker/setup-buildx-action (pinned via driver-opts).
+  # Cached and pre-loaded so buildx can fall back to the local copy when its
+  # Docker Hub pull fails.
+  BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
 
 on:
   pull_request:
@@ -54,10 +58,11 @@ permissions:
   contents: read
 
 jobs:
-  # Warms the docker-cl-* cache on the default branch (where this workflow's PR
-  # runs restore it) via a dedicated workflow on a paths filter + daily schedule —
-  # the cache only changes when the pinned image versions in this file change.
-  # lookup-only makes it a no-op when the cache already exists.
+  # Warms the docker-cl-* and docker-buildkit-* caches on the default branch
+  # (where this workflow's PR runs restore them) via a dedicated workflow on a
+  # paths filter + daily schedule — the caches only change when the pinned
+  # image versions in this file change. lookup-only makes it a no-op when the
+  # cache already exists.
   warm-third-party-images:
     if: ${{ inputs.cl-images-only }}
     runs-on: ubuntu-latest
@@ -121,6 +126,36 @@ jobs:
           path: /tmp/docker-cache
           key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}
 
+      - name: Check whether buildkit image is already cached
+        id: cache-buildkit-image
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/docker-cache-buildkit
+          key: docker-buildkit-${{ env.BUILDKIT_IMAGE }}
+          lookup-only: true
+
+      - name: Pull buildkit image
+        if: steps.cache-buildkit-image.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/docker-cache-buildkit
+          pull() {
+            for n in 1 2 3; do
+              if docker pull "$1"; then return 0; fi
+              echo "docker pull $1 failed (attempt $n of 3)"
+              sleep $((10 * n))
+            done
+            return 1
+          }
+          pull "${BUILDKIT_IMAGE}"
+          docker save "${BUILDKIT_IMAGE}" -o /tmp/docker-cache-buildkit/buildkit.tar
+
+      - name: Save buildkit image to cache
+        if: steps.cache-buildkit-image.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/docker-cache-buildkit
+          key: docker-buildkit-${{ env.BUILDKIT_IMAGE }}
+
   gloas_test:
     name: gloas_${{ matrix.suite }}_test
     if: ${{ !inputs.cl-images-only && !github.event.pull_request.draft }}
@@ -153,8 +188,49 @@ jobs:
           username: ${{ secrets.DOCKERHUB_PULL_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
 
+      - name: Restore cached buildkit image
+        id: cache-buildkit-image
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/docker-cache-buildkit
+          key: docker-buildkit-${{ env.BUILDKIT_IMAGE }}
+
+      - name: Load cached buildkit image into daemon
+        if: steps.cache-buildkit-image.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/docker-cache-buildkit/buildkit.tar
+
+      # Best-effort: buildx pulls the image itself during bootstrap; this step
+      # only seeds the cache that future runs fall back on.
+      - name: Pull buildkit image for cache
+        id: pull-buildkit-image
+        if: steps.cache-buildkit-image.outputs.cache-hit != 'true'
+        continue-on-error: true
+        run: |
+          pull() {
+            for n in 1 2 3; do
+              if docker pull "$1"; then return 0; fi
+              echo "docker pull $1 failed (attempt $n of 3)"
+              sleep $((10 * n))
+            done
+            return 1
+          }
+          pull "${BUILDKIT_IMAGE}"
+          mkdir -p /tmp/docker-cache-buildkit
+          docker save "${BUILDKIT_IMAGE}" -o /tmp/docker-cache-buildkit/buildkit.tar
+
+      - name: Save buildkit image to cache
+        if: steps.cache-buildkit-image.outputs.cache-hit != 'true' && steps.pull-buildkit-image.outcome == 'success' && github.event_name != 'pull_request'
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/docker-cache-buildkit
+          key: docker-buildkit-${{ env.BUILDKIT_IMAGE }}
+
+      # setup-buildx boots BuildKit by pulling the pinned image from Docker Hub,
+      # falling back to the pre-loaded local copy when the registry is down.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=${{ env.BUILDKIT_IMAGE }}
 
       - name: Restore cached third-party containers
         id: cache-cl-images


### PR DESCRIPTION
## Why

`docker/setup-buildx-action` boots BuildKit by pulling `moby/buildkit` from Docker Hub on every run — the last uncached Docker Hub dependency in the kurtosis jobs. In merge-queue run [27280175556](https://github.com/erigontech/erigon/actions/runs/27280175556/job/80572198019) that pull timed out (`Get "https://registry-1.docker.io/v2/": context deadline exceeded`), failing the CI Gate for #21723 — ironically the PR closing the equivalent gap for the kurtosis engine-bootstrap images. The same Docker Hub connectivity window took out three other CI Gate runs that morning at the `kurtosis engine start` step.

#21735 added a retry around buildx setup, but a retry doesn't survive an outage longer than its window. This removes the hard dependency the same way as the rest of the image-caching series (#21695, #21703, #21723).

## What

- Pin the BuildKit image as `BUILDKIT_IMAGE: moby/buildkit:v0.30.0` (what the moving `buildx-stable-1` tag currently resolves to) and pass it to `setup-buildx-action` via `driver-opts: image=...`, in both `test-kurtosis-assertoor.yml` (`build-erigon-image`) and `test-kurtosis-gloas.yml` (`gloas_test`). Bump alongside the other pinned images.
- Cache it under a single shared key (`docker-buildkit-<image>`) with the established docker save/load + actions/cache pattern, and `docker load` it before buildx setup. buildx's docker-container driver falls back to a locally present image when its pull fails ("pulling failed, using local image"), so with a warm cache the builder boots even while Docker Hub is fully unreachable. Pinning via driver-opts is what makes the fallback engage — the local image name must match what buildx wants to boot.
- The cache-fill pull in the test jobs is best-effort (`continue-on-error`, save gated on pull success): buildx pulls the image itself either way, so a failed seed must not fail an otherwise-good run, and a failed pull never poisons the cache key with an empty archive.
- Warm jobs (`warm-third-party-images` in both files) pull strictly and save the same key — producing the cache is their purpose. Both cache-warming workflows already path-filter on the edited files, so the cache is created on main right after this merges and refreshed daily against LRU eviction.

In gloas, buildx setup previously ran before any caching; the buildkit cache steps are inserted ahead of it.

Not covered (non-gating, can follow up if wanted): `ci-cd-main-branch-docker-images.yml` and `release.yml` also use `setup-buildx-action` but don't block PRs or the merge queue.

actionlint is clean (the two SC2086 infos it reports pre-exist on main in the kurtosis CLI install step).