### PR TITLE
ci: don't evict merge-queue PRs on reshuffle cancellations

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -179,46 +179,37 @@ jobs:
       - sonar
     runs-on: ubuntu-latest
     steps:
+      # cancelled() is only valid in `if:`, so capture it as a step output for
+      # the gate logic below to read.
+      - name: Detect run cancellation
+        id: cancelflag
+        if: cancelled()
+        run: echo "cancelled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: always()
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Check all required jobs
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          echo '${{ toJSON(needs) }}' > needs.json
-          failed=$(jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key' needs.json)
-          if [ -n "$failed" ]; then
-            echo "The following gate jobs failed or were cancelled:"
-            echo "$failed"
-            jobs=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" --paginate) || true
-            # The leaf that fast-cancelled the run is the true root cause; other failed steps may be collateral from that cancellation.
-            root=$(echo "$jobs" | jq -r '.jobs[] | select(any(.steps[]?; .name == "Cancel workflow run on failure" and .conclusion == "success")) | "::error title=CI root cause::" + .name + " — failed step: " + ([.steps[] | select(.conclusion == "failure") | .name] | join("; "))' 2>/dev/null || true)
-            if [ -z "$root" ]; then
-              root=$(echo "$jobs" | jq -r '.jobs[] | select(.name != "ci-gate") | select(any(.steps[]?; .conclusion == "failure")) | "::error title=CI root cause::" + .name + " — failed step: " + ([.steps[] | select(.conclusion == "failure") | .name] | join("; "))' 2>/dev/null || true)
-            fi
-            echo "Root-cause job(s):"
-            echo "$root"
-            exit 1
-          fi
-          echo "All required jobs passed or were skipped."
+          NEEDS: ${{ toJSON(needs) }}
+          RUN_CANCELLED: ${{ steps.cancelflag.outputs.cancelled }}
+        run: bash .github/workflows/scripts/ci-gate-check.sh
 
-      # GitHub does not auto-remove UNMERGEABLE entries from the merge queue
-      # when their required checks fail — they sit at the queue position with
-      # state UNMERGEABLE until someone manually dequeues. This step does that
-      # automatically on real failures (not queue-reshuffle cancellations,
-      # where all needs come back as `cancelled` and GitHub re-creates a fresh
-      # merge_group event for us).
+      # GitHub does not auto-remove entries left UNMERGEABLE by a failed check,
+      # so dequeue explicitly; the gate only fails the job on a real failure.
       - name: Dequeue failed merge-queue PR
         if: failure() && github.event_name == 'merge_group'
         env:
           GH_TOKEN: ${{ github.token }}
-          NEEDS: ${{ toJSON(needs) }}
           REF: ${{ github.ref_name }}
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          if ! echo "$NEEDS" | jq -e 'to_entries[] | select(.value.result == "failure")' > /dev/null; then
-            echo "No gate need failed (only cancellations) — likely a queue reshuffle, skipping dequeue."
-            exit 0
-          fi
           pr_number=$(echo "$REF" | grep -oE 'pr-[0-9]+' | head -1 | cut -d- -f2)
           if [ -z "$pr_number" ]; then
             echo "::warning::Could not parse PR number from ref $REF"

--- a/.github/workflows/scripts/ci-gate-check.sh
+++ b/.github/workflows/scripts/ci-gate-check.sh
@@ -5,6 +5,7 @@
 # this run). Exit 1 = real failure; the caller treats it as a failed check.
 #
 # Inputs (env): NEEDS (toJSON(needs)), RUN_CANCELLED ("true" when cancelled()),
+# GITHUB_EVENT_NAME (reshuffle fast-path is merge_group-only),
 # GH_TOKEN/GITHUB_REPOSITORY/GITHUB_RUN_ID to fetch the jobs list.
 # Test seam: CI_GATE_NO_FETCH=1 uses CI_GATE_JOBS_JSON verbatim instead of the
 # API (an empty value simulates a failed fetch).
@@ -38,9 +39,10 @@ fi
 failed_steps=$(jq -r '.jobs[] | select(.name != "ci-gate") | select(any(.steps[]?; .conclusion == "failure")) | .name' <<<"$jobs" 2>/dev/null || true)
 
 # Run cancelled with no failure = GitHub tore down a superseded merge group
-# (reshuffle); failing here would spuriously evict the PR. Require a successful
-# jobs fetch so an empty failed_steps can be trusted.
-if [ -z "$failed" ] && [ -n "$jobs" ] && [ -z "$failed_steps" ] && [ "${RUN_CANCELLED:-}" = "true" ]; then
+# (reshuffle); failing here would spuriously evict the PR. Scope to merge_group
+# (reshuffles only happen in the queue) and require a successful jobs fetch so an
+# empty failed_steps can be trusted.
+if [ -z "$failed" ] && [ -n "$jobs" ] && [ -z "$failed_steps" ] && [ "${RUN_CANCELLED:-}" = "true" ] && [ "${GITHUB_EVENT_NAME:-}" = "merge_group" ]; then
   echo "::notice::Merge-queue reshuffle cancelled this run (no failed jobs or steps); passing the gate so the PR stays queued."
   echo "Cancelled jobs: $(tr '\n' ' ' <<<"$cancelled")"
   exit 0

--- a/.github/workflows/scripts/ci-gate-check.sh
+++ b/.github/workflows/scripts/ci-gate-check.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Decide whether the CI gate passes for a PR or merge-queue run.
+#
+# Exit 0 = gate passes (including a benign merge-queue reshuffle that cancelled
+# this run). Exit 1 = real failure; the caller treats it as a failed check.
+#
+# Inputs (env): NEEDS (toJSON(needs)), RUN_CANCELLED ("true" when cancelled()),
+# GH_TOKEN/GITHUB_REPOSITORY/GITHUB_RUN_ID to fetch the jobs list.
+# Test seam: CI_GATE_NO_FETCH=1 uses CI_GATE_JOBS_JSON verbatim instead of the
+# API (an empty value simulates a failed fetch).
+set -eo pipefail
+
+needs="${NEEDS:-}"
+[ -n "$needs" ] || needs="{}"
+failed=$(jq -r 'to_entries[] | select(.value.result == "failure") | .key' <<<"$needs")
+cancelled=$(jq -r 'to_entries[] | select(.value.result == "cancelled") | .key' <<<"$needs")
+
+if [ -z "$failed" ] && [ -z "$cancelled" ]; then
+  echo "All required jobs passed or were skipped."
+  exit 0
+fi
+
+if [ -n "${CI_GATE_NO_FETCH:-}" ]; then
+  jobs="${CI_GATE_JOBS_JSON:-}"
+else
+  jobs=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" --paginate) || jobs=""
+fi
+
+# A leaf that fast-cancels the run on its own failure rolls up to "cancelled",
+# so a failed step still signals a real failure.
+failed_steps=$(jq -r '.jobs[] | select(.name != "ci-gate") | select(any(.steps[]?; .conclusion == "failure")) | .name' <<<"$jobs" 2>/dev/null || true)
+
+# Run cancelled with no failure = GitHub tore down a superseded merge group
+# (reshuffle); failing here would spuriously evict the PR. Require a successful
+# jobs fetch so an empty failed_steps can be trusted.
+if [ -z "$failed" ] && [ -n "$jobs" ] && [ -z "$failed_steps" ] && [ "${RUN_CANCELLED:-}" = "true" ]; then
+  echo "::notice::Merge-queue reshuffle cancelled this run (no failed jobs or steps); passing the gate so the PR stays queued."
+  echo "Cancelled jobs: $(tr '\n' ' ' <<<"$cancelled")"
+  exit 0
+fi
+
+echo "The following gate jobs failed or were cancelled:"
+echo "$failed"
+echo "$cancelled"
+# The leaf that fast-cancelled the run is the true root cause; other failed
+# steps may be collateral.
+root=$(jq -r '.jobs[] | select(any(.steps[]?; .name == "Cancel workflow run on failure" and .conclusion == "success")) | "::error title=CI root cause::" + .name + " — failed step: " + ([.steps[] | select(.conclusion == "failure") | .name] | join("; "))' <<<"$jobs" 2>/dev/null || true)
+if [ -z "$root" ]; then
+  root=$(jq -r '.jobs[] | select(.name != "ci-gate") | select(any(.steps[]?; .conclusion == "failure")) | "::error title=CI root cause::" + .name + " — failed step: " + ([.steps[] | select(.conclusion == "failure") | .name] | join("; "))' <<<"$jobs" 2>/dev/null || true)
+fi
+echo "Root-cause job(s):"
+echo "$root"
+exit 1

--- a/.github/workflows/scripts/ci-gate-check.sh
+++ b/.github/workflows/scripts/ci-gate-check.sh
@@ -21,9 +21,16 @@ if [ -z "$failed" ] && [ -z "$cancelled" ]; then
 fi
 
 if [ -n "${CI_GATE_NO_FETCH:-}" ]; then
-  jobs="${CI_GATE_JOBS_JSON:-}"
+  raw="${CI_GATE_JOBS_JSON:-}"
 else
-  jobs=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" --paginate) || jobs=""
+  raw=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" --paginate) || raw=""
+fi
+
+# --paginate emits one JSON object per page; merge into a single {jobs:[...]}
+# so a failure on any page is seen, and fail closed on an empty/invalid fetch.
+jobs=""
+if [ -n "$raw" ]; then
+  jobs=$(jq -s '{jobs: [.[].jobs[]]}' <<<"$raw" 2>/dev/null) || jobs=""
 fi
 
 # A leaf that fast-cancels the run on its own failure rolls up to "cancelled",

--- a/.github/workflows/scripts/ci-gate-check.test.sh
+++ b/.github/workflows/scripts/ci-gate-check.test.sh
@@ -62,6 +62,27 @@ run_case "reshuffle w/ failed jobs fetch (fail closed)" 1 \
   RUN_CANCELLED=true \
   CI_GATE_JOBS_JSON=''
 
+# --paginate emits one object per page; a failure on a later page must be seen.
+run_case "multi-page, failure on page 2 -> fail" 1 \
+  NEEDS='{"hive":{"result":"cancelled"},"bench":{"result":"cancelled"}}' \
+  RUN_CANCELLED=true \
+  CI_GATE_JOBS_JSON='{"jobs":[{"name":"hive","steps":[{"name":"run","conclusion":"cancelled"}]}]}
+{"jobs":[{"name":"bench","steps":[{"name":"unit","conclusion":"failure"}]}]}'
+
+# Multi-page with no failure on any page -> still a benign reshuffle.
+run_case "multi-page reshuffle (no failures)" 0 \
+  NEEDS='{"hive":{"result":"cancelled"},"bench":{"result":"cancelled"}}' \
+  RUN_CANCELLED=true \
+  CI_GATE_JOBS_JSON='{"jobs":[{"name":"hive","steps":[{"name":"run","conclusion":"cancelled"}]}]}
+{"jobs":[{"name":"bench","steps":[{"name":"run","conclusion":"cancelled"}]}]}'
+
+# An error page (no .jobs) among the pages must fail closed, not silently pass.
+run_case "error page mid-pagination -> fail closed" 1 \
+  NEEDS='{"hive":{"result":"cancelled"}}' \
+  RUN_CANCELLED=true \
+  CI_GATE_JOBS_JSON='{"jobs":[{"name":"hive","steps":[{"name":"run","conclusion":"cancelled"}]}]}
+{"message":"Server Error"}'
+
 echo "----"
 printf '%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.github/workflows/scripts/ci-gate-check.test.sh
+++ b/.github/workflows/scripts/ci-gate-check.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Local test harness for ci-gate-check.sh — feeds crafted needs/jobs JSON
+# through the real gate script and asserts its exit code.
+# Run: bash .github/workflows/scripts/ci-gate-check.test.sh
+set -uo pipefail
+
+here=$(dirname -- "$0")
+script="$here/ci-gate-check.sh"
+pass=0
+fail=0
+
+# run_case <name> <want_exit> [VAR=VAL ...]
+run_case() {
+  local name="$1" want="$2"
+  shift 2
+  local out rc
+  out=$(env -i PATH="$PATH" CI_GATE_NO_FETCH=1 "$@" bash "$script" 2>&1)
+  rc=$?
+  if [ "$rc" -eq "$want" ]; then
+    printf 'ok   - %s (exit %d)\n' "$name" "$rc"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL - %s: want exit %d, got %d\n' "$name" "$want" "$rc"
+    printf '%s\n' "$out" | sed 's/^/       | /'
+    fail=$((fail + 1))
+  fi
+}
+
+# Everything green -> pass.
+run_case "all success" 0 \
+  NEEDS='{"lint":{"result":"success"},"tests":{"result":"success"}}'
+
+# Skipped + success -> pass.
+run_case "skipped + success" 0 \
+  NEEDS='{"docs-site":{"result":"skipped"},"lint":{"result":"success"}}'
+
+# A real failure -> fail (evict).
+run_case "real failure" 1 \
+  NEEDS='{"lint":{"result":"failure"},"tests":{"result":"success"}}' \
+  CI_GATE_JOBS_JSON='{"jobs":[]}'
+
+# Reshuffle: all-cancelled, run cancelled, no failed steps -> pass (stay queued).
+run_case "reshuffle cancellation" 0 \
+  NEEDS='{"hive":{"result":"cancelled"},"bench":{"result":"cancelled"},"lint":{"result":"success"}}' \
+  RUN_CANCELLED=true \
+  CI_GATE_JOBS_JSON='{"jobs":[{"name":"bench / benchmarks","steps":[{"name":"run","conclusion":"cancelled"}]}]}'
+
+# Leaf timeout: cancelled need but run NOT cancelled -> fail (real problem).
+run_case "leaf timeout (run not cancelled)" 1 \
+  NEEDS='{"hive":{"result":"cancelled"},"lint":{"result":"success"}}' \
+  CI_GATE_JOBS_JSON='{"jobs":[{"name":"hive","steps":[{"name":"run","conclusion":"cancelled"}]}]}'
+
+# Fail-fast self-cancel: all-cancelled + run cancelled, but a failed step -> fail.
+run_case "fail-fast self-cancel" 1 \
+  NEEDS='{"hive":{"result":"cancelled"},"bench":{"result":"cancelled"}}' \
+  RUN_CANCELLED=true \
+  CI_GATE_JOBS_JSON='{"jobs":[{"name":"hive","steps":[{"name":"unit","conclusion":"failure"},{"name":"Cancel workflow run on failure","conclusion":"success"}]}]}'
+
+# Reshuffle signal but jobs fetch failed (empty) -> fail closed.
+run_case "reshuffle w/ failed jobs fetch (fail closed)" 1 \
+  NEEDS='{"hive":{"result":"cancelled"}}' \
+  RUN_CANCELLED=true \
+  CI_GATE_JOBS_JSON=''
+
+echo "----"
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.github/workflows/scripts/ci-gate-check.test.sh
+++ b/.github/workflows/scripts/ci-gate-check.test.sh
@@ -43,7 +43,16 @@ run_case "real failure" 1 \
 run_case "reshuffle cancellation" 0 \
   NEEDS='{"hive":{"result":"cancelled"},"bench":{"result":"cancelled"},"lint":{"result":"success"}}' \
   RUN_CANCELLED=true \
+  GITHUB_EVENT_NAME=merge_group \
   CI_GATE_JOBS_JSON='{"jobs":[{"name":"bench / benchmarks","steps":[{"name":"run","conclusion":"cancelled"}]}]}'
+
+# Same cancellation on a non-merge_group run (PR supersede / manual cancel) is
+# NOT a benign reshuffle -> fail closed even with no failures.
+run_case "cancelled non-merge_group run -> fail closed" 1 \
+  NEEDS='{"hive":{"result":"cancelled"},"lint":{"result":"success"}}' \
+  RUN_CANCELLED=true \
+  GITHUB_EVENT_NAME=pull_request \
+  CI_GATE_JOBS_JSON='{"jobs":[{"name":"hive","steps":[{"name":"run","conclusion":"cancelled"}]}]}'
 
 # Leaf timeout: cancelled need but run NOT cancelled -> fail (real problem).
 run_case "leaf timeout (run not cancelled)" 1 \
@@ -73,6 +82,7 @@ run_case "multi-page, failure on page 2 -> fail" 1 \
 run_case "multi-page reshuffle (no failures)" 0 \
   NEEDS='{"hive":{"result":"cancelled"},"bench":{"result":"cancelled"}}' \
   RUN_CANCELLED=true \
+  GITHUB_EVENT_NAME=merge_group \
   CI_GATE_JOBS_JSON='{"jobs":[{"name":"hive","steps":[{"name":"run","conclusion":"cancelled"}]}]}
 {"jobs":[{"name":"bench","steps":[{"name":"run","conclusion":"cancelled"}]}]}'
 


### PR DESCRIPTION
## Problem

PR #21561 (a trivial `FUNDING.json` change — approved, mergeable, clean) was removed from the merge queue with GitHub's reason `failed_checks`, despite every check that ran having passed.

## Root cause

#21561 was queued behind #21806 and tested speculatively on top of it. When #21806 merged, GitHub re-formed the queue and cancelled #21561's still-running slow leaves (`hive`, `hive-eest`, `eest-spec-tests`, `bench`, `kurtosis`). The `ci-gate` aggregator lumped `cancelled` in with `failure` and exited 1, so the single required check went red and GitHub evicted the PR with `failed_checks`. Nothing in the PR failed — the gate even logged *"likely a queue reshuffle"* in its dequeue step, but the required check was already red by then, and GitHub evicts on that regardless of whether we self-dequeue.

## Fix

Distinguish a benign reshuffle from real failures instead of treating every non-success `need` as failure:

| Situation | `needs` | failed step? | run cancelled? | event | Gate |
|---|---|---|---|---|---|
| Real failure | a `failure` | — | — | any | exit 1 → evict |
| Fail-fast self-cancel | all `cancelled` | yes | yes | any | exit 1 → evict |
| Leaf timeout | a `cancelled` | no | no | any | exit 1 → real problem |
| Non-queue cancel (PR supersede / manual) | all `cancelled` | no | yes | not `merge_group` | exit 1 → fail closed |
| **Queue reshuffle** | all `cancelled` | no | **yes** | **`merge_group`** | **exit 0 → stays queued** |

Only the last row changes behavior. The discriminator is **run-level cancellation** (`cancelled()`, captured via a tiny `if: cancelled()` step since it is illegal in `env:`), **zero failures anywhere** (no failed need, no failed step, jobs list fetched OK), **and a `merge_group` event** — reshuffles only happen in the queue, so a cancelled `pull_request`/`workflow_dispatch` run fails closed.

**Safety.** The obvious way a naive "cancelled = pass" could merge untested code is a leaf **timeout** — closed here by requiring *run-level* cancellation: a lone timeout doesn't cancel the run, so it still exits 1. Fail-fast self-cancels still exit 1 because a failed *step* survives the rollup-to-`cancelled`. If the jobs fetch fails, we fail closed. And a cancelled non-merge-queue run (a PR superseded via `cancel-in-progress`, or a manual cancel) fails closed too — the `merge_group`-only scoping stops the fast-path from ever greening a PR whose leaves never completed.

The gate decision is extracted to `.github/workflows/scripts/ci-gate-check.sh` (single source of truth, with a `CI_GATE_NO_FETCH` test seam) and exercised by `ci-gate-check.test.sh`:

```
$ bash .github/workflows/scripts/ci-gate-check.test.sh
ok   - all success (exit 0)
ok   - skipped + success (exit 0)
ok   - real failure (exit 1)
ok   - reshuffle cancellation (exit 0)
ok   - cancelled non-merge_group run -> fail closed (exit 1)
ok   - leaf timeout (run not cancelled) (exit 1)
ok   - fail-fast self-cancel (exit 1)
ok   - reshuffle w/ failed jobs fetch (fail closed) (exit 1)
ok   - multi-page, failure on page 2 -> fail (exit 1)
ok   - multi-page reshuffle (no failures) (exit 0)
ok   - error page mid-pagination -> fail closed (exit 1)
11 passed, 0 failed
```

(The harness already caught one real bug during development: a `${NEEDS:-{}}` brace-expansion that appended a stray `}` to the JSON and broke every `jq` call.)

## Residual assumption to verify

This relies on GitHub **not merging** a PR off a *cancelled* merge-group run just because `ci-gate` reports green — i.e. that a superseded/cancelled group is discarded and re-formed, not merged. That model fits all the #21561 evidence (GitHub evicts on a red required check, but re-forms rather than merges on a cancelled group). Worth confirming on a throwaway PR pair before merging: if the model is wrong, a reshuffled PR could merge with its slow leaves (hive/eest/kurtosis/bench) still uncompleted — under-tested code, which is *worse* than today's spurious eviction. So treat verification as a merge blocker, not a nicety.

## Notes

- The `ci-gate` job now does an `actions/checkout` to run the script. In the rare case checkout is interrupted during a cancelled run, the gate falls back to today's behavior (red → evict), never to an unsafe merge.
- The harness is local-only for now (`bash .github/workflows/scripts/ci-gate-check.test.sh`); happy to wire it into a workflow if you'd like it gating PRs.
- `actionlint` clean, `shellcheck` clean, no Go touched.


