### PR TITLE
rpc: fix gasprice

### DIFF
--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -63,7 +63,7 @@ func DefaultBlockGasLimitByChain(chainConfig *chain.Config) uint64 {
 // FullNodeGPO contains default gasprice oracle settings for full node.
 var FullNodeGPO = gaspricecfg.Config{
 	Blocks:           20,
-	Default:          uint256.NewInt(0),
+	Default:          uint256.NewInt(common.GWei / 1000),
 	Percentile:       60,
 	MaxHeaderHistory: 0,
 	MaxBlockHistory:  0,

--- a/rpc/gasprice/gasprice_test.go
+++ b/rpc/gasprice/gasprice_test.go
@@ -303,6 +303,32 @@ func (m *mockOracleBackend) Fork(_ context.Context) (gasprice.OracleBackend, fun
 	return nil, nil, nil // sequential mode
 }
 
+// TestSuggestTipCap_EmptyBlocksFallbackMatchesGeth verifies that on a chain
+// where all sampled blocks are empty, the oracle uses GWei/1000 as the
+// fallback price (matching Geth's miner.DefaultConfig.GasPrice) rather than
+// 0 from an uninitialized cache.
+func TestSuggestTipCap_EmptyBlocksFallbackMatchesGeth(t *testing.T) {
+	head := types.NewEmptyHeaderForAssembling()
+	head.Number.SetUint64(25)
+
+	backend := &mockOracleBackend{head: head}
+	cfg := gaspricecfg.Config{
+		Blocks:      20,
+		Percentile:  60,
+		MaxPrice:    gaspricecfg.DefaultMaxPrice,
+		IgnorePrice: gaspricecfg.DefaultIgnorePrice,
+	}
+
+	cache := jsonrpc.NewGasPriceCache()
+	oracle := gasprice.NewOracle(backend, cfg, cache, nil, log.New())
+
+	got, err := oracle.SuggestTipCap(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(common.GWei/1000), got.Uint64(),
+		"empty-block fallback must be GWei/1000 to match Geth's default start price")
+}
+
 // TestSuggestTipCap_ContextCancelled verifies that a cancelled caller context is
 // propagated as an error rather than silently returning partial/stale results.
 func TestSuggestTipCap_ContextCancelled(t *testing.T) {

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -548,8 +548,7 @@ type GasPriceCache struct {
 
 func NewGasPriceCache() *GasPriceCache {
 	return &GasPriceCache{
-		latestPrice: uint256.NewInt(0),
-		latestHash:  common.Hash{},
+		latestPrice: uint256.NewInt(common.GWei / 1000),
 	}
 }
 


### PR DESCRIPTION


When all sampled blocks are empty the oracle fell back to 0 (uninitialized cache). Use GWei/1000 instead to match Geth's miner.DefaultConfig.GasPrice and avoid returning a zero tip cap to callers.

Fix aligned to Geth 

To get the same response as Geth for the GraphQL query 07_eth_gasPrice