### PR TITLE
execution/p2p: adhere to devp2p GetReceipts response spec

### DIFF
--- a/execution/execmodule/exec_module_devp2p_test.go
+++ b/execution/execmodule/exec_module_devp2p_test.go
@@ -186,31 +186,17 @@ func TestGetBlockReceiptsFrozenBlocks(t *testing.T) {
 				require.NoError(t, err)
 			}
 			m.ReceiveWg.Wait()
-			resp := findReceiptsResponse(t, m, uint64(i+1))
+			sent, err := m.SentMessage(i)
+			require.NoError(t, err)
+			require.Equal(t, eth.ToProto[m.SentryClient.Protocol()][eth.ReceiptsMsg], sent.Id)
+			var resp eth.ReceiptsRLPPacket70
+			require.NoError(t, rlp.DecodeBytes(sent.Data, &resp))
+			require.Equal(t, uint64(i+1), resp.RequestId)
 			require.False(t, resp.LastBlockIncomplete)
 			require.Len(t, resp.ReceiptsRLPPacket, len(tt.expect))
 			for pos, expected := range tt.expect {
 				require.Equal(t, expected, resp.ReceiptsRLPPacket[pos], "receipt list at position %d", pos)
 			}
 		})
-	}
-}
-
-// findReceiptsResponse locates the Receipts response by request id rather than by
-// outbound message position.
-func findReceiptsResponse(t *testing.T, m *execmoduletester.ExecModuleTester, requestId uint64) *eth.ReceiptsRLPPacket70 {
-	t.Helper()
-	receiptsMsgId := eth.ToProto[m.SentryClient.Protocol()][eth.ReceiptsMsg]
-	for i := 0; ; i++ {
-		sent, err := m.SentMessage(i)
-		require.NoError(t, err, "no Receipts response found for request id %d", requestId)
-		if sent.Id != receiptsMsgId {
-			continue
-		}
-		var resp eth.ReceiptsRLPPacket70
-		require.NoError(t, rlp.DecodeBytes(sent.Data, &resp))
-		if resp.RequestId == requestId {
-			return &resp
-		}
 	}
 }

--- a/execution/execmodule/exec_module_devp2p_test.go
+++ b/execution/execmodule/exec_module_devp2p_test.go
@@ -18,7 +18,6 @@ package execmodule_test
 
 import (
 	"bytes"
-	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -84,7 +83,6 @@ func TestGetBlockReceiptsFrozenBlocks(t *testing.T) {
 	// Freeze the first segment's blocks into a snapshot file and prune them from
 	// the DB, exactly as block retirement does.
 	snCfg, _ := snapcfg.KnownCfg(networkname.Mainnet)
-	snCfg.ExpectBlocks = math.MaxUint64
 	require.NoError(t, freezeblocks.DumpBlocks(m.Ctx, 0, snaptype.Erigon2MinSegmentSize, m.ChainConfig, m.Dirs.Tmp, m.Dirs.Snap, m.DB, 1, log.LvlInfo, log.New(), m.BlockReader, snCfg, nil))
 	require.NoError(t, m.BlockSnapshots.OpenFolder())
 	rwTx, err := m.DB.BeginRw(m.Ctx)
@@ -188,17 +186,31 @@ func TestGetBlockReceiptsFrozenBlocks(t *testing.T) {
 				require.NoError(t, err)
 			}
 			m.ReceiveWg.Wait()
-			sent, err := m.SentMessage(i)
-			require.NoError(t, err)
-			require.Equal(t, eth.ToProto[m.SentryClient.Protocol()][eth.ReceiptsMsg], sent.Id)
-			var resp eth.ReceiptsRLPPacket70
-			require.NoError(t, rlp.DecodeBytes(sent.Data, &resp))
-			require.Equal(t, uint64(i+1), resp.RequestId)
+			resp := findReceiptsResponse(t, m, uint64(i+1))
 			require.False(t, resp.LastBlockIncomplete)
 			require.Len(t, resp.ReceiptsRLPPacket, len(tt.expect))
 			for pos, expected := range tt.expect {
 				require.Equal(t, expected, resp.ReceiptsRLPPacket[pos], "receipt list at position %d", pos)
 			}
 		})
