### PR TITLE
cl/sentinel: pass ctx through StartSentinelService → stickToPeers

### DIFF
--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -470,13 +470,16 @@ func (s *Sentinel) connectWithAllPeers(multiAddrs []multiaddr.Multiaddr) error {
 }
 
 func (s *Sentinel) stickToPeers(peers []multiaddr.Multiaddr) {
-	// connect to static peers every one minute
 	go func() {
 		for {
 			if err := s.connectWithAllPeers(peers); err != nil {
 				log.Debug("[Sentinel] Could not connect with static peers", "err", err)
 			}
-			time.Sleep(3 * time.Minute)
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-time.After(3 * time.Minute):
+			}
 		}
 	}()
 }

--- a/cl/sentinel/service/start.go
+++ b/cl/sentinel/service/start.go
@@ -48,6 +48,7 @@ type ServerConfig struct {
 }
 
 func createSentinel(
+	ctx context.Context,
 	cfg *sentinel.SentinelConfig,
 	blockReader freezeblocks.BeaconSnapshotReader,
 	blobStorage blob_storage.BlobStorage,
@@ -60,7 +61,7 @@ func createSentinel(
 	initialStatus *cltypes.Status,
 	logger log.Logger) (*sentinel.Sentinel, *enode.LocalNode, error) {
 	sent, err := sentinel.New(
-		context.Background(),
+		ctx,
 		cfg,
 		ethClock,
 		blockReader,
@@ -90,6 +91,7 @@ func createSentinel(
 }
 
 func StartSentinelService(
+	ctx context.Context,
 	cfg *sentinel.SentinelConfig,
 	blockReader freezeblocks.BeaconSnapshotReader,
 	blobStorage blob_storage.BlobStorage,
@@ -101,8 +103,8 @@ func StartSentinelService(
 	PeerDasStateReader peerdasstate.PeerDasStateReader,
 	p2p p2p.P2PManager,
 	logger log.Logger) (sentinelproto.SentinelClient, *enode.LocalNode, error) {
-	ctx := context.Background()
 	sent, localNode, err := createSentinel(
+		ctx,
 		cfg,
 		blockReader,
 		blobStorage,

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -409,7 +409,7 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	}
 	peerDasState := peerdasstate.NewPeerDasState(beaconConfig, networkConfig)
 	columnStorage := blob_storage.NewDataColumnStore(afero.NewBasePathFs(afero.NewOsFs(), dirs.CaplinColumnData), pruneBlobDistance, beaconConfig, ethClock, emitters)
-	sentinel, localNode, err := service.StartSentinelService(&sentinel.SentinelConfig{
+	sentinel, localNode, err := service.StartSentinelService(ctx, &sentinel.SentinelConfig{
 		P2PConfig: clp2p.P2PConfig{
 			IpAddr:             config.CaplinDiscoveryAddr,
 			Port:               int(config.CaplinDiscoveryPort),


### PR DESCRIPTION
`StartSentinelService` was creating its own `context.Background()`, so the sentinel goroutines had no way to receive shutdown signals.

This PR threads the caller's `ctx` all the way down:

- `StartSentinelService` gains a `ctx context.Context` first parameter
- `createSentinel` forwards it to `sentinel.New` (which stores it as `s.ctx`)
- `stickToPeers` replaces `time.Sleep(3 * time.Minute)` with a `select` on `s.ctx.Done()`, so the reconnect goroutine exits cleanly when the context is cancelled