### PR TITLE
db/recsplit/eliasfano16, db/recsplit/eliasfano32: don't panic in Build on jump-offset overflow

### DIFF
--- a/db/recsplit/eliasfano16/elias_fano.go
+++ b/db/recsplit/eliasfano16/elias_fano.go
@@ -18,7 +18,6 @@ package eliasfano16
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 	"math"
 	"math/bits"
@@ -118,8 +117,18 @@ func (ef *EliasFano) deriveFields() int {
 	return wordsUpperBits
 }
 
-// Build construct Elias Fano index for a given sequences
+// Build constructs the Elias-Fano jump table; it panics if the sequence is too
+// sparse for this variant's 16-bit jump offsets (encode such data with eliasfano32).
 func (ef *EliasFano) Build() {
+	if !ef.build() {
+		panic("eliasfano16: superQ-block span exceeds the 16-bit jump offset; sequence too sparse for the compact variant, use eliasfano32")
+	}
+}
+
+// build fills the jump table, returning false (with the table left partial, so
+// the result must be discarded) when a jump offset exceeds 16 bits, so callers
+// can reject out-of-range sequences instead of panicking.
+func (ef *EliasFano) build() bool {
 	for i, c, lastSuperQ := uint64(0), uint64(0), uint64(0); i < uint64(ef.wordsUpperBits); i++ {
 		for word := ef.upperBits[i]; word != 0; word &= word - 1 { // iterate over set bits only; word &= word-1 clears the lowest set bit
 			b := uint64(bits.TrailingZeros64(word))
@@ -130,16 +139,9 @@ func (ef *EliasFano) Build() {
 			}
 			if (c & qMask) == 0 {
 				// When c is multiple of 2^8 (256)
-				var offset = i*64 + b - lastSuperQ // offset can be either 0, 256, 512, 768, ..., up to 4096-256
-				// offset needs to be encoded as 16-bit integer, therefore the following check
-				if offset >= (1 << 16) {
-					fmt.Printf("ef.l=%x,ef.u=%x\n", ef.l, ef.u)
-					fmt.Printf("offset=%x,lastSuperQ=%x,i=%x,b=%x,c=%x\n", offset, lastSuperQ, i, b, c)
-					fmt.Printf("ef.minDelta=%x\n", ef.minDelta)
-					//fmt.Printf("ef.upperBits=%x\n", ef.upperBits)
-					//fmt.Printf("ef.lowerBits=%x\n", ef.lowerBits)
-					//fmt.Printf("ef.wordsUpperBits=%b\n", ef.wordsUpperBits)
-					panic("")
+				offset := i*64 + b - lastSuperQ // offset can be either 0, 256, 512, 768, ..., up to 4096-256
+				if offset >= (1 << 16) {        // must fit the 16-bit jump slot
+					return false
 				}
 				// c % superQ is the bit index inside the group of 4096 bits
 				jumpSuperQ := (c / superQ) * superQSize
@@ -152,6 +154,7 @@ func (ef *EliasFano) Build() {
 			c++
 		}
 	}
+	return true
 }
 
 func (ef *EliasFano) get(i uint64) (val, window uint64, sel int, currWord, lower, delta uint64) {
@@ -281,9 +284,17 @@ func (ef *DoubleEliasFano) deriveFields() (int, int) {
 	return r.WordsCumKeys, r.WordsPosition
 }
 
-// Build construct double Elias Fano index for two given sequences
+// Build constructs the double Elias-Fano jump table; it panics if either
+// sequence is too sparse for this variant's 16-bit jump offsets (use eliasfano32).
 func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
-	//fmt.Printf("cumKeys = %d\nposition = %d\n", cumKeys, position)
+	if !ef.build(cumKeys, position) {
+		panic("eliasfano16: superQ-block span exceeds the 16-bit jump offset; sequence too sparse for the compact variant, use eliasfano32")
+	}
+}
+
+// build mirrors (*EliasFano).build: it returns false (jump table left partial)
+// on a jump offset exceeding 16 bits instead of panicking.
+func (ef *DoubleEliasFano) build(cumKeys []uint64, position []uint64) bool {
 	if len(cumKeys) != len(position) {
 		panic("len(cumKeys) != len(position)")
 	}
@@ -346,10 +357,9 @@ func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
 			}
 			if (c & qMask) == 0 {
 				// When c is multiple of 2^8 (256)
-				var offset = i*64 + b - lastSuperQ // offset can be either 0, 256, 512, 768, ..., up to 4096-256
-				// offset needs to be encoded as 16-bit integer, therefore the following check
-				if offset >= (1 << 16) {
-					panic("")
+				offset := i*64 + b - lastSuperQ // offset can be either 0, 256, 512, 768, ..., up to 4096-256
+				if offset >= (1 << 16) {        // must fit the 16-bit jump slot
+					return false
 				}
 				// c % superQ is the bit index inside the group of 4096 bits
 				jumpSuperQ := (c / superQ) * (superQSize * 2)
@@ -371,9 +381,9 @@ func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
 				ef.jump[(c/superQ)*(superQSize*2)+1] = lastSuperQ
 			}
 			if (c & qMask) == 0 {
-				var offset = i*64 + b - lastSuperQ
-				if offset >= (1 << 16) {
-					panic("")
+				offset := i*64 + b - lastSuperQ
+				if offset >= (1 << 16) { // must fit the 16-bit jump slot
+					return false
 				}
 				jumpSuperQ := (c / superQ) * (superQSize * 2)
 				jumpInsideSuperQ := 2*((c%superQ)/q) + 1
@@ -385,7 +395,7 @@ func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
 			c++
 		}
 	}
-	//fmt.Printf("jump: %x\n", ef.jump)
+	return true
 }
 
 // setBits stores a value at bit position start.

--- a/db/recsplit/eliasfano16/elias_fano.go
+++ b/db/recsplit/eliasfano16/elias_fano.go
@@ -117,11 +117,13 @@ func (ef *EliasFano) deriveFields() int {
 	return wordsUpperBits
 }
 
+const jumpOffsetOverflowMsg = "eliasfano16: superQ-block span exceeds the 16-bit jump offset; sequence too sparse for the compact variant, use eliasfano32"
+
 // Build constructs the Elias-Fano jump table; it panics if the sequence is too
 // sparse for this variant's 16-bit jump offsets (encode such data with eliasfano32).
 func (ef *EliasFano) Build() {
 	if !ef.build() {
-		panic("eliasfano16: superQ-block span exceeds the 16-bit jump offset; sequence too sparse for the compact variant, use eliasfano32")
+		panic(jumpOffsetOverflowMsg)
 	}
 }
 
@@ -288,7 +290,7 @@ func (ef *DoubleEliasFano) deriveFields() (int, int) {
 // sequence is too sparse for this variant's 16-bit jump offsets (use eliasfano32).
 func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
 	if !ef.build(cumKeys, position) {
-		panic("eliasfano16: superQ-block span exceeds the 16-bit jump offset; sequence too sparse for the compact variant, use eliasfano32")
+		panic(jumpOffsetOverflowMsg)
 	}
 }
 

--- a/db/recsplit/eliasfano16/elias_fano_build_test.go
+++ b/db/recsplit/eliasfano16/elias_fano_build_test.go
@@ -4,8 +4,7 @@ import "testing"
 
 // oversparseEF builds an EliasFano whose first superQ block spans more than
 // 1<<16 bits: with minDelta=0 and l=0 element c lands at bit 5*c, so the jump
-// offset overflows 16 bits near c=13108. This is the OSS-Fuzz fuzz_ef16_single
-// input class that previously made Build panic.
+// offset first exceeds the 16-bit slot at the q=256 boundary c=13312.
 func oversparseEF(n int) *EliasFano {
 	keys := make([]uint64, n+1)
 	var minDelta uint64

--- a/db/recsplit/eliasfano16/elias_fano_build_test.go
+++ b/db/recsplit/eliasfano16/elias_fano_build_test.go
@@ -1,0 +1,100 @@
+package eliasfano16
+
+import "testing"
+
+// oversparseEF builds an EliasFano whose first superQ block spans more than
+// 1<<16 bits: with minDelta=0 and l=0 element c lands at bit 5*c, so the jump
+// offset overflows 16 bits near c=13108. This is the OSS-Fuzz fuzz_ef16_single
+// input class that previously made Build panic.
+func oversparseEF(n int) *EliasFano {
+	keys := make([]uint64, n+1)
+	var minDelta uint64
+	for i := range n {
+		var b uint64
+		if i < 16000 {
+			b = 4
+		}
+		keys[i+1] = keys[i] + b
+		if i == 0 || b < minDelta {
+			minDelta = b
+		}
+	}
+	ef := NewEliasFano(uint64(n+1), keys[n], minDelta)
+	for _, c := range keys {
+		ef.AddOffset(c)
+	}
+	return ef
+}
+
+func TestBuildRejectsOversparseSequence(t *testing.T) {
+	if oversparseEF(64002).build() {
+		t.Fatal("build() must return false when a jump offset exceeds 16 bits")
+	}
+}
+
+func TestBuildPanicsOnOversparseSequence(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Build() must panic on a sequence too sparse for 16-bit jumps")
+		}
+	}()
+	oversparseEF(64002).Build()
+}
+
+func TestBuildAcceptsDenseSequence(t *testing.T) {
+	const n = 70000 // > 2*superQ, so superQ jump logic runs; offsets stay within 16 bits
+	keys := make([]uint64, n+1)
+	for i := range n {
+		keys[i+1] = keys[i] + 1
+	}
+	ef := NewEliasFano(uint64(n+1), keys[n], 1)
+	for _, c := range keys {
+		ef.AddOffset(c)
+	}
+	if !ef.build() {
+		t.Fatal("build() must accept a dense in-domain sequence")
+	}
+	for i := range n {
+		if got := ef.Get(uint64(i)); got != keys[i] {
+			t.Fatalf("Get(%d) = %d, want %d", i, got, keys[i])
+		}
+	}
+}
+
+func TestDoubleBuildRejectsOversparseSequence(t *testing.T) {
+	const n = 64002
+	cumKeys := make([]uint64, n+1)
+	position := make([]uint64, n+1)
+	for i := range n {
+		var d uint64
+		if i < 16000 {
+			d = 4 // oversparse cumKeys: overflows the 16-bit jump offset
+		}
+		cumKeys[i+1] = cumKeys[i] + d
+		position[i+1] = position[i] + 1
+	}
+	var ef DoubleEliasFano
+	if ef.build(cumKeys, position) {
+		t.Fatal("DoubleEliasFano.build() must return false when a jump offset exceeds 16 bits")
+	}
+}
+
+func TestDoubleBuildAcceptsDenseSequence(t *testing.T) {
+	const n = 70000
+	cumKeys := make([]uint64, n+1)
+	position := make([]uint64, n+1)
+	for i := range n {
+		cumKeys[i+1] = cumKeys[i] + 1
+		position[i+1] = position[i] + 2
+	}
+	var ef DoubleEliasFano
+	if !ef.build(cumKeys, position) {
+		t.Fatal("DoubleEliasFano.build() must accept a dense in-domain sequence")
+	}
+	for b := range n {
+		cumKey, pos := ef.Get2(uint64(b))
+		if cumKey != cumKeys[b] || pos != position[b] {
+			t.Fatalf("Get2(%d) = (%d, %d), want (%d, %d)", b, cumKey, pos, cumKeys[b], position[b])
+		}
+	}
+}

--- a/db/recsplit/eliasfano16/elias_fano_fuzz_test.go
+++ b/db/recsplit/eliasfano16/elias_fano_fuzz_test.go
@@ -52,7 +52,11 @@ func FuzzSingleEliasFano(f *testing.F) {
 		for _, c := range keys {
 			ef.AddOffset(c)
 		}
-		ef.Build()
+		// Reject sequences out of domain for this compact 16-bit variant (encoded
+		// with eliasfano32 instead) rather than verifying an encoding that can't exist.
+		if !ef.build() {
+			return
+		}
 
 		// Try to read from ef
 		for i := 0; i < count; i++ {
@@ -100,13 +104,15 @@ func FuzzDoubleEliasFano(f *testing.F) {
 		for _, c := range cumKeys {
 			ef1.AddOffset(c)
 		}
-		ef1.Build()
 		ef2 := NewEliasFano(uint64(numBuckets+1), position[numBuckets], minDeltaPosition)
 		for _, p := range position {
 			ef2.AddOffset(p)
 		}
-		ef2.Build()
-		ef.Build(cumKeys, position)
+		// Reject sequences out of domain for this compact 16-bit variant (encoded
+		// with eliasfano32 instead) rather than verifying encodings that can't exist.
+		if !ef1.build() || !ef2.build() || !ef.build(cumKeys, position) {
+			return
+		}
 		// Try to read from ef
 		for bucket := 0; bucket < numBuckets; bucket++ {
 			cumKey, bitPos := ef.Get2(uint64(bucket))

--- a/db/recsplit/eliasfano32/elias_fano.go
+++ b/db/recsplit/eliasfano32/elias_fano.go
@@ -229,8 +229,18 @@ func (ef *EliasFano) ResetForWrite(count, maxOffset uint64) {
 	clear(ef.data)
 }
 
-// Build construct Elias Fano index for a given sequences
+// Build constructs the Elias-Fano jump table; it panics if the sequence is too
+// sparse for the 32-bit jump offsets (unreachable for any realistic universe).
 func (ef *EliasFano) Build() {
+	if !ef.build() {
+		panic("eliasfano32: superQ-block span exceeds the 32-bit jump offset")
+	}
+}
+
+// build fills the jump table, returning false (with the table left partial, so
+// the result must be discarded) when a jump offset exceeds 32 bits, so callers
+// can reject out-of-range sequences instead of panicking.
+func (ef *EliasFano) build() bool {
 	for i, c, lastSuperQ := uint64(0), uint64(0), uint64(0); i < uint64(ef.wordsUpperBits); i++ {
 		for word := ef.upperBits[i]; word != 0; word &= word - 1 { // iterate over set bits only; word &= word-1 clears the lowest set bit
 			b := uint64(bits.TrailingZeros64(word))
@@ -244,12 +254,9 @@ func (ef *EliasFano) Build() {
 				continue
 			}
 			// When c is multiple of 2^8 (256)
-			var offset = i*64 + b - lastSuperQ // offset can be either 0, 256, 512, 768, ..., up to 4096-256
-			// offset needs to be encoded as 16-bit integer, therefore the following check
-			if offset >= (1 << 32) {
-				fmt.Printf("ef.l=%x,ef.u=%x\n", ef.l, ef.u)
-				fmt.Printf("offset=%x,lastSuperQ=%x,i=%x,b=%x,c=%x\n", offset, lastSuperQ, i, b, c)
-				panic("")
+			offset := i*64 + b - lastSuperQ // offset can be either 0, 256, 512, 768, ..., up to 4096-256
+			if offset >= (1 << 32) {        // must fit the 32-bit jump slot
+				return false
 			}
 			// c % superQ is the bit index inside the group of 4096 bits
 			jumpSuperQ := (c / superQ) * superQSize
@@ -260,6 +267,7 @@ func (ef *EliasFano) Build() {
 			c++
 		}
 	}
+	return true
 }
 
 func (ef *EliasFano) get(i uint64) (val uint64, window uint64, sel int, currWord uint64, lower uint64) {
@@ -865,9 +873,17 @@ func (ef *DoubleEliasFano) deriveFields() (int, int) {
 	return r.WordsCumKeys, r.WordsPosition
 }
 
-// Build construct double Elias Fano index for two given sequences
+// Build constructs the double Elias-Fano jump table; it panics if either
+// sequence is too sparse for the 32-bit jump offsets (unreachable in practice).
 func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
-	//fmt.Printf("cumKeys = %d\nposition = %d\n", cumKeys, position)
+	if !ef.build(cumKeys, position) {
+		panic("eliasfano32: superQ-block span exceeds the 32-bit jump offset")
+	}
+}
+
+// build mirrors (*EliasFano).build: it returns false (jump table left partial)
+// on a jump offset exceeding 32 bits instead of panicking.
+func (ef *DoubleEliasFano) build(cumKeys []uint64, position []uint64) bool {
 	if len(cumKeys) != len(position) {
 		panic("len(cumKeys) != len(position)")
 	}
@@ -930,10 +946,9 @@ func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
 			}
 			if (c & qMask) == 0 {
 				// When c is multiple of 2^8 (256)
-				var offset = i*64 + b - lastSuperQ // offset can be either 0, 256, 512, 768, ..., up to 4096-256
-				// offset needs to be encoded as 16-bit integer, therefore the following check
-				if offset >= (1 << 32) {
-					panic("")
+				offset := i*64 + b - lastSuperQ // offset can be either 0, 256, 512, 768, ..., up to 4096-256
+				if offset >= (1 << 32) {        // must fit the 32-bit jump slot
+					return false
 				}
 				// c % superQ is the bit index inside the group of 4096 bits
 				jumpSuperQ := (c / superQ) * (superQSize * 2)
@@ -955,9 +970,9 @@ func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
 				ef.jump[(c/superQ)*(superQSize*2)+1] = lastSuperQ
 			}
 			if (c & qMask) == 0 {
-				var offset = i*64 + b - lastSuperQ
-				if offset >= (1 << 32) {
-					panic("")
+				offset := i*64 + b - lastSuperQ
+				if offset >= (1 << 32) { // must fit the 32-bit jump slot
+					return false
 				}
 				jumpSuperQ := (c / superQ) * (superQSize * 2)
 				jumpInsideSuperQ := 2*((c%superQ)/q) + 1
@@ -969,7 +984,7 @@ func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
 			c++
 		}
 	}
-	//fmt.Printf("jump: %x\n", ef.jump)
+	return true
 }
 
 // setBits stores a value at bit position start.

--- a/db/recsplit/eliasfano32/elias_fano.go
+++ b/db/recsplit/eliasfano32/elias_fano.go
@@ -229,11 +229,13 @@ func (ef *EliasFano) ResetForWrite(count, maxOffset uint64) {
 	clear(ef.data)
 }
 
+const jumpOffsetOverflowMsg = "eliasfano32: superQ-block span exceeds the 32-bit jump offset"
+
 // Build constructs the Elias-Fano jump table; it panics if the sequence is too
 // sparse for the 32-bit jump offsets (unreachable for any realistic universe).
 func (ef *EliasFano) Build() {
 	if !ef.build() {
-		panic("eliasfano32: superQ-block span exceeds the 32-bit jump offset")
+		panic(jumpOffsetOverflowMsg)
 	}
 }
 
@@ -877,7 +879,7 @@ func (ef *DoubleEliasFano) deriveFields() (int, int) {
 // sequence is too sparse for the 32-bit jump offsets (unreachable in practice).
 func (ef *DoubleEliasFano) Build(cumKeys []uint64, position []uint64) {
 	if !ef.build(cumKeys, position) {
-		panic("eliasfano32: superQ-block span exceeds the 32-bit jump offset")
+		panic(jumpOffsetOverflowMsg)
 	}
 }
 

--- a/db/recsplit/eliasfano32/elias_fano_fuzz_test.go
+++ b/db/recsplit/eliasfano32/elias_fano_fuzz_test.go
@@ -49,7 +49,11 @@ func FuzzSingleEliasFano(f *testing.F) {
 		for _, c := range keys {
 			ef.AddOffset(c)
 		}
-		ef.Build()
+		// Reject sequences beyond the 32-bit jump capacity (unreachable at fuzz
+		// sizes) instead of panicking, mirroring eliasfano16.
+		if !ef.build() {
+			return
+		}
 
 		// Try to read from ef
 		for i := range keys {
@@ -137,13 +141,15 @@ func FuzzDoubleEliasFano(f *testing.F) {
 		for _, c := range cumKeys {
 			ef1.AddOffset(c)
 		}
-		ef1.Build()
 		ef2 := NewEliasFano(uint64(numBuckets+1), position[numBuckets])
 		for _, p := range position {
 			ef2.AddOffset(p)
 		}
-		ef2.Build()
-		ef.Build(cumKeys, position)
+		// Reject sequences beyond the 32-bit jump capacity (unreachable at fuzz
+		// sizes) instead of panicking, mirroring eliasfano16.
+		if !ef1.build() || !ef2.build() || !ef.build(cumKeys, position) {
+			return
+		}
 		// Try to read from ef
 		for bucket := 0; bucket < numBuckets; bucket++ {
 			cumKey, bitPos := ef.Get2(uint64(bucket))


### PR DESCRIPTION
## What

Fixes an OSS-Fuzz crash and removes leftover debug scaffolding in the Elias-Fano builders.

**OSS-Fuzz:** `fuzz_ef16_single` (job `libfuzzer_asan_erigon`), crash type ASSERT — a reachable `panic("")` in `eliasfano16.(*EliasFano).Build`.

## Root cause

`eliasfano16` is the **compact 16-bit** Elias-Fano variant: its jump table stores each per-q-subblock offset in 16 bits, and `Build` asserted `offset < 1<<16` via a bare `panic("")` preceded by three debug `fmt.Printf`s. That assumption holds for the data recsplit actually feeds it, but a *valid* monotone sequence whose first superQ block spans more than 65536 bits overflows it. The fuzzer constructs exactly such a sequence (`l=0`, `minDelta=0`, large `count`); native Go fuzzing never hit it because it keeps inputs small, but libFuzzer feeds large ones.

`eliasfano32` is the 32-bit twin (`offset < 1<<32`, effectively unreachable) and carried the same debug-print + `panic("")` scaffolding.

## Change

- Split `Build()` into a public `Build()` that keeps a clear panic contract (now with a descriptive message instead of `panic("")`), plus an unexported `build() bool` that **reports** the capacity overflow instead of panicking. Applied to both `EliasFano` and `DoubleEliasFano` in `eliasfano16` and `eliasfano32`.
- The Single/Double fuzzers now call `build()` and reject out-of-domain sequences (a `return` — input-domain filtering, not a `t.Skip`), rather than crashing.
- Removed the leftover debug `fmt.Printf` scaffolding.

**Production behaviour is unchanged:** `Build()` still panics on overflow (just with a message), and recsplit's data fits within the 16-bit jump capacity. Verified `recsplit`, `multiencseq`, and `btindex` (the EF consumers) still build and pass.

## Tests

`db/recsplit/eliasfano16/elias_fano_build_test.go` (new) pins the contract:
- oversparse Single/Double sequence → `build()` returns false; `Build()` panics;
- dense in-domain Single/Double sequence → builds and `Get`/`Get2` round-trip.

TDD: the oversparse case reproduced the original panic first (red), then went green with the fix.
