### PR TITLE
btindex: use off-heap EliasFano during build

### DIFF
--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -271,7 +271,12 @@ func (btw *BtIndexWriter) Build() error {
 	log.Log(btw.args.Lvl, "[index] calculating", "file", btw.indexFileName)
 
 	if btw.keysWritten > 0 {
-		btw.ef = eliasfano32.NewEliasFano(btw.keysWritten, btw.maxOffset)
+		efBuilder, err := eliasfano32.NewEliasFanoOffHeap(btw.keysWritten, btw.maxOffset, btw.args.TmpDir)
+		if err != nil {
+			return fmt.Errorf("[index] create offheap ef: %w", err)
+		}
+		defer efBuilder.Close()
+		btw.ef = efBuilder.EliasFano
 
 		nodes := make([]Node, 0, btw.keysWritten/btw.args.M)
 		var ki uint64

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -400,6 +400,7 @@ func TestNewBtIndex(t *testing.T) {
 	require.NotNil(t, bt)
 	bplus := bt.bplus
 	require.GreaterOrEqual(t, len(bplus.mx), keyCount/int(DefaultBtreeM))
+	require.LessOrEqual(t, len(bplus.mx), keyCount/int(DefaultBtreeM)+2)
 
 	for i := 1; i < len(bt.bplus.mx); i++ {
 		require.NotZero(t, bt.bplus.mx[i].di)


### PR DESCRIPTION
Bloatnet has "peak mem jumps during merge". On heap-profiler I saw `3Gb` used by `EF` inside `.bt` building.
And for https://github.com/erigontech/erigon/issues/20638 

This PR:
- using less RAM for `EF` building.  
- no file format change.

Next PR:
- will also remove "greedy keys copy" during build of btindex
