### PR TITLE
domain existance filter: switch to ShardedFuse by default 

### DIFF
--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -355,8 +354,8 @@ type BtIndex struct {
 }
 
 // Decompressor should be managed by caller (could be closed after index is built). When index is built, external getter should be passed to seekInFiles function
-func CreateBtreeIndexWithDecompressor(indexPath string, M uint64, decompressor *seg.Reader, seed uint32, ps *background.ProgressSet, tmpdir string, logger log.Logger, noFsync bool, accessors statecfg.Accessors) (*BtIndex, error) {
-	err := BuildBtreeIndexWithDecompressor(indexPath, decompressor, ps, tmpdir, seed, logger, noFsync, accessors)
+func CreateBtreeIndexWithDecompressor(indexPath string, existenceFilterPath string, M uint64, decompressor *seg.Reader, seed uint32, ps *background.ProgressSet, tmpdir string, logger log.Logger, noFsync bool, accessors statecfg.Accessors) (*BtIndex, error) {
+	err := BuildBtreeIndexWithDecompressor(indexPath, existenceFilterPath, decompressor, ps, tmpdir, seed, logger, noFsync, accessors)
 	if err != nil {
 		return nil, err
 	}
@@ -383,13 +382,12 @@ func OpenBtreeIndexAndDataFile(indexPath, dataPath string, M uint64, compressed 
 	return d, bt, nil
 }
 
-func BuildBtreeIndexWithDecompressor(indexPath string, kv *seg.Reader, ps *background.ProgressSet, tmpdir string, salt uint32, logger log.Logger, noFsync bool, accessors statecfg.Accessors) error {
+func BuildBtreeIndexWithDecompressor(indexPath string, existenceFilterPath string, kv *seg.Reader, ps *background.ProgressSet, tmpdir string, salt uint32, logger log.Logger, noFsync bool, accessors statecfg.Accessors) error {
 	_, indexFileName := filepath.Split(indexPath)
 	p := ps.AddNew(indexFileName, uint64(kv.Count()/2))
 	defer ps.Delete(p)
 
 	defer kv.MadvNormal().DisableReadAhead()
-	existenceFilterPath := strings.TrimSuffix(indexPath, ".bt") + ".kvei"
 
 	var existenceFilter *existence.Filter
 	if accessors.Has(statecfg.AccessorExistence) {

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -394,8 +394,7 @@ func BuildBtreeIndexWithDecompressor(indexPath string, kv *seg.Reader, ps *backg
 	var existenceFilter *existence.Filter
 	if accessors.Has(statecfg.AccessorExistence) {
 		var err error
-		useFuse := false
-		existenceFilter, err = existence.NewFilter(uint64(kv.Count()/2), existenceFilterPath, useFuse)
+		existenceFilter, err = existence.NewFilter(uint64(kv.Count()/2), existenceFilterPath, true)
 		if err != nil {
 			return err
 		}

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -394,7 +394,7 @@ func BuildBtreeIndexWithDecompressor(indexPath string, kv *seg.Reader, ps *backg
 	var existenceFilter *existence.Filter
 	if accessors.Has(statecfg.AccessorExistence) {
 		var err error
-		existenceFilter, err = existence.NewFilter(uint64(kv.Count()/2), existenceFilterPath, true)
+		existenceFilter, err = existence.NewFilter(uint64(kv.Count()/2), existenceFilterPath)
 		if err != nil {
 			return err
 		}

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -46,7 +46,7 @@ func Test_BtreeIndex_Init(t *testing.T) {
 	defer decomp.Close()
 
 	r := seg.NewReader(decomp.MakeGetter(), seg.CompressNone)
-	err = BuildBtreeIndexWithDecompressor(filepath.Join(tmp, "a.bt"), r, background.NewProgressSet(), tmp, 1, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
+	err = BuildBtreeIndexWithDecompressor(filepath.Join(tmp, "a.bt"), filepath.Join(tmp, "a.kvei"), r, background.NewProgressSet(), tmp, 1, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(t, err)
 
 	bt, err := OpenBtreeIndexWithDecompressor(filepath.Join(tmp, "a.bt"), M, r)
@@ -194,7 +194,7 @@ func buildBtreeIndex(tb testing.TB, dataPath, indexPath string, compressed seg.F
 	defer decomp.Close()
 
 	r := seg.NewReader(decomp.MakeGetter(), compressed)
-	err = BuildBtreeIndexWithDecompressor(indexPath, r, background.NewProgressSet(), filepath.Dir(indexPath), seed, logger, noFsync, statecfg.AccessorBTree|statecfg.AccessorExistence)
+	err = BuildBtreeIndexWithDecompressor(indexPath, strings.TrimSuffix(indexPath, ".bt")+".kvei", r, background.NewProgressSet(), filepath.Dir(indexPath), seed, logger, noFsync, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(tb, err)
 }
 

--- a/db/datastruct/btindex/testhelpers_test.go
+++ b/db/datastruct/btindex/testhelpers_test.go
@@ -6,6 +6,7 @@ import (
 	randOld "math/rand"
 	"math/rand/v2"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -118,7 +119,7 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 
 	IndexFile := filepath.Join(tmp, fmt.Sprintf("%dk.bt", keyCount/1000))
 	r := seg.NewReader(decomp.MakeGetter(), compressFlags)
-	err = BuildBtreeIndexWithDecompressor(IndexFile, r, ps, tb.TempDir(), 777, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
+	err = BuildBtreeIndexWithDecompressor(IndexFile, strings.TrimSuffix(IndexFile, ".bt")+".kvei", r, ps, tb.TempDir(), 777, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(tb, err)
 
 	return compPath

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -37,33 +37,23 @@ type Filter struct {
 	fuseWriterSharded  *fusefilter.WriterSharded
 	fuseReader         *fusefilter.Reader
 	fuseReaderSharded  *fusefilter.ReaderSharded
-	useFuse            bool
 	empty              bool
 	FileName, FilePath string
 	noFsync            bool // fsync is enabled by default, but tests can manually disable
 }
 
 func NewFilter(keysCount uint64, filePath string) (*Filter, error) {
-	useFuse := true
 	_, fileName := filepath.Split(filePath)
-	e := &Filter{FilePath: filePath, FileName: fileName, useFuse: useFuse}
+	e := &Filter{FilePath: filePath, FileName: fileName}
 	if keysCount < 2 {
 		e.empty = true
 	} else {
 		var err error
-		if e.useFuse {
-			e.fuseWriterSharded, err = fusefilter.NewWriterSharded(filePath)
-			if err != nil {
-				return nil, err
-			}
-			return e, nil
-		}
-
-		m := bloomfilter.OptimalM(keysCount, 0.01)
-		e.filter, err = bloomfilter.New(m)
+		e.fuseWriterSharded, err = fusefilter.NewWriterSharded(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("%w, %s", err, fileName)
+			return nil, err
 		}
+		return e, nil
 	}
 	return e, nil
 }
@@ -72,11 +62,7 @@ func (b *Filter) AddHash(hash uint64) error {
 	if b.empty {
 		return nil
 	}
-	if b.useFuse {
-		return b.fuseWriterSharded.AddHash(hash)
-	}
-	b.filter.AddHash(hash)
-	return nil
+	return b.fuseWriterSharded.AddHash(hash)
 }
 
 func (b *Filter) ContainsHash(hashedKey uint64) bool {
@@ -109,30 +95,7 @@ func (b *Filter) Build() error {
 		return nil
 	}
 
-	if b.useFuse {
-		return b.fuseWriterSharded.Build()
-	}
-
-	log.Trace("[agg] write file", "file", b.FileName)
-	cf, err := dir.CreateTemp(b.FilePath)
-	if err != nil {
-		return err
-	}
-	defer cf.Close()
-
-	if _, err := b.filter.WriteTo(cf); err != nil {
-		return err
-	}
-	if err = b.fsync(cf); err != nil {
-		return err
-	}
-	if err = cf.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(cf.Name(), b.FilePath); err != nil {
-		return err
-	}
-	return nil
+	return b.fuseWriterSharded.Build()
 }
 
 func (b *Filter) DisableFsync() {
@@ -140,9 +103,7 @@ func (b *Filter) DisableFsync() {
 		return
 	}
 	b.noFsync = true
-	if b.useFuse {
-		b.fuseWriterSharded.DisableFsync()
-	}
+	b.fuseWriterSharded.DisableFsync()
 }
 
 // fsync - other processes/goroutines must see only "fully-complete" (valid) files. No partial-writes.
@@ -169,7 +130,7 @@ func isBloomMagic(peek []byte) bool {
 		peek[8] == 'v' && peek[9] == '0' && peek[10] == '2' && peek[11] == '\n'
 }
 
-// OpenFilter opens a .kvei existence filter file. The useFuse parameter is ignored;
+// OpenFilter opens a .kvei existence filter file
 // the format is auto-detected from the file content (bloom vs fuse v0/v1).
 func OpenFilter(filePath string, _ bool) (idx *Filter, err error) {
 	_, fileName := filepath.Split(filePath)

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -26,7 +26,6 @@ import (
 
 	bloomfilter "github.com/holiman/bloomfilter/v2"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -224,7 +223,6 @@ func OpenFilter(filePath string, _ bool) (idx *Filter, err error) {
 		}
 		idx.filter = filter
 		validationPassed = true
-		log.Warn("[existence] open bloom filter", "file", fileName, "size", common.ByteCount(uint64(stat.Size())))
 		return idx, nil
 	}
 
@@ -242,7 +240,6 @@ func OpenFilter(filePath string, _ bool) (idx *Filter, err error) {
 		return nil, fmt.Errorf("OpenFilter: %w, %s", err, fileName)
 	}
 	validationPassed = true
-	log.Warn("[existence] open fuse filter", "file", fileName, "version", fuseVersion, "size", common.ByteCount(uint64(stat.Size())))
 	return idx, nil
 }
 

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -43,7 +43,8 @@ type Filter struct {
 	noFsync            bool // fsync is enabled by default, but tests can manually disable
 }
 
-func NewFilter(keysCount uint64, filePath string, useFuse bool) (*Filter, error) {
+func NewFilter(keysCount uint64, filePath string) (*Filter, error) {
+	useFuse := true
 	_, fileName := filepath.Split(filePath)
 	e := &Filter{FilePath: filePath, FileName: fileName, useFuse: useFuse}
 	if keysCount < 2 {

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -20,11 +20,13 @@ import (
 	"bufio"
 	"fmt"
 	"hash"
+	"io"
 	"os"
 	"path/filepath"
 
 	bloomfilter "github.com/holiman/bloomfilter/v2"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -33,8 +35,9 @@ import (
 
 type Filter struct {
 	filter             *bloomfilter.Filter
-	fuseWriter         *fusefilter.Writer
+	fuseWriterSharded  *fusefilter.WriterSharded
 	fuseReader         *fusefilter.Reader
+	fuseReaderSharded  *fusefilter.ReaderSharded
 	useFuse            bool
 	empty              bool
 	FileName, FilePath string
@@ -42,7 +45,6 @@ type Filter struct {
 }
 
 func NewFilter(keysCount uint64, filePath string, useFuse bool) (*Filter, error) {
-	//TODO: make filters compatible by usinig same seed/keys
 	_, fileName := filepath.Split(filePath)
 	e := &Filter{FilePath: filePath, FileName: fileName, useFuse: useFuse}
 	if keysCount < 2 {
@@ -50,7 +52,7 @@ func NewFilter(keysCount uint64, filePath string, useFuse bool) (*Filter, error)
 	} else {
 		var err error
 		if e.useFuse {
-			e.fuseWriter, err = fusefilter.NewWriter(filePath)
+			e.fuseWriterSharded, err = fusefilter.NewWriterSharded(filePath)
 			if err != nil {
 				return nil, err
 			}
@@ -71,30 +73,32 @@ func (b *Filter) AddHash(hash uint64) error {
 		return nil
 	}
 	if b.useFuse {
-		if err := b.fuseWriter.AddHash(hash); err != nil {
-			return err
-		}
-		return nil
+		return b.fuseWriterSharded.AddHash(hash)
 	}
 	b.filter.AddHash(hash)
 	return nil
 }
+
 func (b *Filter) ContainsHash(hashedKey uint64) bool {
 	if b.empty {
 		return true
 	}
-	if b.useFuse {
+	if b.fuseReaderSharded != nil {
+		return b.fuseReaderSharded.ContainsHash(hashedKey)
+	}
+	if b.fuseReader != nil {
 		return b.fuseReader.ContainsHash(hashedKey)
 	}
-
 	return b.filter.ContainsHash(hashedKey)
 }
+
 func (b *Filter) Contains(v hash.Hash64) bool {
 	if b.empty {
 		return true
 	}
 	return b.filter.Contains(v)
 }
+
 func (b *Filter) Build() error {
 	if b.empty {
 		cf, err := os.Create(b.FilePath)
@@ -106,7 +110,7 @@ func (b *Filter) Build() error {
 	}
 
 	if b.useFuse {
-		return b.fuseWriter.Build()
+		return b.fuseWriterSharded.Build()
 	}
 
 	log.Trace("[agg] write file", "file", b.FileName)
@@ -137,7 +141,7 @@ func (b *Filter) DisableFsync() {
 	}
 	b.noFsync = true
 	if b.useFuse {
-		b.fuseWriter.DisableFsync()
+		b.fuseWriterSharded.DisableFsync()
 	}
 }
 
@@ -155,14 +159,24 @@ func (b *Filter) fsync(f *os.File) error {
 	return nil
 }
 
-func OpenFilter(filePath string, useFuse bool) (idx *Filter, err error) {
+// isBloomMagic checks the first 12 bytes for holiman/bloomfilter/v2's headerMagic:
+// 8 zero bytes followed by "v02\n". This disambiguates bloom files from fuse files
+// (whose version byte and seed never accidentally match this pattern).
+func isBloomMagic(peek []byte) bool {
+	return len(peek) >= 12 &&
+		peek[0] == 0 && peek[1] == 0 && peek[2] == 0 && peek[3] == 0 &&
+		peek[4] == 0 && peek[5] == 0 && peek[6] == 0 && peek[7] == 0 &&
+		peek[8] == 'v' && peek[9] == '0' && peek[10] == '2' && peek[11] == '\n'
+}
+
+// OpenFilter opens a .kvei existence filter file. The useFuse parameter is ignored;
+// the format is auto-detected from the file content (bloom vs fuse v0/v1).
+func OpenFilter(filePath string, _ bool) (idx *Filter, err error) {
 	_, fileName := filepath.Split(filePath)
-	idx = &Filter{FilePath: filePath, FileName: fileName, useFuse: useFuse}
+	idx = &Filter{FilePath: filePath, FileName: fileName}
 	var validationPassed = false
 	defer func() {
-		// recover from panic if one occurred. Set err to nil if no panic
 		if rec := recover(); rec != nil {
-			// do r with only the stack trace
 			err = fmt.Errorf("incomplete file: %s, %+v, trace: %s", fileName, rec, dbg.Stack())
 		}
 		if err != nil || !validationPassed {
@@ -194,22 +208,84 @@ func OpenFilter(filePath string, useFuse bool) (idx *Filter, err error) {
 		return idx, nil
 	}
 
-	if idx.useFuse {
-		idx.fuseReader, err = fusefilter.NewReader(filePath)
+	var peek [12]byte
+	if _, err = io.ReadFull(f, peek[:]); err != nil {
+		return nil, fmt.Errorf("OpenFilter peek: %w, %s", err, fileName)
+	}
+	if _, err = f.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	if isBloomMagic(peek[:]) {
+		filter := new(bloomfilter.Filter)
+		_, err = filter.UnmarshalFromReaderNoVerify(bufio.NewReaderSize(f, 1*1024*1024))
 		if err != nil {
 			return nil, fmt.Errorf("OpenFilter: %w, %s", err, fileName)
 		}
+		idx.filter = filter
 		validationPassed = true
+		log.Warn("[existence] open bloom filter", "file", fileName, "size", common.ByteCount(uint64(stat.Size())))
 		return idx, nil
 	}
-	filter := new(bloomfilter.Filter)
-	_, err = filter.UnmarshalFromReaderNoVerify(bufio.NewReaderSize(f, 1*1024*1024))
+
+	// fuse format: version byte determines monolithic (0) vs sharded (1)
+	fuseVersion := peek[0]
+	switch fuseVersion {
+	case 0:
+		idx.fuseReader, err = fusefilter.NewReader(filePath)
+	case 1:
+		idx.fuseReaderSharded, err = fusefilter.NewReaderSharded(filePath)
+	default:
+		return nil, fmt.Errorf("OpenFilter: unknown fuse version %d: %s", fuseVersion, fileName)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("OpenFilter: %w, %s", err, fileName)
 	}
-	idx.filter = filter
 	validationPassed = true
+	log.Warn("[existence] open fuse filter", "file", fileName, "version", fuseVersion, "size", common.ByteCount(uint64(stat.Size())))
 	return idx, nil
+}
+
+func (b *Filter) ForceInMem() {
+	if b == nil || b.empty {
+		return
+	}
+	if b.fuseReaderSharded != nil {
+		b.fuseReaderSharded.ForceInMem()
+		return
+	}
+	if b.fuseReader != nil {
+		b.fuseReader.ForceInMem()
+	}
+	// bloom filter is already heap-allocated by OpenFilter — no-op
+}
+
+func (b *Filter) MadvWillNeed() {
+	if b == nil || b.empty {
+		return
+	}
+	if b.fuseReaderSharded != nil {
+		b.fuseReaderSharded.MadvWillNeed()
+		return
+	}
+	if b.fuseReader != nil {
+		b.fuseReader.MadvWillNeed()
+	}
+	// bloom filter is heap-allocated, no mmap to advise — no-op
+}
+
+func (b *Filter) MadvNormal() {
+	if b == nil || b.empty {
+		return
+	}
+	if b.fuseReaderSharded != nil {
+		b.fuseReaderSharded.MadvNormal()
+		return
+	}
+	if b.fuseReader != nil {
+		b.fuseReader.MadvNormal()
+	}
+	// bloom filter is heap-allocated, no mmap to advise — no-op
 }
 
 func (b *Filter) Close() {
@@ -217,4 +293,5 @@ func (b *Filter) Close() {
 		return
 	}
 	b.fuseReader.Close()
+	b.fuseReaderSharded.Close()
 }

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
-	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datastruct/fusefilter"
 )
 
@@ -39,7 +38,6 @@ type Filter struct {
 	fuseReaderSharded  *fusefilter.ReaderSharded
 	empty              bool
 	FileName, FilePath string
-	noFsync            bool // fsync is enabled by default, but tests can manually disable
 }
 
 func NewFilter(keysCount uint64, filePath string) (*Filter, error) {
@@ -79,7 +77,7 @@ func (b *Filter) ContainsHash(hashedKey uint64) bool {
 }
 
 func (b *Filter) Contains(v hash.Hash64) bool {
-	if b.empty {
+	if b.empty || b.filter == nil {
 		return true
 	}
 	return b.filter.Contains(v)
@@ -102,22 +100,7 @@ func (b *Filter) DisableFsync() {
 	if b.empty {
 		return
 	}
-	b.noFsync = true
 	b.fuseWriterSharded.DisableFsync()
-}
-
-// fsync - other processes/goroutines must see only "fully-complete" (valid) files. No partial-writes.
-// To achieve it: write to .tmp file then `rename` when file is ready.
-// Machine may power-off right after `rename` - it means `fsync` must be before `rename`
-func (b *Filter) fsync(f *os.File) error {
-	if b.noFsync {
-		return nil
-	}
-	if err := f.Sync(); err != nil {
-		log.Warn("couldn't fsync", "err", err)
-		return err
-	}
-	return nil
 }
 
 // isBloomMagic checks the first 12 bytes for holiman/bloomfilter/v2's headerMagic:

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -160,8 +160,8 @@ func (b *Filter) fsync(f *os.File) error {
 }
 
 // isBloomMagic checks the first 12 bytes for holiman/bloomfilter/v2's headerMagic:
-// 8 zero bytes followed by "v02\n". This disambiguates bloom files from fuse files
-// (whose version byte and seed never accidentally match this pattern).
+// 8 zero bytes followed by "v02\n". A fuse file can never match: bytes 4-7 hold
+// SegmentCount (v0) or a shard-size entry (v1), both structurally impossible to be zero.
 func isBloomMagic(peek []byte) bool {
 	return len(peek) >= 12 &&
 		peek[0] == 0 && peek[1] == 0 && peek[2] == 0 && peek[3] == 0 &&

--- a/db/datastruct/fusefilter/fusefilter_writer.go
+++ b/db/datastruct/fusefilter/fusefilter_writer.go
@@ -52,7 +52,13 @@ func (w *WriterOffHeap) Close() {
 }
 
 func (w *WriterOffHeap) build() (*xorfilter.BinaryFuse[uint8], error) {
-	defer dir.RemoveFile(w.tmpFilePath)
+	defer func() {
+		if w.tmpFile != nil {
+			w.tmpFile.Close()
+			w.tmpFile = nil
+		}
+		dir.RemoveFile(w.tmpFilePath)
+	}()
 	if w.count%len(w.page) != 0 {
 		if _, err := w.tmpFile.Write(castToBytes(w.page[:w.count%len(w.page)])); err != nil {
 			return nil, err
@@ -245,7 +251,13 @@ func (w *WriterSharded) Build() error {
 // Format: [4 bytes header] then 256 × [8 bytes size | blob] pairs (size==0 means absent).
 // Fully streaming: no intermediate files, one shard's fingerprints in RAM at a time.
 func (w *WriterSharded) BuildTo(fw io.Writer) (int, error) {
-	defer dir.RemoveFile(w.tmpFilePath)
+	defer func() {
+		if w.tmpFile != nil {
+			w.tmpFile.Close()
+			w.tmpFile = nil
+		}
+		dir.RemoveFile(w.tmpFilePath)
+	}()
 
 	if rem := w.count % len(w.page); rem != 0 {
 		if _, err := w.tmpFile.Write(castToBytes(w.page[:rem])); err != nil {

--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -677,7 +678,7 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 
 	IndexFile := filepath.Join(tmp, fmt.Sprintf("%dk.bt", keyCount/1000))
 	r := seg.NewReader(decomp.MakeGetter(), compressFlags)
-	err = btindex.BuildBtreeIndexWithDecompressor(IndexFile, r, ps, tmp, 777, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
+	err = btindex.BuildBtreeIndexWithDecompressor(IndexFile, strings.TrimSuffix(IndexFile, ".bt")+".kvei", r, ps, tmp, 777, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(tb, err)
 
 	return compPath
@@ -691,6 +692,6 @@ func buildBtreeIndex(tb testing.TB, dataPath, indexPath string, compressed seg.F
 	defer decomp.Close()
 
 	r := seg.NewReader(decomp.MakeGetter(), compressed)
-	err = btindex.BuildBtreeIndexWithDecompressor(indexPath, r, background.NewProgressSet(), filepath.Dir(indexPath), seed, logger, noFsync, statecfg.AccessorBTree|statecfg.AccessorExistence)
+	err = btindex.BuildBtreeIndexWithDecompressor(indexPath, strings.TrimSuffix(indexPath, ".bt")+".kvei", r, background.NewProgressSet(), filepath.Dir(indexPath), seed, logger, noFsync, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(tb, err)
 }

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -129,7 +129,8 @@ func generateKV(tb testing.TB, tmp string, keySize, valueSize, keyCount int, log
 
 	IndexFile := filepath.Join(tmp, fmt.Sprintf("%dk.bt", keyCount/1000))
 	r := seg.NewReader(decomp.MakeGetter(), compressFlags)
-	err = btindex.BuildBtreeIndexWithDecompressor(IndexFile, r, ps, tb.TempDir(), 777, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
+	kveiFile := strings.TrimSuffix(IndexFile, ".bt") + ".kvei"
+	err = btindex.BuildBtreeIndexWithDecompressor(IndexFile, kveiFile, r, ps, tb.TempDir(), 777, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(tb, err)
 
 	return compPath

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -892,7 +892,8 @@ func (d *Domain) buildFileRange(ctx context.Context, stepFrom, stepTo kv.Step, c
 
 	if d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := d.kvBtAccessorNewFilePath(stepFrom, stepTo)
-		bt, err = btindex.CreateBtreeIndexWithDecompressor(btPath, btindex.DefaultBtreeM, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
+		kveiPath := d.kvExistenceIdxNewFilePath(stepFrom, stepTo)
+		bt, err = btindex.CreateBtreeIndexWithDecompressor(btPath, kveiPath, btindex.DefaultBtreeM, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
 		if err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s .bt idx: %w", d.FilenameBase, err)
 		}
@@ -994,7 +995,8 @@ func (d *Domain) buildFiles(ctx context.Context, step kv.Step, collation Collati
 
 	if d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := d.kvBtAccessorNewFilePath(step, step+1)
-		bt, err = btindex.CreateBtreeIndexWithDecompressor(btPath, btindex.DefaultBtreeM, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
+		kveiPath := d.kvExistenceIdxNewFilePath(step, step+1)
+		bt, err = btindex.CreateBtreeIndexWithDecompressor(btPath, kveiPath, btindex.DefaultBtreeM, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
 		if err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s .bt idx: %w", d.FilenameBase, err)
 		}
@@ -1098,7 +1100,8 @@ func (d *Domain) BuildMissedAccessors(ctx context.Context, g *errgroup.Group, ps
 
 		g.Go(func() error {
 			idxPath := d.kvBtAccessorNewFilePath(item.StepRange(d.stepSize))
-			if err := btindex.BuildBtreeIndexWithDecompressor(idxPath, d.dataReader(item.decompressor), ps, d.dirs.Tmp, *d.salt.Load(), d.logger, d.noFsync, d.Accessors); err != nil {
+			kveiPath := d.kvExistenceIdxNewFilePath(item.StepRange(d.stepSize))
+			if err := btindex.BuildBtreeIndexWithDecompressor(idxPath, kveiPath, d.dataReader(item.decompressor), ps, d.dirs.Tmp, *d.salt.Load(), d.logger, d.noFsync, d.Accessors); err != nil {
 				return fmt.Errorf("failed to build btree index for %s:  %w", item.decompressor.FileName(), err)
 			}
 			return nil

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -547,11 +547,12 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 
 	if dt.d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := dt.d.kvBtAccessorNewFilePath(fromStep, toStep)
+		kveiPath := dt.d.kvExistenceIdxNewFilePath(fromStep, toStep)
 		btM := btindex.DefaultBtreeM
 		if toStep == 0 && dt.d.FilenameBase == "commitment" {
 			btM = 128
 		}
-		valuesIn.bindex, err = btindex.CreateBtreeIndexWithDecompressor(btPath, btM, dt.dataReader(valuesIn.decompressor), *dt.salt, ps, dt.d.dirs.Tmp, dt.d.logger, dt.d.noFsync, dt.d.Accessors)
+		valuesIn.bindex, err = btindex.CreateBtreeIndexWithDecompressor(btPath, kveiPath, btM, dt.dataReader(valuesIn.decompressor), *dt.salt, ps, dt.d.dirs.Tmp, dt.d.logger, dt.d.noFsync, dt.d.Accessors)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("merge %s btindex [%d-%d]: %w", dt.d.FilenameBase, r.values.from, r.values.to, err)
 		}

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -728,7 +728,7 @@ func populateFiles(t *testing.T, dirs datadir.Dirs, schema SnapNameSchema, allFi
 		}
 
 		if strings.HasSuffix(filename, ".kvei") {
-			filter, err := existence.NewFilter(0, filename, false)
+			filter, err := existence.NewFilter(0, filename)
 			require.NoError(t, err)
 			defer filter.Close()
 			filter.DisableFsync()

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -713,7 +713,8 @@ func populateFiles(t *testing.T, dirs datadir.Dirs, schema SnapNameSchema, allFi
 			defer dir.RemoveFile(sampleFile)
 
 			r := seg.NewReader(seg3.MakeGetter(), seg.CompressNone)
-			bti, err := btindex.CreateBtreeIndexWithDecompressor(filename, 128, r, uint32(1), background.NewProgressSet(), dirs.Tmp, log.New(), true, statecfg.AccessorBTree|statecfg.AccessorExistence)
+			kveiFile := strings.TrimSuffix(filename, ".bt") + ".kvei"
+			bti, err := btindex.CreateBtreeIndexWithDecompressor(filename, kveiFile, 128, r, uint32(1), background.NewProgressSet(), dirs.Tmp, log.New(), true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -41,14 +41,14 @@ func InitSchemasGen() {
 	Schema.RCacheDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.ReceiptDomain.FileVersion.AccessorBT = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.ReceiptDomain.FileVersion.DataKV = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
-	Schema.ReceiptDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
+	Schema.ReceiptDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 3}, version.Version{1, 0}}
 	Schema.ReceiptDomain.Hist.FileVersion.DataV = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.ReceiptDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.ReceiptDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.ReceiptDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.StorageDomain.FileVersion.AccessorBT = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.StorageDomain.FileVersion.DataKV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.StorageDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
+	Schema.StorageDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.StorageDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.StorageDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.StorageDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}

--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -7,7 +7,7 @@ import "github.com/erigontech/erigon/db/version"
 func InitSchemasGen() {
 	Schema.AccountsDomain.FileVersion.AccessorBT = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.AccountsDomain.FileVersion.DataKV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.AccountsDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
+	Schema.AccountsDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.AccountsDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.AccountsDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.AccountsDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
@@ -16,7 +16,7 @@ func InitSchemasGen() {
 	Schema.BodiesBlock.FileVersion.DataSeg = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.CodeDomain.FileVersion.AccessorBT = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.CodeDomain.FileVersion.DataKV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.CodeDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
+	Schema.CodeDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -7,7 +7,7 @@ accounts:
             current: v2.0
             min: v1.0
         kvei:
-            current: v1.1
+            current: v1.2
             min: v1.0
     hist:
         v:
@@ -40,7 +40,7 @@ code:
             current: v2.0
             min: v1.0
         kvei:
-            current: v1.1
+            current: v1.2
             min: v1.0
     hist:
         v:
@@ -133,7 +133,7 @@ receipt:
             current: v3.0
             min: v1.0
         kvei:
-            current: v1.2
+            current: v1.3
             min: v1.0
     hist:
         v:
@@ -158,7 +158,7 @@ storage:
             current: v2.0
             min: v1.0
         kvei:
-            current: v1.1
+            current: v1.2
             min: v1.0
     hist:
         v:


### PR DESCRIPTION
- switch `Domain` from Bloom to ShardedFuse by default (`.kvei` files)
- backward compatible: Erigon still can open Bloom files, and auto-detect them
- and it will allow move storage bloom to mmap (because it eating 9G ram on bloatnet, but bottleneck is at Commitment - not in exec)
- drop `useFuse` field in writer - as it's always `true` now

On bloatnet: 10% smaller, 5% faster