### PR TITLE
cmd/bumper: fix rename include/exclude ext filter and drop non-renamable fields

### DIFF
--- a/cmd/bumper/cmd/inspect.go
+++ b/cmd/bumper/cmd/inspect.go
@@ -74,6 +74,9 @@ func getNames(s *statecfg.SchemaGen) (res map[string]string, domains []string) {
 	res = make(map[string]string)
 	for _, f := range fields {
 		name, ftype := parseName(f.Name)
+		if ftype == "" {
+			continue
+		}
 		res[name] = ftype
 		domains = append(domains, name)
 	}

--- a/cmd/bumper/cmd/selector.go
+++ b/cmd/bumper/cmd/selector.go
@@ -38,8 +38,15 @@ func NewSelectorModel(includeDomains, includeExts, excludeDomains, excludeExts [
 	exts = append(exts, extCfgMap[domainType]...)
 	exts = append(exts, extCfgMap[idxType]...)
 
+	sel := initialSelection(domains, res, includeDomains, includeExts, excludeDomains, excludeExts)
+	return &SelectorModel{domains: domains, exts: exts, selected: sel, domainTypesMap: res}
+}
+
+// initialSelection returns the domains and extensions to pre-select. Each
+// include filter acts as a whitelist when non-empty; otherwise the matching
+// exclude filter acts as a blacklist.
+func initialSelection(domains []string, domainTypes map[string]string, includeDomains, includeExts, excludeDomains, excludeExts []string) map[string]struct{} {
 	sel := map[string]struct{}{}
-	// determine domains to show
 	for _, d := range domains {
 		if len(includeDomains) > 0 {
 			if slices.Contains(includeDomains, d) {
@@ -49,19 +56,21 @@ func NewSelectorModel(includeDomains, includeExts, excludeDomains, excludeExts [
 			sel[d] = struct{}{}
 		}
 	}
-	// determine exts to show
-	for selected := range sel {
-		for _, e := range extCfgMap[res[selected]] {
-			if slices.Contains(includeExts, e) {
-				sel[e] = struct{}{}
-				continue
-			}
-			if !slices.Contains(excludeExts, e) {
+	for _, d := range domains {
+		if _, ok := sel[d]; !ok {
+			continue
+		}
+		for _, e := range extCfgMap[domainTypes[d]] {
+			if len(includeExts) > 0 {
+				if slices.Contains(includeExts, e) {
+					sel[e] = struct{}{}
+				}
+			} else if !slices.Contains(excludeExts, e) {
 				sel[e] = struct{}{}
 			}
 		}
 	}
-	return &SelectorModel{domains: domains, exts: exts, selected: sel, domainTypesMap: res}
+	return sel
 }
 
 func (m *SelectorModel) Init() tea.Cmd { return nil }

--- a/cmd/bumper/cmd/selector_test.go
+++ b/cmd/bumper/cmd/selector_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state/statecfg"
+)
+
+func TestInitialSelection(t *testing.T) {
+	domains := []string{"accounts", "storage", "logaddr"}
+	types := map[string]string{
+		"accounts": domainType,
+		"storage":  domainType,
+		"logaddr":  idxType,
+	}
+	domainExts := extCfgMap[domainType] // .kv .bt .kvi .kvei .vi .v
+	idxExts := extCfgMap[idxType]       // .efi .ef
+
+	tests := []struct {
+		name           string
+		includeDomains []string
+		includeExts    []string
+		excludeDomains []string
+		excludeExts    []string
+		wantPresent    []string
+		wantAbsent     []string
+	}{
+		{
+			name:        "no filters selects everything",
+			wantPresent: concat([]string{"accounts", "storage", "logaddr"}, domainExts, idxExts),
+		},
+		{
+			name:           "include-domains is a whitelist",
+			includeDomains: []string{"accounts"},
+			wantPresent:    []string{"accounts"},
+			wantAbsent:     []string{"storage", "logaddr"},
+		},
+		{
+			name:           "exclude-domains is a blacklist",
+			excludeDomains: []string{"storage"},
+			wantPresent:    []string{"accounts", "logaddr"},
+			wantAbsent:     []string{"storage"},
+		},
+		{
+			name:        "include-exts is a whitelist",
+			includeExts: []string{".kv"},
+			wantPresent: []string{"accounts", "storage", ".kv"},
+			wantAbsent:  []string{".bt", ".kvi", ".kvei", ".vi", ".v", ".ef", ".efi"},
+		},
+		{
+			name:        "include-exts whitelist selects idx exts too",
+			includeExts: []string{".ef"},
+			wantPresent: []string{"logaddr", ".ef"},
+			wantAbsent:  []string{".efi", ".kv", ".bt"},
+		},
+		{
+			name:        "exclude-exts is a blacklist",
+			excludeExts: []string{".bt"},
+			wantPresent: []string{".kv", ".kvi", ".kvei", ".vi", ".v", ".efi", ".ef"},
+			wantAbsent:  []string{".bt"},
+		},
+		{
+			name:        "include-exts overrides exclude-exts",
+			includeExts: []string{".kv"},
+			excludeExts: []string{".kv"},
+			wantPresent: []string{".kv"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sel := initialSelection(domains, types, tc.includeDomains, tc.includeExts, tc.excludeDomains, tc.excludeExts)
+			for _, k := range tc.wantPresent {
+				if _, ok := sel[k]; !ok {
+					t.Errorf("expected %q to be selected, but it was not", k)
+				}
+			}
+			for _, k := range tc.wantAbsent {
+				if _, ok := sel[k]; ok {
+					t.Errorf("expected %q to NOT be selected, but it was", k)
+				}
+			}
+		})
+	}
+}
+
+// getNames must only surface domains that renameFiles can actually rename;
+// renameFiles resolves each selected name via kv.String2Enum and aborts on the
+// first failure, so a non-renamable name (e.g. a block-data field) breaks the
+// whole run.
+func TestGetNamesAreRenamable(t *testing.T) {
+	res, domains := getNames(&statecfg.Schema)
+	if len(domains) == 0 {
+		t.Fatal("getNames returned no domains")
+	}
+	for _, d := range domains {
+		if _, err := kv.String2Enum(d); err != nil {
+			t.Errorf("getNames returned %q, which renameFiles cannot resolve: %v", d, err)
+		}
+		if res[d] == "" {
+			t.Errorf("getNames returned %q with an empty type", d)
+		}
+	}
+}
+
+func concat(parts ...[]string) []string {
+	var out []string
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}


### PR DESCRIPTION
Two bugs in `bumper rename` selection.

1. `--include-exts` did nothing. The extension loop in `NewSelectorModel` missed the `len(includeExts) > 0` guard the domain loop already had. With include set and exclude empty, the second branch still selected every extension, so the flag had no effect.

2. The no-flag run aborted without renaming. `getNames` reflected over the whole schema and returned the block-data fields (`HeadersBlock`, `TransactionsBlock`, `BodiesBlock`, `TxnHash2BlockNumBlock`). `parseName` maps these to an empty type, and `renameFiles` can't resolve them via `kv.String2Enum` — the first one hit returned `unknown name: …` and stopped the run. These are pre-selected by default, so `rename` with no flags renamed nothing.

## Changes

- Pulled the selection logic into `initialSelection` and added the missing guard. Both axes now behave the same: include is a whitelist when non-empty, exclude is a blacklist otherwise, include wins over exclude. Iterate the `domains` slice instead of mutating the selection map while ranging it.
- `getNames` skips fields that are neither a domain nor an inverted index, so only renamable kinds reach the selector and `renameFiles`. `inspect` is untouched — it lists all schema fields directly.

## No-flag behavior

Pre-selects all 10 renamable names (accounts, storage, code, commitment, receipt, rcache + logaddr, logtopic, tracesfrom, tracesto) and their exts (`.kv .bt .kvi .kvei .v .vi` + `.ef .efi`); on confirm renames every matching file to its current schema version.

## Tests

- `TestInitialSelection` — covers the include/exclude matrix on both axes. Red on the old ext loop, green after.
- `TestGetNamesAreRenamable` — every name `getNames` returns must resolve via `kv.String2Enum`. Red before the `getNames` fix (4 block fields), green after.