### PR TITLE
docs: cross-link CLI Reference sections to their dedicated pages

### DIFF
--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -64,7 +64,7 @@ These flags cover the general behavior and configuration of the Erigon client.
 
 ### Database and Caching
 
-These flags control database performance and memory usage.
+These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
 
 * `--db.pagesize value`: Sets the fixed page size for the database.
   * Default: `16KB`
@@ -90,7 +90,7 @@ These flags control database performance and memory usage.
 
 ### Pruning and Snapshots
 
-Flags for managing how old chain data is handled and stored.
+Flags for managing how old chain data is handled and stored. See [Snapshots Management](/fundamentals/snapshots-management) for snapshot tooling and disk usage.
 
 * `--prune.mode value`: Selects a pruning preset (`full`, `archive`, `minimal`, `blocks`). See also [Pruning Modes](/fundamentals/pruning-modes)
   * Default: `"full"`
@@ -115,7 +115,7 @@ Flags for managing how old chain data is handled and stored.
 
 ### Transaction Pool (TxPool)
 
-Options for configuring the transaction pool.
+Options for configuring the [transaction pool](/fundamentals/modules/txpool).
 
 * `--txpool.api.addr value`: The TxPool API network address.
   * Default: Uses the value of `--private.api.addr`
@@ -147,7 +147,7 @@ Options for configuring the transaction pool.
 
 ### Network and Peers
 
-These flags manage network connectivity, peer discovery, and traffic control.
+These flags manage network connectivity, peer discovery, and traffic control. See [Default Ports](/fundamentals/default-ports) for the full port map.
 
 * `--port value`: The main network listening port.
   * Default: `30303`
@@ -174,7 +174,7 @@ These flags manage network connectivity, peer discovery, and traffic control.
 
 ### RPC & API
 
-Flags for configuring various RPC servers and their behavior.
+Flags for configuring various RPC servers and their behavior. See [Interacting with Erigon](/interacting-with-erigon) for the JSON-RPC API reference.
 
 * `--private.api.addr value`: The internal gRPC API address for Erigon's components.
   * Default: `127.0.0.1:9090`
@@ -194,7 +194,7 @@ Flags for configuring various RPC servers and their behavior.
   * Default: `localhost`
 * `--authrpc.port value`: The HTTP-RPC server listening port for the Engine API.
   * Default: `8551`
-* `--authrpc.jwtsecret value`: The path to the JWT secret file for the consensus layer.
+* `--authrpc.jwtsecret value`: The path to the [JWT secret](/fundamentals/jwt) file for the consensus layer.
 * `--http.compression`: Enables compression over HTTP-RPC.
   * Default: `true`
 * `--http.corsdomain value`: A comma-separated list of domains for cross-origin requests.
@@ -271,7 +271,7 @@ Flags for configuring various RPC servers and their behavior.
 
 ### MCP Server
 
-Flags for configuring the Model Context Protocol (MCP) server. The embedded MCP server is **enabled by default** on
+Flags for configuring the Model Context Protocol (MCP) server. The embedded [MCP server](/fundamentals/mcp) is **enabled by default** on
 `127.0.0.1:8553`. Pass `--mcp.disable` to turn it off.
 
 * `--mcp.disable`: Disables the embedded MCP server.
@@ -283,7 +283,7 @@ Flags for configuring the Model Context Protocol (MCP) server. The embedded MCP 
 
 ### Logging and Profiling
 
-Flags for controlling logging and performance profiling.
+Flags for controlling logging and performance profiling. See [Logs](/fundamentals/logs) for log files, levels, and rotation.
 
 * `--log.json`: Formats console logs with JSON.
   * Default: `false`
@@ -313,7 +313,7 @@ Flags for controlling logging and performance profiling.
 * `--trace value`: Writes an execution trace to a file.
 * `--vmtrace value`: Sets the provider tracer.
 * `--vmtrace.jsonconfig value`: Sets the tracer's configuration.
