### PR TITLE
[r3.5] exec: overlay-wrap the worker chainTx once in resetTx so every reader is overlay-aware

### DIFF
--- a/execution/exec/state.go
+++ b/execution/exec/state.go
@@ -100,11 +100,17 @@ func (c *activeCount) Add(i int64) {
 }
 
 type Worker struct {
-	lock        *sync.RWMutex
-	notifier    *sync.Cond
-	runnable    atomic.Bool
-	logger      log.Logger
-	chainDb     kv.TemporalRoDB
+	lock     *sync.RWMutex
+	notifier *sync.Cond
+	runnable atomic.Bool
+	logger   log.Logger
+	chainDb  kv.TemporalRoDB
+	// chainRoTx is the raw MDBX roTx that owns this worker's snapshot — the
+	// only handle that may be Rolled back. chainTx is the overlay-aware view
+	// (chainRoTx wrapped with the SharedDomains BlockOverlay if one is active);
+	// all reads must go through chainTx so any new consumer is overlay-aware
+	// by construction.
+	chainRoTx   kv.TemporalTx
 	chainTx     kv.TemporalTx
 	background  bool // if true - worker does manage RoTx (begin/rollback) in .ResetTx()
 	blockReader services.FullBlockReader
@@ -130,21 +136,16 @@ type Worker struct {
 }
 
 // installWorkerGetHash replaces the EVM's GetHash function with one that
-// uses the worker's own roTx for BLOCKHASH lookups. This avoids sharing
-// the executeBlocks goroutine's roTx across worker goroutines (data race).
-// When a BlockOverlay is active (post-snapshot Caplin blocks), the roTx is
-// wrapped with the overlay so the worker can see headers not yet in MDBX.
+// uses the worker's own chainTx for BLOCKHASH lookups, avoiding any share
+// of the executeBlocks goroutine's roTx across worker goroutines (data
+// race). chainTx is already overlay-aware (see resetTx) so headers staged
+// in the BlockOverlay but not yet flushed to MDBX are visible.
 func (rw *Worker) installWorkerGetHash(txTask Task) {
 	header := txTask.BlockHeader()
 	if header == nil {
 		return
 	}
-	var workerTx kv.Getter = rw.chainTx
-	if rw.rs != nil {
-		if overlay := rw.rs.Domains().BlockOverlay(); overlay != nil {
-			workerTx = overlay.NewReadView(rw.chainTx)
-		}
-	}
+	workerTx := rw.chainTx
 	br := rw.blockReader
 	ctx := rw.ctx
 	rw.evm.Context.GetHash = protocol.GetHashFn(header, func(hash common.Hash, number uint64) (*types.Header, error) {
@@ -276,10 +277,22 @@ func (rw *Worker) resetTxNum(txNum uint64) {
 }
 
 func (rw *Worker) resetTx(chainTx kv.TemporalTx) error {
-	if rw.background && rw.chainTx != nil {
-		rw.chainTx.Rollback()
+	if rw.background && rw.chainRoTx != nil {
+		rw.chainRoTx.Rollback()
 	}
 
+	rw.chainRoTx = chainTx
+	// Wrap with BlockOverlay so block-metadata reads (headers/bodies/td
+	// staged by InsertBlocks at chaintip) are visible. Mirrors the blockTx
+	// pattern in executeBlocks (exec3.go:538-543). Single wrap here so every
+	// consumer of rw.chainTx is overlay-aware by construction.
+	if chainTx != nil && rw.rs != nil {
+		if sd := rw.rs.Domains(); sd != nil {
+			if overlay := sd.BlockOverlay(); overlay != nil {
+				chainTx = overlay.NewReadView(chainTx)
+			}
+		}
+	}
 	rw.chainTx = chainTx
 
 	if rw.chainTx != nil {
@@ -342,8 +355,9 @@ func (rw *Worker) Run() (err error) {
 	// Ensure the worker's roTx is closed when Run exits, preventing
 	// MDBX reader slot leaks that block GC page reclamation.
 	defer func() {
-		if rw.background && rw.chainTx != nil {
-			rw.chainTx.Rollback()
+		if rw.background && rw.chainRoTx != nil {
+			rw.chainRoTx.Rollback()
+			rw.chainRoTx = nil
 			rw.chainTx = nil
 		}
 	}()

--- a/execution/exec/worker_overlay_test.go
+++ b/execution/exec/worker_overlay_test.go
@@ -1,0 +1,235 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/mdbx"
+	"github.com/erigontech/erigon/db/kv/temporal"
+	"github.com/erigontech/erigon/db/rawdb"
+	dbstate "github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// Pins that a Worker's chain reader (rw.chain) sees headers staged in the
+// SharedDomains BlockOverlay even when they have NOT been flushed to MDBX.
+// This is the path AuRa.Initialize takes via verifyGasLimitOverride →
+// chain.GetHeaderByHash; an overlay-blind worker tx returns nil and the
+// consensus engine reports ErrUnknownAncestor, wedging tip-tracking on the
+// first FCU whose parent block lives only in the overlay.
+//
+// Red-first verified locally: removing the BlockOverlay wrap in Worker.resetTx
+// makes the require.NotNil for GetHeader fail (parent header invisible).
+func TestWorker_ChainReader_SeesOverlayHeader(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	rawDB := mdbx.New(dbcfg.ChainDB, logger).
+		InMem(t, dirs.Chaindata).
+		GrowthStep(32 * datasize.MB).
+		MapSize(2 * datasize.GB).
+		MustOpen()
+	t.Cleanup(rawDB.Close)
+
+	agg := dbstate.NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), rawDB)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	db, err := temporal.New(rawDB, agg, nil)
+	require.NoError(t, err)
+
+	roTx, err := db.BeginTemporalRo(t.Context())
+	require.NoError(t, err)
+	defer roTx.Rollback()
+
+	doms, err := execctx.NewSharedDomains(t.Context(), roTx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+	require.NoError(t, doms.InitBlockOverlay(roTx, dirs.Tmp))
+
+	header := &types.Header{
+		Number:     *uint256.NewInt(2_713_395),
+		ParentHash: empty.RootHash,
+		Difficulty: *uint256.NewInt(0),
+	}
+	hash, number := header.Hash(), header.Number.Uint64()
+
+	require.NoError(t, rawdb.WriteHeader(doms.BlockOverlay(), header))
+
+	rs := state.NewStateV3Buffered(state.NewStateV3(doms, false, logger))
+
+	// nil blockReader → consensuschain.Reader uses rawdb.ReadHeader directly,
+	// keeping the test focused on the tx + overlay path without any
+	// snapshot-file plumbing.
+	rw := NewWorker(t.Context(), true, nil, db, nil, nil,
+		&chain.Config{ChainID: uint256.NewInt(1)}, nil, nil, nil, dirs, logger)
+	rw.rs = rs
+
+	// workerRoTx ownership transfers to rw on ResetTx; rolling it back
+	// directly here would double-Rollback against rw.chainRoTx.
+	workerRoTx, err := db.BeginTemporalRo(t.Context()) //nolint:gocritic
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if rw.chainRoTx != nil {
+			rw.chainRoTx.Rollback()
+			rw.chainRoTx = nil
+		}
+	})
+	require.NoError(t, rw.ResetTx(workerRoTx))
+
+	got := rw.chain.GetHeader(hash, number)
+	require.NotNil(t, got,
+		"chain reader must see headers staged in the BlockOverlay; raw MDBX would return nil because the header was never flushed")
+	require.Equal(t, number, got.Number.Uint64())
+	require.Equal(t, hash, got.Hash())
+}
+
+// Pins that when no BlockOverlay is active, the chain reader still works —
+// a no-overlay worker (e.g. initial sync from snapshots) must not regress.
+func TestWorker_ChainReader_NoOverlayStillWorks(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	rawDB := mdbx.New(dbcfg.ChainDB, logger).
+		InMem(t, dirs.Chaindata).
+		GrowthStep(32 * datasize.MB).
+		MapSize(2 * datasize.GB).
+		MustOpen()
+	t.Cleanup(rawDB.Close)
+
+	agg := dbstate.NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), rawDB)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	db, err := temporal.New(rawDB, agg, nil)
+	require.NoError(t, err)
+
+	rwTx, err := db.BeginTemporalRw(t.Context())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	header := &types.Header{
+		Number:     *uint256.NewInt(42),
+		ParentHash: empty.RootHash,
+		Difficulty: *uint256.NewInt(0),
+	}
+	hash, number := header.Hash(), header.Number.Uint64()
+	require.NoError(t, rawdb.WriteHeader(rwTx, header))
+	require.NoError(t, rwTx.Commit())
+
+	roTx, err := db.BeginTemporalRo(t.Context())
+	require.NoError(t, err)
+	defer roTx.Rollback()
+	doms, err := execctx.NewSharedDomains(t.Context(), roTx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+	// Deliberately do NOT InitBlockOverlay — chain reads must still resolve
+	// through the worker's raw roTx for committed MDBX data.
+	require.Nil(t, doms.BlockOverlay())
+
+	rs := state.NewStateV3Buffered(state.NewStateV3(doms, false, logger))
+
+	// nil blockReader → consensuschain.Reader uses rawdb.ReadHeader directly,
+	// keeping the test focused on the tx + overlay path without any
+	// snapshot-file plumbing.
+	rw := NewWorker(t.Context(), true, nil, db, nil, nil,
+		&chain.Config{ChainID: uint256.NewInt(1)}, nil, nil, nil, dirs, logger)
+	rw.rs = rs
+
+	// workerRoTx ownership transfers to rw on ResetTx; rolling it back
+	// directly here would double-Rollback against rw.chainRoTx.
+	workerRoTx, err := db.BeginTemporalRo(t.Context()) //nolint:gocritic
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if rw.chainRoTx != nil {
+			rw.chainRoTx.Rollback()
+			rw.chainRoTx = nil
+		}
+	})
+	require.NoError(t, rw.ResetTx(workerRoTx))
+
+	got := rw.chain.GetHeader(hash, number)
+	require.NotNil(t, got, "committed-MDBX header must still resolve when no overlay is active")
+	require.Equal(t, number, got.Number.Uint64())
+}
+
+// Pins that overlay-staged data is invisible without the wrap — the
+// regression guard for the gnosis tip-tracking 'unknown ancestor' wedge.
+// This test builds a Worker WITHOUT the overlay wrap on its chainTx (the
+// pre-fix shape) and verifies the chain reader returns nil for an
+// overlay-only header, then builds one WITH the wrap and verifies it
+// resolves. Any future change that drops the wrap from Worker.resetTx
+// turns this red.
+func TestWorker_ChainReader_OverlayWrapIsLoadBearing(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	rawDB := mdbx.New(dbcfg.ChainDB, logger).
+		InMem(t, dirs.Chaindata).
+		GrowthStep(32 * datasize.MB).
+		MapSize(2 * datasize.GB).
+		MustOpen()
+	t.Cleanup(rawDB.Close)
+
+	agg := dbstate.NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), rawDB)
+	t.Cleanup(agg.Close)
+	require.NoError(t, agg.OpenFolder())
+
+	db, err := temporal.New(rawDB, agg, nil)
+	require.NoError(t, err)
+
+	roTx, err := db.BeginTemporalRo(t.Context())
+	require.NoError(t, err)
+	defer roTx.Rollback()
+	doms, err := execctx.NewSharedDomains(t.Context(), roTx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+	require.NoError(t, doms.InitBlockOverlay(roTx, dirs.Tmp))
+
+	header := &types.Header{
+		Number:     *uint256.NewInt(46_827_710),
+		ParentHash: empty.RootHash,
+		Difficulty: *uint256.NewInt(0),
+	}
+	hash, number := header.Hash(), header.Number.Uint64()
+	require.NoError(t, rawdb.WriteHeader(doms.BlockOverlay(), header))
+
+	rawWorkerTx, err := db.BeginTemporalRo(t.Context())
+	require.NoError(t, err)
+	defer rawWorkerTx.Rollback()
+
+	require.Nil(t, rawdb.ReadHeader(rawWorkerTx, hash, number),
+		"raw MDBX tx must NOT see an overlay-staged header — the wedge condition")
+
+	overlayTx := doms.BlockOverlay().NewReadView(rawWorkerTx)
+	require.NotNil(t, rawdb.ReadHeader(overlayTx, hash, number),
+		"BlockOverlay.NewReadView wrap must surface the staged header — the fix path")
+}

--- a/execution/exec/worker_overlay_test.go
+++ b/execution/exec/worker_overlay_test.go
@@ -37,15 +37,15 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-// Pins that a Worker's chain reader (rw.chain) sees headers staged in the
-// SharedDomains BlockOverlay even when they have NOT been flushed to MDBX.
-// This is the path AuRa.Initialize takes via verifyGasLimitOverride →
-// chain.GetHeaderByHash; an overlay-blind worker tx returns nil and the
-// consensus engine reports ErrUnknownAncestor, wedging tip-tracking on the
-// first FCU whose parent block lives only in the overlay.
+// Pins that a Worker's chain reader (rw.chain) resolves an overlay-staged
+// header via GetHeaderByHash — the exact path the wedge takes:
+// AuRa.Initialize → verifyGasLimitOverride → chain.GetHeaderByHash(parentHash).
+// GetHeaderByHash goes hash → HeaderNumber → Headers, so both overlay
+// entries must be visible through the worker's chainTx.
 //
-// Red-first verified locally: removing the BlockOverlay wrap in Worker.resetTx
-// makes the require.NotNil for GetHeader fail (parent header invisible).
+// Red-first verified locally: removing the BlockOverlay wrap in
+// Worker.resetTx makes the require.NotNil here fail (HeaderNumber lookup
+// misses → parent header invisible → consensus reports ErrUnknownAncestor).
 func TestWorker_ChainReader_SeesOverlayHeader(t *testing.T) {
 	t.Parallel()
 
@@ -104,9 +104,9 @@ func TestWorker_ChainReader_SeesOverlayHeader(t *testing.T) {
 	})
 	require.NoError(t, rw.ResetTx(workerRoTx))
 
-	got := rw.chain.GetHeader(hash, number)
+	got := rw.chain.GetHeaderByHash(hash)
 	require.NotNil(t, got,
-		"chain reader must see headers staged in the BlockOverlay; raw MDBX would return nil because the header was never flushed")
+		"chain reader must resolve an overlay-staged header by hash; AuRa.verifyGasLimitOverride takes this exact path")
 	require.Equal(t, number, got.Number.Uint64())
 	require.Equal(t, hash, got.Hash())
 }
