### PR TITLE
[r3.5] execution/state, execution/stagedsync: retain AuRa SystemAddress in all EIP-161 empty-removal paths

### DIFF
--- a/execution/stagedsync/calc_state_test.go
+++ b/execution/stagedsync/calc_state_test.go
@@ -310,7 +310,7 @@ func (r *preBlockReader) TracePrefix() string                                   
 //	    BalancePath = 0
 //	    StoragePath[k] = 0  for each k in stateObject.dirtyStorage
 //	  → those land in blockIO.WriteSet → rawWrites
-//	  → normalizeWriteSet(rawWrites, vm, txIndex, incarnation, stateReader, nil, true)
+//	  → normalizeWriteSet(rawWrites, vm, txIndex, incarnation, stateReader, nil, true, false)
 //	  → calcState.ApplyWrites(normalized)
 //	  → calcState.FlushToUpdates(updates)
 //
@@ -378,7 +378,7 @@ func TestSDOfPreExistingContract_FullPipeline(t *testing.T) {
 	vm.Write(addr, state.BalancePath, accounts.NilKey, ver, uint256.Int{}, true)
 
 	stateReader := &preBlockReader{addr: addr, acc: original}
-	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, stateReader, nil, true)
+	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, stateReader, nil, true, false)
 
 	// SD-aware filtering: only SelfDestructPath survives in the normalized
 	// writeset for the SD'd address. The raw IncarnationPath/BalancePath
@@ -488,7 +488,7 @@ func TestSDStorageCascade_EmitsPerSlotDeletes(t *testing.T) {
 	}
 
 	stateReader := &preBlockReader{addr: addr, acc: original}
-	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, stateReader, nil, true)
+	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, stateReader, nil, true, false)
 
 	// Sanity: normalizeWriteSet should have appended one StoragePath=0
 	// entry per slot in vm.StorageKeys(addr) — this is the load-bearing
@@ -563,7 +563,7 @@ func TestNormalizeWriteSet_GenesisBypassRetainsEmptyAccount(t *testing.T) {
 		vm.Write(w.Address, w.Path, accounts.NilKey, ver, w.Val, true)
 	}
 
-	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, nil, nil, false)
+	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, nil, nil, false, false)
 
 	for _, w := range normalized {
 		assert.NotEqual(t, state.SelfDestructPath, w.Path,
@@ -602,7 +602,7 @@ func TestNormalizeWriteSet_PostGenesisEmptyAccountTriggersEIP161(t *testing.T) {
 		vm.Write(w.Address, w.Path, accounts.NilKey, ver, w.Val, true)
 	}
 
-	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, nil, nil, true)
+	normalized := normalizeWriteSet(rawWrites, vm, 0, 0, nil, nil, true, false)
 
 	sdSeen := false
 	for _, w := range normalized {

--- a/execution/stagedsync/exec3_finalize_test.go
+++ b/execution/stagedsync/exec3_finalize_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/exec"
+	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/types"
@@ -1326,7 +1327,7 @@ func TestNormalizeWriteSet_StorageNoOp(t *testing.T) {
 	}
 	vm.FlushVersionedWrites(writeSet, true, "")
 
-	result := normalizeWriteSet(writeSet, vm, 1, 0, nil, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 1, 0, nil, nil, true, false)
 
 	storageCount := countPath(result, state.StoragePath)
 	assert.Equal(t, 0, storageCount, "no-op storage write should be filtered")
@@ -1354,7 +1355,7 @@ func TestNormalizeWriteSet_StorageChanged(t *testing.T) {
 	}
 	vm.FlushVersionedWrites(writeSet, true, "")
 
-	result := normalizeWriteSet(writeSet, vm, 1, 0, nil, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 1, 0, nil, nil, true, false)
 
 	storageCount := countPath(result, state.StoragePath)
 	assert.Equal(t, 1, storageCount, "changed storage write should be kept")
@@ -1379,7 +1380,7 @@ func TestNormalizeWriteSet_StorageNewKey(t *testing.T) {
 	}
 	vm.FlushVersionedWrites(writeSet, true, "")
 
-	result := normalizeWriteSet(writeSet, vm, 0, 0, nil, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 0, 0, nil, nil, true, false)
 
 	storageCount := countPath(result, state.StoragePath)
 	assert.Equal(t, 1, storageCount, "new storage key should be kept")
@@ -1420,7 +1421,7 @@ func TestNormalizeWriteSet_StaleIncarnation(t *testing.T) {
 			Version: state.Version{TxIndex: 5, Incarnation: 0}}, // stale
 	}
 
-	result := normalizeWriteSet(allWrites, vm, 5, 1, nil, nil, true)
+	result := normalizeWriteSet(allWrites, vm, 5, 1, nil, nil, true, false)
 
 	storageCount := countPath(result, state.StoragePath)
 	assert.Equal(t, 1, storageCount, "only incarnation 1's slotA should survive")
@@ -1454,7 +1455,7 @@ func TestNormalizeWriteSet_SelfDestruct(t *testing.T) {
 	}
 	vm.FlushVersionedWrites(writeSet, true, "")
 
-	result := normalizeWriteSet(writeSet, vm, 1, 0, nil, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 1, 0, nil, nil, true, false)
 
 	// Should have: SelfDestructPath + DELETE for slotA + DELETE for slotB
 	sdCount := countPath(result, state.SelfDestructPath)
@@ -1495,7 +1496,7 @@ func TestNormalizeWriteSet_AccountFieldResolution(t *testing.T) {
 			Version: state.Version{TxIndex: 1, Incarnation: 0}},
 	}
 
