### PR TITLE
[r3.4] db/config3: shrink default step size to LegacyStepSize/4

### DIFF
--- a/db/config3/config3.go
+++ b/db/config3/config3.go
@@ -26,12 +26,12 @@ const LegacyStepsInFrozenFile = 64
 
 // DefaultStepSize is the default number of transactions (txNums) in one "step".
 // Prefer reading the actual step size from erigondb.toml via state.ResolveErigonDBSettings or tx.Debug().StepSize().
-const DefaultStepSize = 1_562_500
+const DefaultStepSize = LegacyStepSize / 4 // 390_625
 
 // DefaultStepsInFrozenFile - files of this size are completely frozen/immutable.
 // files of smaller size are also immutable, but can be removed after merge to bigger files.
 // Prefer reading the actual value from erigondb.toml via state.ResolveErigonDBSettings.
-const DefaultStepsInFrozenFile = 64
+const DefaultStepsInFrozenFile = LegacyStepsInFrozenFile * 4 // 256
 
 // UnboundedDomainMerge is a sentinel "steps in frozen file" value used to signal domain merges
 // are unbounded, i.e., can be merged infinitely. This was the default behavior for Erigon <= 3.4 and


### PR DESCRIPTION
Cherry-pick of #21152 to release/3.4.

The release/3.4 snapshot buckets already publish `step_size=390625, steps_in_frozen_file=256`, but the release/3.4 code default was still `1562500/64`. A fresh node with a downloader picks up the bucket's `erigondb.toml` (390625) regardless, so this only affects no-downloader/legacy init — it makes the code default consistent with what's actually published. Frozen-file txn span is preserved (`390625*256 == 1562500*64 == 100_000_000`).