### PR TITLE
execution/commitment: materialize collapse-sibling branch in toWitnessTrie

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1388,6 +1388,28 @@ func (hph *HexPatriciaHashed) witnessMaterializeBranchChild(branchPrefix []byte,
 	return branchNode, nil
 }
 
+// witnessDivergedBranchChild is the node attached below a folded extension whose path
+// diverges from the witnessed key: the materialized branch in exclusion-proof mode (so a
+// strict verifier can descend it), otherwise its hash. depth is the cell's grid depth, used
+// to compute the hash when the cell carries no precomputed hash-ref.
+func (hph *HexPatriciaHashed) witnessDivergedBranchChild(produceExclusionProofs bool, cell *cell, branchPrefix []byte, depth int16) (trie.Node, error) {
+	if cell.hashLen > 0 {
+		wantHash := cell.hash[:cell.hashLen]
+		if produceExclusionProofs {
+			return hph.witnessMaterializeBranchChild(branchPrefix, int16(len(branchPrefix))+1, wantHash)
+		}
+		return trie.NewHashNode(common.Copy(wantHash)), nil
+	}
+	cellHash, _, _, err := hph.witnessComputeCellHashWithStorage(cell, depth, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(cellHash) == length.Hash+1 { // strip the 0xa0 prefix
+		cellHash = cellHash[1:]
+	}
+	return trie.NewHashNode(common.Copy(cellHash)), nil
+}
+
 func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[common.Hash]witnesstypes.CodeWithHash, produceExclusionProofs bool) (*trie.Trie, error) {
 	var rootNode trie.Node = &trie.FullNode{}
 	var currentNode trie.Node = rootNode
@@ -1441,21 +1463,14 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 				// the traversal can be stopped at this level
 				pathDivergenceFound = true
 				short := &trie.ShortNode{Key: common.Copy(hashedExtKey)}
-				// For an absent account or storage key diverging at a folded extension, a strict
-				// sparse-trie verifier needs the branch behind the extension
-				// materialized, not a bare HashNode. The branch hashes
-				// to the same value, so the witness root is unchanged.
-				if produceExclusionProofs && (len(hashedKey) == 64 || len(hashedKey) == 128) && cellToExpand.hashLen > 0 {
-					branchPrefix := make([]byte, 0, int(keyPos)+1+len(hashedExtKey))
-					branchPrefix = append(branchPrefix, hashedKey[:keyPos+1]...)
-					branchPrefix = append(branchPrefix, hashedExtKey...)
-					branchNode, err := hph.witnessMaterializeBranchChild(branchPrefix, int16(len(branchPrefix))+1, cellToExpand.hash[:cellToExpand.hashLen])
-					if err != nil {
-						return nil, err
-					}
-					short.Val = branchNode
+				branchPrefix := make([]byte, 0, int(keyPos)+1+len(hashedExtKey))
+				branchPrefix = append(branchPrefix, hashedKey[:keyPos+1]...)
+				branchPrefix = append(branchPrefix, hashedExtKey...)
+				child, cerr := hph.witnessDivergedBranchChild(produceExclusionProofs, cellToExpand, branchPrefix, hph.depths[row])
+				if cerr != nil {
+					return nil, cerr
 				}
-				// Otherwise Val is set to a HashNode of the branch it points to when the current node is processed.
+				short.Val = child
 				nextNode = short
 			} else {
 				keyPos += extKeyLength // jump ahead
@@ -1587,15 +1602,6 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 				}
 			}
 
