### PR TITLE
.claude: anchor the comment policy as a rule + advisory write-time hook

### DIFF
--- a/.claude/hooks/comment-policy.py
+++ b/.claude/hooks/comment-policy.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Advisory PostToolUse hook: flag comment-policy violations in Go edits.
+
+Never blocks. On a Write/Edit to a *.go file it scans the ADDED text's comment
+lines for the narration the project keeps having to strip (scope/limitation,
+incident/reproduction, task references) and, if any are found, returns
+additionalContext so the model can self-correct in a follow-up edit.
+
+See .claude/rules/comments.md for the policy this enforces.
+"""
+import json
+import re
+import sys
+
+# (label, regex) — case-insensitive. Targeted at the recurring offenders, kept
+# conservative to avoid false-positive noise on legitimate why-comments.
+PATTERNS = [
+    ("scope/limitation narration (→ PR body)",
+     re.compile(r"forward[- ](only|prevention)|safety[- ]?net|cannot repair|snapshot unwind|\bNOTE:\s", re.I)),
+    ("incident/reproduction narration (→ PR body)",
+     re.compile(r"\bmainnet\b|\bblock[s]?\s+\d{6,9}\b|\b2[0-9]{7}\b|\bcalled\b.*\bblocks? later\b", re.I)),
+    ("task/PR/issue reference (→ commit msg / PR; keep only genuine workaround links)",
+     re.compile(r"#\d{3,6}\b|\bPR\s*#?\d{3,6}\b|as requested|in review")),
+]
+
+
+def added_comment_lines(tool_name, tool_input):
+    if tool_name == "Write":
+        text = tool_input.get("content", "")
+    elif tool_name in ("Edit", "MultiEdit"):
+        # new_string for Edit; concatenate edits for MultiEdit
+        if "new_string" in tool_input:
+            text = tool_input.get("new_string", "")
+        else:
+            text = "\n".join(e.get("new_string", "") for e in tool_input.get("edits", []))
+    else:
+        return []
+    out = []
+    for ln in text.splitlines():
+        s = ln.strip()
+        if s.startswith("//") or s.startswith("/*") or s.startswith("*"):
+            out.append(s)
+    return out
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # never interfere
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {}) or {}
+    path = tool_input.get("file_path", "")
+    if not path.endswith(".go"):
+        sys.exit(0)
+
+    comments = added_comment_lines(tool_name, tool_input)
+    if not comments:
+        sys.exit(0)
+
+    flagged = []
+    for line in comments:
+        for label, rx in PATTERNS:
+            if rx.search(line):
+                flagged.append((label, line))
+                break
+
+    if not flagged:
+        sys.exit(0)
+
+    msg = ["Comment-policy check (.claude/rules/comments.md) — review these added comment lines; "
+           "scope/incident/task narration belongs in the commit message or PR body, not the code:"]
+    for label, line in flagged[:12]:
+        snippet = line if len(line) <= 100 else line[:97] + "..."
+        msg.append(f"  - [{label}] {snippet}")
+    msg.append("If a flagged line is a genuine why-comment (e.g. a workaround issue link), keep it.")
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": "\n".join(msg),
+        }
+    }))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,24 @@
+# Comment Policy
+
+Default to **no comment**. Clear names and small functions should carry the meaning. Write a comment only when the code genuinely can't tell the reader *why*.
+
+## Write a comment only for
+
+- Workarounds for bugs in deps/runtime/other code (link the issue/commit).
+- Non-obvious invariants or constraints not enforced by types.
+- Surprising edge cases easy to miss when reading.
+- Performance choices where the straightforward code would be wrong.
+
+## Never put in code (→ goes in the commit message or PR body)
+
+- **Scope / limitation / "honest" narration** — "forward-only", "safety net", "cannot repair X", "needs a snapshot unwind", "NOTE: this only…". That's PR-description material.
+- **Incident / reproduction narration** — mainnet block numbers, "deployed via X, called N blocks later at M", post-mortem storytelling.
+- **Task references** — PR numbers, issue numbers (except a genuine workaround link), "added for the X flow", "as requested in review".
+- **Restating the code** — `// increment counter`, narrating what the next line obviously does.
+- **The same rationale repeated at multiple sites** — state the *why* once at the canonical place (the field/type/function it belongs to); use terse pointers elsewhere, not the full paragraph again.
+
+## When a comment is warranted
+
+Keep it short and *why*-focused. If a reader could delete it without losing information, it shouldn't exist. Two tight lines beat a six-line essay.
+
+Test docstrings get slightly more latitude (explaining a non-obvious scenario the test pins), but the same rules apply — no incident/scope/task narration.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,19 @@
       "Bash(gh pr:*)"
     ]
   },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/comment-policy.py\""
+          }
+        ]
+      }
+    ]
+  },
   "includeCoAuthoredBy": false,
   "attribution": {
     "commit": "",


### PR DESCRIPTION
Anchors the project's comment policy in two places that the current CLAUDE.md
prose can't: a focused, high-salience **rule file** and an advisory **write-time
hook**.

## Why this anchors comments better than the CLAUDE.md version

The policy already exists as a sub-section of `CLAUDE.md` ("Code Style → Comments"),
but in practice it doesn't hold:

- **Low salience.** It's one paragraph buried in a long, multi-topic file, competing
  with build/lint/PR-workflow instructions. Guidance that deep gets deprioritised the
  moment a task gets demanding — which is exactly when over-commenting happens (right
  after root-causing something, the urge is to narrate the finding in the code).
- **No enforcement.** Comment quality is the *only* style rule with no mechanical
  backstop. Formatting has three — `gofmt`, `golangci-lint`/`ruleguard`, and a
  dedicated `.claude/rules/lint-fixes.md` — plus `make lint` before every push.
  Comments have nothing, so violations are caught only by a human noticing them in
  review (or not).

This PR closes both gaps:

### 1. `.claude/rules/comments.md` — salience

A short, imperative rule, surfaced as a top-level project instruction like
`branch-naming.md` and `lint-fixes.md` rather than buried prose. It states the policy
crisply and adds the rule the prose lacked: **scope / limitation / "honest" narration
(forward-only, safety-net, can't-repair, needs-X) and incident/reproduction
storytelling belong in the commit message or PR body, not the code** — and don't
repeat the same rationale at multiple sites.

### 2. `.claude/hooks/comment-policy.py` — enforcement

An advisory `PostToolUse` hook (Write/Edit/MultiEdit on `*.go`). It scans the *added*
comment lines for the recurring offenders — scope/limitation phrasing, mainnet block
numbers / "called N blocks later", PR/issue references — and returns context so the
author self-corrects. It is the comment analogue of the lint backstop, applied at
write time so violations are fixed before they reach a commit or a reviewer.

**It never blocks.** On a hit it only surfaces a reminder; on a clean comment it is
silent; it always exits 0.

## Notes

- The hook command is `python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/comment-policy.py"`
  (python3 on PATH — standard on macOS/Linux). Because it's an advisory `PostToolUse`
  hook, a missing interpreter degrades gracefully: the edit still applies, you just
  don't get the nudge.
- Patterns are deliberately conservative to avoid false-positive noise, and genuine
  why-comments (e.g. a workaround issue link) are meant to be kept.
- `CLAUDE.md` is left as-is; this layers the anchored rule + enforcement on top.
  Reviewers may want to slim the `CLAUDE.md` paragraph to a pointer once this lands.
