### PR TITLE
cl/sentinel: add caplin_peer_count metric

### DIFF
--- a/cl/sentinel/metrics.go
+++ b/cl/sentinel/metrics.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package sentinel
+
+import "github.com/erigontech/erigon/diagnostics/metrics"
+
+// caplin_peer_count is the consensus-layer counterpart to the EL's p2p_peers
+// gauge: the number of currently-connected Caplin peers.
+var peerCountGauge = metrics.GetOrCreateGauge("caplin_peer_count")
+
+func recordPeerMetrics(connected int) {
+	peerCountGauge.SetInt(connected)
+}

--- a/cl/sentinel/metrics.go
+++ b/cl/sentinel/metrics.go
@@ -16,12 +16,22 @@
 
 package sentinel
 
-import "github.com/erigontech/erigon/diagnostics/metrics"
+import (
+	"sync"
 
-// caplin_peer_count is the consensus-layer counterpart to the EL's p2p_peers
-// gauge: the number of currently-connected Caplin peers.
-var peerCountGauge = metrics.GetOrCreateGauge("caplin_peer_count")
+	"github.com/erigontech/erigon/diagnostics/metrics"
+)
+
+var (
+	peerCountGauge   metrics.Gauge
+	peerCountGaugeMu sync.Mutex
+)
 
 func recordPeerMetrics(connected int) {
+	peerCountGaugeMu.Lock()
+	defer peerCountGaugeMu.Unlock()
+	if peerCountGauge == nil {
+		peerCountGauge = metrics.GetOrCreateGauge("caplin_peer_count")
+	}
 	peerCountGauge.SetInt(connected)
 }

