### PR TITLE
domain: allow per-domain configuration of "existence filter on mmap"

### DIFF
--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -230,6 +230,19 @@ func (b *Filter) MadvNormal() {
 	// bloom filter is heap-allocated, no mmap to advise — no-op
 }
 
+func (b *Filter) MadvRandom() {
+	if b == nil || b.empty {
+		return
+	}
+	if b.fuseReaderSharded != nil {
+		b.fuseReaderSharded.MadvRandom()
+		return
+	}
+	if b.fuseReader != nil {
+		b.fuseReader.MadvRandom()
+	}
+}
+
 func (b *Filter) Close() {
 	if b == nil {
 		return

--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -185,6 +185,14 @@ func (r *Reader) MadvNormal() {
 		panic(err)
 	}
 }
+func (r *Reader) MadvRandom() {
+	if r == nil || r.f == nil || r.m == nil || len(r.m) == 0 || r.keepInMem {
+		return
+	}
+	if err := mm.MadviseRandom(r.m); err != nil {
+		panic(err)
+	}
+}
 func (r *Reader) FileName() string           { return r.fileName }
 func (r *Reader) ContainsHash(v uint64) bool { return r.inner.Contains(v) }
 func (r *Reader) Close() {
@@ -334,6 +342,14 @@ func (r *ReaderSharded) MadvNormal() {
 		return
 	}
 	if err := mm.MadviseNormal(r.m); err != nil {
+		panic(err)
+	}
+}
+func (r *ReaderSharded) MadvRandom() {
+	if r == nil || len(r.m) == 0 || r.keepInMem {
+		return
+	}
+	if err := mm.MadviseRandom(r.m); err != nil {
 		panic(err)
 	}
 }

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -333,6 +333,19 @@ func (idx *Index) ForceExistenceFilterNormal() {
 		idx.existenceV2.MadvNormal()
 	}
 }
