### PR TITLE
cmd/utils/app: implement `seg index --rebuild`

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2885,6 +2885,39 @@ func doDecompressSpeed(cliCtx *cli.Context) error {
 	return nil
 }
 
+// removeAccessorsForRebuild deletes all accessor/index files so the subsequent
+// BuildMissed* passes regenerate them from the data files (.seg/.kv/.v/.ef).
+func removeAccessorsForRebuild(dirs datadir.Dirs, logger log.Logger) error {
+	targets := []struct {
+		dir  string
+		exts []string
+	}{
+		{dirs.Snap, []string{".idx"}},
+		{dirs.SnapCaplin, []string{".idx"}},
+		{dirs.SnapAccessors, []string{".vi", ".efi"}},
+		{dirs.SnapDomain, []string{".kvi", ".bt", ".kvei"}},
+	}
+	for _, t := range targets {
+		files, err := dir2.ListFiles(t.dir, t.exts...)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return err
+		}
+		for _, fPath := range files {
+			if err := dir2.RemoveFile(fPath); err != nil {
+				return fmt.Errorf("rebuild: remove %s: %w", fPath, err)
+			}
+			if err := dir2.RemoveFile(fPath + ".torrent"); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("rebuild: remove %s: %w", fPath+".torrent", err)
+			}
+			logger.Info("[rebuild] removed accessor", "file", filepath.Base(fPath))
+		}
+	}
+	return nil
+}
+
 func doIndicesCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	logger := log.Root()
 	defer logger.Info("Done")
