### PR TITLE
cmd: accept N+ syntax in seg rm-state --step flag

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -319,7 +319,7 @@ var snapshotCommand = cli.Command{
 			Action:  doRmStateSnapshots,
 			Flags: joinFlags([]cli.Flag{
 				&utils.DataDirFlag,
-				&cli.StringFlag{Name: "step"},
+				&cli.StringFlag{Name: "step", Usage: "step range to remove: 'from-to' (e.g. 5-10), or 'from+' (e.g. 5+) for everything from step N to the latest"},
 				&cli.BoolFlag{Name: "recentStep", Aliases: []string{"latest", "latestStep", "recent"}, Usage: "remove minimal possible recent/latest files: and Domain and History. Useful when have 1 corrupted recent file"},
 				&cli.BoolFlag{Name: "dry-run"},
 				&cli.StringSliceFlag{Name: "domain"},
@@ -748,6 +748,22 @@ type DeleteStateSnapshotsArgs struct {
 	DomainNames            []string
 }
 
+// parseStepRange parses a --step value of "from-to" (e.g. "5-10") or "from+"
+// (e.g. "5+"), where "+" means from the given step to maxAvailableStep.
+func parseStepRange(stepRange string, maxAvailableStep uint64) (from, to uint64, err error) {
+	if prefix, ok := strings.CutSuffix(stepRange, "+"); ok {
+		from, err = strconv.ParseUint(prefix, 10, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("step expected in format from-to or N+, got %s", stepRange)
+		}
+		return from, maxAvailableStep, nil
+	}
+	if _, err = fmt.Sscanf(stepRange, "%d-%d", &from, &to); err != nil {
+		return 0, 0, fmt.Errorf("step expected in format from-to or N+, got %s", stepRange)
+	}
+	return from, to, nil
+}
+
 func DeleteStateSnapshots(args DeleteStateSnapshotsArgs) error {
 	dirs := args.Dirs
 	removeLatest := args.RemoveLatest
@@ -877,15 +893,12 @@ func DeleteStateSnapshots(args DeleteStateSnapshotsArgs) error {
 	if stepRange != "" || removeLatest {
 		var minS, maxS uint64
 		if stepRange != "" {
-			parseStep := func(step string) (uint64, uint64, error) {
-				var from, to uint64
-				if _, err := fmt.Sscanf(step, "%d-%d", &from, &to); err != nil {
-					return 0, 0, fmt.Errorf("step expected in format from-to, got %s", step)
-				}
-				return from, to, nil
+			var maxAvailableStep uint64
+			for _, res := range files {
+				maxAvailableStep = max(maxAvailableStep, res.To)
 			}
 			var err error
-			minS, maxS, err = parseStep(stepRange)
+			minS, maxS, err = parseStepRange(stepRange, maxAvailableStep)
 			if err != nil {
 				return err
 			}

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -758,7 +758,16 @@ func parseStepRange(stepRange string, maxAvailableStep uint64) (from, to uint64,
 		}
 		return from, maxAvailableStep, nil
 	}
-	if _, err = fmt.Sscanf(stepRange, "%d-%d", &from, &to); err != nil {
+	fromS, toS, ok := strings.Cut(stepRange, "-")
+	if !ok {
+		return 0, 0, fmt.Errorf("step expected in format from-to or N+, got %s", stepRange)
+	}
+	from, err = strconv.ParseUint(fromS, 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("step expected in format from-to or N+, got %s", stepRange)
+	}
+	to, err = strconv.ParseUint(toS, 10, 64)
+	if err != nil {
 		return 0, 0, fmt.Errorf("step expected in format from-to or N+, got %s", stepRange)
 	}
 	return from, to, nil

--- a/cmd/utils/app/snapshots_cmd_test.go
+++ b/cmd/utils/app/snapshots_cmd_test.go
@@ -331,6 +331,70 @@ func Test_DeleteStateSnaps_StepRange_SubsetRemoval(t *testing.T) {
 	confirmExist(t, file)
 }
 
+func Test_parseStepRange(t *testing.T) {
+	const maxStep = 224
+	for _, tc := range []struct {
+		name     string
+		in       string
+		from, to uint64
+		wantErr  bool
+	}{
+		{name: "range", in: "5-10", from: 5, to: 10},
+		{name: "range from zero", in: "0-128", from: 0, to: 128},
+		{name: "from plus", in: "5+", from: 5, to: maxStep},
+		{name: "from plus zero", in: "0+", from: 0, to: maxStep},
+		{name: "from plus equals max", in: "224+", from: 224, to: maxStep},
+		{name: "empty", in: "", wantErr: true},
+		{name: "plus only", in: "+", wantErr: true},
+		{name: "single number", in: "5", wantErr: true},
+		{name: "bad plus prefix", in: "5x+", wantErr: true},
+		{name: "not a number", in: "abc", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			from, to, err := parseStepRange(tc.in, maxStep)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.from, from)
+			require.Equal(t, tc.to, to)
+		})
+	}
+}
+
+// Test_DeleteStateSnaps_StepRange_FromPlus verifies that "N+" resolves "to" to the
+// highest available step, removing everything from step N to the latest.
+func Test_DeleteStateSnaps_StepRange_FromPlus(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+	b := bundle{}
+	dc := statecfg.Schema.ReceiptDomain
+	b.domain, b.history, b.ii = state.SnapSchemaFromDomainCfg(dc, dirs, 1)
+
+	ranges := [][2]int{
+		{0, 128}, {128, 192},
+		{192, 224},
+		{192, 208}, {208, 216}, {216, 220}, {220, 222}, {222, 223}, {223, 224},
+	}
+	for _, r := range ranges {
+		createFiles(t, dirs, r[0], r[1], &b)
+	}
+
+	// "192+" must behave like "192-224" because 224 is the highest available step.
+	err := DeleteStateSnapshots(DeleteStateSnapshotsArgs{Dirs: dirs, StepRange: "192+", DomainNames: []string{"receipt"}})
+	require.NoError(t, err)
+
+	for _, r := range [][2]int{{192, 224}, {192, 208}, {208, 216}, {216, 220}, {220, 222}, {222, 223}, {223, 224}} {
+		file, _ := b.domain.DataFile(version.V1_0, RootNum(r[0]), RootNum(r[1]))
+		confirmDoesntExist(t, file)
+	}
+
+	file, _ := b.domain.DataFile(version.V1_0, RootNum(0), RootNum(128))
+	confirmExist(t, file)
+	file, _ = b.domain.DataFile(version.V1_0, RootNum(128), RootNum(192))
+	confirmExist(t, file)
+}
+
 // Test_DeleteLatestStateSnaps_NoFalseSubsetRemoval verifies that sub-range files
 // of a non-removed merged file are NOT incorrectly removed by the subset pass.
 func Test_DeleteLatestStateSnaps_NoFalseSubsetRemoval(t *testing.T) {

--- a/cmd/utils/app/snapshots_cmd_test.go
+++ b/cmd/utils/app/snapshots_cmd_test.go
@@ -348,6 +348,8 @@ func Test_parseStepRange(t *testing.T) {
 		{name: "plus only", in: "+", wantErr: true},
 		{name: "single number", in: "5", wantErr: true},
 		{name: "bad plus prefix", in: "5x+", wantErr: true},
+		{name: "range trailing chars", in: "5-10x", wantErr: true},
+		{name: "range extra dash", in: "5-10-20", wantErr: true},
 		{name: "not a number", in: "abc", wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What

`erigon seg rm-state --step` now accepts an `N+` form meaning "from step N to the latest available step":

- `--step 5+` — remove everything from step 5 to the latest
- `--step 5-10` — unchanged

Previously the only way to express "from step N to the end" was an arbitrarily large upper bound like `--step 5-9999999`.

## How

The `--step` parsing is extracted into `parseStepRange(stepRange, maxAvailableStep)`. For the `N+` form it parses the prefix as `from` and sets `to` to the highest `toStep` among the state files already scanned by `DeleteStateSnapshots` (respecting any `--domain` filter). The `from-to` form is unchanged. Only the range parsing changed — the file-removal logic is untouched.

## Tests

- `Test_parseStepRange` — table-driven unit test covering both formats and error cases (empty, `+` only, bad prefix, non-numeric).
- `Test_DeleteStateSnaps_StepRange_FromPlus` — end-to-end: `192+` removes the `192-224` merged file plus its sub-ranges and keeps `0-128` / `128-192`, identical to `192-224` since 224 is the highest step.

`make lint` clean; `go test ./cmd/utils/app/` passing.
