### PR TITLE
[r3.5] cl/beacon: add v2 proposer-duties endpoint and guard epoch-slot overflow

### DIFF
--- a/cl/beacon/handler/duties_attester.go
+++ b/cl/beacon/handler/duties_attester.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -29,6 +30,10 @@ import (
 )
 
 const maxEpochsLookaheadForDuties = 32
+
+func epochSlotOverflows(epoch, slotsPerEpoch uint64) bool {
+	return slotsPerEpoch > 0 && epoch > math.MaxUint64/slotsPerEpoch-1
+}
 
 type attesterDutyResponse struct {
 	Pubkey                  common.Bytes48 `json:"pubkey"`
@@ -75,6 +80,9 @@ func (a *ApiHandler) getAttesterDuties(w http.ResponseWriter, r *http.Request) (
 	epoch, err := beaconhttp.EpochFromRequest(r)
 	if err != nil {
 		return nil, err
+	}
+	if epochSlotOverflows(epoch, a.beaconChainCfg.SlotsPerEpoch) {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("epoch %d overflows slot computation", epoch))
 	}
 
 	dependentRoot, err := a.getDependentRoot(epoch, true)

--- a/cl/beacon/handler/duties_attester.go
+++ b/cl/beacon/handler/duties_attester.go
@@ -35,6 +35,19 @@ func epochSlotOverflows(epoch, slotsPerEpoch uint64) bool {
 	return slotsPerEpoch > 0 && epoch > math.MaxUint64/slotsPerEpoch-1
 }
 
+func computeDependentRootSlot(epoch, slotsPerEpoch uint64, attester bool) uint64 {
+	switch {
+	case epoch == 0:
+		return 0
+	case attester && epoch <= 1:
+		return 0
+	case attester:
+		return (epoch-1)*slotsPerEpoch - 1
+	default:
+		return epoch*slotsPerEpoch - 1
+	}
+}
+
 type attesterDutyResponse struct {
 	Pubkey                  common.Bytes48 `json:"pubkey"`
 	ValidatorIndex          uint64         `json:"validator_index,string"`
@@ -51,10 +64,7 @@ func (a *ApiHandler) getDependentRoot(epoch uint64, attester bool) (common.Hash,
 		err           error
 	)
 	return dependentRoot, a.syncedData.ViewHeadState(func(s *state.CachingBeaconState) error {
-		dependentRootSlot := (epoch * a.beaconChainCfg.SlotsPerEpoch) - 1
-		if attester {
-			dependentRootSlot = ((epoch - 1) * a.beaconChainCfg.SlotsPerEpoch) - 1
-		}
+		dependentRootSlot := computeDependentRootSlot(epoch, a.beaconChainCfg.SlotsPerEpoch, attester)
 		if !a.syncedData.Syncing() && dependentRootSlot == a.syncedData.HeadSlot() {
 			dependentRoot = a.syncedData.HeadRoot()
 			return nil

--- a/cl/beacon/handler/duties_proposer.go
+++ b/cl/beacon/handler/duties_proposer.go
@@ -49,9 +49,29 @@ func (a *ApiHandler) isProposerDutyInLookaheadVector(s *state.CachingBeaconState
 }
 
 func (a *ApiHandler) getDutiesProposer(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
+	return a.getDutiesProposerForVersion(w, r, false)
+}
+
+func (a *ApiHandler) getDutiesProposerV2(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {
+	return a.getDutiesProposerForVersion(w, r, true)
+}
+
+// getProposerDependentRoot returns the attester-style dependent root for v2 from Fulu onwards,
+// and the original proposer-style root for v1 and all pre-Fulu epochs.
+func (a *ApiHandler) getProposerDependentRoot(epoch uint64, v2 bool) (common.Hash, error) {
+	if v2 && a.beaconChainCfg.GetCurrentStateVersion(epoch) >= clparams.FuluVersion {
+		return a.getDependentRoot(epoch, true)
+	}
+	return a.getDependentRoot(epoch, false)
+}
+
+func (a *ApiHandler) getDutiesProposerForVersion(w http.ResponseWriter, r *http.Request, v2 bool) (*beaconhttp.BeaconResponse, error) {
 	epoch, err := beaconhttp.EpochFromRequest(r)
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
+	}
+	if epochSlotOverflows(epoch, a.beaconChainCfg.SlotsPerEpoch) {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("epoch %d overflows slot computation", epoch))
 	}
 
 	expectedSlot := epoch * a.beaconChainCfg.SlotsPerEpoch
@@ -70,7 +90,7 @@ func (a *ApiHandler) getDutiesProposer(w http.ResponseWriter, r *http.Request) (
 		}
 		stateGetter := state_accessors.GetValFnTxAndSnapshot(tx, view)
 
-		dependentRoot, err := a.getHistoricalProposerDependentRoot(tx, stateGetter, epoch)
+		dependentRoot, err := a.getHistoricalProposerDependentRoot(tx, stateGetter, epoch, v2)
 		if err != nil {
 			return nil, err
 		}
@@ -81,7 +101,7 @@ func (a *ApiHandler) getDutiesProposer(w http.ResponseWriter, r *http.Request) (
 		return newBeaconResponse(duties).WithFinalized(true).WithVersion(a.beaconChainCfg.GetCurrentStateVersion(epoch)).With("dependent_root", dependentRoot), nil
 	}
 
-	dependentRoot, err := a.getDependentRoot(epoch, false)
+	dependentRoot, err := a.getProposerDependentRoot(epoch, v2)
 	if err != nil {
 		return nil, err
 	}
@@ -203,8 +223,9 @@ func fillProposerDutiesFromIndices(duties []proposerDuties, s *state.CachingBeac
 	return nil
 }
 
-func (a *ApiHandler) getHistoricalProposerDependentRoot(tx kv.Tx, stateGetter state_accessors.GetValFn, epoch uint64) (common.Hash, error) {
-	if epoch == 0 {
+func (a *ApiHandler) getHistoricalProposerDependentRoot(tx kv.Tx, stateGetter state_accessors.GetValFn, epoch uint64, v2 bool) (common.Hash, error) {
+	targetVersion := a.beaconChainCfg.GetCurrentStateVersion(epoch)
+	if epoch == 0 || (v2 && targetVersion >= clparams.FuluVersion && epoch <= 1) {
 		rootBytes, err := stateGetter(kv.BlockRoot, base_encoding.Encode64ToBytes4(0))
 		if err != nil {
 			return common.Hash{}, err
@@ -222,7 +243,11 @@ func (a *ApiHandler) getHistoricalProposerDependentRoot(tx kv.Tx, stateGetter st
 		return root, nil
 	}
 
-	dependentRootSlot := epoch*a.beaconChainCfg.SlotsPerEpoch - 1
+	dependentRootEpoch := epoch
+	if v2 && targetVersion >= clparams.FuluVersion {
+		dependentRootEpoch = epoch - 1
+	}
+	dependentRootSlot := dependentRootEpoch*a.beaconChainCfg.SlotsPerEpoch - 1
 	dependentRootBytes, err := stateGetter(kv.BlockRoot, base_encoding.Encode64ToBytes4(dependentRootSlot))
 	if err != nil {
 		return common.Hash{}, err

--- a/cl/beacon/handler/duties_proposer_test.go
+++ b/cl/beacon/handler/duties_proposer_test.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -88,9 +89,18 @@ func TestGetHistoricalProposerDependentRootEpochZeroReturnsGenesisRoot(t *testin
 	roTx, err := db.BeginRo(context.Background())
 	require.NoError(t, err)
 	defer roTx.Rollback()
-	dependentRoot, err := handler.getHistoricalProposerDependentRoot(roTx, state_accessors.GetValFnTxAndSnapshot(roTx, nil), 0)
+	dependentRoot, err := handler.getHistoricalProposerDependentRoot(roTx, state_accessors.GetValFnTxAndSnapshot(roTx, nil), 0, false)
 	require.NoError(t, err)
 	require.Equal(t, genesisRoot, dependentRoot)
+}
+
+func TestEpochSlotOverflows(t *testing.T) {
+	require.False(t, epochSlotOverflows(0, 32))
+	require.False(t, epochSlotOverflows(1000, 32))
+	require.False(t, epochSlotOverflows(math.MaxUint64/32-1, 32))
+	require.True(t, epochSlotOverflows(math.MaxUint64/32, 32))
+	require.True(t, epochSlotOverflows(math.MaxUint64, 32))
+	require.False(t, epochSlotOverflows(0, 0))
 }
 
 func TestGetDutiesProposerEpochZeroReturnsGenesisRootAndDuties(t *testing.T) {

--- a/cl/beacon/handler/duties_proposer_test.go
+++ b/cl/beacon/handler/duties_proposer_test.go
@@ -103,6 +103,67 @@ func TestEpochSlotOverflows(t *testing.T) {
 	require.False(t, epochSlotOverflows(0, 0))
 }
 
+func TestComputeDependentRootSlot(t *testing.T) {
+	const spe = uint64(32)
+	// Epoch 0 always maps to the genesis slot.
+	require.Equal(t, uint64(0), computeDependentRootSlot(0, spe, false))
+	require.Equal(t, uint64(0), computeDependentRootSlot(0, spe, true))
+	// Attester (v2 from Fulu) epoch <= 1 maps to genesis, avoiding the (epoch-1) underflow.
+	require.Equal(t, uint64(0), computeDependentRootSlot(1, spe, true))
+	// Proposer / v1 style: epoch*spe - 1.
+	require.Equal(t, spe-1, computeDependentRootSlot(1, spe, false))
+	require.Equal(t, 5*spe-1, computeDependentRootSlot(5, spe, false))
+	// Attester / v2 style diverges by one epoch: (epoch-1)*spe - 1.
+	require.Equal(t, 4*spe-1, computeDependentRootSlot(5, spe, true))
+}
+
+func TestGetHistoricalProposerDependentRootV2Fulu(t *testing.T) {
+	db, _, _, preState, _, handler, _, _, _, _ := setupTestingHandler(t, clparams.BellatrixVersion, log.Root(), true)
+	handler.beaconChainCfg.CapellaForkEpoch = 1
+	handler.beaconChainCfg.DenebForkEpoch = 1
+	handler.beaconChainCfg.ElectraForkEpoch = 1
+	handler.beaconChainCfg.FuluForkEpoch = 1
+	handler.beaconChainCfg.InitializeForkSchedule()
+	spe := handler.beaconChainCfg.SlotsPerEpoch
+
+	genesisRoot, err := preState.GetBlockRootAtSlot(0)
+	require.NoError(t, err)
+
+	// A high epoch whose dependent-root slots lie beyond the antiquated chain, so the
+	// canonical-root fallback resolves deterministically to the marked roots below.
+	const epoch = uint64(100)
+	require.GreaterOrEqual(t, handler.beaconChainCfg.GetCurrentStateVersion(epoch), clparams.FuluVersion)
+	v2Root := common.Hash{0xa1}
+	v1Root := common.Hash{0xb2}
+
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+	require.NoError(t, beacon_indicies.MarkRootCanonical(context.Background(), tx, 0, genesisRoot))
+	require.NoError(t, beacon_indicies.MarkRootCanonical(context.Background(), tx, (epoch-1)*spe-1, v2Root))
+	require.NoError(t, beacon_indicies.MarkRootCanonical(context.Background(), tx, epoch*spe-1, v1Root))
+	require.NoError(t, tx.Commit())
+
+	roTx, err := db.BeginRo(context.Background())
+	require.NoError(t, err)
+	defer roTx.Rollback()
+	getter := state_accessors.GetValFnTxAndSnapshot(roTx, nil)
+
+	// Epoch <= 1 under v2+Fulu resolves to the genesis root rather than underflowing.
+	earlyRoot, err := handler.getHistoricalProposerDependentRoot(roTx, getter, 1, true)
+	require.NoError(t, err)
+	require.Equal(t, genesisRoot, earlyRoot)
+
+	// v2 uses the previous epoch's dependent root; v1 uses the target epoch's. They diverge.
+	gotV2, err := handler.getHistoricalProposerDependentRoot(roTx, getter, epoch, true)
+	require.NoError(t, err)
+	require.Equal(t, v2Root, gotV2)
+	gotV1, err := handler.getHistoricalProposerDependentRoot(roTx, getter, epoch, false)
+	require.NoError(t, err)
+	require.Equal(t, v1Root, gotV1)
+	require.NotEqual(t, gotV1, gotV2)
+}
+
 func TestGetDutiesProposerEpochZeroReturnsGenesisRootAndDuties(t *testing.T) {
 	db, _, _, _, _, handler, _, _, fcu, _ := setupTestingHandler(t, clparams.Phase0Version, log.Root(), true)
 

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -439,6 +439,9 @@ func (a *ApiHandler) init() {
 			}
 			if a.routerCfg.Validator {
 				r.Route("/validator", func(r chi.Router) {
+					r.Route("/duties", func(r chi.Router) {
+						r.Get("/proposer/{epoch}", beaconhttp.HandleEndpointFunc(a.getDutiesProposerV2))
+					})
 					r.Get("/blocks/{slot}", beaconhttp.HandleEndpointFunc(a.GetEthV3ValidatorBlock)) // deprecate
 					r.Get("/aggregate_attestation", beaconhttp.HandleEndpointFunc(a.GetEthV2ValidatorAggregateAttestation))
 					r.Post("/aggregate_and_proofs", a.PostEthV1ValidatorAggregatesAndProof) // reuse

--- a/cl/beacon/handler/harness/duties_attester.yml
+++ b/cl/beacon/handler/harness/duties_attester.yml
@@ -43,3 +43,13 @@ tests:
     compare:
       exprs:
        - "actual_code == 400"
+  - name: attester duties overflow epoch
+    actual:
+      handler: i
+      path: /eth/v1/validator/duties/attester/576460752303423488
+      method: post
+      body:
+       data: ["0","1","2","3","4","5","6","7","8","9"]
+    compare:
+      exprs:
+       - "actual_code == 400"

--- a/cl/beacon/handler/harness/duties_proposer.yml
+++ b/cl/beacon/handler/harness/duties_proposer.yml
@@ -40,3 +40,35 @@ tests:
        - has(actual.data[0].pubkey)
        - has(actual.data[0].validator_index)
        - has(actual.data[0].slot)
+  - name: proposer duties v2
+    actual:
+      handler: i
+      path: /eth/v2/validator/duties/proposer/{{.Vars.head_epoch}}
+    compare:
+      exprs:
+       - actual_code == 200
+       - size(actual.data) == 32
+       - has(actual.data[0].pubkey)
+       - has(actual.data[0].validator_index)
+       - has(actual.data[0].slot)
+  - name: proposer duties v2 bad epoch
+    actual:
+      handler: i
+      path: /eth/v2/validator/duties/proposer/abc
+    compare:
+      exprs:
+       - actual_code == 400
+  - name: proposer duties overflow epoch
+    actual:
+      handler: i
+      path: /eth/v1/validator/duties/proposer/576460752303423488
+    compare:
+      exprs:
+       - actual_code == 400
+  - name: proposer duties v2 overflow epoch
+    actual:
+      handler: i
+      path: /eth/v2/validator/duties/proposer/576460752303423488
+    compare:
+      exprs:
+       - actual_code == 400


### PR DESCRIPTION
## Problem

Lighthouse 8.2.0 (and other current consensus clients) request proposer duties from `GET /eth/v2/validator/duties/proposer/{epoch}` **by default** — the v2 endpoint reports the correct `dependent_root`, whereas v1 returns one that triggers spurious "proposer duties re-org" warnings.

Caplin on `release/3.5` only registered the **v1** route, so the validator client received a `404` and could **miss block proposals** until the operator set the non-obvious `--disable-proposer-duties-v2` VC flag. Every other major CL (Prysm, Teku, Nimbus, Lodestar) serves v2.

## Change

- Register `GET /eth/v2/validator/duties/proposer/{epoch}`, sharing the v1 handler body via `getDutiesProposerForVersion`. The v2 dependent root is the attester-style root **from Fulu onwards** (both the live and historical paths) and is identical to v1 for all pre-Fulu epochs, so behaviour on current networks is unchanged.
- Guard the unbounded `{epoch}` path variable: `epoch * SlotsPerEpoch` could overflow `uint64` and **wrap to a small slot**, making the proposer endpoint return `HTTP 200` with bogus duties for genesis slots (confirmed: epoch `2^59` → duties for slots 0–31). Reject overflowing epochs with `400` on both the proposer and attester duties endpoints, via a shared `epochSlotOverflows` helper (matches `main`).

This ports the v2 endpoint from `main`, where it was introduced in #21655 ("glamsterdam devnet-5 fixes") entangled with unrelated Gloas/EIP-7732 + engine-API changes — so it is a surgical port, not a cherry-pick.

## Tests

- `duties_proposer.yml`: v2 route returns 200 (regression guard against the 404 — verified red without the route), v2 bad-epoch 400, v1+v2 overflow-epoch 400.
- `duties_attester.yml`: overflow-epoch 400.
- `TestEpochSlotOverflows` unit test; updated `getHistoricalProposerDependentRoot` caller for the new `v2` parameter.
- `make lint` clean; `make erigon integration` builds.