### PR TITLE
[r3.4] cl/beacon: add v2 proposer-duties endpoint and guard epoch-slot overflow

### DIFF
--- a/cl/beacon/handler/duties_attester.go
+++ b/cl/beacon/handler/duties_attester.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -29,6 +30,11 @@ import (
 )
 
 const maxEpochsLookaheadForDuties = 32
+
+// epochSlotOverflows reports whether epoch*slotsPerEpoch would overflow uint64.
+func epochSlotOverflows(epoch, slotsPerEpoch uint64) bool {
+	return slotsPerEpoch > 0 && epoch > math.MaxUint64/slotsPerEpoch-1
+}
 
 type attesterDutyResponse struct {
 	Pubkey                  common.Bytes48 `json:"pubkey"`
@@ -75,6 +81,9 @@ func (a *ApiHandler) getAttesterDuties(w http.ResponseWriter, r *http.Request) (
 	epoch, err := beaconhttp.EpochFromRequest(r)
 	if err != nil {
 		return nil, err
+	}
+	if epochSlotOverflows(epoch, a.beaconChainCfg.SlotsPerEpoch) {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("epoch %d overflows slot computation", epoch))
 	}
 
 	dependentRoot, err := a.getDependentRoot(epoch, true)

--- a/cl/beacon/handler/duties_proposer.go
+++ b/cl/beacon/handler/duties_proposer.go
@@ -43,12 +43,32 @@ func (a *ApiHandler) isProposerDutyInLookaheadVector(s *state.CachingBeaconState
 }
 
 func (a *ApiHandler) getDutiesProposer(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
+	return a.getDutiesProposerForVersion(w, r, false)
+}
+
+func (a *ApiHandler) getDutiesProposerV2(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
+	return a.getDutiesProposerForVersion(w, r, true)
+}
+
+// getProposerDependentRoot returns the attester-style dependent root for v2 from Fulu onwards,
+// and the original proposer-style root for v1 and all pre-Fulu epochs.
+func (a *ApiHandler) getProposerDependentRoot(epoch uint64, v2 bool) (common.Hash, error) {
+	if v2 && a.beaconChainCfg.GetCurrentStateVersion(epoch) >= clparams.FuluVersion {
+		return a.getDependentRoot(epoch, true)
+	}
+	return a.getDependentRoot(epoch, false)
+}
+
+func (a *ApiHandler) getDutiesProposerForVersion(w http.ResponseWriter, r *http.Request, v2 bool) (*beaconhttp.BeaconResponse, error) {
 	epoch, err := beaconhttp.EpochFromRequest(r)
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
+	if epochSlotOverflows(epoch, a.beaconChainCfg.SlotsPerEpoch) {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("epoch %d overflows slot computation", epoch))
+	}
 
-	dependentRoot, err := a.getDependentRoot(epoch, false)
+	dependentRoot, err := a.getProposerDependentRoot(epoch, v2)
 	if err != nil {
 		return nil, err
 	}

--- a/cl/beacon/handler/duties_proposer_test.go
+++ b/cl/beacon/handler/duties_proposer_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEpochSlotOverflows(t *testing.T) {
+	require.False(t, epochSlotOverflows(0, 32))
+	require.False(t, epochSlotOverflows(1000, 32))
+	require.False(t, epochSlotOverflows(math.MaxUint64/32-1, 32))
+	require.True(t, epochSlotOverflows(math.MaxUint64/32, 32))
+	require.True(t, epochSlotOverflows(math.MaxUint64, 32))
+	require.False(t, epochSlotOverflows(0, 0))
+}

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -375,6 +375,9 @@ func (a *ApiHandler) init() {
 			}
 			if a.routerCfg.Validator {
 				r.Route("/validator", func(r chi.Router) {
+					r.Route("/duties", func(r chi.Router) {
+						r.Get("/proposer/{epoch}", beaconhttp.HandleEndpointFunc(a.getDutiesProposerV2))
+					})
 					r.Get("/blocks/{slot}", beaconhttp.HandleEndpointFunc(a.GetEthV3ValidatorBlock)) // deprecate
 					r.Get("/aggregate_attestation", beaconhttp.HandleEndpointFunc(a.GetEthV2ValidatorAggregateAttestation))
 					r.Post("/aggregate_and_proofs", a.PostEthV1ValidatorAggregatesAndProof) // reuse

--- a/cl/beacon/handler/harness/duties_attester.yml
+++ b/cl/beacon/handler/harness/duties_attester.yml
@@ -43,3 +43,13 @@ tests:
     compare:
       exprs:
        - "actual_code == 400"
+  - name: attester duties overflow epoch
+    actual:
+      handler: i
+      path: /eth/v1/validator/duties/attester/576460752303423488
+      method: post
+      body:
+       data: ["0","1","2","3","4","5","6","7","8","9"]
+    compare:
+      exprs:
+       - "actual_code == 400"

--- a/cl/beacon/handler/harness/duties_proposer.yml
+++ b/cl/beacon/handler/harness/duties_proposer.yml
@@ -40,3 +40,35 @@ tests:
        - has(actual.data[0].pubkey)
        - has(actual.data[0].validator_index)
        - has(actual.data[0].slot)
+  - name: proposer duties v2
+    actual:
+      handler: i
+      path: /eth/v2/validator/duties/proposer/{{.Vars.head_epoch}}
+    compare:
+      exprs:
+       - actual_code == 200
+       - size(actual.data) == 32
+       - has(actual.data[0].pubkey)
+       - has(actual.data[0].validator_index)
+       - has(actual.data[0].slot)
+  - name: proposer duties v2 bad epoch
+    actual:
+      handler: i
+      path: /eth/v2/validator/duties/proposer/abc
+    compare:
+      exprs:
+       - actual_code == 400
+  - name: proposer duties overflow epoch
+    actual:
+      handler: i
+      path: /eth/v1/validator/duties/proposer/576460752303423488
+    compare:
+      exprs:
+       - actual_code == 400
+  - name: proposer duties v2 overflow epoch
+    actual:
+      handler: i
+      path: /eth/v2/validator/duties/proposer/576460752303423488
+    compare:
+      exprs:
+       - actual_code == 400


### PR DESCRIPTION
## Problem

Lighthouse 8.2.0 (and other current consensus clients) request proposer duties from `GET /eth/v2/validator/duties/proposer/{epoch}` **by default** — the v2 endpoint reports the correct `dependent_root`, whereas v1 returns one that triggers spurious "proposer duties re-org" warnings.

Caplin on `release/3.4` only registered the **v1** route, so the validator client received a `404` and could **miss block proposals** until the operator discovered the non-obvious `--disable-proposer-duties-v2` VC flag. Every other major CL (Prysm, Teku, Nimbus, Lodestar) serves v2, so this is an upgrade-compatibility regression rather than a Lighthouse quirk.

## Change

- Register `GET /eth/v2/validator/duties/proposer/{epoch}`, sharing the v1 handler body via `getDutiesProposerForVersion`. The v2 dependent root is the attester-style root **from Fulu onwards** and is byte-for-byte identical to v1 for all pre-Fulu epochs, so behaviour on current networks is unchanged.
- Guard the unbounded `{epoch}` path variable: `epoch * SlotsPerEpoch` could overflow `uint64` and **wrap to a small slot**, making the proposer endpoint return `HTTP 200` with bogus duties for genesis slots (confirmed: epoch `2^59` → duties for slots 0–31, zero `dependent_root`). Reject overflowing epochs with `400` on both the proposer and attester duties endpoints, via a shared `epochSlotOverflows` helper (matches `main`).

This is **not** a clean cherry-pick: the v2 endpoint landed on `main` inside #21655 ("glamsterdam devnet-5 fixes"), entangled with Gloas/EIP-7732, churn-limit, and engine-API changes that don't belong on a release branch. The proposer/attester overflow guards mirror `main`'s `epochSlotOverflows` (duties_attester.go, duties_proposer.go).

## Tests

- `duties_proposer.yml`: v2 route returns 200 (regression guard against the 404 — fails red without the route), v2 bad-epoch 400, v1+v2 overflow-epoch 400.
- `duties_attester.yml`: overflow-epoch 400.
- `TestEpochSlotOverflows` unit test.
- Overflow guard confirmed load-bearing: without it the wrapping epoch returns 200 with garbage duties; with it, 400.
- `make erigon integration` builds; `make lint` clean.

## r3.4-specific adaptations

`release/3.4`'s `getDutiesProposer` is the older parallel-shuffling implementation (not `main`'s refactored version), so only the dependent-root selection and the overflow guard were ported on top of it — the v2 dependent-root semantics match `main`'s `getProposerDependentRoot`. There is no v2 attester or sync endpoint in the spec; only proposer duties gained v2.