### PR TITLE
execution/stagedsync: prune in-RAM overlay when execution unwind is a disk no-op

### DIFF
--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -469,6 +469,25 @@ func SpawnExecuteBlocksStage(s *StageState, u Unwinder, doms *execctx.SharedDoma
 func UnwindExecutionStage(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwTx kv.TemporalRwTx, ctx context.Context, cfg ExecuteBlockCfg, logger log.Logger) (err error) {
 	//fmt.Printf("unwind: %d -> %d\n", u.CurrentBlockNumber, u.UnwindPoint)
 	if u.UnwindPoint >= s.BlockNumber {
+		// The committed execution progress (s.BlockNumber) is at or below the
+		// unwind point, so MDBX has nothing above u.UnwindPoint to roll back and
+		// the disk unwind below would be a no-op. However the in-RAM
+		// SharedDomains / TemporalMemBatch overlay can still hold *uncommitted*
+		// writes for blocks above u.UnwindPoint — e.g. a block whose
+		// post-execution gas check failed mid-batch, before its step was ever
+		// flushed. Those entries must still be pruned: the overlay is reused
+		// across the unwind→retry loop within a single sync.Run, so leaving them
+		// makes the re-execution read a stale value (observed on Hoodi 3004265:
+		// ca5daf64 slot0 kept tx19's first-write, the contract took the
+		// "already initialised" branch, skipped an SSTORE_SET, came up 21045 gas
+		// short, and the node spun in an unwind/retry loop). The committed prune
+		// (#20625) only runs from unwindExec3, which the early return skipped.
+		txNum, err := cfg.blockReader.TxnumReader().Min(ctx, rwTx, u.UnwindPoint+1)
+		if err != nil {
+			return err
+		}
+		doms.Unwind(txNum, nil)
+		doms.SetTxNum(txNum)
 		return nil
 	}
 

--- a/execution/stagedsync/stage_execute_unwind_test.go
+++ b/execution/stagedsync/stage_execute_unwind_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/mdbx"
+	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/kv/temporal"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
@@ -36,6 +37,7 @@ import (
 	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain/networkname"
+	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/ethconfig"
 )
@@ -149,4 +151,125 @@ func makeHeader(num uint64, parentMarker common.Hash) *types.Header {
 		Difficulty: *uint256.NewInt(1),
 		Extra:      parentMarker.Bytes(), // make the hash distinct per `parentMarker`
 	}
+}
+
+// TestUnwindExecutionStage_PrunesUncommittedOverlayWrite is a regression test
+// for the Hoodi block-3004265 gas-used mismatch (release/3.4).
+//
+// Repro of the original chain of events:
+//
+//  1. In serial batch execution, block 3004265 tx19 does a first-time SSTORE to
+//     ca5daf64 slot0. That write lands in the in-RAM SharedDomains /
+//     TemporalMemBatch overlay (stamped with tx19's txNum) but the block then
+//     fails its post-execution gas check, so its step is never committed.
+//  2. The executor schedules UnwindTo(3004264). Because 3004265 was never
+//     committed, the committed execution-stage progress (s.BlockNumber) sits at
+//     or below the unwind point, so UnwindExecutionStage hit the
+//     `u.UnwindPoint >= s.BlockNumber` early return and skipped unwindExec3 —
+//     i.e. it never called sd.Unwind, so the overlay prune added by #20625
+//     (which only runs from unwindExec3) never executed.
+//  3. The same overlay is reused across the unwind→retry loop inside one
+//     sync.Run, so on retry the storage read returned tx19's own stale
+//     first-write (…a3a34) instead of the committed 0. The contract took the
+//     "already initialised" branch, skipped an SSTORE_SET (20000 gas), the block
+//     came up exactly 21045 gas short, and the node spun in an unwind/retry loop.
+//
+// Before the fix, step 2's early return leaves the overlay untouched, so the
+// failed block's write is still visible after the unwind — this test asserts it
+// is gone, while a write at/below the unwind point survives (no over-pruning).
+func TestUnwindExecutionStage_PrunesUncommittedOverlayWrite(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
+	t.Cleanup(rawDb.Close)
+
+	// stepSize far above every txNum used here keeps everything in step 0 — the
+	// overlay prune compares raw txNums, so the commitment/step machinery is moot.
+	agg, err := dbstate.NewTest(dirs).StepSize(10_000).Logger(logger).Open(context.Background(), rawDb)
+	require.NoError(t, err)
+	t.Cleanup(agg.Close)
+
+	db, err := temporal.New(rawDb, agg)
+	require.NoError(t, err)
+
+	// Block reader backed only by MDBX — the unwind range is at the tip, above
+	// any frozen snapshot boundary, so no snapshots are needed.
+	snaps := freezeblocks.NewRoSnapshots(ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}, dirs.Snap, logger)
+	t.Cleanup(snaps.Close)
+	br := freezeblocks.NewBlockReader(snaps, nil)
+
+	ctx := context.Background()
+	tx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	// txNum layout: block b owns txNums [perBlock*b, perBlock*b+perBlock-1], so
+	// TxnumReader().Min(b) == perBlock*b (the block's first/system txNum).
+	const perBlock = uint64(10)
+	for b := uint64(0); b <= 8; b++ {
+		require.NoError(t, rawdbv3.TxNums.Append(tx, b, b*perBlock+perBlock-1))
+	}
+
+	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	defer doms.Close()
+	doms.SetChangesetAccumulator(&changeset.StateChangeSet{})
+
+	const (
+		committedBlock = uint64(5) // execution-stage progress (last flushed block)
+		unwindPoint    = uint64(7) // = failedBlock-1; >= committedBlock => disk no-op
+		failedBlock    = uint64(8) // block whose post-exec gas check failed mid-batch
+	)
+	boundaryTxNum, err := br.TxnumReader().Min(ctx, tx, unwindPoint+1)
+	require.NoError(t, err)
+	require.Equal(t, failedBlock*perBlock, boundaryTxNum, "sanity: Min(failedBlock) == first txNum of failedBlock")
+
+	// staleKey mirrors ca5daf64 slot0: first-written by failedBlock's tx19 at a
+	// txNum strictly above the unwind boundary — must be pruned on unwind.
+	staleAddr := common.HexToAddress("0xca5daf6473971693b760cc65d726f72c6849d615")
+	staleKey := append(append([]byte{}, staleAddr.Bytes()...), common.Hash{}.Bytes()...) // slot 0
+	staleVal := common.HexToHash("0xd7549f2a387fa81a1d5a77adc7bd3f782ac0780c460689d88e22aee6916a3a34").Bytes()
+	const staleTxNum = failedBlock*perBlock + 5 // inside failedBlock, above the boundary
+
+	// keepKey is written by a block at/below the unwind point — must survive.
+	keepAddr := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	keepKey := append(append([]byte{}, keepAddr.Bytes()...), common.Hash{31: 0x01}.Bytes()...)
+	keepVal := []byte{0xbe, 0xef}
+	const keepTxNum = unwindPoint * perBlock // inside the unwind-target block
+
+	doms.SetTxNum(keepTxNum)
+	require.NoError(t, doms.DomainPut(kv.StorageDomain, tx, keepKey, keepVal, keepTxNum, nil))
+	doms.SetTxNum(staleTxNum)
+	require.NoError(t, doms.DomainPut(kv.StorageDomain, tx, staleKey, staleVal, staleTxNum, nil))
+
+	// Sanity: both visible through the overlay before the unwind.
+	got, _, err := doms.GetLatest(kv.StorageDomain, tx, staleKey)
+	require.NoError(t, err)
+	require.Equal(t, staleVal, got, "precondition: stale write must be visible pre-unwind")
+	got, _, err = doms.GetLatest(kv.StorageDomain, tx, keepKey)
+	require.NoError(t, err)
+	require.Equal(t, keepVal, got, "precondition: keep write must be visible pre-unwind")
+
+	cfg := ExecuteBlockCfg{blockReader: br}
+	s := &StageState{ID: stages.Execution, BlockNumber: committedBlock}
+	u := &UnwindState{ID: stages.Execution, UnwindPoint: unwindPoint, CurrentBlockNumber: failedBlock}
+	require.GreaterOrEqual(t, u.UnwindPoint, s.BlockNumber, "test must exercise the no-op-disk-unwind branch")
+
+	require.NoError(t, UnwindExecutionStage(u, s, doms, tx, ctx, cfg, logger))
+
+	// The failed block's first-time write must be gone, so a re-execution reads
+	// the committed value (absent here -> empty) and charges SSTORE_SET again.
+	got, _, err = doms.GetLatest(kv.StorageDomain, tx, staleKey)
+	require.NoError(t, err)
+	require.Empty(t, got,
+		"after Unwind to block %d, the overlay must not return failedBlock(%d) tx write %x (got %x): "+
+			"UnwindExecutionStage skipped the overlay prune on the no-op-disk-unwind path",
+		unwindPoint, failedBlock, staleVal, got)
+
+	// A write at/below the unwind point must be untouched (no over-pruning).
+	got, _, err = doms.GetLatest(kv.StorageDomain, tx, keepKey)
+	require.NoError(t, err)
+	require.Equal(t, keepVal, got, "write at/below the unwind point must survive the prune")
 }


