### PR TITLE
cl/gossip: consolidate service registration logging

### DIFF
--- a/cl/phase1/network/gossip/gossip_manager.go
+++ b/cl/phase1/network/gossip/gossip_manager.go
@@ -210,6 +210,7 @@ func (g *GossipManager) registerGossipService(service serviceintf.Service[any], 
 		return err
 	}
 	// register all topics and subscribe
+	subscribed, expired := 0, 0
 	for _, name := range service.Names() {
 		topic := composeTopic(forkDigest, name)
 		if err := g.p2p.Pubsub().RegisterTopicValidator(topic, validator); err != nil {
@@ -229,11 +230,18 @@ func (g *GossipManager) registerGossipService(service serviceintf.Service[any], 
 			topicHandle.Close()
 			return err
 		}
-		if err := g.subscriptions.SubscribeWithExpiry(topic, g.defaultExpiryForTopic(name)); err != nil && !errors.Is(err, ErrExpiryInThePast) {
+		err = g.subscriptions.SubscribeWithExpiry(topic, g.defaultExpiryForTopic(name))
+		switch {
+		case err == nil:
+			subscribed++
+		case errors.Is(err, ErrExpiryInThePast):
+			expired++
+		default:
 			return err
 		}
 		log.Debug("[GossipManager] registered topic", "topic", topic)
 	}
+	log.Info("[GossipManager] Registered services", "subscribed", subscribed, "expired", expired)
 	return nil
 }
 

--- a/cl/phase1/network/gossip/gossip_manager.go
+++ b/cl/phase1/network/gossip/gossip_manager.go
@@ -203,32 +203,32 @@ func (g *GossipManager) newPubsubValidator(service serviceintf.Service[any], con
 	}
 }
 
