### PR TITLE
db/datastruct/btindex: shrink .bt in-memory node cache (uint64 offsets)

### DIFF
--- a/db/datastruct/btindex/bps_tree.go
+++ b/db/datastruct/btindex/bps_tree.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"math"
 	"time"
-	"unsafe"
 
 	"github.com/c2h5oh/datasize"
 
@@ -63,35 +62,51 @@ func NewBpsTree(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, dataLooku
 // "assert key behind offset == to stored key in bt"
 var envAssertBTKeys = dbg.EnvBool("BT_ASSERT_OFFSETS", false)
 
-func NewBpsTreeWithNodes(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, dataLookup dataLookupFunc, nodes []Node) *BpsTree {
-	bt := &BpsTree{M: M, offt: offt, dataLookupFunc: dataLookup, mx: nodes}
-
-	nsz := uint64(unsafe.Sizeof(Node{}))
-	var cachedBytes uint64
-	for i := range len(nodes) {
-		if envAssertBTKeys {
-			if cmp := bt.compareKey(kv, nodes[i].key, nodes[i].di); cmp != 0 {
-				panic(fmt.Errorf("key mismatch at di=%d i=%d cmp=%d", nodes[i].di, i, cmp))
+func NewBpsTreeWithNodes(kv *seg.Reader, offt *eliasfano32.EliasFano, M uint64, dataLookup dataLookupFunc, keysBlob []byte, nodeOfftEF *eliasfano32.EliasFano, nodeStride uint64) *BpsTree {
+	bt := &BpsTree{M: M, offt: offt, dataLookupFunc: dataLookup, keysBlob: keysBlob, nodeOfftEF: nodeOfftEF, nodeStride: nodeStride}
+	if envAssertBTKeys {
+		for i := range bt.numNodes() {
+			if cmp := bt.compareKey(kv, bt.nodeKey(i), bt.nodeDi(i)); cmp != 0 {
+				panic(fmt.Errorf("key mismatch at di=%d i=%d cmp=%d", bt.nodeDi(i), i, cmp))
 			}
 			kv.Skip() // skip value
 		}
-		cachedBytes += nsz + uint64(len(nodes[i].key))
-
-		nodes[i].off = offt.Get(nodes[i].di)
 	}
-
 	return bt
 }
 
 type BpsTree struct {
-	offt  *eliasfano32.EliasFano // ef with offsets to key/vals
-	mx    []Node
+	offt *eliasfano32.EliasFano // ef with offsets to key/vals
+
+	// pivot cache: keysBlob holds [keyLen:u16][key] records (mmap-backed on-disk,
+	// heap for WarmUp); nodeOfftEF holds record i's offset (Elias-Fano, the only
+	// per-node heap cost) and di is derived as i*nodeStride.
+	keysBlob   []byte
+	nodeOfftEF *eliasfano32.EliasFano
+	nodeStride uint64
+
 	M     uint64 // limit on amount of 'children' for node
 	trace bool
 
 	dataLookupFunc dataLookupFunc
 	cursorGetter   cursorGetter
 }
+
+func (b *BpsTree) numNodes() int {
+	if b.nodeOfftEF == nil {
+		return 0
+	}
+	return int(b.nodeOfftEF.Count())
+}
+
+// nodeKey returns pivot i's key without copying (points into keysBlob).
+func (b *BpsTree) nodeKey(i int) []byte {
+	off := b.nodeOfftEF.Get(uint64(i))
+	l := uint64(binary.BigEndian.Uint16(b.keysBlob[off:]))
+	return b.keysBlob[off+2 : off+2+l]
+}
+
+func (b *BpsTree) nodeDi(i int) uint64 { return uint64(i) * b.nodeStride }
 
 // compareKey resets g to the offset of item di and compares key against the file key.
 // Returns Compare(key, fileKey): 0 on match, <0 if key < fileKey, >0 if key > fileKey.
@@ -142,8 +157,6 @@ type BpsTreeIterator struct {
 
 type Node struct {
 	key []byte
-	off uint64 // offset in kv file to key
-	di  uint64 // key ordinal number in kv
 }
 
 // Encode writes the node key length-prefixed (reusing headerBuf, len >= 2, to
@@ -163,54 +176,84 @@ func (n Node) Encode(w io.Writer, headerBuf []byte) error {
 	return err
 }
 
-// decodeNodes reads count length-prefixed keys (no count prefix on disk — the
-// caller derives count). di is not stored; node i has di = i*m.
-func decodeNodes(data []byte, count, m uint64) ([]Node, int, error) {
+// decodeNodes builds an Elias-Fano index of the byte offsets of count
+// length-prefixed key records within data (no count prefix on disk — the caller
+// derives count). di is not stored; node i has di = i*M, recomputed on read.
+func decodeNodes(data []byte, count uint64) (nodeOfftEF *eliasfano32.EliasFano, end int, err error) {
 	if count > uint64(len(data))/2 { // each node is at least 2 bytes (keyLen)
 		return nil, 0, fmt.Errorf("corrupt index: node count %d exceeds data size", count)
 	}
-	nodes := make([]Node, count)
-	pos := 0
+	if count == 0 {
+		return nil, 0, nil
+	}
+	pos, lastOff := 0, 0
 	for ni := range int(count) {
 		if len(data)-pos < 2 {
 			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
 		}
-		l := int(binary.BigEndian.Uint16(data[pos : pos+2]))
-		pos += 2
-		if len(data)-pos < l {
+		lastOff = pos
+		pos += 2 + int(binary.BigEndian.Uint16(data[pos:pos+2]))
+		if pos > len(data) {
 			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
 		}
-		nodes[ni] = Node{key: data[pos : pos+l], di: uint64(ni) * m}
-		pos += l
 	}
-	return nodes, pos, nil
+	nodeOfftEF = eliasfano32.NewEliasFano(count, uint64(lastOff))
+	for p := 0; p < pos; p += 2 + int(binary.BigEndian.Uint16(data[p:p+2])) {
+		nodeOfftEF.AddOffset(uint64(p))
+	}
+	nodeOfftEF.Build()
+	return nodeOfftEF, pos, nil
 }
 
-// decodeListNodesV0 reads the legacy node list where each node stores its di.
-func decodeListNodesV0(data []byte) ([]Node, int, error) {
+// decodeListNodesV0 builds an Elias-Fano index of the legacy node list
+// ([di:u64][keyLen:u16][key] per node); each offset points past the on-disk di,
+// at the keyLen prefix. di is derived as i*stride; stride comes from the stored
+// di, validated to be the arithmetic progression 0,stride,2*stride,... so a
+// wrong open-time M or a corrupt file is rejected rather than mis-derived.
+func decodeListNodesV0(data []byte) (nodeOfftEF *eliasfano32.EliasFano, stride uint64, end int, err error) {
 	if len(data) < 8 {
-		return nil, 0, fmt.Errorf("truncated index: need 8 bytes for node count, got %d", len(data))
+		return nil, 0, 0, fmt.Errorf("truncated index: need 8 bytes for node count, got %d", len(data))
 	}
 	count := binary.BigEndian.Uint64(data[:8])
 	if count > uint64(len(data)-8)/10 { // each node is at least 10 bytes (di+keyLen)
-		return nil, 0, fmt.Errorf("corrupt index: node count %d exceeds data size", count)
+		return nil, 0, 0, fmt.Errorf("corrupt index: node count %d exceeds data size", count)
 	}
-	nodes := make([]Node, count)
-	pos := 8
+	if count == 0 {
+		return nil, 0, 8, nil
+	}
+	pos, lastOff := 8, 0
 	for ni := range int(count) {
 		if len(data)-pos < 10 {
-			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
+			return nil, 0, 0, fmt.Errorf("decode node %d: short buffer", ni)
 		}
-		nodes[ni].di = binary.BigEndian.Uint64(data[pos : pos+8])
-		l := int(binary.BigEndian.Uint16(data[pos+8 : pos+10]))
-		pos += 10
-		if len(data)-pos < l {
-			return nil, 0, fmt.Errorf("decode node %d: short buffer", ni)
+		di := binary.BigEndian.Uint64(data[pos : pos+8])
+		switch ni {
+		case 0:
+			if di != 0 {
+				return nil, 0, 0, fmt.Errorf("corrupt v0 index: first node di=%d, want 0", di)
+			}
+		case 1:
+			if di == 0 {
+				return nil, 0, 0, fmt.Errorf("corrupt v0 index: second node has zero di (stride must be > 0)")
+			}
+			stride = di
+		default:
+			if di != uint64(ni)*stride { // di must follow the 0,stride,2*stride,... progression
+				return nil, 0, 0, fmt.Errorf("corrupt v0 index: node %d di=%d, want %d", ni, di, uint64(ni)*stride)
+			}
 		}
-		nodes[ni].key = data[pos : pos+l]
-		pos += l
+		lastOff = pos + 8 // skip on-disk di; offset points at the keyLen prefix
+		pos += 10 + int(binary.BigEndian.Uint16(data[pos+8:pos+10]))
+		if pos > len(data) {
+			return nil, 0, 0, fmt.Errorf("decode node %d: short buffer", ni)
+		}
 	}
-	return nodes, pos, nil
+	nodeOfftEF = eliasfano32.NewEliasFano(count, uint64(lastOff))
+	for p := 8; p < pos; p += 10 + int(binary.BigEndian.Uint16(data[p+8:p+10])) {
+		nodeOfftEF.AddOffset(uint64(p + 8))
+	}
+	nodeOfftEF.Build()
+	return nodeOfftEF, stride, pos, nil
 }
 
 func (b *BpsTree) WarmUp(kv *seg.Reader) error {
@@ -219,67 +262,78 @@ func (b *BpsTree) WarmUp(kv *seg.Reader) error {
 	if N == 0 {
 		return nil
 	}
-	b.mx = make([]Node, 0, N/b.M)
-	if b.trace {
-		fmt.Printf("mx cap %d N=%d M=%d\n", cap(b.mx), N, b.M)
-	}
 
 	step := b.M
 	if N < b.M { // cache all keys if less than M
 		step = 1
 	}
+	b.nodeStride = step
 
-	// extremely stupid picking of needed nodes:
-	cachedBytes := uint64(0)
-	nsz := uint64(unsafe.Sizeof(Node{}))
+	nodeCount := (N-1)/step + 1               // ceil(N/step), N>=1 here
+	blob := make([]byte, 0, nodeCount*(2+32)) // 32: rough avg key length
+	if b.trace {
+		fmt.Printf("WarmUp nodes %d N=%d M=%d\n", nodeCount, N, b.M)
+	}
+
 	var key []byte
-	for i := step; i < N; i += step {
-		di := i - 1
-		off := b.offt.Get(di)
+	var hdr [2]byte
+	for i := uint64(0); i < N; i += step {
+		off := b.offt.Get(i)
 		kv.Reset(off)
 		key, _ = kv.Next(key[:0]) // read key only; reuse buffer to avoid allocs
 		kv.Skip()                 // skip value — WarmUp only needs the key
-		b.mx = append(b.mx, Node{off: off, key: common.Copy(key), di: di})
-		cachedBytes += nsz + uint64(len(key))
+		if len(key) > math.MaxUint16 {
+			return fmt.Errorf("WarmUp: key at di=%d too long: %d bytes", i, len(key))
+		}
+		binary.BigEndian.PutUint16(hdr[:], uint16(len(key)))
+		blob = append(blob, hdr[:]...)
+		blob = append(blob, key...)
 	}
+	b.keysBlob = blob
+	nodeOfftEF, _, err := decodeNodes(blob, nodeCount)
+	if err != nil {
+		return err
+	}
+	b.nodeOfftEF = nodeOfftEF
 
 	log.Root().Debug("WarmUp finished", "file", kv.FileName(), "M", b.M, "N", common.PrettyCounter(N),
-		"cached", fmt.Sprintf("%d %.2f%%", len(b.mx), 100*(float64(len(b.mx))/float64(N))),
-		"cacheSize", datasize.ByteSize(cachedBytes).HR(), "fileSize", datasize.ByteSize(kv.Size()).HR(),
+		"cached", fmt.Sprintf("%d %.2f%%", b.numNodes(), 100*(float64(b.numNodes())/float64(N))),
+		"cacheSize", datasize.ByteSize(len(b.keysBlob)).HR(), "fileSize", datasize.ByteSize(kv.Size()).HR(),
 		"took", time.Since(t))
 	return nil
 }
 
 // bs binary-searches the warmed-up pivot list for the [dl,dr) data-index window
 // of key, plus klo/khi: the pivot keys bounding it, used by interpolation search.
-func (b *BpsTree) bs(x []byte) (n *Node, dl, dr uint64, klo, khi []byte) {
+func (b *BpsTree) bs(x []byte) (dl, dr uint64, klo, khi []byte) {
 	dr = b.offt.Count()
-	m, l, r := 0, 0, len(b.mx) //nolint
+	l, r := 0, b.numNodes() //nolint
 
 	for l < r {
-		m = (l + r) >> 1
-		n = &b.mx[m]
+		m := (l + r) >> 1
+		k := b.nodeKey(m)
 
 		if b.trace {
-			fmt.Printf("bs di:%d k:%x\n", n.di, n.key)
+			fmt.Printf("bs di:%d k:%x\n", b.nodeDi(m), k)
 		}
-		switch bytes.Compare(n.key, x) {
+		switch bytes.Compare(k, x) {
 		case 0:
-			return n, n.di, n.di, n.key, n.key
+			di := b.nodeDi(m)
+			return di, di, k, k
 		case 1:
 			r = m
-			dr = n.di
-			khi = n.key
+			dr = b.nodeDi(m)
+			khi = k
 		case -1:
 			l = m + 1
-			dl = n.di
+			dl = b.nodeDi(m)
 			if dl < dr {
 				dl++
 			}
-			klo = n.key
+			klo = k
 		}
 	}
-	return n, dl, dr, klo, khi
+	return dl, dr, klo, khi
 }
 
 // Seek returns cursor pointing at first key which is >= seekKey.
@@ -298,9 +352,13 @@ func (b *BpsTree) Seek(g *seg.Reader, seekKey []byte) (cur *Cursor, err error) {
 	}
 
 	// check cached nodes and narrow roi
-	n, l, r, _, _ := b.bs(seekKey) // l===r when key is found
+	l, r, _, _ := b.bs(seekKey) // l===r when key is found
 	if l == r {
-		cur.Reset(n.di, g)
+		// l can be Count() when seeking past the last key (insertion point);
+		// Reset then reports out-of-bounds and Seek's contract is (nil, nil).
+		if err = cur.Reset(l, g); err != nil {
+			return nil, err
+		}
 		return cur, nil
 	}
 
@@ -372,9 +430,9 @@ func (b *BpsTree) Get(g *seg.Reader, key []byte) (v []byte, ok bool, offset uint
 		return v0, true, 0, nil
 	}
 
-	n, l, r, klo, khi := b.bs(key) // l===r when key is found
+	l, r, klo, khi := b.bs(key) // l===r when key is found
 	if b.trace {
-		fmt.Printf("pivot di: %d di(LR): [%d %d] k: %x found: %t\n", n.di, l, r, n.key, l == r)
+		fmt.Printf("pivot di(LR): [%d %d] k: %x found: %t\n", l, r, key, l == r)
 		defer func() { fmt.Printf("found %x [%d %d]\n", key, l, r) }()
 	}
 
@@ -528,6 +586,7 @@ func (b *BpsTree) Distances() (map[int]int, error) {
 }
 
 func (b *BpsTree) Close() {
-	b.mx = nil
+	b.keysBlob = nil
+	b.nodeOfftEF = nil
 	b.offt = nil
 }

--- a/db/datastruct/btindex/bpstree_bench_test.go
+++ b/db/datastruct/btindex/bpstree_bench_test.go
@@ -220,9 +220,16 @@ func BenchmarkBpsTree_bs(b *testing.B) {
 			}
 			slices.SortFunc(allKeys, bytes.Compare)
 
-			nodes := make([]Node, nodeCount)
-			for i, k := range allKeys {
-				nodes[i] = Node{key: k, di: uint64(i) * uint64(cfg.M), off: uint64(i) * 100}
+			var blob []byte
+			var hdr [2]byte
+			for _, k := range allKeys {
+				binary.BigEndian.PutUint16(hdr[:], uint16(len(k)))
+				blob = append(blob, hdr[:]...)
+				blob = append(blob, k...)
+			}
+			nodeOfftEF, _, err := decodeNodes(blob, uint64(nodeCount))
+			if err != nil {
+				b.Fatal(err)
 			}
 
 			totalCount := uint64(cfg.N)
@@ -232,7 +239,7 @@ func BenchmarkBpsTree_bs(b *testing.B) {
 			}
 			ef.Build()
 
-			bt := &BpsTree{M: uint64(cfg.M), offt: ef, mx: nodes}
+			bt := &BpsTree{M: uint64(cfg.M), offt: ef, keysBlob: blob, nodeOfftEF: nodeOfftEF, nodeStride: uint64(cfg.M)}
 
 			lookupKeys := make([][]byte, 10000)
 			for i := range lookupKeys {

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -512,15 +512,20 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 	}
 	idx.data = idx.m[:idx.size]
 
-	var nodes []Node
+	var nodeOfftEF *eliasfano32.EliasFano
+	var keysBlob []byte
+	var nodeStride uint64
 	switch idx.data[0] {
 	case btFirstByteLegacy: // legacy [EF][nodesCount][di-nodes]
 		var pos int
 		idx.ef, pos = eliasfano32.ReadEliasFano(idx.data)
 		if len(idx.data[pos:]) > 0 {
-			nodes, _, err = decodeListNodesV0(idx.data[pos:])
-			if err != nil {
+			keysBlob = idx.data[pos:]
+			if nodeOfftEF, nodeStride, _, err = decodeListNodesV0(keysBlob); err != nil {
 				return nil, err
+			}
+			if nodeStride == 0 { // <2 nodes: only di=0 exists, stride is irrelevant
+				nodeStride = M
 			}
 		}
 	case btFirstByteUseFooter: // footer-based layout: [leadingByte][nodes][EF][footer][anchor]
@@ -544,8 +549,10 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 		if footer.Meta.KeysCount > 0 {
 			nodesCount = (footer.Meta.KeysCount-1)/M + 1
 		}
+		keysBlob = idx.data[1:]
+		nodeStride = M
 		var nodesEnd int
-		if nodes, nodesEnd, err = decodeNodes(idx.data[1:], nodesCount, M); err != nil {
+		if nodeOfftEF, nodesEnd, err = decodeNodes(keysBlob, nodesCount); err != nil {
 			return nil, err
 		}
 		if footer.Meta.EfOffset != uint64(alignUp(1+nodesEnd, btEFAlign)) { // cross-check ef_offset against the decoded nodes
@@ -566,10 +573,10 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 
 	defer kvGetter.MadvNormal().DisableReadAhead()
 
-	if len(nodes) == 0 {
+	if nodeOfftEF == nil {
 		idx.bplus = NewBpsTree(kvGetter, idx.ef, M, idx.dataLookup)
 	} else {
-		idx.bplus = NewBpsTreeWithNodes(kvGetter, idx.ef, M, idx.dataLookup, nodes)
+		idx.bplus = NewBpsTreeWithNodes(kvGetter, idx.ef, M, idx.dataLookup, keysBlob, nodeOfftEF, nodeStride)
 	}
 	idx.bplus.cursorGetter = idx.newCursor
 

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -210,14 +210,18 @@ func writeV0Index(tb testing.TB, dataPath, indexPath string, compressed seg.File
 
 	if count > 0 {
 		ef := eliasfano32.NewEliasFano(count, uint64(r.Size()))
-		var nodes []Node
+		type v0node struct {
+			key []byte
+			di  uint64
+		}
+		var nodes []v0node
 		var key []byte
 		var pos, di uint64
 		for r.HasNext() {
 			key, _ = r.Next(key[:0])
 			ef.AddOffset(pos)
 			if di%m == 0 {
-				nodes = append(nodes, Node{key: common.Copy(key), di: di})
+				nodes = append(nodes, v0node{key: common.Copy(key), di: di})
 			}
 			di++
 			pos, _ = r.Skip()
@@ -283,6 +287,86 @@ func Test_BtreeIndex_V0_V2_Read(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A v0 file stores di on disk; the reader recovers the node stride from it, so
+// opening with a different M than it was written with (e.g. a changed BT_M) must
+// still resolve every key.
+func Test_BtreeIndex_V0_M_Mismatch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	logger := log.New()
+	const writeM, openM = uint64(32), uint64(256)
+	keyCount := 500
+	compressFlags := seg.CompressKeys | seg.CompressVals
+
+	dataPath := generateKV(t, tmp, 52, 180, keyCount, logger, compressFlags)
+	keys, err := pivotKeysFromKV(dataPath)
+	require.NoError(t, err)
+
+	v0Path := filepath.Join(tmp, "v0.bt")
+	writeV0Index(t, dataPath, v0Path, compressFlags, writeM)
+
+	kv, bt, err := OpenBtreeIndexAndDataFile(v0Path, dataPath, openM, compressFlags, false)
+	require.NoError(t, err)
+	defer bt.Close()
+	defer kv.Close()
+
+	getter := seg.NewReader(kv.MakeGetter(), compressFlags)
+	for i := range keys {
+		cur, err := bt.Seek(getter, keys[i])
+		require.NoErrorf(t, err, "i=%d", i)
+		require.Equalf(t, keys[i], cur.Key(), "seek i=%d", i)
+		cur.Close()
+	}
+}
+
+// Seeking a key greater than the last must return (nil, nil) even when the last
+// cached pivot is the last key (KeysCount % M == 1), where bs() returns an
+// insertion point == KeysCount.
+func TestBtIndex_SeekBeyondLast(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	logger := log.New()
+	const M = uint64(8)
+	const keyCount = 17 // 17 % 8 == 1 -> last pivot di == last key
+	compress := seg.CompressNone
+
+	kvPath := generateKV(t, tmp, 20, 10, keyCount, logger, compress)
+	keys, err := pivotKeysFromKV(kvPath)
+	require.NoError(t, err)
+
+	indexPath := strings.TrimSuffix(kvPath, ".kv") + "_m8.bt"
+	func() {
+		decomp, err := seg.NewDecompressor(kvPath)
+		require.NoError(t, err)
+		defer decomp.Close()
+		iw, err := NewBtIndexWriter(BtIndexWriterArgs{IndexFile: indexPath, TmpDir: tmp, M: M, KeyCount: uint64(decomp.Count() / 2), MaxOffset: uint64(decomp.Size())}, logger)
+		require.NoError(t, err)
+		defer iw.Close()
+		r := seg.NewReader(decomp.MakeGetter(), compress)
+		r.Reset(0)
+		var pos uint64
+		for r.HasNext() {
+			key, _ := r.Next(nil)
+			require.NoError(t, iw.AddKey(key, pos))
+			pos, _ = r.Skip()
+		}
+		iw.DisableFsync()
+		require.NoError(t, iw.Build())
+	}()
+
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, M, compress, false)
+	require.NoError(t, err)
+	defer bt.Close()
+	defer kv.Close()
+	require.EqualValues(t, keyCount, bt.KeyCount())
+
+	getter := seg.NewReader(kv.MakeGetter(), compress)
+	beyond := append(append([]byte{}, keys[len(keys)-1]...), 0xff)
+	cur, err := bt.Seek(getter, beyond)
+	require.NoError(t, err)
+	require.Nil(t, cur, "seek beyond last key must return (nil, nil)")
 }
 
 func TestFooter_EncodeDecodeRoundTrip(t *testing.T) {
@@ -372,7 +456,7 @@ func Test_BtreeIndex_V2_EfOffset(t *testing.T) {
 
 	// ...and equal the position the reader would otherwise derive from the nodes section (which starts after the leading byte).
 	nodesCount := (footer.Meta.KeysCount + footer.Meta.M - 1) / footer.Meta.M
-	_, nodesEnd, err := decodeNodes(data[1:], nodesCount, footer.Meta.M)
+	_, nodesEnd, err := decodeNodes(data[1:], nodesCount)
 	require.NoError(t, err)
 	require.EqualValues(t, alignUp(1+nodesEnd, btEFAlign), footer.Meta.EfOffset)
 }
@@ -590,13 +674,12 @@ func TestNewBtIndex(t *testing.T) {
 	require.NotNil(t, kv)
 	require.NotNil(t, bt)
 	bplus := bt.bplus
-	require.GreaterOrEqual(t, len(bplus.mx), keyCount/int(DefaultBtreeM))
-	require.LessOrEqual(t, len(bplus.mx), keyCount/int(DefaultBtreeM)+2)
+	require.GreaterOrEqual(t, bplus.numNodes(), keyCount/int(DefaultBtreeM))
+	require.LessOrEqual(t, bplus.numNodes(), keyCount/int(DefaultBtreeM)+2)
 
-	for i := 1; i < len(bt.bplus.mx); i++ {
-		require.NotZero(t, bt.bplus.mx[i].di)
-		require.NotZero(t, bt.bplus.mx[i].off)
-		require.NotEmpty(t, bt.bplus.mx[i].key)
+	for i := 1; i < bplus.numNodes(); i++ {
+		require.NotZero(t, bplus.nodeDi(i))
+		require.NotEmpty(t, bplus.nodeKey(i))
 	}
 }
 
@@ -688,19 +771,57 @@ func TestDecodeNodes(t *testing.T) {
 			buf.Write(hdr[:])
 			buf.Write(k)
 		}
-		got, n, err := decodeNodes(buf.Bytes(), uint64(len(keys)), M)
+		got, n, err := decodeNodes(buf.Bytes(), uint64(len(keys)))
 		require.NoError(t, err)
 		require.Equal(t, buf.Len(), n)
-		require.Len(t, got, len(keys))
+		if len(keys) == 0 {
+			require.Nil(t, got)
+			continue
+		}
+		require.EqualValues(t, len(keys), got.Count())
+		bp := &BpsTree{keysBlob: buf.Bytes(), nodeOfftEF: got, nodeStride: M}
 		for i := range keys {
-			require.Equal(t, uint64(i)*M, got[i].di) // di recomputed, not stored
-			require.True(t, bytes.Equal(keys[i], got[i].key))
+			require.Equal(t, uint64(i)*M, bp.nodeDi(i)) // di recomputed, not stored
+			require.True(t, bytes.Equal(keys[i], bp.nodeKey(i)))
 		}
 	}
 }
 
+func TestDecodeListNodesV0_Validation(t *testing.T) {
+	build := func(dis ...uint64) []byte {
+		var buf bytes.Buffer
+		var u8 [8]byte
+		var u2 [2]byte
+		binary.BigEndian.PutUint64(u8[:], uint64(len(dis)))
+		buf.Write(u8[:])
+		for _, di := range dis {
+			binary.BigEndian.PutUint64(u8[:], di)
+			buf.Write(u8[:])
+			binary.BigEndian.PutUint16(u2[:], 1)
+			buf.Write(u2[:])
+			buf.WriteByte('k')
+		}
+		return buf.Bytes()
+	}
+
+	off, stride, _, err := decodeListNodesV0(build(0, 32, 64, 96))
+	require.NoError(t, err)
+	require.Equal(t, uint64(32), stride)
+	require.EqualValues(t, 4, off.Count())
+
+	// di0==0 is required, so stride=di1 can't underflow; corrupt progressions are rejected
+	for name, dis := range map[string][]uint64{
+		"first di != 0":      {8, 40},
+		"zero stride":        {0, 0},
+		"broken progression": {0, 32, 999},
+	} {
+		_, _, _, err := decodeListNodesV0(build(dis...))
+		require.Errorf(t, err, "expected error for %q", name)
+	}
+}
+
 func TestNodeEncode_NoAlloc(t *testing.T) {
-	node := Node{di: 42, key: []byte("some-key")}
+	node := Node{key: []byte("some-key")}
 	var headerBuf [10]byte
 	allocs := testing.AllocsPerRun(1000, func() {
 		if err := node.Encode(io.Discard, headerBuf[:]); err != nil {

--- a/db/datastruct/btindex/nodeofft_ef_test.go
+++ b/db/datastruct/btindex/nodeofft_ef_test.go
@@ -1,0 +1,69 @@
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package btindex
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/seg"
+)
+
+// The pivot offsets are stored Elias-Fano-encoded (nodeOfftEF). Decoding and
+// lookups must be correct for both the v0 (legacy list) and v2 (footer) layouts.
+func Test_BtreeIndex_NodeOfftEF_V0_V2(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	logger := log.New()
+	const M = uint64(32)
+	keyCount := 500
+	compressFlags := seg.CompressKeys | seg.CompressVals
+
+	dataPath := generateKV(t, tmp, 52, 180, keyCount, logger, compressFlags)
+	keys, err := pivotKeysFromKV(dataPath)
+	require.NoError(t, err)
+
+	truth := map[string][]byte{}
+	d, err := seg.NewDecompressor(dataPath)
+	require.NoError(t, err)
+	gt := seg.NewReader(d.MakeGetter(), compressFlags)
+	gt.Reset(0)
+	for gt.HasNext() {
+		k, _ := gt.Next(nil)
+		v, _ := gt.Next(nil)
+		truth[string(k)] = common.Copy(v)
+	}
+	d.Close()
+
+	v2Path := filepath.Join(tmp, "v2.bt")
+	buildBtreeIndex(t, dataPath, v2Path, compressFlags, 1, logger, true)
+	v0Path := filepath.Join(tmp, "v0.bt")
+	writeV0Index(t, dataPath, v0Path, compressFlags, M)
+
+	for _, tc := range []struct{ name, path string }{{"v0", v0Path}, {"v2", v2Path}} {
+		t.Run(tc.name, func(t *testing.T) {
+			kv, bt, err := OpenBtreeIndexAndDataFile(tc.path, dataPath, M, compressFlags, false)
+			require.NoError(t, err)
+			defer bt.Close()
+			defer kv.Close()
+			require.NotNil(t, bt.bplus.nodeOfftEF, "pivot offsets must be Elias-Fano-encoded")
+
+			gr := seg.NewReader(kv.MakeGetter(), compressFlags)
+			for i := range keys {
+				_, v, _, found, err := bt.Get(keys[i], gr)
+				require.NoErrorf(t, err, "i=%d", i)
+				require.Truef(t, found, "key %d not found", i)
+				require.Equalf(t, truth[string(keys[i])], v, "key %d value mismatch", i)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #21875 onto `performance`.