### PR TITLE
execution/vm: refund new-account state gas on pre-existing contract creation under EIP-8037

### DIFF
--- a/execution/protocol/mdgas/md_gas.go
+++ b/execution/protocol/mdgas/md_gas.go
@@ -58,9 +58,13 @@ type FullMdGas struct {
 // a callee that matches a charge an ancestor made (sharing storage via
 // CALLCODE/DELEGATECALL, or against a tx-level intrinsic state charge).
 type MdGasUsage struct {
-	Regular             uint64
-	State               int64
-	StateGasFromGasLeft uint64
+	Regular uint64 // gross regular gas consumed in this frame
+	State   int64  // signed net state-gas consumed in this frame
+
+	// Spilled tracks how much of this frame's regular gas (gas_left)
+	// has been borrowed to cover state-gas charges that exceeded the
+	// reservoir.
+	Spilled uint64
 }
 
 // PlusIntrinsic folds an intrinsic-gas MdGas into the frame-usage report,
@@ -68,9 +72,9 @@ type MdGasUsage struct {
 // negative in the combined value.
 func (u MdGasUsage) PlusIntrinsic(igas MdGas) MdGasUsage {
 	return MdGasUsage{
-		Regular:             u.Regular + igas.Regular,
-		State:               u.State + int64(igas.State),
-		StateGasFromGasLeft: u.StateGasFromGasLeft,
+		Regular: u.Regular + igas.Regular,
+		State:   u.State + int64(igas.State),
+		Spilled: u.Spilled,
 	}
 }
 

--- a/execution/protocol/mdgas/md_gas.go
+++ b/execution/protocol/mdgas/md_gas.go
@@ -58,8 +58,9 @@ type FullMdGas struct {
 // a callee that matches a charge an ancestor made (sharing storage via
 // CALLCODE/DELEGATECALL, or against a tx-level intrinsic state charge).
 type MdGasUsage struct {
-	Regular uint64
-	State   int64
+	Regular             uint64
+	State               int64
+	StateGasFromGasLeft uint64
 }
 
 // PlusIntrinsic folds an intrinsic-gas MdGas into the frame-usage report,
@@ -67,8 +68,9 @@ type MdGasUsage struct {
 // negative in the combined value.
 func (u MdGasUsage) PlusIntrinsic(igas MdGas) MdGasUsage {
 	return MdGasUsage{
-		Regular: u.Regular + igas.Regular,
-		State:   u.State + int64(igas.State),
+		Regular:             u.Regular + igas.Regular,
+		State:               u.State + int64(igas.State),
+		StateGasFromGasLeft: u.StateGasFromGasLeft,
 	}
 }
 

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -601,7 +601,7 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 		// nonce to calculate the address of the contract that is being created
 		// It does get incremented inside the `Create` call, after the computation
 		// of the contract's address, but before the execution of the code.
-		ret, _, st.gasRemaining, gasUsed, vmerr = st.evm.Create(sender, st.data, st.gasRemaining, st.value, nil, bailout)
+		ret, _, st.gasRemaining, gasUsed, _, vmerr = st.evm.Create(sender, st.data, st.gasRemaining, st.value, nil, bailout)
 	} else {
 		ret, st.gasRemaining, gasUsed, vmerr = st.evm.Call(sender, st.to(), st.data, st.gasRemaining, st.value, bailout)
 	}

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/erigontech/erigon/execution/protocol/misc"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/execution/vm"
@@ -295,4 +296,119 @@ func TestPreCheckErrorOrdering_GasBeforeFeeCap(t *testing.T) {
 		gp := NewGasPool(100_000, 0)
 		require.NoError(t, CheckBlockGasInclusion(gp, 50_000, 80_000))
 	})
+}
+
+func TestEIP8037_StateGasRefundPreexisting(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 60_000_000
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	blockCtx := evmtypes.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    misc.Transfer,
+		GasLimit:    blockGasLimit,
+	}
+
+	// 1. Creation at a brand-new address (must charge state gas)
+	ibs1 := state.New(state.NewNoopReader())
+	gp1 := NewGasPool(blockGasLimit, 0)
+	evm1 := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs1, chain.AllProtocolChanges, vm.Config{NoBaseFee: true})
+	// Initcode = STOP (0x00)
+	msg1 := types.NewMessage(
+		sender, accounts.NilAddress, 0, uint256.NewInt(0), 300_000,
+		uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0),
+		[]byte{0x00}, nil,
+		false, false, true, false, nil,
+	)
+	st1 := NewTxnExecutor(evm1, msg1, gp1)
+	result1, err := st1.Execute(true, false)
+	require.NoError(t, err)
+	require.NotNil(t, result1)
+
+	regularStateGas := result1.BlockStateGasUsed
+	require.GreaterOrEqual(t, regularStateGas, uint64(params.StateGasNewAccount))
+
+	// 2. Creation at a pre-existing address (must refund/exclude params.StateGasNewAccount)
+	ibs2 := state.New(state.NewNoopReader())
+	gp2 := NewGasPool(blockGasLimit, 0)
+	evm2 := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs2, chain.AllProtocolChanges, vm.Config{NoBaseFee: true})
+
+	// Compute the contract address for sender at nonce 0
+	targetAddr := accounts.InternAddress(types.CreateAddress(sender.Value(), 0))
+	// Make it pre-existing by giving it balance
+	ibs2.AddBalance(targetAddr, *uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+
+	st2 := NewTxnExecutor(evm2, msg1, gp2)
+	result2, err := st2.Execute(true, false)
+	require.NoError(t, err)
+	require.NotNil(t, result2)
+
+	preexistingStateGas := result2.BlockStateGasUsed
+	t.Logf("State gas used: brand-new = %d, pre-existing = %d", regularStateGas, preexistingStateGas)
+
+	// Verify that the state gas used for pre-existing account is exactly StateGasNewAccount less
+	require.Equal(t, regularStateGas-uint64(params.StateGasNewAccount), preexistingStateGas,
+		"State gas for pre-existing account must be StateGasNewAccount less than brand-new account")
+}
+
+func TestEIP8037_StateGasRefundPreexistingWithCodeDeposit(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 60_000_000
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	blockCtx := evmtypes.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    misc.Transfer,
+		GasLimit:    blockGasLimit,
+	}
+
+	// Bytecode that returns a 10-byte code:
+	// PUSH10 0x0102030405060708090a (0x69 0102030405060708090a)
+	// PUSH1 0x00 (0x60 00)
+	// MSTORE (0x52)
+	// PUSH1 10 (0x60 0a)
+	// PUSH1 22 (0x60 16) - MSTORE stores at offset 32 - 10 = 22 for right alignment
+	// RETURN (0xf3)
+	// Total initcode: 690102030405060708090a600052600a6016f3
+	initCode := common.Hex2Bytes("690102030405060708090a600052600a6016f3")
+
+	// 1. Creation at a brand-new address (must charge state gas for new account + 10 bytes code deposit)
+	ibs1 := state.New(state.NewNoopReader())
+	gp1 := NewGasPool(blockGasLimit, 0)
+	evm1 := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs1, chain.AllProtocolChanges, vm.Config{NoBaseFee: true})
+	msg1 := types.NewMessage(
+		sender, accounts.NilAddress, 0, uint256.NewInt(0), 300_000,
+		uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0),
+		initCode, nil,
+		false, false, true, false, nil,
+	)
+	st1 := NewTxnExecutor(evm1, msg1, gp1)
+	result1, err := st1.Execute(true, false)
+	require.NoError(t, err)
+	require.NotNil(t, result1)
+
+	regularStateGas := result1.BlockStateGasUsed
+	expectedNewAccountGas := uint64(params.StateGasNewAccount) + 10*uint64(params.CostPerStateByte)
+	require.Equal(t, expectedNewAccountGas, regularStateGas)
+
+	// 2. Creation at a pre-existing address (must refund params.StateGasNewAccount but keep 10 bytes code deposit)
+	ibs2 := state.New(state.NewNoopReader())
+	gp2 := NewGasPool(blockGasLimit, 0)
+	evm2 := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs2, chain.AllProtocolChanges, vm.Config{NoBaseFee: true})
+
+	// Compute the contract address for sender at nonce 0
+	targetAddr := accounts.InternAddress(types.CreateAddress(sender.Value(), 0))
+	// Make it pre-existing by giving it balance
+	ibs2.AddBalance(targetAddr, *uint256.NewInt(100), tracing.BalanceChangeUnspecified)
+
+	st2 := NewTxnExecutor(evm2, msg1, gp2)
+	result2, err := st2.Execute(true, false)
+	require.NoError(t, err)
+	require.NotNil(t, result2)
+
+	preexistingStateGas := result2.BlockStateGasUsed
+	t.Logf("State gas used with code: brand-new = %d, pre-existing = %d", regularStateGas, preexistingStateGas)
+
+	// Verify that the state gas used for pre-existing account is exactly 10 * CostPerStateByte
+	require.Equal(t, 10*uint64(params.CostPerStateByte), preexistingStateGas)
 }

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -298,6 +298,14 @@ func TestPreCheckErrorOrdering_GasBeforeFeeCap(t *testing.T) {
 	})
 }
 
+// TestEIP8037_StateGasRefundPreexisting is testing what happens when we create a contract at an address
+// that already exists.
+// Here, basically what we are doing is, first we deploy a contract with no code (initcode is STOP) at a
+// fresh new address. In this case, it must charge the full StateGasNewAccount fee of 183.6k.
+// Next, we try the same deployment, but this time at an address that already exists in the state
+// (we give it some balance first). Under EIP-8037, this pre-existing check should kick in and we must get
+// the StateGasNewAccount fee refunded. So, the state gas used for the pre-existing case should be exactly
+// StateGasNewAccount less than the brand-new creation (which in this case means it becomes 0).
 func TestEIP8037_StateGasRefundPreexisting(t *testing.T) {
 	t.Parallel()
 
@@ -351,6 +359,15 @@ func TestEIP8037_StateGasRefundPreexisting(t *testing.T) {
 		"State gas for pre-existing account must be StateGasNewAccount less than brand-new account")
 }
 
