### PR TITLE
execution/commitment: include exclusion proofs for absent storage slots in execution witness

### DIFF
--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -273,10 +273,10 @@ func (sdc *SharedDomainsCommitmentContext) TouchHashedKey(hashedKey []byte) {
 	sdc.updates.TouchHashedKey(hashedKey)
 }
 
-func (sdc *SharedDomainsCommitmentContext) Witness(ctx context.Context, codeReads map[common.Hash]witnesstypes.CodeWithHash, logPrefix string) (proofTrie *trie.Trie, rootHash []byte, err error) {
+func (sdc *SharedDomainsCommitmentContext) Witness(ctx context.Context, codeReads map[common.Hash]witnesstypes.CodeWithHash, logPrefix string, produceExclusionProofs bool) (proofTrie *trie.Trie, rootHash []byte, err error) {
 	hexPatriciaHashed, ok := sdc.Trie().(*commitment.HexPatriciaHashed)
 	if ok {
-		return hexPatriciaHashed.GenerateWitness(ctx, sdc.updates, codeReads, logPrefix)
+		return hexPatriciaHashed.GenerateWitness(ctx, sdc.updates, codeReads, logPrefix, produceExclusionProofs)
 	}
 
 	return nil, nil, errors.New("shared domains commitment context doesn't have HexPatriciaHashed")

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1547,11 +1547,11 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 				// the traversal can be stopped at this level
 				pathDivergenceFound = true
 				short := &trie.ShortNode{Key: common.Copy(hashedExtKey)}
-				// For an absent storage slot diverging at a folded extension, a strict
+				// For an absent account or storage key diverging at a folded extension, a strict
 				// sparse-trie verifier needs the branch behind the extension
 				// materialized, not a bare HashNode. The branch hashes
 				// to the same value, so the witness root is unchanged.
-				if len(hashedKey) == 128 && cellToExpand.hashLen > 0 {
+				if (len(hashedKey) == 64 || len(hashedKey) == 128) && cellToExpand.hashLen > 0 {
 					branchPrefix := make([]byte, 0, int(keyPos)+1+len(hashedExtKey))
 					branchPrefix = append(branchPrefix, hashedKey[:keyPos+1]...)
 					branchPrefix = append(branchPrefix, hashedExtKey...)

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1451,6 +1451,49 @@ func (hph *HexPatriciaHashed) witnessCreateAccountNode(c *cell, depth int16, has
 }
 
 // Traverse the grid following `hashedKey` and produce the witness `triedeprecated.Trie` for that key
+// witnessMaterializeBranch decodes the branch stored at the given hashed-nibble prefix into
+// a trie.FullNode whose children are HashNodes. Mirrors unfoldBranchNode's branch decode.
+func (hph *HexPatriciaHashed) witnessMaterializeBranch(branchPrefix []byte, childDepth int16) (*trie.FullNode, error) {
+	compact := nibbles.HexToCompact(branchPrefix)
+	branchData, err := hph.readBranchAndCheckForFlushing(compact)
+	if err != nil {
+		return nil, err
+	}
+	if len(branchData) < 2 {
+		return nil, fmt.Errorf("[witness] empty branch data at prefix %x", branchPrefix)
+	}
+	branchData = branchData[2:] // skip touch map
+	bitmap := binary.BigEndian.Uint16(branchData[0:])
+	pos := 2
+	fullNode := &trie.FullNode{}
+	for bitset := bitmap; bitset != 0; {
+		bit := bitset & -bitset
+		nibble := bits.TrailingZeros16(bit)
+		var c cell
+		fieldBits := branchData[pos]
+		pos++
+		if pos, err = c.fillFromFields(branchData, pos, cellFields(fieldBits)); err != nil {
+			return nil, fmt.Errorf("[witness] fillFromFields at prefix %x: %w", branchPrefix, err)
+		}
+		if childDepth > 64 {
+			c.accountAddrLen = 0
+		}
+		if err = c.deriveHashedKeys(childDepth, hph.keccak, hph.accountKeyLen, hph.cellHashBuf[:]); err != nil {
+			return nil, err
+		}
+		cellHash, _, _, err := hph.witnessComputeCellHashWithStorage(&c, childDepth, nil)
+		if err != nil {
+			return nil, err
+		}
+		if len(cellHash) == length.Hash+1 { // strip the 0xa0 prefix
+			cellHash = cellHash[1:]
+		}
+		fullNode.Children[nibble] = trie.NewHashNode(common.Copy(cellHash))
+		bitset ^= bit
+	}
+	return fullNode, nil
+}
+
 func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[common.Hash]witnesstypes.CodeWithHash) (*trie.Trie, error) {
 	var rootNode trie.Node = &trie.FullNode{}
 	var currentNode trie.Node = rootNode
@@ -1503,9 +1546,27 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 				// path has diverged due to the hashedKey not leading to any account or storage
 				// the traversal can be stopped at this level
 				pathDivergenceFound = true
-				// Val will be set to HashNode with hash of branch node it points to when the current node is processed.
-				// Currently necessary, because the commented out code above which reads branch data and converts it
-				nextNode = &trie.ShortNode{Key: common.Copy(hashedExtKey)}
+				short := &trie.ShortNode{Key: common.Copy(hashedExtKey)}
+				// For an absent storage slot diverging at a folded extension, a strict
+				// sparse-trie verifier needs the branch behind the extension
+				// materialized, not a bare HashNode. The branch hashes
+				// to the same value, so the witness root is unchanged.
+				if len(hashedKey) == 128 && cellToExpand.hashLen > 0 {
+					branchPrefix := make([]byte, 0, int(keyPos)+1+len(hashedExtKey))
+					branchPrefix = append(branchPrefix, hashedKey[:keyPos+1]...)
+					branchPrefix = append(branchPrefix, hashedExtKey...)
+					branchNode, err := hph.witnessMaterializeBranch(branchPrefix, int16(len(branchPrefix))+1)
+					if err != nil {
+						return nil, err
+					}
+					subRoot := trie.NewInMemoryTrie(branchNode).Hash()
+					if !bytes.Equal(subRoot[:], cellToExpand.hash[:cellToExpand.hashLen]) {
+						return nil, fmt.Errorf("[witness] materialized extension-child branch root mismatch at prefix %x: got %x want %x", branchPrefix, subRoot, cellToExpand.hash[:cellToExpand.hashLen])
+					}
+					short.Val = branchNode
+				}
+				// Otherwise Val is set to a HashNode of the branch it points to when the current node is processed.
+				nextNode = short
 			} else {
 				keyPos += extKeyLength // jump ahead
 
@@ -1628,9 +1689,12 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 
 			// this deals with the edge case where the extension key in nextNode diverges from hashedKey
 			// and points to a branch node. In this case we just need to provide the hash of this branch node
+			// (unless the branch was already materialized for an absent-slot exclusion proof).
 			if pathDivergenceFound {
-				terminalCell := &hph.grid[row][currentNibble]
-				nextNode.(*trie.ShortNode).Val = trie.NewHashNode(common.Copy(terminalCell.hash[:]))
+				if sn, ok := nextNode.(*trie.ShortNode); ok && sn.Val == nil {
+					terminalCell := &hph.grid[row][currentNibble]
+					sn.Val = trie.NewHashNode(common.Copy(terminalCell.hash[:]))
+				}
 			}
 			fullNode.Children[currentNibble] = nextNode // ready to expand next nibble in the path
 		} else if accNode, ok := currentNode.(*trie.AccountNode); ok {

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1494,7 +1494,7 @@ func (hph *HexPatriciaHashed) witnessMaterializeBranch(branchPrefix []byte, chil
 	return fullNode, nil
 }
 
-func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[common.Hash]witnesstypes.CodeWithHash) (*trie.Trie, error) {
+func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[common.Hash]witnesstypes.CodeWithHash, produceExclusionProofs bool) (*trie.Trie, error) {
 	var rootNode trie.Node = &trie.FullNode{}
 	var currentNode trie.Node = rootNode
 	keyPos := int16(0) // current position in hashedKey (usually same as row, but could be different due to extension nodes)
@@ -1551,7 +1551,7 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 				// sparse-trie verifier needs the branch behind the extension
 				// materialized, not a bare HashNode. The branch hashes
 				// to the same value, so the witness root is unchanged.
-				if (len(hashedKey) == 64 || len(hashedKey) == 128) && cellToExpand.hashLen > 0 {
+				if produceExclusionProofs && (len(hashedKey) == 64 || len(hashedKey) == 128) && cellToExpand.hashLen > 0 {
 					branchPrefix := make([]byte, 0, int(keyPos)+1+len(hashedExtKey))
 					branchPrefix = append(branchPrefix, hashedKey[:keyPos+1]...)
 					branchPrefix = append(branchPrefix, hashedExtKey...)
@@ -2681,7 +2681,7 @@ func (hph *HexPatriciaHashed) foldMounted(ctx context.Context, nib int) (cell, e
 // but currently need to be defined like that for the fold/unfold algorithm) into the grid and traversing the grid to convert it into `triedeprecated.Trie`.
 // All the individual tries are combined to create the final witness trie.
 // Because the grid is lacking information about the code in smart contract accounts which is also part of the witness, we need to provide that as an input parameter to this function (`codeReads`)
-func (hph *HexPatriciaHashed) GenerateWitness(ctx context.Context, updates *Updates, codeReads map[common.Hash]witnesstypes.CodeWithHash, logPrefix string) (witnessTrie *trie.Trie, rootHash []byte, err error) {
+func (hph *HexPatriciaHashed) GenerateWitness(ctx context.Context, updates *Updates, codeReads map[common.Hash]witnesstypes.CodeWithHash, logPrefix string, produceExclusionProofs bool) (witnessTrie *trie.Trie, rootHash []byte, err error) {
 	var (
 		m  runtime.MemStats
 		ki uint64
@@ -2788,7 +2788,7 @@ func (hph *HexPatriciaHashed) GenerateWitness(ctx context.Context, updates *Upda
 		}
 
 		// convert grid to trie.Trie
-		tr, err = hph.toWitnessTrie(hashedKey, codeReads) // build witness trie for this key, based on the current state of the grid
+		tr, err = hph.toWitnessTrie(hashedKey, codeReads, produceExclusionProofs) // build witness trie for this key, based on the current state of the grid
 		if err != nil {
 			return err
 		}

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -2291,7 +2291,7 @@ func Test_WitnessTrie_GenerateWitness(t *testing.T) {
 			toWitness.TouchHashedKey(hk)
 		}
 
-		witnessTrie, rootWitness, err := hph.GenerateWitness(context.Background(), toWitness, nil, "")
+		witnessTrie, rootWitness, err := hph.GenerateWitness(context.Background(), toWitness, nil, "", false)
 		require.NoError(t, err)
 		_ = witnessTrie
 		require.NotNil(t, witnessTrie, "witness trie should not be nil")
@@ -2360,7 +2360,7 @@ func Test_WitnessTrie_GenerateWitness(t *testing.T) {
 			}
 		}
 
-		witnessTrie, rootWitness, err := hph.GenerateWitness(ctx, toWitness, nil, "")
+		witnessTrie, rootWitness, err := hph.GenerateWitness(ctx, toWitness, nil, "", false)
 		require.NoError(t, err)
 		require.NotNil(t, witnessTrie, "witness trie should not be nil")
 		require.NotNil(t, rootWitness, "root witness should not be nil")
@@ -3480,7 +3480,7 @@ func Test_WitnessTrie_GenerateWitness(t *testing.T) {
 		toWitness.TouchPlainKey(string(acctPlain), nil, toWitness.TouchAccount)
 		toWitness.TouchPlainKey(string(storagePlainKey), nil, toWitness.TouchStorage)
 
-		witnessTrie, rootW, err := hph.GenerateWitness(ctx, toWitness, nil, "")
+		witnessTrie, rootW, err := hph.GenerateWitness(ctx, toWitness, nil, "", true)
 		require.NoError(t, err)
 		require.Equal(t, root, rootW, "witness root must equal commitment root")
 
@@ -3527,7 +3527,7 @@ func Test_WitnessTrie_GenerateWitness(t *testing.T) {
 		defer toWitness.Close()
 		toWitness.TouchPlainKey(string(absentAcct), nil, toWitness.TouchAccount)
 
-		witnessTrie, rootW, err := hph.GenerateWitness(ctx, toWitness, nil, "")
+		witnessTrie, rootW, err := hph.GenerateWitness(ctx, toWitness, nil, "", true)
 		require.NoError(t, err)
 		require.Equal(t, root, rootW, "witness root must equal commitment root")
 

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -3440,6 +3440,54 @@ func Test_WitnessTrie_GenerateWitness(t *testing.T) {
 			[][]byte{accountA, fullStorageKey},
 			[]bool{true, false})
 	})
+
+	t.Run("AbsentStorageSlotDivergingAtFoldedExtension", func(t *testing.T) {
+		ctx := context.Background()
+		ms := NewMockState(t)
+		hph := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+		hph.SetTrace(false)
+
+		// several accounts so the storage-bearing account sits inside a branch
+		acctPlains, _ := generatePlainKeysWithSameHashPrefix(t, nil, length.Addr, 2, 6)
+		acctPlain := acctPlains[0]
+		// two storage slots sharing a 5-nibble hashed prefix -> storage extension over a branch
+		storPlain, storHashed := generatePlainKeysWithSameHashPrefix(t, nil, length.Hash, 5, 2)
+
+		builder := NewUpdateBuilder()
+		for i, a := range acctPlains {
+			builder.Balance(common.Bytes2Hex(a), uint64(i+1))
+		}
+		for _, sk := range storPlain {
+			builder.Storage(common.Bytes2Hex(acctPlain), common.Bytes2Hex(sk), common.Bytes2Hex(sk))
+		}
+		plainKeys, updates := builder.Build()
+		require.NoError(t, ms.applyPlainUpdates(plainKeys, updates))
+
+		toProcess := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, plainKeys, updates)
+		defer toProcess.Close()
+		root, err := hph.Process(ctx, toProcess, "", nil, WarmupConfig{})
+		require.NoError(t, err)
+
+		// absent slot sharing the first two nibbles of the extension prefix then diverging at
+		// the third, i.e. it diverges inside the folded extension.
+		shared := storHashed[0]
+		absentPrefix := []byte{shared[0], shared[1], (shared[2] + 1) & 0xf}
+		absentSlotPlain, _ := generateKeyWithHashedPrefix(absentPrefix, length.Hash)
+		storagePlainKey := append(common.Copy(acctPlain), absentSlotPlain...)
+
+		toWitness := NewUpdates(ModeDirect, "", KeyToHexNibbleHash)
+		defer toWitness.Close()
+		toWitness.TouchPlainKey(string(acctPlain), nil, toWitness.TouchAccount)
+		toWitness.TouchPlainKey(string(storagePlainKey), nil, toWitness.TouchStorage)
+
+		witnessTrie, rootW, err := hph.GenerateWitness(ctx, toWitness, nil, "")
+		require.NoError(t, err)
+		require.Equal(t, root, rootW, "witness root must equal commitment root")
+
+		hashedAbsent := KeyToHexNibbleHash(storagePlainKey)
+		require.True(t, witnessResolvesAbsence(witnessTrie.RootNode, hashedAbsent, 0),
+			"witness must materialize the branch behind the diverging extension to prove the absent slot")
+	})
 }
 
 // Test_ModeUpdate_SiblingConsistency verifies that ModeUpdate produces

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -3488,6 +3488,53 @@ func Test_WitnessTrie_GenerateWitness(t *testing.T) {
 		require.True(t, witnessResolvesAbsence(witnessTrie.RootNode, hashedAbsent, 0),
 			"witness must materialize the branch behind the diverging extension to prove the absent slot")
 	})
+
+	t.Run("AbsentAccountDivergingAtFoldedExtension", func(t *testing.T) {
+		ctx := context.Background()
+		ms := NewMockState(t)
+		hph := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+		hph.SetTrace(false)
+
+		// accounts sharing a 5-nibble hashed prefix -> state-trie extension over a branch
+		extAccts, extHashed := generatePlainKeysWithSameHashPrefix(t, nil, length.Addr, 5, 2)
+
+		builder := NewUpdateBuilder()
+		n := 0
+		for _, a := range extAccts {
+			builder.Balance(common.Bytes2Hex(a), uint64(n+1))
+			n++
+		}
+		// random filler accounts so the extension sits below a populated root branch
+		for i := 0; i < 8; i++ {
+			a, _ := generateKeyWithHashedPrefix(nil, length.Addr)
+			builder.Balance(common.Bytes2Hex(a), uint64(n+1))
+			n++
+		}
+		plainKeys, updates := builder.Build()
+		require.NoError(t, ms.applyPlainUpdates(plainKeys, updates))
+
+		toProcess := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, plainKeys, updates)
+		defer toProcess.Close()
+		root, err := hph.Process(ctx, toProcess, "", nil, WarmupConfig{})
+		require.NoError(t, err)
+
+		// absent account sharing the first three nibbles of the extension prefix then diverging
+		shared := extHashed[0]
+		absentPrefix := []byte{shared[0], shared[1], shared[2], (shared[3] + 1) & 0xf}
+		absentAcct, _ := generateKeyWithHashedPrefix(absentPrefix, length.Addr)
+
+		toWitness := NewUpdates(ModeDirect, "", KeyToHexNibbleHash)
+		defer toWitness.Close()
+		toWitness.TouchPlainKey(string(absentAcct), nil, toWitness.TouchAccount)
+
+		witnessTrie, rootW, err := hph.GenerateWitness(ctx, toWitness, nil, "")
+		require.NoError(t, err)
+		require.Equal(t, root, rootW, "witness root must equal commitment root")
+
+		hashedAbsent := KeyToHexNibbleHash(absentAcct)
+		require.True(t, witnessResolvesAbsence(witnessTrie.RootNode, hashedAbsent, 0),
+			"witness must materialize the branch behind the diverging extension to prove the absent account")
+	})
 }
 
 // Test_ModeUpdate_SiblingConsistency verifies that ModeUpdate produces

--- a/execution/commitment/witness_exclusion_test.go
+++ b/execution/commitment/witness_exclusion_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"github.com/erigontech/erigon/execution/commitment/nibbles"
+	"github.com/erigontech/erigon/execution/commitment/trie"
+)
+
+// witnessResolvesAbsence walks the witness trie following key the way a strict stateless
+// verifier does: every node on the path, including the child of a divergent extension, must
+// be materialized. Unlike trie.Get it does not accept a bare HashNode behind a divergent
+// extension as proof of absence.
+func witnessResolvesAbsence(n trie.Node, key []byte, pos int) bool {
+	switch x := n.(type) {
+	case nil:
+		return true
+	case trie.ValueNode:
+		return true
+	case *trie.AccountNode:
+		return witnessResolvesAbsence(x.Storage, key, pos)
+	case *trie.ShortNode:
+		matchlen := nibbles.CommonPrefixLen(key[pos:], x.Key)
+		if matchlen == len(x.Key) || x.Key[matchlen] == 16 {
+			return witnessResolvesAbsence(x.Val, key, pos+matchlen)
+		}
+		_, isHash := x.Val.(*trie.HashNode)
+		return !isHash
+	case *trie.FullNode:
+		child := x.Children[key[pos]]
+		if child == nil {
+			return true
+		}
+		return witnessResolvesAbsence(child, key, pos+1)
+	case *trie.HashNode:
+		return false
+	default:
+		return false
+	}
+}

--- a/execution/commitment/witness_exclusion_test.go
+++ b/execution/commitment/witness_exclusion_test.go
@@ -30,7 +30,9 @@ func witnessResolvesAbsence(n trie.Node, key []byte, pos int) bool {
 	case nil:
 		return true
 	case trie.ValueNode:
-		return true
+		// reaching a value means the key is present; only a value short of the full key
+		// length (a divergent leaf) proves absence
+		return pos < len(key)
 	case *trie.AccountNode:
 		return witnessResolvesAbsence(x.Storage, key, pos)
 	case *trie.ShortNode:

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -750,7 +750,9 @@ func (api *DebugAPIImpl) ExecutionWitness(ctx context.Context, blockNrOrHash rpc
 		return nil, err
 	}
 
-	nodes, err := buildWitnessTrie(ctx, tx, domains, sdCtx, firstTxNumInBlock, expectedParentRoot, siblingPaths, accessed)
+	// Materialize exclusion-proof branches for strict sparse-trie verifiers in legacy/default
+	// mode; canonical mode stays minimal to match the reference witness.
+	nodes, err := buildWitnessTrie(ctx, tx, domains, sdCtx, firstTxNumInBlock, expectedParentRoot, siblingPaths, accessed, resolvedMode != witnessModeCanonical)
 	if err != nil {
 		return nil, err
 	}
@@ -1121,6 +1123,7 @@ func buildWitnessTrie(
 	expectedParentRoot common.Hash,
 	siblingPaths [][]byte,
 	accessed *accessedState,
+	produceExclusionProofs bool,
 ) (encodedNodes []hexutil.Bytes, err error) {
 	encodedNodes = []hexutil.Bytes{}
 
@@ -1140,7 +1143,7 @@ func buildWitnessTrie(
 		}
 	}
 
-	witnessTrie, witnessRoot, err := sdCtx.Witness(ctx, accessed.CodeReads, "debug_executionWitness_witness_construction")
+	witnessTrie, witnessRoot, err := sdCtx.Witness(ctx, accessed.CodeReads, "debug_executionWitness_witness_construction", produceExclusionProofs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate witness: %w", err)
 	}
@@ -1340,7 +1343,7 @@ func (api *DebugAPIImpl) buildExpectedPostState(
 	}
 
 	// Generate the trie with correct storage roots
-	postTrie, postRoot, err := postSdCtx.Witness(ctx, nil, "debug_executionWitness_postState")
+	postTrie, postRoot, err := postSdCtx.Witness(ctx, nil, "debug_executionWitness_postState", false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate post-state trie: %w", err)
 	}

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -507,7 +507,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 	sdCtx.TouchKey(kv.AccountsDomain, string(address[:]), nil)
 
 	// generate the trie for proofs, this works by loading the merkle paths to the touched keys
-	proofTrie, calculatedAccountProofRoot, err := sdCtx.Witness(ctx, nil, "eth_getProof")
+	proofTrie, calculatedAccountProofRoot, err := sdCtx.Witness(ctx, nil, "eth_getProof", false)
 	if err != nil {
 		return nil, err
 	}
@@ -563,7 +563,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 
 		// generate the trie for proofs, this works by loading the merkle paths to the touched key
 		var storageProofRoot []byte
-		proofTrie, storageProofRoot, err = sdCtx.Witness(ctx, nil, "eth_getProof")
+		proofTrie, storageProofRoot, err = sdCtx.Witness(ctx, nil, "eth_getProof", false)
 		if err != nil {
 			return nil, err
 		}
@@ -762,7 +762,7 @@ func (api *BaseAPI) getWitness(ctx context.Context, db kv.TemporalRoDB, blockNrO
 	}
 
 	// generate the block witness, this works by loading the merkle paths to the touched keys (they are loaded from the state at block #blockNr-1)
-	witnessTrie, witnessRootHash, err := sdCtx.Witness(ctx, codeReads, "computeWitness")
+	witnessTrie, witnessRootHash, err := sdCtx.Witness(ctx, codeReads, "computeWitness", false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #21810.

`debug_executionWitness` omitted the exclusion proof for a storage slot read during a block that resolves to zero, when the slot's path diverges at a folded extension. The diverging extension was emitted with a bare hash child, so a strict stateless verifier cannot descend it to prove the slot absent. Erigon's own stateless verifier accepts such a witness, which is why this went unnoticed.

## Fix
Materialize the branch behind the extension in `toWitnessTrie` (`witnessMaterializeBranch`). The branch hashes to the same value, so the witness root is unchanged — the witness just carries the previously-missing branch node, guarded by a `subRoot == cell.hash` check.

## Test
`Test_WitnessTrie_GenerateWitness/AbsentStorageSlotDivergingAtFoldedExtension` builds a storage trie with an extension and witnesses an absent slot diverging inside it. A strict sparse-trie walk over the witness rejects it before the fix and accepts it after.

## Validation
Verified on mainnet blocks 25302399 (the one in the issue), 25302398/400, 25310000, 25315000, 25320000: the witness now passes external stateless validation. Witness node count for 25302399: 10789 -> 10806; commitment root unchanged.