### PR TITLE
[wip] db/state: dedup latest-values per (key,step) in domain flush

### DIFF
--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -457,6 +457,12 @@ type DomainBufferedWriter struct {
 	aux2      []byte  // auxilary buffer for step + val
 	diff      *kv.DomainDiff
 
+	// per-Flush debug counters/timings, read by flushWriters for the [dbg] log
+	lastFlushHist    time.Duration
+	lastFlushVals    time.Duration
+	lastFlushEntries uint64 // collector entries loaded (per-block rewrites)
+	lastFlushKeys    uint64 // distinct (key,step) groups actually written
+
 	h *historyBufferedWriter
 }
 
@@ -471,12 +477,15 @@ func (w *DomainBufferedWriter) Close() {
 }
 
 func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
+	w.lastFlushHist, w.lastFlushVals, w.lastFlushEntries, w.lastFlushKeys = 0, 0, 0, 0
 	if w.discard {
 		return nil
 	}
+	histStart := time.Now()
 	if err := w.h.Flush(ctx, tx); err != nil {
 		return err
 	}
+	w.lastFlushHist = time.Since(histStart)
 
 	if w.largeVals {
 		if err := w.values.Load(tx, w.valsTable, loadFunc, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
@@ -491,18 +500,49 @@ func (w *DomainBufferedWriter) Flush(ctx context.Context, tx kv.RwTx) error {
 		return err
 	}
 	defer valuesCursor.Close()
-	if err := w.values.Load(tx, w.valsTable, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
-		foundVal, err := valuesCursor.SeekBothRange(k, v[:8])
+	valsStart := time.Now()
+	// Within a flush the same key is re-written every block (commitment branches
+	// especially), but the latest-values DupSort table only needs the final value
+	// per (key, ^step). The collector is sorted by key with insertion order
+	// preserved, so a (key, ^step) group is contiguous and its last entry is that
+	// step's final value; collapse it to a single SeekBothRange+Put instead of one
+	// per rewrite.
+	var grpKey, grpVal []byte
+	hasGroup := false
+	writeGroup := func() error {
+		if !hasGroup {
+			return nil
+		}
+		foundVal, err := valuesCursor.SeekBothRange(grpKey, grpVal[:8])
 		if err != nil {
 			return err
 		}
-		if len(foundVal) == 0 || !bytes.Equal(foundVal[:8], v[:8]) {
-			return valuesCursor.Put(k, v)
+		if len(foundVal) == 0 || !bytes.Equal(foundVal[:8], grpVal[:8]) {
+			return valuesCursor.Put(grpKey, grpVal)
 		}
-		return valuesCursor.PutCurrent(k, v) // DeleteCurrent+Put
+		return valuesCursor.PutCurrent(grpKey, grpVal) // DeleteCurrent+Put
+	}
+	if err := w.values.Load(tx, w.valsTable, func(k, v []byte, table etl.CurrentTableReader, next etl.LoadNextFunc) error {
+		w.lastFlushEntries++
+		if hasGroup && bytes.Equal(k, grpKey) && bytes.Equal(v[:8], grpVal[:8]) {
+			grpVal = append(grpVal[:0], v...) // same (key, step): keep the later value
+			return nil
+		}
+		if err := writeGroup(); err != nil { // emit the previous group's final value
+			return err
+		}
+		w.lastFlushKeys++
+		grpKey = append(grpKey[:0], k...)
+		grpVal = append(grpVal[:0], v...)
+		hasGroup = true
+		return nil
 	}, etl.TransformArgs{Quit: ctx.Done(), EmptyVals: true}); err != nil {
 		return err
 	}
+	if err := writeGroup(); err != nil {
+		return err
+	}
+	w.lastFlushVals = time.Since(valsStart)
 	w.Close()
 
 	return nil

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	btree2 "github.com/tidwall/btree"
 
@@ -844,8 +845,14 @@ func (sd *TemporalMemBatch) flushWriters(ctx context.Context, tx kv.RwTx) error 
 		if w == nil {
 			continue
 		}
+		flushStart := time.Now()
 		if err := w.Flush(ctx, tx); err != nil {
 			return err
+		}
+		if kv.Domain(di) == kv.CommitmentDomain {
+			aggTx.d[di].d.logger.Warn("[dbg] domain flush", "domain", kv.Domain(di).String(),
+				"entries", w.lastFlushEntries, "keys", w.lastFlushKeys,
+				"hist", w.lastFlushHist, "vals", w.lastFlushVals, "total", time.Since(flushStart))
 		}
 		aggTx.d[di].closeValsCursor() //TODO: why?
 		w.Close()


### PR DESCRIPTION
## Problem

During a flush, the commitment domain re-writes the same Patricia branch on (nearly) every block, so the values collector accumulates ~100x more entries than there are distinct keys. The flush then replays every one of them into MDBX with a `SeekBothRange`+`PutCurrent` — each overwriting the previous — even though the latest-values DupSort table only needs the **final** value per `(key, ^step)`.

Measured on chiado (one step): ~115k collector entries for ~1k distinct keys (≈100x), and ~96k of those were genuine value changes (not byte-identical), i.e. real per-block churn that only the last write matters for.

## Change

Collapse each contiguous `(key, ^step)` group in the sorted collector to a **single** `SeekBothRange`+`Put`/`PutCurrent`:

- the collector is sorted by key with insertion order preserved, so a `(key, step)` group is contiguous and its last entry is that step's final value;
- the old loop's `PutCurrent` already made it last-wins, so this is **byte-identical** final MDBX state with far fewer cursor ops.

DupSort-safe: dedup is per `(key, ^step)` (the `^step` value-prefix is the discriminator), so multiple per-step dups of a key are preserved — only the within-`(key,step)` rewrites collapse. History is a separate writer and is untouched (it still records every transition).

## WIP

Includes a temporary `[dbg] domain flush` log (commitment only) showing `entries` (collector loads) vs `keys` (actual writes) plus `hist`/`vals` timings, so the dedup ratio is visible. To be dropped to `Debug`/removed before merge. Perf numbers on a >RAM dataset still to come.