### PR TITLE
ci: stop installing make on Windows (already on PATH), pin it

### DIFF
--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -256,10 +256,27 @@ runs:
         sudo apt-get update -qq -o Acquire::Retries=3 \
           && sudo apt-get install -qq -y build-essential 2>/dev/null
 
-    - name: Install make on Windows
+    - name: Ensure make on Windows
       if: ${{ runner.os == 'Windows' }}
       shell: bash
-      run: choco install make -y --no-progress
+      # The hosted Windows image already ships GNU Make on PATH (C:\mingw64\bin),
+      # so the previous unconditional `choco install make` was redundant and added
+      # a flaky community.chocolatey.org/NuGet dependency. Use the present make and
+      # only fall back to a retried install if none is found.
+      run: |
+        set -euo pipefail
+        if ! command -v make >/dev/null 2>&1; then
+          echo "make not on PATH; installing via choco (fallback)"
+          for i in 1 2 3; do
+            choco install make -y --no-progress && break
+            echo "choco install make failed (attempt $i), retrying..."; sleep 30
+          done
+        fi
+        make_path="$(command -v make)" || { echo "::error::make unavailable on Windows"; exit 1; }
+        # Pin this make's directory at the front of PATH so later steps use
+        # exactly this binary, not another make/gmake also present on the image.
+        echo "$(cygpath -w "$(dirname "$make_path")")" >> "$GITHUB_PATH"
+        echo "using make: $make_path -> $(make --version | head -1)"
 
     - name: Debug parallelism
       shell: bash


### PR DESCRIPTION
## Problem

`./.github/actions/setup-erigon` unconditionally runs `choco install make` on Windows. The hosted Windows runner images **already ship GNU Make 4.4.1 on `PATH`** (`C:\mingw64\bin\make`), so this install is redundant — and it adds a dependency on `community.chocolatey.org` / NuGet that intermittently fails the whole job, e.g.:

```
[NuGet] Error downloading 'make.4.4.1' from 'https://community.chocolatey.org/api/v2/package/make/4.4.1'.
The install of make was NOT successful.
##[error]Process completed with exit code 1.
```

## Change

Replace the unconditional install with an "ensure make" step that:

- uses the `make` already present on the runner (the normal path — no network, faster);
- falls back to `choco install make` **only if** no `make` is found, retried 3× (30s apart) to ride out transient registry/NuGet blips;
- **pins the chosen make's directory to the front of `PATH`** via `$GITHUB_PATH`, so later job steps deterministically use that exact binary rather than another `make`/`gmake` that may also be on the image.

Net effect: removes the recurring Windows `choco install make` flake and shaves the install time off every Windows job, while degrading gracefully if a future image ever drops make.
