### PR TITLE
[r3.5] execution/stagedsync: prune overlay to committed boundary on no-op execution unwind

### DIFF
--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -392,78 +392,97 @@ func SpawnExecuteBlocksStage(s *StageState, u Unwinder, doms *execctx.SharedDoma
 
 func UnwindExecutionStage(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwTx kv.TemporalRwTx, ctx context.Context, cfg ExecuteBlockCfg, logger log.Logger) (err error) {
 	//fmt.Printf("unwind: %d -> %d\n", u.CurrentBlockNumber, u.UnwindPoint)
-	if u.UnwindPoint >= s.BlockNumber {
-		// The committed execution progress (s.BlockNumber) is at or below the
-		// unwind point, so MDBX has nothing above u.UnwindPoint to roll back and
-		// the disk unwind below would be a no-op. However the in-RAM
-		// SharedDomains / TemporalMemBatch overlay can still hold *uncommitted*
-		// writes for blocks above u.UnwindPoint — e.g. a block whose
-		// post-execution gas check failed mid-batch, before its step was ever
-		// flushed. Those entries must still be pruned: the overlay is reused
-		// across the unwind→retry loop within a single sync.Run, so leaving them
-		// makes the re-execution read a stale value (observed on Hoodi 3004265:
-		// ca5daf64 slot0 kept tx19's first-write, the contract took the
-		// "already initialised" branch, skipped an SSTORE_SET, came up 21045 gas
-		// short, and the node spun in an unwind/retry loop). The committed prune
-		// (#20625) only runs from unwindExec3, which the early return skipped.
-		txNum, err := cfg.blockReader.TxnumReader().Min(ctx, rwTx, u.UnwindPoint+1)
-		if err != nil {
-			return err
-		}
-		doms.Unwind(txNum, nil)
-		doms.SetTxNum(txNum)
-		return nil
-	}
 
-	logger.Info(fmt.Sprintf("[%s] Unwind Execution", u.LogPrefix()), "from", s.BlockNumber, "to", u.UnwindPoint)
-
-	// Discard any pending deferred commitment updates from the previous
-	// (failed) execution. If left in place, the next ComputeCommitment
-	// would flush stale branch data that doesn't match the unwound state.
+	// Discard any pending deferred commitment updates from the previous (failed)
+	// execution. If left in place, the next ComputeCommitment would flush stale
+	// branch data that doesn't match the unwound state. Both branches below rely
+	// on this — in particular the no-op (overlay-only) path, where a block that
+	// failed its post-execution gas check mid-batch left deferred updates that
+	// must not leak into the re-execution (the pre-refactor early return skipped
+	// this reset).
 	doms.ResetPendingUpdates()
 
-	unwindToLimit, ok, err := rawtemporaldb.CanUnwindBeforeBlockNum(u.UnwindPoint, rwTx)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return fmt.Errorf("%w: %d < %d", ErrTooDeepUnwind, u.UnwindPoint, unwindToLimit)
-	}
+	if u.UnwindPoint < s.BlockNumber {
+		// Execution committed past the unwind point, so roll the committed blocks
+		// (u.UnwindPoint, s.BlockNumber] back on disk. unwindExec3 also prunes the
+		// in-RAM SharedDomains/TemporalMemBatch overlay (down to u.UnwindPoint, via
+		// TemporalMemBatch.Unwind — #20625), and u.Done lowers the stage progress so
+		// re-execution resumes from u.UnwindPoint+1.
+		logger.Info(fmt.Sprintf("[%s] Unwind Execution", u.LogPrefix()), "from", s.BlockNumber, "to", u.UnwindPoint)
 
-	var accumulator *shards.Accumulator
-	if cfg.stateStream && s.BlockNumber-u.UnwindPoint < stateStreamLimit {
-		accumulator = cfg.notifications.Accumulator
-
-		hash, ok, err := cfg.blockReader.CanonicalHash(ctx, rwTx, u.UnwindPoint)
-		if err != nil {
-			return fmt.Errorf("read canonical hash of unwind point: %w", err)
-		}
-		if !ok {
-			return fmt.Errorf("canonical hash not found %d", u.UnwindPoint)
-		}
-		header, err := cfg.blockReader.HeaderByHash(ctx, rwTx, hash)
-		if err != nil {
-			return fmt.Errorf("read canonical header of unwind point: %w", err)
-		}
-		if header == nil {
-			return fmt.Errorf("canonical header for unwind point not found: %s", hash)
-		}
-		txs, err := cfg.blockReader.RawTransactions(ctx, rwTx, u.UnwindPoint, s.BlockNumber)
+		unwindToLimit, ok, err := rawtemporaldb.CanUnwindBeforeBlockNum(u.UnwindPoint, rwTx)
 		if err != nil {
 			return err
 		}
-		accumulator.StartChange(header, txs, true)
+		if !ok {
+			return fmt.Errorf("%w: %d < %d", ErrTooDeepUnwind, u.UnwindPoint, unwindToLimit)
+		}
+
+		var accumulator *shards.Accumulator
+		if cfg.stateStream && s.BlockNumber-u.UnwindPoint < stateStreamLimit {
+			accumulator = cfg.notifications.Accumulator
+
+			hash, ok, err := cfg.blockReader.CanonicalHash(ctx, rwTx, u.UnwindPoint)
+			if err != nil {
+				return fmt.Errorf("read canonical hash of unwind point: %w", err)
+			}
+			if !ok {
+				return fmt.Errorf("canonical hash not found %d", u.UnwindPoint)
+			}
+			header, err := cfg.blockReader.HeaderByHash(ctx, rwTx, hash)
+			if err != nil {
+				return fmt.Errorf("read canonical header of unwind point: %w", err)
+			}
+			if header == nil {
+				return fmt.Errorf("canonical header for unwind point not found: %s", hash)
+			}
+			txs, err := cfg.blockReader.RawTransactions(ctx, rwTx, u.UnwindPoint, s.BlockNumber)
+			if err != nil {
+				return err
+			}
+			accumulator.StartChange(header, txs, true)
+		}
+
+		if err := unwindExec3(u, s, doms, rwTx, ctx, cfg, accumulator, logger); err != nil {
+			return err
+		}
+
+		if err = u.Done(rwTx); err != nil {
+			return err
+		}
+	} else {
+		// Nothing above the unwind point was ever committed (s.BlockNumber <=
+		// u.UnwindPoint), so there is nothing to roll back on disk and we must NOT
+		// call u.Done — lowering the stage progress to u.UnwindPoint would falsely
+		// mark the never-flushed blocks (s.BlockNumber, u.UnwindPoint] as executed.
+		//
+		// But the in-RAM SharedDomains/TemporalMemBatch overlay can still hold
+		// uncommitted writes from those blocks — in particular from a block that
+		// failed its post-execution gas check mid-batch (the overlay is reused
+		// across the unwind→retry loop within a single sync.Run). Re-execution
+		// resumes from the committed progress (SeekCommitment below, == s.BlockNumber+1),
+		// NOT from u.UnwindPoint+1, so prune the overlay to that committed boundary.
+		// Pruning only to u.UnwindPoint+1 would keep the (s.BlockNumber, u.UnwindPoint]
+		// writes, which are then re-executed and re-read their own stale overlay —
+		// the same bug class, just deferred. (Hoodi 3004265: ca5daf64 slot0 kept
+		// tx19's first-write, the contract took the "already initialised" branch,
+		// skipped an SSTORE_SET, came up 21045 gas short, and the node spun in an
+		// unwind/retry loop; there s.BlockNumber == u.UnwindPoint so the two
+		// boundaries coincided.) The on-disk overlay prune in TemporalMemBatch.Unwind
+		// (#20625) only runs via unwindExec3 above, hence this branch.
+		//
+		// NB: the state cache (if any) is not reverted here. Today both executors
+		// clear it per-block via ValidateAndPrepare and the snapshotter attaches no
+		// cache, so this is safe; a caller enabling a cache on this chokepoint must
+		// ensure it is invalidated on retry.
+		committedTxNum, err := cfg.blockReader.TxnumReader().Min(ctx, rwTx, s.BlockNumber+1)
+		if err != nil {
+			return err
+		}
+		doms.Unwind(committedTxNum, nil)
 	}
 
-	if err := unwindExec3(u, s, doms, rwTx, ctx, cfg, accumulator, logger); err != nil {
-		return err
-	}
-
-	if err = u.Done(rwTx); err != nil {
-		return err
-	}
-
-	_, _, _ = doms.SeekCommitment(ctx, rwTx) // ensure internal state of `doms` is set
+	_, _, _ = doms.SeekCommitment(ctx, rwTx) // re-establish doms' position at the post-unwind committed state
 	//dumpPlainStateDebug(tx, nil)
 	return nil
 }

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -393,21 +393,15 @@ func SpawnExecuteBlocksStage(s *StageState, u Unwinder, doms *execctx.SharedDoma
 func UnwindExecutionStage(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwTx kv.TemporalRwTx, ctx context.Context, cfg ExecuteBlockCfg, logger log.Logger) (err error) {
 	//fmt.Printf("unwind: %d -> %d\n", u.CurrentBlockNumber, u.UnwindPoint)
 
-	// Discard any pending deferred commitment updates from the previous (failed)
-	// execution. If left in place, the next ComputeCommitment would flush stale
-	// branch data that doesn't match the unwound state. Both branches below rely
-	// on this — in particular the no-op (overlay-only) path, where a block that
-	// failed its post-execution gas check mid-batch left deferred updates that
-	// must not leak into the re-execution (the pre-refactor early return skipped
-	// this reset).
+	// Discard deferred commitment updates from the previous (failed) execution;
+	// otherwise the next ComputeCommitment flushes stale branch data. Runs on both
+	// unwind paths (the pre-refactor early return skipped it on the no-op path).
 	doms.ResetPendingUpdates()
 
 	if u.UnwindPoint < s.BlockNumber {
-		// Execution committed past the unwind point, so roll the committed blocks
-		// (u.UnwindPoint, s.BlockNumber] back on disk. unwindExec3 also prunes the
-		// in-RAM SharedDomains/TemporalMemBatch overlay (down to u.UnwindPoint, via
-		// TemporalMemBatch.Unwind — #20625), and u.Done lowers the stage progress so
-		// re-execution resumes from u.UnwindPoint+1.
+		// Execution committed past the unwind point: roll the committed blocks back
+		// on disk (unwindExec3 also prunes the in-RAM overlay), and u.Done lowers the
+		// stage progress so re-execution resumes from u.UnwindPoint+1.
 		logger.Info(fmt.Sprintf("[%s] Unwind Execution", u.LogPrefix()), "from", s.BlockNumber, "to", u.UnwindPoint)
 
 		unwindToLimit, ok, err := rawtemporaldb.CanUnwindBeforeBlockNum(u.UnwindPoint, rwTx)
@@ -451,30 +445,11 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, doms *execctx.SharedDom
 			return err
 		}
 	} else {
-		// Nothing above the unwind point was ever committed (s.BlockNumber <=
-		// u.UnwindPoint), so there is nothing to roll back on disk and we must NOT
-		// call u.Done — lowering the stage progress to u.UnwindPoint would falsely
-		// mark the never-flushed blocks (s.BlockNumber, u.UnwindPoint] as executed.
-		//
-		// But the in-RAM SharedDomains/TemporalMemBatch overlay can still hold
-		// uncommitted writes from those blocks — in particular from a block that
-		// failed its post-execution gas check mid-batch (the overlay is reused
-		// across the unwind→retry loop within a single sync.Run). Re-execution
-		// resumes from the committed progress (SeekCommitment below, == s.BlockNumber+1),
-		// NOT from u.UnwindPoint+1, so prune the overlay to that committed boundary.
-		// Pruning only to u.UnwindPoint+1 would keep the (s.BlockNumber, u.UnwindPoint]
-		// writes, which are then re-executed and re-read their own stale overlay —
-		// the same bug class, just deferred. (Hoodi 3004265: ca5daf64 slot0 kept
-		// tx19's first-write, the contract took the "already initialised" branch,
-		// skipped an SSTORE_SET, came up 21045 gas short, and the node spun in an
-		// unwind/retry loop; there s.BlockNumber == u.UnwindPoint so the two
-		// boundaries coincided.) The on-disk overlay prune in TemporalMemBatch.Unwind
-		// (#20625) only runs via unwindExec3 above, hence this branch.
-		//
-		// NB: the state cache (if any) is not reverted here. Today both executors
-		// clear it per-block via ValidateAndPrepare and the snapshotter attaches no
-		// cache, so this is safe; a caller enabling a cache on this chokepoint must
-		// ensure it is invalidated on retry.
+		// Nothing above the unwind point was committed, so there's no disk rollback
+		// and u.Done must NOT run — it would raise stage progress to u.UnwindPoint and
+		// mark uncommitted blocks executed. Re-execution resumes from the committed
+		// block, so prune the in-RAM overlay to that boundary (Min(s.BlockNumber+1)),
+		// not u.UnwindPoint+1.
 		committedTxNum, err := cfg.blockReader.TxnumReader().Min(ctx, rwTx, s.BlockNumber+1)
 		if err != nil {
 			return err
@@ -482,7 +457,11 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, doms *execctx.SharedDom
 		doms.Unwind(committedTxNum, nil)
 	}
 
-	_, _, _ = doms.SeekCommitment(ctx, rwTx) // re-establish doms' position at the post-unwind committed state
+	// Re-establish doms' position at the committed state for re-execution.
+	_, _, err = doms.SeekCommitment(ctx, rwTx)
+	if err != nil {
+		return err
+	}
 	//dumpPlainStateDebug(tx, nil)
 	return nil
 }

--- a/execution/stagedsync/stage_execute_unwind_test.go
+++ b/execution/stagedsync/stage_execute_unwind_test.go
@@ -43,27 +43,19 @@ import (
 // for the Hoodi block-3004265 gas-used mismatch (originally found on
 // release/3.4, same gap on main).
 //
-// Repro of the original chain of events:
-//
-//  1. In serial batch execution, block 3004265 tx19 does a first-time SSTORE to
-//     ca5daf64 slot0. That write lands in the in-RAM SharedDomains /
-//     TemporalMemBatch overlay (stamped with tx19's txNum) but the block then
-//     fails its post-execution gas check, so its step is never committed.
-//  2. The executor schedules UnwindTo(3004264). Because 3004265 was never
-//     committed, the committed execution-stage progress (s.BlockNumber) sits at
-//     or below the unwind point, so UnwindExecutionStage hit the
-//     `u.UnwindPoint >= s.BlockNumber` early return and skipped unwindExec3 —
-//     i.e. it never called sd.Unwind, so the overlay prune added by #20625
-//     (which only runs from unwindExec3) never executed.
-//  3. The same overlay is reused across the unwind→retry loop inside one
-//     sync.Run, so on retry the storage read returned tx19's own stale
-//     first-write (…a3a34) instead of the committed 0. The contract took the
-//     "already initialised" branch, skipped an SSTORE_SET (20000 gas), the block
-//     came up exactly 21045 gas short, and the node spun in an unwind/retry loop.
-//
-// Before the fix, step 2's early return leaves the overlay untouched, so the
-// failed block's write is still visible after the unwind — this test asserts it
-// is gone, while a write at/below the unwind point survives (no over-pruning).
+// When a block fails its post-execution gas check mid-batch, its writes sit in
+// the in-RAM SharedDomains/TemporalMemBatch overlay but were never committed, so
+// the committed execution-stage progress (s.BlockNumber) is <= u.UnwindPoint and
+// UnwindExecutionStage takes the no-disk-rollback branch. That branch does not
+// call u.Done, so re-execution resumes from the committed progress
+// (SeekCommitment == s.BlockNumber+1) — NOT from u.UnwindPoint+1. The overlay
+// must therefore be pruned to the committed boundary: every uncommitted write
+// above s.BlockNumber is dropped (the failed block's, AND a block in
+// (s.BlockNumber, u.UnwindPoint] that is itself re-executed), while a write
+// at/below the committed progress survives (no over-pruning). Otherwise the
+// retry re-reads a stale value (Hoodi: ca5daf64 slot0 kept tx19's first-write,
+// the contract took the "already initialised" branch, skipped an SSTORE_SET,
+// came up 21045 gas short, and the node spun in an unwind/retry loop).
 func TestUnwindExecutionStage_PrunesUncommittedOverlayWrite(t *testing.T) {
 	t.Parallel()
 
@@ -109,38 +101,43 @@ func TestUnwindExecutionStage_PrunesUncommittedOverlayWrite(t *testing.T) {
 		unwindPoint    = uint64(7) // = failedBlock-1; >= committedBlock => disk no-op
 		failedBlock    = uint64(8) // block whose post-exec gas check failed mid-batch
 	)
-	boundaryTxNum, err := br.TxnumReader().Min(ctx, tx, unwindPoint+1)
+	// Re-execution resumes from the committed progress, so the overlay is pruned
+	// to Min(committedBlock+1) — NOT Min(unwindPoint+1).
+	boundaryTxNum, err := br.TxnumReader().Min(ctx, tx, committedBlock+1)
 	require.NoError(t, err)
-	require.Equal(t, failedBlock*perBlock, boundaryTxNum, "sanity: Min(failedBlock) == first txNum of failedBlock")
+	require.Equal(t, (committedBlock+1)*perBlock, boundaryTxNum, "sanity: prune boundary == first txNum past the committed block")
 
-	// staleKey mirrors ca5daf64 slot0: first-written by failedBlock's tx19 at a
-	// txNum strictly above the unwind boundary — must be pruned on unwind.
-	staleAddr := common.HexToAddress("0xca5daf6473971693b760cc65d726f72c6849d615")
-	staleSlot := common.Hash{} // slot 0
-	staleKey := append(append([]byte{}, staleAddr[:]...), staleSlot[:]...)
+	put := func(hexAddr string, slot byte, val []byte, txNum uint64) []byte {
+		addr := common.HexToAddress(hexAddr)
+		slotHash := common.Hash{31: slot}
+		key := append(append([]byte{}, addr[:]...), slotHash[:]...)
+		doms.SetTxNum(txNum)
+		require.NoError(t, doms.DomainPut(kv.StorageDomain, tx, key, val, txNum, nil))
+		return key
+	}
+
+	// survivorKey: committed block, at/below the prune boundary → must survive.
+	survivorVal := []byte{0xbe, 0xef}
+	survivorKey := put("0x00000000000000000000000000000000000000aa", 0x01, survivorVal, committedBlock*perBlock)
+	// midKey: a block in (committedBlock, unwindPoint]. Kept by the old
+	// Min(unwindPoint+1) boundary, but must be dropped — that block is re-executed
+	// from the committed progress and would otherwise re-read its own stale write.
+	midVal := []byte{0x11, 0x22}
+	midKey := put("0x00000000000000000000000000000000000000bb", 0x02, midVal, unwindPoint*perBlock)
+	// staleKey: mirrors ca5daf64 slot0, first-written by the failed block's tx19.
 	staleValHash := common.HexToHash("0xd7549f2a387fa81a1d5a77adc7bd3f782ac0780c460689d88e22aee6916a3a34")
 	staleVal := staleValHash[:]
-	const staleTxNum = failedBlock*perBlock + 5 // inside failedBlock, above the boundary
+	staleKey := put("0xca5daf6473971693b760cc65d726f72c6849d615", 0x00, staleVal, failedBlock*perBlock+5)
 
-	// keepKey is written by a block at/below the unwind point — must survive.
-	keepAddr := common.HexToAddress("0x00000000000000000000000000000000000000aa")
-	keepSlot := common.Hash{31: 0x01}
-	keepKey := append(append([]byte{}, keepAddr[:]...), keepSlot[:]...)
-	keepVal := []byte{0xbe, 0xef}
-	const keepTxNum = unwindPoint * perBlock // inside the unwind-target block
-
-	doms.SetTxNum(keepTxNum)
-	require.NoError(t, doms.DomainPut(kv.StorageDomain, tx, keepKey, keepVal, keepTxNum, nil))
-	doms.SetTxNum(staleTxNum)
-	require.NoError(t, doms.DomainPut(kv.StorageDomain, tx, staleKey, staleVal, staleTxNum, nil))
-
-	// Sanity: both visible through the overlay before the unwind.
-	got, _, err := doms.GetLatest(kv.StorageDomain, tx, staleKey)
-	require.NoError(t, err)
-	require.Equal(t, staleVal, got, "precondition: stale write must be visible pre-unwind")
-	got, _, err = doms.GetLatest(kv.StorageDomain, tx, keepKey)
-	require.NoError(t, err)
-	require.Equal(t, keepVal, got, "precondition: keep write must be visible pre-unwind")
+	// Sanity: all three visible through the overlay before the unwind.
+	for _, c := range []struct {
+		key, val []byte
+		name     string
+	}{{survivorKey, survivorVal, "survivor"}, {midKey, midVal, "mid"}, {staleKey, staleVal, "stale"}} {
+		got, _, err := doms.GetLatest(kv.StorageDomain, tx, c.key)
+		require.NoError(t, err)
+		require.Equal(t, c.val, got, "precondition: %s write must be visible pre-unwind", c.name)
+	}
 
 	cfg := ExecuteBlockCfg{blockReader: br}
 	s := &StageState{ID: stages.Execution, BlockNumber: committedBlock}
@@ -149,17 +146,22 @@ func TestUnwindExecutionStage_PrunesUncommittedOverlayWrite(t *testing.T) {
 
 	require.NoError(t, UnwindExecutionStage(u, s, doms, tx, ctx, cfg, logger))
 
-	// The failed block's first-time write must be gone, so a re-execution reads
-	// the committed value (absent here -> empty) and charges SSTORE_SET again.
-	got, _, err = doms.GetLatest(kv.StorageDomain, tx, staleKey)
-	require.NoError(t, err)
-	require.Empty(t, got,
-		"after Unwind to block %d, the overlay must not return failedBlock(%d) tx write %x (got %x): "+
-			"UnwindExecutionStage skipped the overlay prune on the no-op-disk-unwind path",
-		unwindPoint, failedBlock, staleVal, got)
+	// Both the failed-block write AND the (committedBlock, unwindPoint] write must
+	// be gone: re-execution resumes from the committed boundary and would re-read
+	// either as a stale value.
+	for _, c := range []struct {
+		key  []byte
+		name string
+	}{{staleKey, "failed-block (above unwindPoint)"}, {midKey, "(committedBlock, unwindPoint]"}} {
+		got, _, err := doms.GetLatest(kv.StorageDomain, tx, c.key)
+		require.NoError(t, err)
+		require.Empty(t, got,
+			"after Unwind (committed=%d, unwindPoint=%d), overlay must not return the %s write (got %x)",
+			committedBlock, unwindPoint, c.name, got)
+	}
 
-	// A write at/below the unwind point must be untouched (no over-pruning).
-	got, _, err = doms.GetLatest(kv.StorageDomain, tx, keepKey)
+	// The committed write must be untouched (no over-pruning below committed).
+	got, _, err := doms.GetLatest(kv.StorageDomain, tx, survivorKey)
 	require.NoError(t, err)
-	require.Equal(t, keepVal, got, "write at/below the unwind point must survive the prune")
+	require.Equal(t, survivorVal, got, "write at/below the committed progress must survive the prune")
 }

--- a/execution/stagedsync/stage_execute_unwind_test.go
+++ b/execution/stagedsync/stage_execute_unwind_test.go
@@ -47,9 +47,10 @@ import (
 // the in-RAM SharedDomains/TemporalMemBatch overlay but were never committed, so
 // the committed execution-stage progress (s.BlockNumber) is <= u.UnwindPoint and
 // UnwindExecutionStage takes the no-disk-rollback branch. That branch does not
-// call u.Done, so re-execution resumes from the committed progress
-// (SeekCommitment == s.BlockNumber+1) — NOT from u.UnwindPoint+1. The overlay
-// must therefore be pruned to the committed boundary: every uncommitted write
+// call u.Done, so re-execution resumes from the committed block (SeekCommitment
+// returns s.BlockNumber; re-execution resumes at s.BlockNumber+1) — NOT from
+// u.UnwindPoint+1. The overlay must therefore be pruned to that committed
+// boundary (Min(s.BlockNumber+1)): every uncommitted write
 // above s.BlockNumber is dropped (the failed block's, AND a block in
 // (s.BlockNumber, u.UnwindPoint] that is itself re-executed), while a write
 // at/below the committed progress survives (no over-pruning). Otherwise the


### PR DESCRIPTION
Cherry-pick of #21847 (release/3.4) / #21848 (main) to `release/3.5` (which carries #21826).

Same change: in `UnwindExecutionStage`, prune the in-RAM overlay to the
**committed** boundary (`Min(s.BlockNumber+1)`) on the no-op-disk-unwind path
instead of `Min(u.UnwindPoint+1)`, and restructure into an explicit
`disk-unwind` / `overlay-only` `if`/`else` with a shared tail. Full rationale in
#21847 (yperbasis #1 boundary, AskAlexSharov structure, yperbasis #2 state-cache
note).

Clean cherry-pick of the `main` commit — `release/3.5` matches `main` here
(it has `doms.ResetPendingUpdates()`, which the restructure hoists ahead of the
branch so it runs on both paths; the test uses `[:]` slicing as `common.Hash`/
`common.Address` are raw arrays).

## Verification on release/3.5 + this patch

- red→green: with the merged `Min(u.UnwindPoint+1)` boundary the test fails (the
  `(committed, unwindPoint]` write `0x1122` survives); with this PR it passes.
- `go build ./execution/stagedsync/...` — clean
- `go test ./execution/stagedsync/ -run TestUnwindExecutionStage_PrunesUncommittedOverlayWrite` — pass
- `gofmt` / `golangci-lint run ./execution/stagedsync/` — 0 issues

Relates to #21681.

Co-authored-by: Claude <noreply@anthropic.com>