-func (g *GossipManager) registerGossipService(service serviceintf.Service[any], conditions ...ConditionFunc) error {
+func (g *GossipManager) registerGossipService(service serviceintf.Service[any], conditions ...ConditionFunc) (subscribed, expired int, err error) {
 	validator := g.newPubsubValidator(service, conditions...)
 	forkDigest, err := g.ethClock.CurrentForkDigest()
 	if err != nil {
-		return err
+		return
 	}
 	// register all topics and subscribe
-	subscribed, expired := 0, 0
 	for _, name := range service.Names() {
 		topic := composeTopic(forkDigest, name)
-		if err := g.p2p.Pubsub().RegisterTopicValidator(topic, validator); err != nil {
-			return err
+		if err = g.p2p.Pubsub().RegisterTopicValidator(topic, validator); err != nil {
+			return
 		}
-		topicHandle, err := g.p2p.Pubsub().Join(topic)
-		if err != nil {
-			return err
+		topicHandle, joinErr := g.p2p.Pubsub().Join(topic)
+		if joinErr != nil {
+			err = joinErr
+			return
 		}
 		if params := g.topicScoreParams(name); params != nil {
-			if err := topicHandle.SetScoreParams(params); err != nil {
+			if err = topicHandle.SetScoreParams(params); err != nil {
 				topicHandle.Close()
-				return err
+				return
 			}
 		}
-		if err := g.subscriptions.Add(topic, topicHandle, validator); err != nil {
+		if err = g.subscriptions.Add(topic, topicHandle, validator); err != nil {
 			topicHandle.Close()
-			return err
+			return
 		}
 		err = g.subscriptions.SubscribeWithExpiry(topic, g.defaultExpiryForTopic(name))
 		switch {
@@ -237,12 +237,12 @@ func (g *GossipManager) registerGossipService(service serviceintf.Service[any], 
 		case errors.Is(err, ErrExpiryInThePast):
 			expired++
 		default:
-			return err
+			return
 		}
 		log.Debug("[GossipManager] registered topic", "topic", topic)
 	}
-	log.Info("[GossipManager] Registered services", "subscribed", subscribed, "expired", expired)
-	return nil
+	err = nil
+	return
 }
 
 func (g *GossipManager) defaultExpiryForTopic(name string) time.Time {

--- a/cl/phase1/network/gossip/gossip_manager_test.go
+++ b/cl/phase1/network/gossip/gossip_manager_test.go
@@ -471,7 +471,7 @@ func (s *subscribeUpcomingTopicsTestSuite) TestRegisterGossipService_PropagatesC
 		return false
 	}
 
-	err := s.gm.registerGossipService(service, condition)
+	_, _, err := s.gm.registerGossipService(service, condition)
 	s.Require().NoError(err)
 
 	forkDigest, err := s.mockClock.CurrentForkDigest()
@@ -643,7 +643,7 @@ func (s *subscribeUpcomingTopicsTestSuite) TestRegisterGossipService_ConditionsF
 	// Register via registerGossipService which is the call site that had the bug.
 	// It must forward conditions to newPubsubValidator so that the pubsub
 	// topic validator actually evaluates them.
-	err := s.gm.registerGossipService(wrappedService, condition)
+	_, _, err := s.gm.registerGossipService(wrappedService, condition)
 	s.Require().NoError(err)
 
 	// Verify the topic was registered with pubsub

--- a/cl/phase1/network/gossip/gossip_message_register.go
+++ b/cl/phase1/network/gossip/gossip_message_register.go
@@ -10,16 +10,18 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-func RegisterGossipService[T any](gm *GossipManager, service serviceintf.Service[T], conditions ...ConditionFunc) {
+func RegisterGossipService[T any](gm *GossipManager, service serviceintf.Service[T], conditions ...ConditionFunc) (subscribed, expired int) {
 	wrappedService := wrapService(service)
 	gossipSrv := GossipService{
 		Service:    wrappedService,
 		conditions: conditions,
 	}
 	gm.registeredServices = append(gm.registeredServices, gossipSrv)
-	if err := gm.registerGossipService(wrappedService, conditions...); err != nil {
+	subscribed, expired, err := gm.registerGossipService(wrappedService, conditions...)
+	if err != nil {
 		panic(err)
 	}
+	return
 }
 
 type ConditionFunc func(peer.ID, *pubsub.Message, clparams.StateVersion) bool

--- a/cl/phase1/network/gossip/gossip_subscription.go
+++ b/cl/phase1/network/gossip/gossip_subscription.go
@@ -154,7 +154,7 @@ func (t *TopicSubscriptions) SubscribeWithExpiry(topic string, expiry time.Time)
 		if err != nil {
 			return err
 		}
-		log.Info("[GossipManager] Subscribed to topic", "topic", topic, "expiration", expiry)
+		log.Debug("[GossipManager] Subscribed to topic", "topic", topic, "expiration", expiry)
 		sub.sub = s
 
 		// update ENR only on first subscription, not on expiry renewal

--- a/cl/phase1/network/registry/register.go
+++ b/cl/phase1/network/registry/register.go
@@ -8,6 +8,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/network/gossip"
 	"github.com/erigontech/erigon/cl/phase1/network/services"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common/log/v3"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -37,24 +38,32 @@ func RegisterGossipServices(
 ) {
 	waitReady := withHeadSlotReady(forkChoiceReader, ethClock)
 
+	var subscribed, expired int
+	add := func(s, e int) {
+		subscribed += s
+		expired += e
+	}
+
 	// register services
-	gossip.RegisterGossipService(gm, blockService, withRateLimiterByPeer(1, 2))
-	gossip.RegisterGossipService(gm, syncContributionService, waitReady, withRateLimiterByPeer(8, 16))
-	gossip.RegisterGossipService(gm, aggregateAndProofService, waitReady, withRateLimiterByPeer(8, 16))
-	gossip.RegisterGossipService(gm, syncCommitteeMessagesService, waitReady, withRateLimiterByPeer(8, 16))
-	gossip.RegisterGossipService(gm, attesterSlashingService, waitReady, withRateLimiterByPeer(2, 8))
-	gossip.RegisterGossipService(gm, voluntaryExitService, waitReady, withRateLimiterByPeer(2, 8))
-	gossip.RegisterGossipService(gm, blsToExecutionChangeService, waitReady, withRateLimiterByPeer(2, 8))
-	gossip.RegisterGossipService(gm, proposerSlashingService, waitReady, withRateLimiterByPeer(2, 8))
-	gossip.RegisterGossipService(gm, attestationService, waitReady, withGlobalTimeBasedRateLimiter(6*time.Second, 250))
-	gossip.RegisterGossipService(gm, blobService, withEndVersion(clparams.FuluVersion), withGlobalTimeBasedRateLimiter(6*time.Second, 32))
+	add(gossip.RegisterGossipService(gm, blockService, withRateLimiterByPeer(1, 2)))
+	add(gossip.RegisterGossipService(gm, syncContributionService, waitReady, withRateLimiterByPeer(8, 16)))
+	add(gossip.RegisterGossipService(gm, aggregateAndProofService, waitReady, withRateLimiterByPeer(8, 16)))
+	add(gossip.RegisterGossipService(gm, syncCommitteeMessagesService, waitReady, withRateLimiterByPeer(8, 16)))
+	add(gossip.RegisterGossipService(gm, attesterSlashingService, waitReady, withRateLimiterByPeer(2, 8)))
+	add(gossip.RegisterGossipService(gm, voluntaryExitService, waitReady, withRateLimiterByPeer(2, 8)))
+	add(gossip.RegisterGossipService(gm, blsToExecutionChangeService, waitReady, withRateLimiterByPeer(2, 8)))
+	add(gossip.RegisterGossipService(gm, proposerSlashingService, waitReady, withRateLimiterByPeer(2, 8)))
+	add(gossip.RegisterGossipService(gm, attestationService, waitReady, withGlobalTimeBasedRateLimiter(6*time.Second, 250)))
+	add(gossip.RegisterGossipService(gm, blobService, withEndVersion(clparams.FuluVersion), withGlobalTimeBasedRateLimiter(6*time.Second, 32)))
 	// fulu
-	gossip.RegisterGossipService(gm, dataColumnSidecarService, withBeginVersion(clparams.FuluVersion), withRateLimiterByPeer(32, 64))
+	add(gossip.RegisterGossipService(gm, dataColumnSidecarService, withBeginVersion(clparams.FuluVersion), withRateLimiterByPeer(32, 64)))
 	// gloas
-	gossip.RegisterGossipService(gm, executionPayloadService, waitReady, withBeginVersion(clparams.GloasVersion), withRateLimiterByPeer(2, 4))
-	gossip.RegisterGossipService(gm, payloadAttestationService, waitReady, withBeginVersion(clparams.GloasVersion), withRateLimiterByPeer(8, 16))
-	gossip.RegisterGossipService(gm, proposerPreferencesService, waitReady, withBeginVersion(clparams.GloasVersion), withRateLimiterByPeer(2, 4))
-	gossip.RegisterGossipService(gm, executionPayloadBidService, waitReady, withBeginVersion(clparams.GloasVersion), withRateLimiterByPeer(8, 16))
+	add(gossip.RegisterGossipService(gm, executionPayloadService, waitReady, withBeginVersion(clparams.GloasVersion), withRateLimiterByPeer(2, 4)))
+	add(gossip.RegisterGossipService(gm, payloadAttestationService, waitReady, withBeginVersion(clparams.GloasVersion), withRateLimiterByPeer(8, 16)))
+	add(gossip.RegisterGossipService(gm, proposerPreferencesService, waitReady, withBeginVersion(clparams.GloasVersion), withRateLimiterByPeer(2, 4)))
+	add(gossip.RegisterGossipService(gm, executionPayloadBidService, waitReady, withBeginVersion(clparams.GloasVersion), withRateLimiterByPeer(8, 16)))
+
+	log.Info("[GossipManager] Registered services", "subscribed", subscribed, "expired", expired)
 }
 
 func withHeadSlotReady(forkChoiceReader forkchoice.ForkChoiceStorageReader, ethClock eth_clock.EthereumClock) gossip.ConditionFunc {


### PR DESCRIPTION
Reduces gossip subscription log noise at startup.

- Per-topic `[GossipManager] Subscribed to topic` is demoted from INFO to DEBUG — it previously emitted one INFO line per topic (hundreds, counting attestation/sync-committee/data-column subnets).
- `registerGossipService` now returns `subscribed`/`expired` counts instead of logging per service, and `RegisterGossipServices` aggregates them into a single `INFO [GossipManager] Registered services subscribed=A expired=B` line.

`expired` counts subnet-fanned topics (attestation, sync committee, data-column sidecar) that default to a past expiry and are subscribed later by other modules; `subscribed` counts topics subscribed immediately.
