### PR TITLE
existence filter: build speedup

### DIFF
--- a/db/datastruct/fusefilter/fusefilter_writer.go
+++ b/db/datastruct/fusefilter/fusefilter_writer.go
@@ -17,10 +17,12 @@ import (
 	"github.com/edsrzf/mmap-go"
 )
 
+const bufSize = 4096
+
 // WriterOffHeap does write all keys to temporary mmap file - and using it as a source for `fusefilter` building
 type WriterOffHeap struct {
 	count    int
-	page     [4096]uint64
+	buf      [bufSize]uint64
 	features Features
 
 	tmpFile     *os.File
@@ -53,8 +55,8 @@ func (w *WriterOffHeap) Close() {
 
 func (w *WriterOffHeap) build() (*xorfilter.BinaryFuse[uint8], error) {
 	defer dir.RemoveFile(w.tmpFilePath)
-	if w.count%len(w.page) != 0 {
-		if _, err := w.tmpFile.Write(castToBytes(w.page[:w.count%len(w.page)])); err != nil {
+	if w.count%bufSize != 0 {
+		if _, err := w.tmpFile.Write(castToBytes(w.buf[:w.count%bufSize])); err != nil {
 			return nil, err
 		}
 	}
@@ -109,10 +111,10 @@ func writeFilter(features Features, filter *xorfilter.BinaryFuse[uint8], fw io.W
 }
 
 func (w *WriterOffHeap) AddHash(k uint64) error {
-	w.page[w.count%len(w.page)] = k
+	w.buf[w.count%bufSize] = k
 	w.count++
-	if w.count%len(w.page) == 0 {
-		_, err := w.tmpFile.Write(castToBytes(w.page[:]))
+	if w.count%bufSize == 0 {
+		_, err := w.tmpFile.Write(castToBytes(w.buf[:]))
 		if err != nil {
 			return err
 		}
@@ -247,8 +249,8 @@ func (w *WriterSharded) Build() error {
 func (w *WriterSharded) BuildTo(fw io.Writer) (int, error) {
 	defer dir.RemoveFile(w.tmpFilePath)
 
-	if rem := w.count % len(w.page); rem != 0 {
-		if _, err := w.tmpFile.Write(castToBytes(w.page[:rem])); err != nil {
+	if rem := w.count % bufSize; rem != 0 {
+		if _, err := w.tmpFile.Write(castToBytes(w.buf[:rem])); err != nil {
 			return 0, err
 		}
 	}

--- a/db/datastruct/fusefilter/fusefilter_writer.go
+++ b/db/datastruct/fusefilter/fusefilter_writer.go
@@ -20,7 +20,7 @@ import (
 // WriterOffHeap does write all keys to temporary mmap file - and using it as a source for `fusefilter` building
 type WriterOffHeap struct {
 	count    int
-	page     [512]uint64
+	page     [4096]uint64
 	features Features
 
 	tmpFile     *os.File


### PR DESCRIPTION
7% of .bt build spent in file writes - because too small buffer size:

<img width="1728" height="104" alt="Screenshot 2026-06-13 at 12 52 05" src="https://github.com/user-attachments/assets/8749ed4b-815d-404e-b04b-bcee1b26430d" />


```

  ┌────────────────────────┬───────┬─────────────────────┐
  │          size          │ bytes │ writes per 10M keys │
  ├────────────────────────┼───────┼─────────────────────┤
  │ [512]uint64 (old)      │ 4KB   │ ~19,500             │
  ├────────────────────────┼───────┼─────────────────────┤
  │ [4096]uint64 (current) │ 32KB  │ ~2,440              │
  ├────────────────────────┼───────┼─────────────────────┤
  │ [8192]uint64           │ 64KB  │ ~1,220              │
  └────────────────────────┴───────┴─────────────────────┘

```
