### PR TITLE
execution/commitment: parallel - wrong trie root on whale storage hotfix

### DIFF
--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -130,11 +130,11 @@ func foldStorageLeaf(w *HexPatriciaHashed, childPrefix []byte, group []touchedKe
 }
 
 // deepStorageFold gates the concurrent per-storage-nibble fold of one whale
-// account's storage subtree (foldStorageRoot). Disabled: it produced a wrong
-// trie root and a concurrent-read SIGSEGV on mainnet block 25142734. The
-// top-level per-account-nibble mount fold stays parallel; only the second-tier
-// storage split is off until its correctness + file-view pinning is fixed.
-var deepStorageFold = true
+// account's storage subtree (foldStorageRoot). Disabled: aggregateStorageRoot
+// folds the storage-root branch over only the block-touched first-nibbles
+// without unfolding the on-disk branch, dropping untouched siblings and
+// producing a wrong storage root. Keep off until that unfold is added.
+var deepStorageFold = false
 
 // isDeepStorageAccount reports whether node is an account leaf whose touched storage
 // is large and forked enough to fold concurrently.


### PR DESCRIPTION
Hotfix: `--experimental.parallel-commitment` computes a **wrong trie root** when the whale-storage deep fold (`deepStorageFold`) triggers.

`aggregateStorageRoot` folds a whale account's storage-root branch over only the block-touched first-storage-nibbles and never unfolds the existing on-disk branch, so untouched on-disk sibling subtrees are dropped → wrong storage root → wrong state root. Confirmed on mainnet block 25347998 (parallel `e5ae4b19…` vs expected `5ec40f72…`; same binary with `deepStorageFold=false` crosses it correctly).

Flip the default back to `false` (restores `def65a0d`). The proper fix — unfold the on-disk branch in `aggregateStorageRoot` + regression test — is tracked separately.
