### PR TITLE
rpc: eth_baseFee and eth_blobBaseFee return null for pre-fork chains

### DIFF
--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -258,6 +258,7 @@ The following table shows the current implementation status of Erigon's RPC daem
 | eth_gasPrice                               | Yes     |                                                       |
 | eth_maxPriorityFeePerGas                   | Yes     |                                                       |
 | eth_feeHistory                             | Yes     |                                                       |
+| eth_baseFee                                | Yes     |                                                       |
 | eth_blobBaseFee                            | Yes     |                                                       |
 | eth_config                                 | Yes     | EIP-7910                                              |
 | eth_capabilities                           | Yes     | execution-apis#755                                    |

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -109,6 +109,8 @@ type EthAPI interface {
 	ChainId(ctx context.Context) (hexutil.Uint64, error) /* called eth_protocolVersion elsewhere */
 	ProtocolVersion(_ context.Context) (hexutil.Uint, error)
 	GasPrice(_ context.Context) (*hexutil.Big, error)
+	BaseFee(ctx context.Context) (*hexutil.Big, error)
+	BlobBaseFee(ctx context.Context) (*hexutil.Big, error)
 	Config(ctx context.Context, timeArg *hexutil.Uint64) (*EthConfigResp, error)
 	Capabilities(ctx context.Context) (*CapabilitiesResult, error)
 

--- a/rpc/jsonrpc/eth_system.go
+++ b/rpc/jsonrpc/eth_system.go
@@ -364,14 +364,14 @@ func (api *APIImpl) BlobBaseFee(ctx context.Context) (*hexutil.Big, error) {
 	defer tx.Rollback()
 	header := rawdb.ReadCurrentHeader(tx)
 	if header == nil || header.ExcessBlobGas == nil {
-		return (*hexutil.Big)(common.Big0), nil
+		return nil, nil
 	}
 	config, err := api.BaseAPI.chainConfig(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
 	if config == nil {
-		return (*hexutil.Big)(common.Big0), nil
+		return nil, nil
 	}
 	nextBlockTime := header.Time + config.SecondsPerSlot()
 	ret256, err := misc.GetBlobGasPrice(config, *header.ExcessBlobGas, nextBlockTime)
@@ -391,17 +391,14 @@ func (api *APIImpl) BaseFee(ctx context.Context) (*hexutil.Big, error) {
 	defer tx.Rollback()
 	header := rawdb.ReadCurrentHeader(tx)
 	if header == nil {
-		return (*hexutil.Big)(common.Big0), nil
+		return nil, nil
 	}
 	config, err := api.BaseAPI.chainConfig(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
-	if config == nil {
-		return (*hexutil.Big)(common.Big0), nil
-	}
-	if !config.IsLondon(header.Number.Uint64() + 1) {
-		return (*hexutil.Big)(common.Big0), nil
+	if config == nil || !config.IsLondon(header.Number.Uint64()+1) {
+		return nil, nil
 	}
 	baseFee := misc.CalcBaseFee(config, header)
 	return (*hexutil.Big)(baseFee.ToBig()), nil

--- a/rpc/jsonrpc/eth_system_test.go
+++ b/rpc/jsonrpc/eth_system_test.go
@@ -589,6 +589,67 @@ func TestEthConfig(t *testing.T) {
 	}
 }
 
+func TestBaseFee(t *testing.T) {
+	t.Parallel()
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	t.Run("pre-London returns nil", func(t *testing.T) {
+		t.Parallel()
+		m := execmoduletester.New(t, execmoduletester.WithGenesisSpec(&types.Genesis{
+			Config: chain.TestChainBerlinConfig,
+			Alloc:  types.GenesisAlloc{addr: {Balance: big.NewInt(math.MaxInt64)}},
+		}), execmoduletester.WithKey(key))
+		api := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
+		result, err := api.BaseFee(context.Background())
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("post-London returns fee", func(t *testing.T) {
+		t.Parallel()
+		m := execmoduletester.New(t, execmoduletester.WithGenesisSpec(&types.Genesis{
+			Config: chain.TestChainOsakaConfig,
+			Alloc:  types.GenesisAlloc{addr: {Balance: big.NewInt(math.MaxInt64)}},
+		}), execmoduletester.WithKey(key))
+		api := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
+		result, err := api.BaseFee(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Positive(t, result.ToInt().Sign())
+	})
+}
+
+func TestBlobBaseFee(t *testing.T) {
+	t.Parallel()
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	t.Run("pre-Cancun returns nil", func(t *testing.T) {
+		t.Parallel()
+		m := execmoduletester.New(t, execmoduletester.WithGenesisSpec(&types.Genesis{
+			Config: chain.TestChainBerlinConfig,
+			Alloc:  types.GenesisAlloc{addr: {Balance: big.NewInt(math.MaxInt64)}},
+		}), execmoduletester.WithKey(key))
+		api := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
+		result, err := api.BlobBaseFee(context.Background())
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("post-Cancun returns fee", func(t *testing.T) {
+		t.Parallel()
+		m := execmoduletester.New(t, execmoduletester.WithGenesisSpec(&types.Genesis{
+			Config: chain.TestChainOsakaConfig,
+			Alloc:  types.GenesisAlloc{addr: {Balance: big.NewInt(math.MaxInt64)}},
+		}), execmoduletester.WithKey(key))
+		api := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
+		result, err := api.BlobBaseFee(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+}
+
 func createGasPriceTestKV(t *testing.T, chainSize int) *execmoduletester.ExecModuleTester {
 	var (
 		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")


### PR DESCRIPTION
This PR makes:
* Align with Geth: return null instead of "0x0" when the relevant fork (London / Cancun) is not yet active at the current head.
* Also expose BaseFee and BlobBaseFee in the EthAPI interface, 
* add eth_baseFee to the README API table.