### PR TITLE
cmd/evm: clarify why zkevm witness_validation fixtures are skipped

### DIFF
--- a/cmd/evm/zkevmrunner.go
+++ b/cmd/evm/zkevmrunner.go
@@ -106,11 +106,10 @@ func zkevmTestCmd(ctx *cli.Context) error {
 func newZkevmFailMatcher() *testutil.TestMatcher {
 	tm := new(testutil.TestMatcher)
 
-	// The eip8025_optional_proofs witness_validation_* fixtures are stateless-verifier
-	// negative tests storing a deliberately mutated executionWitness, so producer
-	// comparison always diverges until a stateless-verify consumer mode exists.
-	// https://github.com/erigontech/erigon/issues/21566
-	const verifierNegative = "verifier-negative witness fixture needs a stateless-verify consumer, see #21566"
+	// These witness_validation_* fixtures deliberately store a mutated executionWitness for
+	// stateless verifiers; a stateful EL only produces the canonical witness, so producer
+	// comparison can never match them — out of scope, not pending work. See #21566.
+	const verifierNegative = "verifier-negative fixture: stateful EL can't reproduce a mutated witness, see #21566"
 	for _, p := range []string{
 		`witness_validation_(codes|headers|state)/[a-z0-9_]+_(missing|extra|malformed)_`,
 		`witness_headers/witness_headers_extra_unused_older_ancestor`,


### PR DESCRIPTION
Reword the `newZkevmFailMatcher` skip rationale in `cmd/evm/zkevmrunner.go`. The `witness_validation_*` fixtures store a deliberately mutated `executionWitness` for stateless verifiers; a stateful EL only produces the canonical witness, so producer comparison can never match them. The comment now reads as why-they're-out-of-scope, not a pending TODO ("until a consumer mode exists").

Comment-only change, verified against `tests-zkevm@v0.4.1`. Full context in #21566.
