### PR TITLE
[r3.5] domain: existance filter madvise require page-aligned byte slice

### DIFF
--- a/common/mmap/mmap_unix.go
+++ b/common/mmap/mmap_unix.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"syscall"
 	"unsafe"
 
@@ -29,6 +30,23 @@ import (
 )
 
 const MaxMapSize = 0xFFFFFFFFFFFF
+
+var osPageSize = uintptr(os.Getpagesize())
+
+// pageAligned returns the sub-slice of m covering only whole pages:
+// start rounded up, end rounded down. Returns nil when m spans no full page.
+func pageAligned(m []byte) []byte {
+	if len(m) == 0 {
+		return nil
+	}
+	start := reflect.ValueOf(m).Pointer()
+	skip := int((osPageSize - start%osPageSize) % osPageSize)
+	trim := int((start + uintptr(len(m))) % osPageSize)
+	if skip+trim >= len(m) {
+		return nil
+	}
+	return m[skip : len(m)-trim]
+}
 
 func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
 	// Map the data file to memory.
@@ -47,41 +65,19 @@ func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
 	return mmapHandle1, mmapHandle2, nil
 }
 
-func MadviseSequential(mmapHandle1 []byte) error {
-	err := unix.Madvise(mmapHandle1, syscall.MADV_SEQUENTIAL)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
-		return fmt.Errorf("madvise: %w", err)
+func madvise(m []byte, advice int) error {
+	if aligned := pageAligned(m); len(aligned) > 0 {
+		if err := unix.Madvise(aligned, advice); err != nil && !errors.Is(err, syscall.ENOSYS) {
+			return fmt.Errorf("madvise: %w", err)
+		}
 	}
 	return nil
 }
 
-func MadviseNormal(mmapHandle1 []byte) error {
-	err := unix.Madvise(mmapHandle1, syscall.MADV_NORMAL)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
-		return fmt.Errorf("madvise: %w", err)
-	}
-	return nil
-}
-
-func MadviseWillNeed(mmapHandle1 []byte) error {
-	err := unix.Madvise(mmapHandle1, syscall.MADV_WILLNEED)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
-		return fmt.Errorf("madvise: %w", err)
-	}
-	return nil
-}
-
-func MadviseRandom(mmapHandle1 []byte) error {
-	err := unix.Madvise(mmapHandle1, syscall.MADV_RANDOM)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
-		return fmt.Errorf("madvise: %w", err)
-	}
-	return nil
-}
+func MadviseSequential(m []byte) error { return madvise(m, syscall.MADV_SEQUENTIAL) }
+func MadviseNormal(m []byte) error     { return madvise(m, syscall.MADV_NORMAL) }
+func MadviseWillNeed(m []byte) error   { return madvise(m, syscall.MADV_WILLNEED) }
+func MadviseRandom(m []byte) error     { return madvise(m, syscall.MADV_RANDOM) }
 
 // munmap unmaps a DB's data file from memory.
 func Munmap(mmapHandle1 []byte, _ *[MaxMapSize]byte) error {

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -212,6 +212,36 @@ func OpenFilter(filePath string, useFuse bool) (idx *Filter, err error) {
 	return idx, nil
 }
 
+func (b *Filter) ForceInMem() {
+	if b == nil || b.empty {
+		return
+	}
+	if b.useFuse {
+		b.fuseReader.ForceInMem()
+	}
+	// bloom filter is already heap-allocated by OpenFilter — no-op
+}
+
+func (b *Filter) MadvWillNeed() {
+	if b == nil || b.empty {
+		return
+	}
+	if b.useFuse {
+		b.fuseReader.MadvWillNeed()
+	}
+	// bloom filter is heap-allocated, no mmap to advise — no-op
+}
+
+func (b *Filter) MadvNormal() {
+	if b == nil || b.empty {
+		return
+	}
+	if b.useFuse {
+		b.fuseReader.MadvNormal()
+	}
+	// bloom filter is heap-allocated, no mmap to advise — no-op
+}
+
 func (b *Filter) Close() {
 	if b == nil {
 		return

--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -308,13 +308,8 @@ func (r *ReaderSharded) ContainsHash(v uint64) bool {
 	return s.ContainsHash(v)
 }
 
-// ForceInMem clones the entire mmap region into anonymous heap memory in a
-// single allocation, then re-points each shard's Fingerprints slice into the
-// clone at the same byte offset. Avoids 256 separate allocations.
+// ForceInMem clones each shard's fingerprints into anonymous heap memory.
 func (r *ReaderSharded) ForceInMem() datasize.ByteSize {
-	if len(r.m) == 0 {
-		return 0
-	}
 	var res datasize.ByteSize
 	for i := range r.shards {
 		res += r.shards[i].ForceInMem()

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -448,7 +448,7 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 			if ok {
 				fName := filepath.Base(fPath)
 				d.FileVersion.AccessorKVEI.MustSupport(fileVer, fName)
-				if item.existence, err = existence.OpenFilter(fPath, false); err != nil {
+				if item.existence, err = d.openExistenceFilter(fPath); err != nil {
 					d.logger.Warn("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 					// don't interrupt on error. other files may be good
 				}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -157,16 +157,31 @@ func (d *Domain) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
 	if err != nil {
 		return nil, err
 	}
-	if domainExistenceForceInMem {
+	switch {
+	case domainExistenceForceWillNeed:
+		accessor.ForceExistenceFilterWillNeed()
+	case domainExistenceForceNormal:
+		accessor.ForceExistenceFilterNormal()
+	case domainExistenceForceInMem:
 		accessor.ForceExistenceFilterInRAM()
 	}
-	if domainExistenceForceWillNeed {
-		accessor.ForceExistenceFilterWillNeed()
-	}
-	if domainExistenceForceNormal {
-		accessor.ForceExistenceFilterNormal()
-	}
 	return accessor, nil
+}
+
+func (d *Domain) openExistenceFilter(fPath string) (*existence.Filter, error) {
+	filter, err := existence.OpenFilter(fPath, false)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case domainExistenceForceWillNeed:
+		filter.MadvWillNeed()
+	case domainExistenceForceNormal:
+		filter.MadvNormal()
+	case domainExistenceForceInMem:
+		filter.ForceInMem()
+	}
+	return filter, nil
 }
 
 func (d *Domain) kvFileNameMask(fromStep, toStep kv.Step) string {


### PR DESCRIPTION
Cherry-pick of #21743 to `release/3.5`.

Changes: `madvise` in existence filter and mmap code now uses page-aligned byte slices to avoid SIGBUS on non-page-aligned regions.

Files changed:
- `common/mmap/mmap_unix.go`
- `db/datastruct/existence/existence_filter.go`
- `db/datastruct/fusefilter/fusefilter_reader.go`
- `db/state/dirty_files.go`
- `db/state/domain.go`