### PR TITLE
execution/stagedsync: sample parallel-exec batch buffer size on a 5s tick

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -834,6 +834,11 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 	applyTx := pe.applyTx
 	pe.RUnlock()
 
+	// SizeEstimate takes the hot latestStateLock; sample the batch buffer on its
+	// own 5s cadence rather than on every applied block.
+	bufSizeEvery := time.NewTicker(5 * time.Second)
+	defer bufSizeEvery.Stop()
+
 	for {
 		err := func() error {
 			pe.Lock()
@@ -1021,12 +1026,18 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 
 				// Use AfterCommitment estimate (2x) in per-block mode since
 				// commitment is already computed. BeforeCommitment (4x) is
-				// for batch mode where commitment hasn't run yet.
+				// for batch mode where commitment hasn't run yet. Sampled only on
+				// the 5s tick — reading it every block contends on latestStateLock;
+				// between ticks sizeEst stays 0 so no size-flush fires.
 				var sizeEst uint64
-				if dbg.BatchCommitments {
-					sizeEst = pe.rs.SizeEstimateBeforeCommitment()
-				} else {
-					sizeEst = pe.rs.SizeEstimateAfterCommitment()
+				select {
+				case <-bufSizeEvery.C:
+					if dbg.BatchCommitments {
+						sizeEst = pe.rs.SizeEstimateBeforeCommitment()
+					} else {
+						sizeEst = pe.rs.SizeEstimateAfterCommitment()
+					}
+				default:
 				}
 				batchLimit := pe.cfg.batchSize.Bytes()
 				// We are inside the `blockResult != nil` branch, so at least one


### PR DESCRIPTION
The parallel executor read `SizeEstimate*()` on every applied block to decide whether to size-flush the batch. `SizeEstimate` takes the hot `latestStateLock`, so this contended on the apply path.

Sample the batch buffer size on its own 5s ticker instead. Between ticks `sizeEst` stays 0, so no size-based flush fires; the batch still flushes on the byte limit when a tick lands.

Split out of the page-cache warmup work — independent of it.