### PR TITLE
.github/actions: drop flaky Microsoft/Chrome apt sources in setup-erigon

### DIFF
--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -250,8 +250,8 @@ runs:
       # updating (we never install from them); the Ubuntu archive retries on blips.
       # Can't suppress "Reading database..." from apt-get install. Also it's very slow...
       run: |
-        sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
-          /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
+        sudo grep -rlZE 'dl\.google\.com|packages\.microsoft\.com' \
+          /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f || true
         sudo apt-get update -qq -o Acquire::Retries=3 \
           && sudo apt-get install -qq -y build-essential 2>/dev/null
 

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -243,16 +243,16 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       shell: bash
       # erigon only needs build-essential (gcc/make). The hosted runner image
-      # ships extra third-party apt repos (Google Chrome, Microsoft, …) that are
-      # periodically mid-mirror-sync and answer with a Packages.gz size mismatch,
-      # which fails `apt-get update` and so the whole job — the recurring
-      # "dl.google.com/linux/chrome-stable … File has unexpected size" flake.
-      # Drop those repos before updating (we never install from them) and let the
-      # remaining Ubuntu archive retry on transient blips.
+      # ships extra third-party apt repos (Google Chrome, Microsoft, azure-cli)
+      # that periodically break `apt-get update` — a mid-mirror-sync Packages.gz
+      # size mismatch, or a 403 "repository is no longer signed" — and so fail the
+      # whole job. Drop those repos before updating (we never install from them)
+      # and let the remaining Ubuntu archive retry on transient blips.
       # Can't suppress "Reading database..." from apt-get install. Also it's very slow...
       run: |
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                   /etc/apt/sources.list.d/microsoft-prod.list || true
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.* \
+                   /etc/apt/sources.list.d/microsoft-prod.* \
+                   /etc/apt/sources.list.d/azure-cli.* || true
         sudo apt-get update -qq -o Acquire::Retries=3 \
           && sudo apt-get install -qq -y build-essential 2>/dev/null
 

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -243,16 +243,15 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       shell: bash
       # erigon only needs build-essential (gcc/make). The hosted runner image
-      # ships extra third-party apt repos (Google Chrome, Microsoft, azure-cli)
-      # that periodically break `apt-get update` — a mid-mirror-sync Packages.gz
-      # size mismatch, or a 403 "repository is no longer signed" — and so fail the
-      # whole job. Drop those repos before updating (we never install from them)
-      # and let the remaining Ubuntu archive retry on transient blips.
+      # ships third-party apt repos (Google Chrome, Microsoft/azure-cli) whose
+      # CDNs intermittently break `apt-get update` — a Packages.gz size mismatch
+      # mid-mirror-sync, or a 403 "no longer signed" on the azure-cli repo —
+      # failing the whole job. Drop every source pointing at those CDNs before
+      # updating (we never install from them); the Ubuntu archive retries on blips.
       # Can't suppress "Reading database..." from apt-get install. Also it's very slow...
       run: |
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.* \
-                   /etc/apt/sources.list.d/microsoft-prod.* \
-                   /etc/apt/sources.list.d/azure-cli.* || true
+        sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+          /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
         sudo apt-get update -qq -o Acquire::Retries=3 \
           && sudo apt-get install -qq -y build-essential 2>/dev/null
 


### PR DESCRIPTION
## Problem

`setup-erigon`'s Linux dependency step removed a couple of apt sources by name before `apt-get update`, so the runner image's `azure-cli` source slipped through and 403'd ("repository is no longer signed"), failing the job with **exit code 100 before any tests run** ([run 28160342365](https://github.com/erigontech/erigon/actions/runs/28160342365/job/83398965668)). The action is shared by PR, merge-queue and cache-warming jobs, so this can also fast-cancel and dequeue PRs.

## Fix

Before `apt-get update`, drop every `sources.list.d/` entry that points at the flaky third-party CDNs:

```yaml
sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
  /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
```

Matching by CDN host covers any such source (azure-cli, microsoft-prod, microsoft-edge, …) regardless of filename or `.list` vs deb822 `.sources` format. erigon only needs `build-essential` and never installs from these repos, so removing them is safe.