### PR TITLE
execution/stagedsync: AuRa genesis bypass for parallel-exec emptyRemoval

### DIFF
--- a/execution/stagedsync/calc_state_test.go
+++ b/execution/stagedsync/calc_state_test.go
@@ -603,3 +603,83 @@ func lookupKeyUpdate(t *testing.T, updates *commitment.Updates, plainKey string)
 	require.NotNil(t, found, "no Update emitted for plainKey %x", plainKey)
 	return found
 }
+
+// TestNormalizeWriteSet_GenesisBypassRetainsEmptyAccount pins that emptyRemoval=false
+// retains an empty account as a full UPDATE rather than emitting SelfDestructPath.
+func TestNormalizeWriteSet_GenesisBypassRetainsEmptyAccount(t *testing.T) {
+	zeroAddr := accounts.InternAddress([20]byte{})
+
+	ver := state.Version{TxIndex: 0, Incarnation: 0}
+	rawWrites := state.VersionedWrites{
+		&state.VersionedWrite{Address: zeroAddr, Path: state.BalancePath, Val: uint256.Int{}, Version: ver},
+		&state.VersionedWrite{Address: zeroAddr, Path: state.NoncePath, Val: uint64(0), Version: ver},
+		&state.VersionedWrite{Address: zeroAddr, Path: state.CodeHashPath, Val: accounts.EmptyCodeHash, Version: ver},
+	}
+	vm := state.NewVersionMap(nil)
+	for _, w := range rawWrites {
+		vm.Write(w.Address, w.Path, accounts.NilKey, ver, w.Val, true)
+	}
+
+	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, nil, nil, false)
+
+	for _, w := range normalized {
+		assert.NotEqual(t, state.SelfDestructPath, w.Path,
+			"emptyRemoval=false must suppress SelfDestructPath emission for empty accounts")
+	}
+
+	cs := newTestCalcState()
+	cs.ApplyWrites(normalized)
+	acc, ok := cs.accounts[zeroAddr]
+	require.True(t, ok)
+	assert.False(t, acc.Deleted)
+
+	updates := newTestUpdates()
+	cs.FlushToUpdates(updates)
+	keyVal := zeroAddr.Value()
+	got := lookupKeyUpdate(t, updates, string(keyVal[:]))
+	assert.Equal(t,
+		commitment.BalanceUpdate|commitment.NonceUpdate|commitment.CodeUpdate,
+		got.Flags,
+		"empty account at genesis must emit full UPDATE, matching serial's TrieContext.Account")
+}
+
+// TestNormalizeWriteSet_PostGenesisEmptyAccountTriggersEIP161 pins that emptyRemoval=true
+// emits SelfDestructPath for an empty account and flushes as DeleteUpdate.
+func TestNormalizeWriteSet_PostGenesisEmptyAccountTriggersEIP161(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xab, 0xcd})
+
+	ver := state.Version{TxIndex: 0, Incarnation: 0}
+	rawWrites := state.VersionedWrites{
+		&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: uint256.Int{}, Version: ver},
+		&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: uint64(0), Version: ver},
+		&state.VersionedWrite{Address: addr, Path: state.CodeHashPath, Val: accounts.EmptyCodeHash, Version: ver},
+	}
+	vm := state.NewVersionMap(nil)
+	for _, w := range rawWrites {
+		vm.Write(w.Address, w.Path, accounts.NilKey, ver, w.Val, true)
+	}
+
+	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, nil, nil, true)
+
+	sdSeen := false
+	for _, w := range normalized {
+		if w.Path == state.SelfDestructPath && w.Address == addr {
+			v, _ := w.Val.(bool)
+			sdSeen = sdSeen || v
+		}
+	}
+	require.True(t, sdSeen, "emptyRemoval=true must emit SelfDestructPath=true for empty account")
+
+	cs := newTestCalcState()
+	cs.ApplyWrites(normalized)
+	acc, ok := cs.accounts[addr]
+	require.True(t, ok)
+	assert.True(t, acc.Deleted)
+
+	updates := newTestUpdates()
+	cs.FlushToUpdates(updates)
+	keyVal := addr.Value()
+	got := lookupKeyUpdate(t, updates, string(keyVal[:]))
+	assert.Equal(t, commitment.DeleteUpdate, got.Flags,
+		"empty account with emptyRemoval=true must emit DeleteUpdate (EIP-161)")
+}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2589,7 +2589,9 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 						}
 						return keys
 					}
-					txResult.writes = normalizeWriteSet(rawWrites, be.versionMap, txVersion.TxIndex, resultIncarnation, stateReader, domainStorageKeys, pe.cfg.chainConfig.IsSpuriousDragon(be.blockNum))
+					// Mirror txtask.go's genesis rules-clobber so empty allocs (AuRa ZeroAddress) survive.
+					emptyRemoval := be.blockNum != 0 && pe.cfg.chainConfig.IsSpuriousDragon(be.blockNum)
+					txResult.writes = normalizeWriteSet(rawWrites, be.versionMap, txVersion.TxIndex, resultIncarnation, stateReader, domainStorageKeys, emptyRemoval)
 				}
 
 				// Snapshot the finalized result before pushing — prevents


### PR DESCRIPTION
Fixes #21712.

## Summary
- AuRa's `CreateAccount(ZeroAddress, false)` at genesis (genesiswrite/genesis_write.go) creates an empty account that serial deliberately retains via the rules-clobber at exec/txtask.go (`rules = &chain.Rules{}` at block 0 — "For Genesis, rules should be empty, so that empty accounts can be included").
- Parallel's `normalizeWriteSet` ignored that override and applied EIP-161 emptyRemoval at block 0, emitting `SelfDestructPath=true` for ZeroAddress → calc_state produced `DeleteUpdate` → divergent trie root.
- Fix: gate `emptyRemoval` at the parallel callsite with `be.blockNum != 0`, mirroring serial's bypass.

## Tests
- `TestNormalizeWriteSet_GenesisBypassRetainsEmptyAccount` — pins the new bypass (empty account at block 0 → no SelfDestructPath, FlushToUpdates emits the full account UPDATE).
- `TestNormalizeWriteSet_PostGenesisEmptyAccountTriggersEIP161` — contrast (block > 0: SelfDestructPath emitted, DeleteUpdate flushed).

## Test plan
- [x] New unit tests green.
- [x] Existing \`TestNormalize|TestFlushToUpdates|TestApplyWrites|TestSD\` suite still green.
- [x] End-to-end on release/3.5: chiado parallel sync from empty datadir with \`--prune.mode=archive --prune.include-commitment-history --persist.receipts --snap.skip-state-snapshot-download --sync.loop.block.limit=10000 --batchSize=512mb\` reached chain tip (block 21,732,513, step 168.6) in ~1d13h with zero wrong-trie / invalid-block errors. Same code path on main, so identical behaviour expected.
- [ ] CI green on the PR.

## Backport
An \`[r3.5]\` cherry-pick PR will follow this one targeting \`release/3.5\`.