### PR TITLE
[bloatnet] domain: existance filter madvise require page-aligned byte slice

### DIFF
--- a/common/mmap/mmap_unix.go
+++ b/common/mmap/mmap_unix.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"syscall"
 	"unsafe"
 
@@ -32,15 +33,19 @@ const MaxMapSize = 0xFFFFFFFFFFFF
 
 var osPageSize = uintptr(os.Getpagesize())
 
-// pageAligned expands m to cover whole pages: start rounded down, end rounded up.
+// pageAligned returns the sub-slice of m covering only whole pages:
+// start rounded up, end rounded down. Returns nil when m spans no full page.
 func pageAligned(m []byte) []byte {
 	if len(m) == 0 {
 		return nil
 	}
-	start := uintptr(unsafe.Pointer(&m[0]))
-	alignedStart := start &^ (osPageSize - 1)
-	alignedEnd := (start + uintptr(len(m)) + osPageSize - 1) &^ (osPageSize - 1)
-	return unsafe.Slice((*byte)(unsafe.Pointer(alignedStart)), int(alignedEnd-alignedStart))
+	start := reflect.ValueOf(m).Pointer()
+	skip := int((osPageSize - start%osPageSize) % osPageSize)
+	trim := int((start + uintptr(len(m))) % osPageSize)
+	if skip+trim >= len(m) {
+		return nil
+	}
+	return m[skip : len(m)-trim]
 }
 
 func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
@@ -69,18 +74,20 @@ func MadviseSequential(mmapHandle1 []byte) error {
 	return nil
 }
 
