### PR TITLE
[r3.5] cl/phase1/forkchoice: fix block_importing_latency never recording on Fulu+

### DIFF
--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -80,9 +80,8 @@ func verifyKzgCommitmentsAgainstTransactions(cfg *clparams.BeaconChainConfig, bl
 	return misc.ValidateBlobs(block.Body.ExecutionPayload.BlobGasUsed, cfg.MaxBlobGasPerBlock, maxBlobsPerBlock, expectedBlobHashes, &transactions)
 }
 
-func collectOnBlockLatencyToUnixTime(ethClock eth_clock.EthereumClock, slot uint64) {
-	currSlot := ethClock.GetCurrentSlot()
-	if slot != currSlot {
+func collectOnBlockLatencyToUnixTime(ethClock eth_clock.EthereumClock, slot, currentSlotOnEntry uint64) {
+	if slot != currentSlotOnEntry {
 		return
 	}
 	initialSlotTime := ethClock.GetSlotTime(slot)
@@ -127,6 +126,7 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	if ancestorNode := f.Ancestor(block.Block.ParentRoot, finalizedSlot); ancestorNode.Root != finalizedCheckpoint.Root {
 		return ErrNotFinalizedDescendant
 	}
+	currentSlotOnEntry := f.ethClock.GetCurrentSlot()
 
 	// Validate parent payload status path early (before expensive operations)
 	blockEpoch := f.computeEpochAtSlot(block.Block.Slot)
@@ -258,9 +258,7 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	if block.Block.Slot > f.highestSeen.Load() {
 		f.highestSeen.Store(block.Block.Slot)
 		f.highestSeenRoot.Store(common.Hash(blockRoot))
-		// Recorded on the fork-agnostic tip advance so block_importing_latency
-		// also populates on Fulu+ (the prior call site sat in the Deneb-only blob path).
-		collectOnBlockLatencyToUnixTime(f.ethClock, block.Block.Slot)
+		collectOnBlockLatencyToUnixTime(f.ethClock, block.Block.Slot, currentSlotOnEntry)
 	}
 	startStateProcess := time.Now()
 

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -192,9 +192,6 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 					}
 					return fmt.Errorf("OnBlock: data is not available for block %x: %v", common.Hash(blockRoot), err)
 				}
-				if f.highestSeen.Load() < block.Block.Slot {
-					collectOnBlockLatencyToUnixTime(f.ethClock, block.Block.Slot)
-				}
 			}
 		}
 
@@ -261,6 +258,9 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	if block.Block.Slot > f.highestSeen.Load() {
 		f.highestSeen.Store(block.Block.Slot)
 		f.highestSeenRoot.Store(common.Hash(blockRoot))
+		// Recorded on the fork-agnostic tip advance so block_importing_latency
+		// also populates on Fulu+ (the prior call site sat in the Deneb-only blob path).
+		collectOnBlockLatencyToUnixTime(f.ethClock, block.Block.Slot)
 	}
 	startStateProcess := time.Now()
 

--- a/cl/phase1/forkchoice/on_block_metrics_test.go
+++ b/cl/phase1/forkchoice/on_block_metrics_test.go
@@ -37,14 +37,12 @@ func TestCollectOnBlockLatency(t *testing.T) {
 
 	// A non-current-slot block (e.g. backfill) must not update the metric.
 	g.Set(-1)
-	clock.EXPECT().GetCurrentSlot().Return(uint64(100))
-	collectOnBlockLatencyToUnixTime(clock, 99)
+	collectOnBlockLatencyToUnixTime(clock, 99, 100)
 	require.Equal(t, float64(-1), g.GetValue(), "non-current-slot block must not update the metric")
 
 	// A current-slot block must record a non-negative latency.
-	clock.EXPECT().GetCurrentSlot().Return(uint64(100))
 	clock.EXPECT().GetSlotTime(uint64(100)).Return(time.Now().Add(-1500 * time.Millisecond))
-	collectOnBlockLatencyToUnixTime(clock, 100)
+	collectOnBlockLatencyToUnixTime(clock, 100, 100)
 	v := g.GetValue()
 	require.NotEqual(t, float64(-1), v, "current-slot block must update the metric")
 	require.GreaterOrEqual(t, v, float64(0))

--- a/cl/phase1/forkchoice/on_block_metrics_test.go
+++ b/cl/phase1/forkchoice/on_block_metrics_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package forkchoice
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/diagnostics/metrics"
+)
+
+// block_importing_latency must be recorded for a block imported in its own
+// (current) slot, and skipped for older blocks (e.g. backfill), so the gauge
+// reflects head-arrival latency rather than block age.
+func TestCollectOnBlockLatency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	clock := eth_clock.NewMockEthereumClock(ctrl)
+	g := metrics.GetOrCreateGauge("block_importing_latency")
+
+	// A non-current-slot block (e.g. backfill) must not update the metric.
+	g.Set(-1)
+	clock.EXPECT().GetCurrentSlot().Return(uint64(100))
+	collectOnBlockLatencyToUnixTime(clock, 99)
+	require.Equal(t, float64(-1), g.GetValue(), "non-current-slot block must not update the metric")
+
+	// A current-slot block must record a non-negative latency.
+	clock.EXPECT().GetCurrentSlot().Return(uint64(100))
+	clock.EXPECT().GetSlotTime(uint64(100)).Return(time.Now().Add(-1500 * time.Millisecond))
+	collectOnBlockLatencyToUnixTime(clock, 100)
+	v := g.GetValue()
+	require.NotEqual(t, float64(-1), v, "current-slot block must update the metric")
+	require.GreaterOrEqual(t, v, float64(0))
+}


### PR DESCRIPTION
Cherry-pick of #21842 to release/3.5.

`block_importing_latency` was only recorded from a call nested in the Deneb-only blob data-availability branch of `OnBlock`, so it never fired on Fulu+ (current mainnet) and read a flat 0 in Grafana. Moved to the fork-agnostic `highestSeen` tip-advance so it records once per new head block on all forks. See #21842 for full analysis.

Clean cherry-pick.
