### PR TITLE
cl: pluggable consensus engine for multi-chain (beacon/rollup/dev)

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -1683,7 +1683,7 @@ func (a *ApiHandler) broadcastBlock(ctx context.Context, blk *cltypes.SignedBeac
 				if err != nil {
 					return fmt.Errorf("failed to compute block root: %w", err)
 				}
-				columnsSidecars, err = peerdasutils.GetDataColumnSidecarsGloas(blk.Block.Slot, blockRoot, cellsAndProofsPerBlob)
+				columnsSidecars, err = peerdasutils.GetDataColumnSidecarsGloas(blk.Block.Slot, blockRoot, cellsAndProofsPerBlob, a.beaconChainCfg)
 				if err != nil {
 					return fmt.Errorf("failed to get data column sidecars: %w", err)
 				}
@@ -1697,7 +1697,7 @@ func (a *ApiHandler) broadcastBlock(ctx context.Context, blk *cltypes.SignedBeac
 				for i, h := range inclusionProofRaw {
 					commitmentInclusionProof.Set(i, h)
 				}
-				columnsSidecars, err = peerdasutils.GetDataColumnSidecars(header, kzgCommitments, commitmentInclusionProof, cellsAndProofsPerBlob)
+				columnsSidecars, err = peerdasutils.GetDataColumnSidecars(header, kzgCommitments, commitmentInclusionProof, cellsAndProofsPerBlob, a.beaconChainCfg)
 				if err != nil {
 					return fmt.Errorf("failed to get data column sidecars: %w", err)
 				}
@@ -1745,7 +1745,7 @@ func (a *ApiHandler) broadcastBlock(ctx context.Context, blk *cltypes.SignedBeac
 				a.logger.Error("Failed to encode column sidecar", "err", err)
 				continue
 			}
-			subnet := das.ComputeSubnetForDataColumnSidecar(column.Index)
+			subnet := das.ComputeSubnetForDataColumnSidecar(column.Index, a.beaconChainCfg)
 			if err := a.gossipManager.Publish(ctx, gossip.TopicNameDataColumnSidecar(subnet), columnSSZ); err != nil {
 				a.logger.Error("Failed to publish data column sidecar", "err", err)
 			}

--- a/cl/clparams/global.go
+++ b/cl/clparams/global.go
@@ -1,10 +1,13 @@
 package clparams
 
+import "sync/atomic"
+
 var (
-	globalBeaconConfig *BeaconChainConfig
-	globalCaplinConfig *CaplinConfig
+	globalBeaconConfig atomic.Pointer[BeaconChainConfig]
+	globalCaplinConfig atomic.Pointer[CaplinConfig]
 )
 
+// Safe to call more than once; later calls replace the previous config.
 func InitGlobalStaticConfig(bcfg *BeaconChainConfig, ccfg *CaplinConfig) {
 	if bcfg == nil {
 		panic("cannot initialize globalBeaconConfig with nil")
@@ -12,20 +15,18 @@ func InitGlobalStaticConfig(bcfg *BeaconChainConfig, ccfg *CaplinConfig) {
 	if ccfg == nil {
 		panic("cannot initialize globalCaplinConfig with nil")
 	}
-	if globalCaplinConfig != nil {
-		panic("globalConfig already initialized")
-	}
-	if globalBeaconConfig != nil {
-		panic("globalBeaconConfig already initialized")
-	}
-	globalBeaconConfig = bcfg
-	globalCaplinConfig = ccfg
+	globalBeaconConfig.Store(bcfg)
+	globalCaplinConfig.Store(ccfg)
 }
 
 func GetBeaconConfig() *BeaconChainConfig {
-	return globalBeaconConfig
+	return globalBeaconConfig.Load()
 }
 
 func IsDevnet() bool {
-	return globalCaplinConfig.IsDevnet()
+	cfg := globalCaplinConfig.Load()
+	if cfg == nil {
+		return false
+	}
+	return cfg.IsDevnet()
 }

--- a/cl/cltypes/column_sidecar.go
+++ b/cl/cltypes/column_sidecar.go
@@ -42,7 +42,7 @@ type DataColumnSidecar struct {
 	SignedBlockHeader            *SignedBeaconBlockHeader       `json:"signed_block_header,omitempty"`             // [Removed in Gloas:EIP7732]
 	KzgCommitmentsInclusionProof solid.HashVectorSSZ            `json:"kzg_commitments_inclusion_proof,omitempty"` // [Removed in Gloas:EIP7732]
 
-	version      clparams.StateVersion              // internal: tracks the version for encoding
+	version      clparams.StateVersion       // internal: tracks the version for encoding
 	beaconConfig *clparams.BeaconChainConfig // internal: per-instance config for multi-chain support
 }
 

--- a/cl/cltypes/column_sidecar.go
+++ b/cl/cltypes/column_sidecar.go
@@ -42,19 +42,18 @@ type DataColumnSidecar struct {
 	SignedBlockHeader            *SignedBeaconBlockHeader       `json:"signed_block_header,omitempty"`             // [Removed in Gloas:EIP7732]
 	KzgCommitmentsInclusionProof solid.HashVectorSSZ            `json:"kzg_commitments_inclusion_proof,omitempty"` // [Removed in Gloas:EIP7732]
 
-	version clparams.StateVersion // internal: tracks the version for encoding
+	version      clparams.StateVersion              // internal: tracks the version for encoding
+	beaconConfig *clparams.BeaconChainConfig // internal: per-instance config for multi-chain support
 }
 
-func NewDataColumnSidecar() *DataColumnSidecar {
-	d := &DataColumnSidecar{}
+func NewDataColumnSidecar(cfg *clparams.BeaconChainConfig) *DataColumnSidecar {
+	d := &DataColumnSidecar{beaconConfig: cfg}
 	d.tryInit()
 	return d
 }
 
-// NewDataColumnSidecarWithVersion creates a new DataColumnSidecar with a specific version.
-// Use this when you need version-aware encoding.
-func NewDataColumnSidecarWithVersion(version clparams.StateVersion) *DataColumnSidecar {
-	d := &DataColumnSidecar{version: version}
+func NewDataColumnSidecarWithVersion(version clparams.StateVersion, cfg *clparams.BeaconChainConfig) *DataColumnSidecar {
+	d := &DataColumnSidecar{version: version, beaconConfig: cfg}
 	d.tryInitWithVersion(version)
 	return d
 }
@@ -65,11 +64,15 @@ func (d *DataColumnSidecar) Version() clparams.StateVersion {
 }
 
 func (d *DataColumnSidecar) Clone() clonable.Clonable {
+	if d == nil {
+		return &DataColumnSidecar{beaconConfig: clparams.GetBeaconConfig()}
+	}
 	newSidecar := &DataColumnSidecar{
 		BlockRoot:       d.BlockRoot,
 		Slot:            d.Slot,
 		BeaconBlockRoot: d.BeaconBlockRoot,
 		version:         d.version,
+		beaconConfig:    d.beaconConfig,
 	}
 	newSidecar.tryInitWithVersion(d.version)
 	return newSidecar
@@ -80,7 +83,7 @@ func (d *DataColumnSidecar) tryInit() {
 }
 
 func (d *DataColumnSidecar) tryInitWithVersion(version clparams.StateVersion) {
-	cfg := clparams.GetBeaconConfig()
+	cfg := d.beaconConfig
 	if d.Column == nil {
 		d.Column = solid.NewStaticListSSZ[*Cell](int(cfg.MaxBlobCommittmentsPerBlock), BytesPerCell)
 	}
@@ -239,14 +242,21 @@ type ColumnSidecarsByRangeRequest struct {
 	  count: uint64
 	  columns: List[ColumnIndex, NUMBER_OF_COLUMNS]
 	*/
-	StartSlot uint64
-	Count     uint64
-	Columns   solid.Uint64ListSSZ
+	StartSlot    uint64
+	Count        uint64
+	Columns      solid.Uint64ListSSZ
+	beaconConfig *clparams.BeaconChainConfig
+}
+
+func NewColumnSidecarsByRangeRequest(cfg *clparams.BeaconChainConfig) *ColumnSidecarsByRangeRequest {
+	c := &ColumnSidecarsByRangeRequest{beaconConfig: cfg}
+	c.tryInit()
+	return c
 }
 
 func (c *ColumnSidecarsByRangeRequest) tryInit() {
 	if c.Columns == nil {
-		c.Columns = solid.NewUint64ListSSZ(int(clparams.GetBeaconConfig().NumberOfColumns))
+		c.Columns = solid.NewUint64ListSSZ(int(c.beaconConfig.NumberOfColumns))
 	}
 }
 
@@ -265,8 +275,11 @@ func (c *ColumnSidecarsByRangeRequest) EncodingSizeSSZ() int {
 	return 16 + c.Columns.EncodingSizeSSZ()
 }
 
-func (*ColumnSidecarsByRangeRequest) Clone() clonable.Clonable {
-	return &ColumnSidecarsByRangeRequest{}
+func (c *ColumnSidecarsByRangeRequest) Clone() clonable.Clonable {
+	if c == nil {
+		return &ColumnSidecarsByRangeRequest{beaconConfig: clparams.GetBeaconConfig()}
+	}
+	return &ColumnSidecarsByRangeRequest{beaconConfig: c.beaconConfig}
 }
 
 func (c *ColumnSidecarsByRangeRequest) Static() bool {
@@ -275,19 +288,20 @@ func (c *ColumnSidecarsByRangeRequest) Static() bool {
 
 // DataColumnsByRootIdentifier is the request for getting a range of column sidecars by root identifier.
 type DataColumnsByRootIdentifier struct {
-	BlockRoot common.Hash
-	Columns   solid.Uint64ListSSZ
+	BlockRoot    common.Hash
+	Columns      solid.Uint64ListSSZ
+	beaconConfig *clparams.BeaconChainConfig
 }
 
-func NewDataColumnsByRootIdentifier() *DataColumnsByRootIdentifier {
-	d := &DataColumnsByRootIdentifier{}
+func NewDataColumnsByRootIdentifier(cfg *clparams.BeaconChainConfig) *DataColumnsByRootIdentifier {
+	d := &DataColumnsByRootIdentifier{beaconConfig: cfg}
 	d.tryInit()
 	return d
 }
 
 func (d *DataColumnsByRootIdentifier) tryInit() {
 	if d.Columns == nil {
-		d.Columns = solid.NewUint64ListSSZ(int(clparams.GetBeaconConfig().NumberOfColumns))
+		d.Columns = solid.NewUint64ListSSZ(int(d.beaconConfig.NumberOfColumns))
 	}
 }
 
@@ -307,8 +321,11 @@ func (d *DataColumnsByRootIdentifier) EncodingSizeSSZ() int {
 	return 32 + 4 + d.Columns.EncodingSizeSSZ()
 }
 
-func (*DataColumnsByRootIdentifier) Clone() clonable.Clonable {
-	return &DataColumnsByRootIdentifier{}
+func (d *DataColumnsByRootIdentifier) Clone() clonable.Clonable {
+	if d == nil {
+		return &DataColumnsByRootIdentifier{beaconConfig: clparams.GetBeaconConfig()}
+	}
+	return &DataColumnsByRootIdentifier{beaconConfig: d.beaconConfig}
 }
 
 func (d *DataColumnsByRootIdentifier) Static() bool {

--- a/cl/cltypes/column_sidecar_test.go
+++ b/cl/cltypes/column_sidecar_test.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func TestNewDataColumnSidecar(t *testing.T) {
-	sidecar := cltypes.NewDataColumnSidecar()
+	sidecar := cltypes.NewDataColumnSidecar(&clparams.MainnetBeaconConfig)
 
 	assert.NotNil(t, sidecar.Column, "Column should be initialized")
 	assert.NotNil(t, sidecar.KzgProofs, "KzgProofs should be initialized")
@@ -43,7 +43,7 @@ func TestNewDataColumnSidecar(t *testing.T) {
 }
 
 func TestNewDataColumnSidecarWithVersionFulu(t *testing.T) {
-	sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+	sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion, &clparams.MainnetBeaconConfig)
 
 	assert.Equal(t, clparams.FuluVersion, sidecar.Version())
 	assert.NotNil(t, sidecar.Column, "Column should be initialized")
@@ -55,7 +55,7 @@ func TestNewDataColumnSidecarWithVersionFulu(t *testing.T) {
 }
 
 func TestNewDataColumnSidecarWithVersionGloas(t *testing.T) {
-	sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+	sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion, &clparams.MainnetBeaconConfig)
 
 	assert.Equal(t, clparams.GloasVersion, sidecar.Version())
 	assert.NotNil(t, sidecar.Column, "Column should be initialized")
@@ -70,7 +70,7 @@ func TestDataColumnSidecarEncodeDecodeFulu(t *testing.T) {
 	require := require.New(t)
 
 	// Create a Fulu sidecar
-	original := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+	original := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion, &clparams.MainnetBeaconConfig)
 	original.Index = 42
 	original.SignedBlockHeader.Header.Slot = 1000
 	original.SignedBlockHeader.Header.ProposerIndex = 123
@@ -80,7 +80,7 @@ func TestDataColumnSidecarEncodeDecodeFulu(t *testing.T) {
 	require.NoError(err)
 
 	// Decode
-	decoded := cltypes.NewDataColumnSidecar()
+	decoded := cltypes.NewDataColumnSidecar(&clparams.MainnetBeaconConfig)
 	err = decoded.DecodeSSZ(encoded, int(clparams.FuluVersion))
 	require.NoError(err)
 
@@ -95,7 +95,7 @@ func TestDataColumnSidecarEncodeDecodeGloas(t *testing.T) {
 	require := require.New(t)
 
 	// Create a Gloas sidecar
-	original := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+	original := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion, &clparams.MainnetBeaconConfig)
 	original.Index = 42
 	original.Slot = 2000
 	original.BeaconBlockRoot = [32]byte{1, 2, 3, 4, 5}
@@ -105,7 +105,7 @@ func TestDataColumnSidecarEncodeDecodeGloas(t *testing.T) {
 	require.NoError(err)
 
 	// Decode
-	decoded := cltypes.NewDataColumnSidecar()
+	decoded := cltypes.NewDataColumnSidecar(&clparams.MainnetBeaconConfig)
 	err = decoded.DecodeSSZ(encoded, int(clparams.GloasVersion))
 	require.NoError(err)
 
@@ -118,11 +118,11 @@ func TestDataColumnSidecarEncodeDecodeGloas(t *testing.T) {
 
 func TestDataColumnSidecarEncodingSizeSSZ(t *testing.T) {
 	// Fulu version should include pre-Gloas fields
-	fuluSidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+	fuluSidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion, &clparams.MainnetBeaconConfig)
 	fuluSize := fuluSidecar.EncodingSizeSSZ()
 
 	// Gloas version should be smaller (no pre-Gloas fields)
-	gloasSidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+	gloasSidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion, &clparams.MainnetBeaconConfig)
 	gloasSize := gloasSidecar.EncodingSizeSSZ()
 
 	// Fulu should include SignedBlockHeader, KzgCommitments, etc.
@@ -131,7 +131,7 @@ func TestDataColumnSidecarEncodingSizeSSZ(t *testing.T) {
 }
 
 func TestDataColumnSidecarClone(t *testing.T) {
-	original := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+	original := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion, &clparams.MainnetBeaconConfig)
 	original.Slot = 1000
 	original.BeaconBlockRoot = [32]byte{1, 2, 3}
 	original.BlockRoot = [32]byte{4, 5, 6}
@@ -150,7 +150,7 @@ func TestDataColumnSidecarClone(t *testing.T) {
 }
 
 func TestDataColumnSidecarStatic(t *testing.T) {
-	sidecar := cltypes.NewDataColumnSidecar()
+	sidecar := cltypes.NewDataColumnSidecar(&clparams.MainnetBeaconConfig)
 	assert.False(t, sidecar.Static(), "DataColumnSidecar should not be static")
 }
 
@@ -158,14 +158,14 @@ func TestDataColumnSidecarHashSSZ(t *testing.T) {
 	require := require.New(t)
 
 	// Fulu version
-	fuluSidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+	fuluSidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion, &clparams.MainnetBeaconConfig)
 	fuluSidecar.Index = 1
 	fuluHash, err := fuluSidecar.HashSSZ()
 	require.NoError(err)
 	assert.NotEqual(t, [32]byte{}, fuluHash)
 
 	// Gloas version
-	gloasSidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+	gloasSidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion, &clparams.MainnetBeaconConfig)
 	gloasSidecar.Index = 1
 	gloasHash, err := gloasSidecar.HashSSZ()
 	require.NoError(err)

--- a/cl/cltypes/partial_data_column.go
+++ b/cl/cltypes/partial_data_column.go
@@ -29,17 +29,18 @@ type PartialDataColumnHeader struct {
 	Slot                         uint64                         `json:"slot,omitempty"`                            // [New in Gloas:EIP7732]
 	BeaconBlockRoot              common.Hash                    `json:"beacon_block_root,omitempty"`               // [New in Gloas:EIP7732]
 
-	version clparams.StateVersion
+	version      clparams.StateVersion
+	beaconConfig *clparams.BeaconChainConfig
 }
 
-func NewPartialDataColumnHeader(version clparams.StateVersion) *PartialDataColumnHeader {
-	h := &PartialDataColumnHeader{version: version}
+func NewPartialDataColumnHeader(version clparams.StateVersion, cfg *clparams.BeaconChainConfig) *PartialDataColumnHeader {
+	h := &PartialDataColumnHeader{version: version, beaconConfig: cfg}
 	h.init()
 	return h
 }
 
 func (h *PartialDataColumnHeader) init() {
-	cfg := clparams.GetBeaconConfig()
+	cfg := h.beaconConfig
 	if h.KzgCommitments == nil {
 		h.KzgCommitments = solid.NewStaticListSSZ[*KZGCommitment](int(cfg.MaxBlobCommittmentsPerBlock), 48)
 	}
@@ -96,9 +97,9 @@ func (h *PartialDataColumnHeader) HashSSZ() ([32]byte, error) {
 
 func (h *PartialDataColumnHeader) Clone() clonable.Clonable {
 	if h == nil {
-		return &PartialDataColumnHeader{}
+		return &PartialDataColumnHeader{beaconConfig: clparams.GetBeaconConfig()}
 	}
-	return NewPartialDataColumnHeader(h.version)
+	return NewPartialDataColumnHeader(h.version, h.beaconConfig)
 }
 
 func (h *PartialDataColumnHeader) Static() bool {
@@ -115,17 +116,18 @@ type PartialDataColumnSidecar struct {
 	KzgProofs          *solid.ListSSZ[*KZGProof]                `json:"kzg_proofs"`
 	Header             *solid.ListSSZ[*PartialDataColumnHeader] `json:"header"`
 
-	version clparams.StateVersion
+	version      clparams.StateVersion
+	beaconConfig *clparams.BeaconChainConfig
 }
 
-func NewPartialDataColumnSidecar(version clparams.StateVersion) *PartialDataColumnSidecar {
-	s := &PartialDataColumnSidecar{version: version}
+func NewPartialDataColumnSidecar(version clparams.StateVersion, cfg *clparams.BeaconChainConfig) *PartialDataColumnSidecar {
+	s := &PartialDataColumnSidecar{version: version, beaconConfig: cfg}
 	s.init()
 	return s
 }
 
 func (s *PartialDataColumnSidecar) init() {
-	cfg := clparams.GetBeaconConfig()
+	cfg := s.beaconConfig
 	if s.CellsPresentBitmap == nil {
 		s.CellsPresentBitmap = solid.NewBitList(0, int(cfg.MaxBlobCommittmentsPerBlock))
 	}
@@ -183,9 +185,9 @@ func (s *PartialDataColumnSidecar) HashSSZ() ([32]byte, error) {
 
 func (s *PartialDataColumnSidecar) Clone() clonable.Clonable {
 	if s == nil {
-		return &PartialDataColumnSidecar{}
+		return &PartialDataColumnSidecar{beaconConfig: clparams.GetBeaconConfig()}
 	}
-	return NewPartialDataColumnSidecar(s.version)
+	return NewPartialDataColumnSidecar(s.version, s.beaconConfig)
 }
 
 func (s *PartialDataColumnSidecar) Static() bool {
@@ -206,18 +208,19 @@ func (s *PartialDataColumnSidecar) GetHeader() *PartialDataColumnHeader {
 //
 // Schema: available, requests
 type PartialDataColumnPartsMetadata struct {
-	Available *solid.BitList `json:"available"`
-	Requests  *solid.BitList `json:"requests"`
+	Available    *solid.BitList `json:"available"`
+	Requests     *solid.BitList `json:"requests"`
+	beaconConfig *clparams.BeaconChainConfig
 }
 
-func NewPartialDataColumnPartsMetadata() *PartialDataColumnPartsMetadata {
-	m := &PartialDataColumnPartsMetadata{}
+func NewPartialDataColumnPartsMetadata(cfg *clparams.BeaconChainConfig) *PartialDataColumnPartsMetadata {
+	m := &PartialDataColumnPartsMetadata{beaconConfig: cfg}
 	m.init()
 	return m
 }
 
 func (m *PartialDataColumnPartsMetadata) init() {
-	cfg := clparams.GetBeaconConfig()
+	cfg := m.beaconConfig
 	if m.Available == nil {
 		m.Available = solid.NewBitList(0, int(cfg.MaxBlobCommittmentsPerBlock))
 	}
@@ -247,7 +250,10 @@ func (m *PartialDataColumnPartsMetadata) HashSSZ() ([32]byte, error) {
 }
 
 func (m *PartialDataColumnPartsMetadata) Clone() clonable.Clonable {
-	return NewPartialDataColumnPartsMetadata()
+	if m == nil {
+		return NewPartialDataColumnPartsMetadata(clparams.GetBeaconConfig())
+	}
+	return NewPartialDataColumnPartsMetadata(m.beaconConfig)
 }
 
 func (m *PartialDataColumnPartsMetadata) Static() bool {

--- a/cl/cltypes/partial_data_column_test.go
+++ b/cl/cltypes/partial_data_column_test.go
@@ -72,7 +72,7 @@ func TestPartialDataColumnHeader_Fulu(t *testing.T) {
 	if _, err := os.Stat(testDir); os.IsNotExist(err) {
 		t.Skip("spec test data not found")
 	}
-	obj := cltypes.NewPartialDataColumnHeader(clparams.FuluVersion)
+	obj := cltypes.NewPartialDataColumnHeader(clparams.FuluVersion, &clparams.MainnetBeaconConfig)
 	testSSZRoundTrip(t, testDir, clparams.FuluVersion, obj)
 }
 
@@ -81,7 +81,7 @@ func TestPartialDataColumnHeader_Gloas(t *testing.T) {
 	if _, err := os.Stat(testDir); os.IsNotExist(err) {
 		t.Skip("spec test data not found")
 	}
-	obj := cltypes.NewPartialDataColumnHeader(clparams.GloasVersion)
+	obj := cltypes.NewPartialDataColumnHeader(clparams.GloasVersion, &clparams.MainnetBeaconConfig)
 	testSSZRoundTrip(t, testDir, clparams.GloasVersion, obj)
 }
 
@@ -90,7 +90,7 @@ func TestPartialDataColumnSidecar_Fulu(t *testing.T) {
 	if _, err := os.Stat(testDir); os.IsNotExist(err) {
 		t.Skip("spec test data not found")
 	}
-	obj := cltypes.NewPartialDataColumnSidecar(clparams.FuluVersion)
+	obj := cltypes.NewPartialDataColumnSidecar(clparams.FuluVersion, &clparams.MainnetBeaconConfig)
 	testSSZRoundTrip(t, testDir, clparams.FuluVersion, obj)
 }
 
@@ -99,7 +99,7 @@ func TestPartialDataColumnSidecar_Gloas(t *testing.T) {
 	if _, err := os.Stat(testDir); os.IsNotExist(err) {
 		t.Skip("spec test data not found")
 	}
-	obj := cltypes.NewPartialDataColumnSidecar(clparams.GloasVersion)
+	obj := cltypes.NewPartialDataColumnSidecar(clparams.GloasVersion, &clparams.MainnetBeaconConfig)
 	testSSZRoundTrip(t, testDir, clparams.GloasVersion, obj)
 }
 
@@ -108,7 +108,7 @@ func TestPartialDataColumnPartsMetadata_Fulu(t *testing.T) {
 	if _, err := os.Stat(testDir); os.IsNotExist(err) {
 		t.Skip("spec test data not found")
 	}
-	obj := cltypes.NewPartialDataColumnPartsMetadata()
+	obj := cltypes.NewPartialDataColumnPartsMetadata(&clparams.MainnetBeaconConfig)
 	testSSZRoundTrip(t, testDir, clparams.FuluVersion, obj)
 }
 
@@ -117,6 +117,6 @@ func TestPartialDataColumnPartsMetadata_Gloas(t *testing.T) {
 	if _, err := os.Stat(testDir); os.IsNotExist(err) {
 		t.Skip("spec test data not found")
 	}
-	obj := cltypes.NewPartialDataColumnPartsMetadata()
+	obj := cltypes.NewPartialDataColumnPartsMetadata(&clparams.MainnetBeaconConfig)
 	testSSZRoundTrip(t, testDir, clparams.GloasVersion, obj)
 }

--- a/cl/consensus/beacon/engine.go
+++ b/cl/consensus/beacon/engine.go
@@ -1,0 +1,33 @@
+package beacon
+
+import (
+	"github.com/erigontech/erigon/cl/consensus"
+	"github.com/erigontech/erigon/cl/transition/impl/eth2"
+	"github.com/erigontech/erigon/cl/transition/machine"
+)
+
+// Engine is the L1 beacon chain consensus engine. It wraps the existing
+// eth2.Impl state machine and enables full data availability checking
+// and Casper FFG finality.
+type Engine struct{}
+
+var _ consensus.Engine = (*Engine)(nil)
+
+func (e *Engine) Type() consensus.EngineType {
+	return consensus.BeaconChainEngineType
+}
+
+func (e *Engine) Machine(fullValidation bool, blockRewardsCollector *eth2.BlockRewardsCollector) machine.Interface {
+	return &eth2.Impl{
+		FullValidation:        fullValidation,
+		BlockRewardsCollector: blockRewardsCollector,
+	}
+}
+
+func (e *Engine) ShouldVerifyDataAvailability() bool {
+	return true
+}
+
+func (e *Engine) FinalityMode() consensus.FinalityMode {
+	return consensus.FinalityCasperFFG
+}

--- a/cl/consensus/engine.go
+++ b/cl/consensus/engine.go
@@ -1,0 +1,54 @@
+package consensus
+
+import (
+	"github.com/erigontech/erigon/cl/transition/impl/eth2"
+	"github.com/erigontech/erigon/cl/transition/machine"
+)
+
+// EngineType identifies a consensus engine implementation.
+type EngineType string
+
+const (
+	BeaconChainEngineType EngineType = "beacon"     // L1 beacon chain (full Caplin)
+	RollupEngineType      EngineType = "rollup"     // L2 based rollup (multi-node)
+	DevEngineType         EngineType = "rollup-dev" // L2 dev mode (single node)
+)
+
+// FinalityMode describes how a chain achieves finality.
+type FinalityMode int
+
+const (
+	FinalityCasperFFG FinalityMode = iota // L1: Casper FFG justification/finalization
+	FinalityL1Anchor                      // L2: finality derived from L1 anchor blocks
+	FinalityInstant                       // Dev: blocks finalize immediately
+)
+
+// Engine defines pluggable consensus behavior for the consensus layer,
+// analogous to rules.Engine on the execution layer.
+//
+// The L1 beacon chain and L2 rollup share the same core algorithms
+// (fork choice, committee shuffling, attestation processing) but differ
+// in block validation rules, data availability requirements, state
+// transition operations, and finality mechanism.
+//
+// Engine is threaded through the fork choice store and fork graph so
+// that these shared components can adapt their behavior per chain type.
+type Engine interface {
+	// Type returns the engine identifier.
+	Type() EngineType
+
+	// Machine returns the state transition machine for this engine.
+	// Each call returns a fresh instance configured for the requested
+	// validation mode. The beacon engine returns eth2.Impl (full L1
+	// state transition). A rollup engine returns a machine that skips
+	// L1-specific operations (deposits, eth1 data, sync aggregates).
+	Machine(fullValidation bool, blockRewardsCollector *eth2.BlockRewardsCollector) machine.Interface
+
+	// ShouldVerifyDataAvailability reports whether the engine requires
+	// blob/column data availability checks during block import. L1
+	// returns true (PeerDAS); L2 returns false (no sidecars).
+	ShouldVerifyDataAvailability() bool
+
+	// FinalityMode returns how this chain achieves finality.
+	FinalityMode() FinalityMode
+}

--- a/cl/consensus/engine_test.go
+++ b/cl/consensus/engine_test.go
@@ -1,0 +1,59 @@
+package consensus_test
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/cl/consensus"
+	"github.com/erigontech/erigon/cl/consensus/beacon"
+	"github.com/erigontech/erigon/cl/consensus/rollup"
+	"github.com/erigontech/erigon/cl/transition/machine"
+)
+
+func TestBeaconEngine(t *testing.T) {
+	e := &beacon.Engine{}
+	if e.Type() != consensus.BeaconChainEngineType {
+		t.Fatalf("expected %s, got %s", consensus.BeaconChainEngineType, e.Type())
+	}
+	if !e.ShouldVerifyDataAvailability() {
+		t.Fatal("beacon engine should verify data availability")
+	}
+	if e.FinalityMode() != consensus.FinalityCasperFFG {
+		t.Fatalf("expected FinalityCasperFFG, got %d", e.FinalityMode())
+	}
+	m := e.Machine(false, nil)
+	if m == nil {
+		t.Fatal("Machine() returned nil")
+	}
+	var _ machine.Interface = m
+}
+
+func TestRollupEngine(t *testing.T) {
+	e := rollup.NewEngine()
+	if e.Type() != consensus.RollupEngineType {
+		t.Fatalf("expected %s, got %s", consensus.RollupEngineType, e.Type())
+	}
+	if e.ShouldVerifyDataAvailability() {
+		t.Fatal("rollup engine should not verify data availability")
+	}
+	if e.FinalityMode() != consensus.FinalityL1Anchor {
+		t.Fatalf("expected FinalityL1Anchor, got %d", e.FinalityMode())
+	}
+	m := e.Machine(true, nil)
+	if m == nil {
+		t.Fatal("Machine() returned nil")
+	}
+	var _ machine.Interface = m
+}
+
+func TestDevEngine(t *testing.T) {
+	e := rollup.NewDevEngine()
+	if e.Type() != consensus.DevEngineType {
+		t.Fatalf("expected %s, got %s", consensus.DevEngineType, e.Type())
+	}
+	if e.ShouldVerifyDataAvailability() {
+		t.Fatal("dev engine should not verify data availability")
+	}
+	if e.FinalityMode() != consensus.FinalityInstant {
+		t.Fatalf("expected FinalityInstant, got %d", e.FinalityMode())
+	}
+}

--- a/cl/consensus/rollup/engine.go
+++ b/cl/consensus/rollup/engine.go
@@ -1,0 +1,86 @@
+package rollup
+
+import (
+	"github.com/erigontech/erigon/cl/abstract"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/consensus"
+	"github.com/erigontech/erigon/cl/transition/impl/eth2"
+	"github.com/erigontech/erigon/cl/transition/machine"
+)
+
+// Engine is the L2 based rollup consensus engine. It reuses the core
+// beacon state machine (slot processing, block header, randao, fork
+// choice) but skips L1-specific operations:
+//   - eth1 data voting
+//   - sync aggregate processing
+//   - validator deposits (old-style and EL-triggered)
+//
+// Data availability (PeerDAS/blobs) is not required since L2 blocks
+// are derived from L1 and don't carry sidecars.
+type Engine struct {
+	devMode bool
+}
+
+var _ consensus.Engine = (*Engine)(nil)
+
+func NewEngine() *Engine {
+	return &Engine{}
+}
+
+func NewDevEngine() *Engine {
+	return &Engine{devMode: true}
+}
+
+func (e *Engine) Type() consensus.EngineType {
+	if e.devMode {
+		return consensus.DevEngineType
+	}
+	return consensus.RollupEngineType
+}
+
+func (e *Engine) Machine(fullValidation bool, blockRewardsCollector *eth2.BlockRewardsCollector) machine.Interface {
+	return &rollupMachine{
+		Impl: eth2.Impl{
+			FullValidation:        fullValidation,
+			BlockRewardsCollector: blockRewardsCollector,
+		},
+	}
+}
+
+func (e *Engine) ShouldVerifyDataAvailability() bool {
+	return false
+}
+
+func (e *Engine) FinalityMode() consensus.FinalityMode {
+	if e.devMode {
+		return consensus.FinalityInstant
+	}
+	return consensus.FinalityL1Anchor
+}
+
+// rollupMachine embeds the L1 state machine and overrides L1-specific
+// operations as no-ops. All generic operations (block header, randao,
+// execution payload, attestations, slashings, withdrawals, slot
+// processing) delegate to the embedded eth2.Impl.
+type rollupMachine struct {
+	eth2.Impl
+}
+
+var _ machine.Interface = (*rollupMachine)(nil)
+
+func (m *rollupMachine) ProcessEth1Data(state abstract.BeaconState, eth1Data *cltypes.Eth1Data) error {
+	return nil
+}
+
+func (m *rollupMachine) ProcessSyncAggregate(s abstract.BeaconState, sync *cltypes.SyncAggregate) error {
+	return nil
+}
+
+func (m *rollupMachine) ProcessDeposit(s abstract.BeaconState, deposit *cltypes.Deposit) error {
+	return nil
+}
+
+func (m *rollupMachine) ProcessDepositRequest(s abstract.BeaconState, depositRequest *solid.DepositRequest) error {
+	return nil
+}

--- a/cl/das/p2p_utils.go
+++ b/cl/das/p2p_utils.go
@@ -26,9 +26,9 @@ const (
 // This function is re-entrant and thread-safe.
 // For Fulu: uses KzgCommitments from the sidecar.
 // For GLOAS: use VerifyDataColumnSidecarWithCommitments instead.
-func VerifyDataColumnSidecar(sidecar *cltypes.DataColumnSidecar) bool {
+func VerifyDataColumnSidecar(sidecar *cltypes.DataColumnSidecar, cfg *clparams.BeaconChainConfig) bool {
 	// The sidecar index must be within the valid range
-	if sidecar.Index >= clparams.GetBeaconConfig().NumberOfColumns {
+	if sidecar.Index >= cfg.NumberOfColumns {
 		return false
 	}
 
@@ -59,9 +59,9 @@ func VerifyDataColumnSidecar(sidecar *cltypes.DataColumnSidecar) bool {
 // VerifyDataColumnSidecarWithCommitments verifies if the data column sidecar is valid according to GLOAS protocol rules.
 // [Modified in Gloas:EIP7732] kzg_commitments is now passed as a parameter.
 // This function is re-entrant and thread-safe.
-func VerifyDataColumnSidecarWithCommitments(sidecar *cltypes.DataColumnSidecar, kzgCommitments *solid.ListSSZ[*cltypes.KZGCommitment]) bool {
+func VerifyDataColumnSidecarWithCommitments(sidecar *cltypes.DataColumnSidecar, kzgCommitments *solid.ListSSZ[*cltypes.KZGCommitment], cfg *clparams.BeaconChainConfig) bool {
 	// The sidecar index must be within the valid range
-	if sidecar.Index >= clparams.GetBeaconConfig().NumberOfColumns {
+	if sidecar.Index >= cfg.NumberOfColumns {
 		return false
 	}
 
@@ -162,8 +162,8 @@ func ComputeCells(blobs *cltypes.Blob) ([]cltypes.Cell, error) {
 
 // ComputeSubnetForDataColumnSidecar computes the subnet ID for a given data column sidecar index.
 // This function is re-entrant and thread-safe.
-func ComputeSubnetForDataColumnSidecar(columnIndex cltypes.ColumnIndex) uint64 {
-	return columnIndex % clparams.GetBeaconConfig().DataColumnSidecarSubnetCount
+func ComputeSubnetForDataColumnSidecar(columnIndex cltypes.ColumnIndex, cfg *clparams.BeaconChainConfig) uint64 {
+	return columnIndex % cfg.DataColumnSidecarSubnetCount
 }
 
 // VerifyDataColumnSidecarInclusionProof verifies if the inclusion proof in the sidecar is correct.

--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -528,7 +528,7 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 			}
 			if !exist {
 				blobSize := anyColumnSidecar.Column.Len()
-				sidecar := cltypes.NewDataColumnSidecar()
+				sidecar := cltypes.NewDataColumnSidecar(d.beaconConfig)
 				sidecar.Index = columnIndex
 				sidecar.SignedBlockHeader = anyColumnSidecar.SignedBlockHeader
 				// [Modified in Gloas:EIP7732] GLOAS sidecars don't have KzgCommitmentsInclusionProof and KzgCommitments
@@ -1071,10 +1071,8 @@ func (d *downloadRequest) requestData() *solid.ListSSZ[*cltypes.DataColumnsByRoo
 	d.tableMutex.RLock()
 	defer d.tableMutex.RUnlock()
 	for entry, columns := range d.downloadTable {
-		id := &cltypes.DataColumnsByRootIdentifier{
-			BlockRoot: entry.blockRoot,
-			Columns:   solid.NewUint64ListSSZ(int(d.beaconConfig.NumberOfColumns)),
-		}
+		id := cltypes.NewDataColumnsByRootIdentifier(d.beaconConfig)
+		id.BlockRoot = entry.blockRoot
 		for column := range columns {
 			id.Columns.Append(column)
 		}

--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -310,7 +310,7 @@ func (d *peerdas) resubscribeGossip() {
 		return
 	}
 	for column := range custodyColumns {
-		subnet := ComputeSubnetForDataColumnSidecar(column)
+		subnet := ComputeSubnetForDataColumnSidecar(column, d.beaconConfig)
 		topicName := gossip.TopicNameDataColumnSidecar(subnet)
 		expiry := time.Unix(0, math.MaxInt64)
 		if err := d.gossipManager.SubscribeWithExpiry(topicName, expiry); err != nil {
@@ -545,7 +545,7 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 				// verify the sidecar
 				// [Modified in Gloas:EIP7732] Version-aware verification
 				if isGloas {
-					if !VerifyDataColumnSidecarWithCommitments(sidecar, kzgCommitmentsFromBlock) {
+					if !VerifyDataColumnSidecarWithCommitments(sidecar, kzgCommitmentsFromBlock, d.beaconConfig) {
 						log.Warn("[blobsRecover] failed to verify column sidecar (GLOAS)", "slot", slot, "blockRoot", blockRoot, "column", columnIndex)
 						continue
 					}
@@ -554,7 +554,7 @@ func (d *peerdas) blobsRecoverWorker(ctx context.Context) {
 						continue
 					}
 				} else {
-					if !VerifyDataColumnSidecar(sidecar) {
+					if !VerifyDataColumnSidecar(sidecar, d.beaconConfig) {
 						log.Warn("[blobsRecover] failed to verify column sidecar", "slot", slot, "blockRoot", blockRoot, "column", columnIndex)
 						continue
 					}
@@ -898,7 +898,7 @@ mainloop:
 							log.Debug("failed to get kzg commitments for GLOAS", "err", err, "blockRoot", blockRoot)
 							return
 						}
-						if !VerifyDataColumnSidecarWithCommitments(sidecar, kzgCommitments) {
+						if !VerifyDataColumnSidecarWithCommitments(sidecar, kzgCommitments, d.beaconConfig) {
 							log.Debug("failed to verify column sidecar (GLOAS)", "blockRoot", blockRoot, "columnIndex", sidecar.Index)
 							d.rpc.BanPeer(result.pid)
 							return
@@ -910,7 +910,7 @@ mainloop:
 						}
 					} else {
 						// Fulu: kzg_commitments are in the sidecar
-						if !VerifyDataColumnSidecar(sidecar) {
+						if !VerifyDataColumnSidecar(sidecar, d.beaconConfig) {
 							log.Debug("failed to verify column sidecar", "blockRoot", blockRoot, "columnIndex", sidecar.Index)
 							d.rpc.BanPeer(result.pid)
 							return

--- a/cl/das/state/state.go
+++ b/cl/das/state/state.go
@@ -91,8 +91,8 @@ func (s *PeerDasState) GetMyCustodyColumns() (map[cltypes.CustodyIndex]bool, err
 		log.Warn("node ID is not set, return empty map")
 		return make(map[cltypes.CustodyIndex]bool), nil
 	}
-	sampleSize := max(clparams.GetBeaconConfig().SamplesPerSlot, s.GetAdvertisedCgc())
-	updatedCustodyColumns, err := peerdasutils.GetCustodyColumns(node.ID(), sampleSize)
+	sampleSize := max(s.beaconConfig.SamplesPerSlot, s.GetAdvertisedCgc())
+	updatedCustodyColumns, err := peerdasutils.GetCustodyColumns(node.ID(), sampleSize, s.beaconConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/cl/das/utils/block_produce_utils.go
+++ b/cl/das/utils/block_produce_utils.go
@@ -103,7 +103,7 @@ func GetDataColumnSidecarsGloas(
 			columnProofs.Append(proof)
 		}
 
-		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion, cfg)
 		sidecar.Index = columnIndex
 		sidecar.Column = columnCells
 		sidecar.KzgProofs = columnProofs

--- a/cl/das/utils/block_produce_utils.go
+++ b/cl/das/utils/block_produce_utils.go
@@ -39,13 +39,12 @@ func GetDataColumnSidecars(
 	kzgCommitments *solid.ListSSZ[*cltypes.KZGCommitment],
 	kzgCommitmentsInclusionProof solid.HashVectorSSZ,
 	cellsAndKZGProofs []CellsAndKZGProofs,
+	cfg *clparams.BeaconChainConfig,
 ) ([]*cltypes.DataColumnSidecar, error) {
 
 	if len(cellsAndKZGProofs) != kzgCommitments.Len() {
 		return nil, fmt.Errorf("number of cells/proofs entries (%d) does not match number of KZG commitments (%d)", len(cellsAndKZGProofs), kzgCommitments.Len())
 	}
-
-	cfg := clparams.GetBeaconConfig()
 	sidecars := make([]*cltypes.DataColumnSidecar, cfg.NumberOfColumns)
 
 	// Initialize sidecars for each column
@@ -84,8 +83,8 @@ func GetDataColumnSidecarsGloas(
 	slot uint64,
 	beaconBlockRoot common.Hash,
 	cellsAndKZGProofs []CellsAndKZGProofs,
+	cfg *clparams.BeaconChainConfig,
 ) ([]*cltypes.DataColumnSidecar, error) {
-	cfg := clparams.GetBeaconConfig()
 	sidecars := make([]*cltypes.DataColumnSidecar, cfg.NumberOfColumns)
 
 	// Initialize sidecars for each column

--- a/cl/das/utils/das_utils.go
+++ b/cl/das/utils/das_utils.go
@@ -30,8 +30,7 @@ var (
 
 // GetCustodyGroups generates custody groups for a given node ID.
 // This function is re-entrant and thread-safe.
-func GetCustodyGroups(nodeID enode.ID, custodyGroupCount uint64) ([]CustodyIndex, error) {
-	cfg := clparams.GetBeaconConfig()
+func GetCustodyGroups(nodeID enode.ID, custodyGroupCount uint64, cfg *clparams.BeaconChainConfig) ([]CustodyIndex, error) {
 	if custodyGroupCount > cfg.NumberOfCustodyGroups {
 		return nil, fmt.Errorf("custody group count %d exceeds maximum allowed %d", custodyGroupCount, cfg.NumberOfCustodyGroups)
 	}
@@ -71,9 +70,9 @@ func GetCustodyGroups(nodeID enode.ID, custodyGroupCount uint64) ([]CustodyIndex
 
 // ComputeColumnsForCustodyGroup returns the column indices that belong to a given custody group.
 // This function is re-entrant and thread-safe.
-func ComputeColumnsForCustodyGroup(custodyGroup CustodyIndex) ([]ColumnIndex, error) {
-	numberOfCustodyGroups := clparams.GetBeaconConfig().NumberOfCustodyGroups
-	numberOfColumns := clparams.GetBeaconConfig().NumberOfColumns
+func ComputeColumnsForCustodyGroup(custodyGroup CustodyIndex, cfg *clparams.BeaconChainConfig) ([]ColumnIndex, error) {
+	numberOfCustodyGroups := cfg.NumberOfCustodyGroups
+	numberOfColumns := cfg.NumberOfColumns
 
 	if custodyGroup >= numberOfCustodyGroups {
 		return nil, fmt.Errorf("custody group %d is greater than or equal to the number of custody groups (%d)", custodyGroup, numberOfCustodyGroups)
@@ -91,8 +90,8 @@ func ComputeColumnsForCustodyGroup(custodyGroup CustodyIndex) ([]ColumnIndex, er
 
 // ComputeMatrix takes a slice of blobs and returns a flattened sequence of matrix entries.
 // This function is re-entrant and thread-safe.
-func ComputeMatrix(blobs [][]byte) ([]cltypes.MatrixEntry, error) {
-	numberOfColumns := clparams.GetBeaconConfig().NumberOfColumns
+func ComputeMatrix(blobs [][]byte, cfg *clparams.BeaconChainConfig) ([]cltypes.MatrixEntry, error) {
+	numberOfColumns := cfg.NumberOfColumns
 	matrix := make([]cltypes.MatrixEntry, 0, len(blobs)*int(numberOfColumns))
 
 	for blobIndex, blob := range blobs {
@@ -202,16 +201,15 @@ func ComputeCellsAndKZGProofs(blob []byte) ([]cltypes.Cell, []cltypes.KZGProof, 
 	return convertCells, convertProofs, nil
 }
 
-func GetCustodyColumns(nodeID enode.ID, cgc uint64) (map[cltypes.CustodyIndex]bool, error) {
-	// TODO: cache the following computations in terms of custody columns
-	groups, err := GetCustodyGroups(nodeID, cgc)
+func GetCustodyColumns(nodeID enode.ID, cgc uint64, cfg *clparams.BeaconChainConfig) (map[cltypes.CustodyIndex]bool, error) {
+	groups, err := GetCustodyGroups(nodeID, cgc, cfg)
 	if err != nil {
 		return nil, err
 	}
 	// compute all required custody columns
 	custodyColumns := map[cltypes.CustodyIndex]bool{}
 	for _, group := range groups {
-		columns, err := ComputeColumnsForCustodyGroup(group)
+		columns, err := ComputeColumnsForCustodyGroup(group, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/cl/persistence/blob_storage/data_column_db.go
+++ b/cl/persistence/blob_storage/data_column_db.go
@@ -126,8 +126,8 @@ func (s *dataColumnStorageImpl) ReadColumnSidecarByColumnIndex(ctx context.Conte
 		return nil, err
 	}
 	defer fh.Close()
-	data := &cltypes.DataColumnSidecar{}
 	version := s.beaconChainConfig.GetCurrentStateVersion(slot / s.beaconChainConfig.SlotsPerEpoch)
+	data := cltypes.NewDataColumnSidecarWithVersion(version, s.beaconChainConfig)
 	if err := ssz_snappy.DecodeAndReadNoForkDigest(fh, data, version); err != nil {
 		return nil, err
 	}

--- a/cl/persistence/blob_storage/data_column_db_test.go
+++ b/cl/persistence/blob_storage/data_column_db_test.go
@@ -56,7 +56,7 @@ func setupTestDataColumnStorage(t *testing.T) (DataColumnStorage, afero.Fs, *clp
 // Mock implementation removed - using eth_clock.NewMockEthereumClock instead
 
 func createTestDataColumnSidecar(slot uint64, columnIndex int64) *cltypes.DataColumnSidecar {
-	sidecar := cltypes.NewDataColumnSidecar()
+	sidecar := cltypes.NewDataColumnSidecar(globalBeaconConfig)
 	sidecar.Index = uint64(columnIndex)
 	sidecar.SignedBlockHeader = &cltypes.SignedBeaconBlockHeader{
 		Header: &cltypes.BeaconBlockHeader{
@@ -293,8 +293,8 @@ func TestWriteStream(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the streamed data can be decoded
-	streamedData := &cltypes.DataColumnSidecar{}
 	version := storage.(*dataColumnStorageImpl).beaconChainConfig.GetCurrentStateVersion(1000 / 32)
+	streamedData := cltypes.NewDataColumnSidecarWithVersion(version, globalBeaconConfig)
 	err = ssz_snappy.DecodeAndReadNoForkDigest(&buf, streamedData, version)
 	require.NoError(t, err)
 	assert.Equal(t, sidecar.SignedBlockHeader.Header.Slot, streamedData.SignedBlockHeader.Header.Slot)

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -32,9 +32,11 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/lightclient_utils"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/consensus"
+	beaconengine "github.com/erigontech/erigon/cl/consensus/beacon"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
-	"github.com/erigontech/erigon/cl/transition"
 	"github.com/erigontech/erigon/cl/transition/impl/eth2"
+	"github.com/erigontech/erigon/cl/transition/machine"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 )
@@ -135,15 +137,16 @@ type forkGraphDisk struct {
 	sszSnappyWriter *snappy.Writer
 	sszSnappyReader *snappy.Reader
 
-	rcfg       beacon_router_configuration.RouterConfiguration
-	emitter    *beaconevents.EventEmitter
-	syncedData synced_data.SyncedData
+	rcfg            beacon_router_configuration.RouterConfiguration
+	emitter         *beaconevents.EventEmitter
+	syncedData      synced_data.SyncedData
+	consensusEngine consensus.Engine
 
 	stateDumpLock sync.Mutex
 }
 
 // Initialize fork graph with a new state.
-func NewForkGraphDisk(anchorState *state.CachingBeaconState, syncedData synced_data.SyncedData, aferoFs afero.Fs, rcfg beacon_router_configuration.RouterConfiguration, emitter *beaconevents.EventEmitter) ForkGraph {
+func NewForkGraphDisk(anchorState *state.CachingBeaconState, syncedData synced_data.SyncedData, aferoFs afero.Fs, rcfg beacon_router_configuration.RouterConfiguration, emitter *beaconevents.EventEmitter, engine ...consensus.Engine) ForkGraph {
 	farthestExtendingPath := make(map[common.Hash]bool)
 	anchorRoot, err := anchorState.BlockRoot()
 	if err != nil {
@@ -184,19 +187,26 @@ func NewForkGraphDisk(anchorState *state.CachingBeaconState, syncedData synced_d
 
 	farthestExtendingPath[anchorRoot] = true
 
+	var ce consensus.Engine
+	if len(engine) > 0 && engine[0] != nil {
+		ce = engine[0]
+	} else {
+		ce = &beaconengine.Engine{}
+	}
 	f := &forkGraphDisk{
 		fs: aferoFs,
 		// current state data
 		currentState:          anchorState,
 		currentStateBlockRoot: anchorRoot,
 		// configuration
-		beaconCfg:   anchorState.BeaconConfig(),
-		genesisTime: anchorState.GenesisTime(),
-		anchorSlot:  anchorState.Slot(),
-		anchorRoot:  anchorRoot,
-		rcfg:        rcfg,
-		emitter:     emitter,
-		syncedData:  syncedData,
+		beaconCfg:       anchorState.BeaconConfig(),
+		genesisTime:     anchorState.GenesisTime(),
+		anchorSlot:      anchorState.Slot(),
+		anchorRoot:      anchorRoot,
+		rcfg:            rcfg,
+		emitter:         emitter,
+		syncedData:      syncedData,
+		consensusEngine: ce,
 	}
 	f.lowestAvailableBlock.Store(anchorState.Slot())
 	f.headers.Store(common.Hash(anchorRoot), &anchorHeader)
@@ -324,8 +334,9 @@ func (f *forkGraphDisk) AddChainSegment(signedBlock *cltypes.SignedBeaconBlock, 
 	blockRewardsCollector := &eth2.BlockRewardsCollector{}
 
 	if !isBlockRootTheCurrentState {
-		// Execute the state
-		if invalidBlockErr := transition.TransitionState(newState, signedBlock, blockRewardsCollector, fullValidation); invalidBlockErr != nil {
+		// Execute the state using the consensus engine's machine
+		cvm := f.consensusEngine.Machine(fullValidation, blockRewardsCollector)
+		if invalidBlockErr := machine.TransitionState(cvm, newState, signedBlock); invalidBlockErr != nil {
 			// Add block to list of invalid blocks
 			log.Warn("Invalid beacon block", "slot", block.Slot, "blockRoot", common.Bytes2Hex(blockRoot[:]), "reason", invalidBlockErr)
 			f.blocks.Delete(common.Hash(blockRoot)) // remove early-stored block
@@ -550,7 +561,8 @@ func (f *forkGraphDisk) getState(blockRoot common.Hash, alwaysCopy bool, addChai
 
 	// Traverse the blocks from top to bottom.
 	for i := len(blocksInTheWay) - 1; i >= 0; i-- {
-		if err := transition.TransitionState(copyReferencedState, blocksInTheWay[i], nil, false); err != nil {
+		replayCvm := f.consensusEngine.Machine(false, nil)
+		if err := machine.TransitionState(replayCvm, copyReferencedState, blocksInTheWay[i]); err != nil {
 			if addChainSegment {
 				f.currentStateMu.Lock()
 				f.currentState = nil

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -29,6 +29,8 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/consensus"
+	beaconengine "github.com/erigontech/erigon/cl/consensus/beacon"
 	"github.com/erigontech/erigon/cl/das"
 	"github.com/erigontech/erigon/cl/persistence/blob_storage"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
@@ -153,6 +155,9 @@ type ForkChoiceStore struct {
 	// EL
 	engine execution_client.ExecutionEngine
 
+	// CL consensus engine (pluggable per chain type)
+	consensusEngine consensus.Engine
+
 	// operations pool
 	operationsPool pool.OperationsPool
 	beaconCfg      *clparams.BeaconChainConfig
@@ -225,6 +230,7 @@ func NewForkChoiceStore(
 	localValidators *validator_params.ValidatorParams,
 	probabilisticHeadGetter bool,
 	db kv.RwDB,
+	clEngine ...consensus.Engine,
 ) (*ForkChoiceStore, error) {
 	anchorRoot, err := anchorState.BlockRoot()
 	if err != nil {
@@ -345,6 +351,12 @@ func NewForkChoiceStore(
 		eth2Roots.Add(common.Hash{}, anchorExecHeader.BlockHash)
 	}
 
+	var ce consensus.Engine
+	if len(clEngine) > 0 && clEngine[0] != nil {
+		ce = clEngine[0]
+	} else {
+		ce = &beaconengine.Engine{}
+	}
 	headSet := make(map[common.Hash]struct{})
 	headSet[anchorRoot] = struct{}{}
 	f := &ForkChoiceStore{
@@ -385,6 +397,7 @@ func NewForkChoiceStore(
 		payloadStatusByRoot:            payloadStatusByRoot,
 		executionPayloadGasLimit:       executionPayloadGasLimit,
 		db:                             db,
+		consensusEngine:                ce,
 	}
 	f.justifiedCheckpoint.Store(anchorCheckpoint)
 	f.finalizedCheckpoint.Store(anchorCheckpoint)
@@ -574,6 +587,10 @@ func (f *ForkChoiceStore) Engine() execution_client.ExecutionEngine {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	return f.engine
+}
+
+func (f *ForkChoiceStore) ConsensusEngine() consensus.Engine {
+	return f.consensusEngine
 }
 
 // FinalizedCheckpoint returns justified checkpoint

--- a/cl/phase1/forkchoice/interface.go
+++ b/cl/phase1/forkchoice/interface.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/consensus"
 	"github.com/erigontech/erigon/cl/das"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
@@ -39,6 +40,7 @@ type ForkChoiceStorageReader interface {
 	AnchorSlot() uint64
 	AnchorRoot() common.Hash
 	Engine() execution_client.ExecutionEngine
+	ConsensusEngine() consensus.Engine
 	FinalizedCheckpoint() solid.Checkpoint
 	FinalizedSlot() uint64
 	LowestAvailableSlot() uint64

--- a/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
+++ b/cl/phase1/forkchoice/mock_services/forkchoice_mock.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/consensus"
+	beaconengine "github.com/erigontech/erigon/cl/consensus/beacon"
 	"github.com/erigontech/erigon/cl/das"
 	"github.com/erigontech/erigon/cl/das/mock_services"
 	peerdasstatemock "github.com/erigontech/erigon/cl/das/state/mock_services"
@@ -240,6 +242,10 @@ func (f *ForkChoiceStorageMock) AnchorRoot() common.Hash {
 
 func (f *ForkChoiceStorageMock) Engine() execution_client.ExecutionEngine {
 	panic("implement me")
+}
+
+func (f *ForkChoiceStorageMock) ConsensusEngine() consensus.Engine {
+	return &beaconengine.Engine{}
 }
 
 func (f *ForkChoiceStorageMock) FinalizedCheckpoint() solid.Checkpoint {

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -89,6 +89,7 @@ func collectOnBlockLatencyToUnixTime(ethClock eth_clock.EthereumClock, slot, cur
 }
 
 func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeaconBlock, newPayload, fullValidation, checkDataAvaiability bool) error {
+	checkDataAvaiability = checkDataAvaiability && f.consensusEngine.ShouldVerifyDataAvailability()
 	f.mu.Lock()
 	unlocked := false
 	defer func() {

--- a/cl/phase1/forkchoice/on_execution_payload.go
+++ b/cl/phase1/forkchoice/on_execution_payload.go
@@ -485,6 +485,7 @@ func (f *ForkChoiceStore) StoreAnchorEnvelope(blockRoot common.Hash, signedEnvel
 //   - checkBlobData: if true, verify blob data availability via PeerDAS before processing
 //   - validatePayload: if true, call engine.NewPayload() to validate with EL before state transition
 func (f *ForkChoiceStore) OnExecutionPayload(ctx context.Context, signedEnvelope *cltypes.SignedExecutionPayloadEnvelope, checkBlobData, validatePayload bool) error {
+	checkBlobData = checkBlobData && f.consensusEngine.ShouldVerifyDataAvailability()
 	if signedEnvelope == nil || signedEnvelope.Message == nil {
 		return errors.New("nil execution payload envelope")
 	}

--- a/cl/phase1/network/services/data_column_sidecar_service.go
+++ b/cl/phase1/network/services/data_column_sidecar_service.go
@@ -123,7 +123,7 @@ func (s *dataColumnSidecarService) IsMyGossipMessage(name string) bool {
 }
 
 func (s *dataColumnSidecarService) DecodeGossipMessage(_ peer.ID, data []byte, version clparams.StateVersion) (*cltypes.DataColumnSidecar, error) {
-	obj := cltypes.NewDataColumnSidecarWithVersion(version)
+	obj := cltypes.NewDataColumnSidecarWithVersion(version, s.cfg)
 	if err := obj.DecodeSSZ(data, int(version)); err != nil {
 		return nil, err
 	}

--- a/cl/phase1/network/services/data_column_sidecar_service.go
+++ b/cl/phase1/network/services/data_column_sidecar_service.go
@@ -188,12 +188,12 @@ func (s *dataColumnSidecarService) processFuluMessage(ctx context.Context, subne
 	}
 
 	// [REJECT] The sidecar is valid as verified by verify_data_column_sidecar(sidecar).
-	if !verifyDataColumnSidecar(msg) {
+	if !verifyDataColumnSidecar(msg, s.cfg) {
 		return errors.New("invalid data column sidecar")
 	}
 
 	// [REJECT] The sidecar is for the correct subnet
-	if subnet != nil && *subnet != computeSubnetForDataColumnSidecar(msg.Index) {
+	if subnet != nil && *subnet != computeSubnetForDataColumnSidecar(msg.Index, s.cfg) {
 		return fmt.Errorf("incorrect subnet %d for data column sidecar index %d", *subnet, msg.Index)
 	}
 
@@ -324,12 +324,12 @@ func (s *dataColumnSidecarService) processGloasMessage(ctx context.Context, subn
 	}
 
 	// [REJECT] The sidecar is valid as verified by verify_data_column_sidecar(sidecar, bid.blob_kzg_commitments)
-	if !verifyDataColumnSidecarWithCommitments(msg, kzgCommitments) {
+	if !verifyDataColumnSidecarWithCommitments(msg, kzgCommitments, s.cfg) {
 		return errors.New("invalid data column sidecar")
 	}
 
 	// [REJECT] The sidecar is for the correct subnet
-	if subnet != nil && *subnet != computeSubnetForDataColumnSidecar(msg.Index) {
+	if subnet != nil && *subnet != computeSubnetForDataColumnSidecar(msg.Index, s.cfg) {
 		return fmt.Errorf("incorrect subnet %d for data column sidecar index %d", *subnet, msg.Index)
 	}
 

--- a/cl/phase1/network/services/data_column_sidecar_service_test.go
+++ b/cl/phase1/network/services/data_column_sidecar_service_test.go
@@ -231,7 +231,7 @@ func (t *dataColumnSidecarTestSuite) TestProcessMessage_WhenInvalidDataColumnSid
 func (t *dataColumnSidecarTestSuite) TestProcessMessage_WhenIncorrectSubnet_ReturnsError() {
 	// Setup mock functions
 	incorrectSubnet := uint64(987654321)
-	computeSubnetForDataColumnSidecar = func(index uint64) uint64 { return 1234 } // Return different subnet
+	computeSubnetForDataColumnSidecar = func(index uint64, _ *clparams.BeaconChainConfig) uint64 { return 1234 } // Return different subnet
 	verifyDataColumnSidecar = t.mockFuncs.VerifyDataColumnSidecar
 	blsVerify = t.mockFuncs.BlsVerify
 
@@ -618,7 +618,7 @@ func (t *dataColumnSidecarTestSuite) TestGloasProcessMessage_WhenInvalidSidecar_
 // TestGloasProcessMessage_WhenIncorrectSubnet_ReturnsError tests GLOAS subnet validation
 func (t *dataColumnSidecarTestSuite) TestGloasProcessMessage_WhenIncorrectSubnet_ReturnsError() {
 	verifyDataColumnSidecarWithCommitments = t.mockFuncs.VerifyDataColumnSidecarWithCommitments
-	computeSubnetForDataColumnSidecar = func(index uint64) uint64 { return 1234 }
+	computeSubnetForDataColumnSidecar = func(index uint64, _ *clparams.BeaconChainConfig) uint64 { return 1234 }
 
 	incorrectSubnet := uint64(9999)
 

--- a/cl/phase1/network/services/data_column_sidecar_service_test.go
+++ b/cl/phase1/network/services/data_column_sidecar_service_test.go
@@ -469,7 +469,7 @@ var testBlockRoot = common.Hash{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 
 
 // createMockGloasDataColumnSidecar creates a GLOAS-style sidecar with Slot and BeaconBlockRoot
 func createMockGloasDataColumnSidecar(slot uint64, index uint64, blockRoot common.Hash) *cltypes.DataColumnSidecar {
-	sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+	sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion, &clparams.MainnetBeaconConfig)
 	sidecar.Index = index
 	sidecar.Slot = slot
 	sidecar.BeaconBlockRoot = blockRoot

--- a/cl/phase1/network/services/global_mock_test.go
+++ b/cl/phase1/network/services/global_mock_test.go
@@ -19,6 +19,7 @@ package services
 import (
 	"go.uber.org/mock/gomock"
 
+	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/common/ssz"
@@ -66,7 +67,7 @@ func (m *mockFuncs) VerifyDataColumnSidecarKZGProofs(sidecar *cltypes.DataColumn
 	return ret0
 }
 
-func (m *mockFuncs) VerifyDataColumnSidecar(sidecar *cltypes.DataColumnSidecar) bool {
+func (m *mockFuncs) VerifyDataColumnSidecar(sidecar *cltypes.DataColumnSidecar, _ *clparams.BeaconChainConfig) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyDataColumnSidecar", sidecar)
 	ret0, _ := ret[0].(bool)
@@ -74,7 +75,7 @@ func (m *mockFuncs) VerifyDataColumnSidecar(sidecar *cltypes.DataColumnSidecar) 
 }
 
 // [New in Gloas:EIP7732] GLOAS verification functions with kzg_commitments parameter
-func (m *mockFuncs) VerifyDataColumnSidecarWithCommitments(sidecar *cltypes.DataColumnSidecar, kzgCommitments *solid.ListSSZ[*cltypes.KZGCommitment]) bool {
+func (m *mockFuncs) VerifyDataColumnSidecarWithCommitments(sidecar *cltypes.DataColumnSidecar, kzgCommitments *solid.ListSSZ[*cltypes.KZGCommitment], _ *clparams.BeaconChainConfig) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyDataColumnSidecarWithCommitments", sidecar, kzgCommitments)
 	ret0, _ := ret[0].(bool)

--- a/cl/rpc/peer_selection.go
+++ b/cl/rpc/peer_selection.go
@@ -121,7 +121,7 @@ func (c *columnDataPeers) refreshPeers(ctx context.Context) {
 			} else {
 				// get custody indices
 				enodeId := enode.HexID(peer.EnodeId)
-				custodyIndices, err = peerdasutils.GetCustodyColumns(enodeId, *metadata.CustodyGroupCount)
+				custodyIndices, err = peerdasutils.GetCustodyColumns(enodeId, *metadata.CustodyGroupCount, c.beaconConfig)
 				if err != nil {
 					log.Debug("[peerSelector] failed to get custody indices", "peer", pid, "err", err)
 					continue

--- a/cl/rpc/peer_selection.go
+++ b/cl/rpc/peer_selection.go
@@ -202,7 +202,7 @@ func (c *columnDataPeers) pickPeerRoundRobin(
 				// full mask, no need to filter
 				newReq.Append(item)
 			} else {
-				identifier := cltypes.NewDataColumnsByRootIdentifier()
+				identifier := cltypes.NewDataColumnsByRootIdentifier(c.beaconConfig)
 				item.Columns.Range(func(_ int, column uint64, _ int) bool {
 					if peer.mask[column] {
 						identifier.Columns.Append(column)

--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -147,7 +147,7 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRootIdentifierReq(
 
 	ColumnSidecars := []*cltypes.DataColumnSidecar{}
 	for _, data := range responsePacket {
-		columnSidecar := &cltypes.DataColumnSidecar{}
+		columnSidecar := cltypes.NewDataColumnSidecarWithVersion(data.version, b.beaconConfig)
 		if err := columnSidecar.DecodeSSZ(data.raw, int(data.version)); err != nil {
 			return nil, pid, err
 		}
@@ -162,11 +162,9 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRangeReqV1(
 	start, count uint64,
 	columns []uint64,
 ) ([]*cltypes.DataColumnSidecar, string, error) {
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: start,
-		Count:     count,
-		Columns:   solid.NewUint64ListSSZ(int(b.beaconConfig.NumberOfColumns)),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(b.beaconConfig)
+	req.StartSlot = start
+	req.Count = count
 	for _, column := range columns {
 		req.Columns.Append(column)
 	}
@@ -182,7 +180,7 @@ func (b *BeaconRpcP2P) SendColumnSidecarsByRangeReqV1(
 
 	ColumnSidecars := []*cltypes.DataColumnSidecar{}
 	for _, data := range responsePacket {
-		columnSidecar := &cltypes.DataColumnSidecar{}
+		columnSidecar := cltypes.NewDataColumnSidecarWithVersion(data.version, b.beaconConfig)
 		if err := columnSidecar.DecodeSSZ(data.raw, int(data.version)); err != nil {
 			return nil, pid, err
 		}

--- a/cl/sentinel/handlers/data_cloumn_sidecar.go
+++ b/cl/sentinel/handlers/data_cloumn_sidecar.go
@@ -24,7 +24,7 @@ func (c *ConsensusHandlers) dataColumnSidecarsByRangeHandler(s network.Stream) e
 
 	// Use current epoch's version for decoding (supports Fulu and GLOAS)
 	version := c.beaconConfig.GetCurrentStateVersion(curEpoch)
-	req := &cltypes.ColumnSidecarsByRangeRequest{}
+	req := cltypes.NewColumnSidecarsByRangeRequest(c.beaconConfig)
 	if err := ssz_snappy.DecodeAndReadNoForkDigest(s, req, version); err != nil {
 		return ssz_snappy.EncodeAndWrite(s, &emptyString{}, InvalidRequestPrefix)
 	}

--- a/cl/sentinel/handlers/data_column_sidecar_test.go
+++ b/cl/sentinel/handlers/data_column_sidecar_test.go
@@ -53,10 +53,8 @@ func TestDataColumnSidecarsByRootMissingRootReturnsResourceUnavailable(t *testin
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
 	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
-	id := &cltypes.DataColumnsByRootIdentifier{
-		BlockRoot: common.Hash{0x42},
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	id := cltypes.NewDataColumnsByRootIdentifier(beaconCfg)
+	id.BlockRoot = common.Hash{0x42}
 	id.Columns.Append(0)
 	req.Append(id)
 
@@ -74,10 +72,8 @@ func TestDataColumnSidecarsByRootBeforeFuluReturnsResourceUnavailable(t *testing
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTestWithFuluForkEpoch(t, math.MaxUint64)
 
 	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
-	id := &cltypes.DataColumnsByRootIdentifier{
-		BlockRoot: common.Hash{0x42},
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	id := cltypes.NewDataColumnsByRootIdentifier(beaconCfg)
+	id.BlockRoot = common.Hash{0x42}
 	id.Columns.Append(0)
 	req.Append(id)
 
@@ -95,10 +91,9 @@ func TestDataColumnSidecarsByRootBeforeFuluInvalidColumnReturnsInvalidRequest(t 
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTestWithFuluForkEpoch(t, math.MaxUint64)
 
 	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
-	id := &cltypes.DataColumnsByRootIdentifier{
-		BlockRoot: common.Hash{0x42},
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
-	}
+	id := cltypes.NewDataColumnsByRootIdentifier(beaconCfg)
+	id.BlockRoot = common.Hash{0x42}
+	id.Columns = solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1)
 	id.Columns.Append(beaconCfg.NumberOfColumns)
 	req.Append(id)
 
@@ -126,16 +121,14 @@ func TestDataColumnSidecarsByRootFoundSidecarReturnsSuccessWithoutTrailingResour
 	blockRoot, err := header.Header.HashSSZ()
 	require.NoError(t, err)
 	columnIndex := uint64(0)
-	sidecar := cltypes.NewDataColumnSidecar()
+	sidecar := cltypes.NewDataColumnSidecar(beaconCfg)
 	sidecar.Index = columnIndex
 	sidecar.SignedBlockHeader.Header.Slot = slot
 	require.NoError(t, columnStorage.WriteColumnSidecars(ctx, blockRoot, int64(columnIndex), sidecar))
 
 	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
-	id := &cltypes.DataColumnsByRootIdentifier{
-		BlockRoot: blockRoot,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	id := cltypes.NewDataColumnsByRootIdentifier(beaconCfg)
+	id.BlockRoot = blockRoot
 	id.Columns.Append(columnIndex)
 	req.Append(id)
 
@@ -159,7 +152,7 @@ func TestDataColumnSidecarsByRootFoundSidecarReturnsSuccessWithoutTrailingResour
 	_, err = io.ReadFull(stream, forkDigest)
 	require.NoError(t, err)
 
-	got := cltypes.NewDataColumnSidecar()
+	got := cltypes.NewDataColumnSidecar(beaconCfg)
 	require.NoError(t, ssz_snappy.DecodeAndReadNoForkDigest(stream, got, clparams.FuluVersion))
 	require.Equal(t, columnIndex, got.Index)
 
@@ -189,10 +182,9 @@ func TestDataColumnSidecarsByRootEmptyColumnsReturnsEmptySuccess(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
 	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
-	req.Append(&cltypes.DataColumnsByRootIdentifier{
-		BlockRoot: common.Hash{0x42},
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	})
+	emptyId := cltypes.NewDataColumnsByRootIdentifier(beaconCfg)
+	emptyId.BlockRoot = common.Hash{0x42}
+	req.Append(emptyId)
 
 	var reqBuf bytes.Buffer
 	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
@@ -208,10 +200,9 @@ func TestDataColumnSidecarsByRootInvalidColumnReturnsInvalidRequest(t *testing.T
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
 	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
-	id := &cltypes.DataColumnsByRootIdentifier{
-		BlockRoot: common.Hash{0x42},
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
-	}
+	id := cltypes.NewDataColumnsByRootIdentifier(beaconCfg)
+	id.BlockRoot = common.Hash{0x42}
+	id.Columns = solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1)
 	id.Columns.Append(beaconCfg.NumberOfColumns)
 	req.Append(id)
 
@@ -229,10 +220,9 @@ func TestDataColumnSidecarsByRootTooManyColumnsReturnsInvalidRequest(t *testing.
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
 	req := solid.NewDynamicListSSZ[*cltypes.DataColumnsByRootIdentifier](1)
-	id := &cltypes.DataColumnsByRootIdentifier{
-		BlockRoot: common.Hash{0x42},
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
-	}
+	id := cltypes.NewDataColumnsByRootIdentifier(beaconCfg)
+	id.BlockRoot = common.Hash{0x42}
+	id.Columns = solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1)
 	for range beaconCfg.NumberOfColumns + 1 {
 		id.Columns.Append(0)
 	}
@@ -251,11 +241,8 @@ func TestDataColumnSidecarsByRootTooManyColumnsReturnsInvalidRequest(t *testing.
 func TestDataColumnSidecarsByRangeZeroCountReturnsEmptySuccess(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: 0,
-		Count:     0,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(beaconCfg)
+	req.Count = 0
 	req.Columns.Append(0)
 
 	var reqBuf bytes.Buffer
@@ -271,11 +258,8 @@ func TestDataColumnSidecarsByRangeZeroCountReturnsEmptySuccess(t *testing.T) {
 func TestDataColumnSidecarsByRangeEmptyColumnsReturnsEmptySuccess(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: 0,
-		Count:     1,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(beaconCfg)
+	req.Count = 1
 
 	var reqBuf bytes.Buffer
 	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
@@ -290,11 +274,8 @@ func TestDataColumnSidecarsByRangeEmptyColumnsReturnsEmptySuccess(t *testing.T) 
 func TestDataColumnSidecarsByRangeMissingSidecarsReturnsEmptySuccess(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: 0,
-		Count:     1,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(beaconCfg)
+	req.Count = 1
 	req.Columns.Append(0)
 
 	var reqBuf bytes.Buffer
@@ -310,11 +291,9 @@ func TestDataColumnSidecarsByRangeMissingSidecarsReturnsEmptySuccess(t *testing.
 func TestDataColumnSidecarsByRangeFutureRangeReturnsEmptySuccess(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: getEthClock(t).GetCurrentSlot() + 1,
-		Count:     1,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(beaconCfg)
+	req.StartSlot = getEthClock(t).GetCurrentSlot() + 1
+	req.Count = 1
 	req.Columns.Append(0)
 
 	var reqBuf bytes.Buffer
@@ -330,11 +309,8 @@ func TestDataColumnSidecarsByRangeFutureRangeReturnsEmptySuccess(t *testing.T) {
 func TestDataColumnSidecarsByRangeBeforeFuluReturnsEmptySuccess(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTestWithFuluForkEpoch(t, 1)
 
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: 0,
-		Count:     beaconCfg.SlotsPerEpoch,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(beaconCfg)
+	req.Count = beaconCfg.SlotsPerEpoch
 	req.Columns.Append(0)
 
 	var reqBuf bytes.Buffer
@@ -350,11 +326,9 @@ func TestDataColumnSidecarsByRangeBeforeFuluReturnsEmptySuccess(t *testing.T) {
 func TestDataColumnSidecarsByRangeInvalidColumnReturnsInvalidRequest(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: 0,
-		Count:     1,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(beaconCfg)
+	req.Count = 1
+	req.Columns = solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1)
 	req.Columns.Append(beaconCfg.NumberOfColumns)
 
 	var reqBuf bytes.Buffer
@@ -370,11 +344,9 @@ func TestDataColumnSidecarsByRangeInvalidColumnReturnsInvalidRequest(t *testing.
 func TestDataColumnSidecarsByRangeTooManyColumnsReturnsInvalidRequest(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: 0,
-		Count:     1,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(beaconCfg)
+	req.Count = 1
+	req.Columns = solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns) + 1)
 	for range beaconCfg.NumberOfColumns + 1 {
 		req.Columns.Append(0)
 	}
@@ -392,11 +364,9 @@ func TestDataColumnSidecarsByRangeTooManyColumnsReturnsInvalidRequest(t *testing
 func TestDataColumnSidecarsByRangeOverflowReturnsInvalidRequest(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: math.MaxUint64,
-		Count:     1,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(beaconCfg)
+	req.StartSlot = math.MaxUint64
+	req.Count = 1
 	req.Columns.Append(0)
 
 	var reqBuf bytes.Buffer
@@ -412,11 +382,8 @@ func TestDataColumnSidecarsByRangeOverflowReturnsInvalidRequest(t *testing.T) {
 func TestDataColumnSidecarsByRangeTooLargeReturnsInvalidRequest(t *testing.T) {
 	ctx, host, host1, beaconCfg := setupDataColumnSidecarHandlerTest(t)
 
-	req := &cltypes.ColumnSidecarsByRangeRequest{
-		StartSlot: 0,
-		Count:     beaconCfg.MinEpochsForDataColumnSidecarsRequests*beaconCfg.SlotsPerEpoch + 1,
-		Columns:   solid.NewUint64ListSSZ(int(beaconCfg.NumberOfColumns)),
-	}
+	req := cltypes.NewColumnSidecarsByRangeRequest(beaconCfg)
+	req.Count = beaconCfg.MinEpochsForDataColumnSidecarsRequests*beaconCfg.SlotsPerEpoch + 1
 	req.Columns.Append(0)
 
 	var reqBuf bytes.Buffer

--- a/cl/spectest/consensus_tests/appendix.go
+++ b/cl/spectest/consensus_tests/appendix.go
@@ -214,24 +214,27 @@ func addSszTests() {
 		With("PendingConsolidation", sszStaticTestByEmptyObject(&solid.PendingConsolidation{}, runAfterVersion(clparams.ElectraVersion))).         // no need json test
 		With("PendingDeposit", sszStaticTestByEmptyObject(&solid.PendingDeposit{}, runAfterVersion(clparams.ElectraVersion))).                     // no need json test
 		With("PendingPartialWithdrawal", sszStaticTestByEmptyObject(&solid.PendingPartialWithdrawal{}, runAfterVersion(clparams.ElectraVersion))). // no need json test
-		With("DataColumnsByRootIdentifier", sszStaticTestByEmptyObject(&cltypes.DataColumnsByRootIdentifier{}, runAfterVersion(clparams.FuluVersion))).
+		With("DataColumnsByRootIdentifier", sszStaticTestNewObjectByFunc(
+			func(v clparams.StateVersion) *cltypes.DataColumnsByRootIdentifier {
+				return cltypes.NewDataColumnsByRootIdentifier(&clparams.MainnetBeaconConfig)
+			}, runAfterVersion(clparams.FuluVersion))).
 		With("MatrixEntry", sszStaticTestByEmptyObject(&cltypes.MatrixEntry{}, withTestJson(), runAfterVersion(clparams.FuluVersion))).
 		With("DataColumnSidecar", sszStaticTestNewObjectByFunc(
 			func(v clparams.StateVersion) *cltypes.DataColumnSidecar {
-				return cltypes.NewDataColumnSidecarWithVersion(v)
+				return cltypes.NewDataColumnSidecarWithVersion(v, &clparams.MainnetBeaconConfig)
 			}, withTestJson(), runAfterVersion(clparams.FuluVersion))).
 		// [New in Fulu] Partial data column types
 		With("PartialDataColumnHeader", sszStaticTestNewObjectByFunc(
 			func(v clparams.StateVersion) *cltypes.PartialDataColumnHeader {
-				return cltypes.NewPartialDataColumnHeader(v)
+				return cltypes.NewPartialDataColumnHeader(v, &clparams.MainnetBeaconConfig)
 			}, runAfterVersion(clparams.FuluVersion))).
 		With("PartialDataColumnSidecar", sszStaticTestNewObjectByFunc(
 			func(v clparams.StateVersion) *cltypes.PartialDataColumnSidecar {
-				return cltypes.NewPartialDataColumnSidecar(v)
+				return cltypes.NewPartialDataColumnSidecar(v, &clparams.MainnetBeaconConfig)
 			}, runAfterVersion(clparams.FuluVersion))).
 		With("PartialDataColumnPartsMetadata", sszStaticTestNewObjectByFunc(
 			func(v clparams.StateVersion) *cltypes.PartialDataColumnPartsMetadata {
-				return cltypes.NewPartialDataColumnPartsMetadata()
+				return cltypes.NewPartialDataColumnPartsMetadata(&clparams.MainnetBeaconConfig)
 			}, runAfterVersion(clparams.FuluVersion))).
 		// [New in Gloas:EIP7732] GLOAS SSZ types
 		With("Builder", sszStaticTestByEmptyObject(&cltypes.Builder{}, runAfterVersion(clparams.GloasVersion))).

--- a/cl/spectest/consensus_tests/fork_choice.go
+++ b/cl/spectest/consensus_tests/fork_choice.go
@@ -371,7 +371,7 @@ func (b *ForkChoice) Run(t *testing.T, root fs.FS, c spectest.TestCase) (err err
 			if step.GetColumns() != nil {
 				allok := true
 				for _, filename := range step.GetColumns() {
-					column := cltypes.NewDataColumnSidecar()
+					column := cltypes.NewDataColumnSidecar(beaconConfig)
 					err := spectest.ReadSsz(root, c.Version(), filename+".ssz_snappy", column)
 					require.NoError(t, err, stepstr)
 					if das.VerifyDataColumnSidecar(column, beaconConfig) && das.VerifyDataColumnSidecarInclusionProof(column) && das.VerifyDataColumnSidecarKZGProofs(column) {

--- a/cl/spectest/consensus_tests/fork_choice.go
+++ b/cl/spectest/consensus_tests/fork_choice.go
@@ -374,7 +374,7 @@ func (b *ForkChoice) Run(t *testing.T, root fs.FS, c spectest.TestCase) (err err
 					column := cltypes.NewDataColumnSidecar()
 					err := spectest.ReadSsz(root, c.Version(), filename+".ssz_snappy", column)
 					require.NoError(t, err, stepstr)
-					if das.VerifyDataColumnSidecar(column) && das.VerifyDataColumnSidecarInclusionProof(column) && das.VerifyDataColumnSidecarKZGProofs(column) {
+					if das.VerifyDataColumnSidecar(column, beaconConfig) && das.VerifyDataColumnSidecarInclusionProof(column) && das.VerifyDataColumnSidecarKZGProofs(column) {
 						// write to columnStorage
 						blockRoot, err := blk.Block.HashSSZ()
 						require.NoError(t, err)

--- a/cl/spectest/consensus_tests/networking.go
+++ b/cl/spectest/consensus_tests/networking.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/cl/clparams"
 	peerdasutils "github.com/erigontech/erigon/cl/das/utils"
 	"github.com/erigontech/erigon/cl/spectest/spectest"
 	"github.com/erigontech/erigon/p2p/enode"
@@ -29,7 +30,7 @@ func TestGetCustodyGroups(t *testing.T, root fs.FS, c spectest.TestCase) (err er
 	bigInt.FillBytes(nodeIDBytes)
 	nodeID := enode.ID(nodeIDBytes)
 
-	custodyGroups, err := peerdasutils.GetCustodyGroups(nodeID, meta.CustodyGroupCount)
+	custodyGroups, err := peerdasutils.GetCustodyGroups(nodeID, meta.CustodyGroupCount, &clparams.MainnetBeaconConfig)
 	require.NoError(t, err)
 
 	assert.Equal(t, meta.Result, custodyGroups)
@@ -44,7 +45,7 @@ func TestComputeColumnsForCustodyGroup(t *testing.T, root fs.FS, c spectest.Test
 	err = spectest.ReadMeta(root, "meta.yaml", &meta)
 	require.NoError(t, err)
 
-	columns, err := peerdasutils.ComputeColumnsForCustodyGroup(meta.CustodyGroup)
+	columns, err := peerdasutils.ComputeColumnsForCustodyGroup(meta.CustodyGroup, &clparams.MainnetBeaconConfig)
 	require.NoError(t, err)
 
 	assert.Equal(t, meta.Result, columns)

--- a/cmd/caplin/caplin1/run.go
+++ b/cmd/caplin/caplin1/run.go
@@ -38,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/clparams/initial_state"
 	"github.com/erigontech/erigon/cl/cltypes"
+	beaconengine "github.com/erigontech/erigon/cl/consensus/beacon"
 	"github.com/erigontech/erigon/cl/das"
 	peerdasstate "github.com/erigontech/erigon/cl/das/state"
 	clp2p "github.com/erigontech/erigon/cl/p2p"
@@ -359,9 +360,10 @@ func RunCaplinService(ctx context.Context, engine execution_client.ExecutionEngi
 	// create the public keys registry
 	pksRegistry := public_keys_registry.NewHeadViewPublicKeysRegistry(syncedDataManager)
 	validatorParameters := validator_params.NewValidatorParams()
+	clConsensusEngine := &beaconengine.Engine{}
 	forkChoice, err := forkchoice.NewForkChoiceStore(
-		ethClock, state, engine, pool, fork_graph.NewForkGraphDisk(state, syncedDataManager, fcuFs, config.BeaconAPIRouter, emitters),
-		emitters, syncedDataManager, blobStorage, pksRegistry, validatorParameters, doLMDSampling, indexDB)
+		ethClock, state, engine, pool, fork_graph.NewForkGraphDisk(state, syncedDataManager, fcuFs, config.BeaconAPIRouter, emitters, clConsensusEngine),
+		emitters, syncedDataManager, blobStorage, pksRegistry, validatorParameters, doLMDSampling, indexDB, clConsensusEngine)
 	if err != nil {
 		logger.Error("Could not create forkchoice", "err", err)
 		return err


### PR DESCRIPTION
## Summary

Adds a `consensus.Engine` interface to the CL, analogous to `rules.Engine` on the EL. This lets Caplin select different consensus models per chain — needed for running L2 based rollups alongside L1 in a single process.

Three engine implementations:
- **beacon** — L1 beacon chain: Casper FFG finality, full data availability checks
- **rollup** — L2 based rollup: L1-anchored finality, DA checks disabled (L1 handles DA)
- **rollup-dev** — single-node L2 dev mode: instant finality, no DA

The engine controls three axes:
1. `Machine()` — state transition implementation. The rollup machine embeds `eth2.Impl` and no-ops L1-specific operations (Eth1Data, SyncAggregate, Deposit, DepositRequest)
2. `ShouldVerifyDataAvailability()` — gates DA checks in `OnBlock` and `OnExecutionPayload`
3. `FinalityMode()` — Casper FFG vs L1-anchored vs instant

Threaded through `ForkChoiceStore` and `forkGraphDisk` via variadic params that default to the beacon engine, preserving all existing L1 behaviour.

Builds on #22017 (CL multi-instance).

## Changes

| File | What |
|------|------|
| `cl/consensus/engine.go` | Core interface: `Engine`, `EngineType`, `FinalityMode` |
| `cl/consensus/beacon/engine.go` | L1 beacon engine (delegates to `eth2.Impl`) |
| `cl/consensus/rollup/engine.go` | L2 rollup engine (no-ops L1-specific ops) |
| `cl/consensus/engine_test.go` | Tests for all three engine types |
| `cl/phase1/forkchoice/forkchoice.go` | Accept engine via variadic param, expose `ConsensusEngine()` |
| `cl/phase1/forkchoice/interface.go` | Add `ConsensusEngine()` to `ForkChoiceStorageReader` |
| `cl/phase1/forkchoice/on_block.go` | Gate DA check via `engine.ShouldVerifyDataAvailability()` |
| `cl/phase1/forkchoice/on_execution_payload.go` | Gate blob DA check via engine |
| `cl/phase1/forkchoice/fork_graph/fork_graph_disk.go` | Use `engine.Machine()` for state transitions |
| `cl/phase1/forkchoice/mock_services/forkchoice_mock.go` | Implement `ConsensusEngine()` |
| `cmd/caplin/caplin1/run.go` | Wire beacon engine into fork graph + fork choice |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cl/consensus/...` passes (3 engine types verified)
- [x] `go test ./cl/...` passes
- [x] `gofmt` clean on all changed files
- [x] Existing L1 behaviour unchanged (beacon engine is default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)