### PR TITLE
cmd/utils/app: add --keep-blocks to seg step-rebase

### DIFF
--- a/.claude/skills/erigon-seg-rebase/SKILL.md
+++ b/.claude/skills/erigon-seg-rebase/SKILL.md
@@ -15,10 +15,13 @@ The `erigon seg step-rebase` command changes the step size of an existing Erigon
 ./build/bin/erigon seg step-rebase --datadir=<path> --new-step-size=<size> [other-flags]
 ```
 
-## Required Flags
+## Flags
 
 - `--datadir`: Path to the Erigon datadir (required)
-- `--new-step-size`: New step size to rebase to (default: 1562500)
+- `--new-step-size`: New step size to rebase to (required; must be an exact divisor or multiple of the current step size from `snapshots/erigondb.toml`)
+- `--keep-blocks`: Keep chaindata instead of deleting it. Resets only execution state (domains, history, changesets, prune progress) via the same logic as `integration stage_exec --reset`, so already-downloaded blocks stay in the DB and get re-executed on next start. Without this flag the whole chaindata DB is deleted and the block tail must be re-downloaded from the network.
+
+The command is interactive: it prints the full rename/delete plan and waits for a `y/N` confirmation on stdin (`echo y | erigon seg step-rebase ...` when scripting).
 
 ## Common Step Sizes
 
@@ -37,6 +40,12 @@ The `erigon seg step-rebase` command changes the step size of an existing Erigon
 ```bash
 ./build/bin/erigon seg step-rebase --datadir=/path/to/datadir --new-step-size=390625
 ```
+
+### Rebase Keeping Already-Downloaded Blocks
+```bash
+./build/bin/erigon seg step-rebase --datadir=/path/to/datadir --new-step-size=781250 --keep-blocks
+```
+Run `erigon seg retire` first to minimize the re-execution window, then after the rebase start erigon (or run `integration stage_exec`) to re-execute the kept blocks from the snapshot files' end.
 
 ## Important Considerations
 

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -590,6 +590,7 @@ var snapshotCommand = cli.Command{
 			Flags: joinFlags([]cli.Flag{
 				&utils.DataDirFlag,
 				&cli.Uint64Flag{Name: "new-step-size", Required: true, DefaultText: strconv.FormatUint(config3.DefaultStepSize, 10)},
+				&cli.BoolFlag{Name: "keep-blocks", Usage: "keep chaindata and reset only execution state in it, so already-downloaded blocks can be re-executed, instead of deleting the whole DB"},
 			}),
 		},
 		{

--- a/cmd/utils/app/step_cmd.go
+++ b/cmd/utils/app/step_cmd.go
@@ -127,6 +127,11 @@ func printStepRebasePlan(plan stepRebasePlan) {
 }
 
 func applyStepRebasePlan(ctx context.Context, dirs datadir.Dirs, plan stepRebasePlan, logger log.Logger) error {
+	unlock, err := dirs.TryFlock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	// reset before renaming: a crash mid-apply then leaves old settings with old file
 	// names and cleared exec state, which is a consistent datadir and a re-runnable command
 	if plan.resetExec {
@@ -155,7 +160,18 @@ func applyStepRebasePlan(ctx context.Context, dirs datadir.Dirs, plan stepRebase
 }
 
 func resetExecState(ctx context.Context, dirs datadir.Dirs, logger log.Logger) error {
-	chainDB := dbCfg(dbcfg.ChainDB, dirs.Chaindata).MustOpen()
+	exists, err := dir.FileExist(filepath.Join(dirs.Chaindata, "mdbx.dat"))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("no chaindata database to keep at %s", dirs.Chaindata)
+	}
+	// exclusive non-Accede open: fail fast if the DB is in use rather than resetting a live node
+	chainDB, err := dbCfg(dbcfg.ChainDB, dirs.Chaindata).Accede(false).Exclusive(true).Open(ctx)
+	if err != nil {
+		return err
+	}
 	defer chainDB.Close()
 	agg := openAgg(ctx, dirs, chainDB, logger)
 	defer agg.Close()

--- a/cmd/utils/app/step_cmd.go
+++ b/cmd/utils/app/step_cmd.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/urfave/cli/v2"
@@ -17,46 +17,64 @@ import (
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/temporal"
 	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/execution/stagedsync/rawdbreset"
 )
+
+type stepRebasePlan struct {
+	renames   []string // flattened from/to pairs
+	deletions []string
+	resetExec bool
+	settings  state.ErigonDBSettings
+}
 
 func stepRebase(cliCtx *cli.Context) error {
 	logger := log.Root()
-
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-
 	dirs := datadir.Open(cliCtx.String("datadir"))
 	settings, err := state.ResolveErigonDBSettings(dirs, logger, true)
 	if err != nil {
 		return err
 	}
-
-	currentStepSize := settings.StepSize
 	newStepSize := cliCtx.Uint64("new-step-size")
-	logger.Info("Rebasing step size", "current", currentStepSize, "new", newStepSize)
-
+	keepBlocks := cliCtx.Bool("keep-blocks")
+	logger.Info("Rebasing step size", "current", settings.StepSize, "new", newStepSize, "keep-blocks", keepBlocks)
 	if newStepSize == 0 {
 		logger.Crit("Invalid step size", "new-step-size", newStepSize)
 		return fmt.Errorf("new step size must be greater than 0")
 	}
-	if currentStepSize == 0 {
-		logger.Crit("Invalid current step size", "current-step-size", currentStepSize)
+	if settings.StepSize == 0 {
+		logger.Crit("Invalid current step size", "current-step-size", settings.StepSize)
 		return fmt.Errorf("current step size must be greater than 0")
 	}
-
-	if newStepSize == currentStepSize {
+	if newStepSize == settings.StepSize {
 		logger.Info("Step size is already at the desired value; exiting", "new-step-size", newStepSize)
 		return nil
 	}
-	if newStepSize > currentStepSize && newStepSize%currentStepSize != 0 {
-		logger.Crit("Invalid step size", "new-step-size", newStepSize)
-		return fmt.Errorf("new step size must be a multiple of %d", currentStepSize)
-	} else if currentStepSize > newStepSize && currentStepSize%newStepSize != 0 {
-		logger.Crit("Invalid step size", "new-step-size", newStepSize)
-		return fmt.Errorf("new step size must be divisible from %d", currentStepSize)
+	plan, err := buildStepRebasePlan(dirs, settings, newStepSize, keepBlocks, logger)
+	if err != nil {
+		return err
 	}
+	printStepRebasePlan(plan)
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Proceed with these changes? [y/N]: ")
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		return fmt.Errorf("aborted by user")
+	}
+	return applyStepRebasePlan(cliCtx.Context, dirs, plan, logger)
+}
 
+func buildStepRebasePlan(dirs datadir.Dirs, settings *state.ErigonDBSettings, newStepSize uint64, keepBlocks bool, logger log.Logger) (stepRebasePlan, error) {
+	currentStepSize := settings.StepSize
+	if newStepSize > currentStepSize && newStepSize%currentStepSize != 0 {
+		return stepRebasePlan{}, fmt.Errorf("new step size must be a multiple of %d", currentStepSize)
+	}
+	if currentStepSize > newStepSize && currentStepSize%newStepSize != 0 {
+		return stepRebasePlan{}, fmt.Errorf("new step size must be divisible from %d", currentStepSize)
+	}
 	factor := newStepSize / currentStepSize
 	decr := newStepSize < currentStepSize
 	if decr {
@@ -65,114 +83,87 @@ func stepRebase(cliCtx *cli.Context) error {
 	} else {
 		logger.Info("Increasing step size", "factor", factor)
 	}
-
-	// Look for files to be renamed
 	re := regexp.MustCompile(`^v(\d+(?:\.\d+)?)-(.+)\.(\d+)-(\d+)\.([^.]+)$`)
-
+	stateSnapDirs := []string{dirs.SnapDomain, dirs.SnapHistory, dirs.SnapAccessors, dirs.SnapIdx}
 	rens := make([]string, 0, 100)
-	domains, err := collectRenameList(dirs.SnapDomain, re, decr, factor)
-	if err != nil {
-		return err
+	for _, p := range stateSnapDirs {
+		list, err := collectRenameList(p, re, decr, factor)
+		if err != nil {
+			return stepRebasePlan{}, err
+		}
+		rens = append(rens, list...)
 	}
-	hists, err := collectRenameList(dirs.SnapHistory, re, decr, factor)
-	if err != nil {
-		return err
-	}
-	accessors, err := collectRenameList(dirs.SnapAccessors, re, decr, factor)
-	if err != nil {
-		return err
-	}
-	idxs, err := collectRenameList(dirs.SnapIdx, re, decr, factor)
-	if err != nil {
-		return err
-	}
-	rens = append(rens, domains...)
-	rens = append(rens, hists...)
-	rens = append(rens, accessors...)
-	rens = append(rens, idxs...)
-
-	// List files to be renamed
-	for i := 0; i < len(rens); i += 2 {
-		fmt.Printf("R: %s => %s\n", rens[i], rens[i+1])
-	}
-
-	// Collect and list .torrent files to be deleted
 	dels := make([]string, 0, 100)
-	domainTorrents, err := collectTorrentFiles(dirs.SnapDomain)
-	if err != nil {
-		return err
+	for _, p := range stateSnapDirs {
+		list, err := collectTorrentFiles(p)
+		if err != nil {
+			return stepRebasePlan{}, err
+		}
+		dels = append(dels, list...)
 	}
-	histTorrents, err := collectTorrentFiles(dirs.SnapHistory)
-	if err != nil {
-		return err
+	if !keepBlocks {
+		dels = append(dels, dirs.Chaindata)
 	}
-	accessorTorrents, err := collectTorrentFiles(dirs.SnapAccessors)
-	if err != nil {
-		return err
-	}
-	idxTorrents, err := collectTorrentFiles(dirs.SnapIdx)
-	if err != nil {
-		return err
-	}
-	dels = append(dels, domainTorrents...)
-	dels = append(dels, histTorrents...)
-	dels = append(dels, accessorTorrents...)
-	dels = append(dels, idxTorrents...)
-
-	// include whole chaindata directory for deletion
-	dels = append(dels, dirs.Chaindata) //nolint:gocritic
-
-	// include erigondb.toml.torrent which is invalidated by the rebase
+	// erigondb.toml.torrent is invalidated by the rebase
 	dels = append(dels, filepath.Join(dirs.Snap, "erigondb.toml.torrent"))
+	newFrozenSteps := settings.StepsInFrozenFile / factor
+	if decr {
+		newFrozenSteps = settings.StepsInFrozenFile * factor
+	}
+	newSettings := state.ErigonDBSettings{StepSize: newStepSize, StepsInFrozenFile: newFrozenSteps}
+	return stepRebasePlan{renames: rens, deletions: dels, resetExec: keepBlocks, settings: newSettings}, nil
+}
 
-	for _, f := range dels {
+func printStepRebasePlan(plan stepRebasePlan) {
+	for i := 0; i < len(plan.renames); i += 2 {
+		fmt.Printf("R: %s => %s\n", plan.renames[i], plan.renames[i+1])
+	}
+	for _, f := range plan.deletions {
 		fmt.Printf("D: %s\n", f)
 	}
-
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("Proceed with these changes? [y/N]: ")
-	answer, _ := reader.ReadString('\n')
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer != "y" && answer != "yes" {
-		return fmt.Errorf("aborted by user")
+	if plan.resetExec {
+		fmt.Printf("Reset: execution state tables in chaindata (blocks kept)\n")
 	}
+}
 
-	// Perform renames
-	for i := 0; i < len(rens); i += 2 {
-		from := rens[i]
-		to := rens[i+1]
+func applyStepRebasePlan(ctx context.Context, dirs datadir.Dirs, plan stepRebasePlan, logger log.Logger) error {
+	// reset before renaming: a crash mid-apply then leaves old settings with old file
+	// names and cleared exec state, which is a consistent datadir and a re-runnable command
+	if plan.resetExec {
+		if err := resetExecState(ctx, dirs, logger); err != nil {
+			return err
+		}
+	}
+	for i := 0; i < len(plan.renames); i += 2 {
+		from, to := plan.renames[i], plan.renames[i+1]
 		if err := os.Rename(from, to); err != nil {
 			return fmt.Errorf("rename %s -> %s: %w", from, to, err)
 		}
 		fmt.Printf("Renamed: %s => %s\n", from, to)
 	}
-
-	// Perform deletions
-	for _, p := range dels {
+	for _, p := range plan.deletions {
 		if err := dir.RemoveAll(p); err != nil {
 			return fmt.Errorf("delete %s: %w", p, err)
 		}
 		fmt.Printf("Deleted: %s\n", p)
 	}
-
-	// Write rebased settings
-	settings.StepSize = newStepSize
-	newFrozenSteps := settings.StepsInFrozenFile / factor
-	if decr {
-		newFrozenSteps = settings.StepsInFrozenFile * factor
-	}
-	settings.StepsInFrozenFile = newFrozenSteps
-
-	settingsBytes, err := toml.Marshal(settings)
+	settingsBytes, err := toml.Marshal(plan.settings)
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(filepath.Join(dirs.Snap, state.ERIGONDB_SETTINGS_FILE), settingsBytes, 0644)
+	return os.WriteFile(filepath.Join(dirs.Snap, state.ERIGONDB_SETTINGS_FILE), settingsBytes, 0644)
+}
+
+func resetExecState(ctx context.Context, dirs datadir.Dirs, logger log.Logger) error {
+	chainDB := dbCfg(dbcfg.ChainDB, dirs.Chaindata).MustOpen()
+	defer chainDB.Close()
+	agg := openAgg(ctx, dirs, chainDB, logger)
+	defer agg.Close()
+	tdb, err := temporal.New(chainDB, agg)
 	if err != nil {
 		return err
 	}
-
-	return nil
+	return rawdbreset.ResetExec(ctx, tdb)
 }
 
 // collectRenameList walks the snapshot domain directory and builds a list of

--- a/cmd/utils/app/step_cmd_test.go
+++ b/cmd/utils/app/step_cmd_test.go
@@ -92,6 +92,47 @@ func TestStepRebaseDeletesChaindataByDefault(t *testing.T) {
 	require.Equal(t, uint64(8), rebased.StepsInFrozenFile)
 }
 
+func TestStepRebaseKeepBlocksFailsFastWhenDatadirInUse(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	writeTestErigonDBSettings(t, dirs, 16, 4)
+	_, err := state.GetStateIndicesSalt(dirs, true, logger)
+	require.NoError(t, err)
+	writeTestChaindata(t, dirs)
+	settings, err := state.ResolveErigonDBSettings(dirs, logger, true)
+	require.NoError(t, err)
+	plan, err := buildStepRebasePlan(dirs, settings, 8, true, logger)
+	require.NoError(t, err)
+	unlock, err := dirs.TryFlock()
+	require.NoError(t, err)
+	defer unlock()
+	err = applyStepRebasePlan(context.Background(), dirs, plan, logger)
+	require.ErrorIs(t, err, datadir.ErrDataDirLocked)
+	tx, err := openTestChaindata(t, dirs).BeginRo(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+	accVal, err := tx.GetOne(kv.TblAccountVals, []byte("acc-key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("acc-val"), accVal)
+	untouched, err := state.ResolveErigonDBSettings(dirs, logger, true)
+	require.NoError(t, err)
+	require.Equal(t, uint64(16), untouched.StepSize)
+}
+
+func TestStepRebaseKeepBlocksFailsWithoutChaindata(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	writeTestErigonDBSettings(t, dirs, 16, 4)
+	_, err := state.GetStateIndicesSalt(dirs, true, logger)
+	require.NoError(t, err)
+	settings, err := state.ResolveErigonDBSettings(dirs, logger, true)
+	require.NoError(t, err)
+	plan, err := buildStepRebasePlan(dirs, settings, 8, true, logger)
+	require.NoError(t, err)
+	err = applyStepRebasePlan(context.Background(), dirs, plan, logger)
+	require.ErrorContains(t, err, "chaindata")
+}
+
 func writeTestErigonDBSettings(t *testing.T, dirs datadir.Dirs, stepSize, stepsInFrozenFile uint64) {
 	t.Helper()
 	content := fmt.Sprintf("step_size = %d\nsteps_in_frozen_file = %d\n", stepSize, stepsInFrozenFile)

--- a/cmd/utils/app/step_cmd_test.go
+++ b/cmd/utils/app/step_cmd_test.go
@@ -1,0 +1,127 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/mdbx"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/execution/stagedsync/stages"
+)
+
+func TestStepRebaseKeepBlocksResetsExecStateAndKeepsChaindata(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	writeTestErigonDBSettings(t, dirs, 16, 4)
+	_, err := state.GetStateIndicesSalt(dirs, true, logger)
+	require.NoError(t, err)
+	writeTestChaindata(t, dirs)
+	settings, err := state.ResolveErigonDBSettings(dirs, logger, true)
+	require.NoError(t, err)
+	plan, err := buildStepRebasePlan(dirs, settings, 8, true, logger)
+	require.NoError(t, err)
+	require.True(t, plan.resetExec)
+	require.NotContains(t, plan.deletions, dirs.Chaindata)
+	require.NoError(t, applyStepRebasePlan(context.Background(), dirs, plan, logger))
+	require.DirExists(t, dirs.Chaindata)
+	tx, err := openTestChaindata(t, dirs).BeginRo(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+	headerVal, err := tx.GetOne(kv.Headers, []byte("header-key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("header-val"), headerVal)
+	accVal, err := tx.GetOne(kv.TblAccountVals, []byte("acc-key"))
+	require.NoError(t, err)
+	require.Nil(t, accVal)
+	csVal, err := tx.GetOne(kv.ChangeSets3, []byte("cs-key"))
+	require.NoError(t, err)
+	require.Nil(t, csVal)
+	ppVal, err := tx.GetOne(kv.TblPruningProgress, []byte("pp-key"))
+	require.NoError(t, err)
+	require.Nil(t, ppVal)
+	execProgress, err := tx.GetOne(kv.SyncStageProgress, []byte(stages.Execution))
+	require.NoError(t, err)
+	require.Nil(t, execProgress)
+	sendersProgress, err := stages.GetStageProgress(tx, stages.Senders)
+	require.NoError(t, err)
+	require.Equal(t, uint64(9), sendersProgress)
+	rebased, err := state.ResolveErigonDBSettings(dirs, logger, true)
+	require.NoError(t, err)
+	require.Equal(t, uint64(8), rebased.StepSize)
+	require.Equal(t, uint64(8), rebased.StepsInFrozenFile)
+}
+
+func TestStepRebaseDeletesChaindataByDefault(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	writeTestErigonDBSettings(t, dirs, 16, 4)
+	writeTestFile(t, filepath.Join(dirs.SnapDomain, "v1.0-accounts.0-2.kv"))
+	writeTestFile(t, filepath.Join(dirs.SnapHistory, "v1.0-accounts.0-2.v"))
+	writeTestFile(t, filepath.Join(dirs.SnapAccessors, "v1.0-accounts.0-2.vi"))
+	writeTestFile(t, filepath.Join(dirs.SnapIdx, "v1.0-accounts.0-2.ef"))
+	writeTestFile(t, filepath.Join(dirs.SnapDomain, "v1.0-accounts.0-2.kv.torrent"))
+	writeTestFile(t, filepath.Join(dirs.Snap, "erigondb.toml.torrent"))
+	writeTestFile(t, filepath.Join(dirs.Chaindata, "mdbx.dat"))
+	settings, err := state.ResolveErigonDBSettings(dirs, logger, true)
+	require.NoError(t, err)
+	plan, err := buildStepRebasePlan(dirs, settings, 8, false, logger)
+	require.NoError(t, err)
+	require.False(t, plan.resetExec)
+	require.Contains(t, plan.deletions, dirs.Chaindata)
+	require.NoError(t, applyStepRebasePlan(context.Background(), dirs, plan, logger))
+	require.FileExists(t, filepath.Join(dirs.SnapDomain, "v1.0-accounts.0-4.kv"))
+	require.FileExists(t, filepath.Join(dirs.SnapHistory, "v1.0-accounts.0-4.v"))
+	require.FileExists(t, filepath.Join(dirs.SnapAccessors, "v1.0-accounts.0-4.vi"))
+	require.FileExists(t, filepath.Join(dirs.SnapIdx, "v1.0-accounts.0-4.ef"))
+	require.NoFileExists(t, filepath.Join(dirs.SnapDomain, "v1.0-accounts.0-2.kv"))
+	require.NoFileExists(t, filepath.Join(dirs.SnapDomain, "v1.0-accounts.0-2.kv.torrent"))
+	require.NoFileExists(t, filepath.Join(dirs.Snap, "erigondb.toml.torrent"))
+	require.NoDirExists(t, dirs.Chaindata)
+	rebased, err := state.ResolveErigonDBSettings(dirs, logger, true)
+	require.NoError(t, err)
+	require.Equal(t, uint64(8), rebased.StepSize)
+	require.Equal(t, uint64(8), rebased.StepsInFrozenFile)
+}
+
+func writeTestErigonDBSettings(t *testing.T, dirs datadir.Dirs, stepSize, stepsInFrozenFile uint64) {
+	t.Helper()
+	content := fmt.Sprintf("step_size = %d\nsteps_in_frozen_file = %d\n", stepSize, stepsInFrozenFile)
+	require.NoError(t, os.WriteFile(filepath.Join(dirs.Snap, state.ERIGONDB_SETTINGS_FILE), []byte(content), 0644))
+}
+
+func writeTestChaindata(t *testing.T, dirs datadir.Dirs) {
+	t.Helper()
+	db := mdbx.New(dbcfg.ChainDB, log.New()).Path(dirs.Chaindata).MustOpen()
+	defer db.Close()
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+	require.NoError(t, tx.Put(kv.Headers, []byte("header-key"), []byte("header-val")))
+	require.NoError(t, tx.Put(kv.TblAccountVals, []byte("acc-key"), []byte("acc-val")))
+	require.NoError(t, tx.Put(kv.ChangeSets3, []byte("cs-key"), []byte("cs-val")))
+	require.NoError(t, tx.Put(kv.TblPruningProgress, []byte("pp-key"), []byte("pp-val")))
+	require.NoError(t, stages.SaveStageProgress(tx, stages.Execution, 7))
+	require.NoError(t, stages.SaveStageProgress(tx, stages.Senders, 9))
+	require.NoError(t, tx.Commit())
+}
+
+func openTestChaindata(t *testing.T, dirs datadir.Dirs) kv.RwDB {
+	t.Helper()
+	db := mdbx.New(dbcfg.ChainDB, log.New()).Path(dirs.Chaindata).MustOpen()
+	t.Cleanup(db.Close)
+	return db
+}
+
+func writeTestFile(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0644))
+}


### PR DESCRIPTION
## What

Adds a `--keep-blocks` flag to `erigon seg step-rebase`. With the flag set, the rebase keeps the chaindata DB and resets only the execution state in it, instead of deleting the whole DB.

## Why

`step-rebase` deletes chaindata because parts of it encode the step size: domain rows carry an inverted-step suffix computed as `txNum / stepSize` at write time, and changesets + prune-progress entries embed the same step bytes. But block data (headers, bodies, transactions, senders) is step-size-independent — deleting it forces an unnecessary re-download of every block past the last block snapshot. Keeping the blocks and dropping only the step-dependent execution state lets the node re-execute the tail from the snapshot files' end with no network involved.

## How

- `stepRebase` is split into `buildStepRebasePlan` / `applyStepRebasePlan`; with `--keep-blocks` the plan excludes chaindata from the deletion list and instead runs `rawdbreset.ResetExec` — the same logic behind `integration stage_exec --reset` — which clears the domain/history/ii tables, `ChangeSets3`, `TblPruningProgress`/`TblPruningValsProg`, and deletes the Execution stage progress entry. On next start, `SeekCommitment` falls back to the snapshot files and execution resumes from there using the kept blocks.
- The reset runs **before** the file renames: a crash mid-apply then leaves old settings + old file names + cleared exec state, which is a consistent datadir and a re-runnable command. The reverse order could strand a new `erigondb.toml` contradicting old-step DB rows.
- Recommended flow stays retire-first: `seg retire` → `seg step-rebase --keep-blocks` → start erigon (re-executes the small tail).
- The `erigon-seg-rebase` agent skill doc is updated to match (new flag, required `--new-step-size`, interactive y/N prompt).

## Testing

TDD: the keep-blocks test was written first and failed on "exec state survived apply" before the implementation landed; a second characterization test pins the default delete-chaindata path so the refactor couldn't change existing behavior. `make lint` clean (run twice), `make erigon integration` builds, full `cmd/utils/app` package suite passes.