-* `--metrics`: Enables metrics collection and reporting.
+* `--metrics`: Enables metrics collection and reporting. See [Creating a dashboard](/fundamentals/creating-a-dashboard).
   * Default: `false`
 * `--metrics.addr value`: The stand-alone metrics HTTP server listening interface.
   * Default: `127.0.0.1`
@@ -354,7 +354,7 @@ Flags related to consensus mechanisms and network forks.
 
 ### Sentry
 
-Flags for configuring the Sentry component.
+Flags for configuring the [Sentry](/fundamentals/modules/sentry) component.
 
 * `--sentry.api.addr value`: A comma-separated list of Sentry addresses.
 * `--sentry.log-peer-info`: Logs detailed peer info when a peer connects or disconnects.
@@ -368,7 +368,7 @@ Flags for configuring the Sentry component.
 
 ### Downloader and Synchronization
 
-These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings.
+These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings. See [Downloader](/fundamentals/modules/downloader) for how snapshot downloading works.
 
 * `--downloader.api.addr value`: The Downloader address.
 * `--downloader.disable.ipv4`: Disables IPv4 for the Downloader.
@@ -438,7 +438,7 @@ Flags for configuring the parallel block execution engine.
 
 ### Caplin (Consensus Layer)
 
-Flags for configuring the Caplin consensus layer.
+Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
 
 * `--caplin.discovery.addr value`: The address for the Caplin DISCV5 protocol.
   * Default: `0.0.0.0`
@@ -487,7 +487,7 @@ Flags for configuring the Caplin consensus layer.
 
 ### Shutter Network Encrypted Transactions
 
-Flags for configuring the Shutter Network encrypted transactions mempool.
+Flags for configuring the [Shutter Network](/staking/shutter-network) encrypted transactions mempool.
 
 * `--shutter`: Enables the Shutter encrypted transactions mempool.
   * Default: `false`
@@ -582,7 +582,7 @@ Erigon supports configuration through environment variables, primarily for exper
 
 ### Docker Environment Variables
 
-When running Erigon in Docker, you can configure user permissions and data directories:
+When running Erigon in [Docker](/fundamentals/docker-compose), you can configure user permissions and data directories:
 
 * `DOCKER_UID` - The UID of the Docker user
 * `DOCKER_GID` - The GID of the Docker user

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -1930,7 +1930,7 @@ These flags cover the general behavior and configuration of the Erigon client.
 
 ### Database and Caching
 
-These flags control database performance and memory usage.
+These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
 
 * `--db.pagesize value`: Sets the fixed page size for the database.
   * Default: `16KB`
@@ -1956,7 +1956,7 @@ These flags control database performance and memory usage.
 
 ### Pruning and Snapshots
 
-Flags for managing how old chain data is handled and stored.
+Flags for managing how old chain data is handled and stored. See [Snapshots Management](/fundamentals/snapshots-management) for snapshot tooling and disk usage.
 
 * `--prune.mode value`: Selects a pruning preset (`full`, `archive`, `minimal`, `blocks`). See also [Pruning Modes](/fundamentals/pruning-modes)
   * Default: `"full"`
@@ -1981,7 +1981,7 @@ Flags for managing how old chain data is handled and stored.
 
 ### Transaction Pool (TxPool)
 
-Options for configuring the transaction pool.
+Options for configuring the [transaction pool](/fundamentals/modules/txpool).
 
 * `--txpool.api.addr value`: The TxPool API network address.
   * Default: Uses the value of `--private.api.addr`
@@ -2013,7 +2013,7 @@ Options for configuring the transaction pool.
 
 ### Network and Peers
 
-These flags manage network connectivity, peer discovery, and traffic control.
+These flags manage network connectivity, peer discovery, and traffic control. See [Default Ports](/fundamentals/default-ports) for the full port map.
 
 * `--port value`: The main network listening port.
   * Default: `30303`
@@ -2040,7 +2040,7 @@ These flags manage network connectivity, peer discovery, and traffic control.
 
 ### RPC & API
 
