### PR TITLE
polygon/sync: fix lost-wakeup race in EventChannel.waitForEvent

### DIFF
--- a/polygon/sync/event_channel.go
+++ b/polygon/sync/event_channel.go
@@ -118,8 +118,11 @@ func (ec *EventChannel[TEvent]) waitForEvent(ctx context.Context) (TEvent, error
 	// wait for the waiting goroutine or the parent context to finish, whichever happens first
 	<-waitCtx.Done()
 
-	// if the parent context is done, force the waiting goroutine to exit
+	// Signal under the mutex to avoid a lost-wakeup: without the lock, Signal can
+	// fire between the inner goroutine's condition check and its Wait() call.
+	ec.queueMutex.Lock()
 	ec.queueCond.Signal()
+	ec.queueMutex.Unlock()
 	wg.Wait()
 
 	return e, ctx.Err()


### PR DESCRIPTION
`Signal()` was called without holding `queueMutex`, creating a window where the signal fires after the inner goroutine checked `waitCtx.Err() == nil` but before it called `queueCond.Wait()`. The signal is silently consumed and the inner goroutine blocks forever — manifesting as `TestTipEventsNewBlockHashesEmitsEvent` timing out after 1h in CI.

Fix: acquire the mutex before `Signal()`. `sync.Cond.Signal` does not require the mutex, but calling it under the lock prevents the race: the outer goroutine blocks until the inner is either inside `Wait()` (where it will be woken up) or has already exited the loop.