### PR TITLE
[r3.4] .github/workflows: run windows tests on GitHub-hosted runner (selfhosted-win decommissioned)

### DIFF
--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -147,8 +147,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-2025 ]
-    runs-on:
-      group: "selfhosted-win"
+    runs-on: ${{ matrix.os }}
 
     env:
       GOMODCACHE: C:\go-cache\mod


### PR DESCRIPTION
## Problem

On `release/3.4`, the `tests-windows` job in `test-all-erigon.yml` runs on the self-hosted runner group `selfhosted-win` — which has been **decommissioned** (there are no self-hosted Windows runners anymore). With no runner to pick it up, the job sits **queued and is auto-cancelled by GitHub at the 24h limit on every run** (e.g. `started 06-19T14:25:47Z` → `cancelled 06-20T14:25:47Z`). The mac/linux jobs in the same runs succeed; only Windows is dead.

This affects every consumer of the reusable workflow — cache-warming (`push` to `release/3.4`) and ci-gate PR / merge_group runs — so Windows test coverage on 3.4 is effectively down.

## Fix

Point the `tests-windows` job back at the **GitHub-hosted `windows-2025`** runner:

```diff
-    runs-on:
-      group: "selfhosted-win"
+    runs-on: ${{ matrix.os }}
```

The matrix already pins `os: [ windows-2025 ]`, so `runs-on: ${{ matrix.os }}` resolves to the GitHub-hosted runner. This is exactly what **release/3.3**, **release/3.5**, and **main** already do — 3.4 was the only branch left on `selfhosted-win` (introduced by #19466, never propagated). It reverts only the self-hosted-runner half of that change.

## Notes

`selfhosted-win` was the only self-hosted-Windows reference on 3.4 (other Windows jobs, e.g. caplin's, already use GitHub-hosted `${{ matrix.os }}`). actionlint clean.