+// TestEIP8037_StateGasRefundPreexistingWithCodeDeposit is verifying how the refund works when code is
+// actually deposited.
+// Here, we deploy a contract that returns a 10-byte runtime code.
+// For a brand-new address, it should charge the new account fee (183.6k) plus the code deposit cost
+// (10 * 192 = 1,920 gas).
+// But for a pre-existing target address, the new account fee must be refunded, but the code deposit
+// fee of 1,920 gas must still be charged!
+// So, we are checking that the pre-existing target's state gas usage ends up being exactly the code
+// deposit cost, and the base creation fee is successfully refunded.
 func TestEIP8037_StateGasRefundPreexistingWithCodeDeposit(t *testing.T) {
 	t.Parallel()
 
@@ -413,6 +430,12 @@ func TestEIP8037_StateGasRefundPreexistingWithCodeDeposit(t *testing.T) {
 	require.Equal(t, 10*uint64(params.CostPerStateByte), preexistingStateGas)
 }
 
+// TestEIP8037_StateGasSpilloverRevert checks what happens when a nested contract creation reverts.
+// Here, basically what we are doing is, we are testing that if a sub-creation reverts,
+// then whatever state gas was charged for it (which actually spilled over into the regular gas pool
+// because the reservoir was empty) should be fully refunded back to the regular gas pool of the parent.
+// So, at the end, only the parent's creation state gas of 183.6k should be charged, and the reverted
+// child's state gas must be returned completely.
 func TestEIP8037_StateGasSpilloverRevert(t *testing.T) {
 	t.Parallel()
 
@@ -454,6 +477,12 @@ func TestEIP8037_StateGasSpilloverRevert(t *testing.T) {
 		"The reverted sub-creation must not leave any net state gas charge")
 }
 
+// TestEIP8037_StateGasSpilloverHalt checks the exceptional halt scenario.
+// In this test, we are checking that if the child contract creation execution fails with an INVALID
+// instruction, the child frame halts. According to EIP-8037 rules, since it is a halt, all the regular
+// gas given to it is gone/burned. But, the state changes are rolled back, so the state gas charged for
+// the sub-creation must still be restored/refunded. Therefore, the net state gas charged at the
+// transaction level should only be for the parent creation, and the child's charge must not be kept.
 func TestEIP8037_StateGasSpilloverHalt(t *testing.T) {
 	t.Parallel()
 

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -412,3 +412,83 @@ func TestEIP8037_StateGasRefundPreexistingWithCodeDeposit(t *testing.T) {
 	// Verify that the state gas used for pre-existing account is exactly 10 * CostPerStateByte
 	require.Equal(t, 10*uint64(params.CostPerStateByte), preexistingStateGas)
 }
+
+func TestEIP8037_StateGasSpilloverRevert(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 60_000_000
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	blockCtx := evmtypes.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    misc.Transfer,
+		GasLimit:    blockGasLimit,
+	}
+
+	// Parent initcode that runs CREATE on a child that reverts.
+	// Bytecode: 6460006000fd6000526005601b6000f05000
+	initCode := common.Hex2Bytes("6460006000fd6000526005601b6000f05000")
+
+	ibs := state.New(state.NewNoopReader())
+	gp := NewGasPool(blockGasLimit, 0)
+	evm := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs, chain.AllProtocolChanges, vm.Config{NoBaseFee: true})
+
+	// Use a small gas limit (but enough to run without OOG) so that the state reservoir split is 0,
+	// forcing the 183.6k CREATE state gas charge to spill over into the regular gas pool.
+	msg := types.NewMessage(
+		sender, accounts.NilAddress, 0, uint256.NewInt(0), 500_000,
+		uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0),
+		initCode, nil,
+		false, false, true, false, nil,
+	)
+	st := NewTxnExecutor(evm, msg, gp)
+	result, err := st.Execute(true, false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	t.Logf("Spillover revert test - regular gas used: %d, state gas used: %d", result.BlockRegularGasUsed, result.BlockStateGasUsed)
+
+	// Since the sub-creation reverted, the state gas charged for it should be fully refunded.
+	// The parent creation itself succeeded (it returned empty code via STOP).
+	// So the only net state gas charge should be the parent contract creation cost (params.StateGasNewAccount = 183600).
+	require.Equal(t, uint64(params.StateGasNewAccount), result.BlockStateGasUsed,
+		"The reverted sub-creation must not leave any net state gas charge")
+}
+
+func TestEIP8037_StateGasSpilloverHalt(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 60_000_000
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	blockCtx := evmtypes.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    misc.Transfer,
+		GasLimit:    blockGasLimit,
+	}
+
+	// Parent initcode that runs CREATE on a child that executes INVALID (0xfe).
+	// Bytecode: 626000fe6000526003601d6000f05000
+	initCode := common.Hex2Bytes("626000fe6000526003601d6000f05000")
+
+	ibs := state.New(state.NewNoopReader())
+	gp := NewGasPool(blockGasLimit, 0)
+	evm := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs, chain.AllProtocolChanges, vm.Config{NoBaseFee: true})
+
+	msg := types.NewMessage(
+		sender, accounts.NilAddress, 0, uint256.NewInt(0), 500_000,
+		uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0),
+		initCode, nil,
+		false, false, true, false, nil,
+	)
+	st := NewTxnExecutor(evm, msg, gp)
+	result, err := st.Execute(true, false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	t.Logf("Spillover halt test - regular gas used: %d, state gas used: %d", result.BlockRegularGasUsed, result.BlockStateGasUsed)
+
+	// The child halted, so the child's state changes are reverted and the sub-creation cost is refunded.
+	// Parent creation succeeded.
+	require.Equal(t, uint64(params.StateGasNewAccount), result.BlockStateGasUsed,
+		"The halted sub-creation must not leave any net state gas charge")
+}
+

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -315,7 +315,8 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 	snapshot := evm.intraBlockState.PushSnapshot()
 	defer evm.intraBlockState.PopSnapshot(snapshot)
 
-	if typ == CALL {
+	switch typ {
+	case CALL:
 		exist, err := evm.intraBlockState.Exist(addr)
 		if err != nil {
 			return nil, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
@@ -347,7 +348,7 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 				return nil, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 			}
 		}
-	} else if typ == STATICCALL {
+	case STATICCALL:
 		// Trigger a touch on the callee so EIP-161 state clearing applies to
 		// empty accounts (matters on test networks; on Mainnet all empties are
 		// gone by Byzantium). Use TouchAccount rather than AddBalance(0): the
@@ -379,7 +380,8 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 			return nil, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 		}
 		var contract Contract