@@ -2895,7 +2928,9 @@ func doIndicesCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	defer chainDB.Close()
 
 	if rebuild {
-		panic("not implemented")
+		if err := removeAccessorsForRebuild(dirs, logger); err != nil {
+			return err
+		}
 	}
 
 	if err := freezeblocks.RemoveIncompatibleIndices(dirs); err != nil {

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2897,6 +2897,13 @@ func removeAccessorsForRebuild(dirs datadir.Dirs, logger log.Logger) error {
 		{dirs.SnapAccessors, []string{".vi", ".efi"}},
 		{dirs.SnapDomain, []string{".kvi", ".bt", ".kvei"}},
 	}
+	remove := func(fPath string) error {
+		if err := dir2.RemoveFile(fPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("rebuild: remove %s: %w", fPath, err)
+		}
+		logger.Info("[rebuild] removed accessor", "file", filepath.Base(fPath))
+		return nil
+	}
 	for _, t := range targets {
 		files, err := dir2.ListFiles(t.dir, t.exts...)
 		if err != nil {
@@ -2906,13 +2913,22 @@ func removeAccessorsForRebuild(dirs datadir.Dirs, logger log.Logger) error {
 			return err
 		}
 		for _, fPath := range files {
-			if err := dir2.RemoveFile(fPath); err != nil {
-				return fmt.Errorf("rebuild: remove %s: %w", fPath, err)
+			if err := remove(fPath); err != nil {
+				return err
 			}
-			if err := dir2.RemoveFile(fPath + ".torrent"); err != nil && !errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("rebuild: remove %s: %w", fPath+".torrent", err)
+		}
+		torrents, err := dir2.ListFiles(t.dir, ".torrent")
+		if err != nil {
+			return err
+		}
+		for _, fPath := range torrents {
+			base := strings.TrimSuffix(fPath, ".torrent")
+			if !slices.ContainsFunc(t.exts, func(ext string) bool { return strings.HasSuffix(base, ext) }) {
+				continue
 			}
-			logger.Info("[rebuild] removed accessor", "file", filepath.Base(fPath))
+			if err := remove(fPath); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/cmd/utils/app/snapshots_cmd_test.go
+++ b/cmd/utils/app/snapshots_cmd_test.go
@@ -1461,13 +1461,20 @@ func Test_removeAccessorsForRebuild(t *testing.T) {
 		touch(f)
 	}
 
+	orphanTorrent := filepath.Join(dirs.SnapDomain, "v1.0-storage.0-64.kvi.torrent")
+	touch(orphanTorrent)
+	dataTorrent := filepath.Join(dirs.Snap, "v1.0-headers.0-500.seg.torrent")
+	touch(dataTorrent)
+
 	require.NoError(t, removeAccessorsForRebuild(dirs, log.New()))
 
 	for _, f := range accessors {
 		confirmDoesntExist(t, f)
 		confirmDoesntExist(t, f+".torrent")
 	}
+	confirmDoesntExist(t, orphanTorrent)
 	for _, f := range dataFiles {
 		confirmExist(t, f)
 	}
+	confirmExist(t, dataTorrent)
 }

--- a/cmd/utils/app/snapshots_cmd_test.go
+++ b/cmd/utils/app/snapshots_cmd_test.go
@@ -1427,3 +1427,47 @@ func Test_DeleteBlockSnaps_NoBlockFilesSweepsTmp(t *testing.T) {
 
 	confirmDoesntExist(t, tmp)
 }
+
+func Test_removeAccessorsForRebuild(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+
+	touch := func(path string) {
+		f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	accessors := []string{
+		filepath.Join(dirs.Snap, "v1.0-headers.0-500.idx"),
+		filepath.Join(dirs.SnapCaplin, "v1.0-beaconstate.0-100.idx"),
+		filepath.Join(dirs.SnapAccessors, "v1.0-accounts.0-64.vi"),
+		filepath.Join(dirs.SnapAccessors, "v1.0-accounts.0-64.efi"),
+		filepath.Join(dirs.SnapDomain, "v1.0-accounts.0-64.kvi"),
+		filepath.Join(dirs.SnapDomain, "v1.0-accounts.0-64.bt"),
+		filepath.Join(dirs.SnapDomain, "v1.0-accounts.0-64.kvei"),
+	}
+	dataFiles := []string{
+		filepath.Join(dirs.Snap, "v1.0-headers.0-500.seg"),
+		filepath.Join(dirs.SnapCaplin, "v1.0-beaconstate.0-100.seg"),
+		filepath.Join(dirs.SnapIdx, "v1.0-accounts.0-64.ef"),
+		filepath.Join(dirs.SnapHistory, "v1.0-accounts.0-64.v"),
+		filepath.Join(dirs.SnapDomain, "v1.0-accounts.0-64.kv"),
+	}
+	for _, f := range accessors {
+		touch(f)
+		touch(f + ".torrent")
+	}
+	for _, f := range dataFiles {
+		touch(f)
+	}
+
+	require.NoError(t, removeAccessorsForRebuild(dirs, log.New()))
+
+	for _, f := range accessors {
+		confirmDoesntExist(t, f)
+		confirmDoesntExist(t, f+".torrent")
+	}
+	for _, f := range dataFiles {
+		confirmExist(t, f)
+	}
+}


### PR DESCRIPTION
`seg index --rebuild` previously `panic("not implemented")`. Now it deletes all accessor/index files and lets the existing `BuildMissed*` passes regenerate them from the data files.

Removed (then rebuilt) per directory:

| Ext | Dir | Data file | Rebuilt by |
|-----|-----|-----------|-----------|
| `.idx` | `snapshots/` | `.seg` (blocks + caplin beacon) | `br.BuildMissedIndicesIfNeed` / `caplinSnaps.BuildMissingIndices` |
| `.idx` | `snapshots/caplin/` | `.seg` (caplin state) | `caplinStateSnaps.BuildMissingIndices` |
| `.vi` | `snapshots/accessor/` | `.v` | `temporalDb.BuildMissedAccessors` |
| `.efi` | `snapshots/accessor/` | `.ef` | `temporalDb.BuildMissedAccessors` |
| `.kvi` `.bt` `.kvei` | `snapshots/domain/` | `.kv` | `temporalDb.BuildMissedAccessors` |

The removed set is exactly the set the build path regenerates — every accessor type is covered (caplin state included), and only accessors are touched; data files are left intact. `.torrent` sidecars of removed accessors are deleted too.

Adds `Test_removeAccessorsForRebuild` covering removal of all six accessor types + preservation of data files.