### PR TITLE
cl/beacon: anchor the EL build window to the attestation deadline

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -65,6 +65,7 @@ import (
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
 
 type BlockPublishingValidation string
@@ -83,51 +84,109 @@ var defaultGraffitiString = "Caplin"
 
 const minPayloadPollingWindow = 100 * time.Millisecond
 
+// Polling for the assembled payload stops attestationDeadline/payloadPublicationDivisor before the
+// attestation deadline, reserving that margin for consensus processing, signing and gossip so the
+// produced block still reaches attesters in time to earn the proposer boost.
+const payloadPublicationDivisor = 4
+
 type blockBuilderWindow struct {
-	builderBudget time.Duration
-	firstGetAt    time.Time
-	pollUntil     time.Time
+	firstGetAt time.Time
+	pollUntil  time.Time
 }
 
 func attestationDue(cfg *clparams.BeaconChainConfig, stateVersion clparams.StateVersion) time.Duration {
-	if cfg == nil || cfg.SecondsPerSlot == 0 {
-		return 0
-	}
-	if stateVersion.AfterOrEqual(clparams.GloasVersion) {
-		return time.Duration(cfg.SecondsPerSlot*clparams.AttestationDueBpsGloas/(clparams.BpsFactor/1000)) * time.Millisecond
-	}
-	if cfg.IntervalsPerSlot == 0 {
-		return 0
-	}
-	return time.Duration(cfg.SecondsPerSlot*1000/cfg.IntervalsPerSlot) * time.Millisecond
+	return time.Duration(cfg.AttestationDueMs(stateVersion.AfterOrEqual(clparams.GloasVersion))) * time.Millisecond
 }
 
+// computeBlockBuilderWindow returns when to first poll for the assembled payload and when to stop,
+// reserving a publication margin before the attestation deadline (see payloadPublicationDivisor).
 func computeBlockBuilderWindow(now, slotStart time.Time, cfg *clparams.BeaconChainConfig, stateVersion clparams.StateVersion) blockBuilderWindow {
-	var builderBudget time.Duration
-	if cfg != nil {
-		builderBudget = time.Duration(cfg.SecondsPerSlot/4) * time.Second
-	}
-	deadline := slotStart.Add(attestationDue(cfg, stateVersion))
-	firstGetAt := now.Add(builderBudget)
-	latestFirstGetAt := deadline.Add(-minPayloadPollingWindow)
-	if latestFirstGetAt.Before(now) {
-		latestFirstGetAt = now
-	}
-	if firstGetAt.After(latestFirstGetAt) {
-		firstGetAt = latestFirstGetAt
-	}
+	due := attestationDue(cfg, stateVersion)
+	grabBy := slotStart.Add(due - due/payloadPublicationDivisor)
+	firstGetAt := grabBy.Add(-minPayloadPollingWindow)
 	if firstGetAt.Before(now) {
 		firstGetAt = now
 	}
+	pollUntil := grabBy
+	if pollUntil.Before(firstGetAt) {
+		pollUntil = firstGetAt
+	}
 	return blockBuilderWindow{
-		builderBudget: builderBudget,
-		firstGetAt:    firstGetAt,
-		pollUntil:     deadline,
+		firstGetAt: firstGetAt,
+		pollUntil:  pollUntil,
 	}
 }
 
 func shouldRetryGetPayload(now, deadline time.Time) bool {
 	return now.Before(deadline)
+}
+
+// pollAssembledPayload waits out the build window, then polls get (which stops the EL builder) until
+// it returns a payload or the deadline passes; ok is false when no payload was produced in time.
+func pollAssembledPayload(
+	ctx context.Context,
+	window blockBuilderWindow,
+	retryTime time.Duration,
+	get func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error),
+) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, bool) {
+	if wait := time.Until(window.firstGetAt); wait > 0 {
+		buildTimer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			buildTimer.Stop()
+			return nil, nil, nil, nil, false
+		case <-buildTimer.C:
+		}
+	}
+	pollTimeout := time.Until(window.pollUntil)
+	if pollTimeout < 0 {
+		pollTimeout = 0
+	}
+	stopTimer := time.NewTimer(pollTimeout)
+	defer stopTimer.Stop()
+	// Grab once immediately before enabling deadline polling, so late requests still get a payload.
+	retryTimer := time.NewTimer(0)
+	defer retryTimer.Stop()
+	var stopPolling <-chan time.Time
+	firstPayloadAttempt := true
+	schedulePayloadRetry := func() bool {
+		if !shouldRetryGetPayload(time.Now(), window.pollUntil) {
+			return false
+		}
+		stopPolling = stopTimer.C
+		retryTimer.Reset(retryTime)
+		return true
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, nil, nil, nil, false
+		case <-stopPolling:
+			return nil, nil, nil, nil, false
+		case <-retryTimer.C:
+			stopPolling = stopTimer.C
+			if firstPayloadAttempt {
+				firstPayloadAttempt = false
+			} else if !shouldRetryGetPayload(time.Now(), window.pollUntil) {
+				return nil, nil, nil, nil, false
+			}
+			payload, bundles, requestsBundle, blockValue, err := get()
+			if err != nil {
+				log.Error("BlockProduction: Failed to get payload", "err", err)
+				if !schedulePayloadRetry() {
+					return nil, nil, nil, nil, false
+				}
+				continue
+			}
+			if payload == nil {
+				if !schedulePayloadRetry() {
+					return nil, nil, nil, nil, false
+				}
+				continue
+			}
+			return payload, bundles, requestsBundle, blockValue, true
+		}
+	}
 }
 
 func (a *ApiHandler) waitForHeadSlot(slot uint64) {
@@ -918,246 +977,193 @@ func (a *ApiHandler) produceBeaconBody(
 			log.Warn("BlockProduction: ForkchoiceUpdate returned no payload id (EL may be syncing)", "slot", targetSlot)
 			return
 		}
-		// GetAssembledBlock stops the EL builder, so delay the first call until the builder budget or forkchoice deadline matures.
-		slotStart := time.Unix(int64(state.ComputeTimestampAtSlot(baseState, targetSlot)), 0)
+		slotStart := a.ethClock.GetSlotTime(targetSlot)
 		buildWindow := computeBlockBuilderWindow(builderStartedAt, slotStart, a.beaconChainCfg, stateVersion)
-		if wait := time.Until(buildWindow.firstGetAt); wait > 0 {
-			buildTimer := time.NewTimer(wait)
-			select {
-			case <-ctx.Done():
-				buildTimer.Stop()
+		payload, bundles, requestsBundle, blockValue, ok := pollAssembledPayload(ctx, buildWindow, retryTime, func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			return a.engine.GetAssembledBlock(ctx, idBytes, stateVersion)
+		})
+		if !ok {
+			return
+		}
+		// Determine block value
+		if blockValue == nil {
+			executionValue = 0
+		} else {
+			executionValue = blockValue.Uint64()
+		}
+
+		if stateVersion.Before(clparams.FuluVersion) {
+			if len(bundles.Blobs) != len(bundles.Proofs) ||
+				len(bundles.Commitments) != len(bundles.Proofs) {
+				log.Error("BlockProduction: Invalid bundle")
 				return
-			case <-buildTimer.C:
 			}
-		}
-		pollTimeout := time.Until(buildWindow.pollUntil)
-		if pollTimeout < 0 {
-			pollTimeout = 0
-		}
-		stopTimer := time.NewTimer(pollTimeout)
-		defer stopTimer.Stop()
-		// Start with an immediate payload attempt before enabling deadline polling, so late requests still grab once.
-		retryTimer := time.NewTimer(0)
-		defer retryTimer.Stop()
-		var stopPolling <-chan time.Time
-		firstPayloadAttempt := true
-		schedulePayloadRetry := func() bool {
-			if !shouldRetryGetPayload(time.Now(), buildWindow.pollUntil) {
-				return false
-			}
-			stopPolling = stopTimer.C
-			retryTimer.Reset(retryTime)
-			return true
-		}
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-stopPolling:
-				return
-			case <-retryTimer.C:
-				stopPolling = stopTimer.C
-				if firstPayloadAttempt {
-					firstPayloadAttempt = false
-				} else if !shouldRetryGetPayload(time.Now(), buildWindow.pollUntil) {
-					return
-				}
-				payload, bundles, requestsBundle, blockValue, err := a.engine.GetAssembledBlock(ctx, idBytes, stateVersion)
-				if err != nil {
-					log.Error("BlockProduction: Failed to get payload", "err", err)
-					if !schedulePayloadRetry() {
-						return
-					}
-					continue
-				}
-				if payload == nil {
-					if !schedulePayloadRetry() {
-						return
-					}
-					continue
-				}
-				// Determine block value
-				if blockValue == nil {
-					executionValue = 0
-				} else {
-					executionValue = blockValue.Uint64()
-				}
-
-				if stateVersion.Before(clparams.FuluVersion) {
-					if len(bundles.Blobs) != len(bundles.Proofs) ||
-						len(bundles.Commitments) != len(bundles.Proofs) {
-						log.Error("BlockProduction: Invalid bundle")
-						return
-					}
-				} else {
-					if len(bundles.Blobs) != len(bundles.Commitments) ||
-						len(bundles.Proofs) != len(bundles.Blobs)*int(a.beaconChainCfg.NumberOfColumns) {
-						log.Error("BlockProduction: Invalid peerdas bundle")
-						return
-					}
-				}
-
-				for i := range bundles.Blobs {
-					if len(bundles.Commitments[i]) != length.Bytes48 {
-						log.Error("BlockProduction: Invalid commitment length")
-						return
-					}
-					if stateVersion.Before(clparams.FuluVersion) && len(bundles.Proofs[i]) != length.Bytes48 {
-						log.Error("BlockProduction: Invalid commitment length")
-						return
-					}
-					if len(bundles.Blobs[i]) != cltypes.BYTES_PER_BLOB {
-						log.Error("BlockProduction: Invalid blob length")
-						return
-					}
-
-					// TODO: after the hard fork, remove this legacy code
-					if stateVersion.Before(clparams.FuluVersion) {
-						// add the bundle to recently produced blobs
-						a.blobBundles.Add(common.Bytes48(bundles.Commitments[i]), BlobBundle{
-							Blob:       (*cltypes.Blob)(bundles.Blobs[i]),
-							KzgProofs:  []common.Bytes48{common.Bytes48(bundles.Proofs[i])},
-							Commitment: common.Bytes48(bundles.Commitments[i]),
-						})
-					} else {
-						kzgProofs := make([]common.Bytes48, a.beaconChainCfg.NumberOfColumns)
-						for j := uint64(0); j < a.beaconChainCfg.NumberOfColumns; j++ {
-							kzgProofs[j] = common.Bytes48(bundles.Proofs[i*int(a.beaconChainCfg.NumberOfColumns)+int(j)])
-						}
-						// add the bundle to recently produced blobs
-						a.blobBundles.Add(common.Bytes48(bundles.Commitments[i]), BlobBundle{
-							Blob:       (*cltypes.Blob)(bundles.Blobs[i]),
-							KzgProofs:  kzgProofs,
-							Commitment: common.Bytes48(bundles.Commitments[i]),
-						})
-					}
-
-					// Assemble the KZG commitments list
-					if stateVersion.Before(clparams.GloasVersion) {
-						// Pre-GLOAS: commitments in BeaconBody
-						var c cltypes.KZGCommitment
-						copy(c[:], bundles.Commitments[i])
-						beaconBody.BlobKzgCommitments.Append(&c)
-					} else {
-						// GLOAS: commitments in the bid
-						var c cltypes.KZGCommitment
-						copy(c[:], bundles.Commitments[i])
-						beaconBody.SignedExecutionPayloadBid.Message.BlobKzgCommitments.Append(&c)
-					}
-				}
-
-				// Add the requests bundle (pre-GLOAS only; in GLOAS, ExecutionRequests live in the envelope)
-				if stateVersion.Before(clparams.GloasVersion) && requestsBundle != nil && requestsBundle.GetRequests() != nil {
-					if len(requestsBundle.GetRequests()) > 0 {
-						log.Info("BlockProduction: Received requests bundle", "len", len(requestsBundle.GetRequests()))
-					}
-
-					for _, request := range requestsBundle.GetRequests() {
-						rType := request[0]
-						requestData := request[1:]
-						switch rType {
-						case types.DepositRequestType:
-							if beaconBody.ExecutionRequests.Deposits.Len() > 0 {
-								log.Error("BlockProduction: Deposit request already exists")
-							} else if err := beaconBody.ExecutionRequests.Deposits.DecodeSSZ(requestData, int(stateVersion)); err != nil {
-								log.Error("BlockProduction: Failed to decode deposit request", "err", err)
-							} else {
-								log.Info("BlockProduction: Decoded deposit request", "len", beaconBody.ExecutionRequests.Deposits.Len())
-							}
-						case types.WithdrawalRequestType:
-
-							if beaconBody.ExecutionRequests.Withdrawals.Len() > 0 {
-								log.Error("BlockProduction: Withdrawal request already exists")
-							} else if err := beaconBody.ExecutionRequests.Withdrawals.DecodeSSZ(requestData, int(stateVersion)); err != nil {
-								log.Error("BlockProduction: Failed to decode withdrawal request", "err", err)
-							} else {
-								log.Info("BlockProduction: Decoded withdrawal request", "len", beaconBody.ExecutionRequests.Withdrawals.Len())
-							}
-
-						case types.ConsolidationRequestType:
-							if beaconBody.ExecutionRequests.Consolidations.Len() > 0 {
-								log.Error("BlockProduction: Consolidation request already exists")
-							} else if err := beaconBody.ExecutionRequests.Consolidations.DecodeSSZ(requestData, int(stateVersion)); err != nil {
-								log.Error("BlockProduction: Failed to decode consolidation request", "err", err)
-							} else {
-								log.Info("BlockProduction: Decoded consolidation request", "len", beaconBody.ExecutionRequests.Consolidations.Len())
-							}
-						}
-					}
-				}
-
-				// GLOAS: decode execution requests from the bundle to compute the bid's ExecutionRequestsRoot.
-				if stateVersion.AfterOrEqual(clparams.GloasVersion) {
-					if requestsBundle != nil && requestsBundle.GetRequests() != nil {
-						execReqs := cltypes.NewExecutionRequests(a.beaconChainCfg)
-						for _, request := range requestsBundle.GetRequests() {
-							rType := request[0]
-							requestData := request[1:]
-							switch rType {
-							case types.DepositRequestType:
-								if err := execReqs.Deposits.DecodeSSZ(requestData, int(stateVersion)); err != nil {
-									log.Error("BlockProduction: GLOAS failed to decode deposit request for root", "err", err)
-								}
-							case types.WithdrawalRequestType:
-								if err := execReqs.Withdrawals.DecodeSSZ(requestData, int(stateVersion)); err != nil {
-									log.Error("BlockProduction: GLOAS failed to decode withdrawal request for root", "err", err)
-								}
-							case types.ConsolidationRequestType:
-								if err := execReqs.Consolidations.DecodeSSZ(requestData, int(stateVersion)); err != nil {
-									log.Error("BlockProduction: GLOAS failed to decode consolidation request for root", "err", err)
-								}
-							}
-						}
-						gloasExecRequests = execReqs
-					}
-					// Always compute the root from the (possibly empty) gloasExecRequests
-					// so the bid's ExecutionRequestsRoot matches the envelope's actual root.
-					root, err := gloasExecRequests.HashSSZ()
-					if err != nil {
-						log.Error("BlockProduction: GLOAS failed to compute ExecutionRequestsRoot", "err", err)
-					} else {
-						executionRequestsRoot = common.Hash(root)
-					}
-				}
-
-				// Setup executionPayload
-				executionPayload = cltypes.NewEth1Block(beaconBody.Version, a.beaconChainCfg)
-				executionPayload.BlockHash = payload.BlockHash
-				executionPayload.ParentHash = payload.ParentHash
-				executionPayload.StateRoot = payload.StateRoot
-				executionPayload.ReceiptsRoot = payload.ReceiptsRoot
-				executionPayload.LogsBloom = payload.LogsBloom
-				executionPayload.BlockNumber = payload.BlockNumber
-				executionPayload.GasLimit = payload.GasLimit
-				executionPayload.GasUsed = payload.GasUsed
-				executionPayload.Time = payload.Time
-				executionPayload.Extra = payload.Extra
-				executionPayload.BlobGasUsed = payload.BlobGasUsed
-				executionPayload.ExcessBlobGas = payload.ExcessBlobGas
-				executionPayload.BaseFeePerGas = payload.BaseFeePerGas
-				executionPayload.BlockHash = payload.BlockHash
-				executionPayload.FeeRecipient = payload.FeeRecipient
-				executionPayload.PrevRandao = payload.PrevRandao
-				// Reset the limit of withdrawals
-				executionPayload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](
-					int(a.beaconChainCfg.MaxWithdrawalsPerPayload),
-					44,
-				)
-				payload.Withdrawals.Range(
-					func(index int, value *cltypes.Withdrawal, length int) bool {
-						executionPayload.Withdrawals.Append(value)
-						return true
-					},
-				)
-				executionPayload.Transactions = payload.Transactions
-				executionPayload.BlockAccessList = payload.BlockAccessList
-				executionPayload.SlotNumber = payload.SlotNumber
-				// Cache the block body so the beacon API can return transactions
-				// immediately, before the EL commits to its database.
-				a.cacheExecutionBody(payload)
+		} else {
+			if len(bundles.Blobs) != len(bundles.Commitments) ||
+				len(bundles.Proofs) != len(bundles.Blobs)*int(a.beaconChainCfg.NumberOfColumns) {
+				log.Error("BlockProduction: Invalid peerdas bundle")
 				return
 			}
 		}
