### PR TITLE
[wip] execution/stagedsync: clear BlockAccessList on exec reset

### DIFF
--- a/execution/stagedsync/rawdbreset/reset_stages.go
+++ b/execution/stagedsync/rawdbreset/reset_stages.go
@@ -237,6 +237,7 @@ var stateHistoryBuckets = []string{
 	kv.TblPruningProgress,
 	kv.TblPruningValsProg,
 	kv.ChangeSets3,
+	kv.BlockAccessList,
 }
 
 func clearStageProgress(tx kv.RwTx, stagesList ...stages.SyncStage) error {


### PR DESCRIPTION
`ResetExec` (used by `integration stage_exec --reset`) is meant to clear all execution-written state, but `BlockAccessList` was missing from the cleanup list — so stale block access lists survived a from-0 exec reset.

This adds `kv.BlockAccessList` to `stateHistoryBuckets`, alongside `ChangeSets3` (already present). Those two are exactly the raw exec-history tables pruned together by `PruneExecutionBlockHistory`.

For completeness, the rest of what the Execution stage writes is already covered: the 6 domains plus their history/inverted-index tables via `DomainTables(...)`, the 4 standalone inverted indexes via `InvertedIdxTables(...)`, and the pruning-progress tables. `MaxTxNum` is intentionally not here — it is a block-level index owned by the bodies/blocks reset (`TruncateBodies` + snapshot refill), not by execution.