### PR TITLE
cmd/integration: remove domain purification (compact_domains)

### DIFF
--- a/RELEASE_INSTRUCTIONS.md
+++ b/RELEASE_INSTRUCTIONS.md
@@ -11,14 +11,6 @@ In the file `db/kv/remotedbserver/remotedbserver.go` there is variable `KvServic
 database schema, leading to data migrations.
 In most cases, it is enough to bump minor version. It is best to change both DB schema version and remote KV version together.
 
-## Compact the state domains if a regeneration is done
-
-If a regeneration is done, the state domains need to be compacted. This can be done by running the following command:
-````
-make integration
-./build/bin/integration compact_domains --datadir=<path to datadir> --replace-in-datadir
-````
-
 ## Update app.go
 
 After a release branch has been created, update `db/version/app.go`.

--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -17,39 +17,25 @@
 package commands
 
 import (
-	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
-	"runtime"
-	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/dir"
-	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
-	"github.com/erigontech/erigon/db/etl"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/mdbx"
-	"github.com/erigontech/erigon/db/seg"
-	downloadertype "github.com/erigontech/erigon/db/snaptype"
-	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
-	"github.com/erigontech/erigon/db/state/statecfg"
-	"github.com/erigontech/erigon/db/version"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
-	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types/accounts"
 	erigoncli "github.com/erigontech/erigon/node/cli"
@@ -68,29 +54,12 @@ func init() {
 	withStartTx(readDomains)
 
 	rootCmd.AddCommand(readDomains)
-
-	withDataDir(compactDomains)
-	withDomain(compactDomains)
-	compactDomains.Flags().StringVar(&outDatadir, "out", "out-compacted", "")
-	compactDomains.Flags().BoolVar(&replaceInDatadir, "replace-in-datadir", false, "replace the compacted domains directly in datadir (will remove .kvei and .bt too)")
-	compactDomains.Flags().BoolVar(&doIndexBuild, "build-idx", false, "build index for compacted domains")
-	compactDomains.Flags().Float64Var(&minSkipRatioL0, "min-skip-ratio-l0", 0.1, "deprecated: minimum ratio of keys to skip in L0")
-	compactDomains.Flags().Float64Var(&minSkipRatio, "min-skip-ratio", 0.1, "minimum ratio of keys to skip - otherwise keep file unchanged")
-	compactDomains.Flags().Uint64Var(&fromStepCompaction, "from", 0, "step from which domains would be compacted")
-	compactDomains.Flags().Uint64Var(&toStepCompaction, "to", 1e18, "step to which domains would be compacted")
-	rootCmd.AddCommand(compactDomains)
 }
 
 // if trie variant is not hex, we could not have another rootHash with to verify it
 var (
-	stepSize                     uint64
-	lastStep                     uint64
-	minSkipRatioL0, minSkipRatio float64
-	outDatadir                   string
-	replaceInDatadir             bool
-	doIndexBuild                 bool
-	fromStepCompaction           uint64
-	toStepCompaction             uint64
+	stepSize uint64
+	lastStep uint64
 )
 
 // write command to just seek and query state by addr and domain from state db and files (if any)
@@ -156,374 +125,6 @@ var readDomains = &cobra.Command{
 			return
 		}
 	},
-}
-
-var compactDomains = &cobra.Command{
-	Use:     "compact_domains",
-	Aliases: []string{"purify_domains"},
-	Short:   `Regenerate kv files without repeating keys.`,
-	Example: "go run ./cmd/integration compact_domains --datadir=... --verbosity=3",
-	Args:    cobra.ArbitraryArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx, _ := common.RootContext()
-		dirs := datadir.New(datadirCli)
-		logger := debug.SetupCobra(cmd, "integration")
-		if minSkipRatio <= 0.0 {
-			panic("--min-skip-ratio must be > 0")
-		}
-
-		if !replaceInDatadir && doIndexBuild {
-			panic("can't build index when replace-in-datadir=false (consider removing --build-idx)")
-		}
-
-		chainDb, err := openDB(dbCfg(dbcfg.ChainDB, dirs.Chaindata), true, chain, logger)
-		if err != nil {
-			logger.Error("Opening DB", "error", err)
-			return
-		}
-		defer chainDb.Close()
-
-		tx, err := chainDb.BeginTemporalRo(ctx)
-		if err != nil {
-			logger.Error("Opening temporal DB", "error", err)
-			return
-		}
-		defer tx.Rollback()
-		defer dbstate.AggTx(tx).MadvNormal().DisableReadAhead()
-
-		// Iterate over all the files in  dirs.SnapDomain and print them
-		domainDir := dirs.SnapDomain
-
-		// make a temporary dir
-		tmpDir, err := os.MkdirTemp(dirs.Tmp, "compactTemp") // make a temporary dir to store the keys
-		if err != nil {
-			logger.Error("Error creating temporary directory", "error", err)
-			return
-		}
-		defer dir.RemoveAll(tmpDir)
-		// make a temporary DB to store the keys
-
-		compactionDB := mdbx.MustOpen(tmpDir)
-		defer compactionDB.Close()
-
-		domainsStr := strings.Split(domain, ",")
-		if len(domainsStr) == 0 {
-			logger.Error("No domains specified")
-			return
-		}
-		supportedDomain := []kv.Domain{kv.CommitmentDomain, kv.AccountsDomain, kv.StorageDomain}
-		var compactionDomains []kv.Domain
-
-		for _, domain := range domainsStr {
-			found := false
-			for _, supportedDomain := range supportedDomain {
-				if strings.ToLower(domain) == strings.ToLower(supportedDomain.String()) {
-					found = true
-					compactionDomains = append(compactionDomains, supportedDomain)
-					break
-				}
-			}
-			if !found {
-				logger.Error("Domain not supported", "domain", domain)
-				return
-			}
-		}
-
-		for _, domain := range compactionDomains {
-			filesToProcess := tx.Debug().DomainFiles(domain).Fullpaths()
-			if err := makeCompactableIndexDB(ctx, compactionDB, filesToProcess, dirs, log.New(), domain); err != nil {
-				logger.Error("Error making compactable index DB", "error", err)
-				return
-			}
-		}
-		somethingCompacted := false
-		for _, domain := range compactionDomains {
-			filesToProcess := tx.Debug().DomainFiles(domain).Fullpaths()
-			something, err := makeCompactDomains(ctx, compactionDB, filesToProcess, dirs, log.New(), domain)
-			if err != nil {
-				logger.Error("Error making compact domains", "error", err)
-				return
-			}
-			somethingCompacted = somethingCompacted || something
-		}
-		if replaceInDatadir && doIndexBuild && somethingCompacted {
-			logger.Info("building index for the compacted files...")
-			if err := chainDb.Debug().ReloadFiles(); err != nil {
-				logger.Error("Error re-opening folder after compaction", "error", err)
-				return
-			}
-
-			if err := chainDb.Debug().BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers()); err != nil {
-				logger.Error("Error rebuilding missed accessors", "error", err)
-				return
-			}
-		}
-		if err != nil {
-			logger.Error("error walking the path", "domainDir", domainDir, "error", err)
-		}
-	},
-}
-
-func makeCompactableIndexDB(ctx context.Context, db kv.RwDB, files []string, dirs datadir.Dirs, logger log.Logger, domain kv.Domain) error {
-	var tbl string
-	switch domain {
-	case kv.AccountsDomain:
-		tbl = kv.MaxTxNum
-	case kv.StorageDomain:
-		tbl = kv.HeaderNumber
-	case kv.CodeDomain:
-		tbl = kv.HeaderCanonical
-	case kv.CommitmentDomain:
-		tbl = kv.HeaderTD
-	case kv.ReceiptDomain:
-		tbl = kv.BadHeaderNumber
-	default:
-		return fmt.Errorf("invalid domain %s", domain)
-	}
-	// Iterate over all the files in  dirs.SnapDomain and print them
-	fileInfos := []downloadertype.FileInfo{}
-	for _, f := range files {
-		dirPart, fileName := filepath.Split(f)
-		res, ok, _ := downloadertype.ParseFileName(dirPart, fileName)
-		if !ok {
-			panic("invalid file name")
-		}
-		if res.From < fromStepCompaction || res.To > toStepCompaction {
-			continue
-		}
-		fileInfos = append(fileInfos, res)
-	}
-	// sort the files by name
-	sort.Slice(fileInfos, func(i, j int) bool {
-		return fileInfos[i].CompareTo(fileInfos[j]) <= 0
-	})
-
-	collector := etl.NewCollectorWithAllocator("Compaction", dirs.Tmp, etl.LargeSortableBuffers, logger)
-	defer collector.Close()
-	collector.LogLvl(log.LvlDebug)
-	collector.SortAndFlushInBackground(true)
-
-	tx, err := db.BeginRw(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to start transaction: %w", err)
-	}
-	defer tx.Rollback()
-
-	// now start the file indexing
-	for i, fileInfo := range fileInfos {
-		if i == 0 {
-			continue // we can skip first layer as all the keys are already mapped to 0.
-		}
-		baseFileName := fileInfo.Base()
-		layerBytes := make([]byte, 4)
-		binary.BigEndian.PutUint32(layerBytes, uint32(i))
-		count := 0
-
-		dec, err := seg.NewDecompressor(fileInfo.Path)
-		if err != nil {
-			return fmt.Errorf("failed to create decompressor: %w", err)
-		}
-		defer dec.Close()
-		getter := dec.MakeGetter()
-		logger.Info("Indexing", "file", baseFileName)
-		var buf []byte
-		for getter.HasNext() {
-			buf, _ = getter.Next(buf[:0])
-
-			if err := collector.Collect(buf, layerBytes); err != nil {
-				return err
-			}
-			count++
-			//fmt.Println("count: ", count, "keyLength: ", len(buf))
-			if count%10_000_000 == 0 {
-				logger.Info(fmt.Sprintf("[compaction] Indexed %dM keys in file %s", count/1_000_000, baseFileName))
-			}
-			// skip values
-			getter.Skip()
-		}
-		logger.Info(fmt.Sprintf("Indexed %dM keys in file %s", count/1_000_000, baseFileName))
-	}
-	logger.Info("Loading the keys to DB")
-	if err := collector.Load(tx, tbl, etl.IdentityLoadFunc, etl.TransformArgs{Quit: ctx.Done()}); err != nil {
-		return fmt.Errorf("failed to load: %w", err)
-	}
-
-	return tx.Commit()
-}
-
-func makeCompactDomains(ctx context.Context, db kv.RwDB, files []string, dirs datadir.Dirs, logger log.Logger, domain kv.Domain) (somethingCompacted bool, err error) {
-	compressionType := statecfg.Schema.GetDomainCfg(domain).Compression
-	compressCfg := statecfg.Schema.GetDomainCfg(domain).CompressCfg
-	compressCfg.Workers = runtime.NumCPU()
-	var tbl string
-	switch domain {
-	case kv.AccountsDomain:
-		tbl = kv.MaxTxNum
-	case kv.StorageDomain:
-		tbl = kv.HeaderNumber
-	case kv.CodeDomain:
-		tbl = kv.HeaderCanonical
-	case kv.CommitmentDomain:
-		tbl = kv.HeaderTD
-	case kv.ReceiptDomain:
-		tbl = kv.BadHeaderNumber
-	case kv.RCacheDomain:
-		tbl = kv.BlockBody
-	default:
-		return false, fmt.Errorf("invalid domainName %s", domain.String())
-	}
-	// Iterate over all the files in  dirs.SnapDomain and print them
-	fileInfos := []downloadertype.FileInfo{}
-	for _, f := range files {
-		dirPart, fileName := filepath.Split(f)
-		res, ok, _ := downloadertype.ParseFileName(dirPart, fileName)
-		if !ok {
-			panic("invalid file name")
-		}
-		if res.From < fromStepCompaction || res.To > toStepCompaction {
-			continue
-		}
-		fileInfos = append(fileInfos, res)
-	}
-	// sort the files by name
-	sort.Slice(fileInfos, func(i, j int) bool {
-		return fileInfos[i].CompareTo(fileInfos[j]) <= 0
-	})
-
-	tx, err := db.BeginRo(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to start transaction: %w", err)
-	}
-	defer tx.Rollback()
-	outD := datadir.New(outDatadir)
-	accessors := statecfg.Schema.GetDomainCfg(domain).Accessors
-
-	// now start the file indexing
-	for currentLayer, fileInfo := range fileInfos {
-		baseFileName := fileInfo.Base()
-		outputFilePath := filepath.Join(outD.SnapDomain, baseFileName)
-		count := 0
-		skipped := 0
-
-		dec, err := seg.NewDecompressor(fileInfo.Path)
-		if err != nil {
-			return false, fmt.Errorf("failed to create decompressor: %w", err)
-		}
-		defer dec.Close()
-		getter := dec.MakeGetter()
-
-		valuesComp, err := seg.NewCompressor(ctx, "Compaction", outputFilePath, dirs.Tmp, compressCfg, log.LvlTrace, log.New())
-		if err != nil {
-			return false, fmt.Errorf("create %s values compressor: %w", outputFilePath, err)
-		}
-		defer valuesComp.Close()
-
-		comp := seg.NewWriter(valuesComp, compressionType)
-		defer comp.Close()
-
-		logger.Info("Indexing", "file", baseFileName)
-		var k, v []byte
-
-		var layer uint32
-		for getter.HasNext() {
-			// get the key and value for the current entry
-			k, _ = getter.Next(k[:0])
-			v, _ = getter.Next(v[:0])
-
-			layerBytes, err := tx.GetOne(tbl, k)
-			if err != nil {
-				return false, fmt.Errorf("failed to get key %x: %w", k, err)
-			}
-			// if the key is not found, then the layer is 0
-			layer = 0
-			if len(layerBytes) == 4 {
-				layer = binary.BigEndian.Uint32(layerBytes)
-			}
-			if layer != uint32(currentLayer) && !(domain == kv.CommitmentDomain && bytes.Equal(k, commitmentdb.KeyCommitmentState)) {
-				skipped++
-				continue
-			}
-			if _, err := comp.Write(k); err != nil {
-				return false, fmt.Errorf("failed to add key %x: %w", k, err)
-			}
-			if _, err := comp.Write(v); err != nil {
-				return false, fmt.Errorf("failed to add val %x: %w", v, err)
-			}
-			count++
-			if count%10_000_000 == 0 {
-				skipRatio := float64(skipped) / float64(count)
-				logger.Info(fmt.Sprintf("Indexed %dM keys, skipped %dM, in file %s. skip ratio: %.2f", count/1_000_000, skipped/1_000_000, baseFileName, skipRatio))
-			}
-		}
-
-		skipRatio := float64(skipped) / float64(count)
-		if skipRatio < minSkipRatio {
-			logger.Info(fmt.Sprintf("Skip ratio %.2f is less than min-skip-ratio %.2f, skipping %s", skipRatio, minSkipRatio, baseFileName))
-			continue
-		}
-		logger.Info(fmt.Sprintf("Loaded %dM keys in file %s. now compressing...", count/1_000_000, baseFileName))
-		if err := comp.Compress(); err != nil {
-			return false, fmt.Errorf("failed to compress: %w", err)
-		}
-		logger.Info(fmt.Sprintf("Compressed %dM keys in file %s", count/1_000_000, baseFileName))
-		comp.Close()
-		if replaceInDatadir {
-			logger.Info(fmt.Sprintf("Replacing the file %s in datadir", baseFileName))
-			if err := os.Rename(outputFilePath, fileInfo.Path); err != nil {
-				return false, fmt.Errorf("failed to replace the file %s: %w", baseFileName, err)
-			}
-
-			maskedBaseFileName, err := version.ReplaceVersionWithMask(baseFileName)
-			if err != nil {
-				return false, err
-			}
-
-			if accessors.Has(statecfg.AccessorExistence) {
-				kveiFile := strings.ReplaceAll(maskedBaseFileName, ".kv", ".kvei")
-				kveiFile2, _, found, err := version.FindFilesWithVersionsByPattern(filepath.Join(dirs.SnapDomain, kveiFile))
-				if err != nil {
-					return false, err
-				}
-				if !found {
-					return false, fmt.Errorf("missing file %s at path %s", kveiFile, kveiFile2)
-				}
-				log.Info("Removing the file", "file", filepath.Base(kveiFile2))
-				dir.RemoveFile(kveiFile2)
-				dir.RemoveFile(kveiFile2 + ".torrent")
-			}
-
-			if accessors.Has(statecfg.AccessorBTree) {
-				btFile := strings.ReplaceAll(maskedBaseFileName, ".kv", ".bt")
-				btFile2, _, found, err := version.FindFilesWithVersionsByPattern(filepath.Join(dirs.SnapDomain, btFile))
-				if err != nil {
-					return false, err
-				}
-				if !found {
-					return false, fmt.Errorf("missing file %s at path %s", btFile, btFile2)
-				}
-				log.Info("Removing the file", "file", filepath.Base(btFile2))
-				dir.RemoveFile(btFile2)
-				dir.RemoveFile(btFile2 + ".torrent")
-			}
-
-			if accessors.Has(statecfg.AccessorHashMap) {
-				kviFile := strings.ReplaceAll(maskedBaseFileName, ".kv", ".kvi")
-				kviFile2, _, found, err := version.FindFilesWithVersionsByPattern(filepath.Join(dirs.SnapDomain, kviFile))
-				if err != nil {
-					return false, err
-				}
-				if !found {
-					return false, fmt.Errorf("missing file %s at path %s", kviFile, kviFile2)
-				}
-				log.Info("Removing the file", "file", filepath.Base(kviFile2))
-				dir.RemoveFile(kviFile2)
-				dir.RemoveFile(kviFile2 + ".torrent")
-			}
-		}
-		somethingCompacted = true
-	}
-
-	return somethingCompacted, nil
 }
 
 func requestDomains(chainDb, stateDb kv.RwDB, ctx context.Context, readDomain string, addrs [][]byte, logger log.Logger) error {


### PR DESCRIPTION
## Motivation

Domain purification — the `compact_domains` (alias `purify_domains`) integration command — rewrites domain `.kv` files with repeated keys dropped. A key live at step X may then exist only in an earlier file, so a file ending at step X no longer holds the state present at step X.

That invariant breaks tooling that works off the latest on-disk state:
- **commitment rebuild**
- **`seg rm-state --latest`** (and working off the resulting state)

## Change

Removes the command and everything exclusive to it:
- `compactDomains` cobra command + its flags (`--out`, `--replace-in-datadir`, `--build-idx`, `--min-skip-ratio[-l0]`, `--from`, `--to`)
- helpers `makeCompactableIndexDB`, `makeCompactDomains`
- the `RELEASE_INSTRUCTIONS.md` step that ran it

`read_domains` / `requestDomains` in the same file are untouched. The `db/integrity` comments about purification stay — already-published files remain purified, so that handling is still needed.

Net: -409 lines. `make lint` clean; `cmd/integration` builds + vets.