### PR TITLE
bloatnet: reduce word-level compress sampling

### DIFF
--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -429,7 +429,7 @@ var DomainCompressCfg = seg.Cfg{
 	DictReducerSoftLimit: 2000000,
 	MinPatternLen:        20,
 	MaxPatternLen:        128,
-	SamplingFactor:       1,
+	SamplingFactor:       4,
 	MaxDictPatterns:      64 * 1024,
 	Workers:              1,
 }
@@ -439,7 +439,7 @@ var HistoryCompressCfg = seg.Cfg{
 	DictReducerSoftLimit: 2000000,
 	MinPatternLen:        20,
 	MaxPatternLen:        128,
-	SamplingFactor:       1,
+	SamplingFactor:       4,
 	MaxDictPatterns:      64 * 1024,
 	Workers:              1,
 }


### PR DESCRIPTION
to speedup merge: increase sampling of `DomainCompressCfg` and `HistoryCompressCfg`
@sudeepdino008 do you thing we must go this way? Need cherry-pick some bug-fix?