### PR TITLE
db/datadir/reset: drop stale data file when its torrent infohash mismatches

### DIFF
--- a/db/datadir/reset/reset.go
+++ b/db/datadir/reset/reset.go
@@ -132,6 +132,10 @@ type resetItemInfo struct {
 func (me *Reset) doSnapshots() (err error) {
 	snapDir := me.dataDirOsPath().Join(datadir.SnapDir)
 	ra := me.makeRemoveAll(snapDir)
+	// Data files retained this pass, keyed by their preverified name. A data file is walked before
+	// its sibling ".torrent" (os.ReadDir sorts, and "x.ef" < "x.ef.torrent"), so when an incorrect
+	// torrent is later removed we can retract the stale data file it vouched for.
+	retainedDataFiles := map[string]OsFilePath{}
 	ra.wrapRemove(func(inner removeAllRemoveFunc, filePath OsFilePath, info fs.FileInfo) error {
 		itemName := string(filePath.mustLocalRelSlash(snapDir))
 		itemName, _ = strings.CutSuffix(itemName, ".part")
@@ -151,6 +155,20 @@ func (me *Reset) doSnapshots() (err error) {
 			if err != nil {
 				return fmt.Errorf("removing file %v: %w", filePath, err)
 			}
+			// An incorrect torrent for a preverified file means the data it describes is unverifiable
+			// (stale local build): drop it too so the downloader re-fetches the canonical copy.
+			if isTorrent && ok {
+				if dataPath, retained := retainedDataFiles[itemName]; retained {
+					if err = inner(dataPath, nil); err != nil {
+						return fmt.Errorf("removing stale data file %v: %w", dataPath, err)
+					}
+					delete(retainedDataFiles, itemName)
+					me.stats.retained.DataFiles--
+					me.stats.removed.DataFiles++
+				}
+			}
+		} else if !isTorrent {
+			retainedDataFiles[itemName] = filePath
 		}
 		if isTorrent {
 			stats.TorrentFiles++
@@ -174,7 +192,6 @@ func (me *Reset) decideRemove(file resetItemInfo) bool {
 		}
 		return me.RemoveUnknown
 	}
-	// TODO: missing or incorrect torrent delete data file?
 	if file.isTorrent {
 		mi, err := me.loadMetainfoFromFile(file.filePath)
 		if err != nil {

--- a/db/datadir/reset/reset_test.go
+++ b/db/datadir/reset/reset_test.go
@@ -1,6 +1,7 @@
 package reset
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"iter"
@@ -14,6 +15,8 @@ import (
 	"testing"
 
 	g "github.com/anacrolix/generics"
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
 	"github.com/go-quicktest/qt"
 
 	"github.com/erigontech/erigon/common/dir"
@@ -44,6 +47,33 @@ func TestSnapshots(t *testing.T) {
 		r.PreverifiedSnapshots.Sort()
 		qt.Assert(t, qt.IsNil(r.Run()))
 		checkFs(t, root.FS(), haveEntries(startEntries[0])...)
+	})
+}
+
+// A data file whose torrent has an infohash that doesn't match preverified is a stale local build:
+// reset must drop both the torrent and the data file so the downloader re-fetches the canonical copy.
+func TestIncorrectTorrentRemovesDataFile(t *testing.T) {
+	withOsRoot(t, func(root *os.Root) {
+		var mi metainfo.MetaInfo
+		infoBytes, err := bencode.Marshal(metainfo.Info{Name: "foo.ef", PieceLength: 16384, Pieces: make([]byte, 20)})
+		qt.Assert(t, qt.IsNil(err))
+		mi.InfoBytes = infoBytes
+		var torrentBuf bytes.Buffer
+		qt.Assert(t, qt.IsNil(mi.Write(&torrentBuf)))
+
+		wrongHash := "0000000000000000000000000000000000000000"
+		qt.Assert(t, qt.Not(qt.Equals(mi.HashInfoBytes().String(), wrongHash)))
+
+		startEntries := []fsEntry{
+			{Name: "snapshots/idx/foo.ef"},
+			{Name: "snapshots/idx/foo.ef.torrent", Data: torrentBuf.String()},
+		}
+		makeEntries(t, startEntries, root)
+		r := makeTestingReset(t, startEntries, root, "", ".")
+		r.PreverifiedSnapshots = preverified.SortedItems{{Name: "idx/foo.ef", Hash: wrongHash}}
+		r.PreverifiedSnapshots.Sort()
+		qt.Assert(t, qt.IsNil(r.Run()))
+		checkFs(t, root.FS(), haveEntries(fsEntry{Name: "snapshots", Mode: fs.ModeDir})...)
 	})
 }
 
@@ -379,6 +409,10 @@ func makeEntries(t *testing.T, entries []fsEntry, root *os.Root) {
 		} else {
 			f, err := root.Create(localName)
 			assertNoErr(err)
+			if entry.Data != "" {
+				_, err = f.WriteString(entry.Data)
+				assertNoErr(err)
+			}
 			f.Close()
 		}
 	}


### PR DESCRIPTION
## Motivation

`seg reset` removed a `.torrent` whose infohash didn't match the preverified set (a locally-built file whose bytes differ from the published copy) but **kept the data file it described** — leaving an unverified local build on disk with no torrent, for the downloader to reconcile later. That delete-and-re-fetch handoff is what surfaces as the recurring `[agg] gap in visible files` warning after a reset (see #21876).

The relevant `decideRemove` path already had an acknowledged `// TODO: missing or incorrect torrent delete data file?`.

## Change

| before | after |
|---|---|
| incorrect torrent → remove torrent, **keep** data file | incorrect torrent → remove torrent **and** the data file it vouched for |

- When reset removes an in-preverified torrent (incorrect/corrupt infohash), it now also removes the corresponding data file, so the downloader re-fetches the canonical copy deterministically instead of racing on stale content.
- A data file is walked before its sibling `.torrent` (`os.ReadDir` sorts; `x.ef` < `x.ef.torrent`), so the retraction is order-deterministic.
- Test helper `makeEntries` now writes file contents, so a torrent fixture with a controllable infohash can exercise the mismatch path.

## Test

`TestIncorrectTorrentRemovesDataFile` builds a torrent with a mismatched infohash and asserts both the torrent and its data file are removed. Red before the change (data file survived), green after.

## Scope note

This fixes reset's internal consistency — it no longer retains a file whose hash it just determined is wrong. It does not change the inherent transient warning while a missing file is being (re)downloaded; it makes the re-download deterministic and avoids leaving known-stale data when the downloader is disabled.