### PR DESCRIPTION
## What

Fixes a `gas used by execution` mismatch that puts the node into an infinite
unwind/retry loop. Observed on the Hoodi snapshotter (e3.4.3, serial batch
execution) stuck on block **3004265**:

```
gas used mismatch block=3004265 header=58278345 execution=58257300 diff=-21045 txCount=45
```

## Root cause

`#20625` / `#21538` correctly prunes the in-RAM `TemporalMemBatch` overlay by
`txNum` inside `TemporalMemBatch.Unwind` (for accounts **and** storage). That
prune is reached from `unwindExec3`.

The gap is one level up, in `UnwindExecutionStage`:

```go
if u.UnwindPoint >= s.BlockNumber {
    return nil   // early return — unwindExec3 (and thus sd.Unwind) never runs
}
```

When a block fails its **post-execution gas check mid-batch**, its writes are
already in the overlay but the block was **never committed**, so the committed
execution-stage progress `s.BlockNumber` is at or below the unwind point and
this early return fires. The overlay prune is skipped entirely. Because the
same `SharedDomains` is reused across the unwind→retry loop inside one
`sync.Run`, the stale write survives:

- tx19 of 3004265 does a first-time `SSTORE` to `ca5daf64` slot0 → overlay holds
  `…a3a34` at tx19's txNum.
