### PR TITLE
seg: SamplingFactor>1 produced only 1 sample

### DIFF
--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -123,6 +123,8 @@ type Compressor struct {
 	// this is needed for using ordinary (one string) suffix sorting algorithm instead of a generalised (many superstrings) suffix
 	// sorting algorithm
 	superstring       []byte
+	scannedBytes      int
+	superstringLimit  int
 	wordsCount        uint64
 	superstringCount  uint64
 	uncompressedBytes int
@@ -187,6 +189,7 @@ func NewCompressor(ctx context.Context, logPrefix, outputFile, tmpDir string, cf
 		wg:               wg,
 		logger:           logger,
 		version:          FileCompressionFormatV1,
+		superstringLimit: superstringLimit,
 	}
 
 	if cfg.ValuesOnCompressedPage > 0 {
@@ -267,16 +270,8 @@ func (c *Compressor) AddWord(word []byte) error {
 		}
 	}
 
-	l := 2*len(word) + 2
-	if len(c.superstring)+l > superstringLimit {
-		if c.superstringCount%c.SamplingFactor == 0 {
-			c.superstrings <- c.superstring
-		}
-		c.superstringCount++
-		c.superstring = superStringsPool.Get().([]byte)[:0]
-	}
-
-	if c.superstringCount%c.SamplingFactor == 0 {
+	c.advanceScan(2*len(word) + 2)
+	if c.sampledSuperstring() {
 		for _, a := range word {
 			c.superstring = append(c.superstring, 1, a)
 		}
@@ -285,6 +280,25 @@ func (c *Compressor) AddWord(word []byte) error {
 
 	c.uncompressedBytes += len(word)
 	return c.uncompressedFile.Append(word)
+}
+
+func (c *Compressor) sampledSuperstring() bool { return c.superstringCount%c.SamplingFactor == 0 }
+
+// advanceScan accounts for the next word (encoded size l) and cuts a new superstring when the
+// current one would overflow. Bytes are counted for every word so boundaries don't depend on
+// sampling; a superstring fills only when sampled, so only a non-empty buffer is sent and replaced.
+func (c *Compressor) advanceScan(l int) {
+	if c.scannedBytes+l <= c.superstringLimit {
+		c.scannedBytes += l
+		return
+	}
+
+	if len(c.superstring) > 0 {
+		c.superstrings <- c.superstring
+		c.superstring = superStringsPool.Get().([]byte)[:0]
+	}
+	c.superstringCount++
+	c.scannedBytes = 0
 }
 
 func (c *Compressor) AddUncompressedWord(word []byte) error {

--- a/db/seg/compress_test.go
+++ b/db/seg/compress_test.go
@@ -387,3 +387,40 @@ func TestCompressNoWordPatterns(t *testing.T) {
 		t.Errorf("fast-path output differs from main, checksum=%d", cs)
 	}
 }
+
+// The number of superstring windows a file is split into is a property of the data, so it
+// must not depend on SamplingFactor — sampling only selects which windows feed the dict.
+func TestCompressSamplingCoversWholeFile(t *testing.T) {
+	const word = "mykeyabc"
+	const nWords = 5000
+
+	windowCount := func(samplingFactor uint64) uint64 {
+		logger := log.New()
+		tmpDir := t.TempDir()
+		file := filepath.Join(tmpDir, "compressed")
+		cfg := DefaultCfg
+		cfg.MinPatternScore = 1
+		cfg.SamplingFactor = samplingFactor
+		c, err := NewCompressor(t.Context(), t.Name(), file, tmpDir, cfg, log.LvlDebug, logger)
+		require.NoError(t, err)
+		defer c.Close()
+		c.superstringLimit = 1000
+
+		for i := 0; i < nWords; i++ {
+			require.NoError(t, c.AddWord([]byte(word)))
+		}
+		count := c.superstringCount
+		require.NoError(t, c.Compress())
+
+		d, err := NewDecompressor(file)
+		require.NoError(t, err)
+		defer d.Close()
+		require.EqualValues(t, nWords, d.Count())
+		return count
+	}
+
+	full := windowCount(1)
+	require.Greater(t, full, uint64(1))
+	require.Equal(t, full, windowCount(4))
+	require.Equal(t, full, windowCount(8))
+}


### PR DESCRIPTION
Cherry-pick of #21806 to `performance` branch.