### PR TITLE
[3.6] recsplit: enable ShardedFuse by default

### DIFF
--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -57,9 +57,9 @@ const MaxLeafSize = 24
 // ExistenceFilterVersion selects the existence-filter format written for new index files.
 //
 //	0 = byte-array of first-bytes (legacy, no FuseFilter)
-//	1 = BinaryFuse[uint8] — monolithic FuseFilter (current default)
-//	2 = BinaryFuse[uint8] sharded by keyHash>>56 (256 shards; reduces build-time RAM 256×)
-const ExistenceFilterVersion version.DataStructureVersion = 1
+//	1 = BinaryFuse[uint8] — monolithic FuseFilter
+//	2 = BinaryFuse[uint8] sharded by keyHash>>56 (256 shards; reduces build-time RAM 256×; current default)
+const ExistenceFilterVersion version.DataStructureVersion = 2
 
 func newExistenceFilterWriter(filePath string, v version.DataStructureVersion) (v1 *fusefilter.WriterOffHeap, v2 *fusefilter.WriterSharded, err error) {
 	if v == 2 {


### PR DESCRIPTION
## Summary

Re-enable the sharded FuseFilter existence-filter format by setting `ExistenceFilterVersion` back from `1` to `2` in `db/recsplit/recsplit.go`. This is the switch that #21164 turned off after #20644 introduced the format. New index files (`.kvi`/`.efi`) will again embed the sharded BinaryFuse filter (256 shards by `keyHash>>56`), which cuts existence-filter build-time RAM ~256× (the motivation was bloatnet 3B-key `.efi` builds).

## Why it's safe

- **Read path is version-aware.** `db/recsplit/index.go` reads the embedded `dataStructureVersion` per file and dispatches to v0/v1/v2 readers, so existing v1 files stay readable and new v2 files are read by the matching `case 2` path.
- **Accessor/existence files are built locally, not seeded.** `SeedableV3Extensions()` publishes only `.kv/.v/.ef/.ap`; `.kvi/.efi/.kvei` are rebuilt locally via `BuildMissedAccessors`, so this does not affect the shared snapshot set.

## Test plan
- [ ] CI green