+	}
+}
+
+// findReceiptsResponse locates the Receipts response by request id rather than by
+// outbound message position.
+func findReceiptsResponse(t *testing.T, m *execmoduletester.ExecModuleTester, requestId uint64) *eth.ReceiptsRLPPacket70 {
+	t.Helper()
+	receiptsMsgId := eth.ToProto[m.SentryClient.Protocol()][eth.ReceiptsMsg]
+	for i := 0; ; i++ {
+		sent, err := m.SentMessage(i)
+		require.NoError(t, err, "no Receipts response found for request id %d", requestId)
+		if sent.Id != receiptsMsgId {
+			continue
+		}
+		var resp eth.ReceiptsRLPPacket70
+		require.NoError(t, rlp.DecodeBytes(sent.Data, &resp))
+		if resp.RequestId == requestId {
+			return &resp
+		}
 	}
 }

--- a/execution/execmodule/exec_module_devp2p_test.go
+++ b/execution/execmodule/exec_module_devp2p_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execmodule_test
+
+import (
+	"bytes"
+	"math"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/rawdb"
+	"github.com/erigontech/erigon/db/snapcfg"
+	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/chain/networkname"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/direct"
+	"github.com/erigontech/erigon/node/gointerfaces/sentryproto"
+	"github.com/erigontech/erigon/p2p/protocols/eth"
+	"github.com/erigontech/erigon/rpc/jsonrpc/receipts"
+)
+
+// TestGetBlockReceiptsFrozenBlocks covers GetReceipts serving for blocks that live
+// only in snapshot segments (headers pruned from the DB). Responses must carry one
+// receipt list per requested block in request order — an empty list for empty
+// blocks — and end at the first block that cannot be served.
+func TestGetBlockReceiptsFrozenBlocks(t *testing.T) {
+	t.Parallel()
+	const (
+		// The chain is one minimal block segment (file names encode block/1000, so
+		// segments cannot be smaller) plus a small tail that stays unfrozen in the DB.
+		frozenChainLength   = snaptype.Erigon2MinSegmentSize + 10
+		frozenEmptyBlockNum = 500
+	)
+	devp2pTestKey, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	require.NoError(t, err)
+	devp2pTestAddr := crypto.PubkeyToAddress(devp2pTestKey.PublicKey)
+	m := execmoduletester.New(
+		t,
+		execmoduletester.WithGenesisSpec(&types.Genesis{
+			Config: chain.AllProtocolChanges,
+			Alloc:  types.GenesisAlloc{devp2pTestAddr: {Balance: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)}},
+		}),
+		execmoduletester.WithKey(devp2pTestKey),
+		execmoduletester.WithSentryProtocol(direct.ETH70),
+	)
+	signer := types.LatestSignerForChainID(nil)
+	generated, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, frozenChainLength, func(i int, block *blockgen.BlockGen) {
+		if i+1 == frozenEmptyBlockNum {
+			return // one empty block surrounded by non-empty ones
+		}
+		tx, err := types.SignTx(types.NewTransaction(block.TxNonce(devp2pTestAddr), common.Address{1}, uint256.NewInt(1), params.TxGas, uint256.NewInt(m.Genesis.BaseFee().Uint64()), nil), *signer, devp2pTestKey)
+		require.NoError(t, err)
+		block.AddTx(tx)
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(generated))
+	// Freeze the first segment's blocks into a snapshot file and prune them from
+	// the DB, exactly as block retirement does.
+	snCfg, _ := snapcfg.KnownCfg(networkname.Mainnet)
+	snCfg.ExpectBlocks = math.MaxUint64
+	require.NoError(t, freezeblocks.DumpBlocks(m.Ctx, 0, snaptype.Erigon2MinSegmentSize, m.ChainConfig, m.Dirs.Tmp, m.Dirs.Snap, m.DB, 1, log.LvlInfo, log.New(), m.BlockReader, snCfg, nil))
+	require.NoError(t, m.BlockSnapshots.OpenFolder())
+	rwTx, err := m.DB.BeginRw(m.Ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	deleted, err := rawdb.PruneBlocks(rwTx, snaptype.Erigon2MinSegmentSize, snaptype.Erigon2MinSegmentSize)
+	require.NoError(t, err)
+	require.Equal(t, snaptype.Erigon2MinSegmentSize-1, deleted)
+	require.NoError(t, rwTx.Commit())
+	tx, err := m.DB.BeginTemporalRo(m.Ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	blockHash := func(num uint64) common.Hash {
+		block, err := m.BlockReader.BlockByNumber(m.Ctx, tx, num)
+		require.NoError(t, err)
+		require.NotNil(t, block)
+		return block.Hash()
+	}
+	emptyBlockHash := blockHash(frozenEmptyBlockNum)
+	// Precondition making the scenario real: the empty block is readable via the
+	// snapshot-aware block reader but its header is gone from the DB tables.
+	require.GreaterOrEqual(t, m.BlockReader.FrozenBlocks(), uint64(snaptype.Erigon2MinSegmentSize-1))
+	prunedHeader, err := rawdb.ReadHeaderByHash(tx, emptyBlockHash)
+	require.NoError(t, err)
+	require.Nil(t, prunedHeader)
+	receiptsGetter := receipts.NewGenerator(m.Dirs, m.BlockReader, m.Engine, nil, time.Minute)
+	encodedReceipts := func(num uint64) rlp.RawValue {
+		block, err := m.BlockReader.BlockByNumber(m.Ctx, tx, num)
+		require.NoError(t, err)
+		r, err := receiptsGetter.GetReceipts(m.Ctx, m.ChainConfig, tx, block, eth.ReceiptsOpts{})
+		require.NoError(t, err)
+		perReceipt := make([]rlp.RawValue, 0, len(r))
+		for _, receipt := range r {
+			var buf bytes.Buffer
+			require.NoError(t, receipt.EncodeRLP69(&buf))
+			perReceipt = append(perReceipt, buf.Bytes())
+		}
+		encoded, err := rlp.EncodeToBytes(perReceipt)
+		require.NoError(t, err)
+		return encoded
+	}
+	var unknownHash common.Hash
+	for i := range unknownHash {
+		unknownHash[i] = byte(i)
+	}
+	emptyList, err := rlp.EncodeToBytes([]rlp.RawValue{})
+	require.NoError(t, err)
+	tests := []struct {
+		name   string
+		query  []common.Hash
+		expect []rlp.RawValue
+	}{
+		{
+			// An empty block mid-request must yield an empty receipt list at its
+			// position, not be omitted: omission desyncs the positional matching
+			// peers use to validate the response, and they drop us for it.
+			name: "empty block mid request",
+			query: []common.Hash{
+				blockHash(frozenEmptyBlockNum - 2), blockHash(frozenEmptyBlockNum - 1),
+				emptyBlockHash,
+				blockHash(frozenEmptyBlockNum + 1), blockHash(frozenEmptyBlockNum + 2),
+			},
+			expect: []rlp.RawValue{
+				encodedReceipts(frozenEmptyBlockNum - 2), encodedReceipts(frozenEmptyBlockNum - 1),
+				emptyList,
+				encodedReceipts(frozenEmptyBlockNum + 1), encodedReceipts(frozenEmptyBlockNum + 2),
+			},
+		},
+		{
+			// A block we cannot serve ends the response at that block, so what we
+			// do send still corresponds positionally to the request prefix.
+			name: "unknown hash mid request",
+			query: []common.Hash{
+				blockHash(frozenEmptyBlockNum - 2), blockHash(frozenEmptyBlockNum - 1),
+				unknownHash,
+				blockHash(frozenEmptyBlockNum + 1),
+			},
+			expect: []rlp.RawValue{
+				encodedReceipts(frozenEmptyBlockNum - 2), encodedReceipts(frozenEmptyBlockNum - 1),
+			},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := rlp.EncodeToBytes(eth.GetReceiptsPacket70{RequestId: uint64(i + 1), GetReceiptsPacket: tt.query})
+			require.NoError(t, err)
+			m.StreamWg.Wait()
+			m.ReceiveWg.Add(1)
+			for _, err = range m.Send(&sentryproto.InboundMessage{Id: eth.ToProto[direct.ETH70][eth.GetReceiptsMsg], Data: b, PeerId: m.PeerId}) {
+				require.NoError(t, err)
+			}
+			m.ReceiveWg.Wait()
+			sent, err := m.SentMessage(i)
+			require.NoError(t, err)
+			require.Equal(t, eth.ToProto[m.SentryClient.Protocol()][eth.ReceiptsMsg], sent.Id)
+			var resp eth.ReceiptsRLPPacket70
+			require.NoError(t, rlp.DecodeBytes(sent.Data, &resp))
+			require.Equal(t, uint64(i+1), resp.RequestId)
+			require.False(t, resp.LastBlockIncomplete)
+			require.Len(t, resp.ReceiptsRLPPacket, len(tt.expect))
+			for pos, expected := range tt.expect {
+				require.Equal(t, expected, resp.ReceiptsRLPPacket[pos], "receipt list at position %d", pos)
+			}
+		})
+	}
+}

