### PR TITLE
chore: fix typos in code comments

### DIFF
--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -601,7 +601,7 @@ func (s *Sentinel) onConnection(_ network.Network, conn network.Conn) {
 			// Handshake had a transport error AND returned invalid — keep anyway.
 			s.peers.RecordHandshakeFailure(peerId)
 		} else {
-			// we were able to succesfully connect, so add this peer to our pool
+			// we were able to successfully connect, so add this peer to our pool
 			s.peers.AddPeer(peerId)
 
 			log.Trace("[Sentinel] Peer validated and added", "peer", peerId)

--- a/db/kv/remotedbserver/remotedbserver.go
+++ b/db/kv/remotedbserver/remotedbserver.go
@@ -49,7 +49,7 @@ import (
 //
 // It's done by `renew` method: after `renew` call reader will see all changes committed after last `renew` call.
 //
-// Erigon has much Historical data - which is immutable: reading of historical data for hours still gives you consistant data.
+// Erigon has much Historical data - which is immutable: reading of historical data for hours still gives you consistent data.
 const MaxTxTTL = 60 * time.Second
 
 // KvServiceAPIVersion - use it to track changes in API

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -56,10 +56,10 @@ const (
 	//   It makes .seg files "warm" - which is bad because they are big and
 	//      data-locality of touches is bad (and maybe need visit a lot of shards to find key).
 	//   Can add a built-in "existence filter" (like bloom/cuckoo/ribbon/xor-filter/fuse-filter); it will improve
-	//      data-locality - filters are small-enough and existance-chekcs will be co-located on disk.
+	//      data-locality - filters are small-enough and existence-checks will be co-located on disk.
 	//   But there are 2 additional properties we have in our data:
 	//      "keys are known", "keys are hashed" (.idx works on murmur3), ".idx can calc key-number by key".
-	//   It means: if we rely on this properties then we can do better than general-purpose-existance-filter.
+	//   It means: if we rely on this properties then we can do better than general-purpose-existence-filter.
 	//   Seems just an "array of 1-st bytes of key-hashes" is great alternative:
 	//      general-purpose-filter: 9bits/key, 0.3% false-positives, 3 mem access
 	//      first-bytes-array: 8bits/key, 1/256=0.4% false-positives, 1 mem access

--- a/diagnostics/metrics/ema.go
+++ b/diagnostics/metrics/ema.go
@@ -11,7 +11,7 @@ type number interface {
 // EMA holds the Exponential Moving Average of a float64 with a the given
 // default α value. Safe to access concurrently.
 // https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average.
-// It can also optionally have β which controls decrease rate seperately.
+// It can also optionally have β which controls decrease rate separately.
 type EMA[T number] struct {
 	defaultAlpha float64
 	defaultBeta  float64
@@ -24,7 +24,7 @@ func NewEma[T number](defaultValue T, defaultAlpha float64) *EMA[T] {
 	return NewEmaWithBeta(defaultValue, defaultAlpha, defaultAlpha)
 }
 
-// NewWithBeta is the same as New but supplies a seperate beta to control the
+// NewWithBeta is the same as New but supplies a separate beta to control the
 // decrease rate
 func NewEmaWithBeta[T number](defaultValue T, defaultAlpha float64, defaultBeta float64) *EMA[T] {
 	return &EMA[T]{defaultAlpha: defaultAlpha, defaultBeta: defaultBeta, defaultValue: defaultValue}

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -244,7 +244,7 @@ func unwindExec3State(ctx context.Context,
 		//TODO: This is broken - becuase it does not handle the way value changes
 		// for previous steps are represented - they will pass nil values here
 		// which will look like a delete (12/11/25 - I've not fixed this as it has
-		// been here for a while and I'm not sure what if anything recieves these
+		// been here for a while and I'm not sure what if anything receives these
 		// changes at what it does with them)
 		if len(k) == length.Addr {
 			if len(v) > 0 {

--- a/execution/state/genesiswrite/genesis_write.go
+++ b/execution/state/genesiswrite/genesis_write.go
@@ -553,7 +553,7 @@ func GenesisWithoutStateToBlock(g *types.Genesis) (head *types.Header, withdrawa
 		}
 	}
 
-	// these fields need to be overriden for Bor running in a kurtosis devnet
+	// these fields need to be overridden for Bor running in a kurtosis devnet
 	if g.Config != nil && g.Config.Bor != nil && g.Config.ChainID.Uint64() == polygonchain.BorKurtosisDevnetChainId {
 		withdrawals = []*types.Withdrawal{}
 		head.BlobGasUsed = new(uint64)

--- a/node/gointerfaces/downloaderproto/downloader.pb.go
+++ b/node/gointerfaces/downloaderproto/downloader.pb.go
@@ -113,7 +113,7 @@ func (x *SeedRequest) GetPaths() []string {
 
 // DownloadItem:
 // - if Erigon created new snapshot and want seed it
-// - if Erigon wnat download files - it fills only "torrent_hash" field
+// - if Erigon want download files - it fills only "torrent_hash" field
 type DownloadItem struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`

--- a/node/interfaces/downloader/downloader.proto
+++ b/node/interfaces/downloader/downloader.proto
@@ -28,7 +28,7 @@ message SeedRequest {
 
 // DownloadItem:
 // - if Erigon created new snapshot and want seed it
-// - if Erigon wnat download files - it fills only "torrent_hash" field
+// - if Erigon want download files - it fills only "torrent_hash" field
 message DownloadItem {
   string path = 1;
   types.H160 torrent_hash = 2; // will be resolved as magnet link

--- a/polygon/bridge/mdbx_store.go
+++ b/polygon/bridge/mdbx_store.go
@@ -522,7 +522,7 @@ func (s txStore) PutEvents(ctx context.Context, events []*EventRecordWithTime) e
 	return nil
 }
 
-// EventsByTimeframe returns events withing [timeFrom, timeTo) interval.
+// EventsByTimeframe returns events within [timeFrom, timeTo) interval.
 func (s txStore) EventsByTimeframe(ctx context.Context, timeFrom, timeTo uint64) ([][]byte, []uint64, error) {
 	var events [][]byte
 	var ids []uint64

--- a/polygon/heimdall/span_block_producers_tracker.go
+++ b/polygon/heimdall/span_block_producers_tracker.go
@@ -102,7 +102,7 @@ func (t *spanBlockProducersTracker) Run(ctx context.Context) error {
 	}
 }
 
-// Anticipates a new span to be observe and fully processed withing the given timeout period.
+// Anticipates a new span to be observe and fully processed within the given timeout period.
 // Returns true if a new span was processed, false if no new span was processed
 func (t *spanBlockProducersTracker) AnticipateNewSpanWithTimeout(ctx context.Context, timeout time.Duration) (bool, error) {
 	select {


### PR DESCRIPTION
Fixes several spelling mistakes in code comments (and one doc-string in `downloader.proto`, with its generated `.pb.go` kept in sync). Comment-only — no functional changes.

| File | Before | After |
|---|---|---|
| `polygon/heimdall/span_block_producers_tracker.go` | withing | within |
| `polygon/bridge/mdbx_store.go` | withing | within |
| `execution/stagedsync/stage_execute.go` | recieves | receives |
| `execution/state/genesiswrite/genesis_write.go` | overriden | overridden |
| `db/recsplit/index.go` | existance / chekcs | existence / checks |
| `db/kv/remotedbserver/remotedbserver.go` | consistant | consistent |
| `diagnostics/metrics/ema.go` | seperate(ly) | separate(ly) |
| `cl/sentinel/discovery.go` | succesfully | successfully |
| `node/interfaces/downloader/downloader.proto` (+ generated `.pb.go`) | wnat | want |

🤖 Generated with [Claude Code](https://claude.com/claude-code)