### PR TITLE
txnprovider/shutter: wait for chain head before loading submissions on init

### DIFF
--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -42,10 +42,13 @@ import (
 	"github.com/erigontech/erigon/rpc/rpchelper"
 )
 
+// ErrBlockRangeIntoFuture is the eth_getLogs message for a range past the
+// executed head, exported so other packages can match on the condition.
+const ErrBlockRangeIntoFuture = "block range extends beyond current head block"
+
 var (
 	errInvalidBlockRange               = "invalid block range params"
 	errExceedBlockRange                = "query block range exceeds server limit, narrow your filter"
-	errBlockRangeIntoFuture            = "block range extends beyond current head block"
 	errBlockHashWithRange              = "can't specify fromBlock/toBlock with blockHash"
 	errExceedMaxTopics                 = "exceed max topics"
 	errExceedLogQueryLimit             = "exceed max addresses or topics per search position"
@@ -147,7 +150,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 			}
 
 			if begin > latest {
-				return nil, &rpc.CustomError{Message: errBlockRangeIntoFuture, Code: rpc.ErrCodeInvalidParams}
+				return nil, &rpc.CustomError{Message: ErrBlockRangeIntoFuture, Code: rpc.ErrCodeInvalidParams}
 			}
 		}
 		end = latest
@@ -164,7 +167,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 			}
 
 			if end > latest {
-				return nil, &rpc.CustomError{Message: errBlockRangeIntoFuture, Code: rpc.ErrCodeInvalidParams}
+				return nil, &rpc.CustomError{Message: ErrBlockRangeIntoFuture, Code: rpc.ErrCodeInvalidParams}
 			}
 		}
 	}

--- a/txnprovider/shutter/encrypted_txns_pool.go
+++ b/txnprovider/shutter/encrypted_txns_pool.go
@@ -21,6 +21,7 @@ package shutter
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -214,7 +215,7 @@ func (etp *EncryptedTxnsPool) watchSubmissions(ctx context.Context) error {
 		case err := <-submissionEventSub.Err():
 			return err
 		case event := <-submissionEventC:
-			err := etp.handleEncryptedTxnSubmissionEvent(event)
+			err := etp.handleEncryptedTxnSubmissionEvent(ctx, event)
 			if err != nil {
 				return fmt.Errorf("failed to handle encrypted txn submission event: %w", err)
 			}
@@ -222,7 +223,7 @@ func (etp *EncryptedTxnsPool) watchSubmissions(ctx context.Context) error {
 	}
 }
 