@@ -175,61 +175,7 @@ func TestWorker_ChainReader_NoOverlayStillWorks(t *testing.T) {
 	})
 	require.NoError(t, rw.ResetTx(workerRoTx))
 
-	got := rw.chain.GetHeader(hash, number)
+	got := rw.chain.GetHeaderByHash(hash)
 	require.NotNil(t, got, "committed-MDBX header must still resolve when no overlay is active")
 	require.Equal(t, number, got.Number.Uint64())
-}
-
-// Pins that overlay-staged data is invisible without the wrap — the
-// regression guard for the gnosis tip-tracking 'unknown ancestor' wedge.
-// This test builds a Worker WITHOUT the overlay wrap on its chainTx (the
-// pre-fix shape) and verifies the chain reader returns nil for an
-// overlay-only header, then builds one WITH the wrap and verifies it
-// resolves. Any future change that drops the wrap from Worker.resetTx
-// turns this red.
-func TestWorker_ChainReader_OverlayWrapIsLoadBearing(t *testing.T) {
-	t.Parallel()
-
-	logger := log.New()
-	dirs := datadir.New(t.TempDir())
-	rawDB := mdbx.New(dbcfg.ChainDB, logger).
-		InMem(t, dirs.Chaindata).
-		GrowthStep(32 * datasize.MB).
-		MapSize(2 * datasize.GB).
-		MustOpen()
-	t.Cleanup(rawDB.Close)
-
-	agg := dbstate.NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), rawDB)
-	t.Cleanup(agg.Close)
-	require.NoError(t, agg.OpenFolder())
-
-	db, err := temporal.New(rawDB, agg, nil)
-	require.NoError(t, err)
-
-	roTx, err := db.BeginTemporalRo(t.Context())
-	require.NoError(t, err)
-	defer roTx.Rollback()
-	doms, err := execctx.NewSharedDomains(t.Context(), roTx, logger)
-	require.NoError(t, err)
-	t.Cleanup(doms.Close)
-	require.NoError(t, doms.InitBlockOverlay(roTx, dirs.Tmp))
-
-	header := &types.Header{
-		Number:     *uint256.NewInt(46_827_710),
-		ParentHash: empty.RootHash,
-		Difficulty: *uint256.NewInt(0),
-	}
-	hash, number := header.Hash(), header.Number.Uint64()
-	require.NoError(t, rawdb.WriteHeader(doms.BlockOverlay(), header))
-
-	rawWorkerTx, err := db.BeginTemporalRo(t.Context())
-	require.NoError(t, err)
-	defer rawWorkerTx.Rollback()
-
-	require.Nil(t, rawdb.ReadHeader(rawWorkerTx, hash, number),
-		"raw MDBX tx must NOT see an overlay-staged header — the wedge condition")
-
-	overlayTx := doms.BlockOverlay().NewReadView(rawWorkerTx)
-	require.NotNil(t, rawdb.ReadHeader(overlayTx, hash, number),
-		"BlockOverlay.NewReadView wrap must surface the staged header — the fix path")
 }


### PR DESCRIPTION
Cherry-pick of #21962 to release/3.5.

Fixes the QA gnosis tip-tracking wedge that's been failing on `release/3.5` for ~3 weeks with `invalid block: could not apply tx N:-1 […]: unknown ancestor` — AuRa's system-init txTask reads the parent header through a per-worker MDBX roTx that was not overlay-aware, so headers staged in the `SharedDomains.BlockOverlay` at chaintip were invisible.

Same diff as #21962, applied cleanly to release/3.5 (no rebase needed).

## Test plan
- [x] `make lint` clean (x2)
- [x] `make erigon` clean
- [x] `TestWorker_ChainReader_SeesOverlayHeader` + `_NoOverlayStillWorks` green on release/3.5
- [ ] CI green
- [ ] QA gnosis tip-tracking on release/3.5 goes green on the merged commit