### PR TITLE
execution/stagedsync: fix parallel-exec "limit" log underflow

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -196,8 +196,12 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 	rootResults := make(chan commitmentResult, 64)
 
 	if blockLimit > 0 && min(startBlockNum+blockLimit, maxBlockNum) > startBlockNum+16 || maxBlockNum > startBlockNum+16 {
+		lastBlock := maxBlockNum
+		if blockLimit > 0 {
+			lastBlock = min(startBlockNum+blockLimit-1, maxBlockNum)
+		}
 		log.Info(fmt.Sprintf("[%s] parallel starting", execStage.LogPrefix()),
-			"from", startBlockNum, "to", maxBlockNum, "limit", startBlockNum+blockLimit-1, "initialTxNum", initialTxNum,
+			"from", startBlockNum, "to", maxBlockNum, "limit", lastBlock, "initialTxNum", initialTxNum,
 			"initialBlockTxOffset", offsetFromBlockBeginning, "initialCycle", initialCycle,
 			"isForkValidation", pe.isForkValidation, "isApplyingBlocks", pe.isApplyingBlocks)
 	}


### PR DESCRIPTION
## Problem

The `parallel starting` log line prints a garbage `limit`:

```
[6/8 Execution] parallel starting from=0 to=21715999 limit=18446744073709551615 ...
```

`18446744073709551615` is `math.MaxUint64`: the log computed `limit` as `startBlockNum+blockLimit-1`, which underflows when `blockLimit == 0` (the "no per-cycle limit" case — e.g. `integration stage_exec` from block 0, where `LoopBlockLimit` is 0).

## Fix

Log the effective last block of the cycle:
- `maxBlockNum` when there's no per-cycle limit (`blockLimit == 0`),
- otherwise `min(startBlockNum+blockLimit-1, maxBlockNum)`.

This mirrors how the serial path already computes `toBlockNum` (`exec3_serial.go`). Log-only change — execution behavior is unaffected.

Now logs:
```
[6/8 Execution] parallel starting from=0 to=21715999 limit=21715999 ...
```