### PR TITLE
[r3.4] caplin: serialize uint64 beacon API fields as JSON strings (#20564)

### DIFF
--- a/cl/beacon/handler/validators.go
+++ b/cl/beacon/handler/validators.go
@@ -874,9 +874,9 @@ type validatorIdentityResponse struct {
 		"activation_epoch": "1"
 	}
 	*/
-	Index           uint64         `json:"index"`
+	Index           uint64         `json:"index,string"`
 	Pubkey          common.Bytes48 `json:"pubkey"`
-	ActivationEpoch uint64         `json:"activation_epoch"`
+	ActivationEpoch uint64         `json:"activation_epoch,string"`
 }
 
 func (v *validatorIdentityResponse) EncodeSSZ(buf []byte) ([]byte, error) {

--- a/cl/beacon/handler/validators_test.go
+++ b/cl/beacon/handler/validators_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Per the beacon-APIs spec, Uint64 fields in ValidatorIdentityResponse must be
+// serialized as JSON strings. Regression test for erigon#20562.
+func TestValidatorIdentityResponseJSONUint64AsString(t *testing.T) {
+	v := &validatorIdentityResponse{Index: 1, ActivationEpoch: 1}
+	got, err := json.Marshal(v)
+	require.NoError(t, err)
+	require.Contains(t, string(got), `"index":"1"`)
+	require.Contains(t, string(got), `"activation_epoch":"1"`)
+}

--- a/cl/cltypes/solid/consolidation.go
+++ b/cl/cltypes/solid/consolidation.go
@@ -53,8 +53,8 @@ func (p *ConsolidationRequest) Static() bool {
 }
 
 type PendingConsolidation struct {
-	SourceIndex uint64 `json:"source_index"` // validator index
-	TargetIndex uint64 `json:"target_index"` // validator index
+	SourceIndex uint64 `json:"source_index,string"` // validator index
+	TargetIndex uint64 `json:"target_index,string"` // validator index
 }
 
 func (p *PendingConsolidation) EncodingSizeSSZ() int {

--- a/cl/cltypes/solid/consolidation_test.go
+++ b/cl/cltypes/solid/consolidation_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package solid
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Per the beacon-APIs spec, Uint64 fields must be serialized as JSON strings.
+// Regression test for erigon#20562.
+func TestPendingConsolidationJSONUint64AsString(t *testing.T) {
+	c := &PendingConsolidation{SourceIndex: 1, TargetIndex: 2}
+	got, err := json.Marshal(c)
+	require.NoError(t, err)
+	require.Contains(t, string(got), `"source_index":"1"`)
+	require.Contains(t, string(got), `"target_index":"2"`)
+}

--- a/cl/cltypes/solid/deposits.go
+++ b/cl/cltypes/solid/deposits.go
@@ -25,9 +25,9 @@ const (
 type DepositRequest struct {
 	PubKey                common.Bytes48 `json:"pubkey"` // BLS public key
 	WithdrawalCredentials common.Hash    `json:"withdrawal_credentials"`
-	Amount                uint64         `json:"amount"`    // Gwei
-	Signature             common.Bytes96 `json:"signature"` // BLS signature
-	Index                 uint64         `json:"index"`     // validator index
+	Amount                uint64         `json:"amount,string"` // Gwei
+	Signature             common.Bytes96 `json:"signature"`     // BLS signature
+	Index                 uint64         `json:"index,string"`  // validator index
 }
 
 func (p *DepositRequest) EncodingSizeSSZ() int {
@@ -57,9 +57,9 @@ func (p *DepositRequest) Static() bool {
 type PendingDeposit struct {
 	PubKey                common.Bytes48 `json:"pubkey"` // BLS public key
 	WithdrawalCredentials common.Hash    `json:"withdrawal_credentials"`
-	Amount                uint64         `json:"amount"`    // Gwei
-	Signature             common.Bytes96 `json:"signature"` // BLS signature
-	Slot                  uint64         `json:"slot"`
+	Amount                uint64         `json:"amount,string"` // Gwei
+	Signature             common.Bytes96 `json:"signature"`     // BLS signature
+	Slot                  uint64         `json:"slot,string"`
 }
 
 func (p *PendingDeposit) EncodingSizeSSZ() int {

--- a/cl/cltypes/solid/deposits_test.go
+++ b/cl/cltypes/solid/deposits_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package solid
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Per the beacon-APIs spec, Uint64 (and Gwei) fields must be serialized as
+// JSON strings. Regression test for erigon#20562.
+func TestDepositRequestJSONUint64AsString(t *testing.T) {
+	d := &DepositRequest{Amount: 32000000000, Index: 2457249}
+	got, err := json.Marshal(d)
+	require.NoError(t, err)
+	require.Contains(t, string(got), `"amount":"32000000000"`)
+	require.Contains(t, string(got), `"index":"2457249"`)
+}
+
+func TestPendingDepositJSONUint64AsString(t *testing.T) {
+	d := &PendingDeposit{Amount: 32000000000, Slot: 13605852}
+	got, err := json.Marshal(d)
+	require.NoError(t, err)
+	require.Contains(t, string(got), `"amount":"32000000000"`)
+	require.Contains(t, string(got), `"slot":"13605852"`)
+}

--- a/cl/cltypes/solid/withdrawal.go
+++ b/cl/cltypes/solid/withdrawal.go
@@ -25,7 +25,7 @@ const (
 type WithdrawalRequest struct {
 	SourceAddress   common.Address `json:"source_address"`
 	ValidatorPubKey common.Bytes48 `json:"validator_pubkey"` // BLS public key
-	Amount          uint64         `json:"amount"`           // Gwei
+	Amount          uint64         `json:"amount,string"`    // Gwei
 }
 
 func (p *WithdrawalRequest) EncodingSizeSSZ() int {
@@ -53,9 +53,9 @@ func (p *WithdrawalRequest) Static() bool {
 }
 
 type PendingPartialWithdrawal struct {
-	ValidatorIndex    uint64 `json:"validator_index"`    // validator index
-	Amount            uint64 `json:"amount"`             // Gwei
-	WithdrawableEpoch uint64 `json:"withdrawable_epoch"` // epoch when the withdrawal can be processed
+	ValidatorIndex    uint64 `json:"validator_index,string"`    // validator index
+	Amount            uint64 `json:"amount,string"`             // Gwei
+	WithdrawableEpoch uint64 `json:"withdrawable_epoch,string"` // epoch when the withdrawal can be processed
 }
 
 func (p *PendingPartialWithdrawal) EncodingSizeSSZ() int {

--- a/cl/cltypes/solid/withdrawal_test.go
+++ b/cl/cltypes/solid/withdrawal_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package solid
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Per the beacon-APIs spec, Uint64 (and Gwei) fields must be serialized as
+// JSON strings. Regression test for erigon#20562.
+func TestWithdrawalRequestJSONUint64AsString(t *testing.T) {
+	w := &WithdrawalRequest{Amount: 798102025}
+	got, err := json.Marshal(w)
+	require.NoError(t, err)
+	require.Contains(t, string(got), `"amount":"798102025"`)
+}
+
+func TestPendingPartialWithdrawalJSONUint64AsString(t *testing.T) {
+	w := &PendingPartialWithdrawal{
+		ValidatorIndex:    42,
+		Amount:            1000000000,
+		WithdrawableEpoch: 123456,
+	}
+	got, err := json.Marshal(w)
+	require.NoError(t, err)
+	require.Contains(t, string(got), `"validator_index":"42"`)
+	require.Contains(t, string(got), `"amount":"1000000000"`)
+	require.Contains(t, string(got), `"withdrawable_epoch":"123456"`)
+}


### PR DESCRIPTION
Cherry-pick of #20564 to `release/3.4`.

## Why
Per the [beacon-APIs spec](https://github.com/ethereum/beacon-APIs/blob/master/types/primitive.yaml), `Uint64`/`Gwei` fields must be serialized as JSON strings. Several Caplin response types were emitting them as JSON numbers, breaking spec-compliant clients. Fixes #20562.

## Adaptations
None — clean cherry-pick, no `release/3.4`-specific changes needed.

## Verification on release/3.4 + this patch
- `go build ./cl/...` — clean
- `go test ./cl/beacon/handler/... ./cl/cltypes/solid/...` — pass
- `go tool golangci-lint run ./cl/beacon/handler/... ./cl/cltypes/solid/...` — 0 issues