-func (etp *EncryptedTxnsPool) handleEncryptedTxnSubmissionEvent(event *contracts.SequencerTransactionSubmitted) error {
+func (etp *EncryptedTxnsPool) handleEncryptedTxnSubmissionEvent(ctx context.Context, event *contracts.SequencerTransactionSubmitted) error {
 	encryptedTxnSubmission := EncryptedTxnSubmissionFromLogEvent(event)
 	etp.logger.Debug(
 		"received encrypted txn submission event",
@@ -257,13 +258,13 @@ func (etp *EncryptedTxnsPool) handleEncryptedTxnSubmissionEvent(event *contracts
 
 	etp.addSubmission(encryptedTxnSubmission)
 	if ok && !EncryptedTxnSubmissionsAreConsecutive(lastEncryptedTxnSubmission, encryptedTxnSubmission) {
-		return etp.fillSubmissionGap(lastEncryptedTxnSubmission, encryptedTxnSubmission)
+		return etp.fillSubmissionGap(ctx, lastEncryptedTxnSubmission, encryptedTxnSubmission)
 	}
 
 	return nil
 }
 
-func (etp *EncryptedTxnsPool) fillSubmissionGap(last, new EncryptedTxnSubmission) error {
+func (etp *EncryptedTxnsPool) fillSubmissionGap(ctx context.Context, last, new EncryptedTxnSubmission) error {
 	fromTxnIndex := last.TxnIndex + 1
 	startBlockNum := last.BlockNum + 1
 	endBlockNum := new.BlockNum
@@ -280,7 +281,7 @@ func (etp *EncryptedTxnsPool) fillSubmissionGap(last, new EncryptedTxnSubmission
 		etp.logger.Info("adjusted gap as it is too big", "startBlockNum", startBlockNum, "endBlockNum", endBlockNum)
 	}
 
-	return etp.loadSubmissions(startBlockNum, endBlockNum)
+	return etp.loadSubmissions(ctx, startBlockNum, endBlockNum)
 }
 
 func (etp *EncryptedTxnsPool) watchFirstBlockAfterInit(ctx context.Context) error {
@@ -308,12 +309,12 @@ func (etp *EncryptedTxnsPool) watchFirstBlockAfterInit(ctx context.Context) erro
 			}
 
 			// load submissions and complete
-			return etp.loadPastSubmissionsOnFirstBlock(blockEvent.LatestBlockNum)
+			return etp.loadPastSubmissionsOnFirstBlock(ctx, blockEvent.LatestBlockNum)
 		}
 	}
 }
 
-func (etp *EncryptedTxnsPool) loadPastSubmissionsOnFirstBlock(blockNum uint64) error {
+func (etp *EncryptedTxnsPool) loadPastSubmissionsOnFirstBlock(ctx context.Context, blockNum uint64) error {
 	etp.mu.Lock()
 	defer etp.mu.Unlock()
 
@@ -324,7 +325,7 @@ func (etp *EncryptedTxnsPool) loadPastSubmissionsOnFirstBlock(blockNum uint64) e
 	}
 
 	etp.logger.Info("loading past submissions on first block", "start", start, "end", end)
-	err := etp.loadSubmissions(start, end)
+	err := etp.loadSubmissions(ctx, start, end)
 	if err != nil {
 		return fmt.Errorf("failed to load submissions on init: %w", err)
 	}
@@ -332,7 +333,7 @@ func (etp *EncryptedTxnsPool) loadPastSubmissionsOnFirstBlock(blockNum uint64) e
 	return nil // we are done
 }
 
-func (etp *EncryptedTxnsPool) loadSubmissions(start, end uint64) error {
+func (etp *EncryptedTxnsPool) loadSubmissions(ctx context.Context, start, end uint64) error {
 	startTime := time.Now()
 	defer func() {
 		duration := time.Since(startTime)
@@ -340,11 +341,12 @@ func (etp *EncryptedTxnsPool) loadSubmissions(start, end uint64) error {
 	}()
 
 	opts := bind.FilterOpts{
-		Start: start,
-		End:   &end,
+		Start:   start,
+		End:     &end,
+		Context: ctx,
 	}
 
-	submissionsIter, err := etp.sequencerContract.FilterTransactionSubmitted(&opts)
+	submissionsIter, err := etp.filterSubmissionsWaitingForHead(ctx, &opts)
 	if err != nil {
 		return fmt.Errorf("failed to filter submissions from sequencer contract: %w", err)
 	}
@@ -368,6 +370,36 @@ func (etp *EncryptedTxnsPool) loadSubmissions(start, end uint64) error {
 	}
 
 	return nil
+}
+
+// errBlockRangeIntoFuture mirrors the rpc/jsonrpc eth_getLogs error for a
+// toBlock past the executed head; the block-event stream can momentarily run
+// ahead of the head a fresh RO tx in the RPC path sees.
+const errBlockRangeIntoFuture = "block range extends beyond current head block"
+
+const chainHeadCatchUpRetryWait = 50 * time.Millisecond
+
+func isChainHeadBehindErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errBlockRangeIntoFuture)
+}
+
+// filterSubmissionsWaitingForHead retries the log filter while the chain head is
+// still behind opts.End, so a transient head lag waits rather than killing the
+// pool. Other errors are returned immediately.
+func (etp *EncryptedTxnsPool) filterSubmissionsWaitingForHead(ctx context.Context, opts *bind.FilterOpts) (*contracts.SequencerTransactionSubmittedIterator, error) {
+	for {
+		iter, err := etp.sequencerContract.FilterTransactionSubmitted(opts)
+		if !isChainHeadBehindErr(err) {
+			return iter, err
+		}
+
+		etp.logger.Debug("waiting for chain head to catch up before loading submissions", "err", err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(chainHeadCatchUpRetryWait):
+		}
+	}
 }
 
 func (etp *EncryptedTxnsPool) addSubmission(submission EncryptedTxnSubmission) {

--- a/txnprovider/shutter/encrypted_txns_pool.go
+++ b/txnprovider/shutter/encrypted_txns_pool.go
@@ -369,6 +369,10 @@ func (etp *EncryptedTxnsPool) loadSubmissions(ctx context.Context, start, end ui
 		etp.addSubmission(encryptedTxnSubmission)
 	}
 
+	if err := submissionsIter.Error(); err != nil {
+		return fmt.Errorf("failed to iterate submissions from sequencer contract: %w", err)
+	}
+
 	return nil
 }
 

--- a/txnprovider/shutter/encrypted_txns_pool.go
+++ b/txnprovider/shutter/encrypted_txns_pool.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/abi/bind"
+	"github.com/erigontech/erigon/rpc/jsonrpc"
 	"github.com/erigontech/erigon/txnprovider/shutter/internal/contracts"
 	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 )
