### PR TITLE
db/seg/patricia: make FuzzLongestMatch oracle linear to fix fuzz timeout

### DIFF
--- a/db/seg/patricia/patricia_fuzz_test.go
+++ b/db/seg/patricia/patricia_fuzz_test.go
@@ -81,6 +81,13 @@ func FuzzPatricia(f *testing.F) {
 	})
 }
 
+type oracleNode struct {
+	next  map[byte]*oracleNode
+	isKey bool
+}
+
+func newOracleNode() *oracleNode { return &oracleNode{next: make(map[byte]*oracleNode)} }
+
 func FuzzLongestMatch(f *testing.F) {
 	f.Fuzz(func(t *testing.T, build []byte, test []byte) {
 		var pt PatriciaTree
@@ -125,17 +132,36 @@ func FuzzLongestMatch(f *testing.F) {
 		ft := pt.Flatten()
 		mf3 := NewMatchFinder3(ft)
 		_ = mf3.FindLongestMatches(data)
-		// AC is validated against a brute-force oracle instead of MatchFinder:
+		// AC is validated against an independent trie oracle instead of MatchFinder:
 		// patricia.Insert loses an existing key when inserting its proper
-		// prefix, so MF3 under-reports matches on prefix-nested dicts.
+		// prefix, so MF3 under-reports matches on prefix-nested dicts. The walk
+		// is O(len(data)*maxKeyLen) so the fuzzer can't drive it to a timeout.
+		oracleRoot := newOracleNode()
+		for key := range keyMap {
+			nd := oracleRoot
+			for j := 0; j < len(key); j++ {
+				c := nd.next[key[j]]
+				if c == nil {
+					c = newOracleNode()
+					nd.next[key[j]] = c
+				}
+				nd = c
+			}
+			nd.isKey = true
+		}
 		var oracle Matches
 		lastEnd := 0
 		for s := 0; s < len(data); s++ {
 			best := 0
-			for key := range keyMap {
-				kl := len(key)
-				if kl > best && s+kl <= len(data) && string(data[s:s+kl]) == key {
-					best = kl
+			nd := oracleRoot
+			for d := 0; s+d < len(data); d++ {
+				c := nd.next[data[s+d]]
+				if c == nil {
+					break
+				}
+				nd = c
+				if nd.isKey {
+					best = d + 1
 				}
 			}
 			if best > 0 && s+best > lastEnd {


### PR DESCRIPTION
## What

`FuzzLongestMatch`'s brute-force validation oracle was `O(len(data) × numKeys × keyLen)`. Since `data` grows up to ~8× `len(test)` (each test chunk appends a key plus its reverse), the coverage-guided fuzzer could drive the oracle past the 60s OSS-Fuzz timeout.

Fixes OSS-Fuzz issue 527099028 (`erigon:fuzz_patricia_longest_match: Timeout`).

## Root cause

The timeout is in the **fuzz harness**, not production code. Timing a 320KB-data × 4000-key input:

| Stage | Time |
|---|---|
| `MatchFinder3.FindLongestMatches` (prod) | ~23 ms |
| `ACMatcher.FindLongestMatches` (prod) | ~15 ms |
| **brute-force oracle (test)** | **10.5 s** |

The production matchers are bounded by trie depth (max key length), so they stay linear even on degenerate all-zeros / prefix-nested input. Only the test oracle was quadratic.

## Fix

Replace the inner per-key scan with an independent byte-trie walk — `O(len(data) × maxKeyLen)`, identical greedy longest-match semantics. It's a separate implementation from the AC/MF3 code under test, so it remains a valid oracle.

## Verification

- Element-by-element identical output to the old oracle (verified on a 100k-match input).
- ~175× faster on that input: 10.5s → 60ms.
- Seed corpus passes; a 40s `-fuzz` run did 2.4M execs with no crashes/timeouts and still gained coverage.
- `make lint` clean.

Test-only change, so no TDD cycle applies (per CLAUDE.md: this is a fuzz-harness performance fix, not a behavior change).