+
+		for i := range bundles.Blobs {
+			if len(bundles.Commitments[i]) != length.Bytes48 {
+				log.Error("BlockProduction: Invalid commitment length")
+				return
+			}
+			if stateVersion.Before(clparams.FuluVersion) && len(bundles.Proofs[i]) != length.Bytes48 {
+				log.Error("BlockProduction: Invalid commitment length")
+				return
+			}
+			if len(bundles.Blobs[i]) != cltypes.BYTES_PER_BLOB {
+				log.Error("BlockProduction: Invalid blob length")
+				return
+			}
+
+			// TODO: after the hard fork, remove this legacy code
+			if stateVersion.Before(clparams.FuluVersion) {
+				// add the bundle to recently produced blobs
+				a.blobBundles.Add(common.Bytes48(bundles.Commitments[i]), BlobBundle{
+					Blob:       (*cltypes.Blob)(bundles.Blobs[i]),
+					KzgProofs:  []common.Bytes48{common.Bytes48(bundles.Proofs[i])},
+					Commitment: common.Bytes48(bundles.Commitments[i]),
+				})
+			} else {
+				kzgProofs := make([]common.Bytes48, a.beaconChainCfg.NumberOfColumns)
+				for j := uint64(0); j < a.beaconChainCfg.NumberOfColumns; j++ {
+					kzgProofs[j] = common.Bytes48(bundles.Proofs[i*int(a.beaconChainCfg.NumberOfColumns)+int(j)])
+				}
+				// add the bundle to recently produced blobs
+				a.blobBundles.Add(common.Bytes48(bundles.Commitments[i]), BlobBundle{
+					Blob:       (*cltypes.Blob)(bundles.Blobs[i]),
+					KzgProofs:  kzgProofs,
+					Commitment: common.Bytes48(bundles.Commitments[i]),
+				})
+			}
+
+			// Assemble the KZG commitments list
+			if stateVersion.Before(clparams.GloasVersion) {
+				// Pre-GLOAS: commitments in BeaconBody
+				var c cltypes.KZGCommitment
+				copy(c[:], bundles.Commitments[i])
+				beaconBody.BlobKzgCommitments.Append(&c)
+			} else {
+				// GLOAS: commitments in the bid
+				var c cltypes.KZGCommitment
+				copy(c[:], bundles.Commitments[i])
+				beaconBody.SignedExecutionPayloadBid.Message.BlobKzgCommitments.Append(&c)
+			}
+		}
+
+		// Add the requests bundle (pre-GLOAS only; in GLOAS, ExecutionRequests live in the envelope)
+		if stateVersion.Before(clparams.GloasVersion) && requestsBundle != nil && requestsBundle.GetRequests() != nil {
+			if len(requestsBundle.GetRequests()) > 0 {
+				log.Info("BlockProduction: Received requests bundle", "len", len(requestsBundle.GetRequests()))
+			}
+
+			for _, request := range requestsBundle.GetRequests() {
+				rType := request[0]
+				requestData := request[1:]
+				switch rType {
+				case types.DepositRequestType:
+					if beaconBody.ExecutionRequests.Deposits.Len() > 0 {
+						log.Error("BlockProduction: Deposit request already exists")
+					} else if err := beaconBody.ExecutionRequests.Deposits.DecodeSSZ(requestData, int(stateVersion)); err != nil {
+						log.Error("BlockProduction: Failed to decode deposit request", "err", err)
+					} else {
+						log.Info("BlockProduction: Decoded deposit request", "len", beaconBody.ExecutionRequests.Deposits.Len())
+					}
+				case types.WithdrawalRequestType:
+
+					if beaconBody.ExecutionRequests.Withdrawals.Len() > 0 {
+						log.Error("BlockProduction: Withdrawal request already exists")
+					} else if err := beaconBody.ExecutionRequests.Withdrawals.DecodeSSZ(requestData, int(stateVersion)); err != nil {
+						log.Error("BlockProduction: Failed to decode withdrawal request", "err", err)
+					} else {
+						log.Info("BlockProduction: Decoded withdrawal request", "len", beaconBody.ExecutionRequests.Withdrawals.Len())
+					}
+
+				case types.ConsolidationRequestType:
+					if beaconBody.ExecutionRequests.Consolidations.Len() > 0 {
+						log.Error("BlockProduction: Consolidation request already exists")
+					} else if err := beaconBody.ExecutionRequests.Consolidations.DecodeSSZ(requestData, int(stateVersion)); err != nil {
+						log.Error("BlockProduction: Failed to decode consolidation request", "err", err)
+					} else {
+						log.Info("BlockProduction: Decoded consolidation request", "len", beaconBody.ExecutionRequests.Consolidations.Len())
+					}
+				}
+			}
+		}
+
+		// GLOAS: decode execution requests from the bundle to compute the bid's ExecutionRequestsRoot.
+		if stateVersion.AfterOrEqual(clparams.GloasVersion) {
+			if requestsBundle != nil && requestsBundle.GetRequests() != nil {
+				execReqs := cltypes.NewExecutionRequests(a.beaconChainCfg)
+				for _, request := range requestsBundle.GetRequests() {
+					rType := request[0]
+					requestData := request[1:]
+					switch rType {
+					case types.DepositRequestType:
+						if err := execReqs.Deposits.DecodeSSZ(requestData, int(stateVersion)); err != nil {
+							log.Error("BlockProduction: GLOAS failed to decode deposit request for root", "err", err)
+						}
+					case types.WithdrawalRequestType:
+						if err := execReqs.Withdrawals.DecodeSSZ(requestData, int(stateVersion)); err != nil {
+							log.Error("BlockProduction: GLOAS failed to decode withdrawal request for root", "err", err)
+						}
+					case types.ConsolidationRequestType:
+						if err := execReqs.Consolidations.DecodeSSZ(requestData, int(stateVersion)); err != nil {
+							log.Error("BlockProduction: GLOAS failed to decode consolidation request for root", "err", err)
+						}
+					}
+				}
+				gloasExecRequests = execReqs
+			}
+			// Always compute the root from the (possibly empty) gloasExecRequests
+			// so the bid's ExecutionRequestsRoot matches the envelope's actual root.
+			root, err := gloasExecRequests.HashSSZ()
+			if err != nil {
+				log.Error("BlockProduction: GLOAS failed to compute ExecutionRequestsRoot", "err", err)
+			} else {
+				executionRequestsRoot = common.Hash(root)
+			}
+		}
+
+		// Setup executionPayload
+		executionPayload = cltypes.NewEth1Block(beaconBody.Version, a.beaconChainCfg)
+		executionPayload.BlockHash = payload.BlockHash
+		executionPayload.ParentHash = payload.ParentHash
+		executionPayload.StateRoot = payload.StateRoot
+		executionPayload.ReceiptsRoot = payload.ReceiptsRoot
+		executionPayload.LogsBloom = payload.LogsBloom
+		executionPayload.BlockNumber = payload.BlockNumber
+		executionPayload.GasLimit = payload.GasLimit
+		executionPayload.GasUsed = payload.GasUsed
+		executionPayload.Time = payload.Time
+		executionPayload.Extra = payload.Extra
+		executionPayload.BlobGasUsed = payload.BlobGasUsed
+		executionPayload.ExcessBlobGas = payload.ExcessBlobGas
+		executionPayload.BaseFeePerGas = payload.BaseFeePerGas
+		executionPayload.BlockHash = payload.BlockHash
+		executionPayload.FeeRecipient = payload.FeeRecipient
+		executionPayload.PrevRandao = payload.PrevRandao
+		// Reset the limit of withdrawals
+		executionPayload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](
+			int(a.beaconChainCfg.MaxWithdrawalsPerPayload),
+			44,
+		)
+		payload.Withdrawals.Range(
+			func(index int, value *cltypes.Withdrawal, length int) bool {
+				executionPayload.Withdrawals.Append(value)
+				return true
+			},
+		)
+		executionPayload.Transactions = payload.Transactions
+		executionPayload.BlockAccessList = payload.BlockAccessList
+		executionPayload.SlotNumber = payload.SlotNumber
+		// Cache the block body so the beacon API can return transactions
+		// immediately, before the EL commits to its database.
+		a.cacheExecutionBody(payload)
 	}()
 	// process the sync aggregate in parallel
 	wg.Add(1)

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -1012,7 +1012,7 @@ func (a *ApiHandler) produceBeaconBody(
 				return
 			}
 			if stateVersion.Before(clparams.FuluVersion) && len(bundles.Proofs[i]) != length.Bytes48 {
-				log.Error("BlockProduction: Invalid commitment length")
+				log.Error("BlockProduction: Invalid proof length")
 				return
 			}
 			if len(bundles.Blobs[i]) != cltypes.BYTES_PER_BLOB {

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -19,6 +19,8 @@ package handler
 import (
 	"bytes"
 	"context"
+	"errors"
+	"math/big"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -40,6 +42,7 @@ import (
 	"github.com/erigontech/erigon/execution/tests/blockgen"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
 
 func TestBlockBuilderWindowPreGloas(t *testing.T) {
@@ -52,9 +55,9 @@ func TestBlockBuilderWindowPreGloas(t *testing.T) {
 
 	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.ElectraVersion)
 
-	require.Equal(t, 3*time.Second, window.builderBudget)
-	require.Equal(t, slotStart.Add(3*time.Second), window.firstGetAt)
-	require.Equal(t, slotStart.Add(4*time.Second), window.pollUntil)
+	// Attestation deadline is 4s; polling stops a quarter of it (1s) earlier, at 3s.
+	require.Equal(t, slotStart.Add(3*time.Second).Add(-minPayloadPollingWindow), window.firstGetAt)
+	require.Equal(t, slotStart.Add(3*time.Second), window.pollUntil)
 }
 
 func TestBlockBuilderWindowGloas(t *testing.T) {
@@ -67,23 +70,24 @@ func TestBlockBuilderWindowGloas(t *testing.T) {
 
 	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.GloasVersion)
 
-	require.Equal(t, 3*time.Second, window.builderBudget)
-	require.Equal(t, slotStart.Add(3*time.Second).Add(-minPayloadPollingWindow), window.firstGetAt)
-	require.Equal(t, slotStart.Add(3*time.Second), window.pollUntil)
+	// Attestation deadline is 3s; polling stops a quarter of it (750ms) earlier, at 2.25s.
+	require.Equal(t, slotStart.Add(2250*time.Millisecond).Add(-minPayloadPollingWindow), window.firstGetAt)
+	require.Equal(t, slotStart.Add(2250*time.Millisecond), window.pollUntil)
 }
 
-func TestBlockBuilderWindowPreGloasLateStartKeepsRetryWindow(t *testing.T) {
+func TestBlockBuilderWindowLateStartKeepsPublicationMargin(t *testing.T) {
 	cfg := &clparams.BeaconChainConfig{
 		SecondsPerSlot:   12,
 		IntervalsPerSlot: 3,
 	}
 	slotStart := time.Unix(100, 0)
-	now := slotStart.Add(1500 * time.Millisecond)
+	now := slotStart.Add(2950 * time.Millisecond)
 
 	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.ElectraVersion)
 
-	require.Equal(t, slotStart.Add(4*time.Second).Add(-minPayloadPollingWindow), window.firstGetAt)
-	require.Equal(t, slotStart.Add(4*time.Second), window.pollUntil)
+	// A late request clamps the first poll up to now but still stops at 3s, preserving the margin.
+	require.Equal(t, now, window.firstGetAt)
+	require.Equal(t, slotStart.Add(3*time.Second), window.pollUntil)
 }
 
 func TestBlockBuilderWindowLateRequestGrabsImmediately(t *testing.T) {
@@ -97,7 +101,32 @@ func TestBlockBuilderWindowLateRequestGrabsImmediately(t *testing.T) {
 	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.GloasVersion)
 
 	require.Equal(t, now, window.firstGetAt)
-	require.Equal(t, slotStart.Add(3*time.Second), window.pollUntil)
+	require.Equal(t, now, window.pollUntil)
+}
+
+func TestBlockBuilderWindowReservesPublicationMargin(t *testing.T) {
+	cfg := &clparams.BeaconChainConfig{
+		SecondsPerSlot:   12,
+		IntervalsPerSlot: 3,
+	}
+	slotStart := time.Unix(100, 0)
+
+	for _, tc := range []struct {
+		name          string
+		version       clparams.StateVersion
+		deadline      time.Duration
+		wantPollUntil time.Duration
+	}{
+		{"pre-gloas", clparams.ElectraVersion, 4 * time.Second, 3 * time.Second},
+		{"gloas", clparams.GloasVersion, 3 * time.Second, 2250 * time.Millisecond},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			window := computeBlockBuilderWindow(slotStart, slotStart, cfg, tc.version)
+			require.Equal(t, slotStart.Add(tc.wantPollUntil), window.pollUntil)
+			require.True(t, window.pollUntil.Before(slotStart.Add(tc.deadline)),
+				"polling must stop before the attestation deadline to leave publication margin")
+		})
+	}
 }
 
 func TestShouldRetryGetPayloadStopsAtDeadline(t *testing.T) {
@@ -108,18 +137,97 @@ func TestShouldRetryGetPayloadStopsAtDeadline(t *testing.T) {
 	require.False(t, shouldRetryGetPayload(deadline.Add(time.Nanosecond), deadline))
 }
 
-func TestBlockBuilderWindowUsesExecutionBuilderIntegerBudget(t *testing.T) {
-	cfg := &clparams.BeaconChainConfig{
-		SecondsPerSlot:   5,
-		IntervalsPerSlot: 3,
-	}
-	slotStart := time.Unix(100, 0)
-	now := slotStart
+func TestPollAssembledPayloadReturnsReadyPayload(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now.Add(-time.Millisecond), pollUntil: now.Add(time.Second)}
+	want := &cltypes.Eth1Block{}
+	calls := 0
+	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			return want, nil, nil, nil, nil
+		})
+	require.True(t, ok)
+	require.Same(t, want, payload)
+	require.Equal(t, 1, calls)
+}
 
