### PR TITLE
node/components/downloader: always register torrent client status on default mux

### DIFF
--- a/node/components/downloader/provider.go
+++ b/node/components/downloader/provider.go
@@ -125,9 +125,11 @@ func (p *Provider) initDownloader(ctx context.Context) (downloaderproto.Download
 	}
 	p.Downloader = d
 
-	if p.debugMux != nil {
-		d.HandleTorrentClientStatus(p.debugMux)
-	}
+	// Always call: HandleTorrentClientStatus registers the status handler on
+	// http.DefaultServeMux (reachable via GOPPROF=http) regardless of whether
+	// debugMux is nil. Guarding on p.debugMux != nil drops the default-mux
+	// registration when --metrics/--pprof are disabled.
+	d.HandleTorrentClientStatus(p.debugMux)
 
 	bittorrentServer, err := dl.NewGrpcServer(d)
 	if err != nil {


### PR DESCRIPTION
The torrent client status endpoint (`/downloader/torrentClientStatus`) became unreachable via `GOPPROF=http` when `--metrics`/`--pprof` are disabled.

#20471 extracted the downloader into a component and wrapped the registration call in `if p.debugMux != nil`. `HandleTorrentClientStatus` registers on `http.DefaultServeMux` unconditionally (the `GOPPROF=http` path) and only conditionally on the debug mux, so the guard silently dropped the default-mux registration whenever no debug mux exists (no `--metrics`/`--pprof`). The function already nil-guards `debugMux` internally, so the call is safe to make unconditionally.

This restores the behavior documented in `db/downloader/README.md` and the `HandleTorrentClientStatus` doc-comment.