### PR TITLE
merge: less ram usage in .bt build and compression

### DIFF
--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -147,14 +147,18 @@ type Node struct {
 }
 
 func encodeListNodes(nodes []Node, w io.Writer) error {
-	numBuf := make([]byte, 8)
-	binary.BigEndian.PutUint64(numBuf, uint64(len(nodes)))
-	if _, err := w.Write(numBuf); err != nil {
+	var hdr [10]byte
+	binary.BigEndian.PutUint64(hdr[:8], uint64(len(nodes)))
+	if _, err := w.Write(hdr[:8]); err != nil {
 		return err
 	}
-
-	for ni := 0; ni < len(nodes); ni++ {
-		if _, err := w.Write(nodes[ni].Encode()); err != nil {
+	for i := range nodes {
+		binary.BigEndian.PutUint64(hdr[:8], nodes[i].di)
+		binary.BigEndian.PutUint16(hdr[8:], uint16(len(nodes[i].key)))
+		if _, err := w.Write(hdr[:]); err != nil {
+			return err
+		}
+		if _, err := w.Write(nodes[i].key); err != nil {
 			return err
 		}
 	}
@@ -173,14 +177,6 @@ func decodeListNodes(data []byte) ([]Node, error) {
 		pos += int(dp)
 	}
 	return nodes, nil
-}
-
-func (n Node) Encode() []byte {
-	buf := make([]byte, 8+2+len(n.key))
-	binary.BigEndian.PutUint64(buf[:8], n.di)
-	binary.BigEndian.PutUint16(buf[8:10], uint16(len(n.key)))
-	copy(buf[10:], n.key)
-	return buf
 }
 
 func (n *Node) Decode(buf []byte) (uint64, error) {

--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -147,15 +147,15 @@ type Node struct {
 }
 
 func encodeListNodes(nodes []Node, w io.Writer) error {
-	var hdr [10]byte
-	binary.BigEndian.PutUint64(hdr[:8], uint64(len(nodes)))
-	if _, err := w.Write(hdr[:8]); err != nil {
+	var header [10]byte
+	binary.BigEndian.PutUint64(header[:8], uint64(len(nodes)))
+	if _, err := w.Write(header[:8]); err != nil {
 		return err
 	}
 	for i := range nodes {
-		binary.BigEndian.PutUint64(hdr[:8], nodes[i].di)
-		binary.BigEndian.PutUint16(hdr[8:], uint16(len(nodes[i].key)))
-		if _, err := w.Write(hdr[:]); err != nil {
+		binary.BigEndian.PutUint64(header[:8], nodes[i].di)
+		binary.BigEndian.PutUint16(header[8:], uint16(len(nodes[i].key)))
+		if _, err := w.Write(header[:]); err != nil {
 			return err
 		}
 		if _, err := w.Write(nodes[i].key); err != nil {

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -215,7 +215,7 @@ func NewBtIndexWriter(args BtIndexWriterArgs, logger log.Logger) (*BtIndexWriter
 	_, fname := filepath.Split(btw.args.IndexFile)
 	btw.indexFileName = fname
 
-	btw.collector = etl.NewCollectorWithAllocator(BtreeLogPrefix+" "+fname, btw.args.TmpDir, etl.LargeSortableBuffers, logger)
+	btw.collector = etl.NewCollectorWithAllocator(BtreeLogPrefix+" "+fname, btw.args.TmpDir, etl.SmallSortableBuffers, logger)
 	btw.collector.SortAndFlushInBackground(false)
 	btw.collector.LogLvl(btw.args.Lvl)
 

--- a/db/seg/parallel_compress.go
+++ b/db/seg/parallel_compress.go
@@ -1034,7 +1034,7 @@ func extractPatternsInSuperstrings(ctx context.Context, superstringCh chan []byt
 
 func DictionaryBuilderFromCollectors(ctx context.Context, cfg Cfg, logPrefix, tmpDir string, collectors []*etl.Collector, lvl log.Lvl, logger log.Logger) (*DictionaryBuilder, error) {
 	t := time.Now()
-	dictCollector := etl.NewCollectorWithAllocator(logPrefix+"_collectDict", tmpDir, etl.LargeSortableBuffers, logger)
+	dictCollector := etl.NewCollectorWithAllocator(logPrefix+"_collectDict", tmpDir, etl.SmallSortableBuffers, logger)
 	defer dictCollector.Close()
 	dictCollector.SortAndFlushInBackground(false)
 	dictCollector.LogLvl(lvl)


### PR DESCRIPTION
for https://github.com/erigontech/erigon/issues/20638

- smaller etl limit (and more widely used `pool`)
- reduce amount of allocs in .bt build