-Flags for configuring various RPC servers and their behavior.
+Flags for configuring various RPC servers and their behavior. See [Interacting with Erigon](/interacting-with-erigon) for the JSON-RPC API reference.
 
 * `--private.api.addr value`: The internal gRPC API address for Erigon's components.
   * Default: `127.0.0.1:9090`
@@ -2060,7 +2060,7 @@ Flags for configuring various RPC servers and their behavior.
   * Default: `localhost`
 * `--authrpc.port value`: The HTTP-RPC server listening port for the Engine API.
   * Default: `8551`
-* `--authrpc.jwtsecret value`: The path to the JWT secret file for the consensus layer.
+* `--authrpc.jwtsecret value`: The path to the [JWT secret](/fundamentals/jwt) file for the consensus layer.
 * `--http.compression`: Enables compression over HTTP-RPC.
   * Default: `true`
 * `--http.corsdomain value`: A comma-separated list of domains for cross-origin requests.
@@ -2137,7 +2137,7 @@ Flags for configuring various RPC servers and their behavior.
 
 ### MCP Server
 
-Flags for configuring the Model Context Protocol (MCP) server. The embedded MCP server is **enabled by default** on
+Flags for configuring the Model Context Protocol (MCP) server. The embedded [MCP server](/fundamentals/mcp) is **enabled by default** on
 `127.0.0.1:8553`. Pass `--mcp.disable` to turn it off.
 
 * `--mcp.disable`: Disables the embedded MCP server.
@@ -2149,7 +2149,7 @@ Flags for configuring the Model Context Protocol (MCP) server. The embedded MCP 
 
 ### Logging and Profiling
 
-Flags for controlling logging and performance profiling.
+Flags for controlling logging and performance profiling. See [Logs](/fundamentals/logs) for log files, levels, and rotation.
 
 * `--log.json`: Formats console logs with JSON.
   * Default: `false`
@@ -2179,7 +2179,7 @@ Flags for controlling logging and performance profiling.
 * `--trace value`: Writes an execution trace to a file.
 * `--vmtrace value`: Sets the provider tracer.
 * `--vmtrace.jsonconfig value`: Sets the tracer's configuration.
-* `--metrics`: Enables metrics collection and reporting.
+* `--metrics`: Enables metrics collection and reporting. See [Creating a dashboard](/fundamentals/creating-a-dashboard).
   * Default: `false`
 * `--metrics.addr value`: The stand-alone metrics HTTP server listening interface.
   * Default: `127.0.0.1`
@@ -2220,7 +2220,7 @@ Flags related to consensus mechanisms and network forks.
 
 ### Sentry
 
-Flags for configuring the Sentry component.
+Flags for configuring the [Sentry](/fundamentals/modules/sentry) component.
 
 * `--sentry.api.addr value`: A comma-separated list of Sentry addresses.
 * `--sentry.log-peer-info`: Logs detailed peer info when a peer connects or disconnects.
@@ -2234,7 +2234,7 @@ Flags for configuring the Sentry component.
 
 ### Downloader and Synchronization
 
-These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings.
+These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings. See [Downloader](/fundamentals/modules/downloader) for how snapshot downloading works.
 
 * `--downloader.api.addr value`: The Downloader address.
 * `--downloader.disable.ipv4`: Disables IPv4 for the Downloader.
@@ -2304,7 +2304,7 @@ Flags for configuring the parallel block execution engine.
 
 ### Caplin (Consensus Layer)
 
-Flags for configuring the Caplin consensus layer.
+Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
 
 * `--caplin.discovery.addr value`: The address for the Caplin DISCV5 protocol.
   * Default: `0.0.0.0`
@@ -2353,7 +2353,7 @@ Flags for configuring the Caplin consensus layer.
 
 ### Shutter Network Encrypted Transactions
 
