### PR TITLE
cl/validator/devvalidator: fix dev-mode validator drain that halts the chain (Electra attestation gap + divide-by-zero guard)

### DIFF
--- a/cl/phase1/core/state/cache_accessors.go
+++ b/cl/phase1/core/state/cache_accessors.go
@@ -364,6 +364,9 @@ func (b *CachingBeaconState) ComputeNextSyncCommittee() (*solid.SyncCommittee, e
 	//math.MaxUint8
 	activeValidatorIndicies := b.GetActiveValidatorsIndices(epoch)
 	activeValidatorCount := uint64(len(activeValidatorIndicies))
+	if activeValidatorCount == 0 {
+		return nil, fmt.Errorf("cannot compute next sync committee: no active validators at epoch %d", epoch)
+	}
 	mixPosition := (epoch + beaconConfig.EpochsPerHistoricalVector - beaconConfig.MinSeedLookahead - 1) %
 		beaconConfig.EpochsPerHistoricalVector
 	// Input for the seed hash.

--- a/cl/phase1/core/state/cache_accessors_test.go
+++ b/cl/phase1/core/state/cache_accessors_test.go
@@ -1,0 +1,49 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+)
+
+// TestComputeNextSyncCommittee_ZeroActiveValidators verifies that computing the
+// next sync committee on a state with no active validators returns an error
+// instead of panicking with an integer divide-by-zero (i % activeValidatorCount).
+func TestComputeNextSyncCommittee_ZeroActiveValidators(t *testing.T) {
+	s := state.New(&clparams.MainnetBeaconConfig)
+	for i := 0; i < 100; i++ {
+		var pk [48]byte
+		binary.BigEndian.PutUint64(pk[:], uint64(i))
+		v := solid.NewValidator()
+		v.SetActivationEpoch(0)
+		v.SetExitEpoch(0) // already exited → not active at any epoch
+		v.SetPublicKey(pk)
+		v.SetEffectiveBalance(2000000000)
+		s.AddValidator(v, 2000000000)
+	}
+	s.SetSlot(8160)
+
+	_, err := s.ComputeNextSyncCommittee()
+	require.Error(t, err)
+}

--- a/cl/validator/devvalidator/aggregate.go
+++ b/cl/validator/devvalidator/aggregate.go
@@ -1,0 +1,70 @@
+package devvalidator
+
+import (
+	"context"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/common"
+)
+
+// buildAggregateAttestation wraps a validator's SingleAttestation into the
+// Electra Attestation form (committee bits + aggregation bits) suitable for
+// inclusion in an AggregateAndProof.
+func buildAggregateAttestation(
+	single *solid.SingleAttestation,
+	validatorPosition, committeeLength uint64,
+	cfg *clparams.BeaconChainConfig,
+) *solid.Attestation {
+	return single.ToAttestation(int(validatorPosition), int(committeeLength), int(cfg.MaxCommitteesPerSlot), cfg)
+}
+
+// submitAggregateAndProof builds and submits a signed aggregate-and-proof for
+// the validator's attestation. Block production only includes attestations that
+// reach the operations pool via this path, so without it the chain never
+// finalizes. With dev's small committees every validator is an aggregator.
+func (s *Service) submitAggregateAndProof(
+	ctx context.Context,
+	slot, committeeIndex uint64,
+	key *ValidatorKey,
+	attData *solid.AttestationData,
+	sig common.Bytes96,
+	committeeLength, validatorPosition uint64,
+) {
+	selectionProof, err := signSelectionProof(key, slot, s.cfg, s.genesisValidatorsRoot)
+	if err != nil {
+		s.logger.Warn("[dev-validator] selection proof sign failed", "err", err)
+		return
+	}
+	if !state.IsAggregator(s.cfg, committeeLength, committeeIndex, selectionProof) {
+		return
+	}
+
+	single := &solid.SingleAttestation{
+		CommitteeIndex: committeeIndex,
+		AttesterIndex:  key.ValidatorIndex,
+		Data:           attData,
+		Signature:      sig,
+	}
+	aggregate := buildAggregateAttestation(single, validatorPosition, committeeLength, s.cfg)
+
+	msg := &cltypes.AggregateAndProof{
+		AggregatorIndex: key.ValidatorIndex,
+		Aggregate:       aggregate,
+		SelectionProof:  selectionProof,
+	}
+	aggregatorSig, err := signAggregateAndProof(key, msg, slot, s.cfg, s.genesisValidatorsRoot)
+	if err != nil {
+		s.logger.Warn("[dev-validator] aggregate sign failed", "err", err)
+		return
+	}
+	signed := &cltypes.SignedAggregateAndProof{
+		Message:   msg,
+		Signature: aggregatorSig,
+	}
+	if err := s.client.post(ctx, "/eth/v1/validator/aggregate_and_proofs", []interface{}{signed}); err != nil {
+		s.logger.Debug("[dev-validator] aggregate submit failed", "slot", slot, "err", err)
+	}
+}

