### PR TITLE
cl/beacon/beacontest: evaluate the singular `expr` comparison field

### DIFF
--- a/cl/beacon/beacontest/comparison_test.go
+++ b/cl/beacon/beacontest/comparison_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package beacontest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComparisonExprList(t *testing.T) {
+	// Singular expr must be evaluated, not silently dropped.
+	require.Equal(t, []string{"actual_code == 400"}, (&Comparison{Expr: "actual_code == 400"}).exprList())
+	// Plural exprs are used as-is.
+	require.Equal(t, []string{"a", "b"}, (&Comparison{Exprs: []string{"a", "b"}}).exprList())
+	// Both forms combine.
+	require.Equal(t, []string{"a", "actual_code == 400"}, (&Comparison{Exprs: []string{"a"}, Expr: "actual_code == 400"}).exprList())
+	// Neither falls back to the defaults.
+	require.Equal(t, []string{"actual_code == 200", "actual == expect"}, (&Comparison{}).exprList())
+}

--- a/cl/beacon/beacontest/harness.go
+++ b/cl/beacon/beacontest/harness.go
@@ -208,6 +208,19 @@ type Comparison struct {
 	Literal bool     `json:"literal"`
 }
 
+// exprList returns every assertion to evaluate: the plural exprs, the singular expr if set,
+// and the default assertions only when neither is provided.
+func (c *Comparison) exprList() []string {
+	out := append([]string{}, c.Exprs...)
+	if c.Expr != "" {
+		out = append(out, c.Expr)
+	}
+	if len(c.Exprs) == 0 && c.Expr == "" {
+		out = append(out, "actual_code == 200", "actual == expect")
+	}
+	return out
+}
+
 func (c *Comparison) Compare(t *testing.T, aRaw, bRaw json.RawMessage, aCode, bCode int) error {
 	var err error
 	var a, b any
@@ -252,11 +265,7 @@ func (c *Comparison) Compare(t *testing.T, aRaw, bRaw json.RawMessage, aCode, bC
 		bType = cel.StringType
 	}
 
-	exprs := []string{}
-	// if no default expr set and no exprs are set, then add the default expr
-	if len(c.Exprs) == 0 && c.Expr == "" {
-		exprs = append(exprs, "actual_code == 200", "actual == expect")
-	}
+	exprs := c.exprList()
 
 	env, err := cel.NewEnv(
 		cel.Variable("expect", aType),
@@ -268,7 +277,7 @@ func (c *Comparison) Compare(t *testing.T, aRaw, bRaw json.RawMessage, aCode, bC
 		return err
 	}
 
-	for _, expr := range append(c.Exprs, exprs...) {
+	for _, expr := range exprs {
 		ast, issues := env.Compile(expr)
 		if issues != nil && issues.Err() != nil {
 			return issues.Err()

--- a/cl/beacon/handler/harness/duties_proposer.yml
+++ b/cl/beacon/handler/harness/duties_proposer.yml
@@ -23,12 +23,13 @@ tests:
     compare:
       expr: "actual_code == 400"
 
-  - name: proposer duties not synced
+  - name: proposer duties early epoch dependent root missing
     actual:
       handler: i
       path: /eth/v1/validator/duties/proposer/1
     compare:
-      expr: "actual_code == 503"
+      exprs:
+       - actual_code == 404
   - name: fcu historical
     actual:
       handler: i


### PR DESCRIPTION
## Problem

`beacontest`'s `Comparison.Compare` evaluated only the **plural** `exprs:` field (plus auto-injected defaults). The **singular** `expr:` field was parsed into the struct but never added to the evaluated set, so any test case written with `expr:` ran **zero assertions and passed unconditionally**.

Repo-wide, 14 comparison cases use the singular `expr:`. They were all silently vacuous.

## Change

- Extract the assertion set into `Comparison.exprList()`, which now includes the singular `expr` (alongside `exprs` and the neither-set defaults). `Compare` ranges over that list.
- Add `TestComparisonExprList` covering all four combinations (singular / plural / both / neither).

## Unmasked assertion

Enabling `expr:` evaluation surfaced exactly **one** previously-hidden mismatch (the other 13 cases assert correctly): the `duties_proposer` "proposer duties not synced" case asserted `503` for `/eth/v1/validator/duties/proposer/1`. The harness node is synced (head epoch 260), and the endpoint actually returns **404** — the dependent root for that early epoch is not backfilled in the test state, so `getDependentRoot` returns "dependent root not found". The expectation is corrected to `404` (and renamed), which also preserves the original intent of exercising an unavailable-epoch error path.

## Tests

- `TestComparisonExprList` (unit) — fails if `expr` is dropped from the evaluated set again.
- Full `beacontest` package and all `cl/beacon/handler` `TestHarness*` suites green.
- `make lint` clean; `make erigon` builds.

Follow-up: this will be backported to `release/3.5`.