### PR TITLE
.github/actions: bump actions/cache to v5 (silence Node 20 deprecation)

### DIFF
--- a/.github/actions/cleanup-erigon/action.yml
+++ b/.github/actions/cleanup-erigon/action.yml
@@ -12,7 +12,7 @@ runs:
       id: gocache-probe
       if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_GOCACHE_PATH != '' && env.ERIGON_CI_GOCACHE_KEY != '' }}
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.ERIGON_CI_GOCACHE_PATH }}
         key: ${{ env.ERIGON_CI_GOCACHE_KEY }}
@@ -33,7 +33,7 @@ runs:
       id: modcache-probe
       if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_MODCACHE != '' && env.ERIGON_CI_MODCACHE_KEY != '' }}
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.ERIGON_CI_MODCACHE }}/cache/download
         key: ${{ env.ERIGON_CI_MODCACHE_KEY }}
@@ -50,7 +50,7 @@ runs:
         ${{ always()
         && env.ERIGON_CI_GITOBJECTS_CACHE_KEY != ''
         && env.ERIGON_CI_GITOBJECTS_CACHE_RESTORED_KEY != env.ERIGON_CI_GITOBJECTS_CACHE_KEY }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: |
           .git/modules

--- a/.github/actions/restore-build-cache/action.yml
+++ b/.github/actions/restore-build-cache/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
     - id: restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ inputs.gocache-path }}
         key: gocache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ inputs.goversion }}|${{ runner.os }}|${{ runner.arch }}|${{ github.run_id }}|${{ github.run_attempt }}

--- a/.github/actions/restore-mod-cache/action.yml
+++ b/.github/actions/restore-mod-cache/action.yml
@@ -25,7 +25,7 @@ runs:
   using: composite
   steps:
     - id: restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ inputs.modcache-path }}/cache/download
         key: gomodcache|${{ inputs.workflow-id }}|${{ github.job }}|${{ inputs.matrix-key }}|${{ runner.os }}|${{ hashFiles('go.sum') }}|${{ github.run_id }}|${{ github.run_attempt }}

--- a/.github/actions/save-build-cache/action.yml
+++ b/.github/actions/save-build-cache/action.yml
@@ -28,7 +28,7 @@ runs:
       shell: bash
       run: go clean -fuzzcache
 
-    - uses: actions/cache/save@v4
+    - uses: actions/cache/save@v5
       if: ${{ always() }}
       with:
         path: ${{ inputs.gocache }}

--- a/.github/actions/save-mod-cache/action.yml
+++ b/.github/actions/save-mod-cache/action.yml
@@ -19,7 +19,7 @@ runs:
         time du -hs "${{ inputs.modcache-path }}" || true
         time du -hs "${{ inputs.modcache-path }}/cache/download" || true
 
-    - uses: actions/cache/save@v4
+    - uses: actions/cache/save@v5
       if: ${{ always() }}
       with:
         path: ${{ inputs.modcache-path }}/cache/download

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -130,7 +130,7 @@ runs:
     - name: Restore submodule git objects cache
       id: restore-submodules
       if: ${{ inputs.submodules == 'true' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           .git/modules


### PR DESCRIPTION
## Problem

Workflows that use the shared cache composites log:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache/restore@v4`, `actions/cache/save@v4`

8 usages remained on `@v4`, all in `.github/actions/*/action.yml`: `cleanup-erigon` (×3), `save-build-cache`, `restore-build-cache`, `save-mod-cache`, `restore-mod-cache`, `setup-erigon`.

## Why these lagged (and why a manual PR)

The `.github/workflows/` cache usages are already on `@v5`, but these composite-action usages aren't — because **Dependabot's `github-actions` ecosystem updates workflow files only, not local composite actions**. So Dependabot won't ever bump these; they need a manual bump.

## Fix

Bump the 8 to `actions/cache/{restore,save}@v5` (Node 24 release, same inputs/outputs — drop-in). Since these composites are used by nearly every workflow, this clears the Node 20 deprecation warning **repo-wide**. No behavior change.

## Reviewer note
`actions/cache@v5` needs Node 24 + the v2 cache service; GitHub-hosted runners support it, and the deprecation notice shows runners are already forced onto Node 24. Worth a sanity check on self-hosted runners (`devops-01-self-hosted`).

## Other warnings in the same runs (not in this PR)
- `"Go build/module cache miss — no matching key found"` are *intentional* `::warning::` signals in `restore-build-cache`/`restore-mod-cache` — left as-is.
- The nightly fuzz `"path does not exist, no cache saved"` warning is separate (the corpus path is pruned by `cleanup-erigon` before save) — a follow-up.