@@ -376,15 +377,12 @@ func (etp *EncryptedTxnsPool) loadSubmissions(ctx context.Context, start, end ui
 	return nil
 }
 
-// errBlockRangeIntoFuture mirrors the rpc/jsonrpc eth_getLogs error for a
-// toBlock past the executed head; the block-event stream can momentarily run
-// ahead of the head a fresh RO tx in the RPC path sees.
-const errBlockRangeIntoFuture = "block range extends beyond current head block"
-
 const chainHeadCatchUpRetryWait = 50 * time.Millisecond
 
+// isChainHeadBehindErr reports the transient eth_getLogs rejection from the
+// block-event stream momentarily running ahead of the RPC path's RO view.
 func isChainHeadBehindErr(err error) bool {
-	return err != nil && strings.Contains(err.Error(), errBlockRangeIntoFuture)
+	return err != nil && strings.Contains(err.Error(), jsonrpc.ErrBlockRangeIntoFuture)
 }
 
 // filterSubmissionsWaitingForHead retries the log filter while the chain head is

--- a/txnprovider/shutter/encrypted_txns_pool_test.go
+++ b/txnprovider/shutter/encrypted_txns_pool_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/rpc/contracts"
+	"github.com/erigontech/erigon/rpc/jsonrpc"
 	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 )
 
@@ -65,13 +66,13 @@ func newTestEncryptedTxnsPool(t *testing.T, backend *contracts.MockBackend) *Enc
 
 // The block-event stream can report a new head before the eth_getLogs path
 // (a fresh RO tx) sees it, so the initial submissions load races ahead of the
