### PR TITLE
execution/vm: skip PUSH-free words in JUMPDEST analysis

### DIFF
--- a/execution/vm/analysis.go
+++ b/execution/vm/analysis.go
@@ -19,27 +19,59 @@
 
 package vm
 
+import "encoding/binary"
+
+// SWAR (SIMD-within-a-register) constants for scanning a uint64 of code 8 bytes
+// at a time. A byte b is a PUSH opcode (PUSH1..PUSH32, 0x60..0x7f) iff
+// b&0xe0 == 0x60, so (b&swarPushHi)^swarPushPat is zero exactly for PUSH bytes;
+// the classic has-zero-byte trick then locates them.
+const (
+	swarPushHi  = 0xe0e0e0e0e0e0e0e0
+	swarPushPat = 0x6060606060606060
+	swarLow     = 0x0101010101010101
+	swarHigh    = 0x8080808080808080
+)
+
 // codeBitmap collects data locations in code.
 func codeBitmap(code []byte) bitvec {
 	// The bitmap is 4 bytes longer than necessary, in case the code
 	// ends with a PUSH32, the algorithm will push zeroes onto the
 	// bitvector outside the bounds of the actual code.
 	bits := make(bitvec, (len(code)+32+63)/64)
-	for pc := uint64(0); pc < uint64(len(code)); {
-		op := OpCode(code[pc])
-		pc++
-		if int8(op) < int8(PUSH1) { // If not PUSH (the int8(op) > int(PUSH32) is always false).
-			continue
+	codeLen := uint64(len(code))
+	pc := uint64(0)
+	for pc < codeLen {
+		// Fast path: only PUSH opcodes contribute data bits. pc is always at an
+		// opcode boundary here, so an 8-byte word with no PUSH opcode is 8 pure
+		// opcodes (e.g. JUMPDEST-heavy code) with nothing to mark — skip it.
+		if pc+8 <= codeLen {
+			w := binary.LittleEndian.Uint64(code[pc : pc+8])
+			t := (w & swarPushHi) ^ swarPushPat
+			if (t-swarLow)&^t&swarHigh == 0 { // no PUSH byte in this word
+				pc += 8
+				continue
+			}
 		}
-		if op == PUSH1 {
-			bits.set1(pc)
-			pc += 1
-			continue
+		// This word contains a PUSH (or fewer than 8 bytes remain): walk it
+		// byte-at-a-time with the canonical logic. Advancing at least to the
+		// next 8-byte boundary amortises the peek over >=8 bytes, so push-dense
+		// code is not penalised.
+		wordEnd := pc + 8
+		for pc < codeLen && pc < wordEnd {
+			op := OpCode(code[pc])
+			pc++
+			if int8(op) < int8(PUSH1) { // not PUSH (int8(op) > int8(PUSH32) is always false)
+				continue
+			}
+			if op == PUSH1 {
+				bits.set1(pc)
+				pc++
+				continue
+			}
+			numbits := uint64(op - PUSH1 + 1)
+			bits.setN(uint64(1)<<numbits-1, pc)
+			pc += numbits
 		}
-
-		numbits := uint64(op - PUSH1 + 1)
-		bits.setN(uint64(1)<<numbits-1, pc)
-		pc += numbits
 	}
 	return bits
 }

--- a/execution/vm/analysis_swar_test.go
+++ b/execution/vm/analysis_swar_test.go
@@ -109,8 +109,7 @@ func BenchmarkJumpdestAnalysisJumpdest24k(b *testing.B) {
 	for i := range code {
 		code[i] = 0x5b
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		codeBitmap(code)
 	}
 }

--- a/execution/vm/analysis_swar_test.go
+++ b/execution/vm/analysis_swar_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// codeBitmapRef is the straightforward byte-at-a-time reference that the SWAR
+// codeBitmap must match exactly.
+func codeBitmapRef(code []byte) bitvec {
+	bits := make(bitvec, (len(code)+32+63)/64)
+	for pc := uint64(0); pc < uint64(len(code)); {
+		op := OpCode(code[pc])
+		pc++
+		if int8(op) < int8(PUSH1) {
+			continue
+		}
+		if op == PUSH1 {
+			bits.set1(pc)
+			pc++
+			continue
+		}
+		numbits := uint64(op - PUSH1 + 1)
+		bits.setN(uint64(1)<<numbits-1, pc)
+		pc += numbits
+	}
+	return bits
+}
+
+func equalBitvec(a, b bitvec) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestCodeBitmapSWAREquivalence fuzzes codeBitmap against the reference across
+// jumpdest-heavy, push-dense and fully-random code, plus boundary edge cases.
+func TestCodeBitmapSWAREquivalence(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	gen := func(n, mode int) []byte {
+		c := make([]byte, n)
+		for i := range c {
+			switch mode {
+			case 0: // jumpdest-heavy (the unique-code adversarial shape)
+				if r.Intn(20) == 0 {
+					c[i] = byte(0x60 + r.Intn(32))
+				} else {
+					c[i] = 0x5b
+				}
+			case 1: // push-dense
+				if r.Intn(2) == 0 {
+					c[i] = byte(0x60 + r.Intn(32))
+				} else {
+					c[i] = byte(r.Intn(256))
+				}
+			default: // uniform random
+				c[i] = byte(r.Intn(256))
+			}
+		}
+		return c
+	}
+	for iter := 0; iter < 20000; iter++ {
+		code := gen(r.Intn(260), iter%3)
+		if !equalBitvec(codeBitmap(code), codeBitmapRef(code)) {
+			t.Fatalf("mismatch (len=%d) code=%x", len(code), code)
+		}
+	}
+	edges := [][]byte{{}, {0x5b}, {0x60}, {0x7f}, {0x00}}
+	for n := 0; n < 48; n++ {
+		edges = append(edges,
+			append([]byte{0x7f}, make([]byte, n)...),       // PUSH32 + n bytes
+			append([]byte{0x5b, 0x7f}, make([]byte, n)...), // JUMPDEST, PUSH32, ...
+			append(make([]byte, n), 0x7f),                  // trailing PUSH32
+		)
+	}
+	for _, code := range edges {
+		if !equalBitvec(codeBitmap(code), codeBitmapRef(code)) {
+			t.Fatalf("edge mismatch code=%x", code)
+		}
+	}
+}
+
+// BenchmarkJumpdestAnalysisJumpdest24k mirrors the EIP-2780
+// unique_code_jumpdest receiver: 24KiB of JUMPDEST with no PUSH data.
+func BenchmarkJumpdestAnalysisJumpdest24k(b *testing.B) {
+	code := make([]byte, 24576)
+	for i := range code {
+		code[i] = 0x5b
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		codeBitmap(code)
+	}
+}


### PR DESCRIPTION
## Problem

`codeBitmap` (JUMPDEST analysis) scans bytecode one byte at a time. Only PUSH opcodes contribute data bits, so runs of non-PUSH bytes have nothing to mark — yet they're still walked byte-by-byte. This is worst for the EIP-2780 `test_ether_transfers_onchain_receivers` **`diff_to_unique_code_jumpdest_contract`** case: each receiver is a unique 24 KiB contract that is almost entirely JUMPDEST padding, and (being unique code) the per-codehash analysis cache can't help, so every transfer rescans 24 KiB.

## Change

Detect whether an 8-byte word contains a PUSH opcode with a **SWAR** (SIMD-within-a-register) test — `(b & 0xe0) == 0x60` for every byte via the classic has-zero-byte trick — and skip whole PUSH-free words. A word containing a PUSH falls back to the canonical byte loop, advanced at least to the next 8-byte boundary so the peek is amortised over ≥8 bytes and **PUSH-dense code is not penalised**.

This is the portable-Go analogue of Nethermind's SIMD jumpdest scan. Erigon's *data*-bitmap representation makes a PUSH-free word a pure skip (nothing to write), so the fast path is just `pc += 8`.

## Benchmarks (`execution/vm`)

| Case | before | after |
|---|---|---|
| 24 KiB all-JUMPDEST (unique-code receiver) | ~5.9 µs | **~2.5 µs (2.3×)** |
| no-PUSH 1.2 MB | ~290 µs | **~125 µs (2.3×)** |
| real Solidity contract (PUSH-dense) | ~306 ns | ~298 ns (neutral) |

## Correctness

New `TestCodeBitmapSWAREquivalence` fuzzes the result against the byte-at-a-time reference across jumpdest-heavy, push-dense and uniform-random code (20k cases) plus boundary edge cases (lone / trailing PUSH spanning word boundaries), asserting byte-identical bitvecs. Existing `TestJumpDestAnalysis` and the full `execution/vm` suite pass; `make lint` clean.

## Scope

This speeds up the analysis itself; on the end-to-end EIP-2780 import it's a small CPU fraction of an I/O-bound (commitment) workload, so it won't move the headline MGas/s much on its own — it's a free, zero-regression win that's most visible on JUMPDEST-heavy / low-PUSH code. Opened as draft for review.