### PR TITLE
btindex: add `M` to file, reduce RAM usage of `Build()`

### DIFF
--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -19,9 +19,9 @@ package btindex
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
+	"math"
 	"time"
 	"unsafe"
 
@@ -143,50 +143,68 @@ type Node struct {
 	di  uint64 // key ordinal number in kv
 }
 
-func encodeListNodes(nodes []Node, w io.Writer) error {
-	var header [10]byte
-	binary.BigEndian.PutUint64(header[:8], uint64(len(nodes)))
-	if _, err := w.Write(header[:8]); err != nil {
+// Encode writes the node key length-prefixed (reusing headerBuf, len >= 2, to
+// avoid a per-node alloc). di is not stored: node i is the i-th kept key, di=i*M.
+func (n Node) Encode(w io.Writer, headerBuf []byte) error {
+	if len(n.key) > math.MaxUint16 {
+		return fmt.Errorf("node key too long: %d bytes", len(n.key))
+	}
+	binary.BigEndian.PutUint16(headerBuf, uint16(len(n.key)))
+	if _, err := w.Write(headerBuf[:2]); err != nil {
 		return err
 	}
-	for i := range nodes {
-		binary.BigEndian.PutUint64(header[:8], nodes[i].di)
-		binary.BigEndian.PutUint16(header[8:], uint16(len(nodes[i].key)))
-		if _, err := w.Write(header[:]); err != nil {
-			return err
-		}
-		if _, err := w.Write(nodes[i].key); err != nil {
-			return err
-		}
-	}
-	return nil
+	_, err := w.Write(n.key)
+	return err
 }
 
-func decodeListNodes(data []byte) ([]Node, error) {
+// decodeNodes reads count length-prefixed keys (no count prefix on disk — the
+// caller derives count). di is not stored; node i has di = i*m.
+func decodeNodes(data []byte, count, m uint64) ([]Node, int, error) {
+	if count > uint64(len(data))/2 { // each node is at least 2 bytes (keyLen)
+		return nil, 0, fmt.Errorf("corrupt index: node count %d exceeds data size", count)
+	}
+	nodes := make([]Node, count)
+	pos := 0
+	for ni := range int(count) {
+		if len(data)-pos < 2 {
+			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
+		}
+		l := int(binary.BigEndian.Uint16(data[pos : pos+2]))
+		pos += 2
+		if len(data)-pos < l {
+			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
+		}
+		nodes[ni] = Node{key: data[pos : pos+l], di: uint64(ni) * m}
+		pos += l
+	}
+	return nodes, pos, nil
+}
+
+// decodeListNodesV0 reads the legacy node list where each node stores its di.
+func decodeListNodesV0(data []byte) ([]Node, int, error) {
+	if len(data) < 8 {
+		return nil, 0, fmt.Errorf("truncated index: need 8 bytes for node count, got %d", len(data))
+	}
 	count := binary.BigEndian.Uint64(data[:8])
+	if count > uint64(len(data)-8)/10 { // each node is at least 10 bytes (di+keyLen)
+		return nil, 0, fmt.Errorf("corrupt index: node count %d exceeds data size", count)
+	}
 	nodes := make([]Node, count)
 	pos := 8
 	for ni := range int(count) {
-		dp, err := nodes[ni].Decode(data[pos:])
-		if err != nil {
-			return nil, fmt.Errorf("decode node %d: %w", ni, err)
+		if len(data)-pos < 10 {
+			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
 		}
-		pos += int(dp)
+		nodes[ni].di = binary.BigEndian.Uint64(data[pos : pos+8])
+		l := int(binary.BigEndian.Uint16(data[pos+8 : pos+10]))
+		pos += 10
+		if len(data)-pos < l {
+			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
+		}
+		nodes[ni].key = data[pos : pos+l]
+		pos += l
 	}
-	return nodes, nil
-}
-
-func (n *Node) Decode(buf []byte) (uint64, error) {
-	if len(buf) < 10 {
-		return 0, errors.New("short buffer (less than 10b)")
-	}
-	n.di = binary.BigEndian.Uint64(buf[:8])
-	l := int(binary.BigEndian.Uint16(buf[8:10]))
-	if len(buf) < 10+l {
-		return 0, errors.New("short buffer")
-	}
-	n.key = buf[10 : 10+l]
-	return uint64(10 + l), nil
+	return nodes, pos, nil
 }
 
 func (b *BpsTree) WarmUp(kv *seg.Reader) error {

--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -149,7 +149,10 @@ func (n Node) Encode(w io.Writer, headerBuf []byte) error {
 	if len(n.key) > math.MaxUint16 {
 		return fmt.Errorf("node key too long: %d bytes", len(n.key))
 	}
-	binary.BigEndian.PutUint16(headerBuf, uint16(len(n.key)))
+	if len(headerBuf) < 2 {
+		return fmt.Errorf("node header buffer too small: %d bytes", len(headerBuf))
+	}
+	binary.BigEndian.PutUint16(headerBuf[:2], uint16(len(n.key)))
 	if _, err := w.Write(headerBuf[:2]); err != nil {
 		return err
 	}

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -290,7 +290,7 @@ func (btw *BtIndexWriter) Build() error {
 		if err = btw.writer.padTo(btEFAlign); err != nil {
 			return fmt.Errorf("[index] pad before ef: %w", err)
 		}
-		efOffset := uint64(btw.writer.written)
+		efOffset := btw.writer.written
 
 		btw.ef.Build()
 		if err = btw.ef.Write(btw.writer); err != nil {
@@ -475,6 +475,7 @@ func BuildBtreeIndexWithDecompressor(indexPath string, existenceFilterPath strin
 func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Reader) (bt *BtIndex, err error) {
 	idx := &BtIndex{
 		filePath: indexPath,
+		indexM:   M,
 	}
 
 	var validationPassed bool

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -200,7 +200,7 @@ type BtIndexWriterArgs struct {
 	TmpDir    string
 	M         uint64
 	KeyCount  uint64
-	MaxOffset uint64 // any upper bound on key offsets is fine (e.g. data file size)
+	MaxOffset uint64 // must be >= the largest offset passed to AddKey; an over-estimate (e.g. data file size) is fine
 	Lvl       log.Lvl
 }
 

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -18,9 +18,9 @@ package btindex
 
 import (
 	"bufio"
-	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -28,16 +28,15 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/edsrzf/mmap-go"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/background"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/murmur3"
 	"github.com/erigontech/erigon/db/datastruct/existence"
-	"github.com/erigontech/erigon/db/etl"
 	"github.com/erigontech/erigon/db/recsplit/eliasfano32"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
@@ -50,6 +49,14 @@ const BtreeLogPrefix = "btree"
 var DefaultBtreeM = uint64(dbg.EnvInt("BT_M", 256))
 
 const DefaultBtreeStartSkip = uint64(4) // defines smallest shard available for scan instead of binsearch
+
+const (
+	// btFirstByteLegacy (0x00) is the released legacy layout's first byte (the EF count's MSB).
+	btFirstByteLegacy = byte(0x00)
+	// btFirstByteUseFooter is the (non-zero) first byte of footer-based files; it lets the reader fall
+	// back to the legacy layout from the first byte. The format version lives in the footer, not here.
+	btFirstByteUseFooter = byte(0x01)
+)
 
 // BtInterp enables interpolation search in the leaf window, falling back to binary after BtInterpBudget probes.
 var BtInterp = dbg.EnvBool("BT_INTERP", true)
@@ -171,18 +178,16 @@ func (c *Cursor) readKV() error {
 }
 
 type BtIndexWriter struct {
-	maxOffset  uint64
-	prevOffset uint64
-	indexF     *os.File
-	ef         *eliasfano32.EliasFano
-	collector  *etl.Collector
+	indexF    *os.File
+	writer    *countingWriter
+	ef        *eliasfano32.EliasFano
+	efBuilder *eliasfano32.OffHeapBuilder
 
 	args BtIndexWriterArgs
 
 	indexFileName string
 
-	numBuf      [8]byte
-	keysWritten uint64
+	nodeHeaderBuf [2]byte
 
 	built   bool
 	lvl     log.Lvl
@@ -191,10 +196,11 @@ type BtIndexWriter struct {
 }
 
 type BtIndexWriterArgs struct {
-	IndexFile string // File name where the index and the minimal perfect hash function will be written to
+	IndexFile string
 	TmpDir    string
 	M         uint64
-	KeyCount  int
+	KeyCount  uint64
+	MaxOffset uint64 // any upper bound on key offsets is fine (e.g. data file size)
 	Lvl       log.Lvl
 }
 
@@ -202,48 +208,66 @@ type BtIndexWriterArgs struct {
 // Typical bucket size is 100 - 2048, larger bucket sizes result in smaller representations of hash functions, at a cost of slower access
 // salt parameters is used to randomise the hash function construction, to ensure that different Erigon instances (nodes)
 // are likely to use different hash function, to collision attacks are unlikely to slow down any meaningful number of nodes at the same time
-func NewBtIndexWriter(args BtIndexWriterArgs, logger log.Logger) (*BtIndexWriter, error) {
+func NewBtIndexWriter(args BtIndexWriterArgs, logger log.Logger) (_ *BtIndexWriter, err error) {
 	if args.Lvl == 0 {
 		args.Lvl = log.LvlTrace
 	}
 
 	btw := &BtIndexWriter{lvl: args.Lvl, logger: logger, args: args}
+	defer func() {
+		if err != nil {
+			btw.Close()
+		}
+	}()
 
 	_, fname := filepath.Split(btw.args.IndexFile)
 	btw.indexFileName = fname
 
-	btw.collector = etl.NewCollectorWithAllocator(BtreeLogPrefix+" "+fname, btw.args.TmpDir, etl.SmallSortableBuffers, logger)
-	btw.collector.SortAndFlushInBackground(false)
-	btw.collector.LogLvl(btw.args.Lvl)
+	if btw.indexF, err = dir.CreateTemp(args.IndexFile); err != nil {
+		return nil, fmt.Errorf("create temp index file for %s: %w", args.IndexFile, err)
+	}
+	btw.writer = &countingWriter{w: getBufioWriter(btw.indexF)}
+
+	if args.KeyCount > 0 {
+		if args.M == 0 {
+			return nil, fmt.Errorf("[index] %s: M must be > 0", btw.indexFileName)
+		}
+		if btw.efBuilder, err = eliasfano32.NewEliasFanoOffHeap(args.KeyCount, args.MaxOffset, args.TmpDir); err != nil {
+			return nil, fmt.Errorf("[index] create offheap ef: %w", err)
+		}
+		btw.ef = btw.efBuilder.EliasFano
+
+		if _, err = btw.writer.Write([]byte{btFirstByteUseFooter}); err != nil {
+			return nil, fmt.Errorf("[index] write format byte: %w", err)
+		}
+	}
 
 	return btw, nil
 }
 
-func (btw *BtIndexWriter) AddKey(key []byte, offset uint64, keep bool) error {
+func (btw *BtIndexWriter) AddKey(key []byte, offset uint64) error {
 	if btw.built {
 		return errors.New("cannot add keys after perfect hash function had been built")
 	}
-
-	binary.BigEndian.PutUint64(btw.numBuf[:], offset)
-	if offset > btw.maxOffset {
-		btw.maxOffset = offset
+	if btw.ef == nil {
+		return fmt.Errorf("[index] %s: AddKey called with KeyCount==0", btw.indexFileName)
 	}
-
-	keepKey := keep
-	if btw.keysWritten > 0 {
-		keepKey = btw.keysWritten%btw.args.M == 0
+	di := btw.ef.AddedCount()
+	if di >= btw.args.KeyCount {
+		return fmt.Errorf("[index] %s: AddKey beyond KeyCount=%d", btw.indexFileName, btw.args.KeyCount)
 	}
-
-	var k []byte
-	if keepKey {
-		k = key
+	if offset > btw.args.MaxOffset { // EF is pre-sized for [0, MaxOffset]; a larger offset would write out of bounds
+		return fmt.Errorf("[index] %s: offset %d exceeds MaxOffset %d", btw.indexFileName, offset, btw.args.MaxOffset)
 	}
+	btw.ef.AddOffset(offset)
 
-	if err := btw.collector.Collect(btw.numBuf[:], k); err != nil {
+	// every M-th key (di==0 included) is kept as a B-tree node
+	if di%btw.args.M != 0 {
+		return nil
+	}
+	if err := (Node{key: key}).Encode(btw.writer, btw.nodeHeaderBuf[:]); err != nil {
 		return err
 	}
-	btw.keysWritten++
-	btw.prevOffset = offset
 	return nil
 }
 
@@ -253,62 +277,52 @@ func (btw *BtIndexWriter) Build() error {
 	if btw.built {
 		return errors.New("already built")
 	}
-	var err error
-	if btw.indexF, err = dir.CreateTemp(btw.args.IndexFile); err != nil {
-		return fmt.Errorf("create temp index file for %s: %w", btw.args.IndexFile, err)
+	defer btw.closeTemps()
+	if btw.args.KeyCount > 0 && btw.ef.AddedCount() != btw.args.KeyCount {
+		return fmt.Errorf("[index] %s: KeyCount=%d but %d keys added", btw.indexFileName, btw.args.KeyCount, btw.ef.AddedCount())
 	}
-	defer btw.indexF.Close()
-	indexW := bufio.NewWriterSize(btw.indexF, etl.BufIOSize)
 
-	defer btw.collector.Close()
 	log.Log(btw.args.Lvl, "[index] calculating", "file", btw.indexFileName)
 
-	if btw.keysWritten > 0 {
-		efBuilder, err := eliasfano32.NewEliasFanoOffHeap(btw.keysWritten, btw.maxOffset, btw.args.TmpDir)
-		if err != nil {
-			return fmt.Errorf("[index] create offheap ef: %w", err)
+	var err error
+	if btw.args.KeyCount > 0 {
+		// nodes were streamed straight into the index file during AddKey
+		if err = btw.writer.padTo(btEFAlign); err != nil {
+			return fmt.Errorf("[index] pad before ef: %w", err)
 		}
-		defer efBuilder.Close()
-		btw.ef = efBuilder.EliasFano
+		efOffset := uint64(btw.writer.written)
 
-		nodes := make([]Node, 0, btw.keysWritten/btw.args.M)
-		var ki uint64
-		if err = btw.collector.Load(nil, "", func(offt, k []byte, _ etl.CurrentTableReader, _ etl.LoadNextFunc) error {
-			btw.ef.AddOffset(binary.BigEndian.Uint64(offt))
-
-			if len(k) > 0 { // for every M-th key, keep the key
-				nodes = append(nodes, Node{key: common.Copy(k), di: ki})
-			}
-			ki++ // we need to keep key ordinal so count every key
-			return nil
-		}, etl.TransformArgs{}); err != nil {
-			return err
-		}
 		btw.ef.Build()
-
-		if err := btw.ef.Write(indexW); err != nil {
+		if err = btw.ef.Write(btw.writer); err != nil {
 			return fmt.Errorf("[index] write ef: %w", err)
 		}
-		if err = encodeListNodes(nodes, indexW); err != nil {
-			return fmt.Errorf("[index] write nodes: %w", err)
+		if err = btw.writer.padTo(btFooterAlign); err != nil {
+			return fmt.Errorf("[index] pad before footer: %w", err)
+		}
+
+		footer := Footer{Meta: Metadata{KeysCount: btw.args.KeyCount, M: btw.args.M, EfOffset: efOffset}, FormatVersion: btVersion}
+		if err = footer.Encode(btw.writer); err != nil {
+			return fmt.Errorf("[index] write footer: %w", err)
 		}
 	}
 
 	btw.logger.Log(btw.args.Lvl, "[index] write", "file", btw.indexFileName)
 	btw.built = true
 
-	if err = indexW.Flush(); err != nil {
+	if err = btw.writer.Flush(); err != nil {
 		return err
 	}
 	if err = btw.fsync(); err != nil {
 		return err
 	}
+	tmpName := btw.indexF.Name()
 	if err = btw.indexF.Close(); err != nil {
 		return err
 	}
-	if err = os.Rename(btw.indexF.Name(), btw.args.IndexFile); err != nil {
+	if err = os.Rename(tmpName, btw.args.IndexFile); err != nil {
 		return err
 	}
+	btw.indexF = nil
 	return nil
 }
 
@@ -328,16 +342,26 @@ func (btw *BtIndexWriter) fsync() error {
 	return nil
 }
 
+func (btw *BtIndexWriter) closeTemps() {
+	if btw.efBuilder != nil {
+		btw.efBuilder.Close()
+		btw.efBuilder = nil
+		btw.ef = nil
+	}
+}
+
 func (btw *BtIndexWriter) Close() {
-	if btw.indexF != nil {
+	if btw.writer != nil {
+		putBufioWriter(btw.writer.w)
+		btw.writer = nil
+	}
+	if btw.indexF != nil { // non-nil means Build didn't rename it: drop the partial .tmp
+		name := btw.indexF.Name()
 		btw.indexF.Close()
+		_ = dir.RemoveFile(name)
+		btw.indexF = nil
 	}
-	if btw.collector != nil {
-		btw.collector.Close()
-	}
-	//if btw.offsetCollector != nil {
-	//	btw.offsetCollector.Close()
-	//}
+	btw.closeTemps()
 }
 
 type BtIndex struct {
@@ -349,6 +373,7 @@ type BtIndex struct {
 	size     int64
 	modTime  time.Time
 	filePath string
+	indexM   uint64
 	pool     sync.Pool
 }
 
@@ -404,6 +429,8 @@ func BuildBtreeIndexWithDecompressor(indexPath string, existenceFilterPath strin
 		IndexFile: indexPath,
 		TmpDir:    tmpdir,
 		M:         DefaultBtreeM,
+		KeyCount:  uint64(kv.Count() / 2),
+		MaxOffset: uint64(kv.Size()),
 	}
 
 	iw, err := NewBtIndexWriter(args, logger)
@@ -417,16 +444,9 @@ func BuildBtreeIndexWithDecompressor(indexPath string, existenceFilterPath strin
 	key := make([]byte, 0, 64)
 	var pos uint64
 
-	var b0 [256]bool
 	for kv.HasNext() {
 		key, _ = kv.Next(key[:0])
-		keep := false
-		if !b0[key[0]] {
-			b0[key[0]] = true
-			keep = true
-		}
-		err = iw.AddKey(key, pos, keep)
-		if err != nil {
+		if err = iw.AddKey(key, pos); err != nil {
 			return err
 		}
 		hi, _ := murmur3.Sum128WithSeed(key, salt)
@@ -452,7 +472,6 @@ func BuildBtreeIndexWithDecompressor(indexPath string, existenceFilterPath strin
 	return nil
 }
 
-// For now, M is not stored inside index file.
 func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Reader) (bt *BtIndex, err error) {
 	idx := &BtIndex{
 		filePath: indexPath,
@@ -492,31 +511,63 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 	}
 	idx.data = idx.m[:idx.size]
 
-	var pos int
-	if len(idx.data[pos:]) == 0 {
-		return idx, nil
+	var nodes []Node
+	switch idx.data[0] {
+	case btFirstByteLegacy: // legacy [EF][nodesCount][di-nodes]
+		var pos int
+		idx.ef, pos = eliasfano32.ReadEliasFano(idx.data)
+		if len(idx.data[pos:]) > 0 {
+			nodes, _, err = decodeListNodesV0(idx.data[pos:])
+			if err != nil {
+				return nil, err
+			}
+		}
+	case btFirstByteUseFooter: // footer-based layout: [leadingByte][nodes][EF][footer][anchor]
+		var footer Footer
+		var footerStart int
+		if footer, footerStart, err = ReadFooter(idx.data); err != nil {
+			return nil, fmt.Errorf("btindex: %s: %w", indexPath, err)
+		}
+		if footer.FormatVersion != btVersion {
+			return nil, fmt.Errorf("btindex: %s: unsupported format version %d (want %d): upgrade Erigon", indexPath, footer.FormatVersion, btVersion)
+		}
+		M = footer.Meta.M
+		if M == 0 || footer.Meta.EfOffset >= uint64(footerStart) {
+			return nil, fmt.Errorf("btindex: corrupt footer in %s (M=%d ef_offset=%d body=%d)", indexPath, M, footer.Meta.EfOffset, footerStart)
+		}
+		// ceil(K/M) overflow-safe: (K+M-1)/M overflows when K≈MaxUint64; use (K-1)/M+1 for K>0.
+		var nodesCount uint64
+		if footer.Meta.KeysCount > 0 {
+			nodesCount = (footer.Meta.KeysCount-1)/M + 1
+		}
+		var nodesEnd int
+		if nodes, nodesEnd, err = decodeNodes(idx.data[1:], nodesCount, M); err != nil {
+			return nil, err
+		}
+		if footer.Meta.EfOffset != uint64(alignUp(1+nodesEnd, btEFAlign)) { // cross-check ef_offset against the decoded nodes
+			return nil, fmt.Errorf("btindex: corrupt footer in %s: ef_offset=%d but nodes end at %d", indexPath, footer.Meta.EfOffset, alignUp(1+nodesEnd, btEFAlign))
+		}
+		idx.ef, _ = eliasfano32.ReadEliasFano(idx.data[footer.Meta.EfOffset:])
+		if idx.ef.Count() != footer.Meta.KeysCount {
+			return nil, fmt.Errorf("btindex: corrupt file %s: ef has %d keys, footer says %d", indexPath, idx.ef.Count(), footer.Meta.KeysCount)
+		}
+	default:
+		return nil, fmt.Errorf("btindex: %s: unknown format byte %#x", indexPath, idx.data[0])
 	}
 
-	idx.ef, pos = eliasfano32.ReadEliasFano(idx.data[pos:])
-	idx.pool = sync.Pool{}
+	idx.indexM = M
 	idx.pool.New = func() any {
 		return &Cursor{ef: idx.ef, returnInto: &idx.pool}
 	}
 
 	defer kvGetter.MadvNormal().DisableReadAhead()
 
-	if len(idx.data[pos:]) == 0 {
+	if len(nodes) == 0 {
 		idx.bplus = NewBpsTree(kvGetter, idx.ef, M, idx.dataLookup)
-		idx.bplus.cursorGetter = idx.newCursor
-		// fallback for files without nodes encoded
 	} else {
-		nodes, err := decodeListNodes(idx.data[pos:])
-		if err != nil {
-			return nil, err
-		}
 		idx.bplus = NewBpsTreeWithNodes(kvGetter, idx.ef, M, idx.dataLookup, nodes)
-		idx.bplus.cursorGetter = idx.newCursor
 	}
+	idx.bplus.cursorGetter = idx.newCursor
 
 	validationPassed = true
 	return idx, nil
@@ -567,6 +618,8 @@ func (b *BtIndex) ModTime() time.Time { return b.modTime }
 func (b *BtIndex) FilePath() string { return b.filePath }
 
 func (b *BtIndex) FileName() string { return path.Base(b.filePath) }
+
+func (b *BtIndex) M() uint64 { return b.indexM }
 
 func (b *BtIndex) Empty() bool { return b == nil || b.ef == nil || b.ef.Count() == 0 }
 
@@ -660,3 +713,19 @@ func (b *BtIndex) OrdinalLookup(getter *seg.Reader, i uint64) *Cursor {
 
 func (b *BtIndex) Offsets() *eliasfano32.EliasFano { return b.bplus.Offsets() }
 func (b *BtIndex) Distances() (map[int]int, error) { return b.bplus.Distances() }
+
+// Erigon doesn't create tons of bufio readers/writers, but it has tons of
+// parallel small unit-tests which each create many small files and bufio
+// readers/writers — pooling avoids the allocation pressure in that scenario.
+var bufioWriterPool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, int(512*datasize.KB)) }}
+
+func getBufioWriter(w io.Writer) *bufio.Writer {
+	bw := bufioWriterPool.Get().(*bufio.Writer)
+	bw.Reset(w)
+	return bw
+}
+
+// Reset(nil) before Put is required: without it the pool entry retains a
+// reference to the underlying io.Writer/io.Reader, keeping it alive until the
+// next GC cycle or until the entry is reused — whichever comes first.
+func putBufioWriter(w *bufio.Writer) { w.Reset(nil); bufioWriterPool.Put(w) }

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -527,6 +527,9 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 		var footer Footer
 		var footerStart int
 		if footer, footerStart, err = ReadFooter(idx.data); err != nil {
+			if errors.Is(err, errNotFooterFormat) {
+				return nil, fmt.Errorf("btindex: %s: truncated or corrupt footer (missing trailing magic)", indexPath)
+			}
 			return nil, fmt.Errorf("btindex: %s: %w", indexPath, err)
 		}
 		if footer.FormatVersion != btVersion {

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -614,6 +614,7 @@ func TestBtIndex_MStoredInFile(t *testing.T) {
 	indexPath := strings.TrimSuffix(kvPath, ".kv") + "_m8.bt"
 	iw, err := NewBtIndexWriter(BtIndexWriterArgs{IndexFile: indexPath, TmpDir: tmp, M: wantM, KeyCount: uint64(decomp.Count() / 2), MaxOffset: uint64(decomp.Size())}, logger)
 	require.NoError(t, err)
+	defer iw.Close()
 
 	r := seg.NewReader(decomp.MakeGetter(), seg.CompressNone)
 	r.Reset(0)

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -18,7 +18,10 @@ package btindex
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -184,6 +187,194 @@ func Test_BtreeIndex_Build(t *testing.T) {
 		require.Equal(t, keys[i], c.Key())
 		c.Close()
 	}
+}
+
+// writeV0Index writes a legacy v0-format .bt over dataPath: [EF][nodeCount(8)][di(8)+keyLen(2)+key per node],
+// nodes kept at di = 0, M, 2M, ... The writer no longer emits v0, so this reproduces the released layout to
+// keep the v0 read path (decodeListNodesV0 + EF-first detection) covered.
+func writeV0Index(tb testing.TB, dataPath, indexPath string, compressed seg.FileCompression, m uint64) {
+	tb.Helper()
+	decomp, err := seg.NewDecompressor(dataPath)
+	require.NoError(tb, err)
+	defer decomp.Close()
+
+	r := seg.NewReader(decomp.MakeGetter(), compressed)
+	r.Reset(0)
+	count := uint64(r.Count() / 2)
+
+	f, err := os.Create(indexPath)
+	require.NoError(tb, err)
+	defer f.Close()
+	w := getBufioWriter(f)
+	defer putBufioWriter(w)
+
+	if count > 0 {
+		ef := eliasfano32.NewEliasFano(count, uint64(r.Size()))
+		var nodes []Node
+		var key []byte
+		var pos, di uint64
+		for r.HasNext() {
+			key, _ = r.Next(key[:0])
+			ef.AddOffset(pos)
+			if di%m == 0 {
+				nodes = append(nodes, Node{key: common.Copy(key), di: di})
+			}
+			di++
+			pos, _ = r.Skip()
+		}
+		ef.Build()
+		require.NoError(tb, ef.Write(w))
+
+		var hdr [10]byte
+		binary.BigEndian.PutUint64(hdr[:8], uint64(len(nodes)))
+		_, err = w.Write(hdr[:8])
+		require.NoError(tb, err)
+		for i := range nodes {
+			binary.BigEndian.PutUint64(hdr[:8], nodes[i].di)
+			binary.BigEndian.PutUint16(hdr[8:10], uint16(len(nodes[i].key)))
+			_, err = w.Write(hdr[:10])
+			require.NoError(tb, err)
+			_, err = w.Write(nodes[i].key)
+			require.NoError(tb, err)
+		}
+	}
+	require.NoError(tb, w.Flush())
+}
+
+func Test_BtreeIndex_V0_V2_Read(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	logger := log.New()
+	const M = uint64(32)
+	keyCount := 500
+	compressFlags := seg.CompressKeys | seg.CompressVals
+
+	dataPath := generateKV(t, tmp, 52, 180, keyCount, logger, compressFlags)
+	keys, err := pivotKeysFromKV(dataPath)
+	require.NoError(t, err)
+
+	v2Path := filepath.Join(tmp, "v2.bt")
+	buildBtreeIndex(t, dataPath, v2Path, compressFlags, 1, logger, true)
+
+	v0Path := filepath.Join(tmp, "v0.bt")
+	writeV0Index(t, dataPath, v0Path, compressFlags, M)
+
+	for _, tc := range []struct{ name, path string }{{"v0", v0Path}, {"v2", v2Path}} {
+		t.Run(tc.name, func(t *testing.T) {
+			kv, bt, err := OpenBtreeIndexAndDataFile(tc.path, dataPath, M, compressFlags, false)
+			require.NoError(t, err)
+			defer bt.Close()
+			defer kv.Close()
+			require.EqualValues(t, keyCount, bt.KeyCount())
+
+			getter := seg.NewReader(kv.MakeGetter(), compressFlags)
+			c, err := bt.Seek(getter, nil)
+			require.NoError(t, err)
+			for i := range keys {
+				require.Equalf(t, keys[i], c.Key(), "%s forward scan i=%d", tc.name, i)
+				c.Next()
+			}
+			c.Close()
+			for i := range keys {
+				cur, err := bt.Seek(getter, keys[i])
+				require.NoErrorf(t, err, "%s i=%d", tc.name, i)
+				require.Equalf(t, keys[i], cur.Key(), "%s seek i=%d", tc.name, i)
+				cur.Close()
+			}
+		})
+	}
+}
+
+func TestFooter_EncodeDecodeRoundTrip(t *testing.T) {
+	f := Footer{
+		Meta:          Metadata{KeysCount: 12345, M: 256, EfOffset: 1 << 33}, // EfOffset > 4GiB: must be uint64
+		FormatVersion: btVersion,
+	}
+	var buf bytes.Buffer
+	require.NoError(t, f.Encode(&buf))
+	require.Equal(t, btMetadataLen+btAnchorLen, buf.Len())
+
+	got, footerStart, err := ReadFooter(buf.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, 0, footerStart) // no body in this isolated buffer
+	require.Equal(t, f.Meta.KeysCount, got.Meta.KeysCount)
+	require.Equal(t, f.Meta.M, got.Meta.M)
+	require.Equal(t, f.Meta.EfOffset, got.Meta.EfOffset)
+	require.Equal(t, f.FormatVersion, got.FormatVersion)
+
+	// missing/wrong magic -> legacy fallback signal, not a hard error
+	_, _, err = ReadFooter(bytes.Repeat([]byte{0xAB}, btMetadataLen+btAnchorLen))
+	require.ErrorIs(t, err, errNotFooterFormat)
+	_, _, err = ReadFooter([]byte{0x00})
+	require.ErrorIs(t, err, errNotFooterFormat)
+}
+
+func TestFooter_ZeroKeyCount(t *testing.T) {
+	// A footer-format file with KeysCount=0 must not panic (overflow guard).
+	// The file is well-formed structurally but has no EF data, so Open must
+	// return an error rather than silently succeed with a corrupt index.
+	tmp := t.TempDir()
+
+	// Build a minimal footer-format binary with KeysCount=0:
+	//   [0x01][4095 zeros][64 zeros as fake EF region][footer][anchor]
+	// EfOffset=4096, footerStart=4160: satisfies EfOffset < footerStart.
+	var body bytes.Buffer
+	body.WriteByte(btFirstByteUseFooter)
+	body.Write(make([]byte, 4095)) // pad to EfOffset=4096
+	body.Write(make([]byte, 64))   // fake EF bytes at offset 4096
+	// 4096+64=4160, already 8-byte aligned → footerStart=4160
+	footer := Footer{
+		Meta:          Metadata{KeysCount: 0, M: 256, EfOffset: 4096},
+		FormatVersion: btVersion,
+	}
+	require.NoError(t, footer.Encode(&body))
+
+	indexPath := filepath.Join(tmp, "zero_keys.bt")
+	require.NoError(t, os.WriteFile(indexPath, body.Bytes(), 0644))
+
+	// Use a 1-key KV as the reader — it won't be consulted because Open will
+	// fail before building the BpsTree.
+	dataPath := generateKV(t, tmp, 8, 8, 1, log.New(), seg.CompressNone)
+	_, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, 256, seg.CompressNone, false)
+	if err == nil {
+		defer bt.Close()
+		require.True(t, bt.Empty())
+	}
+	// error is acceptable; what is not acceptable is a panic
+}
+
+func Test_BtreeIndex_V2_EfOffset(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	logger := log.New()
+	keyCount := 5000
+	compressFlags := seg.CompressKeys | seg.CompressVals
+	dataPath := generateKV(t, tmp, 52, 180, keyCount, logger, compressFlags)
+
+	v2Path := filepath.Join(tmp, "v2.bt")
+	buildBtreeIndex(t, dataPath, v2Path, compressFlags, 1, logger, true)
+
+	data, err := os.ReadFile(v2Path)
+	require.NoError(t, err)
+	require.EqualValues(t, btFirstByteUseFooter, data[0], "v2 must start with a non-zero leading byte (no conflict with v0's 0x00)")
+	footer, footerStart, err := ReadFooter(data)
+	require.NoError(t, err)
+	require.EqualValues(t, keyCount, footer.Meta.KeysCount)
+	require.EqualValues(t, DefaultBtreeM, footer.Meta.M)
+
+	require.Zero(t, footer.Meta.EfOffset%btEFAlign, "EF must start 4kb-aligned")
+	require.Positive(t, footer.Meta.EfOffset)
+	require.Less(t, int(footer.Meta.EfOffset), footerStart)
+
+	// EfOffset must point at a valid EF holding all keys...
+	ef, _ := eliasfano32.ReadEliasFano(data[footer.Meta.EfOffset:])
+	require.EqualValues(t, keyCount, ef.Count())
+
+	// ...and equal the position the reader would otherwise derive from the nodes section (which starts after the leading byte).
+	nodesCount := (footer.Meta.KeysCount + footer.Meta.M - 1) / footer.Meta.M
+	_, nodesEnd, err := decodeNodes(data[1:], nodesCount, footer.Meta.M)
+	require.NoError(t, err)
+	require.EqualValues(t, alignUp(1+nodesEnd, btEFAlign), footer.Meta.EfOffset)
 }
 
 // Opens .kv at dataPath and generates index over it to file 'indexPath'
@@ -408,6 +599,40 @@ func TestNewBtIndex(t *testing.T) {
 	}
 }
 
+func TestBtIndex_MStoredInFile(t *testing.T) {
+	t.Parallel()
+
+	const wantM = uint64(8)
+	tmp := t.TempDir()
+	logger := log.New()
+	kvPath := generateKV(t, tmp, 20, 10, 1000, logger, seg.CompressNone)
+
+	decomp, err := seg.NewDecompressor(kvPath)
+	require.NoError(t, err)
+	defer decomp.Close()
+
+	indexPath := strings.TrimSuffix(kvPath, ".kv") + "_m8.bt"
+	iw, err := NewBtIndexWriter(BtIndexWriterArgs{IndexFile: indexPath, TmpDir: tmp, M: wantM, KeyCount: uint64(decomp.Count() / 2), MaxOffset: uint64(decomp.Size())}, logger)
+	require.NoError(t, err)
+
+	r := seg.NewReader(decomp.MakeGetter(), seg.CompressNone)
+	r.Reset(0)
+	var pos uint64
+	for r.HasNext() {
+		key, _ := r.Next(nil)
+		require.NoError(t, iw.AddKey(key, pos))
+		pos, _ = r.Skip()
+	}
+	iw.DisableFsync()
+	require.NoError(t, iw.Build())
+
+	r2 := seg.NewReader(decomp.MakeGetter(), seg.CompressNone)
+	bt, err := OpenBtreeIndexWithDecompressor(indexPath, 1, r2) // pass wrong M — file M should win
+	require.NoError(t, err)
+	defer bt.Close()
+	require.Equal(t, wantM, bt.M())
+}
+
 func BenchmarkBtIndex_Get(b *testing.B) {
 	keyCount := 1_000_000
 	if testing.Short() {
@@ -445,4 +670,40 @@ func BenchmarkBtIndex_Get(b *testing.B) {
 			}
 		})
 	}
+}
+
+func TestDecodeNodes(t *testing.T) {
+	const M = 256
+	for _, keys := range [][][]byte{
+		nil,
+		{[]byte("a")},
+		{[]byte("a"), []byte("bcd"), bytes.Repeat([]byte{0xff}, 300)},
+	} {
+		var buf bytes.Buffer
+		var hdr [2]byte
+		for _, k := range keys {
+			binary.BigEndian.PutUint16(hdr[:], uint16(len(k)))
+			buf.Write(hdr[:])
+			buf.Write(k)
+		}
+		got, n, err := decodeNodes(buf.Bytes(), uint64(len(keys)), M)
+		require.NoError(t, err)
+		require.Equal(t, buf.Len(), n)
+		require.Len(t, got, len(keys))
+		for i := range keys {
+			require.Equal(t, uint64(i)*M, got[i].di) // di recomputed, not stored
+			require.True(t, bytes.Equal(keys[i], got[i].key))
+		}
+	}
+}
+
+func TestNodeEncode_NoAlloc(t *testing.T) {
+	node := Node{di: 42, key: []byte("some-key")}
+	var headerBuf [10]byte
+	allocs := testing.AllocsPerRun(1000, func() {
+		if err := node.Encode(io.Discard, headerBuf[:]); err != nil {
+			t.Fatal(err)
+		}
+	})
+	require.Zero(t, allocs)
 }

--- a/db/datastruct/btindex/footer.go
+++ b/db/datastruct/btindex/footer.go
@@ -1,0 +1,141 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package btindex
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// btFooterMagic is the file's trailing 8 bytes: it identifies the format and proves the file isn't truncated.
+var btFooterMagic = binary.BigEndian.Uint64([]byte("erigon\x00\x00"))
+
+const (
+	// btVersion is the bt format version (v1), stored in the footer anchor next to the magic so the layout can change later.
+	btVersion = uint16(1)
+
+	btMetadataLen = 24 // keys_count(8) + M(8) + ef_offset(8)
+	btAnchorLen   = 16 // footer_len(4) + flags(2) + format_version(2) + magic(8)
+
+	btEFAlign     = 4096 // EF section starts page-aligned for mmap/SIMD-friendly unsafe reads (nodes are byte-parsed, so left unaligned)
+	btFooterAlign = 8
+)
+
+var errNotFooterFormat = errors.New("btindex: not a footer-format file")
+
+// Metadata is the footer payload: what a reader needs that the body doesn't already carry.
+type Metadata struct {
+	KeysCount uint64
+	M         uint64
+	EfOffset  uint64 // byte offset of the EF section, so a reader can locate it without decoding nodes
+}
+
+// Footer store metadata at `Footer`: wins at write-once by append-only use-cases.
+// Store metadata at `Header`: wins at forward-stream consumers (sockets, tar to tape), mutable
+// page-addressed files (SQLite, Postgres, InnoDB — when mutate/extend file Footer will change its offset).
+//
+// `Footer` style file (for example `.bt`):
+//
+//	[ body ] # variable length. 4kb-alignment
+//	[ footer: keys_count | M | ef_offset ] # variable length. 8-bytes-alignment
+//	[ ANCHOR: footer_len:u32 | flags:u16 | format_version:u16 | magic:u64 ] # Fixed length. 8-bytes-alignment
+//
+// Build such files will be much more streaming-style-friendly. Don't need `etl` all incoming keys
+// only to calculate `keys_count` (like we do now in `.bt`).
+//
+// On file open:
+//   - Validate the `magic` first (right format + not truncated) -> fail-fast. Not u16 - because
+//     probability of collision is high.
+//   - `format_version` is next to the `magic` - then it will allow change ANCHOR format/len in the future.
+type Footer struct {
+	Meta          Metadata
+	Flags         uint16
+	FormatVersion uint16
+}
+
+// Encode writes the footer payload followed by the fixed anchor. The caller must
+// have already padded so the footer starts 8-byte aligned.
+func (f Footer) Encode(w io.Writer) error {
+	var buf [btMetadataLen + btAnchorLen]byte
+	binary.BigEndian.PutUint64(buf[0:8], f.Meta.KeysCount)
+	binary.BigEndian.PutUint64(buf[8:16], f.Meta.M)
+	binary.BigEndian.PutUint64(buf[16:24], f.Meta.EfOffset)
+	binary.BigEndian.PutUint32(buf[24:28], uint32(btMetadataLen))
+	binary.BigEndian.PutUint16(buf[28:30], f.Flags)
+	binary.BigEndian.PutUint16(buf[30:32], f.FormatVersion)
+	binary.BigEndian.PutUint64(buf[32:40], btFooterMagic)
+	_, err := w.Write(buf[:])
+	return err
+}
+
+// ReadFooter parses the footer from the end of data. It returns errNotFooterFormat when the
+// trailing magic is absent (e.g. a legacy file), so the caller can fall back to legacy dispatch.
+// footerStart is the byte offset where the footer begins (i.e. where the body ends).
+func ReadFooter(data []byte) (f Footer, footerStart int, err error) {
+	if len(data) < btAnchorLen {
+		return Footer{}, 0, errNotFooterFormat
+	}
+	anchor := data[len(data)-btAnchorLen:]
+	if binary.BigEndian.Uint64(anchor[8:16]) != btFooterMagic {
+		return Footer{}, 0, errNotFooterFormat
+	}
+	footerLen := int(binary.BigEndian.Uint32(anchor[0:4]))
+	footerStart = len(data) - btAnchorLen - footerLen
+	if footerStart < 0 || footerLen < btMetadataLen {
+		return Footer{}, 0, fmt.Errorf("btindex: corrupt footer (footer_len=%d, file=%d)", footerLen, len(data))
+	}
+	payload := data[footerStart : len(data)-btAnchorLen]
+	return Footer{
+		Meta: Metadata{
+			KeysCount: binary.BigEndian.Uint64(payload[0:8]),
+			M:         binary.BigEndian.Uint64(payload[8:16]),
+			EfOffset:  binary.BigEndian.Uint64(payload[16:24]),
+		},
+		Flags:         binary.BigEndian.Uint16(anchor[4:6]),
+		FormatVersion: binary.BigEndian.Uint16(anchor[6:8]),
+	}, footerStart, nil
+}
+
+func alignUp(n, a int) int { return (n + a - 1) &^ (a - 1) }
+
+var alignPad [btEFAlign]byte
+
+// countingWriter tracks the byte offset so sections can be padded to alignment.
+type countingWriter struct {
+	w       *bufio.Writer
+	written int
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.written += n
+	return n, err
+}
+
+func (c *countingWriter) Flush() error { return c.w.Flush() }
+
+func (c *countingWriter) padTo(align int) error {
+	pad := alignUp(c.written, align) - c.written
+	if pad == 0 {
+		return nil
+	}
+	_, err := c.Write(alignPad[:pad])
+	return err
+}

--- a/db/datastruct/btindex/footer.go
+++ b/db/datastruct/btindex/footer.go
@@ -113,26 +113,26 @@ func ReadFooter(data []byte) (f Footer, footerStart int, err error) {
 	}, footerStart, nil
 }
 
-func alignUp(n, a int) int { return (n + a - 1) &^ (a - 1) }
+func alignUp[T ~int | ~uint64](n, a T) T { return (n + a - 1) &^ (a - 1) }
 
 var alignPad [btEFAlign]byte
 
 // countingWriter tracks the byte offset so sections can be padded to alignment.
 type countingWriter struct {
 	w       *bufio.Writer
-	written int
+	written uint64
 }
 
 func (c *countingWriter) Write(p []byte) (int, error) {
 	n, err := c.w.Write(p)
-	c.written += n
+	c.written += uint64(n)
 	return n, err
 }
 
 func (c *countingWriter) Flush() error { return c.w.Flush() }
 
 func (c *countingWriter) padTo(align int) error {
-	pad := alignUp(c.written, align) - c.written
+	pad := alignUp(c.written, uint64(align)) - c.written
 	if pad == 0 {
 		return nil
 	}

--- a/db/datastruct/btindex/footer.go
+++ b/db/datastruct/btindex/footer.go
@@ -132,7 +132,7 @@ func (c *countingWriter) Write(p []byte) (int, error) {
 func (c *countingWriter) Flush() error { return c.w.Flush() }
 
 func (c *countingWriter) padTo(align int) error {
-	pad := alignUp(c.written, uint64(align)) - c.written
+	pad := int(alignUp(c.written, uint64(align)) - c.written)
 	if pad == 0 {
 		return nil
 	}

--- a/db/recsplit/eliasfano32/elias_fano.go
+++ b/db/recsplit/eliasfano32/elias_fano.go
@@ -515,6 +515,11 @@ func (ef *EliasFano) Count() uint64 {
 	return ef.count + 1
 }
 
+// AddedCount is the number of AddOffset calls so far (build-time position).
+func (ef *EliasFano) AddedCount() uint64 {
+	return ef.i
+}
+
 func (ef *EliasFano) Iterator() *EliasFanoIter {
 	it := &EliasFanoIter{
 		ef:            ef,

--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -5,7 +5,7 @@ package statecfg
 import "github.com/erigontech/erigon/db/version"
 
 func InitSchemasGen() {
-	Schema.AccountsDomain.FileVersion.AccessorBT = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
+	Schema.AccountsDomain.FileVersion.AccessorBT = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.AccountsDomain.FileVersion.DataKV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.AccountsDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.AccountsDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
@@ -14,7 +14,7 @@ func InitSchemasGen() {
 	Schema.AccountsDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.BodiesBlock.FileVersion.AccessorIdx = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.BodiesBlock.FileVersion.DataSeg = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
-	Schema.CodeDomain.FileVersion.AccessorBT = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
+	Schema.CodeDomain.FileVersion.AccessorBT = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.CodeDomain.FileVersion.DataKV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.CodeDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
@@ -39,14 +39,14 @@ func InitSchemasGen() {
 	Schema.RCacheDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.RCacheDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.RCacheDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.ReceiptDomain.FileVersion.AccessorBT = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
+	Schema.ReceiptDomain.FileVersion.AccessorBT = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.ReceiptDomain.FileVersion.DataKV = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.ReceiptDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 3}, version.Version{1, 0}}
 	Schema.ReceiptDomain.Hist.FileVersion.DataV = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.ReceiptDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.ReceiptDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.ReceiptDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
-	Schema.StorageDomain.FileVersion.AccessorBT = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
+	Schema.StorageDomain.FileVersion.AccessorBT = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.StorageDomain.FileVersion.DataKV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.StorageDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.StorageDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -1,7 +1,7 @@
 accounts:
     domain:
         bt:
-            current: v1.2
+            current: v2.0
             min: v1.0
         kv:
             current: v2.0
@@ -34,7 +34,7 @@ bodies:
 code:
     domain:
         bt:
-            current: v1.2
+            current: v2.0
             min: v1.0
         kv:
             current: v2.0
@@ -127,7 +127,7 @@ rcache:
 receipt:
     domain:
         bt:
-            current: v1.3
+            current: v2.0
             min: v1.0
         kv:
             current: v3.0
@@ -152,7 +152,7 @@ receipt:
 storage:
     domain:
         bt:
-            current: v1.2
+            current: v2.0
             min: v1.0
         kv:
             current: v2.0

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -1,7 +1,7 @@
 accounts:
     domain:
         bt:
-            current: v1.1
+            current: v1.2
             min: v1.0
         kv:
             current: v2.0
@@ -34,7 +34,7 @@ bodies:
 code:
     domain:
         bt:
-            current: v1.1
+            current: v1.2
             min: v1.0
         kv:
             current: v2.0
@@ -127,7 +127,7 @@ rcache:
 receipt:
     domain:
         bt:
-            current: v1.2
+            current: v1.3
             min: v1.0
         kv:
             current: v3.0
@@ -152,7 +152,7 @@ receipt:
 storage:
     domain:
         bt:
-            current: v1.1
+            current: v1.2
             min: v1.0
         kv:
             current: v2.0


### PR DESCRIPTION
based on: https://github.com/erigontech/erigon/pull/21777

- `.bt` file format change
- backwards compatible

In PR:
- reduce .Build() RAM usage by building `ef_offsets` eagerly off-heap and streaming `nodes` straight to the file (no big in-mem structs)
- Add `M` inside file metadata
- Removed `di` from file (node `i` has `di = i*M`, recomputed on read)
- metadata stored in `Footer` of file
- only the `EF` section is 4kb-aligned (for mmap/SIMD-friendly reads); `nodes` are byte-parsed, so left unaligned; footer is 8-byte aligned
- completely removed `ETL` usage: because now `AddKey()` can write directly to file, also `Footer` written at the end (when all required fields calculated).
- but keep 1 leading byte - just for legacy format detection

----- 
I realized that for building `.bt` we don't really need ETL (keys already always sorted, keys_count we know from decompressor, etc...). And I realized more - maybe other places in Erigon also can be more streaming-friendly (can build without ETL - in 1-pass).

To generalize idea we need move "header metadata" to "footer" - then if metadata storing `keys_count` we can write it at the end: 

- Store metadata at `Footer`: wins at write-once by append-only use-cases. 
- Store metadata at `Header`: wins at forward-stream consumers (sockets, tar to tape), mutable page-addressed files (SQLite, Postgres, InnoDB — when mutate/extend file Footer will change its offset).

`Footer` style file `.bt`:
```
[ leading_byte:u8 ]                                                      # 1 byte: legacy-format detection
[ nodes: (key_len:u16 | key)* ]                                          # variable length. unaligned (byte-parsed)
[ EF: elias-fano of all key offsets ]                                    # variable length. 4kb-aligned
[ footer: keys_count:u64 | M:u64 | ef_offset:u64 ]                       # 24 bytes. 8-byte-aligned
[ ANCHOR: footer_len:u32 | flags:u16 | format_version:u16 | magic:u64 ]  # 16 bytes. Fixed length
```

Build such files will be much more streaming-style-friendly. Don't need `etl` all incoming keys only to calculate `keys_count` (like we do now in `.bt`).

On file open:
- Validate the `magic` first (right format + not truncated) -> fail-fast. Not u16 - because probability of collision is high.
- `format_version` is next to the `magic` - then it will allow change ANCHOR format/len in the future.

(yes, exactly in our case: EF inside .bt requires to know key_count in advance - but we already have it - and maybe in future we can change it). 

Also `Footer` allowing easy to add `checksum` to metadata fields in future, etc...