-func MadviseNormal(mmapHandle1 []byte) error {
-	err := unix.Madvise(pageAligned(mmapHandle1), syscall.MADV_NORMAL)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		return fmt.Errorf("madvise: %w", err)
+func MadviseNormal(m []byte) error {
+	if aligned := pageAligned(m); len(aligned) > 0 {
+		if err := unix.Madvise(aligned, syscall.MADV_NORMAL); err != nil && !errors.Is(err, syscall.ENOSYS) {
+			return fmt.Errorf("madvise: %w", err)
+		}
 	}
 	return nil
 }
 
-func MadviseWillNeed(mmapHandle1 []byte) error {
-	err := unix.Madvise(pageAligned(mmapHandle1), syscall.MADV_WILLNEED)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		return fmt.Errorf("madvise: %w", err)
+func MadviseWillNeed(m []byte) error {
+	if aligned := pageAligned(m); len(aligned) > 0 {
+		if err := unix.Madvise(aligned, syscall.MADV_WILLNEED); err != nil && !errors.Is(err, syscall.ENOSYS) {
+			return fmt.Errorf("madvise: %w", err)
+		}
 	}
 	return nil
 }

--- a/common/mmap/mmap_unix.go
+++ b/common/mmap/mmap_unix.go
@@ -30,6 +30,19 @@ import (
 
 const MaxMapSize = 0xFFFFFFFFFFFF
 
+var osPageSize = uintptr(os.Getpagesize())
+
+// pageAligned expands m to cover whole pages: start rounded down, end rounded up.
+func pageAligned(m []byte) []byte {
+	if len(m) == 0 {
+		return nil
+	}
+	start := uintptr(unsafe.Pointer(&m[0]))
+	alignedStart := start &^ (osPageSize - 1)
+	alignedEnd := (start + uintptr(len(m)) + osPageSize - 1) &^ (osPageSize - 1)
+	return unsafe.Slice((*byte)(unsafe.Pointer(alignedStart)), int(alignedEnd-alignedStart))
+}
+
 func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
 	// Map the data file to memory.
 	mmapHandle1, err := unix.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
@@ -57,18 +70,16 @@ func MadviseSequential(mmapHandle1 []byte) error {
 }
 
 func MadviseNormal(mmapHandle1 []byte) error {
-	err := unix.Madvise(mmapHandle1, syscall.MADV_NORMAL)
+	err := unix.Madvise(pageAligned(mmapHandle1), syscall.MADV_NORMAL)
 	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
 		return fmt.Errorf("madvise: %w", err)
 	}
 	return nil
 }
 
 func MadviseWillNeed(mmapHandle1 []byte) error {
-	err := unix.Madvise(mmapHandle1, syscall.MADV_WILLNEED)
+	err := unix.Madvise(pageAligned(mmapHandle1), syscall.MADV_WILLNEED)
 	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
 		return fmt.Errorf("madvise: %w", err)
 	}
 	return nil

--- a/common/mmap/mmap_unix.go
+++ b/common/mmap/mmap_unix.go
@@ -65,41 +65,19 @@ func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
 	return mmapHandle1, mmapHandle2, nil
 }
 
-func MadviseSequential(mmapHandle1 []byte) error {
-	err := unix.Madvise(mmapHandle1, syscall.MADV_SEQUENTIAL)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
-		return fmt.Errorf("madvise: %w", err)
-	}
-	return nil
-}
-
-func MadviseNormal(m []byte) error {
+func madvise(m []byte, advice int) error {
 	if aligned := pageAligned(m); len(aligned) > 0 {
-		if err := unix.Madvise(aligned, syscall.MADV_NORMAL); err != nil && !errors.Is(err, syscall.ENOSYS) {
+		if err := unix.Madvise(aligned, advice); err != nil && !errors.Is(err, syscall.ENOSYS) {
 			return fmt.Errorf("madvise: %w", err)
 		}
 	}
 	return nil
 }
 
-func MadviseWillNeed(m []byte) error {
-	if aligned := pageAligned(m); len(aligned) > 0 {
-		if err := unix.Madvise(aligned, syscall.MADV_WILLNEED); err != nil && !errors.Is(err, syscall.ENOSYS) {
-			return fmt.Errorf("madvise: %w", err)
-		}
-	}
-	return nil
-}
-
-func MadviseRandom(mmapHandle1 []byte) error {
-	err := unix.Madvise(mmapHandle1, syscall.MADV_RANDOM)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
-		return fmt.Errorf("madvise: %w", err)
-	}
-	return nil
-}
+func MadviseSequential(m []byte) error { return madvise(m, syscall.MADV_SEQUENTIAL) }
+func MadviseNormal(m []byte) error     { return madvise(m, syscall.MADV_NORMAL) }
+func MadviseWillNeed(m []byte) error   { return madvise(m, syscall.MADV_WILLNEED) }
+func MadviseRandom(m []byte) error     { return madvise(m, syscall.MADV_RANDOM) }
 
 // munmap unmaps a DB's data file from memory.
 func Munmap(mmapHandle1 []byte, _ *[MaxMapSize]byte) error {

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -212,6 +212,27 @@ func OpenFilter(filePath string, useFuse bool) (idx *Filter, err error) {
 	return idx, nil
 }
 
+func (b *Filter) ForceInMem() {
+	if b == nil || b.empty || !b.useFuse {
+		return
+	}
+	b.fuseReader.ForceInMem()
+}
+
+func (b *Filter) MadvWillNeed() {
+	if b == nil || b.empty || !b.useFuse {
+		return
+	}
+	b.fuseReader.MadvWillNeed()
+}
+
+func (b *Filter) MadvNormal() {
+	if b == nil || b.empty || !b.useFuse {
+		return
+	}
+	b.fuseReader.MadvNormal()
+}
+
 func (b *Filter) Close() {
 	if b == nil {
 		return

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -213,24 +213,33 @@ func OpenFilter(filePath string, useFuse bool) (idx *Filter, err error) {
 }
 
 func (b *Filter) ForceInMem() {
-	if b == nil || b.empty || !b.useFuse {
+	if b == nil || b.empty {
 		return
 	}
-	b.fuseReader.ForceInMem()
+	if b.useFuse {
+		b.fuseReader.ForceInMem()
+	}
+	// bloom filter is already heap-allocated by OpenFilter — no-op
 }
 
 func (b *Filter) MadvWillNeed() {
-	if b == nil || b.empty || !b.useFuse {
+	if b == nil || b.empty {
 		return
 	}
-	b.fuseReader.MadvWillNeed()
+	if b.useFuse {
+		b.fuseReader.MadvWillNeed()
+	}
+	// bloom filter is heap-allocated, no mmap to advise — no-op
 }
 
 func (b *Filter) MadvNormal() {
-	if b == nil || b.empty || !b.useFuse {
+	if b == nil || b.empty {
 		return
 	}
-	b.fuseReader.MadvNormal()
+	if b.useFuse {
+		b.fuseReader.MadvNormal()
+	}
+	// bloom filter is heap-allocated, no mmap to advise — no-op
 }
 
 func (b *Filter) Close() {

--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -317,21 +317,6 @@ func (r *ReaderSharded) ForceInMem() datasize.ByteSize {
 	return res
 }
 
-// pageAligned expands m to cover whole pages: rounds the start address down
-// and the end address up to the system page size. Safe to pass to madvise on
-// all platforms (macOS requires page-aligned input; Linux rounds silently).
-// Returns nil when m is empty.
-func pageAligned(m []byte) []byte {
-	if len(m) == 0 {
-		return nil
-	}
-	pageSize := uintptr(os.Getpagesize())
-	start := uintptr(unsafe.Pointer(&m[0]))
-	alignedStart := start &^ (pageSize - 1)
-	alignedEnd := (start + uintptr(len(m)) + pageSize - 1) &^ (pageSize - 1)
-	return unsafe.Slice((*byte)(unsafe.Pointer(alignedStart)), int(alignedEnd-alignedStart))
-}
-
 // MadvWillNeed hints to the OS that all shard blobs will be accessed.
 // One madvise on the outer mmap slice covers all shards in a single syscall,
 // instead of 256 madvise calls on adjacent sub-slices of the same VMA.
@@ -339,7 +324,7 @@ func (r *ReaderSharded) MadvWillNeed() {
 	if r == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	if err := mm.MadviseWillNeed(pageAligned(r.m)); err != nil {
+	if err := mm.MadviseWillNeed(r.m); err != nil {
 		panic(err)
 	}
 }
@@ -348,7 +333,7 @@ func (r *ReaderSharded) MadvNormal() {
 	if r == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	if err := mm.MadviseNormal(pageAligned(r.m)); err != nil {
+	if err := mm.MadviseNormal(r.m); err != nil {
 		panic(err)
 	}
 }

--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -3,7 +3,6 @@ package fusefilter
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -14,6 +13,7 @@ import (
 	"github.com/edsrzf/mmap-go"
 
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/log/v3"
 	mm "github.com/erigontech/erigon/common/mmap"
 )
 
@@ -333,8 +333,7 @@ func (r *ReaderSharded) MadvWillNeed() {
 	addr := uintptr(unsafe.Pointer(&r.m[0]))
 	pageSize := uintptr(os.Getpagesize())
 	pageOffset := addr % pageSize
-	log.Printf("[dbg] MadvWillNeed: fileName=%s addr=0x%x len=%d pageOffset=%d pageAligned=%v",
-		r.fileName, addr, len(r.m), pageOffset, pageOffset == 0)
+	log.Warn("[dbg] MadvWillNeed", "fileName", r.fileName, "addr", fmt.Sprintf("0x%x", addr), "len", len(r.m), "pageOffset", pageOffset, "pageAligned", pageOffset == 0)
 	if err := mm.MadviseWillNeed(r.m); err != nil {
 		panic(err)
 	}

--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -13,7 +13,6 @@ import (
 	"github.com/edsrzf/mmap-go"
 
 	"github.com/erigontech/erigon/common/dbg"
-	"github.com/erigontech/erigon/common/log/v3"
 	mm "github.com/erigontech/erigon/common/mmap"
 )
 
@@ -309,18 +308,28 @@ func (r *ReaderSharded) ContainsHash(v uint64) bool {
 	return s.ContainsHash(v)
 }
 
-// ForceInMem clones the entire mmap region into anonymous heap memory in a
-// single allocation, then re-points each shard's Fingerprints slice into the
-// clone at the same byte offset. Avoids 256 separate allocations.
+// ForceInMem clones each shard's fingerprints into anonymous heap memory.
 func (r *ReaderSharded) ForceInMem() datasize.ByteSize {
-	if len(r.m) == 0 {
-		return 0
-	}
 	var res datasize.ByteSize
 	for i := range r.shards {
 		res += r.shards[i].ForceInMem()
 	}
 	return res
+}
+
+// pageAligned expands m to cover whole pages: rounds the start address down
+// and the end address up to the system page size. Safe to pass to madvise on
+// all platforms (macOS requires page-aligned input; Linux rounds silently).
+// Returns nil when m is empty.
+func pageAligned(m []byte) []byte {
+	if len(m) == 0 {
+		return nil
+	}
+	pageSize := uintptr(os.Getpagesize())
+	start := uintptr(unsafe.Pointer(&m[0]))
+	alignedStart := start &^ (pageSize - 1)
+	alignedEnd := (start + uintptr(len(m)) + pageSize - 1) &^ (pageSize - 1)
+	return unsafe.Slice((*byte)(unsafe.Pointer(alignedStart)), int(alignedEnd-alignedStart))
 }
 
 // MadvWillNeed hints to the OS that all shard blobs will be accessed.
@@ -330,11 +339,7 @@ func (r *ReaderSharded) MadvWillNeed() {
 	if r == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	addr := uintptr(unsafe.Pointer(&r.m[0]))
-	pageSize := uintptr(os.Getpagesize())
-	pageOffset := addr % pageSize
-	log.Warn("[dbg] MadvWillNeed", "fileName", r.fileName, "addr", fmt.Sprintf("0x%x", addr), "len", len(r.m), "pageOffset", pageOffset, "pageAligned", pageOffset == 0)
-	if err := mm.MadviseWillNeed(r.m); err != nil {
+	if err := mm.MadviseWillNeed(pageAligned(r.m)); err != nil {
 		panic(err)
 	}
 }
@@ -343,7 +348,7 @@ func (r *ReaderSharded) MadvNormal() {
 	if r == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	if err := mm.MadviseNormal(r.m); err != nil {
+	if err := mm.MadviseNormal(pageAligned(r.m)); err != nil {
 		panic(err)
 	}
 }

--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -3,6 +3,7 @@ package fusefilter
 import (
 	"encoding/binary"
 	"fmt"
+	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -329,6 +330,11 @@ func (r *ReaderSharded) MadvWillNeed() {
 	if r == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
+	addr := uintptr(unsafe.Pointer(&r.m[0]))
+	pageSize := uintptr(os.Getpagesize())
+	pageOffset := addr % pageSize
+	log.Printf("[dbg] MadvWillNeed: fileName=%s addr=0x%x len=%d pageOffset=%d pageAligned=%v",
+		r.fileName, addr, len(r.m), pageOffset, pageOffset == 0)
 	if err := mm.MadviseWillNeed(r.m); err != nil {
 		panic(err)
 	}

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -448,7 +448,7 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 			if ok {
 				fName := filepath.Base(fPath)
 				d.FileVersion.AccessorKVEI.MustSupport(fileVer, fName)
-				if item.existence, err = existence.OpenFilter(fPath, false); err != nil {
+				if item.existence, err = d.openExistenceFilter(fPath); err != nil {
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 					// don't interrupt on error. other files may be good
 				}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -157,13 +157,12 @@ func (d *Domain) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
 	if err != nil {
 		return nil, err
 	}
-	if domainExistenceForceInMem {
+	switch {
+	case domainExistenceForceInMem:
 		accessor.ForceExistenceFilterInRAM()
-	}
-	if domainExistenceForceWillNeed {
+	case domainExistenceForceWillNeed:
 		accessor.ForceExistenceFilterWillNeed()
-	}
-	if domainExistenceForceNormal {
+	case domainExistenceForceNormal:
 		accessor.ForceExistenceFilterNormal()
 	}
 	return accessor, nil

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -168,6 +168,22 @@ func (d *Domain) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
 	return accessor, nil
 }
 
+func (d *Domain) openExistenceFilter(fPath string) (*existence.Filter, error) {
+	filter, err := existence.OpenFilter(fPath, false)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case domainExistenceForceWillNeed:
+		filter.MadvWillNeed()
+	case domainExistenceForceNormal:
+		filter.MadvNormal()
+	case domainExistenceForceInMem:
+		filter.ForceInMem()
+	}
+	return filter, nil
+}
+
 func (d *Domain) kvFileNameMask(fromStep, toStep kv.Step) string {
 	return fmt.Sprintf("*-%s.%d-%d.kv", d.FilenameBase, fromStep, toStep)
 }

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -158,12 +158,12 @@ func (d *Domain) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
 		return nil, err
 	}
 	switch {
-	case domainExistenceForceInMem:
-		accessor.ForceExistenceFilterInRAM()
 	case domainExistenceForceWillNeed:
 		accessor.ForceExistenceFilterWillNeed()
 	case domainExistenceForceNormal:
 		accessor.ForceExistenceFilterNormal()
+	case domainExistenceForceInMem:
+		accessor.ForceExistenceFilterInRAM()
 	}
 	return accessor, nil
 }


### PR DESCRIPTION
madvise require page-aligned bytes slice
```
panic: madvise: invalid argument

goroutine 8879 [running]:
github.com/erigontech/erigon/db/datastruct/fusefilter.(*ReaderSharded).MadvWillNeed(0x9fa43c44a88)
	github.com/erigontech/erigon/db/datastruct/fusefilter/fusefilter_reader.go:338 +0x2b0
github.com/erigontech/erigon/db/recsplit.(*Index).ForceExistenceFilterWillNeed(0x9fa59cd5b80?)
	github.com/erigontech/erigon/db/recsplit/index.go:319 +0x4f
github.com/erigontech/erigon/db/state.(*Domain).openHashMapAccessor(0x2?, {0x9fa59cd5b80?, 0x1?})
	github.com/erigontech/erigon/db/state/domain.go:164 +0x4b
github.com/erigontech/erigon/db/state.(*Domain).openDirtyFiles(0x9fa3d652b08, {0x9fa483d8588, 0x54, 0x54})
	github.com/erigontech/erigon/db/state/dirty_files.go:419 +0x792
github.com/erigontech/erigon/db/state.(*Domain).OpenList(0x9fa3d652b08, {{0x9fa483d8588, 0x54, 0x54}, {0x6f28b40, 0x0, 0x0}, {0x9fa3faae400, 0x20, 0x20}, ...})
	github.com/erigontech/erigon/db/state/domain.go:240 +0x105
github.com/erigontech/erigon/db/state.(*Domain).openFolder(...)
	github.com/erigontech/erigon/db/state/domain.go:258
github.com/erigontech/erigon/db/state.(*Aggregator).openFolder.func1()
	github.com/erigontech/erigon/db/state/aggregator.go:500 +0x107
golang.org/x/sync/errgroup.(*Group).Go.func1()
```