--- a/cl/sentinel/metrics_test.go
+++ b/cl/sentinel/metrics_test.go
@@ -17,12 +17,23 @@
 package sentinel
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	if peerCountGauge != nil {
+		fmt.Fprintln(os.Stderr, "caplin_peer_count gauge is registered before sentinel metrics are recorded")
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
+
 func TestRecordPeerMetrics(t *testing.T) {
 	recordPeerMetrics(7)
+	require.NotNil(t, peerCountGauge)
 	require.Equal(t, float64(7), peerCountGauge.GetValue())
 }

--- a/cl/sentinel/metrics_test.go
+++ b/cl/sentinel/metrics_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package sentinel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordPeerMetrics(t *testing.T) {
+	recordPeerMetrics(7)
+	require.Equal(t, float64(7), peerCountGauge.GetValue())
+}

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -56,6 +56,7 @@ type Sentinel struct {
 	started  bool
 	listener *discover.UDPv5 // this is us in the network.
 	ctx      context.Context
+	cancel   context.CancelFunc
 	cfg      *SentinelConfig
 	peers    *peers.Pool
 	p2p      p2p.P2PManager
@@ -105,22 +106,6 @@ func New(
 	peerDasStateReader peerdasstate.PeerDasStateReader,
 	p2p p2p.P2PManager,
 ) (*Sentinel, error) {
-	s := &Sentinel{
-		ctx:                ctx,
-		cfg:                cfg,
-		blockReader:        blockReader,
-		indiciesDB:         indiciesDB,
-		metrics:            true,
-		logger:             logger,
-		forkChoiceReader:   forkChoiceReader,
-		blobStorage:        blobStorage,
-		ethClock:           ethClock,
-		dataColumnStorage:  dataColumnStorage,
-		peerDasStateReader: peerDasStateReader,
-		p2p:                p2p,
-		connectSem:         semaphore.NewWeighted(int64(goRoutinesOpeningPeerConnections)),
-	}
-
 	// Setup discovery
 	enodes := make([]*enode.Node, len(cfg.NetworkConfig.BootNodes))
 	for i, bootnode := range cfg.NetworkConfig.BootNodes {
@@ -133,6 +118,24 @@ func New(
 	privateKey, err := crypto.GenerateKey()
 	if err != nil {
 		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	s := &Sentinel{
+		ctx:                ctx,
+		cancel:             cancel,
+		cfg:                cfg,
+		blockReader:        blockReader,
+		indiciesDB:         indiciesDB,
+		metrics:            true,
+		logger:             logger,
+		forkChoiceReader:   forkChoiceReader,
+		blobStorage:        blobStorage,
+		ethClock:           ethClock,
+		dataColumnStorage:  dataColumnStorage,
+		peerDasStateReader: peerDasStateReader,
+		p2p:                p2p,
+		connectSem:         semaphore.NewWeighted(int64(goRoutinesOpeningPeerConnections)),
 	}
 	s.discoverConfig = discover.Config{
 		PrivateKey: privateKey,
@@ -193,6 +196,8 @@ func (s *Sentinel) Start() (*enode.LocalNode, error) {
 
 	go s.listenForPeers()
 	go s.proactiveSubnetPeerSearch() // Proactively search for peers when subnet coverage is low
+	_, connected, _ := s.GetPeersCount()
+	recordPeerMetrics(connected)
 	go s.updatePeerMetrics()
 	//go s.forkWatcher()
 
@@ -201,9 +206,6 @@ func (s *Sentinel) Start() (*enode.LocalNode, error) {
 
 const peerMetricsUpdateInterval = 15 * time.Second
 
-// updatePeerMetrics periodically publishes the connected/disconnected peer
-// counts as the caplin_peer_count gauge. Runs only while the sentinel is up, so
-// the metric is absent when erigon uses an external CL.
 func (s *Sentinel) updatePeerMetrics() {
 	ticker := time.NewTicker(peerMetricsUpdateInterval)
 	defer ticker.Stop()
@@ -221,6 +223,7 @@ func (s *Sentinel) updatePeerMetrics() {
 func (s *Sentinel) Stop() {
 	//s.listener.Close()
 	//s.subManager.Close()
+	s.cancel()
 	s.p2p.Host().Close()
 }
 

--- a/cl/sentinel/sentinel.go
+++ b/cl/sentinel/sentinel.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -192,9 +193,29 @@ func (s *Sentinel) Start() (*enode.LocalNode, error) {
 
 	go s.listenForPeers()
 	go s.proactiveSubnetPeerSearch() // Proactively search for peers when subnet coverage is low
+	go s.updatePeerMetrics()
 	//go s.forkWatcher()
 
 	return s.LocalNode(), nil
+}
+
+const peerMetricsUpdateInterval = 15 * time.Second
+
+// updatePeerMetrics periodically publishes the connected/disconnected peer
+// counts as the caplin_peer_count gauge. Runs only while the sentinel is up, so
+// the metric is absent when erigon uses an external CL.
+func (s *Sentinel) updatePeerMetrics() {
+	ticker := time.NewTicker(peerMetricsUpdateInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-ticker.C:
+			_, connected, _ := s.GetPeersCount()
+			recordPeerMetrics(connected)
+		}
+	}
 }
 
 func (s *Sentinel) Stop() {


### PR DESCRIPTION
## Problem

There was no Prometheus metric for **Caplin (consensus-layer) peers**. The only peer-count gauge is the EL's `p2p_peers` (`p2p/metrics.go`); the sentinel computes peer counts (`Sentinel.GetPeersCount()`) but never published them, so operators had to poll the beacon API `GET /eth/v1/node/peer_count` and scrape it externally.

## Change

Add a single `caplin_peer_count` gauge — the CL counterpart to `p2p_peers` — holding the number of currently-connected Caplin peers, updated every 15s from the sentinel's existing `GetPeersCount()`. Query `caplin_peer_count` to monitor / alert on Caplin peers, exactly as you'd use `p2p_peers` for the EL.

Kept deliberately to a single connected-peer count to match `p2p_peers`: no connected/disconnected split, because in `GetPeersCount` the "disconnected" value is effectively the banned-peer count (the swarm's `Network().Peers()` are already the connected set), which is not a meaningful peer-health series. If churn is ever wanted, the right shape is a separate disconnect-events counter, not a gauge.

## Scope (external CL)

The updater is started from `Sentinel.Start()`, so it runs only while Caplin's sentinel is up:
- **Embedded Caplin** (`--internalcl`, default) → emitted on erigon's metrics endpoint.
- **Standalone Caplin** (`cmd/caplin`) → emitted on Caplin's metrics port.
- **External CL** (`--externalcl`) → the sentinel never starts and the gauge is never set, so **no `caplin_peer_count` series is emitted**. Monitor CL peers via the external client's own metric there.

## Tests

`TestRecordPeerMetrics` asserts the gauge name and value are wired correctly. `make lint` and `make erigon` clean.