--- a/cl/validator/devvalidator/aggregate_test.go
+++ b/cl/validator/devvalidator/aggregate_test.go
@@ -1,0 +1,65 @@
+package devvalidator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/common"
+)
+
+// TestBuildAggregateAttestation verifies the SingleAttestation is wrapped into
+// an Electra Attestation with the committee bit set and exactly one aggregation
+// bit (the validator's position) plus the trailing committee-length sentinel.
+func TestBuildAggregateAttestation(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	sig := common.Bytes96{0x01}
+	single := &solid.SingleAttestation{
+		CommitteeIndex: 2,
+		AttesterIndex:  7,
+		Data:           testAttData(),
+		Signature:      sig,
+	}
+
+	agg := buildAggregateAttestation(single, 1, 4, &cfg)
+	require.NotNil(t, agg)
+	require.Equal(t, sig, agg.Signature)
+	require.True(t, agg.CommitteeBits.GetBitAt(2), "committee bit for index 2 must be set")
+	require.Equal(t, testAttData().Slot, agg.Data.Slot)
+}
+
+// TestSignedAggregateAndProof_RoundTrip verifies a SignedAggregateAndProof
+// marshals to JSON that decodes back into the exact type the validator
+// aggregate_and_proofs endpoint expects.
+func TestSignedAggregateAndProof_RoundTrip(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	single := &solid.SingleAttestation{
+		CommitteeIndex: 1,
+		AttesterIndex:  9,
+		Data:           testAttData(),
+		Signature:      common.Bytes96{0x02},
+	}
+	signed := &cltypes.SignedAggregateAndProof{
+		Message: &cltypes.AggregateAndProof{
+			AggregatorIndex: 9,
+			Aggregate:       buildAggregateAttestation(single, 0, 4, &cfg),
+			SelectionProof:  common.Bytes96{0x03},
+		},
+		Signature: common.Bytes96{0x04},
+	}
+
+	raw, err := json.Marshal([]interface{}{signed})
+	require.NoError(t, err)
+
+	var decoded []*cltypes.SignedAggregateAndProof
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Len(t, decoded, 1)
+	require.Equal(t, uint64(9), decoded[0].Message.AggregatorIndex)
+	require.Equal(t, common.Bytes96{0x03}, decoded[0].Message.SelectionProof)
+	require.Equal(t, common.Bytes96{0x04}, decoded[0].Signature)
+	require.NotNil(t, decoded[0].Message.Aggregate)
+}

--- a/cl/validator/devvalidator/attestation_submission.go
+++ b/cl/validator/devvalidator/attestation_submission.go
@@ -1,0 +1,57 @@
+package devvalidator
+
+import (
+	"strconv"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+)
+
+// attestationSubmission describes the endpoint and body for submitting an
+// attestation, which differs between the pre-Electra and Electra Beacon APIs.
+type attestationSubmission struct {
+	path    string
+	body    interface{}
+	version string // Eth-Consensus-Version header; empty for the pre-Electra V1 route
+}
+
+// buildAttestationSubmission constructs the correct attestation submission for
+// the given fork version. The pre-Electra V1 pool endpoint takes an aggregate
+// with aggregation bits; from Electra onwards a single validator's vote is a
+// SingleAttestation submitted to the V2 endpoint with an Eth-Consensus-Version
+// header.
+func buildAttestationSubmission(
+	version clparams.StateVersion,
+	committeeIndex, validatorIndex uint64,
+	attData *solid.AttestationData,
+	sig common.Bytes96,
+	committeeLength, validatorPosition uint64,
+) attestationSubmission {
+	if version >= clparams.ElectraVersion {
+		single := map[string]interface{}{
+			"committee_index": strconv.FormatUint(committeeIndex, 10),
+			"attester_index":  strconv.FormatUint(validatorIndex, 10),
+			"data":            attData,
+			"signature":       hexutil.Encode(sig[:]),
+		}
+		return attestationSubmission{
+			path:    "/eth/v2/beacon/pool/attestations",
+			body:    []interface{}{single},
+			version: version.String(),
+		}
+	}
+
+	aggBits := make([]byte, (committeeLength+7)/8)
+	aggBits[validatorPosition/8] |= 1 << (validatorPosition % 8)
+	legacy := map[string]interface{}{
+		"aggregation_bits": hexutil.Encode(aggBits),
+		"data":             attData,
+		"signature":        hexutil.Encode(sig[:]),
+	}
+	return attestationSubmission{
+		path: "/eth/v1/beacon/pool/attestations",
+		body: []interface{}{legacy},
+	}
+}

