### PR TITLE
execution/types: reject non-canonical BAL integer values and keys

### DIFF
--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -297,14 +297,11 @@ func (sc *StorageChange) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("read Index: value %d exceeds uint32", idx)
 	}
 	sc.Index = uint32(idx)
-	valBytes, err := s.Bytes()
-	if err != nil {
+	// ReadUint256 enforces canonical (minimal) integer encoding, matching the
+	// encoder and rejecting non-canonical values (leading zero bytes).
+	if err := s.ReadUint256(&sc.Value); err != nil {
 		return fmt.Errorf("read Value: %w", err)
 	}
-	if len(valBytes) > 32 {
-		return fmt.Errorf("read Value: too large (%d bytes)", len(valBytes))
-	}
-	sc.Value.SetBytes(valBytes)
 	return s.ListEnd()
 }
 
@@ -340,14 +337,11 @@ func (bc *BalanceChange) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("read Index: value %d exceeds uint32", idx)
 	}
 	bc.Index = uint32(idx)
-	valBytes, err := s.Bytes()
-	if err != nil {
+	// ReadUint256 enforces canonical (minimal) integer encoding, matching the
+	// encoder and rejecting non-canonical values (leading zero bytes).
+	if err := s.ReadUint256(&bc.Value); err != nil {
 		return fmt.Errorf("read Value: %w", err)
 	}
-	if len(valBytes) > 32 {
-		return fmt.Errorf("read Value: integer too large (%d bytes)", len(valBytes))
-	}
-	bc.Value.SetBytes(valBytes)
 	return s.ListEnd()
 }
 

--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -804,19 +804,14 @@ func hashToUint256(h common.Hash) uint256.Int {
 	return v
 }
 
