### PR TITLE
ci: dequeue merge-queue PR on fast-cancelled leaf failure

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -180,6 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check all required jobs
+        id: gate
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -196,27 +197,32 @@ jobs:
             fi
             echo "Root-cause job(s):"
             echo "$root"
+            # A fast-cancelling leaf failure leaves every need reported as `cancelled`, so a
+            # succeeded cancel step — not the needs results — distinguishes a real failure from a reshuffle.
+            self_cancelled=$(echo "$jobs" | jq '[.jobs[] | select(any(.steps[]?; .name == "Cancel workflow run on failure" and .conclusion == "success"))] | length' 2>/dev/null || echo 0)
+            if jq -e '[to_entries[].value.result] | any(. == "failure")' needs.json >/dev/null || [ "${self_cancelled:-0}" -gt 0 ]; then
+              echo "real_failure=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "real_failure=false" >> "$GITHUB_OUTPUT"
+            fi
             exit 1
           fi
           echo "All required jobs passed or were skipped."
 
-      # GitHub does not auto-remove UNMERGEABLE entries from the merge queue
-      # when their required checks fail — they sit at the queue position with
-      # state UNMERGEABLE until someone manually dequeues. This step does that
-      # automatically on real failures (not queue-reshuffle cancellations,
-      # where all needs come back as `cancelled` and GitHub re-creates a fresh
-      # merge_group event for us).
+      # GitHub leaves an UNMERGEABLE entry sitting in the queue when its required checks
+      # fail, so dequeue it ourselves — but only on a real failure (see real_failure above),
+      # not a reshuffle cancellation, where GitHub re-creates a fresh merge_group for us.
       - name: Dequeue failed merge-queue PR
         if: failure() && github.event_name == 'merge_group'
         env:
           GH_TOKEN: ${{ github.token }}
-          NEEDS: ${{ toJSON(needs) }}
+          REAL_FAILURE: ${{ steps.gate.outputs.real_failure }}
           REF: ${{ github.ref_name }}
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          if ! echo "$NEEDS" | jq -e 'to_entries[] | select(.value.result == "failure")' > /dev/null; then
-            echo "No gate need failed (only cancellations) — likely a queue reshuffle, skipping dequeue."
+          if [ "$REAL_FAILURE" != "true" ]; then
+            echo "ci-gate cancelled with no leaf failure (queue reshuffle / orphaned run) — skipping dequeue."
             exit 0
           fi
           pr_number=$(echo "$REF" | grep -oE 'pr-[0-9]+' | head -1 | cut -d- -f2)


### PR DESCRIPTION
## Problem

When a CI Gate leaf fails in a `merge_group` run, its `Cancel workflow run on failure` step calls `gh run cancel` to fast-cancel the run (so the gate doesn't idle ~80 min waiting for slow siblings). That cancellation leaves **every sibling — and the failed leaf's own reusable-workflow parent — reported as `cancelled`**, not `failure`.

The `Dequeue failed merge-queue PR` step decided off `needs.*.result == "failure"`. Since the real failure is masked as `cancelled`, that check found nothing, so it:

- logged the misleading `No gate need failed (only cancellations) — likely a queue reshuffle, skipping dequeue`, and
- **did not dequeue** the genuinely-failed PR — which then sat `UNMERGEABLE` at its queue position until GitHub or an unrelated reshuffle evicted it.

So a real failure is indistinguishable from a true queue reshuffle at the `needs` level, and both get the "reshuffle, skip" treatment. A scan of recent cancelled `merge_group` runs shows this is common — many were fast-cancelled by a genuine leaf failure (race-tests, hive-eest, eest-spec, kurtosis, …) yet reported as reshuffles.

Concrete case that surfaced this: #21852 was fast-cancelled by a failing `kurtosis / assertoor_*` leaf on three separate merge-queue attempts. Each time the dequeue step skipped, so the PR was never auto-dequeued, and the "queue reshuffle" log actively misdirected investigation.

## Fix

Distinguish a real failure from a reshuffle by the **succeeded `Cancel workflow run on failure` step** — the same fast-cancel signal the root-cause annotation already keys on in `Check all required jobs`. A pure reshuffle / orphan-cancellation has **no** succeeded cancel step, so it still correctly skips (GitHub re-creates a fresh `merge_group` for us).

`Check all required jobs` now exports a `real_failure` output; the dequeue step gates on that instead of re-deriving from `needs`.

## Validation

- `actionlint` (incl. shellcheck on the `run:` blocks) clean.
- Checked the discriminator against real run job-data: the #21852 fast-cancel run has exactly one job with a succeeded `Cancel workflow run on failure` step → `real_failure=true` → dequeue; an orphan-cancelled run (e.g. #21862) has none → `real_failure=false` → skip.

No behaviour change for true reshuffle/orphan cancellations or for ordinary (non-fast-cancel) `needs` failures — those paths are unchanged.