--- a/cl/validator/devvalidator/attestation_submission_test.go
+++ b/cl/validator/devvalidator/attestation_submission_test.go
@@ -1,0 +1,67 @@
+package devvalidator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/common"
+)
+
+func testAttData() *solid.AttestationData {
+	return &solid.AttestationData{
+		Slot:            5,
+		CommitteeIndex:  0, // deprecated/zero from Electra onwards
+		BeaconBlockRoot: common.Hash{0xaa},
+		Source:          solid.Checkpoint{Epoch: 0, Root: common.Hash{0xbb}},
+		Target:          solid.Checkpoint{Epoch: 0, Root: common.Hash{0xcc}},
+	}
+}
+
+// TestBuildAttestationSubmission_Electra verifies that on Electra the dev
+// validator submits a SingleAttestation to the V2 pool endpoint with the
+// consensus-version header, and that the body decodes into exactly the type
+// the beacon node's V2 handler expects ([]*solid.SingleAttestation).
+func TestBuildAttestationSubmission_Electra(t *testing.T) {
+	sig := common.Bytes96{0x01, 0x02, 0x03}
+	sub := buildAttestationSubmission(clparams.ElectraVersion, 3, 7, testAttData(), sig, 4, 1)
+
+	require.Equal(t, "/eth/v2/beacon/pool/attestations", sub.path)
+	require.Equal(t, clparams.ElectraVersion.String(), sub.version)
+
+	raw, err := json.Marshal(sub.body)
+	require.NoError(t, err)
+
+	var decoded []*solid.SingleAttestation
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Len(t, decoded, 1)
+	require.Equal(t, uint64(3), decoded[0].CommitteeIndex)
+	require.Equal(t, uint64(7), decoded[0].AttesterIndex)
+	require.NotNil(t, decoded[0].Data)
+	require.Equal(t, uint64(5), decoded[0].Data.Slot)
+	require.Equal(t, uint64(0), decoded[0].Data.CommitteeIndex)
+	require.Equal(t, sig, decoded[0].Signature)
+}
+
+// TestBuildAttestationSubmission_PreElectra verifies the legacy V1 path still
+// produces an aggregate the V1 handler accepts ([]*solid.Attestation) with
+// exactly one aggregation bit set for the validator's committee position.
+func TestBuildAttestationSubmission_PreElectra(t *testing.T) {
+	sig := common.Bytes96{0x09}
+	sub := buildAttestationSubmission(clparams.DenebVersion, 0, 7, testAttData(), sig, 4, 1)
+
+	require.Equal(t, "/eth/v1/beacon/pool/attestations", sub.path)
+	require.Empty(t, sub.version)
+
+	raw, err := json.Marshal(sub.body)
+	require.NoError(t, err)
+
+	var decoded []*solid.Attestation
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Len(t, decoded, 1)
+	require.Equal(t, sig, decoded[0].Signature)
+	require.Equal(t, uint64(5), decoded[0].Data.Slot)
+}

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -197,6 +197,9 @@ func (s *Service) slotLoop(ctx context.Context) {
 		// Attest for all validators with duties at this slot.
 		s.maybeAttest(ctx, currentSlot)
 
+		// Submit sync committee messages for validators in the current committee.
+		s.maybeSyncCommittee(ctx, currentSlot)
+
 		// Wait for next slot.
 		if time.Now().Before(nextSlotStart) {
 			time.Sleep(time.Until(nextSlotStart))
@@ -341,6 +344,7 @@ func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorK
 // maybeAttest submits attestations for validators with duties at this slot.
 func (s *Service) maybeAttest(ctx context.Context, slot uint64) {
 	epoch := slot / s.cfg.SlotsPerEpoch
+	version := s.cfg.GetCurrentStateVersion(epoch)
 
 	// Get attester duties for this epoch.
 	type attesterDuty struct {
@@ -409,7 +413,6 @@ func (s *Service) maybeAttest(ctx context.Context, slot uint64) {
 			continue
 		}
 
-		// Build aggregation bits — set our bit position.
 		committeeLength, parseErr := strconv.ParseUint(duty.CommitteeLength, 10, 64)
 		if parseErr != nil {
 			continue
@@ -419,21 +422,22 @@ func (s *Service) maybeAttest(ctx context.Context, slot uint64) {
 			continue
 		}
 
-		aggBitsLen := (committeeLength + 7) / 8
-		aggBits := make([]byte, aggBitsLen)
-		aggBits[validatorPosition/8] |= 1 << (validatorPosition % 8)
-
-		// Submit attestation.
-		attestation := map[string]interface{}{
-			"aggregation_bits": hexutil.Encode(aggBits),
-			"data":             &attData,
-			"signature":        hexutil.Encode(sig[:]),
+		sub := buildAttestationSubmission(version, committeeIndex, key.ValidatorIndex, &attData, sig, committeeLength, validatorPosition)
+		var submitErr error
+		if sub.version != "" {
+			submitErr = s.client.postJSON(ctx, sub.path, sub.body, sub.version)
+		} else {
+			submitErr = s.client.post(ctx, sub.path, sub.body)
 		}
-		if err := s.client.post(ctx, "/eth/v1/beacon/pool/attestations", []interface{}{attestation}); err != nil {
-			s.logger.Debug("[dev-validator] attestation submit failed", "slot", slot, "err", err)
+		if submitErr != nil {
+			s.logger.Debug("[dev-validator] attestation submit failed", "slot", slot, "err", submitErr)
 			continue
 		}
 		attested++
+
+		if version >= clparams.ElectraVersion {
+			s.submitAggregateAndProof(ctx, slot, committeeIndex, key, &attData, sig, committeeLength, validatorPosition)
+		}
 	}
 
 	if attested > 0 {

--- a/cl/validator/devvalidator/signing.go
+++ b/cl/validator/devvalidator/signing.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/fork"
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
@@ -79,6 +80,75 @@ func signBlock(
 ) (common.Bytes96, error) {
 	epoch := slot / cfg.SlotsPerEpoch
 	return signObject(key, block, cfg.DomainBeaconProposer, epoch, cfg, genesisValidatorsRoot)
+}
+
+// signSelectionProof signs the slot with DOMAIN_SELECTION_PROOF, proving the
+// validator is selected as an aggregator for that slot.
+func signSelectionProof(
+	key *ValidatorKey,
+	slot uint64,
+	cfg *clparams.BeaconChainConfig,
+	genesisValidatorsRoot common.Hash,
+) (common.Bytes96, error) {
+	epoch := slot / cfg.SlotsPerEpoch
+	return signObject(key, epochSSZ(slot), cfg.DomainSelectionProof, epoch, cfg, genesisValidatorsRoot)
+}
+
+// signAggregateAndProof signs an AggregateAndProof with DOMAIN_AGGREGATE_AND_PROOF.
+func signAggregateAndProof(
+	key *ValidatorKey,
+	msg ssz.HashableSSZ,
+	slot uint64,
+	cfg *clparams.BeaconChainConfig,
+	genesisValidatorsRoot common.Hash,
+) (common.Bytes96, error) {
+	epoch := slot / cfg.SlotsPerEpoch
+	return signObject(key, msg, cfg.DomainAggregateAndProof, epoch, cfg, genesisValidatorsRoot)
+}
+
+// rootSSZ wraps a 32-byte root so it can be signed: the hash tree root of a
+// Root is the root itself.
+type rootSSZ common.Hash
+
+func (r rootSSZ) HashSSZ() ([32]byte, error) { return [32]byte(r), nil }
+
+func (r rootSSZ) EncodingSizeSSZ() int { return 32 }
+
+// signSyncCommitteeSelectionProof signs the SyncAggregatorSelectionData for a
+// slot+subcommittee with DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF.
+func signSyncCommitteeSelectionProof(
+	key *ValidatorKey,
+	slot, subcommitteeIndex uint64,
+	cfg *clparams.BeaconChainConfig,
+	genesisValidatorsRoot common.Hash,
+) (common.Bytes96, error) {
+	epoch := slot / cfg.SlotsPerEpoch
+	data := &cltypes.SyncAggregatorSelectionData{Slot: slot, SubcommitteeIndex: subcommitteeIndex}
+	return signObject(key, data, cfg.DomainSyncCommitteeSelectionProof, epoch, cfg, genesisValidatorsRoot)
+}
+
+// signContributionAndProof signs a ContributionAndProof with DOMAIN_CONTRIBUTION_AND_PROOF.
+func signContributionAndProof(
+	key *ValidatorKey,
+	msg ssz.HashableSSZ,
+	slot uint64,
+	cfg *clparams.BeaconChainConfig,
+	genesisValidatorsRoot common.Hash,
+) (common.Bytes96, error) {
+	epoch := slot / cfg.SlotsPerEpoch
+	return signObject(key, msg, cfg.DomainContributionAndProof, epoch, cfg, genesisValidatorsRoot)
+}
+
+// signSyncCommitteeMessage signs a beacon block root with DOMAIN_SYNC_COMMITTEE.
+func signSyncCommitteeMessage(
+	key *ValidatorKey,
+	blockRoot common.Hash,
+	slot uint64,
+	cfg *clparams.BeaconChainConfig,
+	genesisValidatorsRoot common.Hash,
+) (common.Bytes96, error) {
+	epoch := slot / cfg.SlotsPerEpoch
+	return signObject(key, rootSSZ(blockRoot), cfg.DomainSyncCommittee, epoch, cfg, genesisValidatorsRoot)
 }
 
 // signAttestation signs attestation data with DOMAIN_BEACON_ATTESTER.

--- a/cl/validator/devvalidator/sync_committee.go
+++ b/cl/validator/devvalidator/sync_committee.go
@@ -1,0 +1,148 @@
+package devvalidator
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+)
+
+// buildSyncCommitteeMessage constructs the JSON body for a single
+// SyncCommitteeMessage submitted to /eth/v1/beacon/pool/sync_committees.
+func buildSyncCommitteeMessage(slot uint64, blockRoot common.Hash, validatorIndex uint64, sig common.Bytes96) map[string]interface{} {
+	return map[string]interface{}{
+		"slot":              strconv.FormatUint(slot, 10),
+		"beacon_block_root": blockRoot.Hex(),
+		"validator_index":   strconv.FormatUint(validatorIndex, 10),
+		"signature":         hexutil.Encode(sig[:]),
+	}
+}
+
+// maybeSyncCommittee submits sync committee messages and contributions for any
+// of our validators that are members of the current sync committee. The
+// messages alone are not enough to appear in a block's SyncAggregate — block
+// production reads aggregated contributions — so we submit both.
+func (s *Service) maybeSyncCommittee(ctx context.Context, slot uint64) {
+	epoch := slot / s.cfg.SlotsPerEpoch
+
+	type syncDuty struct {
+		Pubkey                         string   `json:"pubkey"`
+		ValidatorIndex                 string   `json:"validator_index"`
+		ValidatorSyncCommitteeIndicies []string `json:"validator_sync_committee_indices"`
+	}
+
+	indices := make([]string, 0, len(s.keys))
+	for _, k := range s.keys {
+		indices = append(indices, strconv.FormatUint(k.ValidatorIndex, 10))
+	}
+
+	var duties []syncDuty
+	path := fmt.Sprintf("/eth/v1/validator/duties/sync/%d", epoch)
+	if err := s.client.postAndDecode(ctx, path, indices, &duties); err != nil {
+		return
+	}
+	if len(duties) == 0 {
+		return
+	}
+
+	var rootResp struct {
+		Root common.Hash `json:"root"`
+	}
+	if err := s.client.get(ctx, "/eth/v1/beacon/blocks/head/root", &rootResp); err != nil {
+		return
+	}
+
+	syncSubcommitteeSize := s.cfg.SyncCommitteeSize / s.cfg.SyncCommitteeSubnetCount
+
+	msgs := make([]interface{}, 0, len(duties))
+	contributions := make([]interface{}, 0, len(duties))
+	for _, duty := range duties {
+		validatorIndex, parseErr := strconv.ParseUint(duty.ValidatorIndex, 10, 64)
+		if parseErr != nil {
+			continue
+		}
+		pubBytes, err := hexutil.Decode(duty.Pubkey)
+		if err != nil || len(pubBytes) != 48 {
+			continue
+		}
+		var pub common.Bytes48
+		copy(pub[:], pubBytes)
+		key, ok := s.keysByPub[pub]
+		if !ok {
+			continue
+		}
+		sig, err := signSyncCommitteeMessage(key, rootResp.Root, slot, s.cfg, s.genesisValidatorsRoot)
+		if err != nil {
+			s.logger.Warn("[dev-validator] sync committee sign failed", "err", err)
+			continue
+		}
+		msgs = append(msgs, buildSyncCommitteeMessage(slot, rootResp.Root, validatorIndex, sig))
+
+		if c := s.buildContributions(slot, rootResp.Root, key, duty.ValidatorSyncCommitteeIndicies, syncSubcommitteeSize, sig); len(c) > 0 {
+			contributions = append(contributions, c...)
+		}
+	}
+
+	if len(msgs) > 0 {
+		if err := s.client.post(ctx, "/eth/v1/beacon/pool/sync_committees", msgs); err != nil {
+			s.logger.Debug("[dev-validator] sync committee submit failed", "slot", slot, "err", err)
+		}
+	}
+	if len(contributions) > 0 {
+		if err := s.client.post(ctx, "/eth/v1/validator/contribution_and_proofs", contributions); err != nil {
+			s.logger.Debug("[dev-validator] sync contribution submit failed", "slot", slot, "err", err)
+		}
+	}
+}
+
+// buildContributions produces at most one signed sync committee contribution per
+// subcommittee the validator participates in (the spec accepts only the first
+// per aggregator+slot+subcommittee), each with the validator's single bit set.
+func (s *Service) buildContributions(
+	slot uint64,
+	blockRoot common.Hash,
+	key *ValidatorKey,
+	committeeIndicesStr []string,
+	syncSubcommitteeSize uint64,
+	sig common.Bytes96,
+) []interface{} {
+	seenSubcommittees := map[uint64]struct{}{}
+	out := make([]interface{}, 0, len(committeeIndicesStr))
+	for _, posStr := range committeeIndicesStr {
+		pos, err := strconv.ParseUint(posStr, 10, 64)
+		if err != nil || syncSubcommitteeSize == 0 {
+			continue
+		}
+		subcommitteeIndex := pos / syncSubcommitteeSize
+		if _, done := seenSubcommittees[subcommitteeIndex]; done {
+			continue
+		}
+		bitIndex := pos % syncSubcommitteeSize
+
+		selectionProof, err := signSyncCommitteeSelectionProof(key, slot, subcommitteeIndex, s.cfg, s.genesisValidatorsRoot)
+		if err != nil {
+			s.logger.Warn("[dev-validator] sync selection proof sign failed", "err", err)
+			continue
+		}
+		if !isSyncCommitteeAggregator(s.cfg, selectionProof) {
+			continue
+		}
+		seenSubcommittees[subcommitteeIndex] = struct{}{}
+
+		msg := &cltypes.ContributionAndProof{
+			AggregatorIndex: key.ValidatorIndex,
+			Contribution:    buildContribution(slot, blockRoot, subcommitteeIndex, bitIndex, sig, s.cfg),
+			SelectionProof:  selectionProof,
+		}
+		contribSig, err := signContributionAndProof(key, msg, slot, s.cfg, s.genesisValidatorsRoot)
+		if err != nil {
+			s.logger.Warn("[dev-validator] sync contribution sign failed", "err", err)
+			continue
+		}
+		out = append(out, &cltypes.SignedContributionAndProof{Message: msg, Signature: contribSig})
+	}
+	return out
+}

--- a/cl/validator/devvalidator/sync_committee_test.go
+++ b/cl/validator/devvalidator/sync_committee_test.go
@@ -1,0 +1,32 @@
+package devvalidator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/common"
+)
+
+// TestBuildSyncCommitteeMessage verifies the submission body decodes into the
+// exact type the beacon node's pool handler expects
+// ([]*cltypes.SyncCommitteeMessage), with all fields preserved.
+func TestBuildSyncCommitteeMessage(t *testing.T) {
+	root := common.Hash{0xde, 0xad, 0xbe, 0xef}
+	sig := common.Bytes96{0x11, 0x22, 0x33}
+
+	body := []interface{}{buildSyncCommitteeMessage(42, root, 7, sig)}
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var decoded []*cltypes.SyncCommitteeMessage
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Len(t, decoded, 1)
+	require.Equal(t, uint64(42), decoded[0].Slot)
+	require.Equal(t, root, decoded[0].BeaconBlockRoot)
+	require.Equal(t, uint64(7), decoded[0].ValidatorIndex)
+	require.Equal(t, sig, decoded[0].Signature)
+}

--- a/cl/validator/devvalidator/sync_contribution.go
+++ b/cl/validator/devvalidator/sync_contribution.go
@@ -1,0 +1,38 @@
+package devvalidator
+
+import (
+	"encoding/binary"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/common"
+)
+
+// isSyncCommitteeAggregator reports whether the selection proof selects the
+// validator as a sync committee contribution aggregator for its subcommittee.
+func isSyncCommitteeAggregator(cfg *clparams.BeaconChainConfig, selectionProof common.Bytes96) bool {
+	modulo := max(1, cfg.SyncCommitteeSize/cfg.SyncCommitteeSubnetCount/cfg.TargetAggregatorsPerSyncSubcommittee)
+	hash := utils.Sha256(selectionProof[:])
+	return binary.LittleEndian.Uint64(hash[:8])%modulo == 0
+}
+
+// buildContribution constructs a single-participant sync committee contribution
+// for the validator's position within a subcommittee.
+func buildContribution(
+	slot uint64,
+	blockRoot common.Hash,
+	subcommitteeIndex, bitIndex uint64,
+	sig common.Bytes96,
+	cfg *clparams.BeaconChainConfig,
+) *cltypes.Contribution {
+	aggBits := make([]byte, cfg.SyncCommitteeAggregationBitsSize())
+	aggBits[bitIndex/8] |= 1 << (bitIndex % 8)
+	return &cltypes.Contribution{
+		Slot:              slot,
+		BeaconBlockRoot:   blockRoot,
+		SubcommitteeIndex: subcommitteeIndex,
+		AggregationBits:   aggBits,
+		Signature:         sig,
+	}
+}

--- a/cl/validator/devvalidator/sync_contribution_test.go
+++ b/cl/validator/devvalidator/sync_contribution_test.go
@@ -1,0 +1,55 @@
+package devvalidator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/common"
+)
+
+// TestBuildContribution verifies the contribution has the validator's single
+// bit set at the right position and round-trips through the type the
+// contribution_and_proofs endpoint decodes.
+func TestBuildContribution(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig // SyncCommitteeSize=512, subnets=4 → 16-byte agg bits
+	root := common.Hash{0xab}
+	sig := common.Bytes96{0x05}
+
+	contrib := buildContribution(7, root, 2, 9, sig, &cfg)
+	require.Equal(t, cfg.SyncCommitteeAggregationBitsSize(), len(contrib.AggregationBits))
+	require.Equal(t, byte(1<<(9%8)), contrib.AggregationBits[9/8])
+	require.Equal(t, uint64(2), contrib.SubcommitteeIndex)
+	require.Equal(t, root, contrib.BeaconBlockRoot)
+
+	signed := &cltypes.SignedContributionAndProof{
+		Message: &cltypes.ContributionAndProof{
+			AggregatorIndex: 7,
+			Contribution:    contrib,
+			SelectionProof:  common.Bytes96{0x06},
+		},
+		Signature: common.Bytes96{0x07},
+	}
+	raw, err := json.Marshal([]interface{}{signed})
+	require.NoError(t, err)
+
+	var decoded []*cltypes.SignedContributionAndProof
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Len(t, decoded, 1)
+	require.Equal(t, uint64(7), decoded[0].Message.AggregatorIndex)
+	require.Equal(t, uint64(2), decoded[0].Message.Contribution.SubcommitteeIndex)
+	require.Equal(t, common.Bytes96{0x07}, decoded[0].Signature)
+}
+
+// TestIsSyncCommitteeAggregator_MinimalAlwaysAggregator confirms that on the
+// minimal preset (SyncCommitteeSize=32) the modulo is 1, so any selection proof
+// makes the validator an aggregator.
+func TestIsSyncCommitteeAggregator_MinimalAlwaysAggregator(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.SyncCommitteeSize = 32 // minimal preset → modulo = max(1, 32/4/16) = 1
+	require.True(t, isSyncCommitteeAggregator(&cfg, common.Bytes96{0x01}))
+	require.True(t, isSyncCommitteeAggregator(&cfg, common.Bytes96{0xff, 0xff}))
+}


### PR DESCRIPTION
## Summary: dev-mode validator drain that eventually halts the chain

Any node running the embedded dev-mode validator (`--chain=dev`, `cl/validator/devvalidator`) has a **finite lifetime**: it produces blocks normally for a while, then permanently stops. This is not a hang — it is a slow, deterministic **validator drain** that ends in a wedged chain.

Observed directly: a long-running dev node **halted at block 33,406 after ~18.5 hours** of continuous 2s-slot operation and never produced another block, even though the process stayed alive.

### Why it drains and halts

The dev validator was only half-migrated to Electra. Block production was upgraded, but the attestation path still built the **pre-Electra** `aggregation_bits` form and posted to the V1 pool endpoint, which an Electra chain rejects with `single attestation is empty`. The chain then walks itself into a wall:

1. **No attestation is ever included** — every submission is rejected (`selectedAtts=0` on every block).
2. With zero participation recorded, the **inactivity leak** bleeds every validator's balance each epoch.
3. After enough epochs every validator drops below the 16 ETH **ejection balance** and `process_registry_updates` exits it.
4. Once all validators have exited, the next sync-committee update calls `ComputeNextSyncCommittee`, which computes `i % activeValidatorCount` with `activeValidatorCount == 0` → **integer divide-by-zero panic**. The panic happens inside the beacon HTTP handler, so `net/http` recovers it: the process stays up but **block production for that slot fails forever**, and the chain is wedged.

The drain time is bounded and deterministic (set by the penalty rate, the preset, and the 32→16 ETH headroom), so **every dev node is guaranteed to halt** after a finite number of slots unless attestations are actually included.

## The fix

To get attestations included (and keep validators above the ejection balance) the dev validator needs the duties it was missing, plus a defensive guard on the consensus helper that panicked:

- **Attestation format (Electra):** submit a `SingleAttestation` to `POST /eth/v2/beacon/pool/attestations` with the `Eth-Consensus-Version` header. The attestation-data producer already returns `index=0`, so only the submission format/endpoint was wrong.
- **Aggregate-and-proof duty:** block production only includes attestations that reach the operations pool via the aggregate-and-proof path, so the validator now builds, signs, and submits a `SignedAggregateAndProof` per attestation. This is what actually restores justification and finality. (Dev's small committees give an aggregator modulo of 1, so every validator is an aggregator.)
- **Sync-committee duties:** submit sync-committee messages and contribution-and-proofs so the block `SyncAggregate` is populated.
- **Defensive guard:** `ComputeNextSyncCommittee` now returns an error instead of panicking when there are no active validators at the target epoch — so a degenerate validator set can never wedge block production via a divide-by-zero, regardless of how it arose.

## Tests

- `cache_accessors_test.go`: reproduces the divide-by-zero (panics without the guard) and asserts a clean error with it.
- `devvalidator` tests: each submission body round-trips into the exact type the beacon node decodes (`SingleAttestation`, `SignedAggregateAndProof`, `SyncCommitteeMessage`, `SignedContributionAndProof`); aggregate bit-packing and the sync-committee aggregator check are unit-tested.

## Verification

On a fresh `--chain=dev` node (64 validators): the chain now finalizes (head epoch 10, finalized epoch 8), `selectedAtts=1` on every block, `SyncAggregate` is non-empty, and it runs cleanly **through the sync-committee period boundary that previously panicked** — with no empty-attestation rejections, aggregate/contribution failures, or divide-by-zero. Validator balances stay above the ejection threshold, so the drain no longer occurs.

## Notes

- Sync-committee contributions are single-participant per subcommittee (each validator acts as its own aggregator), so `SyncAggregate` is non-empty but not maximally aggregated. This does not affect finality or balances; full cross-validator sync aggregation could be a follow-up.
