### PR TITLE
[r3.4] db: skip stale unwind changeset fallback during forkchoice re-execution

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -501,6 +501,7 @@ type TemporalMemBatch interface {
 	Unwind(txNumUnwindTo uint64, changeset *[DomainLen][]DomainEntryDiff)
 	GetAsOf(domain Domain, key []byte, ts uint64) (v []byte, ok bool, err error)
 	SetInMemHistoryReads(v bool)
+	SetSkipUnwindFallback(skip bool)
 }
 
 type WithFreezeInfo interface {

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -337,6 +337,14 @@ func (sd *SharedDomains) SetTxNum(txNum uint64) {
 
 func (sd *SharedDomains) TxNum() uint64 { return sd.txNum }
 
+// SetSkipUnwindFallback controls whether state reads consult unwindChangeset.
+// Enable this during forkchoice re-execution after RunUnwind has physically
+// rolled back the database, so reads come from the database instead of stale
+// old-fork values in unwindChangeset.
+func (sd *SharedDomains) SetSkipUnwindFallback(skip bool) {
+	sd.mem.SetSkipUnwindFallback(skip)
+}
+
 func (sd *SharedDomains) SetTrace(b, capture bool) []string {
 	sd.trace = b
 	sd.commitmentCapture = capture

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -281,9 +281,9 @@ func TestSharedDomain_SkipUnwindFallbackAfterForkchoiceUnwind(t *testing.T) {
 	preExistingValue := []byte{0xAA, 0xBB} // value before old fork
 	oldForkValue := []byte{0xDE, 0xAD}     // value written by old fork
 
-	const preWriteTxNum uint64 = 30  // pre-existing write before the fork
-	const unwindTarget uint64 = 50   // unwind point
-	const oldForkTxNum uint64 = 100  // old fork write
+	const preWriteTxNum uint64 = 30 // pre-existing write before the fork
+	const unwindTarget uint64 = 50  // unwind point
+	const oldForkTxNum uint64 = 100 // old fork write
 
 	// 1. Write a pre-existing value at txNum 30 (before the fork divergence).
 	//    This ensures unwindChangeset will have a non-nil fallback value.

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -250,6 +250,135 @@ func TestSharedDomain_UnwindDoesNotRestoreOverlayForNewKey(t *testing.T) {
 		unwindTarget, writeTxNum, v)
 }
 
+// TestSharedDomain_SkipUnwindFallbackAfterForkchoiceUnwind validates the fix for issue #21681.
+// After a forkchoice unwind where the database is physically rolled back, the unwindChangeset
+// fallback must be skipped during re-execution. Otherwise, getLatest returns stale old-fork
+// values instead of correct new-fork values from the database, causing gas mismatches.
+func TestSharedDomain_SkipUnwindFallbackAfterForkchoiceUnwind(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	stepSize := uint64(100)
+	db := newTestDb(t, stepSize)
+	ctx := context.Background()
+
+	rwTx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+
+	domains, err := execctx.NewSharedDomains(ctx, rwTx, log.New())
+	require.NoError(t, err)
+	defer domains.Close()
+
+	stateChangeset := &changeset.StateChangeSet{}
+	domains.SetChangesetAccumulator(stateChangeset)
+
+	addr := common.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7")
+	slot := common.HexToHash("0x5ac7102aad1a639901bc2657323aaed9e90e40c550747c49170f1c82fd664e4f")
+	key := composite(addr[:], slot[:])
+	preExistingValue := []byte{0xAA, 0xBB} // value before old fork
+	oldForkValue := []byte{0xDE, 0xAD}     // value written by old fork
+
+	const preWriteTxNum uint64 = 30  // pre-existing write before the fork
+	const unwindTarget uint64 = 50   // unwind point
+	const oldForkTxNum uint64 = 100  // old fork write
+
+	// 1. Write a pre-existing value at txNum 30 (before the fork divergence).
+	//    This ensures unwindChangeset will have a non-nil fallback value.
+	domains.SetTxNum(preWriteTxNum)
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, rwTx, key, preExistingValue, preWriteTxNum, nil))
+
+	// 2. Old fork writes a different value at txNum 100.
+	domains.SetTxNum(oldForkTxNum)
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, rwTx, key, oldForkValue, oldForkTxNum, nil))
+
+	// 3. Unwind to txNum 50. The overlay entry at txNum 100 is pruned.
+	//    unwindChangeset now contains {key -> preExistingValue} (the pre-overwrite value).
+	var diffSet [kv.DomainLen][]kv.DomainEntryDiff
+	for idx, d := range stateChangeset.Diffs {
+		diffSet[idx] = d.GetDiffSet()
+	}
+	domains.Unwind(unwindTarget, &diffSet)
+
+	// 4. Read the key. The overlay at txNum 30 still exists (not pruned because
+	//    30 <= 50), so getLatest returns preExistingValue from the overlay.
+	domains.SetTxNum(unwindTarget)
+	v, _, err := domains.GetLatest(kv.StorageDomain, rwTx, key)
+	require.NoError(t, err)
+	require.Equal(t, preExistingValue, v, "overlay entry at txNum 30 survives pruning")
+
+	// 5. Now simulate the scenario where the overlay entry has been flushed to
+	//    the database (as happens between execution cycles in forkchoice.go).
+	//    After ClearRam, the overlay is gone, but unwindChangeset is also gone.
+	//    We need to set up a fresh scenario that isolates the fallback behavior.
+	//
+	//    Reset and create a scenario where the key ONLY exists in unwindChangeset.
+	domains.ClearRam(true)
+	stateChangeset2 := &changeset.StateChangeSet{}
+	domains.SetChangesetAccumulator(stateChangeset2)
+
+	// Write only at txNum 100 (above unwind point) so it gets pruned from overlay.
+	domains.SetTxNum(oldForkTxNum)
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, rwTx, key, oldForkValue, oldForkTxNum, nil))
+
+	// Unwind to txNum 50. The overlay entry is pruned. unwindChangeset contains
+	// the pre-write value (nil in this case since the key wasn't in the overlay
+	// before this write). The changeset entry will have Value=nil.
+	var diffSet2 [kv.DomainLen][]kv.DomainEntryDiff
+	for idx, d := range stateChangeset2.Diffs {
+		diffSet2[idx] = d.GetDiffSet()
+	}
+	domains.Unwind(unwindTarget, &diffSet2)
+
+	// 6. Without skipUnwindFallback, getLatest hits unwindChangeset and returns
+	//    ok=false (because Value is nil for a new key). Verify it returns empty.
+	domains.SetTxNum(unwindTarget)
+	v, _, err = domains.GetLatest(kv.StorageDomain, rwTx, key)
+	require.NoError(t, err)
+	require.Empty(t, v, "fallback returns empty for key that was new on old fork")
+
+	// 7. Enable skip flag (as forkchoice does after RunUnwind) and write new
+	//    fork value. After enabling skip, the fallback is bypassed.
+	domains.SetSkipUnwindFallback(true)
+
+	const newForkTxNum uint64 = 60
+	newForkValue := []byte{0xBE, 0xEF}
+	domains.SetTxNum(newForkTxNum)
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, rwTx, key, newForkValue, newForkTxNum, nil))
+
+	// Read — should see new fork value from overlay
+	domains.SetTxNum(70)
+	v, _, err = domains.GetLatest(kv.StorageDomain, rwTx, key)
+	require.NoError(t, err)
+	require.Equal(t, newForkValue, v, "getLatest must return new fork value when skip is enabled")
+
+	// 8. Verify ClearRam resets the skip flag. Write a pre-existing value
+	//    before the overwrite so unwindChangeset has a non-nil entry. If the
+	//    flag is properly reset, the fallback returns the pre-existing value.
+	//    If it were still set, we'd get nil (from the empty database).
+	domains.ClearRam(true)
+	stateChangeset3 := &changeset.StateChangeSet{}
+	domains.SetChangesetAccumulator(stateChangeset3)
+	resetTestValue := []byte{0xCC, 0xDD}
+	domains.SetTxNum(40) // before unwind point
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, rwTx, key, resetTestValue, 40, nil))
+	domains.SetTxNum(oldForkTxNum) // overwrite at txNum 100
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, rwTx, key, oldForkValue, oldForkTxNum, nil))
+	var diffSet3 [kv.DomainLen][]kv.DomainEntryDiff
+	for idx, d := range stateChangeset3.Diffs {
+		diffSet3[idx] = d.GetDiffSet()
+	}
+	domains.Unwind(unwindTarget, &diffSet3)
+	// The overlay still has the txNum 40 entry (40 <= 50). Read it to confirm
+	// the fallback is active (skip was reset by ClearRam).
+	domains.SetTxNum(unwindTarget)
+	v, _, err = domains.GetLatest(kv.StorageDomain, rwTx, key)
+	require.NoError(t, err)
+	require.Equal(t, resetTestValue, v, "after ClearRam, skip flag must be reset")
+}
+
 // TestNewSharedDomains_StateAheadOfBlocks verifies that when the persisted
 // commitment state is ahead of the TxNums index (catch-up scenario),
 // NewSharedDomains returns ErrBehindCommitment but the SharedDomains itself

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -73,6 +73,11 @@ type TemporalMemBatch struct {
 	// it's intentionally collapsed to one entry per real key so a pre-unwind
 	// value can be found by the same key the overlay uses.
 	unwindChangeset *[kv.DomainLen]map[string]kv.DomainEntryDiff
+	// skipUnwindFallback disables the unwindChangeset fallback in getLatest.
+	// Used during forkchoice re-execution where the database has already been
+	// physically unwound, so the fallback would serve stale values from the
+	// old fork instead of correct values from the database.
+	skipUnwindFallback bool
 	// unwindChangesetRaw preserves every diff entry (distinct by Key+step) so
 	// Flush can replay a complete unwind against MDBX, including multiple
 	// step entries for the same real key (e.g. a commitment branch that was
@@ -226,6 +231,12 @@ func (sd *TemporalMemBatch) getLatest(domain kv.Domain, key []byte) (v []byte, s
 	if sd.unwindChangeset == nil {
 		return nil, 0, false
 	}
+	// Skip fallback during forkchoice re-execution when database is already unwound.
+	// In this case, the database contains correct new-fork state, and unwindChangeset
+	// holds stale old-fork values that should not be consulted.
+	if sd.skipUnwindFallback {
+		return nil, 0, false
+	}
 	if values := sd.unwindChangeset[domain]; values != nil {
 		if value, ok2 := values[keyS]; ok2 {
 			keyStep := kv.Step(^binary.BigEndian.Uint64([]byte(value.Key[len(value.Key)-8:])))
@@ -291,6 +302,7 @@ func (sd *TemporalMemBatch) ClearRam() {
 	sd.unwindToTxNum = 0
 	sd.unwindChangeset = nil
 	sd.unwindChangesetRaw = nil
+	sd.skipUnwindFallback = false
 
 	sd.metrics.Lock()
 	defer sd.metrics.Unlock()
@@ -299,6 +311,15 @@ func (sd *TemporalMemBatch) ClearRam() {
 	sd.metrics.CachePutKeySize = 0
 	sd.metrics.CachePutValueSize = 0
 	sd.metrics.Domains = [kv.DomainLen]*changeset.DomainIOMetrics{}
+}
+
+// SetSkipUnwindFallback controls whether getLatest consults unwindChangeset.
+// Should be enabled during forkchoice re-execution where the database is
+// physically unwound and unwindChangeset contains stale old-fork values.
+func (sd *TemporalMemBatch) SetSkipUnwindFallback(skip bool) {
+	sd.latestStateLock.Lock()
+	defer sd.latestStateLock.Unlock()
+	sd.skipUnwindFallback = skip
 }
 
 func (sd *TemporalMemBatch) IteratePrefix(domain kv.Domain, prefix []byte, roTx kv.Tx, it func(k []byte, v []byte) (cont bool, err error)) error {
@@ -639,6 +660,11 @@ func (sd *TemporalMemBatch) Merge(o kv.TemporalMemBatch) error {
 				sd.unwindToTxNum = other.unwindToTxNum
 			}
 		}
+	}
+
+	// Propagate skipUnwindFallback flag from other to sd
+	if other.skipUnwindFallback {
+		sd.skipUnwindFallback = true
 	}
 
 	other.Close()

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -354,6 +354,11 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 			return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 		}
 
+		// Skip unwindChangeset fallback during re-execution. The database has
+		// been physically unwound, so unwindChangeset contains stale old-fork
+		// values that should not be consulted. Reads should come from the database.
+		currentContext.SetSkipUnwindFallback(true)
+
 		UpdateForkChoiceDepth(fcuHeader.Number.Uint64() - 1 - unwindTarget)
 
 		if err := rawdbv3.TxNums.Truncate(tx, currentParentNumber+1); err != nil {


### PR DESCRIPTION
#### Issue
Actually, when we are doing a fork choice reorg, we call `RunUnwind` to physically roll back the database transaction. But in the memory overlay (`TemporalMemBatch`), we still keep the `unwindChangeset` populated with the pre-unwind values from the old fork. 

When EVM executes transactions on the new fork and requests a storage slot that is not in the overlay (as it was pruned by PR #21538), the lookup in `getLatest()` falls back to `unwindChangeset`. Since the fallback is successful, it returns the stale value from the old fork instead of reading the correct, physically unwound value from the database.

**Here is a simple example of the bug vs the fix:**

1. Suppose we have a storage slot that is empty (`0x00`) in the DB.
2. On the **old fork** (at txNum 100), a transaction writes `0xDE` to this slot. The overlay stores `0xDE`.
3. We get a reorg and unwind to txNum 50. During the `Unwind()` call:
   * The database is physically rolled back, so the slot is correctly empty (`0x00`) in the DB.
   * The overlay write at txNum 100 is pruned.
   * The `Unwind()` call populates `unwindChangeset` with the pre-write value (`0x00`).
4. Now, the **new fork** starts executing. A transaction at txNum 60 writes `0xDE` again.
5. Before writing, the EVM checks the current value of the slot to calculate gas:
   * It checks the overlay: **miss** (pruned).
   * **Without the fix (Bug):** It falls back to `unwindChangeset` which hits and returns `0x00` (the old fork's pre-write value) with `ok = true`. The EVM never queries the database and works on stale data, charging incorrect gas.
   * **With the fix:** Since we skip the fallback during re-execution, the check on `unwindChangeset` is bypassed. The query falls through to the database, which correctly returns the latest state after the physical rollback. The EVM sees the correct state and charges the correct gas.

#### Fix

We introduced a `SetSkipUnwindFallback(skip bool)` method in the `kv.TemporalMemBatch` interface and implemented it in `TemporalMemBatch` and `SharedDomains`.

1. In `forkchoice.go`, right after `RunUnwind` succeeds, we call `currentContext.SetSkipUnwindFallback(true)`.
2. Inside `getLatest()`, if `skipUnwindFallback` is active, we bypass the `unwindChangeset` lookup entirely. This forces the state reader to query the correct, physically-unwound data from the database.
3. The flag is reset to `false` in `ClearRam()` so it doesn't affect regular validation or block imports where the database is not rolled back. We also propagate it in `Merge()`.

#### Tests

* `TestSharedDomain_SkipUnwindFallbackAfterForkchoiceUnwind` (added in `domain_shared_test.go`):
  * Verifies that after an unwind, enabling the skip flag successfully bypasses the fallback and reads correct values.
  * Verifies that `ClearRam()` resets the skip flag properly so fallback becomes active again for normal operations.
  
  
Closes #21681 