### PR TITLE
execution/rlp, execution/types: reject malformed RLP instead of dropping elements

### DIFF
--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -358,7 +358,7 @@ func decodeSliceElems(s *Stream, val reflect.Value, elemdec decoder) error {
 			val.SetLen(i + 1)
 		}
 		// decode into element
-		if err := elemdec(s, val.Index(i)); errors.Is(err, EOL) {
+		if err := elemdec(s, val.Index(i)); err == EOL {
 			break
 		} else if err != nil {
 			return addErrorContext(err, fmt.Sprint("[", i, "]"))
@@ -377,7 +377,7 @@ func decodeListArray(s *Stream, val reflect.Value, elemdec decoder) error {
 	vlen := val.Len()
 	i := 0
 	for ; i < vlen; i++ {
-		if err := elemdec(s, val.Index(i)); errors.Is(err, EOL) {
+		if err := elemdec(s, val.Index(i)); err == EOL {
 			break
 		} else if err != nil {
 			return addErrorContext(err, fmt.Sprint("[", i, "]"))
@@ -449,7 +449,7 @@ func makeStructDecoder(typ reflect.Type) (decoder, error) {
 		}
 		for i, f := range fields {
 			err := f.info.decoder(s, val.Field(f.index))
-			if errors.Is(err, EOL) {
+			if err == EOL {
 				if f.optional {
 					// The field is optional, so reaching the end of the list before
 					// reaching the last field is acceptable. All remaining undecoded

--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -303,7 +303,10 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 		// EIP-2718 typed txn receipt. Read the envelope as raw bytes,
 		// then decode from them using a fresh stream.
 		if size == 0 {
-			return rlp.EOL
+			// Empty string is not a valid typed receipt. Return a real error
+			// rather than rlp.EOL: as a slice element EOL would be read as
+			// end-of-list and silently drop the receipt.
+			return errShortTypedReceipt
 		}
 		b := make([]byte, size)
 		if err = s.ReadBytes(b); err != nil {

--- a/execution/types/receipt_test.go
+++ b/execution/types/receipt_test.go
@@ -39,7 +39,10 @@ func TestDecodeEmptyTypedReceipt(t *testing.T) {
 	input := []byte{0x80}
 	var r Receipt
 	err := rlp.DecodeBytes(input, &r)
-	if !errors.Is(err, rlp.EOL) {
+	// An empty typed receipt is invalid and must surface a real error.
+	// It must NOT return rlp.EOL: as a slice element that sentinel would be
+	// read as end-of-list and silently drop the receipt (see FuzzRLP).
+	if !errors.Is(err, errShortTypedReceipt) {
 		t.Fatal("wrong error:", err)
 	}
 }


### PR DESCRIPTION
## Problem

`FuzzRLP` found that slice/struct RLP decoding **silently accepts malformed input and drops elements** instead of erroring. Two independent divergences from go-ethereum:

### 1. `execution/rlp`: wrapped `EOL` swallowed
The generic slice/array/struct element decoders used `errors.Is(err, EOL)` to detect end-of-list. `EOL` is a sentinel meaning "the stream reached the end of this list". A custom `Decoder` (e.g. `Receipt.decodePayload`) legitimately wraps `EOL` via `fmt.Errorf("...: %w", EOL)` on malformed input — `errors.Is` matched those and treated them as end-of-list, dropping the element and swallowing the error. Switched to the exact sentinel match `err == EOL` at all three sites, **as upstream go-ethereum does**.

### 2. `execution/types`: empty typed receipt returned the sentinel
`Receipt.DecodeRLP` returned bare `rlp.EOL` for an empty typed receipt (`0x80`). As a slice element that sentinel is read as end-of-list, silently dropping the receipt. Now returns `errShortTypedReceipt` (the existing "typed receipt too short" error). go-ethereum returns a real error here too; this `rlp.EOL` traces to a 2019 geth-sync.

> **Reviewer note:** `TestDecodeEmptyTypedReceipt` previously asserted the `rlp.EOL` behaviour — it is updated to expect `errShortTypedReceipt`. This is the one intentional behaviour change.

## Impact

Malformed/non-canonical RLP that should be rejected was silently accepted with elements dropped. Bug 1 is **type-generic** (any `[]T`/struct where `T` has a custom `DecodeRLP` that wraps `EOL`). Main risks: inter-client **parsing differential** vs go-ethereum (consensus-divergence surface) and **silent truncation** masking malformed/corrupt data. Not a proven state-forgery — receipts are normally re-checked against the header `receiptsRoot` — but it closes a malleability/silent-drop class and re-aligns with geth.

## Found by / validation

- Found by `FuzzRLP` (inputs `c2c23030` and `c180`).
- `execution/rlp` + `execution/types` suites: green.
- `FuzzRLP`: 240s / 17M execs, no crash (was crashing in seconds).
- `make lint`: 0 issues.

## Related (not in this PR)

`checkErrListEnd` (block.go) uses the same `errors.Is(EOL)` anti-pattern and is used by the EIP-7928 BAL decoders (which wrap `EOL`) and block-body decode. There's a partial `s.ListEnd()` backstop and no fuzzer covering BAL RLP — tracking as a separate follow-up (BAL/block-body RLP fuzzer + `checkErrListEnd` fix).

## Backport

`release/3.5` (and likely `release/3.4`) have both bugs — good cherry-pick candidate.