### PR TITLE
[r3.5] node/components/downloader: always register torrent client status on default mux

### DIFF
--- a/node/components/downloader/provider.go
+++ b/node/components/downloader/provider.go
@@ -125,9 +125,11 @@ func (p *Provider) initDownloader(ctx context.Context) (downloaderproto.Download
 	}
 	p.Downloader = d
 
-	if p.debugMux != nil {
-		d.HandleTorrentClientStatus(p.debugMux)
-	}
+	// Always call: HandleTorrentClientStatus registers the status handler on
+	// http.DefaultServeMux (reachable via GOPPROF=http) regardless of whether
+	// debugMux is nil. Guarding on p.debugMux != nil drops the default-mux
+	// registration when --metrics/--pprof are disabled.
+	d.HandleTorrentClientStatus(p.debugMux)
 
 	bittorrentServer, err := dl.NewGrpcServer(d)
 	if err != nil {


### PR DESCRIPTION
Same fix as #21821, for release/3.5.

The torrent client status endpoint (`/downloader/torrentClientStatus`) became unreachable via `GOPPROF=http` when `--metrics`/`--pprof` are off, after #20471 wrapped the registration call in `if p.debugMux != nil`. `HandleTorrentClientStatus` registers on `http.DefaultServeMux` unconditionally and nil-guards `debugMux` internally, so the guard only dropped the default-mux path. Call it unconditionally to restore documented behavior.