### PR TITLE
[r3.5] execution/rlp, execution/types: reject malformed RLP instead of dropping elements

### DIFF
--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -358,7 +358,7 @@ func decodeSliceElems(s *Stream, val reflect.Value, elemdec decoder) error {
 			val.SetLen(i + 1)
 		}
 		// decode into element
-		if err := elemdec(s, val.Index(i)); errors.Is(err, EOL) {
+		if err := elemdec(s, val.Index(i)); err == EOL {
 			break
 		} else if err != nil {
 			return addErrorContext(err, fmt.Sprint("[", i, "]"))
@@ -377,7 +377,7 @@ func decodeListArray(s *Stream, val reflect.Value, elemdec decoder) error {
 	vlen := val.Len()
 	i := 0
 	for ; i < vlen; i++ {
-		if err := elemdec(s, val.Index(i)); errors.Is(err, EOL) {
+		if err := elemdec(s, val.Index(i)); err == EOL {
 			break
 		} else if err != nil {
 			return addErrorContext(err, fmt.Sprint("[", i, "]"))
@@ -449,7 +449,7 @@ func makeStructDecoder(typ reflect.Type) (decoder, error) {
 		}
 		for i, f := range fields {
 			err := f.info.decoder(s, val.Field(f.index))
-			if errors.Is(err, EOL) {
+			if err == EOL {
 				if f.optional {
 					// The field is optional, so reaching the end of the list before
 					// reaching the last field is acceptable. All remaining undecoded

--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -303,7 +303,10 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 		// EIP-2718 typed txn receipt. Read the envelope as raw bytes,
 		// then decode from them using a fresh stream.
 		if size == 0 {
-			return rlp.EOL
+			// Empty string is not a valid typed receipt. Return a real error
+			// rather than rlp.EOL: as a slice element EOL would be read as
+			// end-of-list and silently drop the receipt.
+			return errShortTypedReceipt
 		}
 		b := make([]byte, size)
 		if err = s.ReadBytes(b); err != nil {

--- a/execution/types/receipt_test.go
+++ b/execution/types/receipt_test.go
@@ -39,7 +39,10 @@ func TestDecodeEmptyTypedReceipt(t *testing.T) {
 	input := []byte{0x80}
 	var r Receipt
 	err := rlp.DecodeBytes(input, &r)
-	if !errors.Is(err, rlp.EOL) {
+	// An empty typed receipt is invalid and must surface a real error.
+	// It must NOT return rlp.EOL: as a slice element that sentinel would be
+	// read as end-of-list and silently drop the receipt (see FuzzRLP).
+	if !errors.Is(err, errShortTypedReceipt) {
 		t.Fatal("wrong error:", err)
 	}
 }


### PR DESCRIPTION
Cherry-pick of #21818 to release/3.5.

release/3.5 has both bugs fixed there. Verified: execution/rlp + execution/types suites green, FuzzRLP clean, make lint 0 issues.