### PR TITLE
ci: per-exec-mode Go cache lineages + skip Go cache saves in merge-queue runs

### DIFF
--- a/.github/actions/cleanup-erigon/action.yml
+++ b/.github/actions/cleanup-erigon/action.yml
@@ -19,12 +19,12 @@ runs:
         lookup-only: true
 
     - name: Prune Go build cache
-      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_GOCACHE_PATH != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_GOCACHE_PATH != '' && env.ERIGON_CI_GOCACHE_KEY != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
       shell: bash
       run: python3 tools/prune-gocache "$ERIGON_CI_GOCACHE_PATH"
 
     - uses: ./.github/actions/save-build-cache
-      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_GOCACHE_PATH != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_GOCACHE_PATH != '' && env.ERIGON_CI_GOCACHE_KEY != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
       with:
         gocache: ${{ env.ERIGON_CI_GOCACHE_PATH }}
         key: ${{ env.ERIGON_CI_GOCACHE_KEY }}
@@ -40,7 +40,7 @@ runs:
         lookup-only: true
 
     - uses: ./.github/actions/save-mod-cache
-      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_MODCACHE != '' && steps.modcache-probe.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_MODCACHE != '' && env.ERIGON_CI_MODCACHE_KEY != '' && steps.modcache-probe.outputs.cache-hit != 'true' }}
       with:
         modcache-path: ${{ env.ERIGON_CI_MODCACHE }}
         key: ${{ env.ERIGON_CI_MODCACHE_KEY }}

--- a/.github/actions/cleanup-erigon/action.yml
+++ b/.github/actions/cleanup-erigon/action.yml
@@ -4,11 +4,13 @@ description: Save build and module caches, and report uncached test packages
 runs:
   using: composite
   steps:
-    # Sibling matrix jobs can share one primary key; skip the prune/tar/upload
-    # when another job in this run has already saved the exact entry.
+    # Skip all Go cache saves in merge-queue runs: caches saved on the ephemeral
+    # merge-queue ref cannot be restored by any later run. Sibling matrix jobs
+    # can also share one primary key; skip the prune/tar/upload when another job
+    # in this run has already saved the exact entry.
     - name: Check for existing build cache entry
       id: gocache-probe
-      if: ${{ always() && env.ERIGON_CI_GOCACHE_PATH != '' && env.ERIGON_CI_GOCACHE_KEY != '' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_GOCACHE_PATH != '' && env.ERIGON_CI_GOCACHE_KEY != '' }}
       continue-on-error: true
       uses: actions/cache/restore@v4
       with:
@@ -17,19 +19,19 @@ runs:
         lookup-only: true
 
     - name: Prune Go build cache
