### PR TITLE
.github/workflows: confine QA build temp to a job-scoped dir and clean it up

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -41,6 +41,20 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
+      - name: Set up job-scoped build temp dir
+        run: |
+          # Confine build temp (Go work dirs + cgo/gcc cc* files) to one job-scoped dir
+          # outside the checkout, so it can be removed wholesale when the job exits.
+          BUILD_TMP="${RUNNER_TEMP}/erigon-build-tmp-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # Drop leftovers from a previously cancelled run (this runner builds serially).
+          find "${RUNNER_TEMP}" -maxdepth 1 -name 'erigon-build-tmp-*' -exec rm -rf {} + 2>/dev/null || true
+          mkdir -p "${BUILD_TMP}"
+          {
+            echo "BUILD_TMP=${BUILD_TMP}"
+            echo "TMPDIR=${BUILD_TMP}"
+            echo "GOTMPDIR=${BUILD_TMP}"
+          } >> "${GITHUB_ENV}"
+
       - name: Read RPC version
         run: |
           source .github/workflows/scripts/rpc_version.env
@@ -178,4 +192,17 @@ jobs:
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'
         run: echo "::notice::Tests completed successfully"
+
+      - name: Clean up job-scoped build temp dir
+        if: always()
+        run: |
+          # Only delete a path of the exact shape we created under RUNNER_TEMP; never a bare/empty var.
+          case "${BUILD_TMP}" in
+            "${RUNNER_TEMP}/erigon-build-tmp-"*)
+              rm -rf -- "${BUILD_TMP}"
+              ;;
+            *)
+              echo "Skipping cleanup: BUILD_TMP='${BUILD_TMP:-}' is empty or unexpected"
+              ;;
+          esac
 

--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -62,6 +62,20 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
+      - name: Set up job-scoped build temp dir
+        run: |
+          # Confine build temp (Go work dirs + cgo/gcc cc* files) to one job-scoped dir
+          # outside the checkout, so it can be removed wholesale when the job exits.
+          BUILD_TMP="${RUNNER_TEMP}/erigon-build-tmp-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # Drop leftovers from a previously cancelled run (this runner builds serially).
+          find "${RUNNER_TEMP}" -maxdepth 1 -name 'erigon-build-tmp-*' -exec rm -rf {} + 2>/dev/null || true
+          mkdir -p "${BUILD_TMP}"
+          {
+            echo "BUILD_TMP=${BUILD_TMP}"
+            echo "TMPDIR=${BUILD_TMP}"
+            echo "GOTMPDIR=${BUILD_TMP}"
+          } >> "${GITHUB_ENV}"
+
       - name: Read RPC version
         run: |
           source .github/workflows/scripts/rpc_version.env
@@ -296,3 +310,16 @@ jobs:
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'
         run: echo "::notice::Tests completed successfully"
+
+      - name: Clean up job-scoped build temp dir
+        if: always()
+        run: |
+          # Only delete a path of the exact shape we created under RUNNER_TEMP; never a bare/empty var.
+          case "${BUILD_TMP}" in
+            "${RUNNER_TEMP}/erigon-build-tmp-"*)
+              rm -rf -- "${BUILD_TMP}"
+              ;;
+            *)
+              echo "Skipping cleanup: BUILD_TMP='${BUILD_TMP:-}' is empty or unexpected"
+              ;;
+          esac

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -41,6 +41,20 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
+      - name: Set up job-scoped build temp dir
+        run: |
+          # Confine build temp (Go work dirs + cgo/gcc cc* files) to one job-scoped dir
+          # outside the checkout, so it can be removed wholesale when the job exits.
+          BUILD_TMP="${RUNNER_TEMP}/erigon-build-tmp-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # Drop leftovers from a previously cancelled run (this runner builds serially).
+          find "${RUNNER_TEMP}" -maxdepth 1 -name 'erigon-build-tmp-*' -exec rm -rf {} + 2>/dev/null || true
+          mkdir -p "${BUILD_TMP}"
+          {
+            echo "BUILD_TMP=${BUILD_TMP}"
+            echo "TMPDIR=${BUILD_TMP}"
+            echo "GOTMPDIR=${BUILD_TMP}"
+          } >> "${GITHUB_ENV}"
+
       - name: Read RPC version
         run: |
           source .github/workflows/scripts/rpc_version.env
@@ -179,4 +193,17 @@ jobs:
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'
         run: echo "::notice::Tests completed successfully"