-			// this deals with the edge case where the extension key in nextNode diverges from hashedKey
-			// and points to a branch node. In this case we just need to provide the hash of this branch node
-			// (unless the branch was already materialized for an absent-slot exclusion proof).
-			if pathDivergenceFound {
-				if sn, ok := nextNode.(*trie.ShortNode); ok && sn.Val == nil {
-					terminalCell := &hph.grid[row][currentNibble]
-					sn.Val = trie.NewHashNode(common.Copy(terminalCell.hash[:]))
-				}
-			}
 			fullNode.Children[currentNibble] = nextNode // ready to expand next nibble in the path
 		} else if accNode, ok := currentNode.(*trie.AccountNode); ok {
 			if len(hashedKey) <= 64 { // no storage, stop here
@@ -1607,22 +1613,6 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 			}
 
 			// there is storage so we need to expand further
-			if pathDivergenceFound {
-				// Same handling as FullNode divergence: set the ShortNode's Val to the
-				// cell's hash so the proof is complete even when the extension diverges.
-				if shortNode, ok := nextNode.(*trie.ShortNode); ok && shortNode.Val == nil {
-					terminalCell := &hph.grid[row][currentNibble]
-					if terminalCell.hashLen > 0 {
-						shortNode.Val = trie.NewHashNode(common.Copy(terminalCell.hash[:terminalCell.hashLen]))
-					} else {
-						cellHash, _, _, _ := hph.witnessComputeCellHashWithStorage(terminalCell, hph.depths[row], nil)
-						if len(cellHash) == length.Hash+1 { // +1 for the a0 prefix
-							cellHash = cellHash[1:] // strip the a0 prefix
-						}
-						shortNode.Val = trie.NewHashNode(common.Copy(cellHash))
-					}
-				}
-			}
 			accNode.Storage = nextNode
 			if hph.trace {
 				fmt.Printf("[witness] AccountNode (+storage) (%d, %0x, depth=%d) %s proof %+v\n", row, currentNibble, hph.depths[row], cellToExpand.FullString(), accNode)

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1373,6 +1373,21 @@ func (hph *HexPatriciaHashed) witnessMaterializeBranch(branchPrefix []byte, chil
 	return fullNode, nil
 }
 
+// witnessMaterializeBranchChild decodes the branch at branchPrefix and verifies it
+// hashes to wantHash, returning a node a strict verifier can descend instead of a bare
+// HashNode. Same hash, so the witness root is unchanged.
+func (hph *HexPatriciaHashed) witnessMaterializeBranchChild(branchPrefix []byte, childDepth int16, wantHash []byte) (*trie.FullNode, error) {
+	branchNode, err := hph.witnessMaterializeBranch(branchPrefix, childDepth)
+	if err != nil {
+		return nil, err
+	}
+	subRoot := trie.NewInMemoryTrie(branchNode).Hash()
+	if !bytes.Equal(subRoot[:], wantHash) {
+		return nil, fmt.Errorf("[witness] materialized branch root mismatch at prefix %x: got %x want %x", branchPrefix, subRoot, wantHash)
+	}
+	return branchNode, nil
+}
+
 func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[common.Hash]witnesstypes.CodeWithHash, produceExclusionProofs bool) (*trie.Trie, error) {
 	var rootNode trie.Node = &trie.FullNode{}
 	var currentNode trie.Node = rootNode
@@ -1434,13 +1449,9 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 					branchPrefix := make([]byte, 0, int(keyPos)+1+len(hashedExtKey))
 					branchPrefix = append(branchPrefix, hashedKey[:keyPos+1]...)
 					branchPrefix = append(branchPrefix, hashedExtKey...)
-					branchNode, err := hph.witnessMaterializeBranch(branchPrefix, int16(len(branchPrefix))+1)
+					branchNode, err := hph.witnessMaterializeBranchChild(branchPrefix, int16(len(branchPrefix))+1, cellToExpand.hash[:cellToExpand.hashLen])
 					if err != nil {
 						return nil, err
-					}
-					subRoot := trie.NewInMemoryTrie(branchNode).Hash()
-					if !bytes.Equal(subRoot[:], cellToExpand.hash[:cellToExpand.hashLen]) {
-						return nil, fmt.Errorf("[witness] materialized extension-child branch root mismatch at prefix %x: got %x want %x", branchPrefix, subRoot, cellToExpand.hash[:cellToExpand.hashLen])
 					}
 					short.Val = branchNode
 				}
@@ -1488,11 +1499,21 @@ func (hph *HexPatriciaHashed) toWitnessTrie(hashedKey []byte, codeReads map[comm
 						//fmt.Printf("witness cell (%d, %0x, depth=%d) %s\n", row, currentNibble, hph.depths[row], cellToExpand.FullString())
 						//nextNode = trie.NewHashNode(cellToExpand.stateHash[:])
 					} else if cellToExpand.hashLen > 0 && len(hashedKey) != 64 && len(hashedKey) != 128 {
-						// Intermediate key (not account or full storage) landing on extension → branch:
-						// extension key should NOT have a terminator, Val is the branch hash.
+						// Intermediate key landing on extension→branch; the extension key carries no
+						// terminator. In exclusion-proof mode materialize the branch (same hash, witness
+						// root unchanged) so a strict verifier collapsing the sibling can descend it.
+						var branchVal trie.Node = trie.NewHashNode(common.Copy(cellToExpand.hash[:cellToExpand.hashLen]))
+						if produceExclusionProofs {
+							branchPrefix := common.Copy(hashedKey[:keyPos+1])
+							branchNode, err := hph.witnessMaterializeBranchChild(branchPrefix, int16(len(branchPrefix))+1, cellToExpand.hash[:cellToExpand.hashLen])
+							if err != nil {
+								return nil, err
+							}
+							branchVal = branchNode
+						}
 						nextNode = &trie.ShortNode{
 							Key: common.Copy(hashedExtKey),
-							Val: trie.NewHashNode(common.Copy(cellToExpand.hash[:cellToExpand.hashLen])),
+							Val: branchVal,
 						}
 					}
 					if keyPos+1 == int16(len(hashedKey)) || keyPos+1 == 128 {

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -3535,6 +3535,69 @@ func Test_WitnessTrie_GenerateWitness(t *testing.T) {
 		require.True(t, witnessResolvesAbsence(witnessTrie.RootNode, hashedAbsent, 0),
 			"witness must materialize the branch behind the diverging extension to prove the absent account")
 	})
+
+	t.Run("CollapseSiblingExtensionMustBeMaterialized", func(t *testing.T) {
+		ctx := context.Background()
+		ms := NewMockState(t)
+		hph := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+		hph.SetTrace(false)
+
+		// storage-bearing account sitting inside a populated state branch
+		acctPlains, _ := generatePlainKeysWithSameHashPrefix(t, nil, length.Addr, 2, 6)
+		acctPlain := acctPlains[0]
+
+		// surviving sibling: two slots sharing a 4-nibble hashed prefix, so under their
+		// 3rd nibble sits an extension (nibble 3) over a sub-branch (split at nibble 4).
+		const storSharedLen = 4
+		storPrefix := []byte{0x4, 0x3}
+		survPlain, survHashed := generatePlainKeysWithSameHashPrefix(t, storPrefix, length.Hash, storSharedLen, 2)
+
+		// doomed sibling: shares only the 2-nibble branch prefix, diverging at nibble 2,
+		// so the branch at storage-depth 2 has exactly two children {doomed leaf, surviving ext}.
+		var doomedPlain []byte
+		for {
+			k, h := generateKeyWithHashedPrefix(storPrefix, length.Hash)
+			if h[2] != survHashed[0][2] {
+				doomedPlain = k
+				break
+			}
+		}
+
+		builder := NewUpdateBuilder()
+		for i, a := range acctPlains {
+			builder.Balance(common.Bytes2Hex(a), uint64(i+1))
+		}
+		builder.Storage(common.Bytes2Hex(acctPlain), common.Bytes2Hex(doomedPlain), common.Bytes2Hex(doomedPlain))
+		for _, sk := range survPlain {
+			builder.Storage(common.Bytes2Hex(acctPlain), common.Bytes2Hex(sk), common.Bytes2Hex(sk))
+		}
+		plainKeys, updates := builder.Build()
+		require.NoError(t, ms.applyPlainUpdates(plainKeys, updates))
+
+		toProcess := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, plainKeys, updates)
+		defer toProcess.Close()
+		root, err := hph.Process(ctx, toProcess, "", nil, WarmupConfig{})
+		require.NoError(t, err)
+
+		// The collapse sibling detectCollapseSiblings records when the doomed slot is
+		// zero-written: the intermediate hashed path to the surviving extension subtree.
+		acctHashed := KeyToHexNibbleHash(acctPlain)
+		siblingPath := append(common.Copy(acctHashed), survHashed[0][:storSharedLen]...)
+
+		toWitness := NewUpdates(ModeDirect, "", KeyToHexNibbleHash)
+		defer toWitness.Close()
+		toWitness.TouchPlainKey(string(acctPlain), nil, toWitness.TouchAccount)
+		toWitness.TouchHashedKey(siblingPath)
+
+		witnessTrie, rootW, err := hph.GenerateWitness(ctx, toWitness, nil, "", true)
+		require.NoError(t, err)
+		require.Equal(t, root, rootW, "witness root must equal commitment root")
+
+		// Collapsing the 2-child branch requires re-forming it around the surviving
+		// sibling; its sub-branch must be materialized, not left as a bare HashNode.
+		require.True(t, witnessMaterializesNodeAt(witnessTrie.RootNode, siblingPath),
+			"collapse-sibling sub-branch must be materialized, not a bare HashNode")
+	})
 }
 
 // Test_ModeUpdate_SiblingConsistency verifies that ModeUpdate produces