-Flags for configuring the Shutter Network encrypted transactions mempool.
+Flags for configuring the [Shutter Network](/staking/shutter-network) encrypted transactions mempool.
 
 * `--shutter`: Enables the Shutter encrypted transactions mempool.
   * Default: `false`
@@ -2448,7 +2448,7 @@ Erigon supports configuration through environment variables, primarily for exper
 
 ### Docker Environment Variables
 
-When running Erigon in Docker, you can configure user permissions and data directories:
+When running Erigon in [Docker](/fundamentals/docker-compose), you can configure user permissions and data directories:
 
 * `DOCKER_UID` - The UID of the Docker user
 * `DOCKER_GID` - The GID of the Docker user

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1930,7 +1930,7 @@ These flags cover the general behavior and configuration of the Erigon client.
 
 ### Database and Caching
 
-These flags control database performance and memory usage.
+These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
 
 * `--db.pagesize value`: Sets the fixed page size for the database.
   * Default: `16KB`
@@ -1956,7 +1956,7 @@ These flags control database performance and memory usage.
 
 ### Pruning and Snapshots
 
-Flags for managing how old chain data is handled and stored.
+Flags for managing how old chain data is handled and stored. See [Snapshots Management](/fundamentals/snapshots-management) for snapshot tooling and disk usage.
 
 * `--prune.mode value`: Selects a pruning preset (`full`, `archive`, `minimal`, `blocks`). See also [Pruning Modes](/fundamentals/pruning-modes)
   * Default: `"full"`
@@ -1981,7 +1981,7 @@ Flags for managing how old chain data is handled and stored.
 
 ### Transaction Pool (TxPool)
 
-Options for configuring the transaction pool.
+Options for configuring the [transaction pool](/fundamentals/modules/txpool).
 
 * `--txpool.api.addr value`: The TxPool API network address.
   * Default: Uses the value of `--private.api.addr`
@@ -2013,7 +2013,7 @@ Options for configuring the transaction pool.
 
 ### Network and Peers
 
-These flags manage network connectivity, peer discovery, and traffic control.
+These flags manage network connectivity, peer discovery, and traffic control. See [Default Ports](/fundamentals/default-ports) for the full port map.
 
 * `--port value`: The main network listening port.
   * Default: `30303`
@@ -2040,7 +2040,7 @@ These flags manage network connectivity, peer discovery, and traffic control.
 
 ### RPC & API
 
-Flags for configuring various RPC servers and their behavior.
+Flags for configuring various RPC servers and their behavior. See [Interacting with Erigon](/interacting-with-erigon) for the JSON-RPC API reference.
 
 * `--private.api.addr value`: The internal gRPC API address for Erigon's components.
   * Default: `127.0.0.1:9090`
@@ -2060,7 +2060,7 @@ Flags for configuring various RPC servers and their behavior.
   * Default: `localhost`
 * `--authrpc.port value`: The HTTP-RPC server listening port for the Engine API.
   * Default: `8551`
-* `--authrpc.jwtsecret value`: The path to the JWT secret file for the consensus layer.
+* `--authrpc.jwtsecret value`: The path to the [JWT secret](/fundamentals/jwt) file for the consensus layer.
 * `--http.compression`: Enables compression over HTTP-RPC.
   * Default: `true`
 * `--http.corsdomain value`: A comma-separated list of domains for cross-origin requests.
@@ -2137,7 +2137,7 @@ Flags for configuring various RPC servers and their behavior.
 
 ### MCP Server
 
-Flags for configuring the Model Context Protocol (MCP) server. The embedded MCP server is **enabled by default** on
+Flags for configuring the Model Context Protocol (MCP) server. The embedded [MCP server](/fundamentals/mcp) is **enabled by default** on
 `127.0.0.1:8553`. Pass `--mcp.disable` to turn it off.
 
 * `--mcp.disable`: Disables the embedded MCP server.
@@ -2149,7 +2149,7 @@ Flags for configuring the Model Context Protocol (MCP) server. The embedded MCP 
 
 ### Logging and Profiling
 
