### PR TITLE
[r3.5] cl/beacon/beacontest: evaluate the singular `expr` comparison field

### DIFF
--- a/cl/beacon/beacontest/comparison_test.go
+++ b/cl/beacon/beacontest/comparison_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package beacontest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComparisonExprList(t *testing.T) {
+	// Singular expr must be evaluated, not silently dropped.
+	require.Equal(t, []string{"actual_code == 400"}, (&Comparison{Expr: "actual_code == 400"}).exprList())
+	// Plural exprs are used as-is.
+	require.Equal(t, []string{"a", "b"}, (&Comparison{Exprs: []string{"a", "b"}}).exprList())
+	// Both forms combine.
+	require.Equal(t, []string{"a", "actual_code == 400"}, (&Comparison{Exprs: []string{"a"}, Expr: "actual_code == 400"}).exprList())
+	// Neither falls back to the defaults.
+	require.Equal(t, []string{"actual_code == 200", "actual == expect"}, (&Comparison{}).exprList())
+}

--- a/cl/beacon/beacontest/harness.go
+++ b/cl/beacon/beacontest/harness.go
@@ -208,6 +208,19 @@ type Comparison struct {
 	Literal bool     `json:"literal"`
 }
 
+// exprList returns every assertion to evaluate: the plural exprs, the singular expr if set,
+// and the default assertions only when neither is provided.
+func (c *Comparison) exprList() []string {
+	out := append([]string{}, c.Exprs...)
+	if c.Expr != "" {
+		out = append(out, c.Expr)
+	}
+	if len(c.Exprs) == 0 && c.Expr == "" {
+		out = append(out, "actual_code == 200", "actual == expect")
+	}
+	return out
+}
+
 func (c *Comparison) Compare(t *testing.T, aRaw, bRaw json.RawMessage, aCode, bCode int) error {
 	var err error
 	var a, b any
@@ -252,11 +265,7 @@ func (c *Comparison) Compare(t *testing.T, aRaw, bRaw json.RawMessage, aCode, bC
 		bType = cel.StringType
 	}
 
-	exprs := []string{}
-	// if no default expr set and no exprs are set, then add the default expr
-	if len(c.Exprs) == 0 && c.Expr == "" {
-		exprs = append(exprs, "actual_code == 200", "actual == expect")
-	}
+	exprs := c.exprList()
 
 	env, err := cel.NewEnv(
 		cel.Variable("expect", aType),
@@ -268,7 +277,7 @@ func (c *Comparison) Compare(t *testing.T, aRaw, bRaw json.RawMessage, aCode, bC
 		return err
 	}
 
-	for _, expr := range append(c.Exprs, exprs...) {
+	for _, expr := range exprs {
 		ast, issues := env.Compile(expr)
 		if issues != nil && issues.Err() != nil {
 			return issues.Err()

--- a/cl/beacon/handler/harness/duties_proposer.yml
+++ b/cl/beacon/handler/harness/duties_proposer.yml
@@ -23,12 +23,17 @@ tests:
     compare:
       expr: "actual_code == 400"
 
-  - name: proposer duties not synced
+  - name: proposer duties early epoch
     actual:
       handler: i
       path: /eth/v1/validator/duties/proposer/1
     compare:
-      expr: "actual_code == 503"
+      exprs:
+       - actual_code == 200
+       - size(actual.data) == 32
+       - has(actual.data[0].pubkey)
+       - has(actual.data[0].validator_index)
+       - has(actual.data[0].slot)
   - name: fcu historical
     actual:
       handler: i


### PR DESCRIPTION
Cherry-pick of #21958 to release/3.5.

## Problem

`beacontest`'s `Comparison.Compare` evaluated only the **plural** `exprs:` field (plus auto-injected defaults). The **singular** `expr:` field was parsed but never added to the evaluated set, so any case written with `expr:` ran **zero assertions and passed unconditionally**.

## Change

- Extract the assertion set into `Comparison.exprList()`, which now includes the singular `expr`. `Compare` ranges over that list.
- Add `TestComparisonExprList` (unit) covering singular / plural / both / neither.
- Correct the one unmasked assertion (see below).

## r3.5-specific adaptations

On `main` (#21958) the unmasked `duties_proposer` "proposer duties not synced" case returns **404** — `getDependentRoot` there has a "dependent root not found" branch. `release/3.5` does **not** have that branch and returns **200** with the epoch's duties, so the corrected expectation asserts `200` + shape (renamed to "proposer duties early epoch") rather than `404`.

## Tests

- `TestComparisonExprList`, full `beacontest` package, and all `cl/beacon/handler` `TestHarness*` suites green.
- `make lint` clean; `make erigon` builds.