### PR TITLE
db/datastruct/btindex: simplify interpolation search

### DIFF
--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -480,11 +480,14 @@ func commonPrefixLen(a, b []byte) int {
 	return n
 }
 
+// Left-aligned + zero-padded so the u64 keeps lexicographic key order across
+// differing key lengths, which interpolation relies on (klo <= key <= khi).
 func u64At(k []byte, p int) uint64 {
-	if p > len(k) {
-		return 0
+	var b [8]byte
+	if p < len(k) {
+		copy(b[:], k[p:])
 	}
-	return common.BytesToUint64(k[p:])
+	return binary.BigEndian.Uint64(b[:])
 }
 
 func (b *BpsTree) Offsets() *eliasfano32.EliasFano { return b.offt }

--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -369,29 +369,29 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 	// small window is handed to the linear scan below either way.
 	if BtInterp && len(klo) > 0 && len(khi) > 0 {
 		probes := uint64(0)
-		var kmBuf, kloBuf, khiBuf []byte
+		var kmBuf []byte
 		for l < r && r-l > DefaultBtreeStartSkip {
 			if probes >= BtInterpBudget {
-				m = (l + r) >> 1
-			} else {
-				m = interpMid(key, klo, khi, l, r)
+				break
 			}
+			m = interpMid(key, klo, khi, l, r)
 			probes++
-			g.Reset(b.offt.Get(m))
+			off := b.offt.Get(m)
+			g.Reset(off)
 			km, _ := g.Next(kmBuf[:0])
 			kmBuf = km
 			cmp = bytes.Compare(key, km)
 			if cmp == 0 {
 				v, _ = g.Next(nil)
-				return v, true, b.offt.Get(m), nil
+				return v, true, off, nil
 			} else if cmp < 0 {
 				r = m
-				khiBuf = append(khiBuf[:0], km...)
-				khi = khiBuf
+				khi = kmBuf
+				kmBuf = nil
 			} else {
 				l = m + 1
-				kloBuf = append(kloBuf[:0], km...)
-				klo = kloBuf
+				klo = kmBuf
+				kmBuf = nil
 			}
 		}
 	}
@@ -458,11 +458,6 @@ func interpMid(key, klo, khi []byte, l, r uint64) uint64 {
 		return (l + r) >> 1
 	}
 	f := float64(x-a) / float64(hi-a)
-	if f < 0 {
-		f = 0
-	} else if f > 1 {
-		f = 1
-	}
 	m := l + uint64(f*float64(r-1-l)+0.5)
 	if m < l {
 		m = l
@@ -486,11 +481,10 @@ func commonPrefixLen(a, b []byte) int {
 }
 
 func u64At(k []byte, p int) uint64 {
-	var buf [8]byte
-	for i := 0; i < 8 && p+i < len(k); i++ {
-		buf[i] = k[p+i]
+	if p > len(k) {
+		return 0
 	}
-	return binary.BigEndian.Uint64(buf[:])
+	return common.BytesToUint64(k[p:])
 }
 
 func (b *BpsTree) Offsets() *eliasfano32.EliasFano { return b.offt }

--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -483,11 +483,14 @@ func commonPrefixLen(a, b []byte) int {
 // Left-aligned + zero-padded so the u64 keeps lexicographic key order across
 // differing key lengths, which interpolation relies on (klo <= key <= khi).
 func u64At(k []byte, p int) uint64 {
-	var b [8]byte
-	if p < len(k) {
-		copy(b[:], k[p:])
+	if p+8 <= len(k) {
+		return binary.BigEndian.Uint64(k[p:])
 	}
-	return binary.BigEndian.Uint64(b[:])
+	var x uint64
+	for i := p; i < len(k); i++ {
+		x |= uint64(k[i]) << (56 - 8*uint(i-p))
+	}
+	return x
 }
 
 func (b *BpsTree) Offsets() *eliasfano32.EliasFano { return b.offt }

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -52,12 +52,7 @@ var DefaultBtreeM = uint64(dbg.EnvInt("BT_M", 256))
 
 const DefaultBtreeStartSkip = uint64(4) // defines smallest shard available for scan instead of binsearch
 
-// BtInterp selects interpolation search inside the leaf window instead of plain
-// binary search. Leaf keys are near-uniformly distributed, so interpolating on
-// the bytes after the bound keys' common prefix lands close to the target and
-// keeps probes spatially clustered -> far fewer distinct cold .kv page faults
-// than binary search's midpoint jumps (cold reads ~1.5-2.4x faster). After
-// BtInterpBudget probes it falls back to binary, bounding degenerate windows.
+// BtInterp enables interpolation search in the leaf window, falling back to binary after BtInterpBudget probes.
 var BtInterp = dbg.EnvBool("BT_INTERP", true)
 var BtInterpBudget = uint64(dbg.EnvInt("BT_INTERP_BUDGET", 8))
 


### PR DESCRIPTION
Simplification pass on #21794.

- `break` on `BtInterpBudget` exhaustion; the existing binary-search loop below already handles the remaining window, so the `m=(l+r)>>1` branch inside the interp loop was dead work.
- Donate `kmBuf` to `klo`/`khi` instead of `append`-copying into two separate `kloBuf`/`khiBuf` buffers. Since exactly one bound is updated per probe, one scratch buffer is enough; setting `kmBuf = nil` after donating lets the next `g.Next` allocate fresh without touching the donated slice.
- Cache `off := b.offt.Get(m)` before `g.Reset(off)` to avoid a second Elias-Fano lookup on key match.
- Remove the `f < 0 / f > 1` guards in `interpMid`: given `klo ≤ key ≤ khi` and `hi > a`, the fraction is always in `[0,1]`; the `m`-clamp at the end is the correct guard.
- `u64At`: delegate to `common.BytesToUint64(k[p:])` (already imported) instead of a manual loop + `[8]byte` buffer.
- Trim `BtInterp` var comment to one sentence per style guide.