### PR TITLE
db/datastruct/btindex: interpolation search without per-probe allocations

### DIFF
--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -369,7 +369,8 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 	// small window is handed to the linear scan below either way.
 	if BtInterp && len(klo) > 0 && len(khi) > 0 {
 		probes := uint64(0)
-		var kmBuf []byte
+		var kmArr, kloArr, khiArr [64]byte // stack; spills to heap only for keys > 64B
+		km := kmArr[:0]
 		for l < r && r-l > DefaultBtreeStartSkip {
 			if probes >= BtInterpBudget {
 				break
@@ -378,20 +379,17 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 			probes++
 			off := b.offt.Get(m)
 			g.Reset(off)
-			km, _ := g.Next(kmBuf[:0])
-			kmBuf = km
+			km, _ = g.Next(km[:0])
 			cmp = bytes.Compare(key, km)
 			if cmp == 0 {
 				v, _ = g.Next(nil)
 				return v, true, off, nil
 			} else if cmp < 0 {
 				r = m
-				khi = kmBuf
-				kmBuf = nil
+				khi = append(khiArr[:0], km...)
 			} else {
 				l = m + 1
-				klo = kmBuf
-				kmBuf = nil
+				klo = append(kloArr[:0], km...)
 			}
 		}
 	}


### PR DESCRIPTION
Stacked on #21794 — removes interpolation search's per-probe heap allocations.

#21794's interp loop materializes each probed key (`g.Next`) to update the `klo`/`khi` interpolation bounds → **~2 heap allocs/Get (59 B)**, vs **0** for binary search (which compares in place via `MatchCmp`). On warm / in-memory reads that's pure GC pressure with no upside.

**Fix:** back the probed-key and bound buffers with fixed-size **stack arrays** (`[64]B`; spills to heap only for keys > 64 B — no `.bt` domain has those: storage 52, accounts/code 20, commitment ≤39). Re-tightening is kept, so the probe sequence — and the cold-read locality the interpolation win depends on — is **byte-for-byte identical**.

`BenchmarkBtIndex_Get/M256`:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before (#21794) | 1063 | 59 | 2 |
| **after** | **671** | **0** | **0** |

It's *faster*, not just alloc-free — removing 2 heap allocs + their GC. Cold locality is preserved by construction (only buffer storage moved to the stack), and the lower ns/op confirms no extra probes.

Also evaluated dropping re-tightening + using `MatchCmp` (0-alloc too, no materialization) — but +42% ns/op from coarser estimates → more probes → would hurt cold locality. Discarded in favor of this.

Equivalence test (`TestInterpEquivBinary`) + `-race` green; `make lint` clean.
