### PR TITLE
p2p/discover: fix waiting wrong duration in lookup iterator slowdown

### DIFF
--- a/p2p/discover/lookup.go
+++ b/p2p/discover/lookup.go
@@ -253,7 +253,7 @@ func (it *lookupIterator) slowdown() {
 	if diff > minInterval {
 		return
 	}
-	wait := time.NewTimer(diff)
+	wait := time.NewTimer(minInterval - diff)
 	defer wait.Stop()
 	select {
 	case <-wait.C:


### PR DESCRIPTION
The `slowdown()` function in `lookupIterator` is meant to ensure at least 1 second gap between consecutive DHT lookups so we don't hot-spin unnecessarily. The timer should wait the remaining time, not the elapsed time - but that's exactly what was happening here. If 200ms had passed since the last lookup, it was sleeping for 200ms again instead of the correct 800ms to complete the 1s gap.
