### PR TITLE
ci: warm lint caches on main + skip golangci-lint cache save in merge queue

### DIFF
--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -12,9 +12,11 @@ name: Cache Warming
 # cache keys identical across both paths.
 #
 # Workflows that benefit from Go test result caching (tests, race-tests,
-# caplin) run their full test suites. Workflows where test result caching
-# is not possible or useful (bench, sonar, eest-spec) use
-# cache-warming-only: true to compile only, keeping those runs fast.
+# caplin) run their full test suites; lint likewise runs in full because
+# golangci-lint's analysis cache is only populated by running the linters,
+# not by compiling. Workflows where result caching is not possible or useful
+# (bench, sonar, eest-spec) use cache-warming-only: true to compile only,
+# keeping those runs fast.
 
 on:
   push:
@@ -36,6 +38,10 @@ jobs:
 
   caplin:
     uses: ./.github/workflows/test-integration-caplin.yml
+    secrets: inherit
+
+  lint:
+    uses: ./.github/workflows/lint.yml
     secrets: inherit
 
   bench:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,8 +75,10 @@ jobs:
       - uses: ./.github/actions/cleanup-erigon
         if: always()
 
+      # Skip in merge-queue runs: a cache saved on the ephemeral merge-queue
+      # ref can't be restored by any later run (matches cleanup-erigon).
       - name: Save golangci-lint cache
-        if: always()
+        if: ${{ always() && github.event_name != 'merge_group' }}
         uses: actions/cache/save@v5
         with:
           path: ~/.cache/golangci-lint


### PR DESCRIPTION
Completes the CI Go-cache work from #21711 and #21748. `lint` was the one Go-building gate job left cold, and profiling #21787's merge-queue run confirmed it: every cache-affected family dropped 17–43%, but lint stayed flat (−3.4%).

## Why lint was still cold

lint's heavy step is `make lintci` → golangci-lint, which type-checks and compiles the whole codebase to run its `go/analysis` linters — so it consumes the Go build/module caches like any test job, plus its own analysis-results cache (`~/.cache/golangci-lint`).

After #21711, lint's setup-erigon uses `cache-namespace: lint`, but **nothing populated those keys on main**: ci-gate has no `push` trigger and `cache-warming.yml` didn't call lint. By GitHub's cache scoping, merge-queue and first-PR lint runs can only restore from main, so they always cold-compiled and re-linted from scratch.

## Changes

- **cache-warming.yml**: add a `lint` job. Unlike bench/sonar/eest (compile-only warming), lint runs in full — golangci-lint's analysis cache is only populated by *running* the linters, not by compiling. This one job warms all three lint caches under main's scope: `gomodcache|lint`, `gocache|lint`, and the golangci-lint analysis cache. Side benefit: lint currently never runs on main, so this also adds a main-branch lint signal.
- **lint.yml**: gate the golangci-lint cache save on `github.event_name != 'merge_group'`. lint has two cache-save paths; the Go caches were already merge-queue-gated in #21748 via cleanup-erigon, and this brings the golangci-lint cache into line — a cache saved on the ephemeral merge-queue ref can't be restored by any later run.

## Cost / trade

One ~13-min `make lintci` per push to `main` / `release/**` / `performance` / `performance-stable` — same risk profile as the `tests` and `race-tests` full suites already in cache-warming. In exchange, merge-queue and first-PR lint runs should restore a warm build cache (cutting golangci-lint's package-load/compile phase) and the analysis cache (skipping re-lint of unchanged packages), moving lint into the same ~15–25% range as the other Go-building families.

CI-only change, no Go code touched, so TDD does not apply; validated with actionlint and zizmor (zero new findings vs HEAD) and `make lint`.
