### PR TITLE
bloatnet: StorageDomain move existence filter to mmap+madv_will_need

### DIFF
--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -219,7 +219,8 @@ var Schema = SchemaGen{
 		Name: kv.StorageDomain, ValuesTable: kv.TblStorageVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressKeys,
 
-		Accessors: AccessorBTree | AccessorExistence,
+		Accessors:       AccessorBTree | AccessorExistence,
+		ExistenceFilter: ExistenceFilterWillNeed,
 
 		Hist: HistCfg{
 			ValuesTable:   kv.TblStorageHistoryVals,


### PR DESCRIPTION
speed: `only Storage domain on mmap 33tx/s` > `All domains in mem 32tx/s` > `All domains on mmap 30tx/s`