### PR TITLE
docs: accept `archive` mode in update-disk-sizes.py (for snapshotter-sourced sizes)

### DIFF
--- a/docs/site/scripts/test_update_disk_sizes.py
+++ b/docs/site/scripts/test_update_disk_sizes.py
@@ -147,6 +147,47 @@ class ArtifactParsingTests(unittest.TestCase):
             self.assertEqual(result["networks"]["gnosis"]["minimal"]["display"], "234.57 GB")
             self.assertEqual(result["networks"]["gnosis"]["minimal"]["source"], "ci")
 
+    def test_mainnet_archive_artifact(self):
+        """Test parsing disk-usage-mainnet-archive.txt (archive mode accepted)"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifacts_dir = Path(tmpdir) / "artifacts"
+            artifacts_dir.mkdir()
+
+            # Create artifact file
+            artifact = artifacts_dir / "disk-usage-mainnet-archive.txt"
+            artifact.write_text("2025696615783")
+
+            # Create initial JSON
+            json_path = Path(tmpdir) / "disk-sizes.json"
+            initial_data = {
+                "networks": {
+                    "mainnet": {
+                        "archive": {"bytes": 0, "display": "0 MB", "measured_at": "2025-01-01", "source": "manual"}
+                    }
+                }
+            }
+            json_path.write_text(json.dumps(initial_data, indent=2))
+
+            # Run the main logic
+            import sys
+            old_argv = sys.argv
+            try:
+                sys.argv = ["update-disk-sizes.py", str(artifacts_dir), str(json_path), "archive"]
+                u.main()
+            except SystemExit:
+                pass
+            finally:
+                sys.argv = old_argv
+
+            # Verify JSON was updated
+            with open(json_path) as f:
+                result = json.load(f)
+
+            self.assertEqual(result["networks"]["mainnet"]["archive"]["bytes"], 2025696615783)
+            self.assertEqual(result["networks"]["mainnet"]["archive"]["display"], "2.03 TB")
+            self.assertEqual(result["networks"]["mainnet"]["archive"]["source"], "ci")
+            self.assertIn("ci_last_updated", result)
+
     def test_unknown_chain_skipped(self):
         """Test that unknown chains are skipped without error"""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/site/scripts/update-disk-sizes.py
+++ b/docs/site/scripts/update-disk-sizes.py
@@ -11,7 +11,7 @@ Usage:
 Arguments:
     artifacts-dir  Directory containing disk-usage-<chain>-<mode>.txt files
     json-path      Path to disk-sizes.json
-    prune-mode     'full' or 'minimal'
+    prune-mode     'full', 'minimal', or 'archive'
 """
 import json
 import sys
@@ -37,8 +37,8 @@ def main() -> None:
     json_path = Path(sys.argv[2])
     prune_mode = sys.argv[3]
 
-    if prune_mode not in ("full", "minimal"):
-        print(f"Error: prune-mode must be 'full' or 'minimal', got {prune_mode!r}")
+    if prune_mode not in ("full", "minimal", "archive"):
+        print(f"Error: prune-mode must be 'full', 'minimal', or 'archive', got {prune_mode!r}")
         sys.exit(1)
 
     today = date.today().isoformat()


### PR DESCRIPTION
Mirrors the still-applicable part of the closed #21580 onto `release/3.5`, reframed around the team decision (2026-06-16) to **source ARCHIVE datadir sizes from our always-on snapshotter machines** rather than from a CI sync-from-scratch run.

### Why snapshotters for archive
A mainnet archive datadir is ~2 TB; syncing one from scratch in CI is impractically slow/expensive, which is why archive sizes have always been stale "manual" values. The snapshotter machines already run archive nodes continuously to produce the `.seg` snapshot files, so their datadir size *is* the current, authoritative archive size.

### What this PR does
`update-disk-sizes.py` currently accepts only `full`/`minimal`. This adds **`archive`** as a valid prune mode (validation + docstring), so a `disk-usage-<chain>-archive.txt` artifact — produced from a snapshotter measurement — can flow into `disk-sizes.json` through the same tooling as full/minimal. Includes a CI-enforced unit test (`test_mainnet_archive_artifact`); `python3 -m unittest discover docs/site/scripts` passes (42 tests).

### Remaining work to fully realize the snapshotter model
- **Source tag:** the script hardcodes `source: "ci"`. Archive entries must be tagged `source: "snapshotter"` so the weekly docs-maintenance staleness check (which alarms on `source: ci` entries older than 14 days as "sync CI may be failing") doesn't misfire on snapshotter-cadence data.
- A small snapshotter-side step that emits the `disk-usage-<chain>-archive.txt` and invokes this script (or dispatches the pipeline consumer in #21782).

### Why only this slice of #21580
The rest of #21580 (node-type→mode mapping, `du -sB1`, dropping the transient `temp/`) lived in the sync-workflow measurement steps, which `release/3.5` has since **refactored out** (`qa-sync-from-scratch.yml` is now RPC-integration tests; no workflow emits `disk-usage-*.txt`). A full port isn't faithful — and under the snapshotter decision the archive measurement no longer belongs in those CI workflows at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