+func (idx *Index) ForceExistenceFilterRandom() {
+	existanceSupported := idx.dataStructureVersion >= 1 && idx.lessFalsePositives && idx.keyCount > 0
+	if !existanceSupported {
+		return
+	}
+	if idx.dataStructureVersion == 1 {
+		idx.existenceV1.MadvRandom()
+		return
+	}
+	if idx.dataStructureVersion >= 2 {
+		idx.existenceV2.MadvRandom()
+	}
+}
 func (idx *Index) ForceExistenceFilterInRAM() datasize.ByteSize {
 	existanceSupported := idx.dataStructureVersion >= 1 && idx.lessFalsePositives && idx.keyCount > 0
 	if !existanceSupported {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -148,22 +149,42 @@ func (d *Domain) kvBtAccessorNewFilePath(fromStep, toStep kv.Step) string {
 	return filepath.Join(d.dirs.SnapDomain, fmt.Sprintf("%s-%s.%d-%d.bt", d.FileVersion.AccessorBT.String(), d.FilenameBase, fromStep, toStep))
 }
 
-var domainExistenceForceInMem = dbg.EnvBool("DOMAIN_EXISTENCE_MEM", true)
-var domainExistenceForceWillNeed = dbg.EnvBool("DOMAIN_EXISTENCE_WILLNEED", false)
-var domainExistenceForceNormal = dbg.EnvBool("DOMAIN_EXISTENCE_NORMAL", false)
+var domainExistenceForceInMem = dbg.EnvStrings("DOMAIN_EXISTENCE_MEM", ",", nil)
+var domainExistenceForceWillNeed = dbg.EnvStrings("DOMAIN_EXISTENCE_WILLNEED", ",", nil)
+var domainExistenceForceNormal = dbg.EnvStrings("DOMAIN_EXISTENCE_NORMAL", ",", nil)
+var domainExistenceForceRandom = dbg.EnvStrings("DOMAIN_EXISTENCE_RANDOM", ",", nil)
+
+func (d *Domain) existenceFilterMode() statecfg.ExistenceFilterMode {
+	name := d.Name.String()
+	switch {
+	case slices.Contains(domainExistenceForceInMem, name):
+		return statecfg.ExistenceFilterInMem
+	case slices.Contains(domainExistenceForceNormal, name):
+		return statecfg.ExistenceFilterNormal
+	case slices.Contains(domainExistenceForceWillNeed, name):
+		return statecfg.ExistenceFilterWillNeed
+	case slices.Contains(domainExistenceForceRandom, name):
+		return statecfg.ExistenceFilterRandom
+	default:
+		return d.ExistenceFilter
+	}
+}
 
 func (d *Domain) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
 	accessor, err := recsplit.OpenIndex(fPath)
 	if err != nil {
 		return nil, err
 	}
-	switch {
-	case domainExistenceForceWillNeed:
-		accessor.ForceExistenceFilterWillNeed()
-	case domainExistenceForceNormal:
-		accessor.ForceExistenceFilterNormal()
-	case domainExistenceForceInMem:
+	mode := d.existenceFilterMode()
+	switch mode {
+	case statecfg.ExistenceFilterInMem:
 		accessor.ForceExistenceFilterInRAM()
+	case statecfg.ExistenceFilterNormal:
+		accessor.ForceExistenceFilterNormal()
+	case statecfg.ExistenceFilterWillNeed:
+		accessor.ForceExistenceFilterWillNeed()
+	case statecfg.ExistenceFilterRandom:
+		accessor.ForceExistenceFilterRandom()
 	}
 	return accessor, nil
 }
@@ -173,13 +194,16 @@ func (d *Domain) openExistenceFilter(fPath string) (*existence.Filter, error) {
 	if err != nil {
 		return nil, err
 	}
-	switch {
-	case domainExistenceForceWillNeed:
-		filter.MadvWillNeed()
-	case domainExistenceForceNormal:
-		filter.MadvNormal()
-	case domainExistenceForceInMem:
+	mode := d.existenceFilterMode()
+	switch mode {
+	case statecfg.ExistenceFilterInMem:
 		filter.ForceInMem()
+	case statecfg.ExistenceFilterNormal:
+		filter.MadvNormal()
+	case statecfg.ExistenceFilterWillNeed:
+		filter.MadvWillNeed()
+	case statecfg.ExistenceFilterRandom:
+		filter.MadvRandom()
 	}
 	return filter, nil
 }

--- a/db/state/statecfg/accessors.go
+++ b/db/state/statecfg/accessors.go
@@ -2,6 +2,30 @@ package statecfg
 
 import "strings"
 
+type ExistenceFilterMode uint8
+
+const (
+	ExistenceFilterInMem    ExistenceFilterMode = 0 // keep bytes in application memory (default)
+	ExistenceFilterWillNeed ExistenceFilterMode = 1 // mmap + MADV_WILLNEED
+	ExistenceFilterNormal   ExistenceFilterMode = 2 // mmap + MADV_NORMAL
+	ExistenceFilterRandom   ExistenceFilterMode = 3 // mmap + MADV_RANDOM
+)
+
+func (m ExistenceFilterMode) String() string {
+	switch m {
+	case ExistenceFilterInMem:
+		return "InMem"
+	case ExistenceFilterWillNeed:
+		return "WillNeed"
+	case ExistenceFilterNormal:
+		return "Normal"
+	case ExistenceFilterRandom:
+		return "Random"
+	default:
+		return "Unknown"
+	}
+}
+
 type Accessors int
 
 func (l Accessors) Has(target Accessors) bool { return l&target != 0 }

--- a/db/state/statecfg/statecfg.go
+++ b/db/state/statecfg/statecfg.go
@@ -20,6 +20,8 @@ type DomainCfg struct {
 	// for commitment domain only
 	ReplaceKeysInValues bool
 
+	ExistenceFilter ExistenceFilterMode
+
 	BuildAccessorsWorkers int // parallel workers for building .kvi accessors (recsplit)
 
 	FileVersion DomainVersionTypes


### PR DESCRIPTION
Reasons:
- Bloatnet has 9G of Storage existence filter + 3G of Commitment existence filter.
- Experiments show moving Storage existence filter to `mmap+madv_willneed` increases perf (less I/O), but doing the same for Commitment reduces perf. So: per-domain control instead of a global toggle.

PR:
- Doesn't change App behavior (in next PR I plan to move StorageDomain.ExistenceFilter to mmap+madv_will_need)
- Replace `ExistenceFilterOnAppMemory bool` with `ExistenceFilterMode` enum: `InMem=0` (default), `WillNeed`, `Normal`, `Random`
- Zero value is InMem — no schema lines needed for the common case

Env-var overrides (per-domain name lists, for debugging):
- `DOMAIN_EXISTENCE_MEM=accounts,storage` — override to InMem
- `DOMAIN_EXISTENCE_WILLNEED=accounts` — override to WillNeed
- `DOMAIN_EXISTENCE_NORMAL=accounts` — override to Normal
- `DOMAIN_EXISTENCE_RANDOM=accounts` — override to Random