### PR TITLE
[r3.5] .github/workflows: pin GLOAS assertoor to pre-EIP-8282 build

### DIFF
--- a/.github/workflows/kurtosis/gloas-caplin-mixed.io
+++ b/.github/workflows/kurtosis/gloas-caplin-mixed.io
@@ -32,4 +32,4 @@ additional_services: [assertoor]
 assertoor_params:
   run_stability_check: false
   run_block_proposal_check: true
-  image: ethpandaops/assertoor:master
+  image: ethpandaops/assertoor:master-2231b3e # pinned pre-EIP-8282 (3-list ExecutionRequests); restore :master after #22008

--- a/.github/workflows/kurtosis/gloas-three-cl-mixed.io
+++ b/.github/workflows/kurtosis/gloas-three-cl-mixed.io
@@ -42,4 +42,4 @@ additional_services: [assertoor]
 assertoor_params:
   run_stability_check: false
   run_block_proposal_check: true
-  image: ethpandaops/assertoor:master
+  image: ethpandaops/assertoor:master-2231b3e # pinned pre-EIP-8282 (3-list ExecutionRequests); restore :master after #22008


### PR DESCRIPTION
## Problem

The **Kurtosis GLOAS Tests** jobs (`gloas_gloas-caplin-mixed_test`, `gloas_gloas-three-cl-mixed_test`) flake / time out on `release/3.5`. The enclave runs `ethpandaops/assertoor:master`, which moved onto the `glamsterdam-devnet-6` branch (EIP-8282, 2026-06-18) and now expects a **5-list** `ExecutionRequests` (`+ builder_deposits`, `+ builder_exits`). The clients pinned here are devnet-4 and emit the **3-list** layout, so assertoor can no longer decode their gloas blocks:

- SSZ (lighthouse-mirrored erigon blocks): `Message.Body.ParentExecutionRequests: unexpected end of SSZ: not enough data for fixed fields (have 12, needed 20)` — 3 offsets present, 5 expected.
- JSON (caplin): `builder_deposits: missing`.

Only pre-gloas (epoch-0 / Fulu) proposals decode, so `block-proposal-check` hangs whenever a client pair doesn't draw an epoch-0 proposer slot, and the job hits the action timeout. This is unrelated to the PRs it blocks (e.g. #21987). Example failing run: https://github.com/erigontech/erigon/actions/runs/28103161617/job/83210197969

## Fix

Pin the kurtosis assertoor image to `master-2231b3e` (2026-06-11) — the last pre-EIP-8282 `master` build, which is gloas-aware but still 3-list, matching the devnet-4 clients. No released tag works: `v0.1.2` predates assertoor's gloas decoding (added 2026-05-19), and assertoor publishes no `glamsterdam-devnet-4/5` image.

## Follow-up

Stopgap only. The durable fix is implementing EIP-8282 in erigon and moving the clients to devnet-6, tracked in #22008 — at which point this pin reverts to `:master`.
