### PR TITLE
tools, makefile, .github/workflows: extract only the shard's EEST fixture set

### DIFF
--- a/.github/workflows/cache-warming-eest-fixtures.yml
+++ b/.github/workflows/cache-warming-eest-fixtures.yml
@@ -60,10 +60,12 @@ jobs:
           lookup-only: true
 
       # Download all four tarballs in one invocation so the single cached entry
-      # is complete (a shard run only fetches the subset it needs).
+      # is complete (a shard run only extracts the set it needs). Download-only:
+      # the cache stores just the tarballs, and extracting all corpora (20G+)
+      # doesn't fit on the smaller hosted runners.
       - name: Download EEST tarballs
         if: steps.probe.outputs.cache-hit != 'true'
-        run: bash tools/test-fixtures.sh test-fixtures.json test-fixtures-cache eest_stable eest_devnet eest_benchmark eest_zkevm
+        run: bash tools/test-fixtures.sh --download-only test-fixtures.json test-fixtures-cache eest_stable eest_devnet eest_benchmark eest_zkevm
 
       - name: Save EEST cache
         if: steps.probe.outputs.cache-hit != 'true'

--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -84,9 +84,10 @@ jobs:
         if: '!inputs.cache-warming-only'
         uses: actions/cache/restore@v5
         with:
-          # Only the .tar.gz files are cached; tools/test-fixtures.sh re-extracts
-          # them each run. cl_mainnet is intentionally excluded (owned by
-          # test-integration-caplin.yml's separate cache).
+          # Only the .tar.gz files are cached; each shard re-extracts just the
+          # fixture set it needs (tools/run-eest-spec-test.sh). cl_mainnet is
+          # intentionally excluded (owned by test-integration-caplin.yml's
+          # separate cache).
           path: |
             test-fixtures-cache/eest_stable.tar.gz
             test-fixtures-cache/eest_devnet.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -275,9 +275,9 @@ test-fixtures-zkevm:
 # .github/workflows/test-eest-spec.yml's load-matrix job and
 # tools/run-eest-spec-test.sh's runtime lookup). Shards whose names contain
 # "-race" dispatch through the race-instrumented evm.race binary so race
-# coverage works without polluting the non-race shards. zkevm-* shards provision
-# the eest_zkevm corpus (test-fixtures-zkevm); all others provision the
-# eest_{stable,devnet,benchmark} corpora (test-fixtures-eest).
+# coverage works without polluting the non-race shards. Each shard provisions
+# only its own fixture set (via tools/run-eest-spec-test.sh); all corpora
+# together are 20G+ extracted and don't fit on the smaller CI runner disks.
 .PHONY: evm.race
 evm.race:
 	$(GO_BUILD_ENV) $(GO) build -race $(GO_FLAGS) -tags $(BUILD_TAGS) -o $(GOBIN)/evm.race ./cmd/evm
@@ -287,23 +287,15 @@ evm.race:
 ifneq ($(filter eest-spec-%,$(MAKECMDGOALS)),)
 $(call check_tools,yq jq,eest-spec targets)
 
-EEST_SPEC_RACE_SHARDS       := $(shell yq -o=json '.' tools/eest-spec-shards.yml | jq -r '.[].shard | select(test("-race")) | select(test("^zkevm") | not)')
-EEST_SPEC_SHARDS            := $(shell yq -o=json '.' tools/eest-spec-shards.yml | jq -r '.[].shard | select(test("-race") | not) | select(test("^zkevm") | not)')
-EEST_SPEC_ZKEVM_RACE_SHARDS := $(shell yq -o=json '.' tools/eest-spec-shards.yml | jq -r '.[].shard | select(test("^zkevm")) | select(test("-race"))')
-EEST_SPEC_ZKEVM_SHARDS      := $(shell yq -o=json '.' tools/eest-spec-shards.yml | jq -r '.[].shard | select(test("^zkevm")) | select(test("-race") | not)')
+EEST_SPEC_RACE_SHARDS := $(shell yq -o=json '.' tools/eest-spec-shards.yml | jq -r '.[].shard | select(test("-race"))')
+EEST_SPEC_SHARDS      := $(shell yq -o=json '.' tools/eest-spec-shards.yml | jq -r '.[].shard | select(test("-race") | not)')
 
-.PHONY: $(addprefix eest-spec-,$(EEST_SPEC_SHARDS)) $(addprefix eest-spec-,$(EEST_SPEC_RACE_SHARDS)) $(addprefix eest-spec-,$(EEST_SPEC_ZKEVM_SHARDS)) $(addprefix eest-spec-,$(EEST_SPEC_ZKEVM_RACE_SHARDS))
+.PHONY: $(addprefix eest-spec-,$(EEST_SPEC_SHARDS)) $(addprefix eest-spec-,$(EEST_SPEC_RACE_SHARDS))
 
-$(addprefix eest-spec-,$(EEST_SPEC_SHARDS)): eest-spec-%: test-fixtures-eest evm
+$(addprefix eest-spec-,$(EEST_SPEC_SHARDS)): eest-spec-%: evm
 	@bash tools/run-eest-spec-test.sh "$*"
 
