### PR TITLE
.github: group @docusaurus and react Dependabot updates for docs/site

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,13 @@ updates:
     directory: "/docs/site"
     schedule:
       interval: "weekly"
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"


### PR DESCRIPTION
## What

Add Dependabot `groups` for the `/docs/site` npm ecosystem so version-locked dependency families update together in a single PR instead of one-PR-per-package:

- **docusaurus** — `@docusaurus/*`
- **react** — `react`, `react-dom`, `@types/react`, `@types/react-dom`

## Why

Recent docs-site Dependabot PRs bumped a single member of a version-locked family, producing broken or untidy states:

- #21967 bumped `react` to 19.2.7 but left `react-dom` at 19.2.5, so `docusaurus build` failed with `Incompatible React versions` (React 19 requires `react` and `react-dom` to be the exact same version).
- #21968 bumped only `@docusaurus/module-type-aliases` to 3.10.1 while the rest of the `@docusaurus/*` family stayed at 3.10.0, duplicating 3.10.0/3.10.1 entries in `package-lock.json`.

Grouping keeps each family in lockstep and avoids both failure modes.