### PR TITLE
db/downloader: use 64 MiB torrent piece size to bound info RAM

### DIFF
--- a/db/downloader/downloadercfg/downloadercfg.go
+++ b/db/downloader/downloadercfg/downloadercfg.go
@@ -45,10 +45,10 @@ import (
 	"github.com/erigontech/erigon/db/snapcfg"
 )
 
-// DefaultPieceSize - Erigon serves many big files, bigger pieces will reduce
-// amount of network announcements, but can't go over 2Mb. TODO: This is definitely not true.
-// see https://wiki.theory.org/BitTorrentSpecification#Metainfo_File_Structure
-const DefaultPieceSize = 2 * 1024 * 1024
+// DefaultPieceSize - Erigon serves many big files, bigger pieces reduce the
+// amount of network announcements and bound the torrent info bytes held in RAM
+// for large snapshot sets.
+const DefaultPieceSize = 64 << 20
 
 // DefaultNetworkChunkSize - how much data request per 1 network call to peer.
 // BitTorrent client default: 16Kb

--- a/db/downloader/util.go
+++ b/db/downloader/util.go
@@ -176,7 +176,6 @@ func BuildTorrentIfNeed(ctx context.Context, fName, root string, torrentFiles *A
 
 	fPath := filepath.Join(root, fName)
 
-	// TODO: Consider using the auto-piece sizing?
 	info := &metainfo.Info{PieceLength: downloadercfg.DefaultPieceSize, Name: fName}
 	if err := info.BuildFromFilePath(fPath); err != nil {
 		return false, fmt.Errorf("createTorrentFileFromSegment: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/anacrolix/log v0.17.1-0.20251118025802-918f1157b7bb
 	github.com/anacrolix/missinggo/v2 v2.10.0
 	github.com/anacrolix/sync v0.5.5-0.20251119100342-d78dd1f686f1
-	github.com/anacrolix/torrent v1.61.1-0.20260423052610-0aa61207b935
+	github.com/anacrolix/torrent v1.61.1-0.20260616065448-83a4fbaf66d5
 	github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -160,7 +160,7 @@ require (
 	github.com/alingse/nilnesserr v0.2.0 // indirect
 	github.com/anacrolix/btree v0.1.1 // indirect
 	github.com/anacrolix/chansync v0.7.0 // indirect
-	github.com/anacrolix/dht/v2 v2.23.0 // indirect
+	github.com/anacrolix/dht/v2 v2.23.1-0.20260525063928-ec3a9bd99456 // indirect
 	github.com/anacrolix/missinggo v1.3.0 // indirect
 	github.com/anacrolix/missinggo/perf v1.0.0 // indirect
 	github.com/anacrolix/mmsg v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/anacrolix/btree v0.1.1 h1:igdFPLrt82L6qovzbEGSMkTeiwcU3EFIGl2K8XWocAc
 github.com/anacrolix/btree v0.1.1/go.mod h1:KHWYRZuUULATjUGJC4dQDXx/BPOnWrJozGR6TndjOmc=
 github.com/anacrolix/chansync v0.7.0 h1:wgwxbsJRmOqNjil4INpxHrDp4rlqQhECxR8/WBP4Et0=
 github.com/anacrolix/chansync v0.7.0/go.mod h1:DZsatdsdXxD0WiwcGl0nJVwyjCKMDv+knl1q2iBjA2k=
-github.com/anacrolix/dht/v2 v2.23.0 h1:EuD17ykTTEkAMPLjBsS5QjGOwuBgLTdQhds6zPAjeVY=
-github.com/anacrolix/dht/v2 v2.23.0/go.mod h1:seXRz6HLw8zEnxlysf9ye2eQbrKUmch6PyOHpe/Nb/U=
+github.com/anacrolix/dht/v2 v2.23.1-0.20260525063928-ec3a9bd99456 h1:5ylkQM8XiZxJw1yhWlV8ICyzl4DNRbEPR4FNlYKpEgs=
+github.com/anacrolix/dht/v2 v2.23.1-0.20260525063928-ec3a9bd99456/go.mod h1:0IpTSbqYnFcjmexGvnINUGq/kbx93S5cKIryH4oJL8U=
 github.com/anacrolix/envpprof v0.0.0-20180404065416-323002cec2fa/go.mod h1:KgHhUaQMc8cC0+cEflSgCFNFbKwi5h54gqtVn8yhP7c=
 github.com/anacrolix/envpprof v1.0.0/go.mod h1:KgHhUaQMc8cC0+cEflSgCFNFbKwi5h54gqtVn8yhP7c=
 github.com/anacrolix/envpprof v1.1.0/go.mod h1:My7T5oSqVfEn4MD4Meczkw/f5lSIndGAKu/0SM/rkf4=
@@ -155,8 +155,8 @@ github.com/anacrolix/sync v0.5.5-0.20251119100342-d78dd1f686f1/go.mod h1:21cUWer
 github.com/anacrolix/tagflag v0.0.0-20180109131632-2146c8d41bf0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.0.0/go.mod h1:1m2U/K6ZT+JZG0+bdMK6qauP49QT4wE5pmhJXOKKCHw=
 github.com/anacrolix/tagflag v1.1.0/go.mod h1:Scxs9CV10NQatSmbyjqmqmeQNwGzlNe0CMUMIxqHIG8=
-github.com/anacrolix/torrent v1.61.1-0.20260423052610-0aa61207b935 h1:7zYUWXNTCDMQSTO/SIYUOXbn/tEp5D5wWQJycahpst0=
-github.com/anacrolix/torrent v1.61.1-0.20260423052610-0aa61207b935/go.mod h1:WOyzkjUtFTK7sZNqgGtoAmWLUsJ0XIwyvw0zLI63h7M=
+github.com/anacrolix/torrent v1.61.1-0.20260616065448-83a4fbaf66d5 h1:EhVVofl783IS1BPTnMN1PIemm+XsgWIbXO9OrVAQL88=
+github.com/anacrolix/torrent v1.61.1-0.20260616065448-83a4fbaf66d5/go.mod h1:XoYwl8ukZrq8ufRqkQzZ/I1ig98D9y3go2TVtHM2nFE=
 github.com/anacrolix/upnp v0.1.4 h1:+2t2KA6QOhm/49zeNyeVwDu1ZYS9dB9wfxyVvh/wk7U=
 github.com/anacrolix/upnp v0.1.4/go.mod h1:Qyhbqo69gwNWvEk1xNTXsS5j7hMHef9hdr984+9fIic=
 github.com/anacrolix/utp v0.1.0 h1:FOpQOmIwYsnENnz7tAGohA+r6iXpRjrq8ssKSre2Cp4=


### PR DESCRIPTION
## What

Raises the torrent piece length used in `BuildTorrentIfNeed` from a fixed 2 MiB to a fixed 64 MiB.

## Why

Closes #21684. At 2 MiB per piece, a large (e.g. archive) snapshot set tracks enough pieces that the torrent *info* bytes alone cost ~1 GiB of RAM. A larger fixed piece size cuts the tracked piece count — and thus torrent-info RAM — by up to ~32× (64 MiB / 2 MiB).

64 MiB is chosen as the upper bound that still stays within the unverified-piece data and per-piece chunk limits (`NetworkChunkSize`). The piece size is fixed rather than scaled per file, so generated torrents remain simple and reproducible.

`DefaultPieceSize` is updated to 64 MiB, which also raises `MaxAllocPeerRequestDataPerConn`'s floor accordingly.

## Effect

Measured against a real Erigon snapshot torrent set (2,843 torrents, 2.67 TiB total — all currently at the fixed 2 MiB piece length), comparing the existing fixed 2 MiB pieces against the new fixed 64 MiB:

| Metric | Value |
|---|---|
| Torrents | 2,843 |
| Total length | 2.67 TiB |
| Current total pieces (fixed 2 MiB) | 1,401,046 |
| New total pieces (fixed 64 MiB) | 45,776 |
| Reduction | **30.6×** |

New per-torrent piece-length distribution (previously a flat 2 MiB for every torrent):

| Piece size | # torrents |
|---|---|
| < 64 MiB (single piece) | 1,402 |
| 64 MiB | 1,441 |

The reduction approaches the theoretical 32× because the bulk of the bytes live in torrents large enough to be split into many 64 MiB pieces; smaller torrents collapse to a single piece.

## Dependency note

The `github.com/anacrolix/torrent` and transitive `github.com/anacrolix/dht/v2` bumps from earlier on this branch are retained; they are harmless and may carry unrelated fixes.
