### PR TITLE
cl/phase1/stages: clamp beacon-history download progress to 100%

### DIFF
--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -354,8 +354,14 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 						"ETA", (time.Duration(remaining/speed) * time.Second).String(),
 						"blk/sec", fmt.Sprintf("%.1f", speed))
 				} else {
+					// Beacon history downloads backward; lowestBlockToReach (the CL
+					// snapshot boundary) is only an estimate of the floor — a full or
+					// archive backfill keeps going below it toward genesis. Clamp the
+					// total to the work done so the X/Y display never runs past 100%.
+					beaconDone := highestBlockSeen - currProgress
+					beaconTotal := max(highestBlockSeen-lowestBlockToReach, beaconDone)
 					log.Info("Downloading Beacon History", "progress",
-						fmt.Sprintf("%d/%d", highestBlockSeen-currProgress, highestBlockSeen-lowestBlockToReach),
+						fmt.Sprintf("%d/%d", beaconDone, beaconTotal),
 						"blk/sec", fmt.Sprintf("%.1f", speed))
 				}
 				// More UX-friendly logging


### PR DESCRIPTION
## Problem

The `Downloading Beacon History` log can run **past 100%** — e.g. `progress=47089/24129` and climbing:

```
[INFO] Downloading Beacon History progress=45620/24129 blk/sec=63.4
[INFO] Downloading Beacon History progress=47089/24129 blk/sec=62.8
```

It prints `(highestBlockSeen - currProgress) / (highestBlockSeen - SegmentsMax)`. Beacon history downloads **backward**, and a full/archive backfill keeps descending **below** the CL snapshot boundary (`SegmentsMax`) toward genesis. Once `currProgress < SegmentsMax`, the numerator outgrows the denominator and the `X/Y` display exceeds 100%.

## Fix

`SegmentsMax` is only an estimate of the floor; the true stop point (connect to CL+EL snapshots, or genesis) isn't cheaply known up front. Clamp the displayed total to the work done so the ratio can't exceed 100% (it shows `X/X` while finishing a full backfill below the snapshot boundary, the growing numbers indicating it's still progressing).

**Display-only** — no change to download behavior, and not consensus logic (it's the progress logging in the history-download goroutine). `make lint` clean; package builds/vets.

Reported from a `release/3.4` node; fixing on `main` only (no backport).