-// chain head and the RPC rejects it with errBlockRangeIntoFuture. The pool must
+// chain head and the RPC rejects it with jsonrpc.ErrBlockRangeIntoFuture. The pool must
 // wait for the head to catch up and retry rather than treating it as fatal.
 func TestEncryptedTxnsPoolLoadSubmissionsRetriesWhenChainHeadIsBehind(t *testing.T) {
 	t.Parallel()
 	ctrl := gomock.NewController(t)
 	backend := contracts.NewMockBackend(ctrl)
-	headBehindErr := errors.New("rpc error: block range extends beyond current head block")
+	headBehindErr := errors.New("rpc error: " + jsonrpc.ErrBlockRangeIntoFuture)
 	gomock.InOrder(
 		backend.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return(nil, headBehindErr),
 		backend.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return([]types.Log{}, nil),

--- a/txnprovider/shutter/encrypted_txns_pool_test.go
+++ b/txnprovider/shutter/encrypted_txns_pool_test.go
@@ -1,13 +1,18 @@
 package shutter
 
 import (
+	"context"
+	"errors"
 	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/testlog"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/rpc/contracts"
 	"github.com/erigontech/erigon/txnprovider/shutter/shuttercfg"
 )
 
@@ -47,4 +52,42 @@ func TestEncryptedTxnsPoolReturnsCorrectTxnWithAReplaySequence(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, txns, 1)
 	require.Equal(t, TxnIndex(38_275), txns[0].TxnIndex)
+}
+
+func newTestEncryptedTxnsPool(t *testing.T, backend *contracts.MockBackend) *EncryptedTxnsPool {
+	config := shuttercfg.Config{
+		SequencerContractAddress: "0x0000000000000000000000000000000000000bad",
+		MaxPooledEncryptedTxns:   1000,
+	}
+	return NewEncryptedTxnsPool(testlog.Logger(t, log.LvlCrit), config, backend, nil)
+}
+
+// The block-event stream can report a new head before the eth_getLogs path
+// (a fresh RO tx) sees it, so the initial submissions load races ahead of the
+// chain head and the RPC rejects it with errBlockRangeIntoFuture. The pool must
+// wait for the head to catch up and retry rather than treating it as fatal.
+func TestEncryptedTxnsPoolLoadSubmissionsRetriesWhenChainHeadIsBehind(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	backend := contracts.NewMockBackend(ctrl)
+	headBehindErr := errors.New("rpc error: block range extends beyond current head block")
+	gomock.InOrder(
+		backend.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return(nil, headBehindErr),
+		backend.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return([]types.Log{}, nil),
+	)
+
+	p := newTestEncryptedTxnsPool(t, backend)
+	err := p.loadSubmissions(context.Background(), 0, 100)
+	require.NoError(t, err)
+}
+
+func TestEncryptedTxnsPoolLoadSubmissionsDoesNotRetryOtherErrors(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	backend := contracts.NewMockBackend(ctrl)
+	backend.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return(nil, errors.New("boom")).Times(1)
+
+	p := newTestEncryptedTxnsPool(t, backend)
+	err := p.loadSubmissions(context.Background(), 0, 100)
+	require.ErrorContains(t, err, "boom")
 }

--- a/txnprovider/shutter/encrypted_txns_pool_test.go
+++ b/txnprovider/shutter/encrypted_txns_pool_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/types"
@@ -90,4 +91,22 @@ func TestEncryptedTxnsPoolLoadSubmissionsDoesNotRetryOtherErrors(t *testing.T) {
 	p := newTestEncryptedTxnsPool(t, backend)
 	err := p.loadSubmissions(context.Background(), 0, 100)
 	require.ErrorContains(t, err, "boom")
+}
+
+func TestEncryptedTxnsPoolLoadSubmissionsSurfacesIteratorError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	backend := contracts.NewMockBackend(ctrl)
+	// a log that cannot be unpacked as a TransactionSubmitted event makes the
+	// iterator fail mid-iteration - the error must not be silently dropped.
+	malformed := types.Log{
+		Address: common.HexToAddress("0x0000000000000000000000000000000000000bad"),
+		Topics:  []common.Hash{common.HexToHash("0x01")},
+		Data:    []byte{0x01},
+	}
+	backend.EXPECT().FilterLogs(gomock.Any(), gomock.Any()).Return([]types.Log{malformed}, nil)
+
+	p := newTestEncryptedTxnsPool(t, backend)
+	err := p.loadSubmissions(context.Background(), 0, 100)
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Problem

`TestShutterBlockBuilding` flakes with `context deadline exceeded`, preceded by:

```
EROR [shutter] Run error err="encrypted txns pool issue: failed to handle first block after init:
  failed to load submissions on init: failed to filter submissions from sequencer contract:
  block range extends beyond current head block"
EROR cannot provide shutter transactions - pool stopped
```

Seen most recently on the `sonar / sonar` coverage job of an unrelated PR ([#21767](https://github.com/erigontech/erigon/pull/21767), [run](https://github.com/erigontech/erigon/actions/runs/27534318658/job/81379755629)). The same commit passed the test in all 6 regular `tests / tests-mac-linux` jobs and the race matrix — it only failed under coverage instrumentation, which slows execution and widens the timing window. It's the same pool-stop race class partially addressed in #20985.

## Root cause

A head-visibility race between two independent views of the chain head:

- `BlockListener` reports the latest block `N` from the **state-changes stream** (`block_listener.go`).
- On its first block, `EncryptedTxnsPool` immediately filters sequencer `TransactionSubmitted` logs up to `N` (`loadPastSubmissionsOnFirstBlock` → `loadSubmissions` → `FilterTransactionSubmitted`, i.e. `eth_getLogs` with `toBlock = N`).
- `GetLogs` reads `LatestExecutedBlockNumber` from a **fresh RO temporal tx** and rejects `toBlock > latest` with `errBlockRangeIntoFuture` = `"block range extends beyond current head block"` (`rpc/jsonrpc/eth_receipts.go`).

For a brief window after a block event, the RPC path's RO view still sees `N-1`, so the init filter is rejected. The pool treated this transient error as **fatal**, killing the errgroup and stopping the whole pool.

## Fix

Make the submissions filter **wait for the head to catch up and retry** (bounded by ctx) instead of dying, since the data arrives within milliseconds. Only the head-lag error is retried; other errors still propagate immediately, preserving fail-loud behaviour. This follows the same resilience approach as #20985.

## Testing

TDD (red → green):
- `TestEncryptedTxnsPoolLoadSubmissionsRetriesWhenChainHeadIsBehind` — head-lag error then success ⇒ `loadSubmissions` retries and succeeds.
- `TestEncryptedTxnsPoolLoadSubmissionsDoesNotRetryOtherErrors` — a non-head-lag error is returned immediately (no retry).

Full `txnprovider/shutter` package (incl. `TestShutterBlockBuilding` and the synctest pool tests) passes; `make lint` clean; `make erigon integration` builds.

Separate from #21767 as requested — that PR's failure was this pre-existing flake, not its change. Likely worth a backport to `release/3.4`.