### PR TITLE
db/datastruct/btindex: interpolation search in BTree leaf

### DIFF
--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -68,7 +68,7 @@ func NewBpsTreeWithNodes(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, 
 
 	nsz := uint64(unsafe.Sizeof(Node{}))
 	var cachedBytes uint64
-	for i := 0; i < len(nodes); i++ {
+	for i := range len(nodes) {
 		if envAssertBTKeys {
 			if cmp := bt.compareKey(kv, nodes[i].key, nodes[i].di); cmp != 0 {
 				panic(fmt.Errorf("key mismatch at di=%d i=%d cmp=%d", nodes[i].di, i, cmp))
@@ -166,7 +166,7 @@ func decodeListNodes(data []byte) ([]Node, error) {
 	count := binary.BigEndian.Uint64(data[:8])
 	nodes := make([]Node, count)
 	pos := 8
-	for ni := 0; ni < int(count); ni++ {
+	for ni := range int(count) {
 		dp, err := nodes[ni].Decode(data[pos:])
 		if err != nil {
 			return nil, fmt.Errorf("decode node %d: %w", ni, err)
@@ -226,8 +226,9 @@ func (b *BpsTree) WarmUp(kv *seg.Reader) error {
 	return nil
 }
 
-// bs performs pre-seach over warmed-up list of nodes to figure out left and right bounds on di for key
-func (b *BpsTree) bs(x []byte) (n *Node, dl, dr uint64) {
+// bs binary-searches the warmed-up pivot list for the [dl,dr) data-index window
+// of key, plus klo/khi: the pivot keys bounding it, used by interpolation search.
+func (b *BpsTree) bs(x []byte) (n *Node, dl, dr uint64, klo, khi []byte) {
 	dr = b.offt.Count()
 	m, l, r := 0, 0, len(b.mx) //nolint
 
@@ -240,19 +241,21 @@ func (b *BpsTree) bs(x []byte) (n *Node, dl, dr uint64) {
 		}
 		switch bytes.Compare(n.key, x) {
 		case 0:
-			return n, n.di, n.di
+			return n, n.di, n.di, n.key, n.key
 		case 1:
 			r = m
 			dr = n.di
+			khi = n.key
 		case -1:
 			l = m + 1
 			dl = n.di
 			if dl < dr {
 				dl++
 			}
+			klo = n.key
 		}
 	}
-	return n, dl, dr
+	return n, dl, dr, klo, khi
 }
 
 // Seek returns cursor pointing at first key which is >= seekKey.
@@ -271,7 +274,7 @@ func (b *BpsTree) Seek(g *seg.Reader, seekKey []byte) (cur *Cursor, err error) {
 	}
 
 	// check cached nodes and narrow roi
-	n, l, r := b.bs(seekKey) // l===r when key is found
+	n, l, r, _, _ := b.bs(seekKey) // l===r when key is found
 	if l == r {
 		cur.Reset(n.di, g)
 		return cur, nil
@@ -345,7 +348,7 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 		return v0, true, 0, nil
 	}
 
-	n, l, r := b.bs(key) // l===r when key is found
+	n, l, r, klo, khi := b.bs(key) // l===r when key is found
 	if b.trace {
 		fmt.Printf("pivot di: %d di(LR): [%d %d] k: %x found: %t\n", n.di, l, r, n.key, l == r)
 		defer func() { fmt.Printf("found %x [%d %d]\n", key, l, r) }()
@@ -353,6 +356,35 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 
 	var cmp int
 	var m uint64
+	// Interpolation search narrows the window with position estimates from the
+	// bound keys; after BtInterpBudget probes fall back to binary. The final
+	// small window is handed to the linear scan below either way.
+	if BtInterp && len(klo) > 0 && len(khi) > 0 {
+		probes := uint64(0)
+		var kmArr, kloArr, khiArr [64]byte // stack; spills to heap only for keys > 64B
+		km := kmArr[:0]
+		for l < r && r-l > DefaultBtreeStartSkip {
+			if probes >= BtInterpBudget {
+				break
+			}
+			m = interpMid(key, klo, khi, l, r)
+			probes++
+			off := b.offt.Get(m)
+			g.Reset(off)
+			km, _ = g.Next(km[:0])
+			cmp = bytes.Compare(key, km)
+			if cmp == 0 {
+				v, _ = g.Next(nil)
+				return v, true, off, nil
+			} else if cmp < 0 {
+				r = m
+				khi = append(khiArr[:0], km...)
+			} else {
+				l = m + 1
+				klo = append(kloArr[:0], km...)
+			}
+		}
+	}
 	for l < r {
 		m = (l + r) >> 1
 		if r-l <= DefaultBtreeStartSkip {
@@ -404,6 +436,49 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 	}
 	v, _ = g.Next(nil)
 	return v, true, b.offt.Get(l), nil
+}
+
+// interpMid estimates the index of searchKey within [l,r) by linear interpolation on
+// the first 8 key bytes after the common prefix of the bound keys. Falls back to
+// the binary midpoint when the span is degenerate; result is clamped to [l, r-1].
+func interpMid(searchKey, klo, khi []byte, l, r uint64) uint64 {
+	p := commonPrefixLen(klo, khi)
+	a, hi, x := u64At(klo, p), u64At(khi, p), u64At(searchKey, p)
+	if hi <= a {
+		return (l + r) >> 1
+	}
+	f := float64(x-a) / float64(hi-a)
+	m := l + uint64(f*float64(r-1-l)+0.5)
+	if m < l {
+		m = l
+	} else if m >= r {
+		m = r - 1
+	}
+	return m
+}
+
+func commonPrefixLen(a, b []byte) int {
+	n := len(a)
+	n = min(n, len(b))
+	for i := range n {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}
+
+// Left-aligned + zero-padded so the u64 keeps lexicographic key order across
+// differing key lengths, which interpolation relies on (klo <= key <= khi).
+func u64At(k []byte, p int) uint64 {
+	if p+8 <= len(k) {
+		return binary.BigEndian.Uint64(k[p:])
+	}
+	var x uint64
+	for i := p; i < len(k); i++ {
+		x |= uint64(k[i]) << (56 - 8*uint(i-p))
+	}
+	return x
 }
 
 func (b *BpsTree) Offsets() *eliasfano32.EliasFano { return b.offt }

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -53,6 +53,10 @@ var DefaultBtreeM = uint64(dbg.EnvInt("BT_M", 256))
 
 const DefaultBtreeStartSkip = uint64(4) // defines smallest shard available for scan instead of binsearch
 
+// BtInterp enables interpolation search in the leaf window, falling back to binary after BtInterpBudget probes.
+var BtInterp = dbg.EnvBool("BT_INTERP", true)
+var BtInterpBudget = uint64(dbg.EnvInt("BT_INTERP_BUDGET", 8))
+
 var ErrBtIndexLookupBounds = errors.New("BtIndex: lookup di bounds error")
 
 type Cursor struct {

--- a/db/datastruct/btindex/interp_search_test.go
+++ b/db/datastruct/btindex/interp_search_test.go
@@ -1,0 +1,64 @@
+package btindex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/seg"
+)
+
+// Interpolation search must return exactly what binary search returns for every
+// key: hits (value+offset) and misses. Checked across budgets, including pure
+// interpolation (large budget) and budget=0 (immediate binary fallback).
+func TestInterpEquivBinary(t *testing.T) {
+	saveInterp, saveBudget := BtInterp, BtInterpBudget
+	defer func() { BtInterp, BtInterpBudget = saveInterp, saveBudget }()
+
+	const keyCount = 50000
+	compress := seg.CompressKeys
+	kvPath := generateKV(t, t.TempDir(), 20, 10, keyCount, log.New(), compress)
+	indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
+	buildBtreeIndex(t, kvPath, indexPath, compress, 1, log.New(), true)
+
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, DefaultBtreeM, compress, false)
+	require.NoError(t, err)
+	defer bt.Close()
+	defer kv.Close()
+
+	keys, err := pivotKeysFromKV(kvPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, keys)
+
+	misses := make([][]byte, 0, len(keys))
+	for _, k := range keys { // flip a middle byte -> key almost certainly absent
+		m := append([]byte(nil), k...)
+		m[len(m)/2] ^= 0xff
+		misses = append(misses, m)
+	}
+
+	g := seg.NewReader(kv.MakeGetter(), compress)
+	get := func(interp bool, budget uint64, k []byte) ([]byte, bool, uint64) {
+		BtInterp, BtInterpBudget = interp, budget
+		v, ok, off, err := bt.bplus.Get(g, k)
+		require.NoError(t, err)
+		return v, ok, off
+	}
+
+	for _, budget := range []uint64{0, 1, 2, 4, 8, 1 << 20} {
+		for i, k := range keys {
+			wv, wok, woff := get(false, 0, k)
+			gv, gok, goff := get(true, budget, k)
+			require.Equalf(t, wok, gok, "hit key %d budget %d", i, budget)
+			require.Equalf(t, wv, gv, "hit value key %d budget %d", i, budget)
+			require.Equalf(t, woff, goff, "hit offset key %d budget %d", i, budget)
+		}
+		for i, k := range misses {
+			_, wok, _ := get(false, 0, k)
+			_, gok, _ := get(true, budget, k)
+			require.Equalf(t, wok, gok, "miss key %d budget %d", i, budget)
+		}
+	}
+}

--- a/db/datastruct/btindex/interp_varlen_test.go
+++ b/db/datastruct/btindex/interp_varlen_test.go
@@ -1,0 +1,115 @@
+package btindex
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/background"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/etl"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
+)
+
+// generateVarLenKV builds a .kv (+ .bt) of unique, variable-length keys (1..40 B)
+// drawn from a small alphabet, so adjacent sorted keys share prefixes and some
+// keys are prefixes of others — the distribution that stresses interpolation on
+// variable-length keys (e.g. commitment), where u64At order-preservation and the
+// interpMid clamp matter.
+func generateVarLenKV(tb testing.TB, tmp string, keyCount int, logger log.Logger, compress seg.FileCompression) string {
+	tb.Helper()
+	rnd := newRnd(3)
+	dataPath := filepath.Join(tmp, "varlen.kv")
+	comp, err := seg.NewCompressor(tb.Context(), "cmp", dataPath, tmp, seg.DefaultCfg, log.LvlDebug, logger)
+	require.NoError(tb, err)
+	collector := etl.NewCollector(BtreeLogPrefix+" varlen", tb.TempDir(), etl.NewSortableBuffer(1*datasize.MB), logger)
+	defer collector.Close()
+
+	seen := make(map[string]struct{}, keyCount)
+	val := make([]byte, 16)
+	for len(seen) < keyCount {
+		key := make([]byte, 1+rnd.IntN(40))
+		for j := range key {
+			key[j] = byte(rnd.IntN(6)) // small alphabet -> shared prefixes + prefix-of-another
+		}
+		if _, ok := seen[string(key)]; ok {
+			continue
+		}
+		seen[string(key)] = struct{}{}
+		n, err := rnd.Read(val[:rnd.IntN(16)+1])
+		require.NoError(tb, err)
+		require.NoError(tb, collector.Collect(key, val[:n]))
+	}
+
+	writer := seg.NewWriter(comp, compress)
+	loader := func(k, v []byte, _ etl.CurrentTableReader, _ etl.LoadNextFunc) error {
+		if _, err := writer.Write(k); err != nil {
+			return err
+		}
+		_, err := writer.Write(v)
+		return err
+	}
+	require.NoError(tb, collector.Load(nil, "", loader, etl.TransformArgs{}))
+	collector.Close()
+	require.NoError(tb, comp.Compress())
+	comp.Close()
+
+	decomp, err := seg.NewDecompressor(dataPath)
+	require.NoError(tb, err)
+	defer decomp.Close()
+	idx := strings.TrimSuffix(dataPath, ".kv") + ".bt"
+	r := seg.NewReader(decomp.MakeGetter(), compress)
+	require.NoError(tb, BuildBtreeIndexWithDecompressor(idx, r,
+		background.NewProgressSet(), tb.TempDir(), 777, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence))
+	return decomp.FilePath()
+}
+
+// Interpolation must return exactly what binary returns for variable-length keys
+// too (commitment-style). Covers hits + misses across budgets incl pure (1<<20)
+// and budget 0 (immediate binary fallback).
+func TestInterpEquivBinaryVarLen(t *testing.T) {
+	saveInterp, saveBudget := BtInterp, BtInterpBudget
+	defer func() { BtInterp, BtInterpBudget = saveInterp, saveBudget }()
+
+	const keyCount = 20000
+	compress := seg.CompressKeys
+	kvPath := generateVarLenKV(t, t.TempDir(), keyCount, log.New(), compress)
+	indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
+
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, DefaultBtreeM, compress, false)
+	require.NoError(t, err)
+	defer bt.Close()
+	defer kv.Close()
+
+	keys, err := pivotKeysFromKV(kvPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, keys)
+
+	g := seg.NewReader(kv.MakeGetter(), compress)
+	get := func(interp bool, budget uint64, k []byte) ([]byte, bool, uint64) {
+		BtInterp, BtInterpBudget = interp, budget
+		v, ok, off, err := bt.bplus.Get(g, k)
+		require.NoError(t, err)
+		return v, ok, off
+	}
+
+	for _, budget := range []uint64{0, 1, 2, 8, 1 << 20} {
+		for i, k := range keys {
+			wv, wok, woff := get(false, 0, k)
+			gv, gok, goff := get(true, budget, k)
+			require.Equalf(t, wok, gok, "hit key %d budget %d", i, budget)
+			require.Equalf(t, wv, gv, "hit value key %d budget %d", i, budget)
+			require.Equalf(t, woff, goff, "hit offset key %d budget %d", i, budget)
+
+			m := append([]byte(nil), k...)
+			m[len(m)/2] ^= 0xff
+			_, wokm, _ := get(false, 0, m)
+			_, gokm, _ := get(true, budget, m)
+			require.Equalf(t, wokm, gokm, "miss key %d budget %d", i, budget)
+		}
+	}
+}


### PR DESCRIPTION
Same change as #21794 (which targets `performance`), here targeting `main`.

Search the BTree leaf window by **interpolation** instead of binary search: estimate the target's position from the bound keys' bytes after their common prefix. Probes stay clustered near the target, so cold reads fault far fewer distinct `.kv` pages.

Default on (`BT_INTERP=true`); falls back to binary after `BtInterpBudget` (8) probes. No index/format change; `M` unchanged (256).

### Cold reads (btnav µs/op, M=256, mainnet `0-8192`, `vmtouch -e`, 15k random keys)

| domain | binary | interp | speedup |
|--------|-------:|-------:|--------:|
| storage  | 171 | 108 | 1.58× |
| accounts | 147 |  94 | 1.56× |
| code     | 258 | 109 | 2.37× |

The win is **page locality, not fewer probes** — on storage, interp does *more* probes than binary (8.43 vs 7.04) yet is fastest cold. Bound buffers are stack-backed, so the probe loop is **allocation-free** (0 allocs/op, same as binary) and ≤ binary warm.

### Correctness — incl. variable-length keys (commitment-safe)

`TestInterpEquivBinary` (fixed 20 B keys) and `TestInterpEquivBinaryVarLen` (**variable-length keys, 1–40 B**, the commitment-domain shape) assert interp returns identical `(value, ok, offset)` as binary for hits + misses across budgets `{0,1,2,8,2²⁰}`. `-race` clean.