-Flags for controlling logging and performance profiling.
+Flags for controlling logging and performance profiling. See [Logs](/fundamentals/logs) for log files, levels, and rotation.
 
 * `--log.json`: Formats console logs with JSON.
   * Default: `false`
@@ -2179,7 +2179,7 @@ Flags for controlling logging and performance profiling.
 * `--trace value`: Writes an execution trace to a file.
 * `--vmtrace value`: Sets the provider tracer.
 * `--vmtrace.jsonconfig value`: Sets the tracer's configuration.
-* `--metrics`: Enables metrics collection and reporting.
+* `--metrics`: Enables metrics collection and reporting. See [Creating a dashboard](/fundamentals/creating-a-dashboard).
   * Default: `false`
 * `--metrics.addr value`: The stand-alone metrics HTTP server listening interface.
   * Default: `127.0.0.1`
@@ -2220,7 +2220,7 @@ Flags related to consensus mechanisms and network forks.
 
 ### Sentry
 
-Flags for configuring the Sentry component.
+Flags for configuring the [Sentry](/fundamentals/modules/sentry) component.
 
 * `--sentry.api.addr value`: A comma-separated list of Sentry addresses.
 * `--sentry.log-peer-info`: Logs detailed peer info when a peer connects or disconnects.
@@ -2234,7 +2234,7 @@ Flags for configuring the Sentry component.
 
 ### Downloader and Synchronization
 
-These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings.
+These flags control the block synchronization and data downloading process, including the BitTorrent protocol settings. See [Downloader](/fundamentals/modules/downloader) for how snapshot downloading works.
 
 * `--downloader.api.addr value`: The Downloader address.
 * `--downloader.disable.ipv4`: Disables IPv4 for the Downloader.
@@ -2304,7 +2304,7 @@ Flags for configuring the parallel block execution engine.
 
 ### Caplin (Consensus Layer)
 
-Flags for configuring the Caplin consensus layer.
+Flags for configuring the [Caplin](/fundamentals/caplin) consensus layer.
 
 * `--caplin.discovery.addr value`: The address for the Caplin DISCV5 protocol.
   * Default: `0.0.0.0`
@@ -2353,7 +2353,7 @@ Flags for configuring the Caplin consensus layer.
 
 ### Shutter Network Encrypted Transactions
 
-Flags for configuring the Shutter Network encrypted transactions mempool.
+Flags for configuring the [Shutter Network](/staking/shutter-network) encrypted transactions mempool.
 
 * `--shutter`: Enables the Shutter encrypted transactions mempool.
   * Default: `false`
@@ -2448,7 +2448,7 @@ Erigon supports configuration through environment variables, primarily for exper
 
 ### Docker Environment Variables
 
-When running Erigon in Docker, you can configure user permissions and data directories:
+When running Erigon in [Docker](/fundamentals/docker-compose), you can configure user permissions and data directories:
 
 * `DOCKER_UID` - The UID of the Docker user
 * `DOCKER_GID` - The GID of the Docker user


### PR DESCRIPTION
Main counterpart of #21763 (which added the same cross-links on release/3.5). Now that #21765 (the #21687 forward-port) has merged, the flattened CLI Reference page and its link targets exist on `main`, so this applies cleanly.

Adds one cross-link per section of the **CLI Reference** (`configuring-erigon`) to its dedicated page — in the section explainer where possible, or on the most relevant flag. One link per target, no duplicates of the links already present (nat / supported-networks / pruning-modes / eth_getProof).

**Explainer links:** Database, Snapshots Management, TxPool, Default Ports, Interacting with Erigon (RPC), MCP, Logs, Sentry, Downloader, Caplin, Shutter Network, Docker Compose.
**Targeted flag links:** JWT (on `--authrpc.jwtsecret`), Creating a dashboard (on `--metrics`).

Build passes the `onBrokenLinks: 'throw'` check; `llms.txt` / `llms-full.txt` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)