--- a/execution/commitment/witness_exclusion_test.go
+++ b/execution/commitment/witness_exclusion_test.go
@@ -54,3 +54,43 @@ func witnessResolvesAbsence(n trie.Node, key []byte, pos int) bool {
 		return false
 	}
 }
+
+// witnessNodeAtPath returns the witness node reached after consuming the whole
+// hashed path, descending account→storage and through extension/branch nodes
+// (terminator-aware). It is used to assert what a strict verifier finds at a
+// collapse sibling's prefix — a materialized branch rather than a bare HashNode.
+func witnessNodeAtPath(n trie.Node, key []byte, pos int) trie.Node {
+	if pos == len(key) {
+		return n
+	}
+	switch x := n.(type) {
+	case *trie.AccountNode:
+		return witnessNodeAtPath(x.Storage, key, pos)
+	case *trie.ShortNode:
+		k := x.Key
+		if len(k) > 0 && k[len(k)-1] == 16 {
+			k = k[:len(k)-1]
+		}
+		if len(key)-pos < len(k) || nibbles.CommonPrefixLen(key[pos:], k) < len(k) {
+			return nil
+		}
+		return witnessNodeAtPath(x.Val, key, pos+len(k))
+	case *trie.FullNode:
+		return witnessNodeAtPath(x.Children[key[pos]], key, pos+1)
+	default:
+		return n
+	}
+}
+
+// witnessMaterializesNodeAt reports whether the witness holds a materialized
+// (present, non-blinded) node at the end of the hashed path. A strict verifier
+// descending to a collapse sibling's prefix must find a real branch/leaf there,
+// not a bare HashNode it cannot re-form the collapsing branch from.
+func witnessMaterializesNodeAt(root trie.Node, key []byte) bool {
+	n := witnessNodeAtPath(root, key, 0)
+	if n == nil {
+		return false
+	}
+	_, blinded := n.(*trie.HashNode)
+	return !blinded
+}


### PR DESCRIPTION
`debug_executionWitness` blinded the surviving sibling of a collapsing storage branch on a zero-value write (#21869). On a slot delete from a two-child branch, `toWitnessTrie` emitted the sibling extension but left the branch it points to a bare `HashNode`. reth's `stateless` verifier can't re-form the collapsed branch from a blinded node, so it returns `BlindedNode` and the post-state root diverges.

Repro: mainnet block 25335936, zero-write to slot `0x43cb…`, sibling `0x43cd` blinded → `SparseTrieError(BlindedNode(Nibbles(0x43cd)))`.

Fix: in exclusion-proof (legacy) mode, materialize that branch via `witnessMaterializeBranch` with a subtrie-root check instead of a `HashNode`. Same hash, witness root unchanged; canonical mode stays minimal. The absent-slot path and this one now share `witnessMaterializeBranchChild`.

Test: `Test_WitnessTrie_GenerateWitness/CollapseSiblingExtensionMustBeMaterialized` — two-child storage branch, sibling is an extension over a sub-branch, delete the other child, assert the sub-branch is a `FullNode` not a `HashNode`. End-to-end: block 25335936 witness passes reth `stateless` (VALID; state nodes 16395 → 16396).

Fixes #21869