### PR TITLE
rpc/jsonrpc: one pre-block read for witness keys[] gate; bound completeness error

### DIFF
--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -409,9 +409,8 @@ func (s *RecordingState) CreateContract(address accounts.Address) error {
 }
 
 // accountExists reports whether the account exists in the post-state: present and
-// non-nil in the write overlay, otherwise not deleted and present in the inner
-// (pre-block) reader. The inner reader is read directly so the check does not
-// re-mark AccessedAccounts.
+// non-nil in the write overlay, otherwise not deleted and present in the pre-block
+// (inner) reader.
 func (s *RecordingState) accountExists(addr common.Address) bool {
 	if _, deleted := s.DeletedAccounts[addr]; deleted {
 		return false
@@ -419,18 +418,28 @@ func (s *RecordingState) accountExists(addr common.Address) bool {
 	if acc, ok := s.accountOverlay[addr]; ok {
 		return acc != nil
 	}
+	return s.innerExists(addr)
+}
+
+// innerExists reports parent-state (pre-block) presence by reading the inner reader
+// directly, so the check does not re-mark AccessedAccounts. A read error counts as
+// existence: over-inclusion is harmless, a dropped key would make the witness incomplete.
+func (s *RecordingState) innerExists(addr common.Address) bool {
 	acc, err := s.inner.ReadAccountData(accounts.InternAddress(addr))
-	// A read error is unexpected for an account accessed this block; include the key
-	// rather than silently drop it — over-inclusion is harmless, a missing key would
-	// make the witness incomplete.
 	return err != nil || acc != nil
 }
 
-// existedPreBlock reports parent-state presence regardless of in-block deletion, so a
-// pre-existing-but-deleted account still contributes its witness-trie preimage.
-func (s *RecordingState) existedPreBlock(addr common.Address) bool {
-	acc, err := s.inner.ReadAccountData(accounts.InternAddress(addr))
-	return err != nil || acc != nil
+// hasWitnessLeaf reports whether addr has a leaf in the witness trie needing a keys[]
+// preimage: it exists in the post-state, or it existed pre-block (so an account emptied
+// and EIP-161 state-cleared in-block still contributes its parent-trie leaf). The inner
+// reader is consulted at most once.
+func (s *RecordingState) hasWitnessLeaf(addr common.Address) bool {
+	if _, deleted := s.DeletedAccounts[addr]; !deleted {
+		if acc, ok := s.accountOverlay[addr]; ok && acc != nil {
+			return true
+		}
+	}
+	return s.innerExists(addr)
 }
 
 // --- Query methods ---
@@ -951,7 +960,7 @@ func collectAccessedState(rs *RecordingState, mode witnessMode) *accessedState {
 	}
 	witnessKeys := make([]hexutil.Bytes, 0, len(out.Addresses)+len(slotSet))
 	for addr := range out.Addresses {
-		if !rs.accountExists(addr) && !rs.existedPreBlock(addr) {
+		if !rs.hasWitnessLeaf(addr) {
 			continue
 		}
 		witnessKeys = append(witnessKeys, bytes.Clone(addr[:]))
@@ -1344,7 +1353,13 @@ func checkWitnessKeysComplete(usedAddrs map[common.Address]struct{}, usedSlots m
 		return nil
 	}
 	slices.Sort(missing)
-	return fmt.Errorf("witness keys[] incomplete: %d preimage(s) for leaves present in state[] missing: %v", len(missing), missing)
+	const maxListed = 16
+	listed, suffix := missing, ""
+	if len(missing) > maxListed {
+		listed = missing[:maxListed]
+		suffix = fmt.Sprintf(" (+%d more)", len(missing)-maxListed)
+	}
+	return fmt.Errorf("witness keys[] incomplete: %d preimage(s) for leaves present in state[] missing: %v%s", len(missing), listed, suffix)
 }
 
 // buildExpectedPostState queries the actual state DB to build expected post-state for verification.

--- a/rpc/jsonrpc/debug_execution_witness_test.go
+++ b/rpc/jsonrpc/debug_execution_witness_test.go
@@ -18,6 +18,7 @@ package jsonrpc
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -52,6 +53,37 @@ func (r *fakeStateReader) ReadAccountIncarnation(address accounts.Address) (uint
 func (r *fakeStateReader) SetTrace(_ bool, _ string) {}
 func (r *fakeStateReader) Trace() bool               { return false }
 func (r *fakeStateReader) TracePrefix() string       { return "" }
+
+// countingStateReader counts ReadAccountData calls per address so a test can pin that the
+// witness-keys gate consults the pre-block reader at most once.
+type countingStateReader struct {
+	*fakeStateReader
+	reads map[common.Address]int
+}
+
+func (r *countingStateReader) ReadAccountData(address accounts.Address) (*accounts.Account, error) {
+	r.reads[address.Value()]++
+	return r.fakeStateReader.ReadAccountData(address)
+}
+
+// TestRecordingState_hasWitnessLeaf_SingleInnerRead pins the gate's single-read property:
+// an account absent from both pre- and post-state is excluded with exactly one inner read,
+// not the two a plain accountExists() || existedPreBlock() composition would issue.
+func TestRecordingState_hasWitnessLeaf_SingleInnerRead(t *testing.T) {
+	never := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	reader := &countingStateReader{
+		fakeStateReader: &fakeStateReader{accounts: map[common.Address]*accounts.Account{}},
+		reads:           map[common.Address]int{},
+	}
+	rs := NewRecordingState(reader)
+
+	if rs.hasWitnessLeaf(never) {
+		t.Fatal("account absent from pre- and post-state must be excluded from keys[]")
+	}
+	if got := reader.reads[never]; got != 1 {
+		t.Fatalf("hasWitnessLeaf consulted the pre-block reader %d times, want 1", got)
+	}
+}
 
 func TestRecordingState_accountExists(t *testing.T) {
 	existing := common.HexToAddress("0x1111111111111111111111111111111111111111")
@@ -294,6 +326,28 @@ func TestCheckWitnessKeysComplete(t *testing.T) {
 		usedS := map[common.Hash]struct{}{slotS: {}}
 		if err := checkWitnessKeysComplete(nil, usedS, []hexutil.Bytes{key32(slotS)}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("large missing list truncated, total preserved", func(t *testing.T) {
+		used := make(map[common.Address]struct{})
+		for i := 0; i < 50; i++ {
+			var a common.Address
+			a[19] = byte(i)
+			used[a] = struct{}{}
+		}
+		err := checkWitnessKeysComplete(used, nil, nil)
+		if err == nil {
+			t.Fatal("expected error: 50 accessed account leaves missing from keys[]")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "50 preimage(s)") {
+			t.Errorf("error must report the full count; got: %s", msg)
+		}
+		if !strings.Contains(msg, "more)") {
+			t.Errorf("error must mark the list as truncated; got: %s", msg)
+		}
+		if n := strings.Count(msg, "0x"); n > 16 {
+			t.Errorf("error listed %d preimages; want the list capped at 16", n)
 		}
 	})
 }


### PR DESCRIPTION
Two review follow-ups from #22000.

### keys[] existence gate: one pre-block read instead of two

`collectAccessedState` gated each address on `!accountExists(addr) && !existedPreBlock(addr)`. When an accessed address exists in neither pre- nor post-state, `accountExists` runs its own `inner.ReadAccountData` and returns false, so `&&` does not short-circuit and `existedPreBlock` reads the same account a second time.

Both are merged into `hasWitnessLeaf`, which reads the inner (pre-block) reader at most once:

- post-state present (overlay non-nil, not deleted) → include, no inner read
- otherwise → one inner read decides it

Predicate is unchanged: `hasWitnessLeaf == accountExists || existedPreBlock` across the full `(deleted, overlay-present, overlay-nonnil, inner-exists)` table. `innerExists` is the shared pre-block primitive; `accountExists` keeps its post-state semantics.

### checkWitnessKeysComplete: bounded error

The completeness check listed every missing preimage in the error string. Capped at 16 with a `(+N more)` suffix; the leading count stays the full total. Verification diagnostic only — no returned witness data changes.

### Tests

- `TestRecordingState_hasWitnessLeaf_SingleInnerRead` — pins the at-most-one-read property via a read-counting reader.
- `TestCheckWitnessKeysComplete/large missing list truncated` — pins truncation and preserved total.

Refs https://github.com/erigontech/erigon/pull/22000#discussion_r3467439686, https://github.com/erigontech/erigon/pull/22000#discussion_r3467439644