-	result := normalizeWriteSet(writeSet, vm, 1, 0, nil, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 1, 0, nil, nil, true, false)
 
 	require.Equal(t, 1, len(result))
 	v := result[0].Val.(uint256.Int)
@@ -1516,7 +1517,7 @@ func TestNormalizeWriteSet_AddressPathExcluded(t *testing.T) {
 	}
 	vm.FlushVersionedWrites(writeSet, true, "")
 
-	result := normalizeWriteSet(writeSet, vm, 0, 0, nil, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 0, 0, nil, nil, true, false)
 
 	addrCount := countPath(result, state.AddressPath)
 	balCount := countPath(result, state.BalancePath)
@@ -1552,7 +1553,7 @@ func TestNormalizeWriteSet_StorageOnlyAddress(t *testing.T) {
 	}
 	vm.FlushVersionedWrites(writeSet, true, "")
 
-	result := normalizeWriteSet(writeSet, vm, 0, 0, reader, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 0, 0, reader, nil, true, false)
 
 	// Should have storage write AND account-level fields for addr.
 	// Serial emits UpdateAccountData for every dirty object.
@@ -1600,7 +1601,7 @@ func TestNormalizeWriteSet_StorageAllNoOps(t *testing.T) {
 	}
 	vm.FlushVersionedWrites(writeSet, true, "")
 
-	result := normalizeWriteSet(writeSet, vm, 1, 0, reader, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 1, 0, reader, nil, true, false)
 
 	// Storage write should be filtered (no-op).
 	// But account fields should still be emitted — the IBS would have
@@ -1637,7 +1638,7 @@ func TestNormalizeWriteSet_CreateContract(t *testing.T) {
 	}
 	vm.FlushVersionedWrites(writeSet, true, "")
 
-	result := normalizeWriteSet(writeSet, vm, 0, 0, nil, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 0, 0, nil, nil, true, false)
 
 	// Should have CreateContractPath + all 4 account fields.
 	// The empty balance should NOT cause deletion because CreateContractPath is present.