-      if: ${{ always() && env.ERIGON_CI_GOCACHE_PATH != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_GOCACHE_PATH != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
       shell: bash
       run: python3 tools/prune-gocache "$ERIGON_CI_GOCACHE_PATH"
 
     - uses: ./.github/actions/save-build-cache
-      if: ${{ always() && env.ERIGON_CI_GOCACHE_PATH != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_GOCACHE_PATH != '' && steps.gocache-probe.outputs.cache-hit != 'true' }}
       with:
         gocache: ${{ env.ERIGON_CI_GOCACHE_PATH }}
         key: ${{ env.ERIGON_CI_GOCACHE_KEY }}
 
     - name: Check for existing module cache entry
       id: modcache-probe
-      if: ${{ always() && env.ERIGON_CI_MODCACHE != '' && env.ERIGON_CI_MODCACHE_KEY != '' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_MODCACHE != '' && env.ERIGON_CI_MODCACHE_KEY != '' }}
       continue-on-error: true
       uses: actions/cache/restore@v4
       with:
@@ -38,7 +40,7 @@ runs:
         lookup-only: true
 
     - uses: ./.github/actions/save-mod-cache
-      if: ${{ always() && env.ERIGON_CI_MODCACHE != '' && steps.modcache-probe.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_MODCACHE != '' && steps.modcache-probe.outputs.cache-hit != 'true' }}
       with:
         modcache-path: ${{ env.ERIGON_CI_MODCACHE }}
         key: ${{ env.ERIGON_CI_MODCACHE_KEY }}

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -280,12 +280,14 @@ runs:
         echo "ERIGON_CI_GOCACHE_PATH=$(go env GOCACHE)" >> "$GITHUB_ENV"
         echo "ERIGON_CI_MODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
 
+    # The module cache is a pure function of go.sum (already in its key), so it
+    # never splits by matrix entry — sibling jobs share one entry per run and
+    # the cleanup-erigon probe dedups the save.
     - id: restore-mod-cache
       uses: ./.github/actions/restore-mod-cache
       with:
         modcache-path: ${{ steps.go-env.outputs.modcache }}
         workflow-id: ${{ steps.go-env.outputs.workflow }}
-        matrix-key: ${{ inputs.build-cache-extra-key }}
 
     - name: Export modcache key
       shell: bash

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -72,7 +72,10 @@ jobs:
         with:
           submodules: true
           cleanup-space: true
-          build-cache-extra-key: ${{ matrix.test-group }}
+          # Go's test cache can't see ERIGON_EXEC3_PARALLEL (read at package
+          # init), so serial and parallel results only stay mode-pure if each
+          # exec mode keeps its own cache lineage.
+          build-cache-extra-key: ${{ matrix.test-group }}-${{ matrix.exec_mode }}
           ramdisk: true
           cache-namespace: test-all-erigon-race
 

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -58,6 +58,10 @@ jobs:
           cleanup-space: true
           ramdisk: true
           cache-namespace: test-all-erigon
+          # Go's test cache can't see ERIGON_EXEC3_PARALLEL (read at package
+          # init), so serial and parallel results only stay mode-pure if each
+          # exec mode keeps its own cache lineage.
+          build-cache-extra-key: ${{ matrix.exec_mode }}
 
       - name: Run all tests on ${{ matrix.os }} (${{ matrix.exec_mode }} exec)
         env:


### PR DESCRIPTION
Follow-up to #21711, informed by profiling its effect on #21720's runs.

## Problem

1. **Cross-mode test-result cache contamination.** `ERIGON_EXEC3_PARALLEL` is read at package init (`common/dbg/experiments.go`), and Go's test cache only records env reads made during test execution — verified by experiment: changing an init-read env var still yields `(cached)`. So serial and parallel jobs share test-result cache entries. Since #21711 made caches genuinely warm, a delayed job can restore its sibling's same-run save (observed live in #21720's PR run) and skip executing *changed code* in its own exec mode — the serial lane silently loses coverage exactly when it matters.
2. **Merge-queue cache saves are write-only.** Caches saved on ephemeral `gh-readonly-queue/*` refs cannot be restored by any later run (branch-scoped isolation; queue re-stacks always use fresh refs). Every queue run paid the full save cost — measured at ~5.8GB of dead storage plus a 12.7-minute discarded GOCACHE tar on the Windows `tests` job in #21720's merge-queue run — for entries nothing could read.
3. **Matrix keys needlessly forked the module cache.** `build-cache-extra-key` feeds both the gocache and gomodcache keys, but GOMODCACHE content is a pure function of go.sum — per-matrix copies are byte-identical duplicates (race: 5 per run, eest: 2 per run, ~250MB each).

## Changes

- **test-all-erigon / test-all-erigon-race**: Go caches keyed per exec mode (`<test-group>-<exec_mode>` for race). Each mode keeps its own lineage, so cached results can only ever come from the same mode; the delayed-sibling hole is closed structurally. This also removes the shared-key save race entirely — every surviving tar ends in a successful upload.
- **test-bench deliberately not split**: `go test -bench` results are never cached (`-bench` is not in Go's cacheable flag set; verified empirically), so its GOCACHE holds only mode-independent build artifacts and a split would be pure storage duplication.
- **cleanup-erigon**: all Go-cache probe/prune/save steps now skip in `merge_group` runs, centrally, covering all nine call sites. Known small sacrifices, judged clearly favorable: same-run late-starting siblings fall back to main's warming caches (rebuild only the PR's delta), and attempt-2 re-runs of queue runs (rare — failed groups are dequeued and their refs deleted) likewise. Review follow-up: the prune/save steps now also require the exported `ERIGON_CI_*_KEY` env vars, matching the probes' guards — if setup-erigon fails before exporting the keys, cleanup skips cleanly instead of doing pointless prune/tar prep and logging `Key is not specified.` warnings (note: an empty-key save warns and exits green per actions/cache's saveImpl, so this is hygiene, not failure-masking).
- **setup-erigon**: the matrix key no longer flows into the module-cache key — sibling jobs share one modcache entry per run and the existing exact-key probe dedups the save. This also removes the pre-existing race 5x and eest 2x modcache duplication.

## Audit of other workflows

No other workflow has the mode-purity gap: eest shards differ in `ERIGON_EXEC3_PARALLEL` within shared class keys but never run `go test` (they execute the `evm` binary against fixtures); sonar's coverage runs are uncacheable; caplin, lint, repro have no matrix entries sharing a key under differing env.

## Rollout

One-time cold starts: new per-mode gocache lineages, and modcache for the race/eest families (test-all's modcache key is unchanged). The first post-merge push to main repopulates everything via cache-warming. The storage delta is net-negative: roughly +1 gocache lineage set vs −5.8GB of dead merge-queue saves per queue run and the deduped modcache copies.

CI-only change, no Go code touched, so TDD does not apply; validated with actionlint and zizmor (zero new findings vs the same files on HEAD).