-	window := computeBlockBuilderWindow(now, slotStart, cfg, clparams.ElectraVersion)
+func TestPollAssembledPayloadRetriesWhileBusy(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
+	want := &cltypes.Eth1Block{}
+	calls := 0
+	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			if calls < 3 {
+				return nil, nil, nil, nil, nil
+			}
+			return want, nil, nil, nil, nil
+		})
+	require.True(t, ok)
+	require.Same(t, want, payload)
+	require.Equal(t, 3, calls)
+}
 
-	require.Equal(t, time.Second, window.builderBudget)
-	require.Equal(t, slotStart.Add(time.Second), window.firstGetAt)
+func TestPollAssembledPayloadRetriesOnError(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
+	want := &cltypes.Eth1Block{}
+	calls := 0
+	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil, nil, nil, errors.New("EL busy")
+			}
+			return want, nil, nil, nil, nil
+		})
+	require.True(t, ok)
+	require.Same(t, want, payload)
+	require.Equal(t, 2, calls)
+}
+
+func TestPollAssembledPayloadStopsAtDeadline(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
+	calls := 0
+	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			return nil, nil, nil, nil, nil
+		})
+	require.False(t, ok)
+	require.Nil(t, payload)
+	require.NotZero(t, calls)
+}
+
+func TestPollAssembledPayloadLateRequestGrabsOnce(t *testing.T) {
+	past := time.Now().Add(-time.Second)
+	window := blockBuilderWindow{firstGetAt: past, pollUntil: past}
+	calls := 0
+	_, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			return nil, nil, nil, nil, nil
+		})
+	require.False(t, ok)
+	require.Equal(t, 1, calls)
+}
+
+func TestPollAssembledPayloadReturnsOnContextCancel(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now.Add(time.Hour), pollUntil: now.Add(time.Hour)}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	_, _, _, _, ok := pollAssembledPayload(ctx, window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			return nil, nil, nil, nil, nil
+		})
+	require.False(t, ok)
+	require.Zero(t, calls)
 }
 
 func TestSetupHeaderResponseForBlockProductionGloasPayloadIncluded(t *testing.T) {

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -769,6 +769,20 @@ func (b *BeaconChainConfig) GetCurrentStateVersion(epoch uint64) StateVersion {
 	return stateVersion
 }
 
+// AttestationDueMs returns the attestation deadline in milliseconds from slot start.
+func (b *BeaconChainConfig) AttestationDueMs(gloas bool) uint64 {
+	if b == nil || b.SecondsPerSlot == 0 {
+		return 0
+	}
+	if gloas {
+		return b.SecondsPerSlot * AttestationDueBpsGloas / (BpsFactor / 1000)
+	}
+	if b.IntervalsPerSlot == 0 {
+		return 0
+	}
+	return b.SecondsPerSlot * 1000 / b.IntervalsPerSlot
+}
+
 // InitializeForkSchedule initializes the schedules forks baked into the config.
 func (b *BeaconChainConfig) InitializeForkSchedule() {
 	b.ForkVersionSchedule = configForkSchedule(b)

--- a/cl/phase1/forkchoice/timing.go
+++ b/cl/phase1/forkchoice/timing.go
@@ -30,14 +30,8 @@ import (
 // post-GLOAS epochs use BPS constants.
 
 // getAttestationDueMs returns the attestation deadline in milliseconds from slot start.
-//
-// Pre-GLOAS:  SecondsPerSlot * 1000 / IntervalsPerSlot  (1/3 of slot = 4000 ms on mainnet)
-// Post-GLOAS: SecondsPerSlot * AttestationDueBpsGloas / 10  (25% of slot = 3000 ms on mainnet)
 func (f *ForkChoiceStore) getAttestationDueMs(epoch uint64) uint64 {
-	if epoch >= f.beaconCfg.GloasForkEpoch {
-		return f.beaconCfg.SecondsPerSlot * clparams.AttestationDueBpsGloas / (clparams.BpsFactor / 1000)
-	}
-	return f.beaconCfg.SecondsPerSlot * 1000 / f.beaconCfg.IntervalsPerSlot
+	return f.beaconCfg.AttestationDueMs(epoch >= f.beaconCfg.GloasForkEpoch)
 }
 
 // getAggregateDueMs returns the aggregate deadline in milliseconds from slot start.


### PR DESCRIPTION
Suggested changes on top of #21989 (based on its branch, so the diff here is only the delta).

## Why
Reviewing #21989 surfaced a GLOAS timeliness bug and an EL/CL coupling:

- **GLOAS:** the build budget (`SecondsPerSlot/4`) equals the GLOAS attestation deadline (both 25% of the slot), so `firstGetAt` clamps to `deadline-100ms` and the block is only publishable *after* the 3s deadline (grab ~2.9s + `ProcessBlock`/`HashSSZ` + sign + gossip). A block received after the attestation deadline does not earn proposer boost (`updateProposerBoostRoot` early-returns on `!isTimely`), so it is reorg-eligible. The live validation in #21989 was on Fulu (4s deadline, ~1s margin); GLOAS has none.
- **Coupling:** the CL hard-codes the EL builder's own `SecondsPerSlot/4` self-stop budget. If the EL ever retunes its build duration the CL would grab before the builder seals → truncated/near-empty block, with no compile-time signal.

## What
- **Anchor the poll window to the attestation deadline** rather than the EL budget: poll until `attestationDue - attestationDue/payloadPublicationDivisor`, reserving a margin for consensus processing + signing + gossip. Preserves the validated pre-GLOAS first grab (~3s, deadline 4s) and gives GLOAS a real margin (grab by ~2.25s, deadline 3s). This also removes the duplicated `SecondsPerSlot/4` — the CL now derives timing only from the attestation deadline it owns.
- **Share the attestation-deadline formula** via `clparams.AttestationDueMs(gloas bool)`; `forkchoice.getAttestationDueMs` and block production both delegate to it so they can't drift.
- **Use the shared `ethClock.GetSlotTime`** for slot start instead of re-deriving it.
- **Extract `pollAssembledPayload`** (the poll/retry/cancel loop) and add unit tests: ready / busy-retry / error-retry / stop-at-deadline / late-request-grabs-once / ctx-cancel. Drops the now-dead `builderBudget` field.

## Spec alignment
Cross-checked against consensus-specs (phase0 + gloas) and EIP-7732:
- The attestation-deadline values match exactly (GLOAS `ATTESTATION_DUE_BPS_GLOAS = 2500` → 3s; pre-GLOAS 1/3 → 4s) and the proposer-boost timeliness gate (`time_into_slot < attestation_due`) is unchanged.
- The build-window timing is **implementation-defined** in the spec (`get_payload` is "implementation dependent"; the spec only says propose at slot start and be timely). So the margin is a legitimate client policy — **`payloadPublicationDivisor = 4` is the one tunable knob**, picked to preserve the validated pre-GLOAS grab while giving GLOAS headroom. Happy to change it if you'd prefer a different reserve.

## Notes
- The `block_production.go` diff looks large but most of it is gofmt re-indentation from lifting the payload-processing block out of the old `for`/`select`/`case`.
- GLOAS self-build intentionally interrupts the EL builder ~0.75s early (timely-but-slightly-smaller beats full-but-reorged); with an external builder this self-build window isn't on the critical path.

Verified: `go test ./cl/beacon/handler ./cl/clparams ./cl/phase1/forkchoice`, `make erigon integration`, scoped golangci-lint clean.