@@ -1670,7 +1671,7 @@ func TestNormalizeWriteSet_NewAccount(t *testing.T) {
 	// stateReader returns nil for this address (doesn't exist yet)
 	reader := newMapStateReader() // empty — no accounts
 
-	result := normalizeWriteSet(writeSet, vm, 0, 0, reader, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 0, 0, reader, nil, true, false)
 
 	balCount := countPath(result, state.BalancePath)
 	nonceCount := countPath(result, state.NoncePath)
@@ -1723,7 +1724,7 @@ func TestNormalizeWriteSet_EmptyAccountRemoval(t *testing.T) {
 		CodeHash: emptyCodeHash,
 	}
 
-	result := normalizeWriteSet(writeSet, vm, 5, 0, reader, nil, true)
+	result := normalizeWriteSet(writeSet, vm, 5, 0, reader, nil, true, false)
 
 	// The normalized output should produce a Delete for this account,
 	// NOT a regular write with Balance=0, Nonce=0.
@@ -1749,6 +1750,54 @@ func TestNormalizeWriteSet_EmptyAccountRemoval(t *testing.T) {
 		"empty account (Balance=0, Nonce=0, empty CodeHash) should be deleted via EIP-161")
 	assert.False(t, hasNonDeleteAccount,
 		"deleted account should NOT have regular account field writes")
+}
+
+// Case 10b: AuRa retains its SystemAddress (0xff…fe) even when empty.
+// The reference AuRa implementation exempts the SystemAddress from EIP-161
+// empty-account removal, so normalizeWriteSet must not turn it into a delete on
+// an AuRa chain — while a non-AuRa chain still removes it like any other empty
+// account.
+func TestNormalizeWriteSet_AuraSystemAddressRetained(t *testing.T) {
+	emptyCodeHash := accounts.InternCodeHash(common.HexToHash(
+		"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"))
+
+	run := func(isAura bool) state.VersionedWrites {
+		vm := state.NewVersionMap(nil)
+		writeSet := state.VersionedWrites{
+			{Address: params.SystemAddress, Path: state.BalancePath, Val: *uint256.NewInt(0),
+				Version: state.Version{TxIndex: 5, Incarnation: 0}},
+			{Address: params.SystemAddress, Path: state.NoncePath, Val: uint64(0),
+				Version: state.Version{TxIndex: 5, Incarnation: 0}},
+			{Address: params.SystemAddress, Path: state.CodeHashPath, Val: emptyCodeHash,
+				Version: state.Version{TxIndex: 5, Incarnation: 0}},
+		}
+		vm.FlushVersionedWrites(writeSet, true, "")
+
+		reader := newMapStateReader()
+		reader.accounts[params.SystemAddress] = &accounts.Account{
+			Balance:  *uint256.NewInt(1400000000000000),
+			Nonce:    2,
+			CodeHash: emptyCodeHash,
+		}
+
+		return normalizeWriteSet(writeSet, vm, 5, 0, reader, nil, true, isAura)
+	}
+
+	hasDelete := func(writes state.VersionedWrites) bool {
+		for _, w := range writes {
+			if w.Address == params.SystemAddress && w.Path == state.SelfDestructPath {
+				if v, ok := w.Val.(bool); ok && v {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	assert.False(t, hasDelete(run(true)),
+		"AuRa SystemAddress must be retained even when empty")
+	assert.True(t, hasDelete(run(false)),
+		"non-AuRa chain removes an empty account, including the system address")
 }
 
 // countPath counts writes with a given path.

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1710,7 +1710,7 @@ func (result *execResult) calcFees(
 	// Use the worker's post-write Nonce / CodeHash (not pre-tx coinbaseAcc) so
 	// that a sender==coinbase tx whose worker wrote a non-empty Nonce isn't
 	// mistakenly treated as empty here when FeeTipped==0.
-	emptyRemoval := chainRules.IsSpuriousDragon
+	coinbaseEmptyRemoval := state.EIP161EmptyRemoval(chainRules.IsSpuriousDragon, chainRules.IsAura, result.Coinbase)
 	// nil pre-state must not short-circuit to empty=true: a worker may
 	// have already bumped Nonce or set CodeHash, and EIP-161 emptiness
 	// must respect those writes — otherwise SelfDestructPath is emitted
@@ -1718,14 +1718,14 @@ func (result *execResult) calcFees(
 	coinbaseEmptyPre := (coinbaseAcc == nil || coinbaseAcc.Balance.IsZero()) &&
 		coinbaseNonce == 0 && coinbaseEmptyCodeHash && !coinbaseHasCodeHashWrite
 	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
-		(emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
+		(coinbaseEmptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
 
 	var addWrites state.VersionedWrites
 	if emitCoinbase {
 		result.CollectorWrites = result.CollectorWrites.SetAccountBalanceOrDelete(
 			result.Coinbase, coinbaseAcc, newCoinbaseBalance,
-			tracing.BalanceIncreaseRewardTransactionFee, emptyRemoval)
-		if emptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero() {
+			tracing.BalanceIncreaseRewardTransactionFee, coinbaseEmptyRemoval)
+		if coinbaseEmptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero() {
 			addWrites = append(addWrites, &state.VersionedWrite{
 				Address: result.Coinbase,
 				Path:    state.SelfDestructPath,
@@ -1769,7 +1769,7 @@ func (result *execResult) calcFees(
 	if hasBurnt && newBurntBalance != oldBurntBalance {
 		result.CollectorWrites = result.CollectorWrites.SetAccountBalanceOrDelete(
 			burntAddr, burntAcc, newBurntBalance,
-			tracing.BalanceDecreaseGasBuy, emptyRemoval)
+			tracing.BalanceDecreaseGasBuy, state.EIP161EmptyRemoval(chainRules.IsSpuriousDragon, chainRules.IsAura, burntAddr))
 		addWrites = append(addWrites, &state.VersionedWrite{
 			Address:             burntAddr,
 			Path:                state.BalancePath,
@@ -2599,7 +2599,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 					}
 					// Mirror txtask.go's genesis rules-clobber so empty allocs (AuRa ZeroAddress) survive.
 					emptyRemoval := be.blockNum != 0 && pe.cfg.chainConfig.IsSpuriousDragon(be.blockNum)
-					txResult.writes = normalizeWriteSet(rawWrites, be.versionMap, txVersion.TxIndex, resultIncarnation, stateReader, domainStorageKeys, emptyRemoval)
+					txResult.writes = normalizeWriteSet(rawWrites, be.versionMap, txVersion.TxIndex, resultIncarnation, stateReader, domainStorageKeys, emptyRemoval, pe.cfg.chainConfig.Aura != nil)
 				}
 
 				// Snapshot the finalized result before pushing — prevents
@@ -3052,7 +3052,7 @@ func MergeVersionedWrites(prev, next state.VersionedWrites) state.VersionedWrite
 // from the trie (wrong root in TestDeleteRecreateAccount / TestSelfDestructReceive
 // / TestEIP161AccountRemoval, all of which SD a contract whose storage predates
 // the block). Pass nil in unit tests that don't exercise pre-block storage.
-func normalizeWriteSet(writes state.VersionedWrites, vm *state.VersionMap, txIndex int, incarnation int, stateReader state.StateReader, domainStorageKeys func(addr accounts.Address) []accounts.StorageKey, emptyRemoval bool) state.VersionedWrites {
+func normalizeWriteSet(writes state.VersionedWrites, vm *state.VersionMap, txIndex int, incarnation int, stateReader state.StateReader, domainStorageKeys func(addr accounts.Address) []accounts.StorageKey, emptyRemoval bool, isAura bool) state.VersionedWrites {
 	filtered := make(state.VersionedWrites, 0, len(writes))
 
 	// sdStorageSlots returns the union of vm.StorageKeys (this batch) and
@@ -3456,12 +3456,11 @@ func normalizeWriteSet(writes state.VersionedWrites, vm *state.VersionMap, txInd
 	// converting it to a delete here would diverge from serial's trie root
 	// (TestEIP161AccountRemoval block 1, pre-SpuriousDragon).
 	emptyAddrs := make(map[accounts.Address]bool)
-	if emptyRemoval {
-		for addr, s := range acctStates {
-			if s.hasBal && s.hasNonce && s.hasCode &&
-				s.balance.IsZero() && s.nonce == 0 && s.codeHash.IsEmpty() {
-				emptyAddrs[addr] = true
-			}
+	for addr, s := range acctStates {
+		if state.EIP161EmptyRemoval(emptyRemoval, isAura, addr) &&
+			s.hasBal && s.hasNonce && s.hasCode &&
+			s.balance.IsZero() && s.nonce == 0 && s.codeHash.IsEmpty() {
+			emptyAddrs[addr] = true
 		}
 	}
 

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2038,8 +2038,15 @@ func (sdb *IntraBlockState) GetRefund() uint64 {
 	return sdb.refund
 }
 
+// EIP161EmptyRemoval reports whether an empty account at addr is removed under
+// EIP-161 (SpuriousDragon). AuRa retains its SystemAddress even when empty, to
+// match the reference implementation.
+func EIP161EmptyRemoval(spuriousDragon, isAura bool, addr accounts.Address) bool {
+	return spuriousDragon && (!isAura || addr != params.SystemAddress)
+}
+
 func updateAccount(EIP161Enabled bool, isAura bool, stateWriter StateWriter, addr accounts.Address, stateObject *stateObject, isDirty bool, trace bool, tracingHooks *tracing.Hooks, useBlockOrigin bool) error {
-	emptyRemoval := EIP161Enabled && stateObject.data.Empty() && (!isAura || addr != params.SystemAddress)
+	emptyRemoval := EIP161EmptyRemoval(EIP161Enabled, isAura, addr) && stateObject.data.Empty()
 	if stateObject.selfdestructed || (isDirty && emptyRemoval) {
 		balance := stateObject.Balance()
 		if tracingHooks != nil && tracingHooks.OnBalanceChange != nil && !(&balance).IsZero() && stateObject.selfdestructed {
@@ -2089,8 +2096,8 @@ func updateAccount(EIP161Enabled bool, isAura bool, stateWriter StateWriter, add
 	return nil
 }
 
-func printAccount(EIP161Enabled bool, addr accounts.Address, stateObject *stateObject, isDirty bool) {
-	emptyRemoval := EIP161Enabled && stateObject.data.Empty()
+func printAccount(EIP161Enabled bool, isAura bool, addr accounts.Address, stateObject *stateObject, isDirty bool) {
+	emptyRemoval := EIP161EmptyRemoval(EIP161Enabled, isAura, addr) && stateObject.data.Empty()
 	if stateObject.selfdestructed || (isDirty && emptyRemoval) {
 		fmt.Printf("delete: %x\n", addr)
 	}
@@ -2328,7 +2335,7 @@ func (sdb *IntraBlockState) Print(chainRules chain.Rules, all bool) {
 		_, isDirty := sdb.stateObjectsDirty[addr]
 		_, isDirty2 := sdb.journal.dirties[addr]
 
-		printAccount(chainRules.IsSpuriousDragon, addr, stateObject, all || isDirty || isDirty2)
+		printAccount(chainRules.IsSpuriousDragon, chainRules.IsAura, addr, stateObject, all || isDirty || isDirty2)
 	}
 }
 

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -303,7 +303,6 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 	}
 
 	var acc accounts.Account
-	emptyRemoval := rules.IsSpuriousDragon
 	for addr, increase := range balanceIncreases {
 		addrValue := addr.Value()
 		// Read current account — from blockCache if available, otherwise domain.
@@ -333,7 +332,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 			}
 		}
 		acc.Balance.Add(&acc.Balance, &increase)
-		if emptyRemoval && acc.Nonce == 0 && acc.Balance.IsZero() && acc.IsEmptyCodeHash() {
+		if EIP161EmptyRemoval(rules.IsSpuriousDragon, rules.IsAura, addr) && acc.Nonce == 0 && acc.Balance.IsZero() && acc.IsEmptyCodeHash() {
 			if blockCache != nil {
 				blockCache.DeleteAccount(addr, txNum)
 				if !domains.InlineTouchKeyDisabled() {

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -1336,3 +1336,27 @@ func TestGetVersionedAccount_SameTxMetamorphicRecreate_ReturnsAccount(t *testing
 	require.Equal(t, uint64(2), account.Incarnation,
 		"the re-created account's Incarnation should reflect the CREATE2 (not the pre-SD value)")
 }
+
+func TestEIP161EmptyRemoval(t *testing.T) {
+	userAddr := accounts.InternAddress(common.HexToAddress("0x1111"))
+
+	tests := []struct {
+		name           string
+		spuriousDragon bool
+		isAura         bool
+		addr           accounts.Address
+		want           bool
+	}{
+		{"pre-spurious-dragon user", false, false, userAddr, false},
+		{"pre-spurious-dragon aura system address", false, true, params.SystemAddress, false},
+		{"non-aura user", true, false, userAddr, true},
+		{"non-aura system address removed", true, false, params.SystemAddress, true},
+		{"aura user", true, true, userAddr, true},
+		{"aura system address retained", true, true, params.SystemAddress, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, EIP161EmptyRemoval(tc.spuriousDragon, tc.isAura, tc.addr))
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #21937 to release/3.5.

Completes the AuRa EIP-161 family on r3.5: #21931 (already merged) shipped the block-0 ZeroAddress-at-genesis carve-out (chiado #21712); this PR adds the SystemAddress carve-out for AuRa across all empty-account-removal sites.

## r3.5-specific adaptations
- Dropped intermediate `TestAsBlockAccessList_Selfdestructed*` tests from `versionedio_test.go` that exist only on main.
- Updated my `TestNormalizeWriteSet_GenesisBypass*` / `TestNormalizeWriteSet_PostGenesisEmptyAccountTriggersEIP161` (landed in r3.5 via #21931) to pass the new `isAura bool` arg.

## Verification
- All new + existing `TestNormalize|TestFlushToUpdates|TestApplyWrites|TestSD|TestEIP161EmptyRemoval` tests green on r3.5.
- `make lint` + `make erigon` clean.
- The end-to-end "fixes gnosis tip-tracking dep-0 wedge" evidence is described in the main PR (#21937) — verified against the exact same diff applied to a r3.5 wedged datadir.

Fixes the gnosis tip-tracking failure observed on release/3.5 QA runs (e.g. https://github.com/erigontech/erigon/actions/runs/27832904647).