### PR TITLE
db/state: move to noref commitment files production, works with 3.4 ref commitment snapshots

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1875,12 +1875,16 @@ func (at *AggregatorRoTx) mergeFiles(ctx context.Context, files *FilesForMerge, 
 
 		g.Go(func() (err error) {
 			var vt valueTransformer
-			if commitmentUseReferencedBranches && kid == kv.CommitmentDomain && r.domain[kid].values.needMerge {
-				accStorageMerged.Wait()
+			if kid == kv.CommitmentDomain && r.domain[kid].values.needMerge {
+				if commitmentUseReferencedBranches {
+					accStorageMerged.Wait()
+				}
 
-				// prepare transformer callback to correctly dereference previously merged accounts/storage plain keys
+				// Always install the transform: with produceRefs=false it derefs any source-side
+				// refs (older v2.0 files) back to full keys, producing a noref merged file; v2.1
+				// noref sources pass through. mergedAccount/mergedStorage are unused in that mode.
 				vt, err = at.d[kv.CommitmentDomain].commitmentValTransformDomain(r.domain[kid].values, at.d[kv.AccountsDomain], at.d[kv.StorageDomain],
-					mf.d[kv.AccountsDomain], mf.d[kv.StorageDomain])
+					mf.d[kv.AccountsDomain], mf.d[kv.StorageDomain], false)
 
 				if err != nil {
 					return fmt.Errorf("failed to create commitment value transformer: %w", err)

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -120,6 +120,11 @@ type FilesItem struct {
 	existence            *existence.Filter
 	startTxNum, endTxNum uint64 //[startTxNum, endTxNum)
 
+	// dataVer is the version parsed from the data file's name. It distinguishes payload formats
+	// that share a file extension: commitment .kv files at v2.0 may carry shortened referenced
+	// keys, v2.1+ are noref-only.
+	dataVer version.Version
+
 	// Frozen: file containing Aggregator.stepsInFrozenFile steps. Completely immutable.
 	// Cold: file containing < Aggregator.stepsInFrozenFile steps. Immutable, but can be closed/removed after merge to bigger file.
 	// Hot: Stored in DB. Providing Snapshot-Isolation by CopyOnWrite.
@@ -393,6 +398,7 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 
 			fName := filepath.Base(fPath)
 			d.FileVersion.DataKV.MustSupport(fileVer, fName)
+			item.dataVer = fileVer
 
 			if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
 				if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1232,6 +1232,7 @@ func (d *Domain) integrateDirtyFiles(sf StaticFiles, txNumFrom, txNumTo uint64) 
 	fi.index = sf.valuesIdx
 	fi.bindex = sf.valuesBt
 	fi.existence = sf.existenceFilter
+	fi.dataVer = d.FileVersion.DataKV.Current
 	d.dirtyFiles.Set(fi)
 }
 

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
@@ -41,35 +42,41 @@ func ValuesPlainKeyReferencingThresholdReached(stepSize, from, to uint64) bool {
 	return (to-from)/stepSize >= commitment.DefaultKeyReferencingMinSteps
 }
 
+// CommitmentFileMayContainRef reports whether a commitment .kv file at this version may carry
+// shortened referenced keys. v2.0 (and earlier) produced refs above the step threshold when
+// squeezing was on; v2.1+ are noref-only.
+func CommitmentFileMayContainRef(dataVer version.Version) bool {
+	return dataVer.Less(version.V2_1)
+}
+
 // replaceShortenedKeysInBranch expands shortened key references (file offsets) in branch data back to full keys
 // by looking them up in the account and storage domain files.
 func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch commitment.BranchData, fStartTxNum uint64, fEndTxNum uint64) (commitment.BranchData, error) {
 	logger := log.Root()
 	aggTx := at
 
-	commitmentUseReferencedBranches := at.a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues
-	if !commitmentUseReferencedBranches || len(branch) == 0 || bytes.Equal(prefix, commitmentdb.KeyCommitmentState) ||
+	// Keyed off the file's version, not the writer-side flag: a noref node may still read a
+	// referenced file from an older datadir. Below-threshold ranges never contained refs.
+	if len(branch) == 0 || bytes.Equal(prefix, commitmentdb.KeyCommitmentState) ||
 		aggTx.TxNumsInFiles(kv.StateDomains...) == 0 || !ValuesPlainKeyReferencingThresholdReached(at.StepSize(), fStartTxNum, fEndTxNum) {
 
 		return branch, nil // do not transform, return as is
 	}
 
+	com := aggTx.d[kv.CommitmentDomain]
+	comItem, err := com.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+	if err != nil {
+		logger.Crit("dereference key during commitment read", "failed", err.Error())
+		return nil, err
+	}
+	if !CommitmentFileMayContainRef(comItem.dataVer) {
+		return branch, nil // v2.1+ file is noref by construction
+	}
+
 	sto := aggTx.d[kv.StorageDomain]
 	acc := aggTx.d[kv.AccountsDomain]
-	storageItem, err := sto.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
-	if err != nil {
-		logger.Crit("dereference key during commitment read", "failed", err.Error())
-		return nil, err
-	}
-	accountItem, err := acc.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
-	if err != nil {
-		logger.Crit("dereference key during commitment read", "failed", err.Error())
-		return nil, err
-	}
-	storageGetter := sto.dataReader(storageItem.decompressor)
-	accountGetter := acc.dataReader(accountItem.decompressor)
 	metricI := 0
-	for i, f := range aggTx.d[kv.CommitmentDomain].files {
+	for i, f := range com.files {
 		if i > 5 {
 			metricI = 5
 			break
@@ -79,6 +86,10 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 		}
 	}
 
+	// Getters resolve on first referenced-key hit, per domain. Branches with only full keys
+	// skip file resolution entirely.
+	var storageGetter, accountGetter *seg.Reader
+
 	result, err := branch.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
 		if isStorage {
 			if len(key) == length.Addr+length.Hash {
@@ -86,6 +97,14 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 			}
 			if dbg.KVReadLevelledMetrics {
 				defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
+			}
+			if storageGetter == nil {
+				item, err := sto.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+				if err != nil {
+					logger.Crit("dereference key during commitment read", "failed", err.Error())
+					return nil, err
+				}
+				storageGetter = sto.dataReader(item.decompressor)
 			}
 			// Optimised key referencing a state file record (file number and offset within the file)
 			storagePlainKey, found := sto.lookupByShortenedKey(key, storageGetter)
@@ -104,6 +123,14 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 
 		if dbg.KVReadLevelledMetrics {
 			defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
+		}
+		if accountGetter == nil {
+			item, err := acc.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
+			if err != nil {
+				logger.Crit("dereference key during commitment read", "failed", err.Error())
+				return nil, err
+			}
+			accountGetter = acc.dataReader(item.decompressor)
 		}
 		apkBuf, found := acc.lookupByShortenedKey(key, accountGetter)
 		if !found {
@@ -241,176 +268,182 @@ func (dt *DomainRoTx) lookupByShortenedKey(shortKey []byte, getter *seg.Reader) 
 	return dt.lookupFullKey, true
 }
 
-// commitmentValTransform parses the value of the commitment record to extract references
-// to accounts and storage items, then looks them up in the new, merged files, and replaces them with
-// the updated references
-func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, storage *DomainRoTx, mergedAccount, mergedStorage *FilesItem) (valueTransformer, error) {
+// commitmentValTransformDomain returns a per-value transform for rewriting commitment values.
+//
+// produceRefs=false (merge): deref any source-side refs back to full keys; full-source values pass
+// through unchanged. Output is always noref. mergedAccount/mergedStorage are unused in this mode.
+//
+// produceRefs=true (squeeze): deref any source-side refs, then re-encode each key as a ref against
+// the merged account/storage file. Output is the legacy referenced encoding.
+func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, storage *DomainRoTx, mergedAccount, mergedStorage *FilesItem, produceRefs bool) (valueTransformer, error) {
 	if !rng.needMerge {
 		panic(fmt.Sprintf("assert: commitmentValTransformDomain called with domain.needMerge=false (from=%d to=%d): caller must guard with values.needMerge", rng.from, rng.to))
 	}
-	var keyBuf [60]byte // 52b key and 8b for inverted step
-	var err error
-	shortened := make([]byte, 16)
 
-	hadToLookupStorage := mergedStorage == nil
-	if mergedStorage == nil {
-		if mergedStorage, err = storage.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
-			// TODO may allow to merge, but storage keys will be stored as plainkeys
-			return nil, err
-		}
-	}
-
-	hadToLookupAccount := mergedAccount == nil
-	if mergedAccount == nil {
-		if mergedAccount, err = accounts.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
-			return nil, err
-		}
-	}
-
-	dr := DomainRanges{values: rng}
-	accountFileMap := make(map[uint64]map[uint64]*seg.Reader)
-	if accountList, _, _ := accounts.staticFilesInRange(dr); accountList != nil {
-		for _, f := range accountList {
-			if _, ok := accountFileMap[f.startTxNum]; !ok {
-				accountFileMap[f.startTxNum] = make(map[uint64]*seg.Reader)
-			}
-			accountFileMap[f.startTxNum][f.endTxNum] = accounts.dataReader(f.decompressor)
-		}
-	}
-	storageFileMap := make(map[uint64]map[uint64]*seg.Reader)
-	if storageList, _, _ := storage.staticFilesInRange(dr); storageList != nil {
-		for _, f := range storageList {
-			if _, ok := storageFileMap[f.startTxNum]; !ok {
-				storageFileMap[f.startTxNum] = make(map[uint64]*seg.Reader)
-			}
-			storageFileMap[f.startTxNum][f.endTxNum] = storage.dataReader(f.decompressor)
-		}
-	}
-
-	ms := storage.dataReader(mergedStorage.decompressor)
-	ma := accounts.dataReader(mergedAccount.decompressor)
-	dt.d.logger.Debug("prepare commitmentValTransformDomain", "merge", rng.String("range", dt.d.stepSize), "Mstorage", hadToLookupStorage, "Maccount", hadToLookupAccount)
-
-	// Per-merge caches for findShortenedKey results. The same merged file is
-	// searched once per plain-key reference per commitment branch — and hot
-	// contracts (USDC, WETH, Uniswap routers, etc.) appear in many branches
-	// in the same merge range, so the same full key recurs many times. CPU
-	// profiling identified findShortenedKey → BtIndex.Get as ~52% of merge
-	// CPU; caching its results avoids the repeat B-tree descents.
-	//
-	// The merged file is read-only for the duration of this transformer, so
-	// (key → offset) is invariant within the closure. Both maps live only
-	// for the merge of one range; no cross-merge state.
+	// findShortenedKey results are invariant within this transformer (the merged file is read-only
+	// for its lifetime); hot contracts recur across many branches in one range, so caching the
+	// (full key → offset) lookup avoids repeat B-tree descents. Used only when produceRefs.
+	var ms, ma *seg.Reader
 	storageKeyCache := make(map[string]uint64)
 	accountKeyCache := make(map[string]uint64)
+	if produceRefs {
+		var err error
+		if mergedStorage == nil {
+			if mergedStorage, err = storage.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
+				return nil, err
+			}
+		}
+		if mergedAccount == nil {
+			if mergedAccount, err = accounts.lookupVisibleFileByRange(rng.from, rng.to); err != nil {
+				return nil, err
+			}
+		}
+		ms = storage.dataReader(mergedStorage.decompressor)
+		ma = accounts.dataReader(mergedAccount.decompressor)
+	}
+
+	type srcCache struct {
+		verKnown      bool
+		mayContainRef bool
+		accountGetter *seg.Reader
+		storageGetter *seg.Reader
+	}
+	perRange := make(map[uint64]map[uint64]*srcCache)
+	getCache := func(from, to uint64) *srcCache {
+		inner, ok := perRange[from]
+		if !ok {
+			inner = make(map[uint64]*srcCache)
+			perRange[from] = inner
+		}
+		c, ok := inner[to]
+		if !ok {
+			c = &srcCache{}
+			inner[to] = c
+		}
+		return c
+	}
 
 	vt := func(valBuf []byte, keyFromTxNum, keyEndTxNum uint64) (transValBuf []byte, err error) {
-		if !dt.d.ReplaceKeysInValues || len(valBuf) == 0 || !ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, rng.from, rng.to) {
+		if len(valBuf) == 0 || !ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, keyFromTxNum, keyEndTxNum) {
 			return valBuf, nil
 		}
-		if _, ok := storageFileMap[keyFromTxNum]; !ok {
-			storageFileMap[keyFromTxNum] = make(map[uint64]*seg.Reader)
-		}
-		sig, ok := storageFileMap[keyFromTxNum][keyEndTxNum]
-		if !ok {
-			f, err := storage.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+
+		c := getCache(keyFromTxNum, keyEndTxNum)
+		if !c.verKnown {
+			srcCom, err := dt.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
 			if err != nil {
-				return nil, fmt.Errorf("storage file not found in visible files: %w", err)
+				return nil, fmt.Errorf("commitment src file not found: %w", err)
 			}
-			sig = storage.dataReader(f.decompressor)
-			storageFileMap[keyFromTxNum][keyEndTxNum] = sig
+			c.mayContainRef = CommitmentFileMayContainRef(srcCom.dataVer)
+			c.verKnown = true
+		}
+		if !c.mayContainRef && !produceRefs {
+			return valBuf, nil // noref source, noref output: nothing to do
 		}
 
-		if _, ok := accountFileMap[keyFromTxNum]; !ok {
-			accountFileMap[keyFromTxNum] = make(map[uint64]*seg.Reader)
-		}
-		aig, ok := accountFileMap[keyFromTxNum][keyEndTxNum]
-		if !ok {
-			f, err := accounts.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
-			if err != nil {
-				return nil, fmt.Errorf("account file not found in visible files: %w", err)
+		derefStorage := func(key []byte) ([]byte, error) {
+			if len(key) == length.Addr+length.Hash {
+				return key, nil
 			}
-			aig = accounts.dataReader(f.decompressor)
-			accountFileMap[keyFromTxNum][keyEndTxNum] = aig
+			if c.storageGetter == nil {
+				f, err := storage.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+				if err != nil {
+					return nil, fmt.Errorf("storage src file not found: %w", err)
+				}
+				c.storageGetter = storage.dataReader(f.decompressor)
+			}
+			fullKey, found := storage.lookupByShortenedKey(key, c.storageGetter)
+			if !found {
+				dt.d.logger.Crit("valTransform: lost storage full key",
+					"shortened", hex.EncodeToString(key),
+					"src", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
+					"merging", rng.String("", dt.d.stepSize),
+					"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
+				)
+				return nil, fmt.Errorf("lookup lost storage full key %x", key)
+			}
+			return fullKey, nil
+		}
+		derefAccount := func(key []byte) ([]byte, error) {
+			if len(key) == length.Addr {
+				return key, nil
+			}
+			if c.accountGetter == nil {
+				f, err := accounts.lookupVisibleFileByRange(keyFromTxNum, keyEndTxNum)
+				if err != nil {
+					return nil, fmt.Errorf("account src file not found: %w", err)
+				}
+				c.accountGetter = accounts.dataReader(f.decompressor)
+			}
+			fullKey, found := accounts.lookupByShortenedKey(key, c.accountGetter)
+			if !found {
+				dt.d.logger.Crit("valTransform: lost account full key",
+					"shortened", hex.EncodeToString(key),
+					"src", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
+					"merging", rng.String("", dt.d.stepSize),
+					"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
+				)
+				return nil, fmt.Errorf("lookup account full key: %x", key)
+			}
+			return fullKey, nil
 		}
 
 		replacer := func(key []byte, isStorage bool) ([]byte, error) {
-			var found bool
-			auxBuf := keyBuf[:0]
 			if isStorage {
-				if len(key) == length.Addr+length.Hash {
-					// Non-optimised key originating from a database record
-					auxBuf = append(auxBuf[:0], key...)
-				} else {
-					// Optimised key referencing a state file record (file number and offset within the file)
-					auxBuf, found = storage.lookupByShortenedKey(key, sig)
-					if !found {
-						dt.d.logger.Crit("valTransform: lost storage full key",
-							"shortened", hex.EncodeToString(key),
-							"merging", rng.String("", dt.d.stepSize),
-							"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
-						)
-						return nil, fmt.Errorf("lookup lost storage full key %x", key)
-					}
+				fullKey, err := derefStorage(key)
+				if err != nil {
+					return nil, err
 				}
-
-				var shortenedKeyOffset uint64
-				if cached, ok := storageKeyCache[string(auxBuf)]; ok {
-					shortenedKeyOffset = cached
-				} else {
+				if !produceRefs {
+					if len(key) == length.Addr+length.Hash {
+						return nil, nil // already full, keep as is
+					}
+					return fullKey, nil
+				}
+				off, ok := storageKeyCache[string(fullKey)]
+				if !ok {
 					var found bool
-					shortenedKeyOffset, found = storage.findShortenedKey(auxBuf, ms, mergedStorage)
+					off, found = storage.findShortenedKey(fullKey, ms, mergedStorage)
 					if !found {
-						if len(auxBuf) == length.Addr+length.Hash {
-							return auxBuf, nil // if plain key is lost, we can save original fullkey
+						if len(fullKey) == length.Addr+length.Hash {
+							return fullKey, nil // lost shortening — save full key
 						}
-						// if shortened key lost, we can't continue
 						dt.d.logger.Crit("valTransform: replacement for full storage key was not found",
 							"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
-							"shortened", hex.EncodeToString(key), "toReplace", hex.EncodeToString(auxBuf))
-
-						return nil, fmt.Errorf("replacement not found for storage %x", auxBuf)
+							"toReplace", hex.EncodeToString(fullKey))
+						return nil, fmt.Errorf("replacement not found for storage %x", fullKey)
 					}
-					storageKeyCache[string(auxBuf)] = shortenedKeyOffset
+					storageKeyCache[string(fullKey)] = off
 				}
-				shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
-				return shortened, nil
+				return EncodeReferenceKey(nil, off), nil
 			}
 
-			if len(key) == length.Addr {
-				// Non-optimised key originating from a database record
-				auxBuf = append(auxBuf[:0], key...)
-			} else {
-				auxBuf, found = accounts.lookupByShortenedKey(key, aig)
-				if !found {
-					dt.d.logger.Crit("valTransform: lost account full key",
-						"shortened", hex.EncodeToString(key),
-						"merging", rng.String("", dt.d.stepSize),
-						"valBuf", fmt.Sprintf("l=%d %x", len(valBuf), valBuf),
-					)
-					return nil, fmt.Errorf("lookup account full key: %x", key)
-				}
+			fullKey, err := derefAccount(key)
+			if err != nil {
+				return nil, err
 			}
-
-			var shortenedKeyOffset uint64
-			if cached, ok := accountKeyCache[string(auxBuf)]; ok {
-				shortenedKeyOffset = cached
-			} else {
+			if !produceRefs {
+				if len(key) == length.Addr {
+					return nil, nil // already full, keep as is
+				}
+				return fullKey, nil
+			}
+			off, ok := accountKeyCache[string(fullKey)]
+			if !ok {
 				var found bool
-				shortenedKeyOffset, found = accounts.findShortenedKey(auxBuf, ma, mergedAccount)
+				off, found = accounts.findShortenedKey(fullKey, ma, mergedAccount)
 				if !found {
-					if len(auxBuf) == length.Addr {
-						return auxBuf, nil // if plain key is lost, we can save original fullkey
+					if len(fullKey) == length.Addr {
+						return fullKey, nil // lost shortening — save full key
 					}
 					dt.d.logger.Crit("valTransform: replacement for full account key was not found",
 						"step", fmt.Sprintf("%d-%d", keyFromTxNum/dt.d.stepSize, keyEndTxNum/dt.d.stepSize),
-						"shortened", hex.EncodeToString(key), "toReplace", hex.EncodeToString(auxBuf))
-					return nil, fmt.Errorf("replacement not found for account  %x", auxBuf)
+						"toReplace", hex.EncodeToString(fullKey))
+					return nil, fmt.Errorf("replacement not found for account %x", fullKey)
 				}
-				accountKeyCache[string(auxBuf)] = shortenedKeyOffset
+				accountKeyCache[string(fullKey)] = off
 			}
-			shortened = EncodeReferenceKey(shortened[:0], shortenedKeyOffset)
-			return shortened, nil
+			return EncodeReferenceKey(nil, off), nil
 		}
 
 		branchData, err := commitment.BranchData(valBuf).ReplacePlainKeys(nil, replacer)

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -539,6 +539,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	if valuesIn.decompressor, err = seg.NewDecompressor(kvFilePath); err != nil {
 		return nil, nil, nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", dt.d.FilenameBase, r.values.from, r.values.to, err)
 	}
+	valuesIn.dataVer = dt.d.FileVersion.DataKV.Current
 
 	if dt.d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := dt.d.kvBtAccessorNewFilePath(fromStep, toStep)

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -1046,7 +1046,7 @@ func TestCommitmentValTransformDomainPanicsWithNeedMergeFalse(t *testing.T) {
 	defer dc.Close()
 
 	require.Panics(t, func() {
-		dc.commitmentValTransformDomain(MergeRange{needMerge: false}, dc, dc, nil, nil)
+		dc.commitmentValTransformDomain(MergeRange{needMerge: false}, dc, dc, nil, nil, false)
 	})
 }
 

--- a/db/state/ref_compat_test.go
+++ b/db/state/ref_compat_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+)
+
+// TestUpgrade_RefV20Sources_ReadsCorrectly_in_V21World simulates the 3.4 → 3.6 upgrade: the
+// on-disk datadir has v2.0 commitment .kv files carrying referenced (shortened) keys, but the
+// running code has AggregatorSqueezeCommitmentValues=false and the schema's current commitment kv
+// version is v2.1. The read path must still deref the source refs — it can no longer gate on the
+// writer-side flag, since that flag is off but the source files still contain refs.
+func TestUpgrade_RefV20Sources_ReadsCorrectly_in_V21World(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	prevVer := statecfg.Schema.CommitmentDomain.FileVersion.DataKV
+	statecfg.Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{
+		Current:      version.V2_0,
+		MinSupported: version.V1_0,
+	}
+	t.Cleanup(func() {
+		statecfg.Schema.CommitmentDomain.FileVersion.DataKV = prevVer
+	})
+
+	cfg := &testAggConfig{stepSize: 10, disableCommitmentBranchTransform: false}
+	db, agg := testDbAggregatorWithFiles(t, cfg)
+	dirs := agg.Dirs()
+
+	// Squeeze so the merged commitment files actually carry refs (squeeze is the only producer of
+	// referenced keys now, mirroring how older datadirs reached this state). Squeeze drops the
+	// .kvi/.bt accessors when it rewrites the .kv, so rebuild them before any read.
+	{
+		rwTx, err := db.BeginTemporalRw(t.Context())
+		require.NoError(t, err)
+		defer rwTx.Rollback()
+		agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+		require.NoError(t, state.SqueezeCommitmentFiles(t.Context(), state.AggTx(rwTx), log.New()))
+		require.NoError(t, rwTx.Commit())
+		require.NoError(t, agg.OpenFolder())
+		require.NoError(t, agg.BuildMissedAccessors(t.Context(), 4))
+		require.NoError(t, agg.OpenFolder())
+	}
+
+	files, err := dir.ListFiles(dirs.SnapDomain, ".kv")
+	require.NoError(t, err)
+	var v20Files []string
+	for _, f := range files {
+		if strings.Contains(f, "commitment") && strings.Contains(f, "v2.0-") {
+			v20Files = append(v20Files, f)
+		}
+	}
+	require.NotEmpty(t, v20Files, "expected v2.0 commitment kv files on disk after squeeze")
+
+	preRoot := readStateRoot(t, db)
+	require.NotEmpty(t, preRoot)
+
+	// Switch to the 3.6 world: schema's current kv version is v2.1 and the writer flag is off.
+	// Existing files keep their v2.0 dataVer; new merges emit v2.1 noref.
+	statecfg.Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{
+		Current:      version.V2_1,
+		MinSupported: version.V1_0,
+	}
+	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+	require.NoError(t, agg.OpenFolder())
+
+	postRoot := readStateRoot(t, db)
+	require.Equal(t, preRoot, postRoot,
+		"read of v2.0 ref source in v2.1 world must deref refs and recover the same root")
+}
+
+// TestUpgrade_NewMergesProduceNorefV21 verifies that with the schema at v2.1 and refs off, every
+// newly-built commitment .kv file is v2.1 with full-key payload.
+func TestUpgrade_NewMergesProduceNorefV21(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	cfg := &testAggConfig{stepSize: 10, disableCommitmentBranchTransform: true}
+	_, agg := testDbAggregatorWithFiles(t, cfg)
+	dirs := agg.Dirs()
+
+	require.Equal(t, version.V2_1, statecfg.Schema.CommitmentDomain.FileVersion.DataKV.Current,
+		"this test assumes the v2.1 schema is in effect")
+
+	files, err := dir.ListFiles(dirs.SnapDomain, ".kv")
+	require.NoError(t, err)
+	var commitmentFiles []string
+	for _, f := range files {
+		if strings.Contains(f, "commitment") {
+			commitmentFiles = append(commitmentFiles, f)
+		}
+	}
+	require.NotEmpty(t, commitmentFiles, "expected at least one commitment kv file")
+
+	for _, f := range commitmentFiles {
+		require.Contains(t, f, "v2.1-",
+			"new merges/builds must tag commitment kv files as v2.1, got %s", f)
+		assertCommitmentFileIsNoref(t, f)
+	}
+}
+
+func readStateRoot(t *testing.T, db kv.TemporalRwDB) []byte {
+	t.Helper()
+	rwTx, err := db.BeginTemporalRw(t.Context())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
+	require.NoError(t, err)
+	defer domains.Close()
+	root, err := domains.ComputeCommitment(t.Context(), rwTx, false, 0, 0, "", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, root)
+	return root
+}
+
+// assertCommitmentFileIsNoref walks every branch value in a commitment .kv file and asserts all
+// account / storage keys are at full length (20B / 52B) — a shorter key would be a ref encoding.
+func assertCommitmentFileIsNoref(t *testing.T, path string) {
+	t.Helper()
+	d, err := seg.NewDecompressor(path)
+	require.NoError(t, err)
+	defer d.Close()
+
+	g := seg.NewReader(d.MakeGetter(), seg.CompressNone)
+	g.Reset(0)
+	var k, v []byte
+	for g.HasNext() {
+		k, _ = g.Next(k[:0])
+		if !g.HasNext() {
+			break
+		}
+		v, _ = g.Next(v[:0])
+		if len(v) == 0 {
+			continue
+		}
+		if bytes.Equal(k, commitmentdb.KeyCommitmentState) {
+			continue
+		}
+		_, err := commitment.BranchData(v).ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+			if isStorage {
+				require.Equal(t, length.Addr+length.Hash, len(key),
+					"noref file %s: storage key length %d (shorter implies ref encoding)", path, len(key))
+			} else {
+				require.Equal(t, length.Addr, len(key),
+					"noref file %s: account key length %d (shorter implies ref encoding)", path, len(key))
+			}
+			return nil, nil
+		})
+		require.NoError(t, err)
+	}
+}

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -238,7 +238,7 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 			reader.Reset(0)
 
 			rng := MergeRange{needMerge: true, from: af.startTxNum, to: af.endTxNum}
-			vt, err := commitment.commitmentValTransformDomain(rng, accounts, storage, af, sf)
+			vt, err := commitment.commitmentValTransformDomain(rng, accounts, storage, af, sf, true)
 			if err != nil {
 				return fmt.Errorf("failed to create commitment value transformer: %w", err)
 			}

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -73,7 +73,10 @@ func Configure(Schema SchemaGen, a AggSetters, dirs datadir.Dirs, salt *uint32, 
 	return nil
 }
 
-const AggregatorSqueezeCommitmentValues = true
+// AggregatorSqueezeCommitmentValues being false makes newly produced commitment files noref
+// (full keys). Older referenced (v2.0) files are still read and merged correctly — the read and
+// merge paths key off each file's parsed version, not this flag.
+const AggregatorSqueezeCommitmentValues = false
 const MaxNonFuriousDirtySpacePerTx = 64 * datasize.MB
 
 var dbgCommBtIndex = dbg.EnvBool("AGG_COMMITMENT_BT", false)


### PR DESCRIPTION
Alternative to #21452 for the 3.4→3.5 commitment-refs transition. Revives #21206 + #21419 against `main`.

The problem with the toml-flag approach (#21452, see [this discussion](https://github.com/erigontech/erigon/pull/21452#discussion_r3409611033)): a node upgrading 3.4→3.5 inherits 3.4 snapshots that carry referenced commitment files and keeps writing referenced files. This PR instead lets ref files coexist while **everything new is produced noref**, and reads/merges pick direction per file, not per global flag.

## Behavior

- `AggregatorSqueezeCommitmentValues = false` → newly collated/merged commitment `.kv` are noref (full keys).
- Read and merge key off **each file's parsed version** (`FilesItem.dataVer`), not the writer flag — a noref node still reads & dereferences older referenced files.
- `v2.0` (and earlier) = *may* contain refs at ranges ≥ `DefaultKeyReferencingMinSteps`; `v2.1+` = noref by construction (fast-path, no per-key walk).
- Merge always derefs source refs → noref output; v2.1 sources pass through. Squeeze keeps producing refs (`produceRefs=true`) so the tool still works.

## Changes

| File | Change |
|---|---|
| `statecfg/state_schema.go` | `AggregatorSqueezeCommitmentValues` → `false` |
| `dirty_files.go` / `domain.go` / `merge.go` | `FilesItem.dataVer`, stamped on open/collate/merge |
| `domain_committed.go` | `CommitmentFileMayContainRef`; version-driven read; `commitmentValTransformDomain(…, produceRefs)` |
| `aggregator.go` | always install commitment merge transform (deref → noref) |
| `squeeze.go` | squeeze passes `produceRefs=true` |
| `ref_compat_test.go` | upgrade read + noref-merge tests |

`main` already had the v2.1 version ceiling (#21780), so versions.yaml is unchanged — this brings the behavior.

## Testing

`make lint` clean, `make erigon integration` builds, `go test -short ./db/state/... ./execution/commitment/...` green.

### Real mainnet upgrade (minimal-prune node)

Fresh ottersync'd **3.4** datadir (canonical v2.0 ref snapshots) → run `release/3.4` to establish state → stop → resume with **this branch**:

- **No crash**, executes across mixed v2.0(ref)+v2.1(noref) files with correct state roots.
- Old 3.4 files stay `v2.0` & referenced (read fine, dereferenced on the fly: e.g. `v2.0-commitment.9128-9132` has 2.75M shortened refs); every new file is `v2.1` noref.

### Bigger ranges via re-exec

Removed the latest ~50 steps (`seg rm-state --step 9088-…` + `integration stage_exec --reset`), restarted the branch, and let it re-execute and then follow the live chain to chaintip. A continuous checker walked every new commitment `.kv` (`seg.CompressKeys` reader → `BranchData.ReplacePlainKeys`, counting full vs shortened keys):

- **138 commitment files auto-verified — all NOREF, 0 shortened refs. 0 crashes.**
- Every merge size noref: 1 → 2 → 4 → 8 → 16 → 32 → **64 steps**.

| File (v2.1) | span | full keys | refs |
|---|---|---|---|
| `9088-9152` | 64 steps | 105,364,063 | **0** |
| `9088-9120` | 32 steps | 56,833,266 | **0** |
| `9088-9104` | 16 steps | 32,091,058 | **0** |
| `9104-9112` | 8 steps | 19,763,903 | **0** |
| `9112-9116` | 4 steps | 9,297,475 | **0** |

Remaining `v2.0` files (`0-8192 … 8960-9088`) are the untouched 3.4 base — still referenced, read/dereferenced correctly throughout.
