### PR TITLE
db/recsplit: use SmallSortableBuffers for bucket collector ETL

### DIFF
--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -111,6 +111,22 @@ type Index struct {
 	readAheadRefcnt atomic.Int32 // ref-counter: allow enable/disable read-ahead from goroutines. only when refcnt=0 - disable read-ahead once
 }
 
+// newIndexFromMemory creates an Index backed by an in-memory slice.
+// The caller owns data and must keep it valid for the Index lifetime.
+// Close is a no-op (no file or mmap to release).
+func newIndexFromMemory(data []byte, fileName string) (*Index, error) {
+	idx := &Index{
+		data:     data,
+		size:     int64(len(data)),
+		fileName: fileName,
+	}
+	if err := idx.init(); err != nil {
+		return nil, err
+	}
+	idx.readers = &sync.Pool{New: func() any { return NewIndexReader(idx) }}
+	return idx, nil
+}
+
 func MustOpen(indexFile string) *Index {
 	idx, err := OpenIndex(indexFile)
 	if err != nil {
@@ -435,9 +451,6 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 		_, fName := filepath.Split(idx.filePath)
 		panic("no Lookup should be done when keyCount==0, please use Empty function to guard " + fName)
 	}
-	if idx.keyCount == 1 {
-		return 0, true
-	}
 	if idx.lessFalsePositives {
 		switch idx.dataStructureVersion {
 		case 1:
@@ -449,6 +462,12 @@ func (idx *Index) Lookup(bucketHash, fingerprint uint64) (uint64, bool) {
 				return 0, false
 			}
 		}
+	}
+	if idx.keyCount == 1 {
+		if !idx.enums {
+			return binary.BigEndian.Uint64(idx.data[9+idx.bytesPerRec:]) & idx.recMask, true
+		}
+		return 0, true
 	}
 
 	var gr GolombRiceReader

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -279,7 +279,7 @@ func NewRecSplit(args RecSplitArgs, logger log.Logger) (*RecSplit, error) {
 	} else {
 		rs.salt = *args.Salt
 	}
-	rs.bucketCollector = etl.NewCollectorWithAllocator(RecSplitLogPrefix+" "+fname, rs.tmpDir, etl.LargeSortableBuffers, logger)
+	rs.bucketCollector = etl.NewCollectorWithAllocator(RecSplitLogPrefix+" "+fname, rs.tmpDir, etl.SmallSortableBuffers, logger)
 	rs.bucketCollector.SortAndFlushInBackground(rs.workers > 1)
 	rs.bucketCollector.LogLvl(log.LvlDebug)
 	var err error

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -515,10 +515,15 @@ func computeGolombRice(m uint16, table []uint32, leafSize, primaryAggrBound, sec
 // spills data onto disk to accommodate that. The key gets copied by the collector, therefore
 // the slice underlying key is not getting accessed by RecSplit after this invocation.
 func (rs *RecSplit) AddKey(key []byte, offset uint64) error {
+	hi, lo := murmur3.Sum128WithSeed(key, rs.salt)
+	return rs.addHashedKey(hi, lo, offset)
+}
+
+// addHashedKey adds a key whose murmur3 halves have already been computed with rs.salt.
+func (rs *RecSplit) addHashedKey(hi, lo, offset uint64) error {
 	if rs.built {
 		return errors.New("cannot add keys after perfect hash function had been built")
 	}
-	hi, lo := murmur3.Sum128WithSeed(key, rs.salt)
 	bucketIdx := uint32(remap(hi, rs.bucketCount))
 	binary.BigEndian.PutUint32(rs.bucketKeyBuf[:], bucketIdx)
 	binary.BigEndian.PutUint64(rs.bucketKeyBuf[4:], lo)
@@ -544,12 +549,9 @@ func (rs *RecSplit) AddKey(key []byte, offset uint64) error {
 		if err := rs.bucketCollector.Collect(rs.bucketKeyBuf[:], rs.numBuf[:]); err != nil {
 			return err
 		}
-		if rs.lessFalsePositives {
-			if rs.dataStructureVersion == 0 {
-				//1 byte from each hashed key
-				if err := rs.existenceWV0.WriteByte(byte(hi)); err != nil {
-					return err
-				}
+		if rs.lessFalsePositives && rs.dataStructureVersion == 0 {
+			if err := rs.existenceWV0.WriteByte(byte(hi)); err != nil {
+				return err
 			}
 		}
 	} else {


### PR DESCRIPTION
Switch `RecSplit.bucketCollector` from `LargeSortableBuffers` to `SmallSortableBuffers` to reduce peak memory usage during `.bt` index builds.

bloatnet: `sys` `23g -> 22g`, merge speed not changed