### PR TITLE
docs: require CL spec map checks for agents

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -26,16 +26,9 @@ Before committing, always verify changes with: `make lint && make erigon integra
 
 ## Local Spec Maps
 
-Before reviewing or modifying consensus-critical code, locate and read the
-applicable `CLAUDE.md` spec maps in the changed path hierarchy.
-
-For changes under `cl/`, read `cl/CLAUDE.md` first, then read each relevant
-subdirectory spec map for the touched areas, such as
-`cl/phase1/forkchoice/CLAUDE.md`, `cl/transition/CLAUDE.md`, or
-`cl/phase1/core/state/CLAUDE.md`.
-
-When declaring the work done, mention which `CLAUDE.md` spec maps were
-consulted.
+For consensus-critical changes, especially under `cl/`, follow the local
+`CLAUDE.md` spec maps required by the component `agents.md`. Local tests are
+not sufficient evidence of consensus correctness.
 
 ## Key Directories
 

--- a/agents.md
+++ b/agents.md
@@ -24,6 +24,19 @@ Before committing, always verify changes with: `make lint && make erigon integra
 - `snapshots` are immutable
 - `Unwind` beyond data in snapshots not allowed
 
+## Local Spec Maps
+
+Before reviewing or modifying consensus-critical code, locate and read the
+applicable `CLAUDE.md` spec maps in the changed path hierarchy.
+
+For changes under `cl/`, read `cl/CLAUDE.md` first, then read each relevant
+subdirectory spec map for the touched areas, such as
+`cl/phase1/forkchoice/CLAUDE.md`, `cl/transition/CLAUDE.md`, or
+`cl/phase1/core/state/CLAUDE.md`.
+
+When declaring the work done, mention which `CLAUDE.md` spec maps were
+consulted.
+
 ## Key Directories
 
 | Directory | Purpose | Component Docs |

--- a/cl/agents.md
+++ b/cl/agents.md
@@ -2,6 +2,19 @@
 
 Caplin is Erigon's embedded Beacon Chain client implementing Ethereum's proof-of-stake consensus.
 
+## Required Spec Map Check
+
+For every change under `cl/`, read `cl/CLAUDE.md` before changing or reviewing
+code. Then read the `CLAUDE.md` file for every touched consensus area that has
+one, for example:
+
+- `cl/phase1/forkchoice/CLAUDE.md`
+- `cl/transition/CLAUDE.md`
+- `cl/phase1/core/state/CLAUDE.md`
+
+Use those files as the spec-conformance checklist, and mention the consulted
+`CLAUDE.md` files in the final summary or review note.
+
 ## Directory Structure
 
 | Directory | Purpose |

--- a/cl/agents.md
+++ b/cl/agents.md
@@ -2,18 +2,26 @@
 
 Caplin is Erigon's embedded Beacon Chain client implementing Ethereum's proof-of-stake consensus.
 
-## Required Spec Map Check
+## Consensus Spec Conformance
 
-For every change under `cl/`, read `cl/CLAUDE.md` before changing or reviewing
-code. Then read the `CLAUDE.md` file for every touched consensus area that has
-one, for example:
+All changes under `cl/` are consensus-critical. Agents must treat the upstream
+Ethereum consensus specs as authoritative; local tests are not sufficient proof
+of correctness.
+
+Before changing or reviewing `cl/` code:
+
+1. Read `cl/CLAUDE.md`.
+2. Read the `CLAUDE.md` file for every touched consensus area that has one, for
+   example:
 
 - `cl/phase1/forkchoice/CLAUDE.md`
 - `cl/transition/CLAUDE.md`
 - `cl/phase1/core/state/CLAUDE.md`
 
-Use those files as the spec-conformance checklist, and mention the consulted
-`CLAUDE.md` files in the final summary or review note.
+3. Identify the upstream spec section for each changed behavior.
+4. Check fork/version boundaries and preserve pre-fork behavior.
+5. Mention the consulted `CLAUDE.md` files and spec sections in the final
+   summary or review note.
 
 ## Directory Structure
 


### PR DESCRIPTION
## Summary

- Require consensus-critical changes to follow local `CLAUDE.md` spec maps required by component `agents.md` files.
- Make `cl/agents.md` explicit that upstream Ethereum consensus specs are authoritative and local tests are not sufficient proof of correctness.
- Require CL agents to read `cl/CLAUDE.md`, touched subdirectory spec maps, identify upstream spec sections, check fork/version boundaries, and report consulted maps/sections.

## Motivation

The CL `CLAUDE.md` files already contain useful spec-conformance checklists, but agents can miss them if only `agents.md` is consulted. This makes strict upstream-spec conformance and the existing spec maps part of the required workflow for CL consensus changes.

## Validation

- `git diff --check`

Docs-only instruction update; no Go tests run.