### PR TITLE
db/datastruct/btindex: EF-encode .bt pivot offsets 

### DIFF
--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -62,10 +62,10 @@ func NewBpsTree(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, dataLooku
 // "assert key behind offset == to stored key in bt"
 var envAssertBTKeys = dbg.EnvBool("BT_ASSERT_OFFSETS", false)
 
-func NewBpsTreeWithNodes(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, dataLookup dataLookupFunc, keysBlob []byte, nodeOfft []uint64, nodeStride uint64) *BpsTree {
-	bt := &BpsTree{M: M, offt: offt, dataLookupFunc: dataLookup, keysBlob: keysBlob, nodeOfft: nodeOfft, nodeStride: nodeStride}
+func NewBpsTreeWithNodes(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, dataLookup dataLookupFunc, keysBlob []byte, nodeOfftEF *eliasfano32.EliasFano, nodeStride uint64) *BpsTree {
+	bt := &BpsTree{M: M, offt: offt, dataLookupFunc: dataLookup, keysBlob: keysBlob, nodeOfftEF: nodeOfftEF, nodeStride: nodeStride}
 	if envAssertBTKeys {
-		for i := range nodeOfft {
+		for i := range bt.numNodes() {
 			if cmp := bt.compareKey(kv, bt.nodeKey(i), bt.nodeDi(i)); cmp != 0 {
 				panic(fmt.Errorf("key mismatch at di=%d i=%d cmp=%d", bt.nodeDi(i), i, cmp))
 			}
@@ -79,9 +79,10 @@ type BpsTree struct {
 	offt *eliasfano32.EliasFano // ef with offsets to key/vals
 
 	// pivot cache: keysBlob holds [keyLen:u16][key] records (mmap-backed on-disk,
-	// heap for WarmUp); nodeOfft[i] is record i's offset and di is derived as i*nodeStride.
+	// heap for WarmUp); nodeOfftEF holds record i's offset (Elias-Fano, the only
+	// per-node heap cost) and di is derived as i*nodeStride.
 	keysBlob   []byte
-	nodeOfft   []uint64
+	nodeOfftEF *eliasfano32.EliasFano
 	nodeStride uint64
 
 	M     uint64 // limit on amount of 'children' for node
@@ -91,11 +92,16 @@ type BpsTree struct {
 	cursorGetter   cursorGetter
 }
 
-func (b *BpsTree) numNodes() int { return len(b.nodeOfft) }
+func (b *BpsTree) numNodes() int {
+	if b.nodeOfftEF == nil {
+		return 0
+	}
+	return int(b.nodeOfftEF.Count())
+}
 
 // nodeKey returns pivot i's key without copying (points into keysBlob).
 func (b *BpsTree) nodeKey(i int) []byte {
-	off := b.nodeOfft[i]
+	off := b.nodeOfftEF.Get(uint64(i))
 	l := uint64(binary.BigEndian.Uint16(b.keysBlob[off:]))
 	return b.keysBlob[off+2 : off+2+l]
 }
@@ -170,36 +176,41 @@ func (n Node) Encode(w io.Writer, headerBuf []byte) error {
 	return err
 }
 
-// decodeNodes indexes count length-prefixed keys (no count prefix on disk — the
-// caller derives count), returning each record's byte offset within data. di is
-// not stored; node i has di = i*M, recomputed on read.
-func decodeNodes(data []byte, count uint64) (nodeOfft []uint64, end int, err error) {
+// decodeNodes builds an Elias-Fano index of the byte offsets of count
+// length-prefixed key records within data (no count prefix on disk — the caller
+// derives count). di is not stored; node i has di = i*M, recomputed on read.
+func decodeNodes(data []byte, count uint64) (nodeOfftEF *eliasfano32.EliasFano, end int, err error) {
 	if count > uint64(len(data))/2 { // each node is at least 2 bytes (keyLen)
 		return nil, 0, fmt.Errorf("corrupt index: node count %d exceeds data size", count)
 	}
-	nodeOfft = make([]uint64, count)
-	pos := 0
+	if count == 0 {
+		return nil, 0, nil
+	}
+	pos, lastOff := 0, 0
 	for ni := range int(count) {
 		if len(data)-pos < 2 {
 			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
 		}
-		nodeOfft[ni] = uint64(pos)
-		l := int(binary.BigEndian.Uint16(data[pos : pos+2]))
-		pos += 2
-		if len(data)-pos < l {
+		lastOff = pos
+		pos += 2 + int(binary.BigEndian.Uint16(data[pos:pos+2]))
+		if pos > len(data) {
 			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
 		}
-		pos += l
 	}
-	return nodeOfft, pos, nil
+	nodeOfftEF = eliasfano32.NewEliasFano(count, uint64(lastOff))
+	for p := 0; p < pos; p += 2 + int(binary.BigEndian.Uint16(data[p:p+2])) {
+		nodeOfftEF.AddOffset(uint64(p))
+	}
+	nodeOfftEF.Build()
+	return nodeOfftEF, pos, nil
 }
 
-// decodeListNodesV0 indexes the legacy node list ([di:u64][keyLen:u16][key] per
-// node), returning each key record's offset past the on-disk di. di is derived
-// as i*stride; stride comes from the stored di, validated to be the arithmetic
-// progression 0,stride,2*stride,... so a wrong open-time M or a corrupt file is
-// rejected rather than silently mis-derived.
-func decodeListNodesV0(data []byte) (nodeOfft []uint64, stride uint64, end int, err error) {
+// decodeListNodesV0 builds an Elias-Fano index of the legacy node list
+// ([di:u64][keyLen:u16][key] per node); each offset points past the on-disk di,
+// at the keyLen prefix. di is derived as i*stride; stride comes from the stored
+// di, validated to be the arithmetic progression 0,stride,2*stride,... so a
+// wrong open-time M or a corrupt file is rejected rather than mis-derived.
+func decodeListNodesV0(data []byte) (nodeOfftEF *eliasfano32.EliasFano, stride uint64, end int, err error) {
 	if len(data) < 8 {
 		return nil, 0, 0, fmt.Errorf("truncated index: need 8 bytes for node count, got %d", len(data))
 	}
@@ -207,8 +218,10 @@ func decodeListNodesV0(data []byte) (nodeOfft []uint64, stride uint64, end int, 
 	if count > uint64(len(data)-8)/10 { // each node is at least 10 bytes (di+keyLen)
 		return nil, 0, 0, fmt.Errorf("corrupt index: node count %d exceeds data size", count)
 	}
-	nodeOfft = make([]uint64, count)
-	pos := 8
+	if count == 0 {
+		return nil, 0, 8, nil
+	}
+	pos, lastOff := 8, 0
 	for ni := range int(count) {
 		if len(data)-pos < 10 {
 			return nil, 0, 0, fmt.Errorf("decode node %d: short buffer", ni)
@@ -229,15 +242,18 @@ func decodeListNodesV0(data []byte) (nodeOfft []uint64, stride uint64, end int, 
 				return nil, 0, 0, fmt.Errorf("corrupt v0 index: node %d di=%d, want %d", ni, di, uint64(ni)*stride)
 			}
 		}
-		l := int(binary.BigEndian.Uint16(data[pos+8 : pos+10]))
-		nodeOfft[ni] = uint64(pos + 8) // skip on-disk di; offset points at the keyLen prefix
-		pos += 10
-		if len(data)-pos < l {
+		lastOff = pos + 8 // skip on-disk di; offset points at the keyLen prefix
+		pos += 10 + int(binary.BigEndian.Uint16(data[pos+8:pos+10]))
+		if pos > len(data) {
 			return nil, 0, 0, fmt.Errorf("decode node %d: short buffer", ni)
 		}
-		pos += l
 	}
-	return nodeOfft, stride, pos, nil
+	nodeOfftEF = eliasfano32.NewEliasFano(count, uint64(lastOff))
+	for p := 8; p < pos; p += 10 + int(binary.BigEndian.Uint16(data[p+8:p+10])) {
+		nodeOfftEF.AddOffset(uint64(p + 8))
+	}
+	nodeOfftEF.Build()
+	return nodeOfftEF, stride, pos, nil
 }
 
 func (b *BpsTree) WarmUp(kv *seg.Reader) error {
@@ -253,8 +269,7 @@ func (b *BpsTree) WarmUp(kv *seg.Reader) error {
 	}
 	b.nodeStride = step
 
-	nodeCount := (N-1)/step + 1 // ceil(N/step), N>=1 here
-	b.nodeOfft = make([]uint64, 0, nodeCount)
+	nodeCount := (N-1)/step + 1               // ceil(N/step), N>=1 here
 	blob := make([]byte, 0, nodeCount*(2+32)) // 32: rough avg key length
 	if b.trace {
 		fmt.Printf("WarmUp nodes %d N=%d M=%d\n", nodeCount, N, b.M)
@@ -270,16 +285,20 @@ func (b *BpsTree) WarmUp(kv *seg.Reader) error {
 		if len(key) > math.MaxUint16 {
 			return fmt.Errorf("WarmUp: key at di=%d too long: %d bytes", i, len(key))
 		}
-		b.nodeOfft = append(b.nodeOfft, uint64(len(blob)))
 		binary.BigEndian.PutUint16(hdr[:], uint16(len(key)))
 		blob = append(blob, hdr[:]...)
 		blob = append(blob, key...)
 	}
 	b.keysBlob = blob
+	nodeOfftEF, _, err := decodeNodes(blob, nodeCount)
+	if err != nil {
+		return err
+	}
+	b.nodeOfftEF = nodeOfftEF
 
 	log.Root().Debug("WarmUp finished", "file", kv.FileName(), "M", b.M, "N", common.PrettyCounter(N),
 		"cached", fmt.Sprintf("%d %.2f%%", b.numNodes(), 100*(float64(b.numNodes())/float64(N))),
-		"cacheSize", datasize.ByteSize(len(b.keysBlob)+len(b.nodeOfft)*8).HR(), "fileSize", datasize.ByteSize(kv.Size()).HR(),
+		"cacheSize", datasize.ByteSize(len(b.keysBlob)).HR(), "fileSize", datasize.ByteSize(kv.Size()).HR(),
 		"took", time.Since(t))
 	return nil
 }
@@ -568,6 +587,6 @@ func (b *BpsTree) Distances() (map[int]int, error) {
 
 func (b *BpsTree) Close() {
 	b.keysBlob = nil
-	b.nodeOfft = nil
+	b.nodeOfftEF = nil
 	b.offt = nil
 }

--- a/db/datastruct/btindex/bpstree_bench_test.go
+++ b/db/datastruct/btindex/bpstree_bench_test.go
@@ -221,13 +221,15 @@ func BenchmarkBpsTree_bs(b *testing.B) {
 			slices.SortFunc(allKeys, bytes.Compare)
 
 			var blob []byte
-			nodeOfft := make([]uint64, nodeCount)
 			var hdr [2]byte
-			for i, k := range allKeys {
-				nodeOfft[i] = uint64(len(blob))
+			for _, k := range allKeys {
 				binary.BigEndian.PutUint16(hdr[:], uint16(len(k)))
 				blob = append(blob, hdr[:]...)
 				blob = append(blob, k...)
+			}
+			nodeOfftEF, _, err := decodeNodes(blob, uint64(nodeCount))
+			if err != nil {
+				b.Fatal(err)
 			}
 
 			totalCount := uint64(cfg.N)
@@ -237,7 +239,7 @@ func BenchmarkBpsTree_bs(b *testing.B) {
 			}
 			ef.Build()
 
-			bt := &BpsTree{M: uint64(cfg.M), offt: ef, keysBlob: blob, nodeOfft: nodeOfft, nodeStride: uint64(cfg.M)}
+			bt := &BpsTree{M: uint64(cfg.M), offt: ef, keysBlob: blob, nodeOfftEF: nodeOfftEF, nodeStride: uint64(cfg.M)}
 
 			lookupKeys := make([][]byte, 10000)
 			for i := range lookupKeys {

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -512,7 +512,7 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 	}
 	idx.data = idx.m[:idx.size]
 
-	var nodeOfft []uint64
+	var nodeOfftEF *eliasfano32.EliasFano
 	var keysBlob []byte
 	var nodeStride uint64
 	switch idx.data[0] {
@@ -521,7 +521,7 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 		idx.ef, pos = eliasfano32.ReadEliasFano(idx.data)
 		if len(idx.data[pos:]) > 0 {
 			keysBlob = idx.data[pos:]
-			if nodeOfft, nodeStride, _, err = decodeListNodesV0(keysBlob); err != nil {
+			if nodeOfftEF, nodeStride, _, err = decodeListNodesV0(keysBlob); err != nil {
 				return nil, err
 			}
 			if nodeStride == 0 { // <2 nodes: only di=0 exists, stride is irrelevant
@@ -552,7 +552,7 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 		keysBlob = idx.data[1:]
 		nodeStride = M
 		var nodesEnd int
-		if nodeOfft, nodesEnd, err = decodeNodes(keysBlob, nodesCount); err != nil {
+		if nodeOfftEF, nodesEnd, err = decodeNodes(keysBlob, nodesCount); err != nil {
 			return nil, err
 		}
 		if footer.Meta.EfOffset != uint64(alignUp(1+nodesEnd, btEFAlign)) { // cross-check ef_offset against the decoded nodes
@@ -573,10 +573,10 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 
 	defer kvGetter.MadvNormal().DisableReadAhead()
 
-	if len(nodeOfft) == 0 {
+	if nodeOfftEF == nil {
 		idx.bplus = NewBpsTree(kvGetter, idx.ef, M, idx.dataLookup)
 	} else {
-		idx.bplus = NewBpsTreeWithNodes(kvGetter, idx.ef, M, idx.dataLookup, keysBlob, nodeOfft, nodeStride)
+		idx.bplus = NewBpsTreeWithNodes(kvGetter, idx.ef, M, idx.dataLookup, keysBlob, nodeOfftEF, nodeStride)
 	}
 	idx.bplus.cursorGetter = idx.newCursor
 

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -774,8 +774,12 @@ func TestDecodeNodes(t *testing.T) {
 		got, n, err := decodeNodes(buf.Bytes(), uint64(len(keys)))
 		require.NoError(t, err)
 		require.Equal(t, buf.Len(), n)
-		require.Len(t, got, len(keys))
-		bp := &BpsTree{keysBlob: buf.Bytes(), nodeOfft: got, nodeStride: M}
+		if len(keys) == 0 {
+			require.Nil(t, got)
+			continue
+		}
+		require.EqualValues(t, len(keys), got.Count())
+		bp := &BpsTree{keysBlob: buf.Bytes(), nodeOfftEF: got, nodeStride: M}
 		for i := range keys {
 			require.Equal(t, uint64(i)*M, bp.nodeDi(i)) // di recomputed, not stored
 			require.True(t, bytes.Equal(keys[i], bp.nodeKey(i)))
@@ -803,7 +807,7 @@ func TestDecodeListNodesV0_Validation(t *testing.T) {
 	off, stride, _, err := decodeListNodesV0(build(0, 32, 64, 96))
 	require.NoError(t, err)
 	require.Equal(t, uint64(32), stride)
-	require.Len(t, off, 4)
+	require.EqualValues(t, 4, off.Count())
 
 	// di0==0 is required, so stride=di1 can't underflow; corrupt progressions are rejected
 	for name, dis := range map[string][]uint64{

--- a/db/datastruct/btindex/nodeofft_ef_test.go
+++ b/db/datastruct/btindex/nodeofft_ef_test.go
@@ -1,0 +1,69 @@
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package btindex
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/seg"
+)
+
+// The pivot offsets are stored Elias-Fano-encoded (nodeOfftEF). Decoding and
+// lookups must be correct for both the v0 (legacy list) and v2 (footer) layouts.
+func Test_BtreeIndex_NodeOfftEF_V0_V2(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	logger := log.New()
+	const M = uint64(32)
+	keyCount := 500
+	compressFlags := seg.CompressKeys | seg.CompressVals
+
+	dataPath := generateKV(t, tmp, 52, 180, keyCount, logger, compressFlags)
+	keys, err := pivotKeysFromKV(dataPath)
+	require.NoError(t, err)
+
+	truth := map[string][]byte{}
+	d, err := seg.NewDecompressor(dataPath)
+	require.NoError(t, err)
+	gt := seg.NewReader(d.MakeGetter(), compressFlags)
+	gt.Reset(0)
+	for gt.HasNext() {
+		k, _ := gt.Next(nil)
+		v, _ := gt.Next(nil)
+		truth[string(k)] = common.Copy(v)
+	}
+	d.Close()
+
+	v2Path := filepath.Join(tmp, "v2.bt")
+	buildBtreeIndex(t, dataPath, v2Path, compressFlags, 1, logger, true)
+	v0Path := filepath.Join(tmp, "v0.bt")
+	writeV0Index(t, dataPath, v0Path, compressFlags, M)
+
+	for _, tc := range []struct{ name, path string }{{"v0", v0Path}, {"v2", v2Path}} {
+		t.Run(tc.name, func(t *testing.T) {
+			kv, bt, err := OpenBtreeIndexAndDataFile(tc.path, dataPath, M, compressFlags, false)
+			require.NoError(t, err)
+			defer bt.Close()
+			defer kv.Close()
+			require.NotNil(t, bt.bplus.nodeOfftEF, "pivot offsets must be Elias-Fano-encoded")
+
+			gr := seg.NewReader(kv.MakeGetter(), compressFlags)
+			for i := range keys {
+				_, v, _, found, err := bt.Get(keys[i], gr)
+				require.NoErrorf(t, err, "i=%d", i)
+				require.Truef(t, found, "key %d not found", i)
+				require.Equalf(t, truth[string(keys[i])], v, "key %d value mismatch", i)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacks on #21875. After that PR, the `.bt` pivot cache's only per-node heap cost is the offset array — a flat `[]uint64` (8 B/node). Those offsets are strictly increasing, so this stores them **Elias-Fano-encoded** (~7 bits/node) as the *only* representation: no flat array, no toggle.

The EF is built at open, directly from the existing nodes section — **no on-disk format change**, and both layouts are covered (v2 footer and v0 legacy list).

### Heap (open pivot cache, commitment, M=256)

| file | pivots (N/M) | flat `[]uint64` (before) | EF (this PR) |
|---|---|---|---|
| 141M keys | 543K | 4.35 MB | **0.46 MB** (9.5×) |
| 1M keys | 4.2K | 34 KB | 5 KB |

≈ 6.8 bits/pivot. On a mainnet node the aggregate pivot heap (storage-dominated, ~340 MB after #21875) drops to **~36 MB**.

### Latency / major-faults (cold = evicted page cache, 15k sampled keys)

| file | variant | cold µs/op | cold faults/op | warm µs/op |
|---|---|---|---|---|
| 141M keys | flat | 140 | 1.57 | 10 |
| 141M keys | **EF** | 143 | 1.57 | 8 |
| 1M keys | flat | 180 | 2.54 | 6 |
| 1M keys | **EF** | 181 | 2.54 | 7 |

Identical fault count, latency within run-to-run noise: the extra `EF.Get` calls in the pivot search are pure CPU and don't register against the ~80 µs/major-fault cost.

### Tests
`Test_BtreeIndex_NodeOfftEF_V0_V2` opens both v0 and v2 files and checks every key resolves to its true `.kv` value through the EF-decoded pivots. `decodeNodes` / `decodeListNodesV0` unit tests updated for the EF return. Full `btindex` suite passes.