-		if typ == CALLCODE {
+		switch typ {
+		case CALLCODE:
 			contract = Contract{
 				caller:   caller,
 				addr:     caller,
@@ -387,7 +389,7 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 				Code:     code,
 				CodeHash: codeHash,
 			}
-		} else if typ == DELEGATECALL {
+		case DELEGATECALL:
 			contract = Contract{
 				caller:   callerAddress,
 				addr:     caller,
@@ -395,7 +397,7 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 				Code:     code,
 				CodeHash: codeHash,
 			}
-		} else {
+		default:
 			contract = Contract{
 				caller:   caller,
 				addr:     addr,
@@ -639,25 +641,21 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 	// be stored due to not enough gas, set an error when we're in Homestead and let it be handled
 	// by the error checking condition below.
 	if err == nil {
-		// EIP-8037: GAS_CODE_DEPOSIT = cpsb/byte (state) + 6*ceil(len/32) (regular)
+		// EIP-8037: GAS_CODE_DEPOSIT = 6*ceil(len/32) (regular) + cpsb/byte (state)
 		// Pre-Amsterdam: GAS_CODE_DEPOSIT = 200/byte (regular only)
 		preDepositGas := gasRemaining
 
-		// Charge state gas (Amsterdam only).
-		stateGasOk := true
-		var stateGas uint64
-		if evm.chainRules.IsAmsterdam {
-			stateGas = uint64(len(ret)) * params.CostPerStateByte
-			gasRemaining, stateGasOk = useMdGas(gasRemaining, stateGas, mdgas.StateGas, evm.Config().Tracer, tracing.GasChangeCallCodeStorage)
-		}
-
-		// Charge regular gas.
+		// Regular gas (hash cost) is charged before state gas (per-byte
+		// storage cost). The ordering has no behavioral
+		// impact: both costs are deterministic from len(ret), and on any
+		// failure both charges are rolled back via preDepositGas below.
 		var regularGasOk bool
-		if stateGasOk {
+		var stateGas uint64
+		{
 			var regularGas uint64
 			if evm.chainRules.IsAmsterdam {
-				// EIP-8037 "Contract deployment cost calculation", success path:
-				// HASH_COST(L) = 6*ceil(L/32); the state component (cpsb*L) is charged above.
+				// EIP-8037 parameter changes: GAS_CODE_DEPOSIT regular component
+				// HASH_COST(L) = 6*ceil(L/32)
 				regularGas = params.Keccak256WordGas * ToWordSize(uint64(len(ret)))
 			} else {
 				regularGas = uint64(len(ret)) * params.CreateDataGas
@@ -665,16 +663,22 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 			gasRemaining, regularGasOk = useMdGas(gasRemaining, regularGas, mdgas.RegularGas, evm.Config().Tracer, tracing.GasChangeCallCodeStorage)
 		}
 
-		if stateGasOk && regularGasOk {
+		// Charge state gas (Amsterdam only) after regular gas.
+		stateGasOk := true
+		if regularGasOk && evm.chainRules.IsAmsterdam {
+			stateGas = uint64(len(ret)) * params.CostPerStateByte
+			gasRemaining, stateGasOk = useMdGas(gasRemaining, stateGas, mdgas.StateGas, evm.Config().Tracer, tracing.GasChangeCallCodeStorage)
+		}
+
+		if regularGasOk && stateGasOk {
 			evm.intraBlockState.SetCode(address, ret, tracing.CodeChangeContractCreation)
 			// EIP-8037: post-Run code-deposit state charge counts toward this
 			// frame's state-gas usage.
 			gasUsed.State += int64(stateGas)
 		} else {
 			if evm.chainRules.IsAmsterdam {
-				// Code deposit failed: per EIP-8037 the failure cost is
-				// GAS_CREATE + initcode_execution_cost only; code deposit
-				// gas (both state and regular) is excluded.
+				// Code deposit OOG: roll back both the regular and state
+				// charges so the frame pays only for initcode execution.
 				gasRemaining = preDepositGas
 			}
 			// If we run out of gas, we do not store the code: the returned code must be empty.

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -186,17 +186,17 @@ func (evm *EVM) handleFrameRevert(gasRemaining *mdgas.MdGas, err error, depth in
 	// refund flows through gasUsed.State (see func doc).
 	//
 	if evm.chainRules.IsAmsterdam && depth > 0 {
-		reservoir := int64(gasRemaining.State) + gasUsed.State - int64(gasUsed.StateGasFromGasLeft)
+		reservoir := int64(gasRemaining.State) + gasUsed.State - int64(gasUsed.Spilled)
 		if reservoir < 0 {
 			log.Error("EIP-8037 invariant violated; clamping parent reservoir to 0",
-				"gasRemainingState", gasRemaining.State, "stateGasUsed", gasUsed.State, "spillover", gasUsed.StateGasFromGasLeft, "depth", depth)
+				"gasRemainingState", gasRemaining.State, "stateGasUsed", gasUsed.State, "spillover", gasUsed.Spilled, "depth", depth)
 			reservoir = 0
 		}
 		if err == ErrExecutionReverted {
-			gasRemaining.Regular += gasUsed.StateGasFromGasLeft
+			gasRemaining.Regular += gasUsed.Spilled
 		}
 		gasRemaining.State = uint64(reservoir)
-		gasUsed.StateGasFromGasLeft = 0
+		gasUsed.Spilled = 0
 	}
 }
 

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -163,7 +163,7 @@ func (evm *EVM) Cancelled() bool { return evm.abort.Load() }
 // evm.create depth==0 defers fold the error semantics into gasUsed.State
 // (reset to 0 for CALL, -StateGasNewAccount for CREATE) so TxnExecutor
 // can read gasUsed.State directly without checking the error.
-func (evm *EVM) handleFrameRevert(gasRemaining *mdgas.MdGas, err error, depth int, snapshot int, stateGasUsed int64) {
+func (evm *EVM) handleFrameRevert(gasRemaining *mdgas.MdGas, err error, depth int, snapshot int, gasUsed *mdgas.MdGasUsage) {
 
 	// 1. Revert state changes.
 	evm.intraBlockState.RevertToSnapshot(snapshot, err)
@@ -186,35 +186,17 @@ func (evm *EVM) handleFrameRevert(gasRemaining *mdgas.MdGas, err error, depth in
 	// refund flows through gasUsed.State (see func doc).
 	//
 	if evm.chainRules.IsAmsterdam && depth > 0 {
-		// Invariant: gasRemaining.State + stateGasUsed >= 0. useMdGas
-		// (charge: stateGas -= a, frameStateUsed += a) and
-		// creditStateGasRefund (refund: stateGas += a, frameStateUsed -= a)
-		// are the only mutators and update both sides in lock-step, so
-		// the sum can only grow (via spillover charges) from the parent's
-		// reservoir R ≥ 0. A negative sum here means some new code path
-		// mutated stateGas or frameStateUsed without the paired update,
-		// or the EIP-8037 accounting was reimplemented incorrectly. We
-		// surface this loudly via a log + clamp; the corrupted accounting
-		// will manifest downstream as wrong execution / gas accounting /
-		// state root.
-		//
-		// The comparison stays in uint64 (`uint64(-stateGasUsed) >
-		// gasRemaining.State`) rather than promoting both sides to int64.
-		// gasRemaining.State is a reservoir balance — unsigned by design
-		// and free to use the full uint64 range — so an int64 cast would
-		// flip any value above 2^63 to negative and break the comparison.
-		// Comparing the magnitudes directly in uint64 keeps the check
-		// correct at any gas size.
-		if stateGasUsed < 0 && uint64(-stateGasUsed) > gasRemaining.State {
+		reservoir := int64(gasRemaining.State) + gasUsed.State - int64(gasUsed.StateGasFromGasLeft)
+		if reservoir < 0 {
 			log.Error("EIP-8037 invariant violated; clamping parent reservoir to 0",
-				"gasRemainingState", gasRemaining.State, "stateGasUsed", stateGasUsed, "depth", depth)
-			gasRemaining.State = 0
-			return
+				"gasRemainingState", gasRemaining.State, "stateGasUsed", gasUsed.State, "spillover", gasUsed.StateGasFromGasLeft, "depth", depth)
+			reservoir = 0
 		}
-		// uint64(negative int64) = 2^64 − |stateGasUsed|; the += then
-		// overflows and wraps into the correct subtraction for negative
-		// stateGasUsed.
-		gasRemaining.State += uint64(stateGasUsed)
+		if err == ErrExecutionReverted {
+			gasRemaining.Regular += gasUsed.StateGasFromGasLeft
+		}
+		gasRemaining.State = uint64(reservoir)
+		gasUsed.StateGasFromGasLeft = 0
 	}
 }
 
@@ -428,11 +410,10 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 		}
 		ret, gasRemaining, gasUsed, err = evm.Run(contract, gas, input, readOnly)
 	}
-	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally
 	// when we're in Homestead this also counts for code storage gas errors.
 	if err != nil || evm.config.RestoreState {
-		evm.handleFrameRevert(&gasRemaining, err, depth, snapshot, gasUsed.State)
+		evm.handleFrameRevert(&gasRemaining, err, depth, snapshot, &gasUsed)
 	}
 
 	return ret, gasRemaining, gasUsed, err
@@ -704,11 +685,10 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 		}
 	}
 
-	// When an error was returned by the EVM or when setting the creation code
 	// above, we revert to the snapshot and consume any gas remaining. Additionally,
 	// when we're in Homestead, this also counts for code storage gas errors.
 	if err != nil && (evm.chainRules.IsHomestead || err != ErrCodeStoreOutOfGas) {
-		evm.handleFrameRevert(&gasRemaining, err, depth, snapshot, gasUsed.State)
+		evm.handleFrameRevert(&gasRemaining, err, depth, snapshot, &gasUsed)
 		return ret, address, gasRemaining, gasUsed, false, err
 	}
 

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -491,11 +491,12 @@ func (c *codeAndHash) Hash() accounts.CodeHash {
 }
 
 func (evm *EVM) OverlayCreate(caller accounts.Address, codeAndHash *codeAndHash, gas mdgas.MdGas, value uint256.Int, address accounts.Address, typ OpCode, incrementNonce bool) ([]byte, accounts.Address, mdgas.MdGas, mdgas.MdGasUsage, error) {
-	return evm.create(caller, codeAndHash, gas, value, address, typ, incrementNonce, false)
+	ret, address, gasRemaining, gasUsed, _, err := evm.create(caller, codeAndHash, gas, value, address, typ, incrementNonce, false)
+	return ret, address, gasRemaining, gasUsed, err
 }
 
 // create creates a new contract using code as deployment code.
-func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas mdgas.MdGas, value uint256.Int, address accounts.Address, typ OpCode, incrementNonce bool, bailout bool) (ret []byte, createAddress accounts.Address, gasRemaining mdgas.MdGas, gasUsed mdgas.MdGasUsage, err error) {
+func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas mdgas.MdGas, value uint256.Int, address accounts.Address, typ OpCode, incrementNonce bool, bailout bool) (ret []byte, createAddress accounts.Address, gasRemaining mdgas.MdGas, gasUsed mdgas.MdGasUsage, creation bool, err error) {
 	gasRemaining = gas
 
 	if dbg.TraceTransactionIO && (evm.intraBlockState.Trace() || dbg.TraceAccount(caller.Handle())) {
@@ -518,7 +519,7 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 	// paths. Regular = (input − leftover) − state in signed int64 so a
 	// negative net state correctly grows the regular component.
 	//
-	// At depth==0 on error, the spec resets the top-frame's state_gas_used
+	// At depth==0 on error or if target already exists, the spec resets the top-frame's state_gas_used
 	// to 0 AND adds STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE to
 	// state_refund (the contract was never created, so the intrinsic
 	// NEW_ACCOUNT state-gas is returned). Mirror both by setting
@@ -530,10 +531,16 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 	// even on call failure.
 	inputTotal := gas.Total()
 	defer func() {
-		gasUsed.Regular = deriveFrameRegularGasUsed(inputTotal, gasRemaining.Total(), gasUsed.State)
-		if depth == 0 && evm.chainRules.IsAmsterdam && err != nil {
-			gasUsed.State = -int64(params.StateGasNewAccount)
+		if depth == 0 && evm.chainRules.IsAmsterdam {
+			if err != nil {
+				gasRemaining.State += params.StateGasNewAccount
+				gasUsed.State = -int64(params.StateGasNewAccount)
+			} else if !creation {
+				gasRemaining.State += params.StateGasNewAccount
+				gasUsed.State -= int64(params.StateGasNewAccount)
+			}
 		}
+		gasUsed.Regular = deriveFrameRegularGasUsed(inputTotal, gasRemaining.Total(), gasUsed.State)
 	}()
 
 	if evm.Config().Tracer != nil {
@@ -547,26 +554,26 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 	// limit.
 	if depth > int(params.CallCreateDepth) {
 		err = ErrDepth
-		return nil, accounts.NilAddress, gasRemaining, mdgas.MdGasUsage{}, err
+		return nil, accounts.NilAddress, gasRemaining, mdgas.MdGasUsage{}, false, err
 	}
 	canTransfer, err := evm.Context.CanTransfer(evm.intraBlockState, caller, value)
 	if err != nil {
-		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, err
+		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, false, err
 	}
 	if !canTransfer {
 		if !bailout {
 			err = ErrInsufficientBalance
-			return nil, accounts.NilAddress, gasRemaining, mdgas.MdGasUsage{}, err
+			return nil, accounts.NilAddress, gasRemaining, mdgas.MdGasUsage{}, false, err
 		}
 	}
 	if incrementNonce {
 		nonce, err := evm.intraBlockState.GetNonce(caller)
 		if err != nil {
-			return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+			return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, false, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 		}
 		if nonce+1 < nonce {
 			err = ErrNonceUintOverflow
-			return nil, accounts.NilAddress, gasRemaining, mdgas.MdGasUsage{}, err
+			return nil, accounts.NilAddress, gasRemaining, mdgas.MdGasUsage{}, false, err
 		}
 		evm.intraBlockState.SetNonce(caller, nonce+1, tracing.NonceChangeContractCreator)
 	}
@@ -585,15 +592,15 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 	// delegated account even if the delegation target is empty.
 	contractHash, err := evm.intraBlockState.GetCodeHash(address)
 	if err != nil {
-		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, false, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 	}
 	nonce, err := evm.intraBlockState.GetNonce(address)
 	if err != nil {
-		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, false, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 	}
 	hasStorage, err := evm.intraBlockState.HasStorage(address)
 	if err != nil {
-		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, false, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 	}
 	if nonce != 0 || !contractHash.IsEmpty() || hasStorage {
 		err = ErrContractAddressCollision
@@ -601,18 +608,25 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 			evm.Config().Tracer.OnGasChange(gasRemaining.Regular, 0, tracing.GasChangeCallFailedExecution)
 		}
 		// Preserve State so the parent's reservoir is restored by restoreChildGas.
-		return nil, accounts.NilAddress, mdgas.MdGas{State: gasRemaining.State}, mdgas.MdGasUsage{}, err
+		return nil, accounts.NilAddress, mdgas.MdGas{State: gasRemaining.State}, mdgas.MdGasUsage{}, false, err
 	}
 	// Create a new account on the state
 	snapshot := evm.intraBlockState.PushSnapshot()
 	defer evm.intraBlockState.PopSnapshot(snapshot)
 
-	evm.intraBlockState.CreateAccount(address, true)
+	exists, err := evm.intraBlockState.Exist(address)
+	if err != nil {
+		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, false, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+	}
+	if !exists {
+		evm.intraBlockState.CreateAccount(address, true)
+		creation = true
+	}
 	if evm.chainRules.IsSpuriousDragon {
 		evm.intraBlockState.SetNonce(address, 1, tracing.NonceChangeNewContract)
 	}
 	if err := evm.Context.Transfer(evm.intraBlockState, caller, address, value, bailout, evm.chainRules); err != nil {
-		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, false, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 	}
 
 	// Initialise a new contract and set the code that is to be used by the EVM.
@@ -626,7 +640,7 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 	}
 
 	if evm.config.NoRecursion && depth > 0 {
-		return nil, address, gasRemaining, mdgas.MdGasUsage{}, nil
+		return nil, address, gasRemaining, mdgas.MdGasUsage{}, false, nil
 	}
 
 	ret, gasRemaining, gasUsed, err = evm.Run(contract, gas, nil, false)
@@ -695,16 +709,17 @@ func (evm *EVM) create(caller accounts.Address, codeAndHash *codeAndHash, gas md
 	// when we're in Homestead, this also counts for code storage gas errors.
 	if err != nil && (evm.chainRules.IsHomestead || err != ErrCodeStoreOutOfGas) {
 		evm.handleFrameRevert(&gasRemaining, err, depth, snapshot, gasUsed.State)
+		return ret, address, gasRemaining, gasUsed, false, err
 	}
 
-	return ret, address, gasRemaining, gasUsed, err
+	return ret, address, gasRemaining, gasUsed, creation, err
 }
 
 // Create creates a new contract using code as deployment code.
 // If salt is non-nil, CREATE2 addressing is used (keccak256(0xff ++ msg.sender ++ salt ++ keccak256(init_code))[12:]);
 // otherwise the usual sender-and-nonce-hash is used (CREATE).
 // DESCRIBED: docs/programmers_guide/guide.md#nonce
-func (evm *EVM) Create(caller accounts.Address, code []byte, gas mdgas.MdGas, endowment uint256.Int, salt *uint256.Int, bailout bool) (ret []byte, contractAddr accounts.Address, gasRemaining mdgas.MdGas, gasUsed mdgas.MdGasUsage, err error) {
+func (evm *EVM) Create(caller accounts.Address, code []byte, gas mdgas.MdGas, endowment uint256.Int, salt *uint256.Int, bailout bool) (ret []byte, contractAddr accounts.Address, gasRemaining mdgas.MdGas, gasUsed mdgas.MdGasUsage, creation bool, err error) {
 	ch := &codeAndHash{code: code}
 	op := CREATE
 	if salt != nil {
@@ -714,7 +729,7 @@ func (evm *EVM) Create(caller accounts.Address, code []byte, gas mdgas.MdGas, en
 		var nonce uint64
 		nonce, err = evm.intraBlockState.GetNonce(caller)
 		if err != nil {
-			return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, err
+			return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, false, err
 		}
 		contractAddr = accounts.InternAddress(types.CreateAddress(caller.Value(), nonce))
 	}
@@ -724,7 +739,7 @@ func (evm *EVM) Create(caller accounts.Address, code []byte, gas mdgas.MdGas, en
 // SysCreate is a special (system) contract creation methods for genesis constructors.
 // Unlike the normal Create & Create2, it doesn't increment caller's nonce.
 func (evm *EVM) SysCreate(caller accounts.Address, code []byte, gas mdgas.MdGas, endowment uint256.Int, contractAddr accounts.Address) (ret []byte, gasRemaining mdgas.MdGas, err error) {
-	ret, _, gasRemaining, _, err = evm.create(caller, &codeAndHash{code: code}, gas, endowment, contractAddr, CREATE, false /* incrementNonce */, false)
+	ret, _, gasRemaining, _, _, err = evm.create(caller, &codeAndHash{code: code}, gas, endowment, contractAddr, CREATE, false /* incrementNonce */, false)
 	return
 }
 

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1028,7 +1028,7 @@ func execCreate(pc uint64, evm *EVM, scope *CallContext, value uint256.Int, inpu
 	scope.useGas(gas.Regular, evm.Config().Tracer, gasChangeReason)
 	scope.stateGas = 0 // pass reservoir to child via callGas; restoreChildGas returns it
 
-	res, addr, returnGas, childUsed, suberr := evm.Create(scope.Contract.Address(), input, gas, value, salt, false)
+	res, addr, returnGas, childUsed, creation, suberr := evm.Create(scope.Contract.Address(), input, gas, value, salt, false)
 	scope.Contract.selfBalanceCached = false
 
 	// Push item on the stack based on the returned error. If the ruleset is
@@ -1047,22 +1047,23 @@ func execCreate(pc uint64, evm *EVM, scope *CallContext, value uint256.Int, inpu
 	}
 	scope.Stack.push(result)
 
-	scope.restoreChildGas(returnGas, evm.config.Tracer)
+	scope.restoreChildGas(returnGas, childUsed, evm.config.Tracer)
 
 	if evm.chainRules.IsAmsterdam {
 		if suberr != nil {
 			// EIP-8037: child CREATE failure refunds the NEW_ACCOUNT state gas
-			// the parent charged at entry. The reservoir was already restored
-			// to the parent via restoreChildGas (handleFrameRevert at depth>0
-			// added childUsed.State back to gas.State).
+			// the parent charged at entry.
 			scope.creditStateGasRefund(params.StateGasNewAccount)
 		} else {
 			// EIP-8037: child success — fold child's net state-gas usage
 			// (signed: charges − inline refunds the child credited) into
-			// our frame. The child's reservoir leftover (which holds any
-			// refunded gas) has already been merged via restoreChildGas
-			// above.
+			// our frame.
 			scope.frameStateUsed += childUsed.State
+			if !creation {
+				// EIP-8037: child success but pre-existing destination refunds the NEW_ACCOUNT state gas
+				// the parent charged at entry.
+				scope.creditStateGasRefund(params.StateGasNewAccount)
+			}
 		}
 	}
 
@@ -1126,7 +1127,7 @@ func opCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
-	scope.restoreChildGas(returnGas, evm.config.Tracer)
+	scope.restoreChildGas(returnGas, childUsed, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
 		scope.frameStateUsed += childUsed.State
 	}
@@ -1175,7 +1176,7 @@ func opCallCode(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
-	scope.restoreChildGas(returnGas, evm.config.Tracer)
+	scope.restoreChildGas(returnGas, childUsed, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
 		scope.frameStateUsed += childUsed.State
 	}
@@ -1220,7 +1221,7 @@ func opDelegateCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, er
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
-	scope.restoreChildGas(returnGas, evm.config.Tracer)
+	scope.restoreChildGas(returnGas, childUsed, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
 		scope.frameStateUsed += childUsed.State
 	}
@@ -1264,7 +1265,7 @@ func opStaticCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, erro
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
-	scope.restoreChildGas(returnGas, evm.config.Tracer)
+	scope.restoreChildGas(returnGas, childUsed, evm.config.Tracer)
 	if evm.chainRules.IsAmsterdam && err == nil {
 		scope.frameStateUsed += childUsed.State
 	}

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1128,8 +1128,26 @@ func opCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	}
 
 	scope.restoreChildGas(returnGas, childUsed, evm.config.Tracer)
-	if evm.chainRules.IsAmsterdam && err == nil {
-		scope.frameStateUsed += childUsed.State
+	if evm.chainRules.IsAmsterdam {
+		if err == nil {
+			scope.frameStateUsed += childUsed.State
+		} else if !value.IsZero() {
+			// EIP-8037: "If the operation is unsuccessful before entering
+			// the call frame (e.g., due to insufficient balance or due to
+			// the stack depth), or if the child frame reverts or halts
+			// exceptionally, the charged state-gas is refilled in LIFO
+			// order and execution_state_gas_used decreases by the same
+			// amount." The new-account state gas was charged by gasCall
+			// (via statefulGasCall) when value > 0 and the target was
+			// empty. Refund it now that the call has failed.
+			//
+			// Note: we must re-check Empty() because the gasCall
+			// charge was conditional on (transfersValue && empty).
+			empty, _ := evm.IntraBlockState().Empty(toAddr)
+			if empty {
+				scope.creditStateGasRefund(params.StateGasNewAccount)
+			}
+		}
 	}
 	scope.Contract.selfBalanceCached = false
 	evm.returnData = ret

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -57,8 +57,9 @@ func (vmConfig *Config) HasEip3860(rules *chain.Rules) bool {
 // CallContext contains the things that are per-call, such as stack and memory,
 // but not transients like pc and gas
 type CallContext struct {
-	gas      uint64
-	stateGas uint64
+	gas                 uint64
+	stateGas            uint64
+	stateGasFromGasLeft uint64
 	// EIP-8037 per-frame net state-gas tracker (signed). Increments on every
 	// state-gas charge (including reservoir→regular spill), decrements on
 	// inline refund (SSTORE clear, CREATE collision/revert) regardless of
@@ -129,6 +130,7 @@ func getCallContext(contract Contract, input []byte, gas mdgas.MdGas) *CallConte
 	ctx.gas = gas.Regular
 	ctx.stateGas = gas.State
 	ctx.frameStateUsed = 0
+	ctx.stateGasFromGasLeft = 0
 	ctx.input = input
 	ctx.Contract = contract
 	return ctx
@@ -139,6 +141,7 @@ func (c *CallContext) put() {
 	c.Stack.Reset()
 	c.cacheGen = 0
 	c.frameStateUsed = 0
+	c.stateGasFromGasLeft = 0
 	// Use sentinel values so that a peek call before the first cacheGen++ is
 	// always a miss rather than returning a stale handle from a prior use.
 	c.cachedKeyGen = ^uint64(0)
@@ -163,11 +166,17 @@ func (c *CallContext) useGas(gas uint64, tracer *tracing.Hooks, reason tracing.G
 func (c *CallContext) useMdGas(gas uint64, t mdgas.MdGasType, tracer *tracing.Hooks, reason tracing.GasChangeReason) (ok bool) {
 	remaining, ok := useMdGas(c.Gas(), gas, t, tracer, reason)
 	if ok {
-		c.gas = remaining.Regular
-		c.stateGas = remaining.State
 		if t == mdgas.StateGas {
+			// If the state gas reservoir does not have enough gas, the extra cost will
+			// spill over and cut from the regular gas. We are tracking this extra cut
+			// here so that we can refund it to regular gas pool later.
+			if gas > c.stateGas {
+				c.stateGasFromGasLeft += gas - c.stateGas
+			}
 			c.frameStateUsed += int64(gas)
 		}
+		c.gas = remaining.Regular
+		c.stateGas = remaining.State
 	}
 	return ok
 }
@@ -181,8 +190,20 @@ func (c *CallContext) useMdGas(gas uint64, t mdgas.MdGasType, tracer *tracing.Ho
 // restored by handleFrameRevert so the refund is dropped along with the
 // reverted state changes.
 func (c *CallContext) creditStateGasRefund(amount uint64) {
-	c.stateGas += amount
 	c.frameStateUsed -= int64(amount)
+	if amount > 0 {
+		// If we had previously used regular gas to pay for state gas spillover,
+		// we should first refund the regular gas pool. This ensures the transaction
+		// does not run out of regular gas incorrectly. Any leftover refund will then
+		// go back to the state gas reservoir.
+		if c.stateGasFromGasLeft > 0 {
+			toGasLeft := min(amount, c.stateGasFromGasLeft)
+			c.gas += toGasLeft
+			c.stateGasFromGasLeft -= toGasLeft
+			amount -= toGasLeft
+		}
+		c.stateGas += amount
+	}
 }
 
 func useGas(initial uint64, gas uint64, tracer *tracing.Hooks, reason tracing.GasChangeReason) (remaining uint64, ok bool) {
@@ -292,8 +313,9 @@ func (ctx *CallContext) Gas() mdgas.MdGas {
 // per EIP-8037: "all state gas consumed by the child… is restored to the
 // parent's reservoir." Early-exit errors (collision, depth, insufficient
 // balance) preserve gasRemaining.State so the reservoir is returned intact.
-func (ctx *CallContext) restoreChildGas(returnGas mdgas.MdGas, tracer *tracing.Hooks) {
+func (ctx *CallContext) restoreChildGas(returnGas mdgas.MdGas, childUsed mdgas.MdGasUsage, tracer *tracing.Hooks) {
 	ctx.stateGas = returnGas.State
+	ctx.stateGasFromGasLeft += childUsed.StateGasFromGasLeft
 	ctx.refundGas(returnGas.Regular, tracer, tracing.GasChangeCallLeftOverRefunded)
 }
 
@@ -423,11 +445,12 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 			}
 		}
 		// EIP-8037: snapshot the frame's net state-gas usage (charges minus
-		// inline refunds, signed) before callContext.put() clears it.
+		// inline refunds, signed) and stateGasFromGasLeft before callContext.put() clears it.
 		// gasUsed.Regular is derived uniformly by evm.call/evm.create's defer
 		// from the final gasRemaining (covers precompile/no-code paths and
 		// handleFrameRevert gas burn).
 		gasUsed.State = callContext.frameStateUsed
+		gasUsed.StateGasFromGasLeft = callContext.stateGasFromGasLeft
 		// this function must execute _after_: the `CaptureState` needs the stacks before
 		callContext.put()
 		if restoreReadonly {

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -57,9 +57,9 @@ func (vmConfig *Config) HasEip3860(rules *chain.Rules) bool {
 // CallContext contains the things that are per-call, such as stack and memory,
 // but not transients like pc and gas
 type CallContext struct {
-	gas                 uint64
-	stateGas            uint64
-	stateGasFromGasLeft uint64
+	gas      uint64
+	stateGas uint64
+	Spilled  uint64
 	// EIP-8037 per-frame net state-gas tracker (signed). Increments on every
 	// state-gas charge (including reservoir→regular spill), decrements on
 	// inline refund (SSTORE clear, CREATE collision/revert) regardless of
@@ -130,7 +130,7 @@ func getCallContext(contract Contract, input []byte, gas mdgas.MdGas) *CallConte
 	ctx.gas = gas.Regular
 	ctx.stateGas = gas.State
 	ctx.frameStateUsed = 0
-	ctx.stateGasFromGasLeft = 0
+	ctx.Spilled = 0
 	ctx.input = input
 	ctx.Contract = contract
 	return ctx
@@ -141,7 +141,7 @@ func (c *CallContext) put() {
 	c.Stack.Reset()
 	c.cacheGen = 0
 	c.frameStateUsed = 0
-	c.stateGasFromGasLeft = 0
+	c.Spilled = 0
 	// Use sentinel values so that a peek call before the first cacheGen++ is
 	// always a miss rather than returning a stale handle from a prior use.
 	c.cachedKeyGen = ^uint64(0)
@@ -171,7 +171,7 @@ func (c *CallContext) useMdGas(gas uint64, t mdgas.MdGasType, tracer *tracing.Ho
 			// spill over and cut from the regular gas. We are tracking this extra cut
 			// here so that we can refund it to regular gas pool later.
 			if gas > c.stateGas {
-				c.stateGasFromGasLeft += gas - c.stateGas
+				c.Spilled += gas - c.stateGas
 			}
 			c.frameStateUsed += int64(gas)
 		}
@@ -196,10 +196,10 @@ func (c *CallContext) creditStateGasRefund(amount uint64) {
 		// we should first refund the regular gas pool. This ensures the transaction
 		// does not run out of regular gas incorrectly. Any leftover refund will then
 		// go back to the state gas reservoir.
-		if c.stateGasFromGasLeft > 0 {
-			toGasLeft := min(amount, c.stateGasFromGasLeft)
+		if c.Spilled > 0 {
+			toGasLeft := min(amount, c.Spilled)
 			c.gas += toGasLeft
-			c.stateGasFromGasLeft -= toGasLeft
+			c.Spilled -= toGasLeft
 			amount -= toGasLeft
 		}
 		c.stateGas += amount
@@ -315,7 +315,7 @@ func (ctx *CallContext) Gas() mdgas.MdGas {
 // balance) preserve gasRemaining.State so the reservoir is returned intact.
 func (ctx *CallContext) restoreChildGas(returnGas mdgas.MdGas, childUsed mdgas.MdGasUsage, tracer *tracing.Hooks) {
 	ctx.stateGas = returnGas.State
-	ctx.stateGasFromGasLeft += childUsed.StateGasFromGasLeft
+	ctx.Spilled += childUsed.Spilled
 	ctx.refundGas(returnGas.Regular, tracer, tracing.GasChangeCallLeftOverRefunded)
 }
 
@@ -445,12 +445,12 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 			}
 		}
 		// EIP-8037: snapshot the frame's net state-gas usage (charges minus
-		// inline refunds, signed) and stateGasFromGasLeft before callContext.put() clears it.
+		// inline refunds, signed) and Spilled before callContext.put() clears it.
 		// gasUsed.Regular is derived uniformly by evm.call/evm.create's defer
 		// from the final gasRemaining (covers precompile/no-code paths and
 		// handleFrameRevert gas burn).
 		gasUsed.State = callContext.frameStateUsed
-		gasUsed.StateGasFromGasLeft = callContext.stateGasFromGasLeft
+		gasUsed.Spilled = callContext.Spilled
 		// this function must execute _after_: the `CaptureState` needs the stacks before
 		callContext.put()
 		if restoreReadonly {

--- a/execution/vm/runtime/eip8037_test.go
+++ b/execution/vm/runtime/eip8037_test.go
@@ -365,6 +365,23 @@ func TestCreatePreexistingTarget(t *testing.T) {
 		"CREATE to pre-existing target must charge only code deposit, not account creation")
 }
 
+// EIP-8037 Gas accounting for new accounts: CREATE onto an address that already
+// has nonce > 0 triggers a collision. The unconditional state-gas charge is
+// refunded because no new account was created.
+func TestCreateAddressCollisionRefill(t *testing.T) {
+	t.Parallel()
+	self := accounts.InternAddress(common.BytesToAddress([]byte("self")))
+	setup := func(db *state.IntraBlockState, _ accounts.Address) {
+		// Derive the CREATE target and give it nonce=1 to trigger collision.
+		derived := accounts.InternAddress(types.CreateAddress(self.Value(), 0))
+		db.SetNonce(derived, 1, tracing.NonceChangeUnspecified)
+	}
+	_, res, err := run8037(t, deployCode(deploy3Init, 0), hugeBudget(), uint256.Int{}, setup)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State,
+		"CREATE address collision must refund state gas (no account created)")
+}
+
 // Ensures CREATE2 charges account creation plus code deposit identically to
 // CREATE. EIP-8037 applies the same unconditional-charge-with-refill model to
 // both opcodes.

--- a/execution/vm/runtime/eip8037_test.go
+++ b/execution/vm/runtime/eip8037_test.go
@@ -98,7 +98,6 @@ func setSlot(slot, val byte) func(*state.IntraBlockState, accounts.Address) {
 	}
 }
 
-
 // fundSelf adds balance to the executing contract.
 func fundSelf(wei uint64) func(*state.IntraBlockState, accounts.Address) {
 	return func(db *state.IntraBlockState, self accounts.Address) {
@@ -401,6 +400,78 @@ func TestCreateCodeDepositChargedSeparately(t *testing.T) {
 		"code-deposit delta (3-byte vs 0-byte) must equal 3 × CPSB")
 }
 
+// ========================= SELFDESTRUCT state-gas =========================
+
+// EIP-8037 Gas accounting for new accounts: SELFDESTRUCT to an empty
+// beneficiary with non-zero self-balance charges STATE_BYTES_PER_NEW_ACCOUNT
+// × CPSB.
+func TestSelfdestructCreatesNewAccount(t *testing.T) {
+	t.Parallel()
+	self := accounts.InternAddress(common.BytesToAddress([]byte("self")))
+	addrVal := freshAddr.Value()
+	code := append([]byte{byte(vm.PUSH20)}, addrVal[:]...)
+	code = append(code, byte(vm.SELFDESTRUCT))
+	setup := func(db *state.IntraBlockState, _ accounts.Address) {
+		db.AddBalance(self, *uint256.NewInt(10), tracing.BalanceChangeUnspecified)
+	}
+	_, res, err := run8037(t, code, hugeBudget(), uint256.Int{}, setup)
+	require.NoError(t, err)
+	require.Equal(t, stateGasNewAccount, res.State,
+		"selfdestruct to fresh beneficiary must charge account creation")
+}
+
+// EIP-8037 Gas accounting for new accounts: SELFDESTRUCT to an existing
+// (non-empty) beneficiary does not charge state gas — no new account leaf is
+// created.
+func TestSelfdestructToExistingAccount(t *testing.T) {
+	t.Parallel()
+	self := accounts.InternAddress(common.BytesToAddress([]byte("self")))
+	addrVal := existAddr.Value()
+	code := append([]byte{byte(vm.PUSH20)}, addrVal[:]...)
+	code = append(code, byte(vm.SELFDESTRUCT))
+	setup := func(db *state.IntraBlockState, _ accounts.Address) {
+		db.AddBalance(existAddr, *uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+		db.AddBalance(self, *uint256.NewInt(10), tracing.BalanceChangeUnspecified)
+	}
+	_, res, err := run8037(t, code, hugeBudget(), uint256.Int{}, setup)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State,
+		"selfdestruct to existing beneficiary must not charge state gas")
+}
+
+// EIP-8037 Gas refills for SELFDESTRUCT: "this operation does not produce
+// any state-gas refills." A contract created and self-destructed in the same
+// tx keeps the account-creation charge.
+func TestSelfdestructSameTxAccountNoRefill(t *testing.T) {
+	t.Parallel()
+	self := accounts.InternAddress(common.BytesToAddress([]byte("self")))
+	// init code selfdestructs to self (existing), so only the create charges.
+	selfVal := self.Value()
+	init := append([]byte{byte(vm.PUSH20)}, selfVal[:]...)
+	init = append(init, byte(vm.SELFDESTRUCT))
+	_, res, err := run8037(t, deployCode(init, 0), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, stateGasNewAccount, res.State,
+		"same-tx selfdestruct must keep account-creation charge")
+}
+
+// EIP-8037 Gas refills for SELFDESTRUCT: "no state-gas refill applies and
+// no changes to execution_state_gas_used." A pre-existing account is not
+// removed by SELFDESTRUCT, so no state growth or shrinkage occurs.
+func TestSelfdestructPreexistingNoRefill(t *testing.T) {
+	t.Parallel()
+	addrVal := existAddr.Value()
+	code := append([]byte{byte(vm.PUSH20)}, addrVal[:]...)
+	code = append(code, byte(vm.SELFDESTRUCT))
+	setup := func(db *state.IntraBlockState, _ accounts.Address) {
+		db.AddBalance(existAddr, *uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+	}
+	_, res, err := run8037(t, code, hugeBudget(), uint256.Int{}, setup)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State,
+		"selfdestruct of pre-existing account must not charge state gas")
+}
+
 // ===================== Reservoir / gas_left mechanics =====================
 
 // Ensures state gas is drawn from the reservoir first: a charge within reservoir
@@ -434,10 +505,10 @@ func TestHaltFrameTerminalState(t *testing.T) {
 	// Top frame: new slot, then calls a child that halts, then INVALID itself.
 	haltChild := accounts.InternAddress(common.BytesToAddress([]byte("halt-child")))
 	top := concat(
-		sstore(0, 1),                  // self: new slot
-		callCode(haltChild, 0, nil),   // child halts (contained)
-		callCode(freshAddr, 1, nil),   // new-account charge
-		[]byte{byte(vm.INVALID)},      // this frame halts
+		sstore(0, 1),                // self: new slot
+		callCode(haltChild, 0, nil), // child halts (contained)
+		callCode(freshAddr, 1, nil), // new-account charge
+		[]byte{byte(vm.INVALID)},    // this frame halts
 	)
 	initial := mdgas.MdGas{Regular: 2_000_000, State: 300_000}
 
@@ -496,8 +567,8 @@ func TestGasOpcodeExcludesReservoir(t *testing.T) {
 	// Bytecode: GAS; PUSH1 0; MSTORE; PUSH1 0x20; PUSH1 0; RETURN
 	// Reads gas_left, stores it in memory, returns the 32-byte word.
 	code := []byte{
-		byte(vm.GAS),                                           // push gas_left
-		byte(vm.PUSH1), 0x00, byte(vm.MSTORE),                  // MSTORE at 0
+		byte(vm.GAS),                          // push gas_left
+		byte(vm.PUSH1), 0x00, byte(vm.MSTORE), // MSTORE at 0
 		byte(vm.PUSH1), 0x20, byte(vm.PUSH1), 0x00, byte(vm.RETURN), // RETURN 32 bytes
 	}
 	regular := uint64(1_000_000)
@@ -566,8 +637,8 @@ func TestHaltFrameTerminalStateFuzz(t *testing.T) {
 	t.Parallel()
 	rng := rand.New(rand.NewSource(80371))
 	steps := [][]byte{
-		sstore(1, 1),                  // new slot charge
-		callCode(haltOKChild, 0, nil), // child success (with grandchild)
+		sstore(1, 1),                   // new slot charge
+		callCode(haltOKChild, 0, nil),  // child success (with grandchild)
 		callCode(haltBadChild, 0, nil), // descendant halts (contained)
 		callCode(freshAddr, 1, nil),    // new-account charge
 	}

--- a/execution/vm/runtime/eip8037_test.go
+++ b/execution/vm/runtime/eip8037_test.go
@@ -1,0 +1,635 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+// Opcode-level tests for EIP-8037 (multidimensional state-gas metering).
+// They drive a single EVM frame via evm.Call or evm.Create and assert the
+// state-gas accounting exposed by the returned MdGasUsage (State / Spilled).
+
+package runtime
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/protocol/mdgas"
+	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/tests/testutil"
+	"github.com/erigontech/erigon/execution/tracing"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
+)
+
+// ---- constants ----
+
+var (
+	stateGasNewSlot    = int64(params.StateGasPerStorageSet) // 97,920
+	stateGasNewAccount = int64(params.StateGasNewAccount)    // 183,600
+)
+
+// ---- helpers ----
+
+// run8037 executes code at a contract address under Amsterdam rules and returns
+// the call's return data and the resulting gas usage. setup mutates the
+// pre-state before the call.
+func run8037(t *testing.T, code []byte, gas mdgas.MdGas, value uint256.Int,
+	setup func(db *state.IntraBlockState, self accounts.Address),
+) ([]byte, mdgas.MdGasUsage, error) {
+	t.Helper()
+
+	db := testutil.TemporalDB(t)
+	tx, domains := testutil.TemporalTxSD(t, db)
+	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+
+	self := accounts.InternAddress(common.BytesToAddress([]byte("self")))
+	statedb.CreateAccount(self, true)
+	statedb.SetCode(self, code, tracing.CodeChangeUnspecified)
+	if setup != nil {
+		setup(statedb, self)
+	}
+
+	cfg := &Config{
+		State:    statedb,
+		GasLimit: gas.Regular + gas.State,
+	}
+	setDefaults(cfg)
+
+	vmenv := NewEnv(cfg)
+	rules := vmenv.ChainRules()
+	statedb.Prepare(rules, cfg.Origin, cfg.Coinbase, self, vm.ActivePrecompiles(rules), nil, nil)
+
+	ret, _, gasUsed, err := vmenv.Call(cfg.Origin, self, nil, gas, value, false)
+	return ret, gasUsed, err
+}
+
+// hugeBudget returns a gas budget large enough that nothing runs out.
+func hugeBudget() mdgas.MdGas {
+	return mdgas.MdGas{Regular: math.MaxUint64 / 2, State: math.MaxUint64 / 2}
+}
+
+// sstore returns "PUSH val; PUSH slot; SSTORE" bytecode.
+func sstore(slot, val byte) []byte {
+	return []byte{byte(vm.PUSH1), val, byte(vm.PUSH1), slot, byte(vm.SSTORE)}
+}
+
+// setSlot commits an original (pre-tx) value into a storage slot.
+func setSlot(slot, val byte) func(*state.IntraBlockState, accounts.Address) {
+	return func(db *state.IntraBlockState, self accounts.Address) {
+		db.SetState(self, accounts.InternKey(common.BytesToHash([]byte{slot})), *uint256.NewInt(uint64(val)))
+	}
+}
+
+
+// fundSelf adds balance to the executing contract.
+func fundSelf(wei uint64) func(*state.IntraBlockState, accounts.Address) {
+	return func(db *state.IntraBlockState, self accounts.Address) {
+		db.AddBalance(self, *uint256.NewInt(wei), tracing.BalanceChangeUnspecified)
+	}
+}
+
+// callCode builds bytecode that CALLs `to` forwarding `value` wei and all gas,
+// followed by `tail`.
+func callCode(to accounts.Address, value byte, tail []byte) []byte {
+	addr := to.Value()
+	b := []byte{
+		byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00,
+		byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00,
+		byte(vm.PUSH1), value, byte(vm.PUSH20),
+	}
+	b = append(b, addr[:]...)
+	b = append(b, byte(vm.GAS), byte(vm.CALL)) // GAS; CALL
+	return append(b, tail...)
+}
+
+// deployCode builds bytecode that MSTOREs init and runs CREATE with the given value.
+func deployCode(init []byte, value byte) []byte {
+	word := make([]byte, 32)
+	copy(word[32-len(init):], init)
+	off, sz := byte(32-len(init)), byte(len(init))
+	b := append([]byte{byte(vm.PUSH32)}, word...) // PUSH32 init-word
+	b = append(b, byte(vm.PUSH1), 0x00, byte(vm.MSTORE))
+	b = append(b, byte(vm.PUSH1), sz, byte(vm.PUSH1), off, byte(vm.PUSH1), value, byte(vm.CREATE))
+	return append(b, byte(vm.STOP))
+}
+
+// deployCode2 builds bytecode that MSTOREs init and runs CREATE2 with the given value and salt=0.
+func deployCode2(init []byte, value byte) []byte {
+	word := make([]byte, 32)
+	copy(word[32-len(init):], init)
+	off, sz := byte(32-len(init)), byte(len(init))
+	b := append([]byte{byte(vm.PUSH32)}, word...) // PUSH32 init-word
+	b = append(b, byte(vm.PUSH1), 0x00, byte(vm.MSTORE))
+	// PUSH1 salt=0; PUSH1 size; PUSH1 offset; PUSH1 value; CREATE2
+	b = append(b, byte(vm.PUSH1), 0x00, byte(vm.PUSH1), sz, byte(vm.PUSH1), off, byte(vm.PUSH1), value, byte(vm.CREATE2))
+	return append(b, byte(vm.STOP))
+}
+
+var (
+	freshAddr   = accounts.InternAddress(common.BytesToAddress([]byte("fresh-target")))
+	existAddr   = accounts.InternAddress(common.BytesToAddress([]byte("exist-target")))
+	balanceAddr = accounts.InternAddress(common.BytesToAddress([]byte("balance-only")))
+	childAddr   = accounts.InternAddress(common.BytesToAddress([]byte("child-frame")))
+	revertInit  = []byte{byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00, byte(vm.REVERT)}
+	invalidInit = []byte{byte(vm.INVALID)}
+	deploy3Init = []byte{byte(vm.PUSH1), 0x03, byte(vm.PUSH1), 0x00, byte(vm.RETURN)} // return 3 bytes
+	deploy0Init = []byte{byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00, byte(vm.RETURN)} // return 0 bytes
+	stop        = []byte{byte(vm.STOP)}
+	revertTail  = []byte{byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00, byte(vm.REVERT)}
+	invalidTail = []byte{byte(vm.INVALID)}
+
+	stateDeposit = int64(3 * params.CostPerStateByte)
+
+	// Addresses for halt-frame fuzz tests.
+	haltOKChild    = accounts.InternAddress(common.BytesToAddress([]byte("child-ok")))
+	haltBadChild   = accounts.InternAddress(common.BytesToAddress([]byte("child-halt")))
+	haltGrandchild = accounts.InternAddress(common.BytesToAddress([]byte("grandchild")))
+)
+
+func concat(parts ...[]byte) []byte {
+	var b []byte
+	for _, p := range parts {
+		b = append(b, p...)
+	}
+	return b
+}
+
+// ============================ SSTORE state-gas ============================
+
+// Ensures a brand-new storage slot is charged one storage-creation state gas unit.
+func TestSStoreNewSlot(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, sstore(0, 1), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, stateGasNewSlot, res.State, "new slot must charge storage-creation state gas")
+}
+
+// Ensures creating then clearing a slot in the same tx results in zero net state gas.
+func TestSStoreClearSameTx(t *testing.T) {
+	t.Parallel()
+	code := append(sstore(0, 1), sstore(0, 0)...)
+	_, res, err := run8037(t, code, hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "0->x->0 must refill net state gas to zero")
+}
+
+// Ensures clearing a slot that was non-zero at tx start generates a state-gas
+// refund. The signed State field goes negative: the slot was created before this
+// frame and removing it credits the frame.
+func TestSStoreClearOriginalNonzero(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, sstore(0, 0), hugeBudget(), uint256.Int{}, setSlot(0, 1))
+	require.NoError(t, err)
+	require.Equal(t, -stateGasNewSlot, res.State, "clearing a pre-existing slot must generate a state-gas refund")
+}
+
+// Ensures clearing then restoring the original value has zero net state gas.
+func TestSStoreRestoreOriginal(t *testing.T) {
+	t.Parallel()
+	code := append(sstore(0, 0), sstore(0, 1)...)
+	_, res, err := run8037(t, code, hugeBudget(), uint256.Int{}, setSlot(0, 1))
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "clearing then restoring original should not adjust state gas")
+}
+
+// Ensures overwriting an existing slot with another value does not charge state gas.
+func TestSStoreOverwriteExisting(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, sstore(0, 2), hugeBudget(), uint256.Int{}, setSlot(0, 1))
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "overwriting existing slot should not charge state gas")
+}
+
+// Ensures that when the reservoir is smaller than the new-slot charge, the excess
+// spills into regular gas.
+func TestSStoreSpillsIntoRegular(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, sstore(0, 1), mdgas.MdGas{Regular: 1_000_000, State: 100}, uint256.Int{}, nil)
+	require.NoError(t, err)
+	want := uint64(stateGasNewSlot) - 100
+	require.Equal(t, want, res.Spilled, "deficit must spill into regular gas")
+}
+
+// ====================== CALL new-account state-gas =======================
+
+// Ensures CALL with value to a non-existent account charges one account creation.
+func TestCallValueToNewAccount(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, callCode(freshAddr, 1, stop), hugeBudget(), uint256.Int{}, fundSelf(10))
+	require.NoError(t, err)
+	require.Equal(t, stateGasNewAccount, res.State, "CALL with value to empty account must charge account creation")
+}
+
+// Ensures CALL with value to an existing account does not charge state gas.
+func TestCallValueToExistingAccount(t *testing.T) {
+	t.Parallel()
+	setup := func(db *state.IntraBlockState, self accounts.Address) {
+		db.CreateAccount(existAddr, true)
+		db.SetCode(existAddr, stop, tracing.CodeChangeUnspecified)
+		db.AddBalance(self, *uint256.NewInt(10), tracing.BalanceChangeUnspecified)
+	}
+	_, res, err := run8037(t, callCode(existAddr, 1, stop), hugeBudget(), uint256.Int{}, setup)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "CALL to existing account should not charge state gas")
+}
+
+// Ensures CALL with zero value creates no account, so nothing is charged.
+func TestCallZeroValueToNewAccount(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, callCode(freshAddr, 0, stop), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "zero-value CALL should not charge state gas")
+}
+
+// EIP-8037: "If the operation is unsuccessful before entering the call frame
+// (e.g., due to insufficient balance or due to the stack depth), ... the
+// charged state-gas is refilled in LIFO order." When a CALL with value targets
+// a fresh (empty) address but the caller lacks balance, the new-account state
+// gas charged at the dynamic gas phase must be refunded, resulting in zero net
+// state gas usage.
+func TestCallInsufficientBalanceRefundsCharge(t *testing.T) {
+	t.Parallel()
+	// self has no balance, so the value transfer fails at CanTransfer.
+	_, res, err := run8037(t, callCode(freshAddr, 1, stop), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State,
+		"CALL new-account state gas must be refilled when the call fails before entering the child")
+}
+
+// Ensures state gas charged inside a child frame is refilled at the frame boundary
+// when the child reverts.
+func TestCallChildRevertRefillsStateGas(t *testing.T) {
+	t.Parallel()
+	// Child SSTOREs a new slot then REVERTs. State changes are rolled back,
+	// so the parent must see zero net state gas from the child.
+	childCode := concat(sstore(0, 1), revertTail)
+	setup := func(db *state.IntraBlockState, self accounts.Address) {
+		db.CreateAccount(childAddr, true)
+		db.SetCode(childAddr, childCode, tracing.CodeChangeUnspecified)
+	}
+	_, res, err := run8037(t, callCode(childAddr, 0, stop), hugeBudget(), uint256.Int{}, setup)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "reverted child state gas should be refilled at frame boundary")
+}
+
+// Ensures state gas charged inside a child frame is refilled at the frame boundary
+// when the child halts exceptionally.
+func TestCallChildHaltRefillsStateGas(t *testing.T) {
+	t.Parallel()
+	childCode := concat(sstore(0, 1), invalidTail)
+	setup := func(db *state.IntraBlockState, self accounts.Address) {
+		db.CreateAccount(childAddr, true)
+		db.SetCode(childAddr, childCode, tracing.CodeChangeUnspecified)
+	}
+	_, res, err := run8037(t, callCode(childAddr, 0, stop), hugeBudget(), uint256.Int{}, setup)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "halted child state gas should be refilled at frame boundary")
+}
+
+// ===================== CREATE / CREATE2 state-gas =========================
+
+// Ensures CREATE to a fresh address charges account creation plus code deposit.
+func TestCreateNewAccount(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, deployCode(deploy3Init, 0), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	want := stateGasNewAccount + stateDeposit
+	require.Equal(t, want, res.State, "new CREATE must charge account creation + code deposit")
+}
+
+// Ensures CREATE whose init code reverts refills the account charge and deposits nothing.
+func TestCreateInitRevertRefill(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, deployCode(revertInit, 0), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "reverted CREATE must refill all state gas")
+}
+
+// Ensures CREATE whose init code halts exceptionally refills the account charge.
+func TestCreateInitHaltRefill(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, deployCode(invalidInit, 0), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "halted CREATE must refill all state gas")
+}
+
+// Ensures CREATE with value exceeding balance fails before the frame and is refilled.
+func TestCreateInsufficientBalanceRefill(t *testing.T) {
+	t.Parallel()
+	// self has no balance; CREATE forwards value 1.
+	_, res, err := run8037(t, deployCode(deploy3Init, 1), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State, "insufficient-balance CREATE must refill state gas")
+}
+
+// Ensures CREATE onto a pre-existing (balance-only) leaf refills the account
+// portion; only the code deposit is charged. Per the EIP-8037 spec: "Creating a
+// contract at such an address updates the existing leaf rather than adding a new
+// one, so only the code-deposit cost (L × CPSB) applies and the
+// STATE_BYTES_PER_NEW_ACCOUNT × CPSB account-creation charge does not."
+//
+// Protocol invariant: account-creation state gas is refunded when the target
+// already has a state trie leaf (EIP-161 existence).
+// Bug prevented: failing to refund the unconditional pre-charge on pre-existing
+// targets would overcharge every CREATE to a funded address.
+func TestCreatePreexistingTarget(t *testing.T) {
+	t.Parallel()
+	self := accounts.InternAddress(common.BytesToAddress([]byte("self")))
+	setup := func(db *state.IntraBlockState, _ accounts.Address) {
+		// Derive the CREATE target: CreateAddress(self, nonce=0).
+		// The test contract's nonce is 0; CREATE increments it to 1.
+		derived := accounts.InternAddress(types.CreateAddress(self.Value(), 0))
+		db.AddBalance(derived, *uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+	}
+	_, res, err := run8037(t, deployCode(deploy3Init, 0), hugeBudget(), uint256.Int{}, setup)
+	require.NoError(t, err)
+	// Only code-deposit state gas (3 bytes × CPSB), not account creation.
+	require.Equal(t, stateDeposit, res.State,
+		"CREATE to pre-existing target must charge only code deposit, not account creation")
+}
+
+// Ensures CREATE2 charges account creation plus code deposit identically to
+// CREATE. EIP-8037 applies the same unconditional-charge-with-refill model to
+// both opcodes.
+//
+// Protocol invariant: CREATE and CREATE2 have identical state-gas semantics.
+// Bug prevented: a missing or misrouted state-gas charge on the CREATE2 path
+// would cause divergence from CREATE behavior.
+func TestCreate2SameSemantics(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, deployCode2(deploy3Init, 0), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	want := stateGasNewAccount + stateDeposit
+	require.Equal(t, want, res.State,
+		"CREATE2 must charge account creation + code deposit identically to CREATE")
+}
+
+// Ensures the code-deposit portion is charged per byte independently of the
+// account charge: the delta between a 3-byte and 0-byte deploy is exactly
+// 3 × CPSB.
+//
+// Protocol invariant: GAS_CODE_DEPOSIT = CPSB per byte, separate from the
+// account-creation charge.
+// Bug prevented: conflating code deposit with account creation would cause
+// incorrect total state gas.
+func TestCreateCodeDepositChargedSeparately(t *testing.T) {
+	t.Parallel()
+	_, res3, err := run8037(t, deployCode(deploy3Init, 0), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	_, res0, err := run8037(t, deployCode(deploy0Init, 0), hugeBudget(), uint256.Int{}, nil)
+	require.NoError(t, err)
+	got := res3.State - res0.State
+	require.Equal(t, stateDeposit, got,
+		"code-deposit delta (3-byte vs 0-byte) must equal 3 × CPSB")
+}
+
+// ===================== Reservoir / gas_left mechanics =====================
+
+// Ensures state gas is drawn from the reservoir first: a charge within reservoir
+// size does not spill into regular gas.
+func TestReservoirDrawnFirst(t *testing.T) {
+	t.Parallel()
+	_, res, err := run8037(t, sstore(0, 1), mdgas.MdGas{Regular: 1_000_000, State: 200_000}, uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), res.Spilled, "charge within reservoir must not spill")
+}
+
+// Ensures that borrowed regular gas is repaid before the reservoir when a
+// state-gas refund is credited (LIFO order).
+func TestLIFORefillOrder(t *testing.T) {
+	t.Parallel()
+	// With zero reservoir, 0->x->0 SSTORE borrows from regular for the charge,
+	// then the refund repays the borrow and leaves the reservoir at 0.
+	code := append(sstore(0, 1), sstore(0, 0)...)
+	_, res, err := run8037(t, code, mdgas.MdGas{Regular: 1_000_000, State: 0}, uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), res.Spilled, "LIFO refill must repay borrowed regular gas")
+	require.Equal(t, int64(0), res.State, "net state gas must be zero after 0->x->0")
+}
+
+// ==================== Halting frame terminal state =========================
+
+// Ensures that a frame terminated by INVALID consumes all regular gas but
+// restores the state reservoir, leaving zero net state gas.
+func TestHaltFrameTerminalState(t *testing.T) {
+	t.Parallel()
+	// Top frame: new slot, then calls a child that halts, then INVALID itself.
+	haltChild := accounts.InternAddress(common.BytesToAddress([]byte("halt-child")))
+	top := concat(
+		sstore(0, 1),                  // self: new slot
+		callCode(haltChild, 0, nil),   // child halts (contained)
+		callCode(freshAddr, 1, nil),   // new-account charge
+		[]byte{byte(vm.INVALID)},      // this frame halts
+	)
+	initial := mdgas.MdGas{Regular: 2_000_000, State: 300_000}
+
+	setup := func(db *state.IntraBlockState, self accounts.Address) {
+		db.AddBalance(self, *uint256.NewInt(1000), tracing.BalanceChangeUnspecified)
+		db.CreateAccount(haltChild, true)
+		db.SetCode(haltChild, concat(sstore(3, 3), invalidTail), tracing.CodeChangeUnspecified)
+	}
+
+	_, res, err := run8037(t, top, initial, uint256.Int{}, setup)
+	// Expect an error (the frame halted exceptionally).
+	require.Error(t, err)
+	require.NotEqual(t, vm.ErrExecutionReverted, err, "expected exceptional halt, not revert")
+	// State gas must be fully refilled on halt.
+	require.Equal(t, int64(0), res.State, "halted frame must have zero net state gas")
+}
+
+// =================== SSTORE reentrancy sentry ===========================
+
+// EIP-8037: the SSTORE reentrancy sentry (2300 gas) checks gas_left only;
+// the state-gas reservoir is excluded. Even with a massive reservoir, if
+// regular gas is at the sentry threshold, the SSTORE must fail.
+//
+// Protocol invariant: the sentry prevents re-entrancy griefing and must
+// operate solely on gas_left regardless of the multi-dimensional budget.
+// Bug prevented: if the sentry summed regular + reservoir, a contract with
+// low regular gas but a huge reservoir could pass the sentry and execute an
+// SSTORE, violating the protection guarantee.
+func TestSStoreStipendExcludesReservoir(t *testing.T) {
+	t.Parallel()
+	// Noop write (slot already == 1, writing 1 again) so only the sentry gate matters.
+	// PUSH1(1) costs 3 gas + PUSH1(0) costs 3 gas = 6 gas consumed before SSTORE.
+	// Sentry threshold: regular gas <= 2300 → fail.
+	// With 2306 regular gas: 2306 - 6 = 2300, fails the sentry (<=).
+	_, _, err := run8037(t, sstore(0, 1), mdgas.MdGas{Regular: 2306, State: math.MaxUint64 / 2}, uint256.Int{}, setSlot(0, 1))
+	require.Error(t, err, "expected sentry failure with regular gas at the limit")
+
+	// With 2307 regular gas: 2307 - 6 = 2301, passes the sentry (> 2300).
+	_, _, err = run8037(t, sstore(0, 1), mdgas.MdGas{Regular: 2307, State: math.MaxUint64 / 2}, uint256.Int{}, setSlot(0, 1))
+	require.NoError(t, err, "one more regular gas above the sentry must succeed")
+}
+
+// =================== GAS opcode excludes reservoir ========================
+
+// EIP-8037: "The GAS (0x5a) opcode returns gas_left, which excludes the
+// reservoir." The GAS opcode must return only the regular gas remaining, not
+// regular + state_gas_reservoir.
+//
+// Protocol invariant: smart contracts that rely on gasleft() for stipend
+// checks or forwarding decisions must not see the reservoir.
+// Bug prevented: if GAS returned regular + reservoir, the 63/64 forwarding
+// rule would forward too much gas, or contracts that check gasleft() < N
+// would behave incorrectly.
+func TestGasOpcodeExcludesReservoir(t *testing.T) {
+	t.Parallel()
+	// Bytecode: GAS; PUSH1 0; MSTORE; PUSH1 0x20; PUSH1 0; RETURN
+	// Reads gas_left, stores it in memory, returns the 32-byte word.
+	code := []byte{
+		byte(vm.GAS),                                           // push gas_left
+		byte(vm.PUSH1), 0x00, byte(vm.MSTORE),                  // MSTORE at 0
+		byte(vm.PUSH1), 0x20, byte(vm.PUSH1), 0x00, byte(vm.RETURN), // RETURN 32 bytes
+	}
+	regular := uint64(1_000_000)
+	reservoir := uint64(500_000)
+	ret, _, err := run8037(t, code, mdgas.MdGas{Regular: regular, State: reservoir}, uint256.Int{}, nil)
+	require.NoError(t, err)
+	require.Len(t, ret, 32, "expected 32-byte return")
+
+	got := new(uint256.Int).SetBytes(ret).Uint64()
+	// GAS opcode itself costs 2 gas (GasQuickStep). At the point GAS executes,
+	// the regular gas has only been decremented by the GAS opcode's constant cost.
+	expected := regular - vm.GasQuickStep
+	require.Equal(t, expected, got,
+		"GAS opcode must return gas_left only; reservoir (%d) must be excluded", reservoir)
+}
+
+// =================== Balance-only account ================================
+
+// EIP-161: an account with a non-zero balance but no code and nonce == 0 is
+// NOT empty. Therefore, a value CALL to such an account must NOT charge the
+// new-account state gas — the account already exists.
+//
+// Protocol invariant: the CALL new-account charge is conditional on the
+// Empty() predicate (EIP-161), not the Exist() predicate.
+// Bug prevented: if the implementation used Exist() instead of Empty(), or
+// if Empty() incorrectly returned true for balance-only accounts, every value
+// CALL to a balance-bearing EOA would be overcharged.
+func TestCallBalanceOnlyAccountIsExistent(t *testing.T) {
+	t.Parallel()
+	setup := func(db *state.IntraBlockState, self accounts.Address) {
+		// Give balanceAddr a balance but no code or nonce — not empty per EIP-161.
+		db.AddBalance(balanceAddr, *uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+		db.AddBalance(self, *uint256.NewInt(10), tracing.BalanceChangeUnspecified)
+	}
+	_, res, err := run8037(t, callCode(balanceAddr, 1, stop), hugeBudget(), uint256.Int{}, setup)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), res.State,
+		"value CALL to balance-only account must not charge account creation state gas")
+}
+
+// =================== Halt-frame terminal state fuzz =======================
+
+// haltFrameFuzzSetup is a run8037 setup that funds self and deploys a 3-level
+// child set: a success child that itself calls a grandchild (which SSTOREs a
+// new slot), and a halting child (SSTOREs a new slot then INVALID).
+func haltFrameFuzzSetup(db *state.IntraBlockState, self accounts.Address) {
+	db.AddBalance(self, *uint256.NewInt(1000), tracing.BalanceChangeUnspecified)
+	db.CreateAccount(haltGrandchild, true)
+	db.SetCode(haltGrandchild, concat(sstore(5, 5), stop), tracing.CodeChangeUnspecified)
+	db.CreateAccount(haltOKChild, true)
+	db.SetCode(haltOKChild, concat(sstore(1, 1), callCode(haltGrandchild, 0, nil), stop), tracing.CodeChangeUnspecified)
+	db.CreateAccount(haltBadChild, true)
+	db.SetCode(haltBadChild, concat(sstore(3, 3), invalidTail), tracing.CodeChangeUnspecified)
+}
+
+// Fuzz: arbitrary sequences of state writes, child calls (success / halting)
+// and new-account calls, always terminated by INVALID. However the descendants
+// behave, a halted frame's terminal budget must always have zero net state gas.
+//
+// Protocol invariant: EIP-8037 requires that on exceptional halt, ALL state gas
+// charged in the frame (and descendants) is refilled to the reservoir. The
+// frame's gas_left is consumed, but the reservoir is made whole.
+// Bug prevented: a leak in the LIFO refill path that doesn't fully restore the
+// reservoir under complex nesting of successes, reverts, and halts.
+func TestHaltFrameTerminalStateFuzz(t *testing.T) {
+	t.Parallel()
+	rng := rand.New(rand.NewSource(80371))
+	steps := [][]byte{
+		sstore(1, 1),                  // new slot charge
+		callCode(haltOKChild, 0, nil), // child success (with grandchild)
+		callCode(haltBadChild, 0, nil), // descendant halts (contained)
+		callCode(freshAddr, 1, nil),    // new-account charge
+	}
+	for trial := 0; trial < 400; trial++ {
+		var code []byte
+		nSteps := 1 + rng.Intn(8)
+		for i := 0; i < nSteps; i++ {
+			code = append(code, steps[rng.Intn(len(steps))]...)
+		}
+		code = append(code, byte(vm.INVALID)) // halt
+		initial := mdgas.MdGas{Regular: 3_000_000, State: uint64(rng.Intn(400_000))}
+		_, res, err := run8037(t, code, initial, uint256.Int{}, haltFrameFuzzSetup)
+		require.Error(t, err, "trial %d: expected exceptional halt", trial)
+		require.NotEqual(t, vm.ErrExecutionReverted, err,
+			"trial %d: expected exceptional halt, not revert", trial)
+		require.Equal(t, int64(0), res.State,
+			"trial %d: halted frame must have zero net state gas (got %d)", trial, res.State)
+	}
+}
+
+// =================== LIFO vector conservation fuzz ========================
+
+// Fuzz: arbitrary sequences of SSTOREs (charge + refund) around the reservoir/
+// spill boundary. The net state gas after a charge-then-refund cycle must be
+// zero, and the spillover must be fully repaid.
+//
+// Protocol invariant: the LIFO refill mechanism correctly conserves gas across
+// arbitrary charge/refund sequences. The reservoir is restored to its initial
+// value, and borrowed regular gas is fully repaid.
+// Bug prevented: an off-by-one in RefundState or creditStateGasRefund that
+// causes gas leakage or underflow under specific spill/refund orderings.
+func TestLIFOVectorFuzz(t *testing.T) {
+	t.Parallel()
+	rng := rand.New(rand.NewSource(8037))
+	for trial := 0; trial < 200; trial++ {
+		// Build a sequence of SSTORE operations that creates new slots
+		// (charging state gas) then clears them back to zero (refunding).
+		// Each slot 1..N is set to 1 (charged) then set to 0 (refunded).
+		nSlots := 1 + rng.Intn(8)
+		var code []byte
+		// Phase 1: create slots 1..N (each charges state gas).
+		for s := 1; s <= nSlots; s++ {
+			code = append(code, sstore(byte(s), 1)...)
+		}
+		// Phase 2: clear slots N..1 in reverse (LIFO refund).
+		for s := nSlots; s >= 1; s-- {
+			code = append(code, sstore(byte(s), 0)...)
+		}
+		code = append(code, byte(vm.STOP))
+
+		// Vary the reservoir size: sometimes it covers all charges,
+		// sometimes none, sometimes partially.
+		reservoir := uint64(rng.Intn(int(stateGasNewSlot) * (nSlots + 1)))
+		gas := mdgas.MdGas{Regular: 10_000_000, State: reservoir}
+
+		_, res, err := run8037(t, code, gas, uint256.Int{}, nil)
+		require.NoError(t, err, "trial %d: unexpected error", trial)
+		require.Equal(t, int64(0), res.State,
+			"trial %d: net state gas must be zero after full charge-then-refund cycle (got %d, reservoir=%d, slots=%d)",
+			trial, res.State, reservoir, nSlots)
+		require.Equal(t, uint64(0), res.Spilled,
+			"trial %d: spilled must be zero after full refund (got %d, reservoir=%d, slots=%d)",
+			trial, res.Spilled, reservoir, nSlots)
+	}
+}

--- a/execution/vm/runtime/eip8037_test.go
+++ b/execution/vm/runtime/eip8037_test.go
@@ -545,27 +545,31 @@ func TestHaltFrameTerminalState(t *testing.T) {
 
 // =================== SSTORE reentrancy sentry ===========================
 
-// EIP-8037: the SSTORE reentrancy sentry (2300 gas) checks gas_left only;
-// the state-gas reservoir is excluded. Even with a massive reservoir, if
-// regular gas is at the sentry threshold, the SSTORE must fail.
+// TestSStoreStipendExcludesReservoir verifies that the SSTORE reentrancy sentry
+// (2300 gas check) only evaluates remaining regular gas, completely ignoring
+// the state-gas reservoir.
 //
-// Protocol invariant: the sentry prevents re-entrancy griefing and must
-// operate solely on gas_left regardless of the multi-dimensional budget.
-// Bug prevented: if the sentry summed regular + reservoir, a contract with
-// low regular gas but a huge reservoir could pass the sentry and execute an
-// SSTORE, violating the protection guarantee.
+// The test performs a no-op write (1->1->1). The two initial PUSH1 instructions
+// consume 6 gas. With an initial regular budget of 2306, exactly 2300 gas is left
+// for the SSTORE, which hits and fails the sentry threshold.
+// Under EIP-8038, if the sentry check is cleared, the cold storage slot access cost
+// is COLD_STORAGE_ACCESS (3000).
 func TestSStoreStipendExcludesReservoir(t *testing.T) {
 	t.Parallel()
-	// Noop write (slot already == 1, writing 1 again) so only the sentry gate matters.
-	// PUSH1(1) costs 3 gas + PUSH1(0) costs 3 gas = 6 gas consumed before SSTORE.
-	// Sentry threshold: regular gas <= 2300 → fail.
-	// With 2306 regular gas: 2306 - 6 = 2300, fails the sentry (<=).
-	_, _, err := run8037(t, sstore(0, 1), mdgas.MdGas{Regular: 2306, State: math.MaxUint64 / 2}, uint256.Int{}, setSlot(0, 1))
-	require.Error(t, err, "expected sentry failure with regular gas at the limit")
-
-	// With 2307 regular gas: 2307 - 6 = 2301, passes the sentry (> 2300).
-	_, _, err = run8037(t, sstore(0, 1), mdgas.MdGas{Regular: 2307, State: math.MaxUint64 / 2}, uint256.Int{}, setSlot(0, 1))
-	require.NoError(t, err, "one more regular gas above the sentry must succeed")
+	// A budget at the exact sentry threshold must fail even with an infinite state-gas reservoir.
+	if _, _, err := run8037(t, sstore(0, 1), mdgas.MdGas{Regular: 2306, State: math.MaxUint64 / 2}, uint256.Int{}, setSlot(0, 1)); err == nil {
+		t.Fatal("expected sentry failure with regular gas at the limit")
+	}
+	// Providing sufficient regular gas to clear the sentry threshold and cover the
+	// cold storage access cost (6 gas for PUSH1s + COLD_STORAGE_ACCESS) succeeds.
+	regular := 6 + params.ColdStorageAccessCostEIP8038
+	if _, _, err := run8037(t, sstore(0, 1), mdgas.MdGas{Regular: regular, State: math.MaxUint64 / 2}, uint256.Int{}, setSlot(0, 1)); err != nil {
+		t.Fatalf("unexpected failure above sentry: %v", err)
+	}
+	// If regular gas is one unit below the cold access cost, it clears the sentry but fails due to Out-Of-Gas (OOG).
+	if _, _, err := run8037(t, sstore(0, 1), mdgas.MdGas{Regular: regular - 1, State: math.MaxUint64 / 2}, uint256.Int{}, setSlot(0, 1)); err == nil {
+		t.Fatal("expected OOG when regular gas cannot cover cold-slot access")
+	}
 }
 
 // =================== GAS opcode excludes reservoir ========================

--- a/execution/vm/runtime/runtime.go
+++ b/execution/vm/runtime/runtime.go
@@ -204,7 +204,7 @@ func Create(input []byte, cfg *Config, blockNr uint64) ([]byte, common.Address, 
 	cfg.State.Prepare(rules, cfg.Origin, cfg.Coinbase, accounts.NilAddress, vm.ActivePrecompiles(rules), nil, nil)
 
 	// Call the code with the given configuration.
-	code, address, leftOverGas, _, err := vmenv.Create(
+	code, address, leftOverGas, _, _, err := vmenv.Create(
 		sender,
 		input,
 		mdgas.SplitTxnGasLimit(cfg.GasLimit, mdgas.MdGas{}, rules),


### PR DESCRIPTION
### Issue
Actually, there is a conflict between [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928) and [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) when deploying a contract. Under EIP-7928, we are not supposed to resolve or load the deployed account until it is actually accessed. But under EIP-8037, we need to check early if the account already exists to decide whether to charge the `StateGasNewAccount` gas cost. This check forces an early read of the state, which violates EIP-7928.

Also, when state gas is refunded (for example, if CREATE fails or targets an already existing account), we were not restoring the regular gas that was used to pay for state gas spillover. Instead, the refund was going directly to the state gas reservoir, which leaves the regular gas pool depleted and can cause out-of-gas errors.

### Fix
To resolve this conflict, we are now unconditionally charging the account-creation state gas cost at the beginning of the CREATE family (CreateTx, CREATE, and CREATE2). Then, during execution when the state is actually read, if the account already exists and was not newly created, we refund this gas cost back to the parent frame or transaction.

We also added a new field `stateGasFromGasLeft` in `CallContext` to track state gas spillover. When a refund is credited, we first refund the regular gas pool up to this tracked amount, and only the remaining refund is added back to the state gas reservoir.

### References
[Conflict of EIP-7928 and EIP-8037](https://hackmd.io/@bFEBbZiVSAO0IURh9qzEFg/BJmFYqCeGl)
[Update-EIP-8037](https://github.com/ethereum/EIPs/pull/11807)
https://github.com/erigontech/erigon/issues/22084