-// decodeMinimalHash reads an RLP byte string and right-aligns it into a 32-byte hash.
-// Handles minimal-encoded values (leading zeros stripped).
+// decodeMinimalHash reads a slot/key into a 32-byte hash; ReadUint256 enforces
+// canonical (minimal) encoding, matching the encoder and preventing key malleability.
 func decodeMinimalHash(s *rlp.Stream) (common.Hash, error) {
-	raw, err := s.Bytes()
-	if err != nil {
+	var v uint256.Int
+	if err := s.ReadUint256(&v); err != nil {
 		return common.Hash{}, err
 	}
-	if len(raw) > 32 {
-		return common.Hash{}, fmt.Errorf("hash too large: %d bytes", len(raw))
-	}
-	var out common.Hash
-	copy(out[32-len(raw):], raw)
-	return out, nil
+	return common.Hash(v.Bytes32()), nil
 }
 
 func (bal BlockAccessList) Hash() common.Hash {

--- a/execution/types/block_access_list_canon_test.go
+++ b/execution/types/block_access_list_canon_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/erigontech/erigon/common"
@@ -17,8 +18,8 @@ func TestStorageChangeRejectsNonCanonicalValue(t *testing.T) {
 	t.Parallel()
 	input := common.FromHex("0xc20100") // list[Index=1, Value=0x00]
 	var sc StorageChange
-	if err := rlp.DecodeBytes(input, &sc); err == nil {
-		t.Fatalf("expected error for non-canonical Value, got nil (Value=%s)", sc.Value.String())
+	if err := rlp.DecodeBytes(input, &sc); !errors.Is(err, rlp.ErrCanonInt) {
+		t.Fatalf("expected ErrCanonInt for non-canonical Value, got %v (Value=%s)", err, sc.Value.String())
 	}
 }
 
@@ -26,8 +27,8 @@ func TestBalanceChangeRejectsNonCanonicalValue(t *testing.T) {
 	t.Parallel()
 	input := common.FromHex("0xc20100") // list[Index=1, Value=0x00]
 	var bc BalanceChange
-	if err := rlp.DecodeBytes(input, &bc); err == nil {
-		t.Fatalf("expected error for non-canonical Value, got nil (Value=%s)", bc.Value.String())
+	if err := rlp.DecodeBytes(input, &bc); !errors.Is(err, rlp.ErrCanonInt) {
+		t.Fatalf("expected ErrCanonInt for non-canonical Value, got %v (Value=%s)", err, bc.Value.String())
 	}
 }
 
@@ -40,8 +41,8 @@ func TestSlotChangesRejectsNonCanonicalSlot(t *testing.T) {
 	// SlotChanges = [Slot, [ [Index=1, Value=1] ]]; slot 0x0001 has a leading zero.
 	nonCanonical := common.FromHex("0xc7820001c3c20101")
 	var sc SlotChanges
-	if err := rlp.DecodeBytes(nonCanonical, &sc); err == nil {
-		t.Fatalf("expected error for non-canonical slot, got nil (slot=%x)", sc.Slot.Value())
+	if err := rlp.DecodeBytes(nonCanonical, &sc); !errors.Is(err, rlp.ErrCanonInt) {
+		t.Fatalf("expected ErrCanonInt for non-canonical slot, got %v (slot=%x)", err, sc.Slot.Value())
 	}
 	// The minimal form 0x01 of the same slot must still decode.
 	canonical := common.FromHex("0xc501c3c20101")
@@ -55,8 +56,8 @@ func TestDecodeMinimalHashRejectsNonCanonical(t *testing.T) {
 	t.Parallel()
 	for _, nonCanonical := range []string{"0x00", "0x820001"} {
 		s := rlp.NewStream(bytes.NewReader(common.FromHex(nonCanonical)), 0)
-		if _, err := decodeMinimalHash(s); err == nil {
-			t.Fatalf("input %s: expected error for non-canonical key, got nil", nonCanonical)
+		if _, err := decodeMinimalHash(s); !errors.Is(err, rlp.ErrCanonInt) {
+			t.Fatalf("input %s: expected ErrCanonInt, got %v", nonCanonical, err)
 		}
 	}
 	for _, c := range []struct {

--- a/execution/types/block_access_list_canon_test.go
+++ b/execution/types/block_access_list_canon_test.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/rlp"
+)
+
+// StorageChange/BalanceChange values are uint256 integers and must be encoded
+// canonically (minimal big-endian, no leading zero bytes; zero is the empty
+// string 0x80). The decoder must reject non-canonical encodings — accepting
+// them is an RLP malleability. Here 0x00 is a non-canonical zero.
+
+func TestStorageChangeRejectsNonCanonicalValue(t *testing.T) {
+	t.Parallel()
+	input := common.FromHex("0xc20100") // list[Index=1, Value=0x00]
+	var sc StorageChange
+	if err := rlp.DecodeBytes(input, &sc); err == nil {
+		t.Fatalf("expected error for non-canonical Value, got nil (Value=%s)", sc.Value.String())
+	}
+}
+
+func TestBalanceChangeRejectsNonCanonicalValue(t *testing.T) {
+	t.Parallel()
+	input := common.FromHex("0xc20100") // list[Index=1, Value=0x00]
+	var bc BalanceChange
+	if err := rlp.DecodeBytes(input, &bc); err == nil {
+		t.Fatalf("expected error for non-canonical Value, got nil (Value=%s)", bc.Value.String())
+	}
+}

--- a/execution/types/block_access_list_canon_test.go
+++ b/execution/types/block_access_list_canon_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/erigontech/erigon/common"
@@ -27,5 +28,48 @@ func TestBalanceChangeRejectsNonCanonicalValue(t *testing.T) {
 	var bc BalanceChange
 	if err := rlp.DecodeBytes(input, &bc); err == nil {
 		t.Fatalf("expected error for non-canonical Value, got nil (Value=%s)", bc.Value.String())
+	}
+}
+
+// Slot keys and storage-read keys (uint256, decoded via decodeMinimalHash) carry
+// the same canonical-encoding requirement as the value fields. A non-minimal slot
+// (leading zero byte) must be rejected, not silently mapped to the same key as its
+// minimal form.
+func TestSlotChangesRejectsNonCanonicalSlot(t *testing.T) {
+	t.Parallel()
+	// SlotChanges = [Slot, [ [Index=1, Value=1] ]]; slot 0x0001 has a leading zero.
+	nonCanonical := common.FromHex("0xc7820001c3c20101")
+	var sc SlotChanges
+	if err := rlp.DecodeBytes(nonCanonical, &sc); err == nil {
+		t.Fatalf("expected error for non-canonical slot, got nil (slot=%x)", sc.Slot.Value())
+	}
+	// The minimal form 0x01 of the same slot must still decode.
+	canonical := common.FromHex("0xc501c3c20101")
+	var sc2 SlotChanges
+	if err := rlp.DecodeBytes(canonical, &sc2); err != nil {
+		t.Fatalf("canonical slot must decode, got %v", err)
+	}
+}
+
+func TestDecodeMinimalHashRejectsNonCanonical(t *testing.T) {
+	t.Parallel()
+	for _, nonCanonical := range []string{"0x00", "0x820001"} {
+		s := rlp.NewStream(bytes.NewReader(common.FromHex(nonCanonical)), 0)
+		if _, err := decodeMinimalHash(s); err == nil {
+			t.Fatalf("input %s: expected error for non-canonical key, got nil", nonCanonical)
+		}
+	}
+	for _, c := range []struct {
+		hex  string
+		want uint64
+	}{{"0x80", 0}, {"0x01", 1}} {
+		s := rlp.NewStream(bytes.NewReader(common.FromHex(c.hex)), 0)
+		h, err := decodeMinimalHash(s)
+		if err != nil {
+			t.Fatalf("input %s: canonical key must decode, got %v", c.hex, err)
+		}
+		if got := h.Big().Uint64(); got != c.want {
+			t.Fatalf("input %s: got key %d, want %d", c.hex, got, c.want)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

In the EIP-7928 block access list decoder, several `uint256` fields were decoded in ways that accept **non-canonical RLP integers** — leading zero bytes, or `0x00` for zero (canonical zero is the empty string `0x80`):

- `StorageChange.Value` and `BalanceChange.Value` — via `s.Bytes()` + `SetBytes`;
- slot keys (`SlotChanges.Slot`) and storage-read keys — via `decodeMinimalHash` (`s.Bytes()` + left-pad), which silently mapped a non-minimal key (e.g. `0x0001`) to the **same** hash as its minimal form (`0x01`).

This is inconsistent with:
- the **encoder**, which writes canonical/minimal values (`rlp.EncodeUint256`, including slot/read keys);
- the **sibling fields**, which decode with canonical-enforcing readers (`s.Uint64`, incl. `NonceChange`);
- the **RLP spec**, under which integers are canonical (EIP-7928 defines `StorageValue`, `Balance`, and storage keys as `uint256`).

So the decoder was more lenient than its own encoder. Since `BlockAccessList.Hash()` re-encodes canonically before hashing, Erigon would treat a non-canonically-encoded BAL as matching a canonical header hash — i.e. **accept input a stricter client would reject**, an RLP malleability with cross-client-divergence risk. Low likelihood from honest producers (they encode canonically), but worth closing while EIP-7928 is still on devnets.

## Fix

Decode these `uint256` fields via `s.ReadUint256`, which enforces minimal encoding (rejects leading zero bytes, `ErrCanonInt`) and the 32-byte bound:

- `StorageChange.Value` / `BalanceChange.Value`;
- `decodeMinimalHash` (slot keys + storage-read keys) now reads via `ReadUint256` and right-aligns the result into the 32-byte hash.

`NonceChange` already used `s.Uint64` and is unaffected.

## Tests

- `TestStorageChangeRejectsNonCanonicalValue` / `TestBalanceChangeRejectsNonCanonicalValue` — input `c20100` = `[Index=1, Value=0x00]`.
- `TestSlotChangesRejectsNonCanonicalSlot` — input `c7820001c3c20101` (slot `0x0001`); rejects the non-minimal slot, still decodes the canonical `0x01` form.
- `TestDecodeMinimalHashRejectsNonCanonical` — rejects `0x00` / `0x820001`, accepts canonical `0x80` (→ 0) and `0x01` (→ 1).

Each fails before its fix and passes after; existing BAL round-trip tests (canonical values) still pass; `make lint` clean.

## Note

This touches EIP-7928 consensus decode — flagging for BAL maintainers' awareness, though the direction is unambiguous (align decoder strictness with the encoder, the sibling fields, and the RLP spec).
