### PR TITLE
cl/beacon: log "Invalid proof length" for the proof-length check

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -914,7 +914,7 @@ func (a *ApiHandler) produceBeaconBody(
 						return
 					}
 					if stateVersion.Before(clparams.FuluVersion) && len(bundles.Proofs[i]) != length.Bytes48 {
-						log.Error("BlockProduction: Invalid commitment length")
+						log.Error("BlockProduction: Invalid proof length")
 						return
 					}
 					if len(bundles.Blobs[i]) != cltypes.BYTES_PER_BLOB {


### PR DESCRIPTION
The proof-length check in `produceBeaconBody` logged `"Invalid commitment length"` — copy-pasted from the commitment check right above it — which is misleading when troubleshooting bundle-format issues. Corrected to `"Invalid proof length"`. Pure log-string fix, no behavior change.

Surfaced by Copilot's review of #21989. That review also flagged a potential nil `bundles` dereference at the same site; I investigated and it is **not reachable**: both execution-client paths build the bundle via `engine_types.BlobsBundleFromTransactions`, which always returns a non-nil `*BlobsBundle` (empty slices for a 0-blob block) and only returns `nil` alongside an `error` — and the caller returns on `err != nil` / `payload == nil` before any deref. So no defensive guard is added (it would be dead code for an unreachable state).