--- a/execution/execmodule/exec_module_devp2p_test.go
+++ b/execution/execmodule/exec_module_devp2p_test.go
@@ -138,6 +138,17 @@ func TestGetBlockReceiptsFrozenBlocks(t *testing.T) {
 		expect []rlp.RawValue
 	}{
 		{
+			// Baseline: every requested block — frozen or still in the DB — yields
+			// its receipt list in request order.
+			name: "all blocks available",
+			query: []common.Hash{
+				blockHash(frozenEmptyBlockNum - 2), blockHash(frozenEmptyBlockNum - 1), blockHash(frozenChainLength - 5),
+			},
+			expect: []rlp.RawValue{
+				encodedReceipts(frozenEmptyBlockNum - 2), encodedReceipts(frozenEmptyBlockNum - 1), encodedReceipts(frozenChainLength - 5),
+			},
+		},
+		{
 			// An empty block mid-request must yield an empty receipt list at its
 			// position, not be omitted: omission desyncs the positional matching
 			// peers use to validate the response, and they drop us for it.

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -349,6 +349,12 @@ func WithFcuBackgroundPrune() Option {
 	}
 }
 
+func WithSentryProtocol(protocol uint) Option {
+	return func(opts *options) {
+		opts.sentryProtocol = protocol
+	}
+}
+
 type options struct {
 	stepSize                 *uint64
 	experimentalBAL          bool
@@ -362,6 +368,7 @@ type options struct {
 	fcuBackgroundCommit      bool
 	fcuBackgroundPrune       bool
 	alwaysGenerateChangesets *bool
+	sentryProtocol           uint
 }
 
 func applyOptions(opts []Option) options {
@@ -372,6 +379,7 @@ func applyOptions(opts []Option) options {
 		pruneMode:       &defaultPruneMode,
 		chainConfig:     chain.TestChainBerlinConfig,
 		experimentalBAL: false,
+		sentryProtocol:  direct.ETH68,
 	}
 	for _, o := range opts {
 		o(&opt)
@@ -536,7 +544,7 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 
 	mock.Address = crypto.PubkeyToAddress(mock.Key.PublicKey)
 
-	mock.SentryClient, err = direct.NewSentryClientDirect(direct.ETH68, mock, nil)
+	mock.SentryClient, err = direct.NewSentryClientDirect(opt.sentryProtocol, mock, nil)
 	require.NoError(tb, err)
 	sentries := []sentryproto.SentryClient{mock.SentryClient}
 

--- a/p2p/protocols/eth/handlers.go
+++ b/p2p/protocols/eth/handlers.go
@@ -395,11 +395,14 @@ func AnswerGetReceiptsQuery(ctx context.Context, cfg *chain.Config, receiptsGett
 		}
 		// The response carries one receipt list per requested block in request
 		// order, so a block we cannot serve ends the response at that block.
-		number, _ := br.HeaderNumber(context.Background(), db, hash)
+		number, err := br.HeaderNumber(ctx, db, hash)
+		if err != nil {
+			return nil, false, err
+		}
 		if number == nil {
 			return receipts, false, nil
 		}
-		b, _, err := br.BlockWithSenders(context.Background(), db, hash, *number)
+		b, _, err := br.BlockWithSenders(ctx, db, hash, *number)
 		if err != nil {
 			return nil, false, err
 		}

--- a/p2p/protocols/eth/handlers.go
+++ b/p2p/protocols/eth/handlers.go
@@ -391,27 +391,27 @@ func AnswerGetReceiptsQuery(ctx context.Context, cfg *chain.Config, receiptsGett
 		hash := query[lookups]
 		if numBytes >= softResponseLimit || len(receipts) >= maxReceiptsServe ||
 			lookups >= 2*maxReceiptsServe {
-			break
+			return receipts, false, nil
 		}
 		// The response carries one receipt list per requested block in request
 		// order, so a block we cannot serve ends the response at that block.
 		number, _ := br.HeaderNumber(context.Background(), db, hash)
 		if number == nil {
-			break
+			return receipts, false, nil
 		}
 		b, _, err := br.BlockWithSenders(context.Background(), db, hash, *number)
 		if err != nil {
 			return nil, false, err
 		}
 		if b == nil {
-			break
+			return receipts, false, nil
 		}
 		results, err := receiptsGetter.GetReceipts(ctx, cfg, db, b, receiptsOpts)
 		if err != nil {
 			return nil, false, err
 		}
 		if results == nil && b.HeaderNoCopy().ReceiptHash != empty.RootHash {
-			break
+			return receipts, false, nil
 		}
 
 		// For the first block, skip receipts before firstBlockReceiptIndex (eth/70)

--- a/p2p/protocols/eth/handlers.go
+++ b/p2p/protocols/eth/handlers.go
@@ -400,12 +400,15 @@ func AnswerGetReceiptsQuery(ctx context.Context, cfg *chain.Config, receiptsGett
 			break
 		}
 		b, _, err := br.BlockWithSenders(context.Background(), db, hash, *number)
-		if err != nil || b == nil {
+		if err != nil {
+			return nil, false, err
+		}
+		if b == nil {
 			break
 		}
 		results, err := receiptsGetter.GetReceipts(ctx, cfg, db, b, receiptsOpts)
 		if err != nil {
-			break
+			return nil, false, err
 		}
 		if results == nil && b.HeaderNoCopy().ReceiptHash != empty.RootHash {
 			break

--- a/p2p/protocols/eth/handlers.go
+++ b/p2p/protocols/eth/handlers.go
@@ -393,31 +393,22 @@ func AnswerGetReceiptsQuery(ctx context.Context, cfg *chain.Config, receiptsGett
 			lookups >= 2*maxReceiptsServe {
 			break
 		}
+		// The response carries one receipt list per requested block in request
+		// order, so a block we cannot serve ends the response at that block.
 		number, _ := br.HeaderNumber(context.Background(), db, hash)
 		if number == nil {
-			return nil, false, nil
+			break
 		}
 		b, _, err := br.BlockWithSenders(context.Background(), db, hash, *number)
-		if err != nil {
-			return nil, false, err
+		if err != nil || b == nil {
+			break
 		}
-		if b == nil {
-			return nil, false, nil
-		}
-
 		results, err := receiptsGetter.GetReceipts(ctx, cfg, db, b, receiptsOpts)
 		if err != nil {
-			return nil, false, err
+			break
 		}
-
-		if results == nil {
-			header, err := rawdb.ReadHeaderByHash(db, hash)
-			if err != nil {
-				return nil, false, err
-			}
-			if header == nil || header.ReceiptHash != empty.RootHash {
-				continue
-			}
+		if results == nil && b.HeaderNoCopy().ReceiptHash != empty.RootHash {
+			break
 		}
 
 		// For the first block, skip receipts before firstBlockReceiptIndex (eth/70)

--- a/p2p/protocols/eth/handlers_receipts_query_test.go
+++ b/p2p/protocols/eth/handlers_receipts_query_test.go
@@ -36,7 +36,8 @@ import (
 
 // Per the devp2p spec, a Receipts response carries one receipt list per requested
 // block in request order, ending at the first block the server cannot serve.
-// These tests pin that down for every way serving a block can fail mid-query.
+// These tests pin that down for the ways a block can be unavailable mid-query;
+// internal errors are propagated to the caller instead.
 
 // A block whose receipts cannot be produced (and is not empty) ends the response;
 // skipping it instead would misalign every later entry against the request.
@@ -49,26 +50,24 @@ func TestAnswerGetReceiptsQuery_EndsResponseWhenReceiptsUnavailable(t *testing.T
 	require.Equal(t, []rlp.RawValue{f.encoded(t, 0)}, resp)
 }
 
-// An error producing one block's receipts ends the response there instead of
-// dropping the entire response (the peer must still get the prefix).
-func TestAnswerGetReceiptsQuery_EndsResponseOnReceiptsError(t *testing.T) {
+// An error producing one block's receipts is returned to the caller.
+func TestAnswerGetReceiptsQuery_ReturnsReceiptsError(t *testing.T) {
 	f := newReceiptsQueryFixture(t, 3)
 	f.getter.errs[f.blocks[1].Hash()] = errors.New("receipts unavailable")
 	resp, lastBlockIncomplete, err := answerQuery(t, f)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "receipts unavailable")
 	require.False(t, lastBlockIncomplete)
-	require.Equal(t, []rlp.RawValue{f.encoded(t, 0)}, resp)
+	require.Nil(t, resp)
 }
 
-// An error reading one block ends the response there instead of dropping the
-// entire response.
-func TestAnswerGetReceiptsQuery_EndsResponseOnBlockReadError(t *testing.T) {
+// An error reading one block is returned to the caller.
+func TestAnswerGetReceiptsQuery_ReturnsBlockReadError(t *testing.T) {
 	f := newReceiptsQueryFixture(t, 3)
 	f.br.blockErrs[f.blocks[1].Hash()] = errors.New("block read failed")
 	resp, lastBlockIncomplete, err := answerQuery(t, f)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "block read failed")
 	require.False(t, lastBlockIncomplete)
-	require.Equal(t, []rlp.RawValue{f.encoded(t, 0)}, resp)
+	require.Nil(t, resp)
 }
 
 // A hash whose number resolves but whose block cannot be read ends the response

--- a/p2p/protocols/eth/handlers_receipts_query_test.go
+++ b/p2p/protocols/eth/handlers_receipts_query_test.go
@@ -70,6 +70,16 @@ func TestAnswerGetReceiptsQuery_ReturnsBlockReadError(t *testing.T) {
 	require.Nil(t, resp)
 }
 
+// An error resolving a hash to a block number is returned to the caller.
+func TestAnswerGetReceiptsQuery_ReturnsHeaderNumberError(t *testing.T) {
+	f := newReceiptsQueryFixture(t, 3)
+	f.br.numberErrs[f.blocks[1].Hash()] = errors.New("header number read failed")
+	resp, lastBlockIncomplete, err := answerQuery(t, f)
+	require.ErrorContains(t, err, "header number read failed")
+	require.False(t, lastBlockIncomplete)
+	require.Nil(t, resp)
+}
+
 // A hash whose number resolves but whose block cannot be read ends the response
 // there; entries collected before it must not be discarded.
 func TestAnswerGetReceiptsQuery_EndsResponseWhenBlockUnreadable(t *testing.T) {
@@ -104,7 +114,7 @@ type receiptsQueryFixture struct {
 func newReceiptsQueryFixture(t *testing.T, n int) *receiptsQueryFixture {
 	t.Helper()
 	f := &receiptsQueryFixture{
-		br:     &queryTestBlockReader{numbers: map[common.Hash]uint64{}, blocks: map[common.Hash]*types.Block{}, blockErrs: map[common.Hash]error{}},
+		br:     &queryTestBlockReader{numbers: map[common.Hash]uint64{}, numberErrs: map[common.Hash]error{}, blocks: map[common.Hash]*types.Block{}, blockErrs: map[common.Hash]error{}},
 		getter: &queryTestReceiptsGetter{receipts: map[common.Hash]types.Receipts{}, errs: map[common.Hash]error{}},
 	}
 	parent := common.Hash{}
@@ -137,12 +147,16 @@ func (f *receiptsQueryFixture) encoded(t *testing.T, blockIdx int) rlp.RawValue 
 
 type queryTestBlockReader struct {
 	services.HeaderAndBodyReader
-	numbers   map[common.Hash]uint64
-	blocks    map[common.Hash]*types.Block
-	blockErrs map[common.Hash]error
+	numbers    map[common.Hash]uint64
+	numberErrs map[common.Hash]error
+	blocks     map[common.Hash]*types.Block
+	blockErrs  map[common.Hash]error
 }
 
 func (m *queryTestBlockReader) HeaderNumber(_ context.Context, _ kv.Getter, hash common.Hash) (*uint64, error) {
+	if err := m.numberErrs[hash]; err != nil {
+		return nil, err
+	}
 	n, ok := m.numbers[hash]
 	if !ok {
 		return nil, nil

--- a/p2p/protocols/eth/handlers_receipts_query_test.go
+++ b/p2p/protocols/eth/handlers_receipts_query_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/temporal"
+	"github.com/erigontech/erigon/db/services"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/direct"
+)
+
+// Per the devp2p spec, a Receipts response carries one receipt list per requested
+// block in request order, ending at the first block the server cannot serve.
+// These tests pin that down for every way serving a block can fail mid-query.
+
+// A block whose receipts cannot be produced (and is not empty) ends the response;
+// skipping it instead would misalign every later entry against the request.
+func TestAnswerGetReceiptsQuery_EndsResponseWhenReceiptsUnavailable(t *testing.T) {
+	f := newReceiptsQueryFixture(t, 3)
+	delete(f.getter.receipts, f.blocks[1].Hash())
+	resp, lastBlockIncomplete, err := answerQuery(t, f)
+	require.NoError(t, err)
+	require.False(t, lastBlockIncomplete)
+	require.Equal(t, []rlp.RawValue{f.encoded(t, 0)}, resp)
+}
+
+// An error producing one block's receipts ends the response there instead of
+// dropping the entire response (the peer must still get the prefix).
+func TestAnswerGetReceiptsQuery_EndsResponseOnReceiptsError(t *testing.T) {
+	f := newReceiptsQueryFixture(t, 3)
+	f.getter.errs[f.blocks[1].Hash()] = errors.New("receipts unavailable")
+	resp, lastBlockIncomplete, err := answerQuery(t, f)
+	require.NoError(t, err)
+	require.False(t, lastBlockIncomplete)
+	require.Equal(t, []rlp.RawValue{f.encoded(t, 0)}, resp)
+}
+
+// An error reading one block ends the response there instead of dropping the
+// entire response.
+func TestAnswerGetReceiptsQuery_EndsResponseOnBlockReadError(t *testing.T) {
+	f := newReceiptsQueryFixture(t, 3)
+	f.br.blockErrs[f.blocks[1].Hash()] = errors.New("block read failed")
+	resp, lastBlockIncomplete, err := answerQuery(t, f)
+	require.NoError(t, err)
+	require.False(t, lastBlockIncomplete)
+	require.Equal(t, []rlp.RawValue{f.encoded(t, 0)}, resp)
+}
+
+// A hash whose number resolves but whose block cannot be read ends the response
+// there; entries collected before it must not be discarded.
+func TestAnswerGetReceiptsQuery_EndsResponseWhenBlockUnreadable(t *testing.T) {
+	f := newReceiptsQueryFixture(t, 3)
+	delete(f.br.blocks, f.blocks[1].Hash())
+	resp, lastBlockIncomplete, err := answerQuery(t, f)
+	require.NoError(t, err)
+	require.False(t, lastBlockIncomplete)
+	require.Equal(t, []rlp.RawValue{f.encoded(t, 0)}, resp)
+}
+
+func answerQuery(t *testing.T, f *receiptsQueryFixture) ([]rlp.RawValue, bool, error) {
+	t.Helper()
+	db := temporal.NewTestDB(t, dbcfg.ChainDB)
+	tx, err := db.BeginTemporalRo(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+	opts := ReceiptQueryOpts{EthVersion: direct.ETH68, SizeLimit: NoSizeLimit}
+	return AnswerGetReceiptsQuery(context.Background(), chain.TestChainBerlinConfig, f.getter, f.br, tx, f.query, nil, opts)
+}
+
+type receiptsQueryFixture struct {
+	blocks   []*types.Block
+	receipts []types.Receipts
+	br       *queryTestBlockReader
+	getter   *queryTestReceiptsGetter
+	query    GetReceiptsPacket
+}
+
+// newReceiptsQueryFixture builds n chained non-empty blocks, each with one receipt,
+// all known to the block reader and the receipts getter.
+func newReceiptsQueryFixture(t *testing.T, n int) *receiptsQueryFixture {
+	t.Helper()
+	f := &receiptsQueryFixture{
+		br:     &queryTestBlockReader{numbers: map[common.Hash]uint64{}, blocks: map[common.Hash]*types.Block{}, blockErrs: map[common.Hash]error{}},
+		getter: &queryTestReceiptsGetter{receipts: map[common.Hash]types.Receipts{}, errs: map[common.Hash]error{}},
+	}
+	parent := common.Hash{}
+	for i := 0; i < n; i++ {
+		header := &types.Header{
+			ParentHash:  parent,
+			ReceiptHash: common.Hash{0xde, 0xad},
+		}
+		header.Number.SetUint64(uint64(i + 1))
+		block := types.NewBlockWithHeader(header)
+		hash := block.Hash()
+		parent = hash
+		receipts := types.Receipts{&types.Receipt{CumulativeGasUsed: uint64(21_000 * (i + 1))}}
+		f.blocks = append(f.blocks, block)
+		f.receipts = append(f.receipts, receipts)
+		f.br.numbers[hash] = uint64(i + 1)
+		f.br.blocks[hash] = block
+		f.getter.receipts[hash] = receipts
+		f.query = append(f.query, hash)
+	}
+	return f
+}
+
+func (f *receiptsQueryFixture) encoded(t *testing.T, blockIdx int) rlp.RawValue {
+	t.Helper()
+	encoded, err := rlp.EncodeToBytes(f.receipts[blockIdx])
+	require.NoError(t, err)
+	return encoded
+}
+
+type queryTestBlockReader struct {
+	services.HeaderAndBodyReader
+	numbers   map[common.Hash]uint64
+	blocks    map[common.Hash]*types.Block
+	blockErrs map[common.Hash]error
+}
+
+func (m *queryTestBlockReader) HeaderNumber(_ context.Context, _ kv.Getter, hash common.Hash) (*uint64, error) {
+	n, ok := m.numbers[hash]
+	if !ok {
+		return nil, nil
+	}
+	return &n, nil
+}
+
+func (m *queryTestBlockReader) BlockWithSenders(_ context.Context, _ kv.Getter, hash common.Hash, _ uint64) (*types.Block, []common.Address, error) {
+	if err := m.blockErrs[hash]; err != nil {
+		return nil, nil, err
+	}
+	return m.blocks[hash], nil, nil
+}
+
+type queryTestReceiptsGetter struct {
+	receipts map[common.Hash]types.Receipts
+	errs     map[common.Hash]error
+}
+
+func (m *queryTestReceiptsGetter) GetReceipts(_ context.Context, _ *chain.Config, _ kv.TemporalTx, block *types.Block, _ ReceiptsOpts) (types.Receipts, error) {
+	if err := m.errs[block.Hash()]; err != nil {
+		return nil, err
+	}
+	return m.receipts[block.Hash()], nil
+}
+
+func (m *queryTestReceiptsGetter) GetCachedReceipts(_ context.Context, _ common.Hash) (types.Receipts, bool) {
+	return nil, false
+}


### PR DESCRIPTION
found in https://discord.com/channels/595666850260713488/892088344438255616/1513781695780749475
nethermind is penalizing us because we do not adhere to the get block receipts devp2p response spec

Per the spec, a Receipts response carries one receipt list per requested block in request order, ending at the first block the server cannot serve.

| gap | before | after |
|---|---|---|
| empty block whose header is only in snapshots (`rawdb.ReadHeaderByHash` is snapshot-blind) | omitted mid-response → positional desync, peers see corrupt receipts | empty list at its position |
| unknown hash | entire response discarded, incl. already-collected entries | response ends at that block |
| receipts unavailable for a known non-empty block | block skipped → positional desync | response ends at that block |
| block unreadable (number resolves, block missing) | entire response discarded | response ends at that block |

Internal errors keep propagating to the caller as before. Every gap is covered by a test that goes red without the fix: e2e in `execution/execmodule/exec_module_devp2p_test.go` (freezes a chain into a real snapshot segment and prunes the DB — the storage state of the misbehaving nodes — then queries via the eth/70 GetReceipts message path) and unit tests in `p2p/protocols/eth/handlers_receipts_query_test.go`.