### PR TITLE
.github, docs, Makefile: nightly fuzz workflow + fuzzing docs + make fuzz

### DIFF
--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -1,0 +1,180 @@
+name: Fuzz
+
+# Active (mutation) fuzzing of Erigon's native Go fuzzers. This is intentionally
+# NOT part of the CI gate: seed-corpus regression already runs inside
+# `go test ./...` (test-all-erigon), and adding mutation fuzzing to the gate
+# would make it flaky (a newly found crash would red unrelated PRs).
+#
+# It complements OSS-Fuzz (google/oss-fuzz projects/erigon): it runs today
+# before that integration is live, and it also covers the txnprovider/txpool
+# targets that link MDBX — these need no sanitizer toolchain under native
+# `go test -fuzz`, so they run here even while deferred upstream.
+#
+# A scheduled failure opens/updates a tracking issue (label `nightly-fuzz`) and,
+# if the `DISCORD_WEBHOOK` secret is configured, posts a Discord alert. Per repo
+# policy a fuzz crash must be investigated and fixed — never skipped.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # nightly 03:00 UTC (runs on the default branch)
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: 'Duration per fuzz target (Go duration, e.g. 120s, 30m, 1h)'
+        required: false
+        default: '120s'
+  workflow_call:
+    inputs:
+      fuzztime:
+        required: false
+        type: string
+        default: '120s'
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write   # notify job opens/updates the tracking issue
+
+jobs:
+  fuzz:
+    # Don't run the nightly schedule on forks.
+    if: github.repository == 'erigontech/erigon' || github.event_name != 'schedule'
+    # GitHub-hosted standard runner — free with unlimited minutes on this public
+    # repo. (Self-hosted/larger runners are the only ones that would cost money.)
+    runs-on: ubuntu-latest
+    # Generous backstop so a long manual `fuzztime` (e.g. up to ~1h) is not
+    # killed; the nightly default (120s) finishes in a few minutes.
+    timeout-minutes: 70
+    strategy:
+      fail-fast: false   # one crashing target must not cancel the others
+      matrix:
+        include:
+          - { name: bitutil-encoder,            pkg: common/bitutil,                 fn: FuzzEncoder }
+          - { name: bitutil-decoder,            pkg: common/bitutil,                 fn: FuzzDecoder }
+          - { name: fusefilter-reader,          pkg: db/datastruct/fusefilter,       fn: FuzzReaderOnBytes }
+          - { name: fusefilter-reader-sharded,  pkg: db/datastruct/fusefilter,       fn: FuzzReaderShardedOnBytes }
+          - { name: fusefilter-writer,          pkg: db/datastruct/fusefilter,       fn: FuzzWriterRoundTrip }
+          - { name: ef16-single,                pkg: db/recsplit/eliasfano16,        fn: FuzzSingleEliasFano }
+          - { name: ef16-double,                pkg: db/recsplit/eliasfano16,        fn: FuzzDoubleEliasFano }
+          - { name: ef32-single,                pkg: db/recsplit/eliasfano32,        fn: FuzzSingleEliasFano }
+          - { name: ef32-double,                pkg: db/recsplit/eliasfano32,        fn: FuzzDoubleEliasFano }
+          - { name: recsplit,                   pkg: db/recsplit,                    fn: FuzzRecSplit }
+          - { name: seg-compress,               pkg: db/seg,                         fn: FuzzCompress }
+          - { name: seg-decompress-match,       pkg: db/seg,                         fn: FuzzDecompressMatch }
+          - { name: patricia,                   pkg: db/seg/patricia,                fn: FuzzPatricia }
+          - { name: patricia-longest-match,     pkg: db/seg/patricia,                fn: FuzzLongestMatch }
+          - { name: abi,                        pkg: execution/abi,                  fn: FuzzABI }
+          - { name: nibbles-hexcompact,         pkg: execution/commitment/nibbles,   fn: FuzzHexCompactRoundtrip }
+          - { name: rlp,                        pkg: execution/types,                fn: FuzzRLP }
+          - { name: precompiles,                pkg: execution/vm,                   fn: FuzzPrecompiledContracts }
+          - { name: vm-runtime,                 pkg: execution/vm/runtime,           fn: FuzzVmRuntime }
+          - { name: txpool-parsetx,             pkg: txnprovider/txpool,             fn: FuzzParseTx }
+          - { name: txpool-pooledtxns66,        pkg: txnprovider/txpool,             fn: FuzzPooledTransactions66 }
+          - { name: txpool-getpooledtxns66,     pkg: txnprovider/txpool,             fn: FuzzGetPooledTransactions66 }
+          - { name: txpool-onnewblocks,         pkg: txnprovider/txpool,             fn: FuzzOnNewBlocks }
+    steps:
+      - name: Checkout custom actions
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-erigon
+        id: erigon
+        with:
+          build-cache-extra-key: fuzz-${{ matrix.name }}
+
+      # Per-target corpus, persisted across runs so each night builds on the
+      # inputs the previous run discovered. Restored AFTER setup-erigon (which
+      # caches all of GOCACHE), so this dedicated entry wins for $GOCACHE/fuzz.
+      - name: Restore fuzz corpus
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.erigon.outputs.build }}/fuzz
+          key: fuzz-corpus-${{ matrix.name }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.name }}-
+
+      - name: Fuzz ${{ matrix.fn }}
+        env:
+          FUZZTIME: ${{ inputs.fuzztime || '120s' }}
+        run: |
+          mkdir -p "${{ steps.erigon.outputs.build }}/fuzz"
+          echo "::group::go test -fuzz ${{ matrix.fn }} (./${{ matrix.pkg }}, ${FUZZTIME})"
+          go test "./${{ matrix.pkg }}/" -run '^$' -fuzz "^${{ matrix.fn }}$" -fuzztime "${FUZZTIME}"
+          echo "::endgroup::"
+
+      # On a crash, `go test` writes the minimized reproducing input to
+      # <pkg>/testdata/fuzz/<Fn>/. Upload it so the failure is replayable.
+      - name: Upload crash reproducer
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-crash-${{ matrix.name }}
+          path: ${{ matrix.pkg }}/testdata/fuzz/${{ matrix.fn }}/
+          if-no-files-found: ignore
+
+      - uses: ./.github/actions/cleanup-erigon
+        if: always()
+
+  notify:
+    needs: [fuzz]
+    # Only alert on scheduled failures: manual/dispatch runs are watched by
+    # whoever triggered them. `always()` lets this run despite `fuzz` failing.
+    if: ${{ always() && needs.fuzz.result == 'failure' && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or update tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create nightly-fuzz --color B60205 \
+            --description "Crash found by the nightly fuzz workflow" --force --repo "$REPO" || true
+
+          body=$(cat <<EOF
+          The nightly **Fuzz** workflow found one or more crashing inputs.
+
+          - Run: ${RUN_URL}
+          - The red matrix legs on that run show which targets crashed.
+          - Each crash's minimized reproducer is attached to the run as an
+            artifact named \`fuzz-crash-<target>\`.
+
+          Per repo policy a fuzz crash must be **investigated and fixed**, not
+          skipped. To reproduce locally, drop the reproducer file into the
+          target package's \`testdata/fuzz/<FuzzName>/\` and run
+          \`go test ./<pkg> -run <FuzzName>\`.
+          EOF
+          )
+
+          num=$(gh issue list --repo "$REPO" --label nightly-fuzz --state open \
+            --json number --jq '.[0].number')
+          if [ -n "$num" ]; then
+            gh issue comment "$num" --repo "$REPO" --body "$body"
+            echo "Updated existing tracking issue #${num}"
+          else
+            gh issue create --repo "$REPO" --label nightly-fuzz \
+              --title "Nightly fuzz crash(es) detected" --body "$body"
+          fi
+
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "${DISCORD_WEBHOOK:-}" ]; then
+            echo "DISCORD_WEBHOOK not set — skipping Discord notification."
+            exit 0
+          fi
+          msg=":x: **Nightly fuzz failure** — one or more targets crashed.\nRun: ${RUN_URL}\nReproducers are uploaded as \`fuzz-crash-*\` artifacts; a tracking issue (label \`nightly-fuzz\`) was opened/updated."
+          payload=$(printf '{"content": "%s"}' "$msg")
+          curl -sS -f -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK" \
+            && echo "Discord notified." \
+            || echo "::warning::Discord notification failed (webhook unreachable or invalid)."

--- a/Makefile
+++ b/Makefile
@@ -304,6 +304,16 @@ test-bench: override GO_FLAGS += -run=^$$ -bench=. -benchtime=1x -short -timeout
 test-bench:
 	$(GOTEST)
 
+## fuzz PKG=<pkg> FUZZ=<FuzzName> [FUZZTIME=60s]:  run one Go fuzz target (see docs/fuzzing.md)
+.PHONY: fuzz
+fuzz:
+	@if [ -z "$(FUZZ)" ] || [ -z "$(PKG)" ]; then \
+		echo "usage: make fuzz PKG=<pkg> FUZZ=<FuzzName> [FUZZTIME=60s]"; \
+		echo "   e.g. make fuzz PKG=./db/seg FUZZ=FuzzCompress FUZZTIME=30s"; \
+		exit 2; \
+	fi
+	$(GO) test $(PKG) -run '^$$' -fuzz '^$(FUZZ)$$' -fuzztime $(or $(FUZZTIME),60s)
+
 test-all-race: override GO_FLAGS := -timeout $(default_test_race_timeout) $(GO_FLAGS) -race
 test-all-race: test-filtered
 

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -1,0 +1,131 @@
+# Fuzzing
+
+Erigon is fuzz-tested at the parsing and decoding boundaries that handle
+untrusted input (peer messages, RLP/ABI payloads, on-disk codecs). This page
+explains what is fuzzed, how to run the fuzzers locally, the nightly CI job, and
+the [OSS-Fuzz](https://github.com/google/oss-fuzz) integration that runs them
+continuously.
+
+## Background
+
+A fuzzer feeds randomly mutated inputs into a function looking for panics,
+hangs, or assertion failures. Erigon uses Go's built-in
+[native fuzzing](https://go.dev/doc/security/fuzz/) (`func FuzzXxx(f *testing.F)`
+in `*_test.go` files) — no external tooling or build tags required.
+
+Two things run these fuzzers:
+
+- **The Go toolchain locally / in CI** (`go test -fuzz`) — see below.
+- **OSS-Fuzz**, Google's continuous fuzzing service, which builds them into
+  libFuzzer binaries and fuzzes them around the clock on dedicated
+  infrastructure, reporting bugs to the Erigon maintainers.
+
+## Fuzz targets
+
+| Package | Fuzzers |
+|---|---|
+| `common/bitutil` | `FuzzEncoder`, `FuzzDecoder` |
+| `db/datastruct/fusefilter` | `FuzzReaderOnBytes`, `FuzzReaderShardedOnBytes`, `FuzzWriterRoundTrip` |
+| `db/recsplit/eliasfano16` | `FuzzSingleEliasFano`, `FuzzDoubleEliasFano` |
+| `db/recsplit/eliasfano32` | `FuzzSingleEliasFano`, `FuzzDoubleEliasFano` |
+| `db/recsplit` | `FuzzRecSplit` |
+| `db/seg` | `FuzzCompress`, `FuzzDecompressMatch` |
+| `db/seg/patricia` | `FuzzPatricia`, `FuzzLongestMatch` |
+| `execution/abi` | `FuzzABI` |
+| `execution/commitment/nibbles` | `FuzzHexCompactRoundtrip` |
+| `execution/types` | `FuzzRLP` |
+| `execution/vm` | `FuzzPrecompiledContracts` |
+| `execution/vm/runtime` | `FuzzVmRuntime` |
+| `txnprovider/txpool` | `FuzzParseTx`, `FuzzPooledTransactions66`, `FuzzGetPooledTransactions66`, `FuzzOnNewBlocks` |
+
+Each target keeps a committed seed corpus under its package's
+`testdata/fuzz/<FuzzName>/`. These seeds are replayed as ordinary unit tests by
+`go test ./...` (no `-fuzz` flag), so the seed corpus is already a regression
+guard in the normal test suite.
+
+## Running locally
+
+Run one target with active mutation, either via the Makefile helper:
+
+```bash
+make fuzz PKG=./db/seg FUZZ=FuzzCompress FUZZTIME=30s   # FUZZTIME defaults to 60s
+```
+
+or directly with `go test`:
+
+```bash
+go test ./db/seg/ -run '^$' -fuzz '^FuzzCompress$' -fuzztime 30s
+```
+
+- `-run '^$'` disables the normal tests so only the fuzzer runs.
+- `-fuzz` takes a single regexp matching one target in that package.
+- Newly discovered "interesting" inputs are cached under
+  `$(go env GOCACHE)/fuzz`; a crashing input is written to the package's
+  `testdata/fuzz/<FuzzName>/` so it can be committed and replayed.
+
+Replay just the seed + discovered corpus (no mutation), e.g. to reproduce a
+crash file someone committed:
+
+```bash
+go test ./db/seg/ -run '^FuzzCompress$'
+```
+
+## Nightly CI
+
+[`.github/workflows/test-fuzz.yml`](../.github/workflows/test-fuzz.yml) runs
+every target nightly (03:00 UTC) on a free GitHub-hosted runner, each for a
+short `fuzztime`, with a per-target corpus cache so each run builds on the
+previous night's findings. It can also be triggered manually
+(`workflow_dispatch`) with a custom `fuzztime` for a deeper ad-hoc run.
+
+This is intentionally **not** part of the PR/merge CI gate: seed-corpus
+regression is already covered by the normal test suite, and putting mutation
+fuzzing on the gate would make it flaky (a newly found crash would fail
+unrelated PRs).
+
+On a scheduled failure the workflow:
+
+1. uploads each crash's minimized reproducer as a `fuzz-crash-<target>`
+   artifact on the run;
+2. opens or updates a tracking issue labelled `nightly-fuzz`;
+3. posts a Discord alert if the `DISCORD_WEBHOOK` repository secret is set
+   (it no-ops quietly otherwise).
+
+## OSS-Fuzz integration
+
+The continuous integration with OSS-Fuzz lives in the
+[`google/oss-fuzz`](https://github.com/google/oss-fuzz) repository under
+`projects/erigon/` (`project.yaml`, `Dockerfile`, `build.sh`) — **not** in this
+repo, to avoid drift with upstream's tooling. The `build.sh` there wires the
+same native fuzzers up via `compile_native_go_fuzzer`.
+
+- Project: https://github.com/google/oss-fuzz/tree/master/projects/erigon
+- Onboarding PR: https://github.com/google/oss-fuzz/pull/15642
+- OSS-Fuzz Go guide: https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/
+
+Bugs found by OSS-Fuzz are reported privately to the project contacts and made
+public after the standard 90-day disclosure window.
+
+> **Note:** the `txnprovider/txpool` targets link the MDBX C library. They run
+> in local/nightly CI fine, but are deferred in the upstream `build.sh` until
+> validated under the OSS-Fuzz sanitizer toolchain.
+
+## Adding a new fuzzer
+
+1. Write `func FuzzXxx(f *testing.F)` in a `*_test.go` file, seeding it with
+   `f.Add(...)` calls.
+2. Commit a small seed corpus under `testdata/fuzz/FuzzXxx/` if useful.
+3. Add the target to the matrix in
+   [`.github/workflows/test-fuzz.yml`](../.github/workflows/test-fuzz.yml).
+4. Add a `compile_native_go_fuzzer` line to `projects/erigon/build.sh` in the
+   OSS-Fuzz repo (separate PR) so it is fuzzed continuously.
+
+New fuzzers are **not** picked up automatically by either CI or OSS-Fuzz — both
+lists are explicit.
+
+## When a fuzzer finds a crash
+
+A fuzz crash is a real failure. Investigate and fix it — do not skip the test or
+delete the crash corpus (see the test-skip policy in the root `CLAUDE.md`).
+Commit the reproducing input under `testdata/fuzz/<FuzzName>/` so the fix is
+verified and the case stays covered.


### PR DESCRIPTION
## What

- **`.github/workflows/test-fuzz.yml`** — scheduled (nightly 03:00 UTC) active fuzzing of all 23 native Go fuzzers (`testing.F`), one matrix leg per target, on `ubuntu-latest` (free/unlimited on this public repo), with a per-target corpus cache. Manually dispatchable with a custom `fuzztime`.
- **`docs/fuzzing.md`** — targets, local usage, the nightly job, and the OSS-Fuzz integration ([google/oss-fuzz#15642](https://github.com/google/oss-fuzz/pull/15642)).
- **`make fuzz PKG=<pkg> FUZZ=<FuzzName> [FUZZTIME=60s]`** — local single-target helper.

## Design

Intentionally **not** part of the CI gate: seed-corpus regression already runs in `go test ./...`, and putting mutation fuzzing on the gate would be flaky (a newly found crash would red unrelated PRs). It complements OSS-Fuzz: runs today before that integration is live, and also covers the `txnprovider/txpool` (MDBX) targets deferred upstream (native `go test -fuzz` needs no sanitizer toolchain).

## Notifications (scheduled failures only)

Uploads each crash reproducer as a `fuzz-crash-<target>` artifact, opens/updates a `nightly-fuzz` tracking issue, and posts to Discord if the `DISCORD_WEBHOOK` secret is set (no-ops otherwise).

## Notes

- Requires a `DISCORD_WEBHOOK` repository secret for Discord alerts (optional; safe to merge without).
- Best merged after #21818 — that fixes the one pre-existing `FuzzRLP` crash this workflow surfaces, so the first nightly starts green.