+
+      - name: Clean up job-scoped build temp dir
+        if: always()
+        run: |
+          # Only delete a path of the exact shape we created under RUNNER_TEMP; never a bare/empty var.
+          case "${BUILD_TMP}" in
+            "${RUNNER_TEMP}/erigon-build-tmp-"*)
+              rm -rf -- "${BUILD_TMP}"
+              ;;
+            *)
+              echo "Skipping cleanup: BUILD_TMP='${BUILD_TMP:-}' is empty or unexpected"
+              ;;
+          esac
 

--- a/.github/workflows/qa-rpc-performance-tests.yml
+++ b/.github/workflows/qa-rpc-performance-tests.yml
@@ -137,6 +137,21 @@ jobs:
           cd ${{runner.workspace}}/rpc-tests
           make rpc_perf
 
+      - name: Set up job-scoped build temp dir
+        if: matrix.client == 'erigon'
+        run: |
+          # Confine build temp (Go work dirs + cgo/gcc cc* files) to one job-scoped dir
+          # outside the checkout, so it can be removed wholesale when the job exits.
+          BUILD_TMP="${RUNNER_TEMP}/erigon-build-tmp-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # Drop leftovers from a previously cancelled run (this runner builds serially).
+          find "${RUNNER_TEMP}" -maxdepth 1 -name 'erigon-build-tmp-*' -exec rm -rf {} + 2>/dev/null || true
+          mkdir -p "${BUILD_TMP}"
+          {
+            echo "BUILD_TMP=${BUILD_TMP}"
+            echo "TMPDIR=${BUILD_TMP}"
+            echo "GOTMPDIR=${BUILD_TMP}"
+          } >> "${GITHUB_ENV}"
+
       - name: Clean Erigon Build Directory
         if: matrix.client == 'erigon'
         run: |
@@ -469,3 +484,16 @@ jobs:
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'
         run: echo "::notice::Tests completed successfully"
+
+      - name: Clean up job-scoped build temp dir
+        if: always()
+        run: |
+          # Only delete a path of the exact shape we created under RUNNER_TEMP; never a bare/empty var.
+          case "${BUILD_TMP}" in
+            "${RUNNER_TEMP}/erigon-build-tmp-"*)
+              rm -rf -- "${BUILD_TMP}"
+              ;;
+            *)
+              echo "Skipping cleanup: BUILD_TMP='${BUILD_TMP:-}' is empty or unexpected"
+              ;;
+          esac


### PR DESCRIPTION
## Problem

The QA RPC integration/performance runners build Erigon with cgo. When a build is killed mid-flight — PR `cancel-in-progress`, OOM, or timeout — the toolchain leaves its scratch in `/tmp`:

- **Go work dirs** `/tmp/go-build*` (~0.5–0.9 GB each)
- **cgo/gcc assembler temp** `/tmp/cc*.s`, `cc*.o`, …

`make clean` only cleans the checkout, never `/tmp`, so these pile up for months. On the Gnosis runner (`-n1`) leftovers were dated back to February.

## Fix

For the QA workflows that build Erigon, confine all build temp to a single **job-scoped directory under `RUNNER_TEMP`** (outside the checkout) and make the workflow self-cleaning:

- A *Set up job-scoped build temp dir* step points `TMPDIR` **and** `GOTMPDIR` at `${RUNNER_TEMP}/erigon-build-tmp-<run_id>-<attempt>`, and sweeps leftovers from a previously **cancelled** run (safe — these runners build serially, so nothing else is mid-build at job start). This covers the one case `if: always()` can't: cancellation skips the teardown step, so the *next* run mops up.
- A *Clean up job-scoped build temp dir* step (`if: always()`) removes it on success and failure.

### Safe teardown

The cleanup only deletes a path matching the exact shape we created:

```sh
case "${BUILD_TMP}" in
  "${RUNNER_TEMP}/erigon-build-tmp-"*) rm -rf -- "${BUILD_TMP}" ;;
  *) echo "Skipping cleanup: BUILD_TMP='${BUILD_TMP:-}' is empty or unexpected" ;;
esac
```

An unset/empty/unexpected variable falls through to the skip branch — no bare `rm -rf ""`, no slash-append footgun, and `rm -rf --` guards against option injection.

## Scope

Applied to the four QA workflows that compile Erigon:

- `qa-rpc-integration-tests-gnosis.yml` (`-n1`)
- `qa-rpc-integration-tests.yml` (`-n2`/`-n4`)
- `qa-rpc-integration-tests-latest.yml` (`-n11`)
- `qa-rpc-performance-tests.yml` (the `erigon` matrix leg only)

`qa-rpc-integration-tests-clients.yml` is intentionally left out — it tests against external geth/nethermind and never builds Erigon, so it produces no such leak.

A one-time manual sweep of the existing leftovers on the runners is being done separately.