### PR TITLE
cmd/utils: fix db.read.concurrency help to match the actual default

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -407,7 +407,7 @@ var (
 	}
 	DBReadConcurrencyFlag = cli.IntFlag{
 		Name:  "db.read.concurrency",
-		Usage: "Does limit amount of parallel db reads. Default: equal to GOMAXPROCS (or number of CPU)",
+		Usage: "Ceiling on concurrent open DB read transactions (MDBX read-tx semaphore); extra readers wait for a slot rather than error. Default scales as min(max(10, GOMAXPROCS*64), 9000) — kept well above CPU count because reads are I/O-bound, and capped below Go's ~10K OS-thread limit. Low values are fine for low read-concurrency nodes (e.g. validators); raise it for nodes serving heavy parallel RPC",
 		Value: min(max(10, runtime.GOMAXPROCS(-1)*64), 9_000),
 	}
 	RpcMaxConcurrentRequestsFlag = cli.IntFlag{


### PR DESCRIPTION
## Problem

The `--db.read.concurrency` help text claimed:

> Does limit amount of parallel db reads. Default: equal to GOMAXPROCS (or number of CPU)

But the actual default has been `min(max(10, GOMAXPROCS*64), 9000)` since #8692 (2023) — the help was **stale and understated the default by ~64×**, and gave no hint of what the flag really controls. (On a 12-core box the real default is 768, on 64 cores 4096, not "number of CPU".)

## What the flag actually does

`node/node.go` builds the database's `RoTxsLimiter` — a weighted **semaphore capping how many read-only transactions can be open at once**. Extra readers **wait for a slot**, they don't error. It's a back-pressure ceiling, not a target or a thread count.

The default is intentionally far above CPU count: reads are I/O-bound (a read that page-faults on cold data parks its goroutine on an OS thread), so you want many in flight; it's capped at 9000 because Go panics above ~10K OS threads (see `db/kv/mdbx/kv_mdbx.go`). A low value is perfectly fine for low read-concurrency nodes (e.g. validators); it only throttles nodes serving heavy parallel RPC.

## Change

Doc-only: rewrite the usage string to describe the ceiling semantics, the real scaling formula, its rationale, and the validator-vs-RPC guidance. Value unchanged. `urfave/cli` still auto-appends the concrete machine default, so `--help` now reads e.g. `… capped below Go's ~10K OS-thread limit. Low values are fine … (default: 1024)` on a 16-core host.
