### PR TITLE
execution: route block validation through Engine, split gas limit

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -1148,6 +1148,15 @@ func (e *remoteRulesEngine) GetPostApplyMessageFunc() evmtypes.PostApplyMessageF
 	return e.engine.GetPostApplyMessageFunc()
 }
 
+func (e *remoteRulesEngine) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
+	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
+	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {
+	if err := e.validateEngineReady(); err != nil {
+		return err
+	}
+	return e.engine.ValidateBlockPostExecution(chainConfig, header, gasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
+}
+
 func (e *remoteRulesEngine) VerifyHeader(_ rules.ChainHeaderReader, _ *types.Header, _ bool) error {
 	panic("remoteRulesEngine.VerifyHeader not supported")
 }

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -378,12 +378,5 @@ func InitializeBlockExecution(engine rules.Engine, chain rules.ChainHeaderReader
 
 // Deprecated: use Engine.ValidateBlockPostExecution instead.
 func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool, receipts types.Receipts, h *types.Header, txns types.Transactions, chainConfig *chain.Config, logger log.Logger) error {
-	err := rules.DefaultBlockPostValidation(chainConfig, h, blockGasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
-	if err != nil && dbg.LogHashMismatchReason() {
-		ethutils.LogReceipts(log.LvlWarn, "post-execution validation failed", receipts, txns, chainConfig, h, logger)
-	}
-	if err == nil && dbg.TraceLogs && dbg.TraceBlock(h.Number.Uint64()) {
-		ethutils.LogReceipts(log.LvlInfo, "trace logs", receipts, txns, chainConfig, h, logger)
-	}
-	return err
+	return rules.DefaultBlockPostValidation(chainConfig, h, blockGasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
 }

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -376,70 +376,14 @@ func InitializeBlockExecution(engine rules.Engine, chain rules.ChainHeaderReader
 	return ibs.FinalizeTx(blockContext.Rules(cc), stateWriter)
 }
 
-var alwaysSkipReceiptCheck = dbg.EnvBool("EXEC_SKIP_RECEIPT_CHECK", false)
-
+// Deprecated: use Engine.ValidateBlockPostExecution instead.
 func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool, receipts types.Receipts, h *types.Header, txns types.Transactions, chainConfig *chain.Config, logger log.Logger) error {
-	if blockGasUsed != h.GasUsed {
-		logger.Warn("gas used mismatch", "block", h.Number.Uint64(), "header", h.GasUsed, "execution", blockGasUsed,
-			"diff", int64(blockGasUsed)-int64(h.GasUsed), "txCount", len(txns), "receiptCount", len(receipts))
-		// Dump per-tx gas for debugging
-		var cumGas uint64
-		for i, r := range receipts {
-			txGas := r.GasUsed
-			cumGas += txGas
-			var txHash string
-			if i < len(txns) {
-				txHash = txns[i].Hash().Hex()[:18]
-			}
-			logger.Warn("  tx gas detail", "block", h.Number.Uint64(), "txIdx", i, "txHash", txHash,
-				"gasUsed", txGas, "cumGasUsed", r.CumulativeGasUsed, "computedCumGas", cumGas, "status", r.Status)
-		}
-		return fmt.Errorf("gas used by execution: %d, in header: %d, headerNum=%d, %x",
-			blockGasUsed, h.GasUsed, h.Number.Uint64(), h.Hash())
+	err := rules.DefaultBlockPostValidation(chainConfig, h, blockGasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
+	if err != nil && dbg.LogHashMismatchReason() {
+		ethutils.LogReceipts(log.LvlWarn, "post-execution validation failed", receipts, txns, chainConfig, h, logger)
 	}
-
-	if h.BlobGasUsed != nil && blobGasUsed != *h.BlobGasUsed {
-		return fmt.Errorf("blobGasUsed by execution: %d, in header: %d, headerNum=%d, %x",
-			blobGasUsed, *h.BlobGasUsed, h.Number.Uint64(), h.Hash())
-	}
-
-	var lbloom types.Bloom
-	bloomFromReceipts := checkReceipts && checkBloom && !alwaysSkipReceiptCheck
-	if checkReceipts && !alwaysSkipReceiptCheck {
-		for _, r := range receipts {
-			r.Bloom = types.CreateBloom(types.Receipts{r})
-			if bloomFromReceipts {
-				lbloom.Or(&r.Bloom)
-			}
-		}
-		receiptHash := types.DeriveSha(receipts)
-		if receiptHash != h.ReceiptHash {
-			if dbg.LogHashMismatchReason() {
-				ethutils.LogReceipts(log.LvlWarn, "receipt hash mismatch in BlockPostValidation", receipts, txns, chainConfig, h, logger)
-			}
-			return fmt.Errorf("receiptHash mismatch: %x != %x, headerNum=%d, %x",
-				receiptHash, h.ReceiptHash, h.Number.Uint64(), h.Hash())
-		}
-	}
-
-	// The logs bloom is part of every block header from Frontier on, so it must
-	// be validated independently of the receipt-root check (which is gated on
-	// Byzantium because pre-Byzantium receipts encode an intermediate state
-	// root that Erigon doesn't materialise). Without this, an invalid bloom on
-	// a pre-Byzantium block (e.g. hive bcInvalidHeaderTest/log1_wrongBloom)
-	// is silently accepted.
-	if checkBloom && !alwaysSkipReceiptCheck {
-		if !bloomFromReceipts {
-			lbloom = types.CreateBloom(receipts)
-		}
-		if lbloom != h.Bloom {
-			return fmt.Errorf("invalid bloom (remote: %x  local: %x)", h.Bloom, lbloom)
-		}
-	}
-
-	if dbg.TraceLogs && dbg.TraceBlock(h.Number.Uint64()) {
+	if err == nil && dbg.TraceLogs && dbg.TraceBlock(h.Number.Uint64()) {
 		ethutils.LogReceipts(log.LvlInfo, "trace logs", receipts, txns, chainConfig, h, logger)
 	}
-
-	return nil
+	return err
 }

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -375,8 +375,3 @@ func InitializeBlockExecution(engine rules.Engine, chain rules.ChainHeaderReader
 	blockContext := NewEVMBlockContext(header, GetHashFn(header, nil), engine, accounts.NilAddress, cc)
 	return ibs.FinalizeTx(blockContext.Rules(cc), stateWriter)
 }
-
-// Deprecated: use Engine.ValidateBlockPostExecution instead.
-func BlockPostValidation(blockGasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool, receipts types.Receipts, h *types.Header, txns types.Transactions, chainConfig *chain.Config, logger log.Logger) error {
-	return rules.DefaultBlockPostValidation(chainConfig, h, blockGasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
-}

--- a/execution/protocol/misc/eip1559.go
+++ b/execution/protocol/misc/eip1559.go
@@ -34,25 +34,11 @@ import (
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
 )
 
-// VerifyEip1559Header verifies some header attributes which were changed in EIP-1559,
-// - gas limit check
-// - basefee check
-func VerifyEip1559Header(config *chain.Config, parent, header *types.Header, skipGasLimit bool) error {
-	if !skipGasLimit {
-		// Verify that the gas limit remains within allowed bounds
-		parentGasLimit := parent.GasLimit
-		if !config.IsLondon(parent.Number.Uint64()) {
-			parentGasLimit = parent.GasLimit * params.ElasticityMultiplier
-		}
-		if err := VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
-			return err
-		}
-	}
-	// Verify the header is not malformed
+// VerifyEip1559Header checks base fee only; gas limit is in VerifyParentGasLimit.
+func VerifyEip1559Header(config *chain.Config, parent, header *types.Header) error {
 	if header.BaseFee == nil {
 		return errors.New("header is missing baseFee")
 	}
-	// Verify the baseFee is correct based on the parent header.
 	expectedBaseFee := CalcBaseFee(config, parent)
 	if header.BaseFee.Cmp(expectedBaseFee) != 0 {
 		return fmt.Errorf("invalid baseFee: have %s, want %s, parentBaseFee %s, parentGasUsed %d",

--- a/execution/protocol/misc/eip1559_test.go
+++ b/execution/protocol/misc/eip1559_test.go
@@ -85,7 +85,11 @@ func TestBlockGasLimits(t *testing.T) {
 			BaseFee:  initial,
 			Number:   *uint256.NewInt(tc.pNum + 1),
 		}
-		err := VerifyEip1559Header(config(), parent, header, false /*skipGasLimit*/)
+		cfg := config()
+		err := VerifyEip1559Header(cfg, parent, header)
+		if err == nil {
+			err = VerifyParentGasLimit(cfg, parent, header)
+		}
 		if tc.ok && err != nil {
 			t.Errorf("test %d: Expected valid header: %s", i, err)
 		}

--- a/execution/protocol/misc/gaslimit.go
+++ b/execution/protocol/misc/gaslimit.go
@@ -22,7 +22,9 @@ package misc
 import (
 	"fmt"
 
+	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/types"
 )
 
 // VerifyGaslimit verifies the header gas limit according increase/decrease
@@ -41,6 +43,16 @@ func VerifyGaslimit(parentGasLimit, headerGasLimit uint64) error {
 		return fmt.Errorf("invalid gas limit below %d", params.MinBlockGasLimit)
 	}
 	return nil
+}
+
+// VerifyParentGasLimit checks the parent-relative gas limit rule (±1/1024).
+// Applies the elasticity multiplier at the London transition boundary.
+func VerifyParentGasLimit(config *chain.Config, parent, header *types.Header) error {
+	parentGasLimit := parent.GasLimit
+	if config.IsLondon(header.Number.Uint64()) && !config.IsLondon(parent.Number.Uint64()) {
+		parentGasLimit = parent.GasLimit * params.ElasticityMultiplier
+	}
+	return VerifyGaslimit(parentGasLimit, header.GasLimit)
 }
 
 // CalcGasLimit computes the gas limit of the next block after parent. It aims

--- a/execution/protocol/rules/aura/aura.go
+++ b/execution/protocol/rules/aura/aura.go
@@ -1206,6 +1206,12 @@ func (c *AuRa) GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc {
 	return nil
 }
 
+func (c *AuRa) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
+	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
+	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {
+	return rules.DefaultBlockPostValidation(chainConfig, header, gasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
+}
+
 /*
 // extracts the empty steps from the header seal. should only be called when there are 3 fields in the seal
 // (i.e. header.number() >= self.empty_steps_transition).

--- a/execution/protocol/rules/aura/aura.go
+++ b/execution/protocol/rules/aura/aura.go
@@ -384,7 +384,13 @@ func (c *AuRa) VerifyHeader(chain rules.ChainHeaderReader, header *types.Header,
 		log.Error("rules.ErrUnknownAncestor", "parentNum", number-1, "hash", header.ParentHash.String())
 		return rules.ErrUnknownAncestor
 	}
-	return ethash.VerifyHeaderBasics(chain, header, parent, true /*checkTimestamp*/, c.HasGasLimitContract() /*skipGasLimit*/)
+	if err := ethash.VerifyHeaderBasics(chain, header, parent, true /*checkTimestamp*/); err != nil {
+		return err
+	}
+	if !c.HasGasLimitContract() {
+		return misc.VerifyParentGasLimit(chain.Config(), parent, header)
+	}
+	return nil
 }
 
 // nolint

--- a/execution/protocol/rules/block_post_validation_test.go
+++ b/execution/protocol/rules/block_post_validation_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-package protocol
+package rules
 
 import (
 	"strings"
@@ -63,7 +63,7 @@ func TestBlockPostValidation_PreByzantiumBloomMismatch(t *testing.T) {
 	const checkReceipts = false // pre-Byzantium gate
 	const checkBloom = true
 
-	err := BlockPostValidation(21912, 0, checkReceipts, checkBloom, receipts, header, nil, cfg, log.New())
+	err := DefaultBlockPostValidation(cfg, header, 21912, 0, checkReceipts, checkBloom, receipts, nil, log.New())
 	if err == nil {
 		t.Fatal("expected bloom-mismatch error on pre-Byzantium block, got nil")
 	}
@@ -73,14 +73,14 @@ func TestBlockPostValidation_PreByzantiumBloomMismatch(t *testing.T) {
 
 	// Set the correct bloom — validation must pass.
 	header.Bloom = correctBloom
-	if err := BlockPostValidation(21912, 0, checkReceipts, checkBloom, receipts, header, nil, cfg, log.New()); err != nil {
+	if err := DefaultBlockPostValidation(cfg, header, 21912, 0, checkReceipts, checkBloom, receipts, nil, log.New()); err != nil {
 		t.Fatalf("expected success when bloom matches, got: %v", err)
 	}
 
 	// With checkBloom disabled the mismatch must not trigger an error
 	// (sanity check that the new flag does gate the new path).
 	header.Bloom = types.Bloom{}
-	if err := BlockPostValidation(21912, 0, checkReceipts, false, receipts, header, nil, cfg, log.New()); err != nil {
+	if err := DefaultBlockPostValidation(cfg, header, 21912, 0, checkReceipts, false, receipts, nil, log.New()); err != nil {
 		t.Fatalf("checkBloom=false should skip bloom validation, got: %v", err)
 	}
 }
@@ -137,12 +137,12 @@ func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
 	const checkReceipts = true
 	const checkBloom = true
 
-	if err := BlockPostValidation(42_000, 0, checkReceipts, checkBloom, receipts, header, nil, cfg, log.New()); err != nil {
+	if err := DefaultBlockPostValidation(cfg, header, 42_000, 0, checkReceipts, checkBloom, receipts, nil, log.New()); err != nil {
 		t.Fatalf("expected receipt+bloom validation to accept OR-merged bloom: %v", err)
 	}
 
 	header.Bloom = types.Bloom{}
-	err := BlockPostValidation(42_000, 0, checkReceipts, checkBloom, receipts, header, nil, cfg, log.New())
+	err := DefaultBlockPostValidation(cfg, header, 42_000, 0, checkReceipts, checkBloom, receipts, nil, log.New())
 	if err == nil {
 		t.Fatal("expected bloom-mismatch error, got nil")
 	}

--- a/execution/protocol/rules/ethash/rules.go
+++ b/execution/protocol/rules/ethash/rules.go
@@ -447,6 +447,12 @@ func (ethash *Ethash) FinalizeAndAssemble(chainConfig *chain.Config, header *typ
 	return types.NewBlock(header, txs, uncles, r, withdrawals), nil, nil
 }
 
+func (ethash *Ethash) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
+	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
+	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {
+	return rules.DefaultBlockPostValidation(chainConfig, header, gasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
+}
+
 // SealHash returns the hash of a block prior to it being sealed.
 func (ethash *Ethash) SealHash(header *types.Header) (hash common.Hash) {
 	hasher := keccak.NewFastKeccak()

--- a/execution/protocol/rules/ethash/rules.go
+++ b/execution/protocol/rules/ethash/rules.go
@@ -200,7 +200,7 @@ func (ethash *Ethash) VerifyUncle(chain rules.ChainHeaderReader, header *types.H
 	return ethash.verifyHeader(chain, uncle, ancestors[uncle.ParentHash], true, seal)
 }
 
-func VerifyHeaderBasics(chain rules.ChainHeaderReader, header, parent *types.Header, checkTimestamp, skipGasLimit bool) error {
+func VerifyHeaderBasics(chain rules.ChainHeaderReader, header, parent *types.Header, checkTimestamp bool) error {
 	// Ensure that the header's extra-data section is of a reasonable size
 	if uint64(len(header.Extra)) > params.MaximumExtraDataSize {
 		return fmt.Errorf("extra-data too long: %d > %d", len(header.Extra), params.MaximumExtraDataSize)
@@ -223,19 +223,11 @@ func VerifyHeaderBasics(chain rules.ChainHeaderReader, header, parent *types.Hea
 	if header.GasUsed > header.GasLimit {
 		return fmt.Errorf("invalid gasUsed: have %d, gasLimit %d", header.GasUsed, header.GasLimit)
 	}
-	// Verify the block's gas usage and (if applicable) verify the base fee.
 	if !chain.Config().IsLondon(header.Number.Uint64()) {
-		// Verify BaseFee not present before EIP-1559 fork.
 		if header.BaseFee != nil {
 			return fmt.Errorf("invalid baseFee before fork: have %d, expected 'nil'", header.BaseFee)
 		}
-		if !skipGasLimit {
-			if err := misc.VerifyGaslimit(parent.GasLimit, header.GasLimit); err != nil {
-				return err
-			}
-		}
-	} else if err := misc.VerifyEip1559Header(chain.Config(), parent, header, skipGasLimit); err != nil {
-		// Verify the header's EIP-1559 attributes.
+	} else if err := misc.VerifyEip1559Header(chain.Config(), parent, header); err != nil {
 		return err
 	}
 
@@ -275,7 +267,10 @@ func VerifyHeaderBasics(chain rules.ChainHeaderReader, header, parent *types.Hea
 // stock Ethereum ethash engine.
 // See YP section 4.3.4. "Block Header Validity"
 func (ethash *Ethash) verifyHeader(chain rules.ChainHeaderReader, header, parent *types.Header, uncle bool, seal bool) error {
-	if err := VerifyHeaderBasics(chain, header, parent, !uncle /*checkTimestamp*/, false /*skipGasLimit*/); err != nil {
+	if err := VerifyHeaderBasics(chain, header, parent, !uncle /*checkTimestamp*/); err != nil {
+		return err
+	}
+	if err := misc.VerifyParentGasLimit(chain.Config(), parent, header); err != nil {
 		return err
 	}
 	// Verify the block's difficulty based on its timestamp and parent's difficulty

--- a/execution/protocol/rules/merge/merge.go
+++ b/execution/protocol/rules/merge/merge.go
@@ -464,6 +464,12 @@ func (s *Merge) GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc {
 	return misc.LogSelfDestructedAccounts // EIP-7708
 }
 
+func (s *Merge) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
+	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
+	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {
+	return rules.DefaultBlockPostValidation(chainConfig, header, gasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
+}
+
 func (s *Merge) Close() error {
 	return s.eth1Engine.Close()
 }

--- a/execution/protocol/rules/merge/merge.go
+++ b/execution/protocol/rules/merge/merge.go
@@ -323,7 +323,10 @@ func (s *Merge) verifyHeader(chain rules.ChainHeaderReader, header, parent *type
 		return errInvalidUncleHash
 	}
 
-	if err := misc.VerifyEip1559Header(chain.Config(), parent, header, false); err != nil {
+	if err := misc.VerifyEip1559Header(chain.Config(), parent, header); err != nil {
+		return err
+	}
+	if err := misc.VerifyParentGasLimit(chain.Config(), parent, header); err != nil {
 		return err
 	}
 

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -21,9 +21,12 @@
 package rules
 
 import (
+	"fmt"
+
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/state"
@@ -134,6 +137,14 @@ type EngineReader interface {
 
 	GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc
 
+	// ValidateBlockPostExecution checks block-level commitments after all
+	// transactions have been executed: gas used vs header, blob gas used,
+	// receipt root, and log bloom. Chain-specific engines may override for
+	// different gas accounting or optional checks.
+	ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
+		gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
+		receipts types.Receipts, txns types.Transactions, logger log.Logger) error
+
 	// Close terminates any background threads, DB's etc maintained by the rules engine.
 	Close() error
 }
@@ -189,6 +200,59 @@ type EngineWriter interface {
 
 	// APIs returns the RPC APIs this rules engine provides.
 	APIs(chain ChainHeaderReader) []rpc.API
+}
+
+// DefaultBlockPostValidation performs the standard Ethereum post-execution
+// checks. Engine implementations that do not need custom validation should
+// call this from their ValidateBlockPostExecution method.
+func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
+	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
+	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {
+
+	alwaysSkipReceiptCheck := dbg.EnvBool("EXEC_SKIP_RECEIPT_CHECK", false)
+
+	if gasUsed != header.GasUsed {
+		logger.Warn("gas used mismatch", "block", header.Number.Uint64(), "header", header.GasUsed, "execution", gasUsed,
+			"diff", int64(gasUsed)-int64(header.GasUsed), "txCount", len(txns), "receiptCount", len(receipts))
+		var cumGas uint64
+		for i, r := range receipts {
+			txGas := r.GasUsed
+			cumGas += txGas
+			var txHash string
+			if i < len(txns) {
+				txHash = txns[i].Hash().Hex()[:18]
+			}
+			logger.Warn("  tx gas detail", "block", header.Number.Uint64(), "txIdx", i, "txHash", txHash,
+				"gasUsed", txGas, "cumGasUsed", r.CumulativeGasUsed, "computedCumGas", cumGas, "status", r.Status)
+		}
+		return fmt.Errorf("gas used by execution: %d, in header: %d, headerNum=%d, %x",
+			gasUsed, header.GasUsed, header.Number.Uint64(), header.Hash())
+	}
+
+	if header.BlobGasUsed != nil && blobGasUsed != *header.BlobGasUsed {
+		return fmt.Errorf("blobGasUsed by execution: %d, in header: %d, headerNum=%d, %x",
+			blobGasUsed, *header.BlobGasUsed, header.Number.Uint64(), header.Hash())
+	}
+
+	if checkReceipts && !alwaysSkipReceiptCheck {
+		for _, r := range receipts {
+			r.Bloom = types.CreateBloom(types.Receipts{r})
+		}
+		receiptHash := types.DeriveSha(receipts)
+		if receiptHash != header.ReceiptHash {
+			return fmt.Errorf("receiptHash mismatch: %x != %x, headerNum=%d, %x",
+				receiptHash, header.ReceiptHash, header.Number.Uint64(), header.Hash())
+		}
+	}
+
+	if checkBloom && !alwaysSkipReceiptCheck {
+		bloom := types.CreateBloom(receipts)
+		if bloom != header.Bloom {
+			return fmt.Errorf("invalid bloom (remote: %x  local: %x)", header.Bloom, bloom)
+		}
+	}
+
+	return nil
 }
 
 // PoW is a rules engine based on proof-of-work.

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -198,12 +198,11 @@ type EngineWriter interface {
 	APIs(chain ChainHeaderReader) []rpc.API
 }
 
+var alwaysSkipReceiptCheck = dbg.EnvBool("EXEC_SKIP_RECEIPT_CHECK", false)
+
 func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
 	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
 	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {
-
-	alwaysSkipReceiptCheck := dbg.EnvBool("EXEC_SKIP_RECEIPT_CHECK", false)
-
 	if gasUsed != header.GasUsed {
 		logger.Warn("gas used mismatch", "block", header.Number.Uint64(), "header", header.GasUsed, "execution", gasUsed,
 			"diff", int64(gasUsed)-int64(header.GasUsed), "txCount", len(txns), "receiptCount", len(receipts))

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -137,10 +137,6 @@ type EngineReader interface {
 
 	GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc
 
-	// ValidateBlockPostExecution checks block-level commitments after all
-	// transactions have been executed: gas used vs header, blob gas used,
-	// receipt root, and log bloom. Chain-specific engines may override for
-	// different gas accounting or optional checks.
 	ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
 		gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
 		receipts types.Receipts, txns types.Transactions, logger log.Logger) error
@@ -202,9 +198,6 @@ type EngineWriter interface {
 	APIs(chain ChainHeaderReader) []rpc.API
 }
 
-// DefaultBlockPostValidation performs the standard Ethereum post-execution
-// checks. Engine implementations that do not need custom validation should
-// call this from their ValidateBlockPostExecution method.
 func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
 	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
 	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -227,9 +227,14 @@ func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
 			blobGasUsed, *header.BlobGasUsed, header.Number.Uint64(), header.Hash())
 	}
 
+	var bloom types.Bloom
+	bloomFromReceipts := checkReceipts && checkBloom && !alwaysSkipReceiptCheck
 	if checkReceipts && !alwaysSkipReceiptCheck {
 		for _, r := range receipts {
 			r.Bloom = types.CreateBloom(types.Receipts{r})
+			if bloomFromReceipts {
+				bloom.Or(&r.Bloom)
+			}
 		}
 		receiptHash := types.DeriveSha(receipts)
 		if receiptHash != header.ReceiptHash {
@@ -239,7 +244,9 @@ func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
 	}
 
 	if checkBloom && !alwaysSkipReceiptCheck {
-		bloom := types.CreateBloom(receipts)
+		if !bloomFromReceipts {
+			bloom = types.CreateBloom(receipts)
+		}
 		if bloom != header.Bloom {
 			return fmt.Errorf("invalid bloom (remote: %x  local: %x)", header.Bloom, bloom)
 		}

--- a/execution/stagedsync/block_post_validator.go
+++ b/execution/stagedsync/block_post_validator.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
-	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/types"
 )
 
-// blockValidator runs BlockPostValidation in a goroutine for a SINGLE block.
+// blockValidator runs ValidateBlockPostExecution in a goroutine for a SINGLE block.
 // One instance per block — no shared state across blocks. The previous
 // shared-across-blocks validator carried v.err and v.wg between blocks,
 // which was prone to leaking wg counters on early-return and to "sticky
@@ -26,12 +25,12 @@ type blockValidator struct {
 
 // newBlockValidator starts validation in a goroutine. The caller must
 // eventually call Wait() to surface the result and to drain the goroutine.
-func newBlockValidator(blockGasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool, receipts types.Receipts,
+func newBlockValidator(engine rules.Engine, blockGasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool, receipts types.Receipts,
 	header *types.Header, txns types.Transactions,
 	chainConfig *chain.Config, logger log.Logger) *blockValidator {
 	bv := &blockValidator{done: make(chan error, 1)}
 	go func() {
-		bv.done <- protocol.BlockPostValidation(blockGasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, header, txns, chainConfig, logger)
+		bv.done <- engine.ValidateBlockPostExecution(chainConfig, header, blockGasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
 	}()
 	return bv
 }

--- a/execution/stagedsync/block_post_validator.go
+++ b/execution/stagedsync/block_post_validator.go
@@ -3,10 +3,12 @@ package stagedsync
 import (
 	"fmt"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/ethutils"
 )
 
 type blockValidator struct {
@@ -18,9 +20,22 @@ func newBlockValidator(engine rules.Engine, blockGasUsed, blobGasUsed uint64, ch
 	chainConfig *chain.Config, logger log.Logger) *blockValidator {
 	bv := &blockValidator{done: make(chan error, 1)}
 	go func() {
-		bv.done <- engine.ValidateBlockPostExecution(chainConfig, header, blockGasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
+		bv.done <- validateBlockPostExecution(engine, chainConfig, header, blockGasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
 	}()
 	return bv
+}
+
+func validateBlockPostExecution(engine rules.Engine, chainConfig *chain.Config, header *types.Header,
+	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
+	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {
+	err := engine.ValidateBlockPostExecution(chainConfig, header, gasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
+	switch {
+	case err != nil && dbg.LogHashMismatchReason():
+		ethutils.LogReceipts(log.LvlWarn, "post-execution validation failed", receipts, txns, chainConfig, header, logger)
+	case err == nil && dbg.TraceLogs && dbg.TraceBlock(header.Number.Uint64()):
+		ethutils.LogReceipts(log.LvlInfo, "trace logs", receipts, txns, chainConfig, header, logger)
+	}
+	return err
 }
 
 // Safe on nil receiver and idempotent (re-stuffs the result after each read).

--- a/execution/stagedsync/block_post_validator.go
+++ b/execution/stagedsync/block_post_validator.go
@@ -9,22 +9,10 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-// blockValidator runs ValidateBlockPostExecution in a goroutine for a SINGLE block.
-// One instance per block — no shared state across blocks. The previous
-// shared-across-blocks validator carried v.err and v.wg between blocks,
-// which was prone to leaking wg counters on early-return and to "sticky
-// errors" propagating from one block's failure into the next. A fresh
-// instance per block eliminates both classes of bug.
-//
-// The shape mirrors the commitmentCalculator: the validator owns its own
-// goroutine and delivers its result through a buffered channel. Wait()
-// is the single point of synchronization.
 type blockValidator struct {
 	done chan error // buffered(1); written once, then re-stuffed on each Wait
 }
 
-// newBlockValidator starts validation in a goroutine. The caller must
-// eventually call Wait() to surface the result and to drain the goroutine.
 func newBlockValidator(engine rules.Engine, blockGasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool, receipts types.Receipts,
 	header *types.Header, txns types.Transactions,
 	chainConfig *chain.Config, logger log.Logger) *blockValidator {
@@ -35,9 +23,7 @@ func newBlockValidator(engine rules.Engine, blockGasUsed, blobGasUsed uint64, ch
 	return bv
 }
 
-// Wait blocks until validation completes and returns the (wrapped) error,
-// or nil. Safe to call on a nil receiver (no-op) and safe to call multiple
-// times — the result is re-stuffed into the channel after each read.
+// Safe on nil receiver and idempotent (re-stuffs the result after each read).
 func (bv *blockValidator) Wait() error {
 	if bv == nil {
 		return nil

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -566,7 +566,7 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 						// Spawn per-block validation in a goroutine — the result is
 						// joined via Wait() below, after the other per-result work
 						// has had a chance to run in parallel with validation.
-						blockValidatorWaiter = newBlockValidator(applyResult.BlockGasUsed, applyResult.BlobGasUsed, checkReceipts, checkBloom, applyResult.Receipts,
+						blockValidatorWaiter = newBlockValidator(pe.cfg.engine, applyResult.BlockGasUsed, applyResult.BlobGasUsed, checkReceipts, checkBloom, applyResult.Receipts,
 							lastHeader, b.Transactions(), pe.cfg.chainConfig, pe.logger)
 
 						if !applyResult.isPartial && !execStage.CurrentSyncCycle.IsInitialCycle {

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -434,7 +434,7 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					//Disable check for genesis. Maybe need somehow improve it in future - to satisfy TestExecutionSpec
 					// Block gas = max(regular, state). Pre-Amsterdam: blockStateGasUsed is 0.
 					blockGasUsed := max(se.blockGasUsed, se.blockStateGasUsed)
-					if err := se.cfg.engine.ValidateBlockPostExecution(se.cfg.chainConfig, txTask.Header, blockGasUsed, se.blobGasUsed, checkReceipts, checkBloom, blockReceipts, txTask.Txs, se.logger); err != nil {
+					if err := validateBlockPostExecution(se.cfg.engine, se.cfg.chainConfig, txTask.Header, blockGasUsed, se.blobGasUsed, checkReceipts, checkBloom, blockReceipts, txTask.Txs, se.logger); err != nil {
 						return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err) //same as in stage_exec.go
 					}
 				}

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -434,7 +434,7 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					//Disable check for genesis. Maybe need somehow improve it in future - to satisfy TestExecutionSpec
 					// Block gas = max(regular, state). Pre-Amsterdam: blockStateGasUsed is 0.
 					blockGasUsed := max(se.blockGasUsed, se.blockStateGasUsed)
-					if err := protocol.BlockPostValidation(blockGasUsed, se.blobGasUsed, checkReceipts, checkBloom, blockReceipts, txTask.Header, txTask.Txs, se.cfg.chainConfig, se.logger); err != nil {
+					if err := se.cfg.engine.ValidateBlockPostExecution(se.cfg.chainConfig, txTask.Header, blockGasUsed, se.blobGasUsed, checkReceipts, checkBloom, blockReceipts, txTask.Txs, se.logger); err != nil {
 						return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err) //same as in stage_exec.go
 					}
 				}

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -597,15 +597,13 @@ func ValidateHeaderGas(header *types.Header, parent *types.Header, chainConfig *
 	}
 
 	if !chainConfig.IsLondon(header.Number.Uint64()) {
-		// Verify BaseFee not present before EIP-1559 fork.
 		if header.BaseFee != nil {
 			return fmt.Errorf("invalid baseFee before fork: have %d, want <nil>", header.BaseFee)
 		}
-		if err := misc.VerifyGaslimit(parent.GasLimit, header.GasLimit); err != nil {
-			return err
-		}
-	} else if err := misc.VerifyEip1559Header(chainConfig, parent, header, false /*skipGasLimit*/); err != nil {
-		// Verify the header's EIP-1559 attributes.
+	} else if err := misc.VerifyEip1559Header(chainConfig, parent, header); err != nil {
+		return err
+	}
+	if err := misc.VerifyParentGasLimit(chainConfig, parent, header); err != nil {
 		return err
 	}
 

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1330,6 +1330,12 @@ func (c *Bor) GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc {
 	return AddFeeTransferLog
 }
 
+func (c *Bor) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
+	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
+	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {
+	return rules.DefaultBlockPostValidation(chainConfig, header, gasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
+}
+
 func (c *Bor) TxDependencies(h *types.Header) [][]int {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()


### PR DESCRIPTION
## Summary

Block validation is scattered across the execution pipeline in ways that prevent
chain-specific engines from customizing it. This PR consolidates validation
behind the `rules.Engine` interface and separates gas limit checking from base fee
verification.

### Why

Two problems drive this change:

1. **Post-execution validation is hardcoded.** `BlockPostValidation()` in
   `block_exec.go` checks gas used, blob gas, receipt root, and bloom — but
   it's called directly from staged sync, bypassing the engine. A rollup engine
   that uses different gas accounting or omits blooms has no way to override
   these checks without forking pipeline code.

2. **Gas limit validation is tangled with base fee verification.** Both
   `VerifyHeaderBasics()` and `VerifyEip1559Header()` take a `skipGasLimit`
   bool — an AuRa-specific workaround. A rollup with operator-set gas limits
   needs the same escape hatch through a different mechanism. The parameter
   mixes two orthogonal concerns (base fee correctness vs parent-relative gas
   limit bounds) into one function.

### What changed

**Commit 1 — `ValidateBlockPostExecution` on Engine interface**

- New method on `EngineReader` with `DefaultBlockPostValidation` helper in
  `rules/rules.go`
- All five engines implement it (ethash, merge, aura, bor, remoteRulesEngine)
- `block_post_validator.go` and `exec3_serial.go` call through the engine
- `exec3_parallel.go` passes engine to `newBlockValidator`
- Old `BlockPostValidation()` deprecated — thin wrapper for test compatibility

**Commit 2 — Split gas limit from `VerifyHeaderBasics` / `VerifyEip1559Header`**

- Remove `skipGasLimit` parameter from both functions
- New `misc.VerifyParentGasLimit()` handles pre-London and post-London paths
  including the elasticity multiplier at the London transition boundary
- Each engine explicitly calls `VerifyParentGasLimit` when appropriate:
  - ethash/merge/bor: unconditionally
  - aura: only when no gas limit contract

### How engines map after this PR

| Engine | Gas limit | Post-execution validation |
|--------|-----------|--------------------------|
| Ethash | `VerifyParentGasLimit` (±1/1024) | `DefaultBlockPostValidation` |
| Merge  | `VerifyParentGasLimit` (±1/1024) | `DefaultBlockPostValidation` |
| Bor    | `VerifyParentGasLimit` (±1/1024) | `DefaultBlockPostValidation` |
| AuRa   | Skipped when gas limit contract active | `DefaultBlockPostValidation` |
| Rollup (future) | Operator cap, no parent-relative | Custom (e.g. skip bloom) |

