### PR TITLE
db/recsplit/eliasfano16, db/recsplit/eliasfano32: don't mutate fuzzer input

### DIFF
--- a/db/recsplit/eliasfano16/elias_fano_fuzz_test.go
+++ b/db/recsplit/eliasfano16/elias_fano_fuzz_test.go
@@ -17,6 +17,7 @@
 package eliasfano16
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -30,6 +31,9 @@ func FuzzSingleEliasFano(f *testing.F) {
 		if len(in) == 0 {
 			t.Skip()
 		}
+		// The fuzzing engine hands the input as a read-only buffer; clone it
+		// before growing so the appends below never write into that buffer.
+		in = bytes.Clone(in)
 		for len(in) < int(2*superQ) { // make input large enough to trigger supreQ jump logic
 			in = append(in, in...)
 		}
@@ -67,6 +71,9 @@ func FuzzDoubleEliasFano(f *testing.F) {
 		if len(in) == 0 {
 			t.Skip()
 		}
+		// The fuzzing engine hands the input as a read-only buffer; clone it
+		// before growing so the appends below never write into that buffer.
+		in = bytes.Clone(in)
 		for len(in) < int(2*superQ) { // make input large enough to trigger supreQ jump logic
 			in = append(in, in...)
 		}

--- a/db/recsplit/eliasfano32/elias_fano_fuzz_test.go
+++ b/db/recsplit/eliasfano32/elias_fano_fuzz_test.go
@@ -32,6 +32,9 @@ func FuzzSingleEliasFano(f *testing.F) {
 		if len(in) == 0 {
 			t.Skip()
 		}
+		// The fuzzing engine hands the input as a read-only buffer; clone it
+		// before growing so the appends below never write into that buffer.
+		in = bytes.Clone(in)
 		for len(in) < int(2*superQ) { // make input large enough to trigger supreQ jump logic
 			in = append(in, in...)
 		}
@@ -112,6 +115,9 @@ func FuzzDoubleEliasFano(f *testing.F) {
 		if len(in) == 0 {
 			t.Skip()
 		}
+		// The fuzzing engine hands the input as a read-only buffer; clone it
+		// before growing so the appends below never write into that buffer.
+		in = bytes.Clone(in)
 		for len(in) < int(2*superQ) { // make input large enough to trigger supreQ jump logic
 			in = append(in, in...)
 		}


### PR DESCRIPTION
Fixes an OSS-Fuzz report (issue 525088104, target `fuzz_ef32_double`, crash type Overwrites-const-input).

The EliasFano fuzzers grew the input with `in = append(in, in...)`. The fuzzing engine passes the input as a read-only buffer (often with spare capacity), so the first append could write into it — ASAN flags this as "Overwrites-const-input". Cloning the input with `bytes.Clone` before growing keeps all appends on our own buffer. Applied to all four EliasFano fuzzers (ef16/ef32 × single/double), which share the pattern.

**Scope:** fuzz-target only. The EliasFano implementation is unaffected (it decodes freshly-allocated cumKeys/position slices, not the input), so there is no runtime/consensus impact and nothing ships in any released binary.