### PR TITLE
db/state/statecfg: bump commitment domain kv/kvi to v2.1

### DIFF
--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -21,8 +21,8 @@ func InitSchemasGen() {
 	Schema.CodeDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.CommitmentDomain.FileVersion.AccessorKVI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
+	Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
+	Schema.CommitmentDomain.FileVersion.AccessorKVI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.CommitmentDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.CommitmentDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.CommitmentDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -59,10 +59,10 @@ code:
 commitment:
     domain:
         kv:
-            current: v2.0
+            current: v2.1
             min: v1.0
         kvi:
-            current: v2.0
+            current: v2.1
             min: v1.0
     hist:
         v:


### PR DESCRIPTION
Cherry-pick of the version bump from #21375.

Erigon panics on startup when it encounters `v2.1-commitment.*.kv` files produced by #21375, because main's schema ceiling was still v2.0.