- block fails the gas check → `UnwindTo(3004264)` → `UnwindExecutionStage`
  no-ops (3004264 ≥ committed progress) → overlay **not** pruned.
- retry: tx19 reads the stale `…a3a34` instead of the committed `0`, takes the
  "already initialised" branch, skips the `SSTORE_SET` (20000 gas) + compute →
  block is **21045 gas** short → fails again → loops forever.

The committed DB is correct (`eth_getStorageAt ca5daf64 0x0` = `0x0`); only the
in-memory overlay was stale, which is why the **state root still matches** and
only `gasUsed` diverges.

## Fix

In the `u.UnwindPoint >= s.BlockNumber` branch, still prune the in-RAM overlay
to the unwind boundary (same `txNum` / `sd.Unwind` call the non-no-op path
already uses). When the overlay has no uncommitted writes above the unwind
point (the normal case) this is a harmless no-op.

## Test

`TestUnwindExecutionStage_PrunesUncommittedOverlayWrite` seeds the overlay with
a first-time storage write at a `txNum` belonging to a block above the unwind
point, drives `UnwindExecutionStage` with `u.UnwindPoint >= s.BlockNumber`, and
asserts the stale write is gone while a write at/below the unwind point
survives.

- **Without the fix** (early return restored): FAILS — the overlay still returns
  the stale value (`d7549f2a…a3a34`, the real bug value).
- **With the fix**: PASSES.

## Verification

- `go build ./execution/stagedsync/... ./db/state/...` — clean
- `go test ./execution/stagedsync/ -short` — pass
- `TestSharedDomain_Unwind*` (the `#20625` regression tests) — still pass
- `TestFindExecutedDiffsetAtHeight_FallsBackAfterCanonicalReorg` — still pass
- `gofmt` / `go vet` / `golangci-lint run ./execution/stagedsync/` — 0 issues

## Notes

Relates to #21681 (the `gas used mismatch in 3.4` reports that persist after
`#20625`). Not auto-closing — the same root cause is the most likely
explanation for those, but they should be confirmed on the snapshotter (incl.
block 25202264) first.

The fix lives in the single execution-unwind chokepoint, so it covers both the
serial and parallel executors. A forward-port to `main` will be opened
separately.

Co-authored-by: Claude <noreply@anthropic.com>
