### PR TITLE
db/state: skip DomainDel(AccountsDomain) when prev value is already nil

### DIFF
--- a/execution/state/parallel_fixes_test.go
+++ b/execution/state/parallel_fixes_test.go
@@ -397,6 +397,55 @@ func TestBlockStateCacheWriteAccountUpdatesCurrent(t *testing.T) {
 	assert.Equal(t, enc2, current, "GetCurrentAccount should return the latest write")
 }
 
+// Pins that a second DeleteAccount in the same block is a writeLog no-op —
+// Flush must emit exactly one DomainDel per address (matching serial's IBS
+// short-circuit). Without this dedup the redundant nil-history entry feeds
+// into commitment-cache step keys and produces a non-deterministic state
+// root between parallel-exec nodes validating each other's blocks.
+func TestBlockStateCacheDeleteAccount_IdempotentInBlock(t *testing.T) {
+	cache := NewBlockStateCache()
+	addr := accounts.InternAddress([20]byte{0x77})
+
+	cache.DeleteAccount(addr, 1)
+	cache.DeleteAccount(addr, 2)
+
+	deletes := 0
+	for i := range cache.writeLog {
+		if cache.writeLog[i].kind == bcOpDeleteAccount && cache.writeLog[i].addr == addr {
+			deletes++
+		}
+	}
+	assert.Equal(t, 1, deletes, "second DeleteAccount in the same block must not append a second writeLog entry")
+
+	enc, present := cache.GetCurrentAccount(addr)
+	assert.True(t, present, "current view must still report addr as present-and-empty")
+	assert.Nil(t, enc, "current view value must remain nil")
+}
+
+// Pins the recreate-then-redelete pattern: an intervening WriteAccount
+// resets the dedup so the next DeleteAccount IS recorded — only the
+// "no write in between" duplicate is collapsed.
+func TestBlockStateCacheDeleteAccount_RecreateThenDeleteRecords(t *testing.T) {
+	cache := NewBlockStateCache()
+	addr := accounts.InternAddress([20]byte{0x88})
+
+	acc := accounts.NewAccount()
+	acc.Balance = *uint256.NewInt(1)
+	enc := accounts.SerialiseV3(&acc)
+
+	cache.DeleteAccount(addr, 1)
+	cache.WriteAccount(addr, enc, 2)
+	cache.DeleteAccount(addr, 3)
+
+	deletes := 0
+	for i := range cache.writeLog {
+		if cache.writeLog[i].kind == bcOpDeleteAccount && cache.writeLog[i].addr == addr {
+			deletes++
+		}
+	}
+	assert.Equal(t, 2, deletes, "delete after recreate must be recorded; only no-op duplicates are collapsed")
+}
+
 // TestSelfDestructKeepsDirtyStorageReadableSameTx verifies that after an
 // account self-destructs (versionMap active), a subsequent same-tx GetState
 // still returns the dirty value written before the SELFDESTRUCT. Pre-Cancun

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -1206,6 +1206,12 @@ func (c *BlockStateCache) DeleteAccount(addr accounts.Address, txNum uint64) {
 	// Mark deleted in the current view so subsequent in-block reads / puts
 	// see the destruction immediately. nil (not absent) so GetCurrentAccount
 	// reports "present but empty" rather than falling back to committed state.
+	if v, present := c.currentAccounts[addr]; present && v == nil {
+		// Already deleted by an earlier tx in this block — match serial's
+		// IBS short-circuit so Flush emits a single DomainDel per address.
+		c.mu.Unlock()
+		return
+	}
 	c.currentAccounts[addr] = nil
 	delete(c.currentCode, addr)
 	delete(c.currentStorage, addr)


### PR DESCRIPTION
Fixes #21685.

## Summary
A second `DomainDel(AccountsDomain, addr)` against an already-deleted account currently writes a duplicate nil-history entry; serial's IBS short-circuits in this case so the duplicate is parallel-only. Per @sudeepdino008's analysis on #21685, mainnet block 2,713,395's two DAO-cleanup txs each emit `SelfDestructPath=true` against the same ~200 already-empty accounts when run under parallel exec — both flushes write nil entries where serial writes only one. Final domain value is the same (nil) in both modes, so reads are correct, but the on-disk `accounts.0-256.v/.ef`, `commitment.0-256.v/.ef`, `rcache.0-256.v` history files diverge from r3.4.

Fix: mirror the existing `kv.CodeDomain` skip a few lines below — when `prevVal == nil` after the GetLatest fetch, skip the AccountsDomain delete entirely. Storage prefix wipe and CodeDomain delete that would have run downstream would have been no-ops anyway.

## Test
- `TestSharedDomain_DomainDel_IdempotentForAlreadyDeletedAccount` — puts an account at txNum=0, deletes at txNum=1, re-deletes at txNum=2; asserts the history index records exactly `[0, 1]`, not `[0, 1, 2]`.
- Red-first verified: without the fix, the test fails with `[0, 1, 2]`.
- Existing `db/state/execctx` test suite still green.

## Test plan
- [x] New test green; red-first behaviour confirmed.
- [x] `make lint` clean (x2, lint is non-deterministic).
- [x] `make erigon` clean.
- [ ] Mainnet exec-from-0 on the deterministic-snapshot harness: verify the three history-file hashes (`accounts.0-256.v/.ef`, `commitment.0-256.v/.ef`, `rcache.0-256.v`) match r3.4 baseline after this fix.
- [ ] CI green.

## Backport
A `[r3.5]` cherry-pick PR will follow.