### PR TITLE
db/snapshotsync: resume caplin state dump per-type to avoid overlapping files

### DIFF
--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -594,7 +594,6 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		}
 		if err := s.stateSn.DumpCaplinState(
 			ctx,
-			s.stateSn.BlocksAvailable()+1,
 			to,
 			blocksPerStatefulFile,
 			s.sn.Salt,

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -604,15 +604,17 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		); err != nil {
 			return err
 		}
-		paths := s.stateSn.SegFileNames(from, to)
+		// Open the new files before collecting paths so the seeder sees them;
+		// seed from 0 since a per-type resume can dump a new type from genesis.
+		if err := s.stateSn.OpenFolder(); err != nil {
+			return err
+		}
 		if s.downloader != nil {
+			paths := s.stateSn.SegFileNames(0, to)
 			// Notify bittorent to seed the new snapshots
 			if err := s.downloader.Seed(s.ctx, paths); err != nil {
 				s.logger.Warn("[Antiquary] Failed to add items to bittorent", "err", err)
 			}
-		}
-		if err := s.stateSn.OpenFolder(); err != nil {
-			return err
 		}
 	}
 

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -1390,7 +1390,7 @@ func (c *DumpStateSnapshots) Run(ctx *Context) error {
 	r, _ := stateSn.Get(kv.BlockRoot, 999424)
 	fmt.Printf("%x\n", r)
 
-	if err := stateSn.DumpCaplinState(ctx, stateSn.BlocksAvailable(), to, c.StepSize, salt, dirs, runtime.NumCPU(), log.LvlInfo, log.Root()); err != nil {
+	if err := stateSn.DumpCaplinState(ctx, to, c.StepSize, salt, dirs, runtime.NumCPU(), log.LvlInfo, log.Root()); err != nil {
 		return err
 	}
 	if err := stateSn.OpenFolder(); err != nil {

--- a/db/snapshotsync/caplin_state_dump_test.go
+++ b/db/snapshotsync/caplin_state_dump_test.go
@@ -73,6 +73,31 @@ func TestPlanStateDumpResumesPerType(t *testing.T) {
 	require.Equal(t, uint64(10_400_000/blocksPerFile), countJobs(jobs, "Empty"))
 }
 
+// A gap in a type's visible segments must cap availability at the contiguous
+// prefix, so planStateDump re-dumps the missing range instead of skipping it.
+func TestBlocksAvailableForTypeStopsAtGap(t *testing.T) {
+	s := &CaplinStateSnapshots{}
+	s.visible.Store("Gapped", []*VisibleSegment{
+		{Range: Range{from: 0, to: 7_150_000}},
+		{Range: Range{from: 7_200_000, to: 7_250_000}}, // 7.15M..7.2M missing
+	})
+	require.Equal(t, uint64(7_150_000), s.blocksAvailableForType("Gapped"))
+}
+
+// Resuming must start exactly at the coverage end, never below it — flooring an
+// unaligned tail to a file boundary would overlap the existing files.
+func TestPlanStateDumpUnalignedResumeHasNoOverlap(t *testing.T) {
+	const blocksPerFile = 50_000
+	jobs := planStateDump(map[string]uint64{"X": 2_725_000}, 2_825_000, blocksPerFile)
+
+	from, ok := firstJobFrom(jobs, "X")
+	require.True(t, ok)
+	require.Equal(t, uint64(2_725_000), from, "must resume at availability, not floor below it")
+	for _, j := range jobs {
+		require.GreaterOrEqual(t, j.from, uint64(2_725_000), "no job may start before existing coverage")
+	}
+}
+
 func TestBlocksAvailableForType(t *testing.T) {
 	s := &CaplinStateSnapshots{}
 	s.visible.Store("A", []*VisibleSegment{

--- a/db/snapshotsync/caplin_state_dump_test.go
+++ b/db/snapshotsync/caplin_state_dump_test.go
@@ -41,30 +41,46 @@ func countJobs(jobs []caplinStateDumpJob, name string) uint64 {
 	return n
 }
 
+// overlapsCoverage reports whether any job lands inside an existing covered range.
+func overlapsCoverage(jobs []caplinStateDumpJob, name string, covered []Range) bool {
+	for _, j := range jobs {
+		if j.name != name {
+			continue
+		}
+		for _, r := range covered {
+			if j.from < r.to && r.from < j.to {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // A new state-snapshot type added to an already-populated datadir must not drag
-// the dump back to genesis for the types that are already caught up: each type
-// resumes from its own coverage, so a full base file is never re-sliced into
-// overlapping sub-files.
+// the dump back to genesis for types that are already caught up: only missing
+// ranges are scheduled, so a full base file is never re-sliced into overlaps.
 func TestPlanStateDumpResumesPerType(t *testing.T) {
 	const blocksPerFile = 50_000
-	availability := map[string]uint64{
-		"Covered": 10_400_000, // already at head (e.g. one 0..7.15M base + increments)
-		"Lagging": 2_700_000,  // newly added type, behind
-		"Empty":   0,          // brand-new type, nothing on disk
+	coverage := map[string][]Range{
+		"Covered": {{from: 0, to: 10_400_000}}, // already at head
+		"Lagging": {{from: 0, to: 2_700_000}},  // newly added type, behind
+		"Empty":   nil,                         // brand-new type, nothing on disk
 	}
 
-	jobs := planStateDump(availability, 10_400_000, blocksPerFile)
+	jobs := planStateDump(coverage, 10_400_000, blocksPerFile)
 
 	for _, j := range jobs {
-		require.NotEqual(t, "Covered", j.name, "already-covered type must not be re-dumped: %+v", j)
-		require.GreaterOrEqual(t, j.from, availability[j.name],
-			"type %s dumped below its own availability (would overlap existing files): from=%d avail=%d", j.name, j.from, availability[j.name])
 		require.Equal(t, blocksPerFile, int(j.to-j.from), "every job must be exactly one full file")
 	}
+	for name, cov := range coverage {
+		require.False(t, overlapsCoverage(jobs, name, cov), "type %s scheduled a job overlapping existing coverage", name)
+	}
+
+	require.Zero(t, countJobs(jobs, "Covered"), "caught-up type must not be re-dumped")
 
 	laggingFrom, ok := firstJobFrom(jobs, "Lagging")
 	require.True(t, ok, "lagging type must be dumped")
-	require.Equal(t, uint64(2_700_000), laggingFrom, "lagging type must resume at its own availability")
+	require.Equal(t, uint64(2_700_000), laggingFrom, "lagging type must resume at its coverage end")
 	require.Equal(t, uint64((10_400_000-2_700_000)/blocksPerFile), countJobs(jobs, "Lagging"))
 
 	emptyFrom, ok := firstJobFrom(jobs, "Empty")
@@ -73,40 +89,39 @@ func TestPlanStateDumpResumesPerType(t *testing.T) {
 	require.Equal(t, uint64(10_400_000/blocksPerFile), countJobs(jobs, "Empty"))
 }
 
-// A gap in a type's visible segments must cap availability at the contiguous
-// prefix, so planStateDump re-dumps the missing range instead of skipping it.
-func TestBlocksAvailableForTypeStopsAtGap(t *testing.T) {
-	s := &CaplinStateSnapshots{}
-	s.visible.Store("Gapped", []*VisibleSegment{
-		{Range: Range{from: 0, to: 7_150_000}},
-		{Range: Range{from: 7_200_000, to: 7_250_000}}, // 7.15M..7.2M missing
-	})
-	require.Equal(t, uint64(7_150_000), s.blocksAvailableForType("Gapped"))
+// A gap between existing segments must be filled, without re-dumping (and thus
+// overlapping) a larger already-present segment that follows the gap.
+func TestPlanStateDumpFillsGapWithoutOverlap(t *testing.T) {
+	const blocksPerFile = 50_000
+	covered := []Range{
+		{from: 0, to: 7_150_000},
+		{from: 7_200_000, to: 10_400_000}, // 7.15M..7.2M missing; tail is one large segment
+	}
+	jobs := planStateDump(map[string][]Range{"X": covered}, 10_400_000, blocksPerFile)
+
+	require.Equal(t, uint64(1), countJobs(jobs, "X"), "only the single missing file should be scheduled")
+	from, _ := firstJobFrom(jobs, "X")
+	require.Equal(t, uint64(7_150_000), from)
+	require.False(t, overlapsCoverage(jobs, "X", covered))
 }
 
-// Resuming must start exactly at the coverage end, never below it — flooring an
-// unaligned tail to a file boundary would overlap the existing files.
+// An unaligned coverage tail must resume exactly at its end, never flooring to a
+// file boundary below it (which would overlap the existing tail).
 func TestPlanStateDumpUnalignedResumeHasNoOverlap(t *testing.T) {
 	const blocksPerFile = 50_000
-	jobs := planStateDump(map[string]uint64{"X": 2_725_000}, 2_825_000, blocksPerFile)
+	covered := []Range{{from: 0, to: 2_725_000}}
+	jobs := planStateDump(map[string][]Range{"X": covered}, 2_825_000, blocksPerFile)
 
 	from, ok := firstJobFrom(jobs, "X")
 	require.True(t, ok)
-	require.Equal(t, uint64(2_725_000), from, "must resume at availability, not floor below it")
-	for _, j := range jobs {
-		require.GreaterOrEqual(t, j.from, uint64(2_725_000), "no job may start before existing coverage")
-	}
+	require.Equal(t, uint64(2_725_000), from, "must resume at coverage end, not floor below it")
+	require.False(t, overlapsCoverage(jobs, "X", covered))
 }
 
-func TestBlocksAvailableForType(t *testing.T) {
-	s := &CaplinStateSnapshots{}
-	s.visible.Store("A", []*VisibleSegment{
-		{Range: Range{from: 0, to: 7_150_000}},
-		{Range: Range{from: 7_150_000, to: 7_200_000}},
-	})
-	s.visible.Store("Empty", []*VisibleSegment{})
-
-	require.Equal(t, uint64(7_200_000), s.blocksAvailableForType("A"))
-	require.Equal(t, uint64(0), s.blocksAvailableForType("Empty"))
-	require.Equal(t, uint64(0), s.blocksAvailableForType("missing"))
+func TestMissingRanges(t *testing.T) {
+	require.Equal(t, []Range(nil), missingRanges([]Range{{from: 0, to: 100}}, 100), "fully covered → nothing missing")
+	require.Equal(t, []Range{{from: 0, to: 100}}, missingRanges(nil, 100), "empty → all missing")
+	require.Equal(t, []Range{{from: 70, to: 100}}, missingRanges([]Range{{from: 0, to: 70}}, 100), "trailing tail")
+	require.Equal(t, []Range{{from: 50, to: 60}}, missingRanges([]Range{{from: 0, to: 50}, {from: 60, to: 100}}, 100), "interior gap only")
+	require.Equal(t, []Range(nil), missingRanges([]Range{{from: 0, to: 200}}, 100), "coverage beyond toSlot → nothing missing")
 }

--- a/db/snapshotsync/caplin_state_dump_test.go
+++ b/db/snapshotsync/caplin_state_dump_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshotsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func firstJobFrom(jobs []caplinStateDumpJob, name string) (uint64, bool) {
+	for _, j := range jobs {
+		if j.name == name {
+			return j.from, true
+		}
+	}
+	return 0, false
+}
+
+func countJobs(jobs []caplinStateDumpJob, name string) uint64 {
+	var n uint64
+	for _, j := range jobs {
+		if j.name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// A new state-snapshot type added to an already-populated datadir must not drag
+// the dump back to genesis for the types that are already caught up: each type
+// resumes from its own coverage, so a full base file is never re-sliced into
+// overlapping sub-files.
+func TestPlanStateDumpResumesPerType(t *testing.T) {
+	const blocksPerFile = 50_000
+	availability := map[string]uint64{
+		"Covered": 10_400_000, // already at head (e.g. one 0..7.15M base + increments)
+		"Lagging": 2_700_000,  // newly added type, behind
+		"Empty":   0,          // brand-new type, nothing on disk
+	}
+
+	jobs := planStateDump(availability, 10_400_000, blocksPerFile)
+
+	for _, j := range jobs {
+		require.NotEqual(t, "Covered", j.name, "already-covered type must not be re-dumped: %+v", j)
+		require.GreaterOrEqual(t, j.from, availability[j.name],
+			"type %s dumped below its own availability (would overlap existing files): from=%d avail=%d", j.name, j.from, availability[j.name])
+		require.Equal(t, blocksPerFile, int(j.to-j.from), "every job must be exactly one full file")
+	}
+
+	laggingFrom, ok := firstJobFrom(jobs, "Lagging")
+	require.True(t, ok, "lagging type must be dumped")
+	require.Equal(t, uint64(2_700_000), laggingFrom, "lagging type must resume at its own availability")
+	require.Equal(t, uint64((10_400_000-2_700_000)/blocksPerFile), countJobs(jobs, "Lagging"))
+
+	emptyFrom, ok := firstJobFrom(jobs, "Empty")
+	require.True(t, ok, "empty type must be dumped from genesis")
+	require.Equal(t, uint64(0), emptyFrom)
+	require.Equal(t, uint64(10_400_000/blocksPerFile), countJobs(jobs, "Empty"))
+}
+
+func TestBlocksAvailableForType(t *testing.T) {
+	s := &CaplinStateSnapshots{}
+	s.visible.Store("A", []*VisibleSegment{
+		{Range: Range{from: 0, to: 7_150_000}},
+		{Range: Range{from: 7_150_000, to: 7_200_000}},
+	})
+	s.visible.Store("Empty", []*VisibleSegment{})
+
+	require.Equal(t, uint64(7_200_000), s.blocksAvailableForType("A"))
+	require.Equal(t, uint64(0), s.blocksAvailableForType("Empty"))
+	require.Equal(t, uint64(0), s.blocksAvailableForType("missing"))
+}

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -262,6 +263,21 @@ func (s *CaplinStateSnapshots) SegFileNames(from, to uint64) []string {
 
 func (s *CaplinStateSnapshots) BlocksAvailable() uint64 {
 	return min(s.segmentsMax.Load(), s.idxMax.Load())
+}
+
+func (s *CaplinStateSnapshots) blocksAvailableForType(name string) uint64 {
+	s.visibleLock.RLock()
+	defer s.visibleLock.RUnlock()
+
+	v, ok := s.visible.Load(name)
+	if !ok {
+		return 0
+	}
+	segs, ok := v.([]*VisibleSegment)
+	if !ok || len(segs) == 0 {
+		return 0
+	}
+	return segs[len(segs)-1].to
 }
 
 func (s *CaplinStateSnapshots) Close() {
@@ -690,20 +706,44 @@ func simpleIdx(ctx context.Context, sn snaptype.FileInfo, salt uint32, tmpDir st
 	return nil
 }
 
-func (s *CaplinStateSnapshots) DumpCaplinState(ctx context.Context, fromSlot, toSlot, blocksPerFile uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
-	fromSlot = (fromSlot / blocksPerFile) * blocksPerFile
+type caplinStateDumpJob struct {
+	name     string
+	from, to uint64
+}
+
+// planStateDump computes the per-type slot ranges to dump. Each type resumes
+// from its own coverage (availability) rather than a shared floor, so a type
+// already caught up is not re-sliced into files that overlap its existing ones,
+// and a newly added type is still dumped from genesis.
+func planStateDump(availability map[string]uint64, toSlot, blocksPerFile uint64) []caplinStateDumpJob {
 	toSlot = (toSlot / blocksPerFile) * blocksPerFile
-	for snapName, kvGetter := range s.snapshotTypes.KeyValueGetters {
-		for i := fromSlot; i < toSlot; i += blocksPerFile {
-			if toSlot-i < blocksPerFile {
-				break
-			}
-			// keep beaconblocks here but whatever....
-			to := i + blocksPerFile
-			logger.Log(lvl, "Dumping "+snapName, "from", i, "to", to)
-			if err := dumpCaplinState(ctx, snapName, kvGetter, i, to, blocksPerFile, salt, dirs, workers, lvl, logger, s.snapshotTypes.Compression[snapName]); err != nil {
-				return err
-			}
+
+	names := make([]string, 0, len(availability))
+	for name := range availability {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	jobs := make([]caplinStateDumpJob, 0)
+	for _, name := range names {
+		from := (availability[name] / blocksPerFile) * blocksPerFile
+		for i := from; i+blocksPerFile <= toSlot; i += blocksPerFile {
+			jobs = append(jobs, caplinStateDumpJob{name: name, from: i, to: i + blocksPerFile})
+		}
+	}
+	return jobs
+}
+
+func (s *CaplinStateSnapshots) DumpCaplinState(ctx context.Context, toSlot, blocksPerFile uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
+	availability := make(map[string]uint64, len(s.snapshotTypes.KeyValueGetters))
+	for name := range s.snapshotTypes.KeyValueGetters {
+		availability[name] = s.blocksAvailableForType(name)
+	}
+
+	for _, job := range planStateDump(availability, toSlot, blocksPerFile) {
+		logger.Log(lvl, "Dumping "+job.name, "from", job.from, "to", job.to)
+		if err := dumpCaplinState(ctx, job.name, s.snapshotTypes.KeyValueGetters[job.name], job.from, job.to, blocksPerFile, salt, dirs, workers, lvl, logger, s.snapshotTypes.Compression[job.name]); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -738,8 +738,6 @@ func planStateDump(availability map[string]uint64, toSlot, blocksPerFile uint64)
 
 	jobs := make([]caplinStateDumpJob, 0)
 	for _, name := range names {
-		// Resume exactly at the type's coverage end; flooring to a file
-		// boundary could re-dump an unaligned tail and create overlap.
 		from := availability[name]
 		for i := from; i+blocksPerFile <= toSlot; i += blocksPerFile {
 			jobs = append(jobs, caplinStateDumpJob{name: name, from: i, to: i + blocksPerFile})

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -274,10 +274,22 @@ func (s *CaplinStateSnapshots) blocksAvailableForType(name string) uint64 {
 		return 0
 	}
 	segs, ok := v.([]*VisibleSegment)
-	if !ok || len(segs) == 0 {
+	if !ok {
 		return 0
 	}
-	return segs[len(segs)-1].to
+	// Contiguous prefix from 0: stop at the first gap so a missing range is
+	// re-dumped rather than skipped (Caplin's recalcVisibleFiles does not
+	// truncate visible segments at gaps).
+	var to uint64
+	for _, seg := range segs {
+		if seg.from > to {
+			break
+		}
+		if seg.to > to {
+			to = seg.to
+		}
+	}
+	return to
 }
 
 func (s *CaplinStateSnapshots) Close() {
@@ -726,7 +738,9 @@ func planStateDump(availability map[string]uint64, toSlot, blocksPerFile uint64)
 
 	jobs := make([]caplinStateDumpJob, 0)
 	for _, name := range names {
-		from := (availability[name] / blocksPerFile) * blocksPerFile
+		// Resume exactly at the type's coverage end; flooring to a file
+		// boundary could re-dump an unaligned tail and create overlap.
+		from := availability[name]
 		for i := from; i+blocksPerFile <= toSlot; i += blocksPerFile {
 			jobs = append(jobs, caplinStateDumpJob{name: name, from: i, to: i + blocksPerFile})
 		}

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -265,31 +265,23 @@ func (s *CaplinStateSnapshots) BlocksAvailable() uint64 {
 	return min(s.segmentsMax.Load(), s.idxMax.Load())
 }
 
-func (s *CaplinStateSnapshots) blocksAvailableForType(name string) uint64 {
+func (s *CaplinStateSnapshots) coveredRangesForType(name string) []Range {
 	s.visibleLock.RLock()
 	defer s.visibleLock.RUnlock()
 
 	v, ok := s.visible.Load(name)
 	if !ok {
-		return 0
+		return nil
 	}
 	segs, ok := v.([]*VisibleSegment)
 	if !ok {
-		return 0
+		return nil
 	}
-	// Contiguous prefix from 0: stop at the first gap so a missing range is
-	// re-dumped rather than skipped (Caplin's recalcVisibleFiles does not
-	// truncate visible segments at gaps).
-	var to uint64
+	ranges := make([]Range, 0, len(segs))
 	for _, seg := range segs {
-		if seg.from > to {
-			break
-		}
-		if seg.to > to {
-			to = seg.to
-		}
+		ranges = append(ranges, seg.Range)
 	}
-	return to
+	return ranges
 }
 
 func (s *CaplinStateSnapshots) Close() {
@@ -723,36 +715,57 @@ type caplinStateDumpJob struct {
 	from, to uint64
 }
 
-// planStateDump computes the per-type slot ranges to dump. Each type resumes
-// from its own coverage (availability) rather than a shared floor, so a type
-// already caught up is not re-sliced into files that overlap its existing ones,
-// and a newly added type is still dumped from genesis.
-func planStateDump(availability map[string]uint64, toSlot, blocksPerFile uint64) []caplinStateDumpJob {
+// missingRanges returns the sub-ranges of [0, toSlot) not covered by `covered`
+// (the type's existing segment ranges, sorted by `from`).
+func missingRanges(covered []Range, toSlot uint64) []Range {
+	var missing []Range
+	var cur uint64
+	for _, r := range covered {
+		if r.from > cur {
+			gapEnd := min(r.from, toSlot)
+			missing = append(missing, Range{from: cur, to: gapEnd})
+		}
+		cur = max(cur, r.to)
+		if cur >= toSlot {
+			return missing
+		}
+	}
+	if cur < toSlot {
+		missing = append(missing, Range{from: cur, to: toSlot})
+	}
+	return missing
+}
+
+// planStateDump schedules only the ranges each type is missing within
+// [0, toSlot), starting every full file at a gap boundary so it fills holes and
+// the trailing tail without overlapping an existing segment.
+func planStateDump(coverage map[string][]Range, toSlot, blocksPerFile uint64) []caplinStateDumpJob {
 	toSlot = (toSlot / blocksPerFile) * blocksPerFile
 
-	names := make([]string, 0, len(availability))
-	for name := range availability {
+	names := make([]string, 0, len(coverage))
+	for name := range coverage {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	jobs := make([]caplinStateDumpJob, 0)
 	for _, name := range names {
-		from := availability[name]
-		for i := from; i+blocksPerFile <= toSlot; i += blocksPerFile {
-			jobs = append(jobs, caplinStateDumpJob{name: name, from: i, to: i + blocksPerFile})
+		for _, gap := range missingRanges(coverage[name], toSlot) {
+			for i := gap.from; i+blocksPerFile <= gap.to; i += blocksPerFile {
+				jobs = append(jobs, caplinStateDumpJob{name: name, from: i, to: i + blocksPerFile})
+			}
 		}
 	}
 	return jobs
 }
 
 func (s *CaplinStateSnapshots) DumpCaplinState(ctx context.Context, toSlot, blocksPerFile uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
-	availability := make(map[string]uint64, len(s.snapshotTypes.KeyValueGetters))
+	coverage := make(map[string][]Range, len(s.snapshotTypes.KeyValueGetters))
 	for name := range s.snapshotTypes.KeyValueGetters {
-		availability[name] = s.blocksAvailableForType(name)
+		coverage[name] = s.coveredRangesForType(name)
 	}
 
-	for _, job := range planStateDump(availability, toSlot, blocksPerFile) {
+	for _, job := range planStateDump(coverage, toSlot, blocksPerFile) {
 		logger.Log(lvl, "Dumping "+job.name, "from", job.from, "to", job.to)
 		if err := dumpCaplinState(ctx, job.name, s.snapshotTypes.KeyValueGetters[job.name], job.from, job.to, blocksPerFile, salt, dirs, workers, lvl, logger, s.snapshotTypes.Compression[job.name]); err != nil {
 			return err


### PR DESCRIPTION
### Problem

When a new Caplin beacon-state snapshot type is added to an already-populated datadir (e.g. the GLOAS `BuilderPendingPayments` table), `seg publishable` starts failing with overlapping and/or short snapshot files.

Root cause is in how state snapshots are dumped:

- `BlocksAvailable()` reports the **minimum** `to` across *all* state types. A newly added type has no files, so the global available slot collapses to 0 (or to that one lagging type's progress).
- `DumpCaplinState` used that single global `from` for **every** type and looped `outer over types, inner over slot ranges` with no per-type resume and no skip-if-exists.

So a restart re-dumped already-caught-up types from the lagging floor, slicing their existing base file (e.g. `000000-007150`) into overlapping 50k sub-files, while the genuinely-new type never reliably caught up to head. Observed on a sepolia snapshotter:

- `PendingDepositsDump` — clean layout **plus** spurious `000000-000050 … 001400-001450` files overlapping its `000000-007150` base.
- `BuilderPendingPayments` — only reached 2.7M, never the head (10.4M).

### Fix

Make the state dump resume **per-type** from each type's own coverage:

- Add `blocksAvailableForType` — last visible segment `to` for a single type.
- Add `planStateDump` — pure function that, given each type's availability and the target `to`, produces the per-type `[from,to)` dump jobs. A caught-up type yields no jobs (so its base file is never re-sliced); a new type still starts from genesis.
- `DumpCaplinState` now builds per-type availability and dumps the plan; the redundant global `fromSlot` parameter is dropped (callers updated).

This also makes dump order deterministic (sorted by type name) instead of relying on Go map iteration order.

### Tests

- `TestPlanStateDumpResumesPerType` — covered types are not re-dumped, lagging types resume at their own availability, new/empty types start at 0.
- `TestBlocksAvailableForType` — last-segment semantics.

Written test-first (Red → Green); the initial failing version surfaced that a shared `fromSlot` floor would leave a genesis gap for brand-new types, which is why the parameter was removed.
