### PR TITLE
execution/types: reduce typed-transaction Hash() allocations (no []any, no reflection)

### DIFF
--- a/execution/types/aa_transaction.go
+++ b/execution/types/aa_transaction.go
@@ -162,21 +162,10 @@ func (tx *AccountAbstractionTransaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(AccountAbstractionTxType, []any{
-		tx.ChainID,
-		tx.NonceKey, tx.Nonce,
-		tx.SenderAddress, tx.SenderValidationData,
-		tx.Deployer, tx.DeployerData,
-		tx.Paymaster, tx.PaymasterData,
-		tx.ExecutionData,
-		tx.BuilderFee,
-		tx.Tip, tx.FeeCap,
-		tx.ValidationGasLimit, tx.PaymasterValidationGasLimit, tx.PostOpGasLimit,
-		tx.GasLimit,
-		tx.AccessList,
-		tx.Authorizations,
+	payloadSize, accessListLen, authorizationsLen := tx.payloadSize()
+	hash := prefixedPayloadHash(AccountAbstractionTxType, func(w io.Writer, b []byte) error {
+		return tx.encodePayload(w, b, payloadSize, accessListLen, authorizationsLen)
 	})
-
 	tx.hash.Store(&hash)
 	return hash
 }

--- a/execution/types/access_list_tx.go
+++ b/execution/types/access_list_tx.go
@@ -408,16 +408,9 @@ func (tx *AccessListTx) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(AccessListTxType, []any{
-		&tx.ChainID,
-		tx.Nonce,
-		&tx.GasPrice,
-		tx.GasLimit,
-		tx.To,
-		&tx.Value,
-		tx.Data,
-		tx.AccessList,
-		tx.V, tx.R, tx.S,
+	payloadSize, accessListLen := tx.payloadSize()
+	hash := prefixedPayloadHash(AccessListTxType, func(w io.Writer, b []byte) error {
+		return tx.encodePayload(w, b, payloadSize, accessListLen)
 	})
 	tx.hash.Store(&hash)
 	return hash

--- a/execution/types/blob_tx.go
+++ b/execution/types/blob_tx.go
@@ -144,19 +144,9 @@ func (stx *BlobTx) Hash() common.Hash {
 	if hash := stx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(BlobTxType, []any{
-		&stx.ChainID,
-		stx.Nonce,
-		&stx.TipCap,
-		&stx.FeeCap,
-		stx.GasLimit,
-		stx.To,
-		&stx.Value,
-		stx.Data,
-		stx.AccessList,
-		&stx.MaxFeePerBlobGas,
-		stx.BlobVersionedHashes,
-		stx.V, stx.R, stx.S,
+	payloadSize, accessListLen, blobHashesLen := stx.payloadSize()
+	hash := prefixedPayloadHash(BlobTxType, func(w io.Writer, b []byte) error {
+		return stx.encodePayload(w, b, payloadSize, accessListLen, blobHashesLen)
 	})
 	stx.hash.Store(&hash)
 	return hash
@@ -271,11 +261,7 @@ func (stx *BlobTx) encodePayload(w io.Writer, b []byte, payloadSize, accessListL
 		return err
 	}
 	// encode To
-	b[0] = 128 + 20
-	if _, err := w.Write(b[:1]); err != nil {
-		return err
-	}
-	if _, err := w.Write(stx.To[:]); err != nil {
+	if err := EncodeOptionalAddress(stx.To, w, b); err != nil {
 		return err
 	}
 	// encode Value

--- a/execution/types/dynamic_fee_tx.go
+++ b/execution/types/dynamic_fee_tx.go
@@ -316,17 +316,9 @@ func (tx *DynamicFeeTransaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(DynamicFeeTxType, []any{
-		&tx.ChainID,
-		tx.Nonce,
-		&tx.TipCap,
-		&tx.FeeCap,
-		tx.GasLimit,
-		tx.To,
-		&tx.Value,
-		tx.Data,
-		tx.AccessList,
-		tx.V, tx.R, tx.S,
+	payloadSize, accessListLen := tx.payloadSize()
+	hash := prefixedPayloadHash(DynamicFeeTxType, func(w io.Writer, b []byte) error {
+		return tx.encodePayload(w, b, payloadSize, accessListLen)
 	})
 	tx.hash.Store(&hash)
 	return hash

--- a/execution/types/hashing.go
+++ b/execution/types/hashing.go
@@ -194,11 +194,33 @@ func init() {
 // given interface. It's used for typed transactions.
 func prefixedRlpHash(prefix byte, x any) common.Hash {
 	sha := crypto.NewKeccakState()
+	defer crypto.ReturnToPool(sha)
 	sha.Write(prefixSlices[prefix]) //nolint:errcheck
 	if err := rlp.Encode(sha, x); err != nil {
 		panic(err)
 	}
-	h := crypto.FinalizeHash(sha)
-	crypto.ReturnToPool(sha)
-	return h
+	return crypto.FinalizeHash(sha)
+}
+
+// rlpPayloadHash hashes keccak256 of whatever encode writes, using a pooled
+// hasher and scratch buffer so callers avoid the reflection-based RlpHash.
+func rlpPayloadHash(encode func(w io.Writer, buf []byte) error) common.Hash {
+	sha := crypto.NewKeccakState()
+	defer crypto.ReturnToPool(sha)
+	buf := rlp.NewEncodingBuf()
+	defer buf.Release()
+	if err := encode(sha, buf[:]); err != nil {
+		panic(err)
+	}
+	return crypto.FinalizeHash(sha)
+}
+
+// prefixedPayloadHash hashes keccak256(prefix || payload) for typed transactions.
+func prefixedPayloadHash(prefix byte, encode func(w io.Writer, buf []byte) error) common.Hash {
+	return rlpPayloadHash(func(w io.Writer, buf []byte) error {
+		if _, err := w.Write(prefixSlices[prefix]); err != nil {
+			return err
+		}
+		return encode(w, buf)
+	})
 }

--- a/execution/types/legacy_tx.go
+++ b/execution/types/legacy_tx.go
@@ -353,14 +353,9 @@ func (tx *LegacyTx) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := RlpHash([]any{
-		tx.Nonce,
-		&tx.GasPrice,
-		tx.GasLimit,
-		tx.To,
-		&tx.Value,
-		tx.Data,
-		tx.V, tx.R, tx.S,
+	payloadSize := tx.payloadSize()
+	hash := rlpPayloadHash(func(w io.Writer, b []byte) error {
+		return tx.encodePayload(w, b, payloadSize)
 	})
 	tx.hash.Store(&hash)
 	return hash

--- a/execution/types/set_code_tx.go
+++ b/execution/types/set_code_tx.go
@@ -175,18 +175,9 @@ func (tx *SetCodeTransaction) Hash() common.Hash {
 	if hash := tx.hash.Load(); hash != nil {
 		return *hash
 	}
-	hash := prefixedRlpHash(SetCodeTxType, []any{
-		&tx.ChainID,
-		tx.Nonce,
-		&tx.TipCap,
-		&tx.FeeCap,
-		tx.GasLimit,
-		tx.To,
-		&tx.Value,
-		tx.Data,
-		tx.AccessList,
-		tx.Authorizations,
-		tx.V, tx.R, tx.S,
+	payloadSize, accessListLen, authorizationsLen := tx.payloadSize()
+	hash := prefixedPayloadHash(SetCodeTxType, func(w io.Writer, b []byte) error {
+		return tx.encodePayload(w, b, payloadSize, accessListLen, authorizationsLen)
 	})
 	tx.hash.Store(&hash)
 	return hash

--- a/execution/types/transaction_hash_opt_test.go
+++ b/execution/types/transaction_hash_opt_test.go
@@ -1,0 +1,188 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+)
+
+// The reference*Hash helpers reproduce the historical reflection-based ([]any)
+// hashing so the encodePayload-based Hash() can be checked byte-for-byte.
+
+func referenceLegacyHash(tx *LegacyTx) common.Hash {
+	return RlpHash([]any{
+		tx.Nonce,
+		&tx.GasPrice,
+		tx.GasLimit,
+		tx.To,
+		&tx.Value,
+		tx.Data,
+		tx.V, tx.R, tx.S,
+	})
+}
+
+func referenceAccessListHash(tx *AccessListTx) common.Hash {
+	return prefixedRlpHash(AccessListTxType, []any{
+		&tx.ChainID,
+		tx.Nonce,
+		&tx.GasPrice,
+		tx.GasLimit,
+		tx.To,
+		&tx.Value,
+		tx.Data,
+		tx.AccessList,
+		tx.V, tx.R, tx.S,
+	})
+}
+
+func referenceDynamicFeeHash(tx *DynamicFeeTransaction) common.Hash {
+	return prefixedRlpHash(DynamicFeeTxType, []any{
+		&tx.ChainID,
+		tx.Nonce,
+		&tx.TipCap,
+		&tx.FeeCap,
+		tx.GasLimit,
+		tx.To,
+		&tx.Value,
+		tx.Data,
+		tx.AccessList,
+		tx.V, tx.R, tx.S,
+	})
+}
+
+func referenceBlobHash(tx *BlobTx) common.Hash {
+	return prefixedRlpHash(BlobTxType, []any{
+		&tx.ChainID,
+		tx.Nonce,
+		&tx.TipCap,
+		&tx.FeeCap,
+		tx.GasLimit,
+		tx.To,
+		&tx.Value,
+		tx.Data,
+		tx.AccessList,
+		&tx.MaxFeePerBlobGas,
+		tx.BlobVersionedHashes,
+		tx.V, tx.R, tx.S,
+	})
+}
+
+func referenceSetCodeHash(tx *SetCodeTransaction) common.Hash {
+	return prefixedRlpHash(SetCodeTxType, []any{
+		&tx.ChainID,
+		tx.Nonce,
+		&tx.TipCap,
+		&tx.FeeCap,
+		tx.GasLimit,
+		tx.To,
+		&tx.Value,
+		tx.Data,
+		tx.AccessList,
+		tx.Authorizations,
+		tx.V, tx.R, tx.S,
+	})
+}
+
+func TestTxHashMatchesReflectionReference(t *testing.T) {
+	t.Parallel()
+	tr := NewTRand()
+	for i := 0; i < 300; i++ {
+		legacy := tr.RandTransaction(LegacyTxType).(*LegacyTx)
+		assertHash(t, "legacy", legacy.Hash(), referenceLegacyHash(legacy))
+
+		al := tr.RandTransaction(AccessListTxType).(*AccessListTx)
+		assertHash(t, "accesslist", al.Hash(), referenceAccessListHash(al))
+
+		dyn := tr.RandTransaction(DynamicFeeTxType).(*DynamicFeeTransaction)
+		assertHash(t, "dynamicfee", dyn.Hash(), referenceDynamicFeeHash(dyn))
+
+		blob := tr.RandTransaction(BlobTxType).(*BlobTx)
+		assertHash(t, "blob", blob.Hash(), referenceBlobHash(blob))
+
+		setcode := tr.RandTransaction(SetCodeTxType).(*SetCodeTransaction)
+		assertHash(t, "setcode", setcode.Hash(), referenceSetCodeHash(setcode))
+	}
+}
+
+func assertHash(t *testing.T, name string, got, want common.Hash) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s: hash mismatch: got %x want %x", name, got, want)
+	}
+}
+
+// TestAAHashMatchesMarshalBinary checks AccountAbstractionTransaction's hash against its
+// canonical serialization. AA can't use the reflection oracle above: its SenderAddress
+// (accounts.Address = unique.Handle) has unexported fields the reflection encoder skips,
+// so the old []any hash dropped the sender. Hash() now uses encodePayload, matching the
+// wire bytes from MarshalBinary.
+func TestAAHashMatchesMarshalBinary(t *testing.T) {
+	t.Parallel()
+	tr := NewTRand()
+	for i := 0; i < 100; i++ {
+		tx := tr.RandTransaction(AccountAbstractionTxType).(*AccountAbstractionTransaction)
+		var buf bytes.Buffer
+		if err := tx.MarshalBinary(&buf); err != nil {
+			t.Fatalf("MarshalBinary: %v", err)
+		}
+		if got, want := tx.Hash(), crypto.HashData(buf.Bytes()); got != want {
+			t.Fatalf("AA Hash %x != keccak(MarshalBinary) %x", got, want)
+		}
+	}
+}
+
+func BenchmarkTxHash(b *testing.B) {
+	tr := NewTRand()
+	for name, txType := range map[string]int{
+		"legacy":     LegacyTxType,
+		"accesslist": AccessListTxType,
+		"dynamicfee": DynamicFeeTxType,
+		"blob":       BlobTxType,
+		"setcode":    SetCodeTxType,
+		"aa":         AccountAbstractionTxType,
+	} {
+		tx := tr.RandTransaction(txType)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				tx.Hash()
+				resetTxHashCache(tx)
+			}
+		})
+	}
+}
+
+func resetTxHashCache(tx Transaction) {
+	switch t := tx.(type) {
+	case *LegacyTx:
+		t.hash.Store(nil)
+	case *AccessListTx:
+		t.hash.Store(nil)
+	case *DynamicFeeTransaction:
+		t.hash.Store(nil)
+	case *BlobTx:
+		t.hash.Store(nil)
+	case *SetCodeTransaction:
+		t.hash.Store(nil)
+	case *AccountAbstractionTransaction:
+		t.hash.Store(nil)
+	}
+}


### PR DESCRIPTION
On Bloatnet i noticed "GC stop-the-world spike"

The win is from **not using `[]any` casting and not using reflection**:

- the old `Hash()` built a `[]any{...}` of the tx fields (slice alloc + boxing each `uint64`/pointer into an interface), then
- handed it to the **reflection-based** `rlp.Encode`, which walks the values dynamically and allocates as it goes.

### Applied to

`LegacyTx`, `AccessListTx`, `DynamicFeeTransaction`, `BlobTx`, `SetCodeTransaction`, `AccountAbstractionTransaction` — every tx type that already has an `encodePayload`.

### Results (`BenchmarkTxHash`, M4 Max — allocs/op)

| type | before | after |
|---|---|---|
| legacy | 8 | 1 |
| accesslist | 9 | 1 |
| dynamicfee | 9 | 1 |
| blob | 10 | 1 |
| setcode | 22 | 1 |
| aa | 13 | 1 |

### Two behavioral notes

- **`BlobTx.encodePayload`** previously dereferenced `To` unconditionally (it had a non-nil-`To` precondition enforced by the `ErrNilToFieldTx` guards in `MarshalBinary`/`EncodeRLP`). It now encodes `To` via `EncodeOptionalAddress` — **byte-identical** for the always-present `To` of a valid blob tx, and consistent with its own `payloadSize` (which already sizes `To` optionally). `MarshalBinary`/`EncodeRLP` keep their `ErrNilToFieldTx` guards, so their external contract is unchanged.
- **`AccountAbstractionTransaction`'s hash value changes.** Its old `[]any` path encoded `SenderAddress` (`accounts.Address` = `unique.Handle`, which has unexported fields) through reflection, which silently **dropped the sender from the hash**. `Hash()` now goes through `encodePayload` and equals `keccak256` of the canonical `MarshalBinary` bytes. AA (RIP-7560) is not live, so this is a latent-bug fix rather than a consensus change.