-$(addprefix eest-spec-,$(EEST_SPEC_RACE_SHARDS)): eest-spec-%: test-fixtures-eest evm.race
-	@EVM_BIN=$(GOBIN)/evm.race bash tools/run-eest-spec-test.sh "$*"
-
-$(addprefix eest-spec-,$(EEST_SPEC_ZKEVM_SHARDS)): eest-spec-%: test-fixtures-zkevm evm
-	@bash tools/run-eest-spec-test.sh "$*"
-
-$(addprefix eest-spec-,$(EEST_SPEC_ZKEVM_RACE_SHARDS)): eest-spec-%: test-fixtures-zkevm evm.race
+$(addprefix eest-spec-,$(EEST_SPEC_RACE_SHARDS)): eest-spec-%: evm.race
 	@EVM_BIN=$(GOBIN)/evm.race bash tools/run-eest-spec-test.sh "$*"
 endif
 

--- a/tools/run-eest-spec-test.sh
+++ b/tools/run-eest-spec-test.sh
@@ -66,15 +66,16 @@ for tool in yq jq; do
 	command -v "$tool" >/dev/null 2>&1 || { echo "run-eest-spec-test: required tool '$tool' not found in PATH" >&2; exit 1; }
 done
 
-# Resolve fixtures base from the shard name. blocktests-{stable,devnet}-race-*
+# Resolve the fixture set from the shard name. blocktests-{stable,devnet}-race-*
 # inherit from the parent shard (stable/devnet).
 case "$shard" in
-	*zkevm*)      base=test-fixtures-cache/eest_zkevm/fixtures ;;
-	*-stable*)    base=test-fixtures-cache/eest_stable/fixtures ;;
-	*-devnet*)    base=test-fixtures-cache/eest_devnet/fixtures ;;
-	*-benchmark*) base=test-fixtures-cache/eest_benchmark/fixtures ;;
+	*zkevm*)      fixtures=eest_zkevm ;;
+	*-stable*)    fixtures=eest_stable ;;
+	*-devnet*)    fixtures=eest_devnet ;;
+	*-benchmark*) fixtures=eest_benchmark ;;
 	*) echo "cannot resolve fixtures for shard: $shard" >&2; exit 2 ;;
 esac
+base=test-fixtures-cache/$fixtures/fixtures
 
 # Resolve workers + failure budget + exec3-parallel flag from the single-source
 # manifest. Both this script and the test-eest-spec.yml load-matrix job read
@@ -146,10 +147,14 @@ if [[ ! -x "$evm_bin" ]]; then
 	echo "$evm_bin not found or not executable; run 'make evm' first" >&2
 	exit 2
 fi
+
+# Provision only this shard's fixture set (no-op when already extracted) —
+# all corpora together are 20G+ extracted and don't fit on the smaller CI
+# runner disks.
+bash tools/test-fixtures.sh test-fixtures.json test-fixtures-cache "$fixtures"
+
 if [[ ! -d "$path" ]]; then
-	fixtures_target=test-fixtures-eest
-	case "$shard" in *zkevm*) fixtures_target=test-fixtures-zkevm ;; esac
-	echo "fixture path $path does not exist; run 'make $fixtures_target' first" >&2
+	echo "fixture path $path does not exist in the $fixtures corpus" >&2
 	exit 2
 fi
 

--- a/tools/test-fixtures.sh
+++ b/tools/test-fixtures.sh
@@ -12,11 +12,18 @@
 # 2x local disk usage vs. extracted-only; CI caches only *.tar.gz to stay
 # under cache budget and re-extracts on each run.
 #
-# Usage: tools/test-fixtures.sh [MANIFEST [CACHE_DIR [KEY...]]]
+# Usage: tools/test-fixtures.sh [--download-only] [MANIFEST [CACHE_DIR [KEY...]]]
+#   --download-only   download & sha256-verify the tarballs, skip extraction
 #   MANIFEST defaults to test-fixtures.json
 #   CACHE_DIR defaults to test-fixtures-cache
 #   KEY...    optional manifest keys; default = all keys
 set -euo pipefail
+
+download_only=false
+if [[ "${1:-}" == "--download-only" ]]; then
+	download_only=true
+	shift
+fi
 
 manifest="${1:-test-fixtures.json}"
 cache="${2:-test-fixtures-cache}"
@@ -68,30 +75,44 @@ tar_path=""
 out_dir=""
 trap 'rm -f "${tar_path}.tmp" 2>/dev/null; rm -rf "${out_dir}.tmp" 2>/dev/null' EXIT
 
