### PR TITLE
rpc/jsonrpc: verify executionWitness keys[] completeness in stateless check

### DIFF
--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -1289,7 +1289,7 @@ func (api *DebugAPIImpl) verifyWitnessStateless(
 		return fmt.Errorf("failed to get chain config: %w", err)
 	}
 
-	newStateRoot, _, err := execBlockStatelessly(result, block, chainCfg, fullEngine)
+	newStateRoot, stateless, err := execBlockStatelessly(result, block, chainCfg, fullEngine)
 	if err != nil {
 		return fmt.Errorf("[debug_executionWitness] stateless block execution failed: %w", err)
 	}
@@ -1299,8 +1299,52 @@ func (api *DebugAPIImpl) verifyWitnessStateless(
 		return fmt.Errorf("[debug_executionWitness] state root mismatch after stateless execution : got %x, expected %x", newStateRoot, expectedRoot)
 	}
 
+	if stateless != nil {
+		if err := checkWitnessKeysComplete(stateless.usedTrieAddrs, stateless.usedTrieSlots, result.Keys); err != nil {
+			return fmt.Errorf("[debug_executionWitness] %w", err)
+		}
+	}
+
 	log.Debug("[debug_executionWitness] witness verified", "blockNum", block.NumberU64())
 	return nil
+}
+
+// checkWitnessKeysComplete verifies result.Keys carries a preimage for every account
+// and storage leaf the stateless re-execution resolved from the witness trie. A missing
+// preimage means a verifier treating keys[] as the closed accessed set cannot route to a
+// leaf that is present in state[]. The protocol system address is exempt (intentionally
+// omitted from keys[] unless it really changes).
+func checkWitnessKeysComplete(usedAddrs map[common.Address]struct{}, usedSlots map[common.Hash]struct{}, keys []hexutil.Bytes) error {
+	keyAddrs := make(map[common.Address]struct{})
+	keySlots := make(map[common.Hash]struct{})
+	for _, k := range keys {
+		switch len(k) {
+		case 20:
+			keyAddrs[common.BytesToAddress(k)] = struct{}{}
+		case 32:
+			keySlots[common.BytesToHash(k)] = struct{}{}
+		}
+	}
+	sysAddr := common.Address(params.SystemAddress.Value())
+	var missing []string
+	for addr := range usedAddrs {
+		if addr == sysAddr {
+			continue
+		}
+		if _, ok := keyAddrs[addr]; !ok {
+			missing = append(missing, addr.Hex())
+		}
+	}
+	for slot := range usedSlots {
+		if _, ok := keySlots[slot]; !ok {
+			missing = append(missing, slot.Hex())
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	slices.Sort(missing)
+	return fmt.Errorf("witness keys[] incomplete: %d preimage(s) for leaves present in state[] missing: %v", len(missing), missing)
 }
 
 // buildExpectedPostState queries the actual state DB to build expected post-state for verification.
@@ -1430,6 +1474,10 @@ type witnessStateless struct {
 	trace          bool
 	strictVerify   bool // error on trie nodes missing from the witness
 
+	// preimages the witness trie actually supplied during re-exec; keys[] must cover these
+	usedTrieAddrs map[common.Address]struct{}
+	usedTrieSlots map[common.Hash]struct{}
+
 	// Debug: addresses to trace operations on
 	accountsToTrace map[common.Address]struct{}
 }
@@ -1488,6 +1536,8 @@ func newWitnessStateless(result *ExecutionWitnessResult) (*witnessStateless, err
 		created:        make(map[common.Address]struct{}),
 		trace:          false,
 		strictVerify:   dbg.EnvBool("WITNESS_STRICT_VERIFY", false),
+		usedTrieAddrs:  make(map[common.Address]struct{}),
+		usedTrieSlots:  make(map[common.Hash]struct{}),
 	}, nil
 }
 
@@ -1538,6 +1588,9 @@ func (s *witnessStateless) ReadAccountData(address accounts.Address) (*accounts.
 
 	// Read from trie
 	acc, ok := s.t.GetAccount(addrHash[:])
+	if ok && acc != nil {
+		s.usedTrieAddrs[addr] = struct{}{}
+	}
 	if s.tracing(addr) {
 		if ok && acc != nil {
 			fmt.Printf("[TRACE-S] ReadAccountData %s -> trie nonce=%d balance=%d codeHash=%x\n", addr.Hex(), acc.Nonce, &acc.Balance, acc.CodeHash)
@@ -1594,6 +1647,7 @@ func (s *witnessStateless) ReadAccountStorage(address accounts.Address, key acco
 	// Read from trie
 	cKey := dbutils.GenerateCompositeTrieKey(addrHash, seckey)
 	if enc, ok := s.t.Get(cKey); ok {
+		s.usedTrieSlots[keyValue] = struct{}{}
 		var res uint256.Int
 		res.SetBytes(enc)
 		if s.tracing(addr) {

--- a/rpc/jsonrpc/debug_execution_witness_test.go
+++ b/rpc/jsonrpc/debug_execution_witness_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
@@ -251,6 +253,49 @@ func TestCollectAccessedState_KeysIncludeDeletedPreExisting(t *testing.T) {
 	if sawCreatedThenDeleted {
 		t.Error("preimage for an account that never existed pre-state and was deleted in-block must be excluded")
 	}
+}
+
+// TestCheckWitnessKeysComplete pins the internal verifier's keys[]-completeness check:
+// every account/storage leaf the stateless re-execution resolved from the witness trie
+// must have its preimage in keys[]; the protocol system address is exempt.
+func TestCheckWitnessKeysComplete(t *testing.T) {
+	addrA := common.HexToAddress("0x16fd7629978addaf41c426601176c37977a0faa7")
+	addrB := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	slotS := common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000aa")
+	sys := common.Address(params.SystemAddress.Value())
+	key20 := func(a common.Address) hexutil.Bytes { return bytes.Clone(a[:]) }
+	key32 := func(h common.Hash) hexutil.Bytes { return bytes.Clone(h[:]) }
+
+	t.Run("missing account preimage flagged", func(t *testing.T) {
+		used := map[common.Address]struct{}{addrA: {}}
+		if err := checkWitnessKeysComplete(used, nil, nil); err == nil {
+			t.Fatal("expected error: accessed account leaf missing from keys[]")
+		}
+	})
+	t.Run("present account preimage ok", func(t *testing.T) {
+		used := map[common.Address]struct{}{addrA: {}}
+		if err := checkWitnessKeysComplete(used, nil, []hexutil.Bytes{key20(addrA)}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("system address exempt", func(t *testing.T) {
+		used := map[common.Address]struct{}{sys: {}}
+		if err := checkWitnessKeysComplete(used, nil, nil); err != nil {
+			t.Fatalf("system address must not require a preimage: %v", err)
+		}
+	})
+	t.Run("missing slot preimage flagged", func(t *testing.T) {
+		usedS := map[common.Hash]struct{}{slotS: {}}
+		if err := checkWitnessKeysComplete(nil, usedS, []hexutil.Bytes{key20(addrB)}); err == nil {
+			t.Fatal("expected error: accessed storage leaf missing from keys[]")
+		}
+	})
+	t.Run("present slot preimage ok", func(t *testing.T) {
+		usedS := map[common.Hash]struct{}{slotS: {}}
+		if err := checkWitnessKeysComplete(nil, usedS, []hexutil.Bytes{key32(slotS)}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestResolveWitnessMode(t *testing.T) {


### PR DESCRIPTION
Stacked on #22000.

The internal stateless verifier re-executes from `state[]`+`codes[]` and matches the root, but never reads `keys[]` — so a witness missing the preimage of an accessed account or storage leaf passes. That is how #21979 slipped past both erigon and reth re-execution.

Record which account/storage leaves the witness trie supplies during the stateless re-exec, then assert `keys[]` carries a preimage for each. The protocol system address is exempt (omitted from `keys[]` unless it really changes).

Validated on a mainnet archive node built from main + this check, without the #21979 gate fix so generation is still buggy:

- block 25350549 → `debug_executionWitness` now rejected: `witness keys[] incomplete: 1 preimage(s) for leaves present in state[] missing: [0x16fD7629978AdDaf41c426601176c37977a0FaA7]`
- blocks 25335936, 25350550 (complete witnesses) → verify ok

This makes the internal verifier stronger than reth on the preimage axis, where reth's re-execution also passes the buggy witness.

Test: `TestCheckWitnessKeysComplete`.