+# ensure_tarball NAME URL WANT: download & verify $tar_path unless it already
+# matches WANT.
+ensure_tarball() {
+	if [[ -f "$tar_path" ]] && [[ "$(sha256 "$tar_path")" == "$3" ]]; then
+		echo "$1: tarball cached (sha256 ${3:0:12})"
+		return 0
+	fi
+	echo "$1: downloading from $2"
+	# Ride out transient upstream 5xx (release CDN) with exponential backoff over a 5-min window.
+	curl -fsSL --retry 10 --retry-all-errors --retry-delay 0 \
+		--retry-max-time 300 --connect-timeout 30 \
+		-o "$tar_path.tmp" "$2"
+	local got
+	got=$(sha256 "$tar_path.tmp")
+	if [[ "$got" != "$3" ]]; then
+		rm -f "$tar_path.tmp"
+		echo "test-fixtures: $1: sha256 mismatch — want $3 got $got" >&2
+		exit 1
+	fi
+	mv "$tar_path.tmp" "$tar_path"
+}
+
 while IFS=$'\t' read -r name url want; do
 	tar_path="$cache/${name}.tar.gz"
 	out_dir="$cache/${name}"
 	sentinel="$out_dir/.sha256"
+
+	if [[ "$download_only" == true ]]; then
+		ensure_tarball "$name" "$url" "$want"
+		continue
+	fi
 
 	if [[ -f "$sentinel" ]] && [[ "$(cat "$sentinel")" == "$want" ]]; then
 		echo "$name: cached (sha256 ${want:0:12})"
 		continue
 	fi
 
-	if [[ ! -f "$tar_path" ]] || [[ "$(sha256 "$tar_path")" != "$want" ]]; then
-		echo "$name: downloading from $url"
-		# Ride out transient upstream 5xx (release CDN) with exponential backoff over a 5-min window.
-		curl -fsSL --retry 10 --retry-all-errors --retry-delay 0 \
-			--retry-max-time 300 --connect-timeout 30 \
-			-o "$tar_path.tmp" "$url"
-		got=$(sha256 "$tar_path.tmp")
-		if [[ "$got" != "$want" ]]; then
-			rm -f "$tar_path.tmp"
-			echo "test-fixtures: $name: sha256 mismatch — want $want got $got" >&2
-			exit 1
-		fi
-		mv "$tar_path.tmp" "$tar_path"
-	fi
+	ensure_tarball "$name" "$url" "$want"
 
 	echo "$name: extracting"
 	rm -rf "$out_dir.tmp" "$out_dir"


### PR DESCRIPTION
## Problem

`eest-spec-enginextests-benchmark-30m-parallel` failed on #21764 with the Go linker dying mid-build ([run](https://github.com/erigontech/erigon/actions/runs/27421370747/job/81047607869)):

```
link: mapping output file failed: no space left on device
```

GitHub's `ubuntu-24.04` hosted pool currently serves two disk flavors — 72G and 145G root volumes. The same shard on the same branch passed 45 minutes earlier on a 145G runner (110G free after cleanup) and failed on a 72G one (36G free after cleanup).

The job's disk demand sits right at that 36G line because every `eest-spec-*` shard provisions **all three** EEST corpora through the blanket `test-fixtures-eest` Make target, while `tools/run-eest-spec-test.sh` only ever reads one of them:

| corpus | tarball | extracted |
|---|---|---|
| eest_benchmark | 1.0G | 5.3G |
| eest_devnet | 0.6G | 10G |
| eest_stable | 0.4G | 8.1G |

36G free − ~8G (Go toolchain + mod/build cache restore) − 2G tarballs − 23.4G extraction ≈ 2.6G left when `go build` starts → ENOSPC at link. The ±1-2G run-to-run variance is why it flakes instead of failing deterministically.

## Fix

- Move fixture provisioning into `tools/run-eest-spec-test.sh`, which already resolves the shard's corpus from its name — each shard now downloads/extracts only the set it reads. Worst-case footprint drops from ~35G to ~22G (devnet shards), ~17G for the benchmark shard that flaked.
- The zkevm/non-zkevm Makefile rule split existed solely to pick the fixture prerequisite, so the four pattern rules collapse to two (race/non-race).
- Add `--download-only` to `tools/test-fixtures.sh` and use it in `cache-warming-eest-fixtures.yml`. The warmer caches only the `.tar.gz` files but was extracting all four corpora (~27G) — on a runner that doesn't even run the cleanup-space step, i.e. the same ENOSPC waiting to happen on a 72G runner whenever the probe misses.

Local `make eest-spec-*` behaviour is unchanged: provisioning is a sentinel-guarded no-op when the corpus is already extracted, and `make test-fixtures-eest`/`test-fixtures-zkevm` remain for prefetching everything.

## Verification

TDD note: infra/shell change with no Go behaviour; verified functionally instead of via Go tests:

- Synthetic end-to-end test of `test-fixtures.sh` (tiny `file://` manifest in a temp dir): download-only cold / idempotent re-run / normal-mode extract from existing tarball / sentinel no-op / download-only re-download after tarball deletion — all pass.
- `make -n` for one shard per class (plain, race, zkevm-race, benchmark): correct binary (`evm` vs `evm.race`), no blanket fixture extraction in any recipe.
- Smoke run of `run-eest-spec-test.sh statetests-stable` against a populated cache: in-script provisioning hits the cached fast-path and proceeds into the run stage.
- `actionlint` on both workflows; `shellcheck` adds no new findings; `make lint` clean twice.