### PR TITLE
execution: remove code duplication from gasCreate/gasCreate2 for EIP-8037

### DIFF
--- a/execution/vm/eips.go
+++ b/execution/vm/eips.go
@@ -387,7 +387,5 @@ func enable7843(jt *JumpTable) {
 // enable8037 applies EIP-8037 (State Creation Gas Cost Increase)
 func enable8037(jt *JumpTable) {
 	jt[CREATE].constantGas = params.CreateGasEIP8037
-	jt[CREATE].dynamicGas = gasCreateEip8037
 	jt[CREATE2].constantGas = params.Create2GasEIP8037
-	jt[CREATE2].dynamicGas = gasCreate2Eip8037
 }

--- a/execution/vm/errors.go
+++ b/execution/vm/errors.go
@@ -174,6 +174,11 @@ const (
 
 func vmErrorCodeFromErr(err error) int {
 	switch {
+	case errors.Is(err, ErrWriteProtection):
+		// Checked before ErrOutOfGas: the interpreter wraps a static-context
+		// write protection from a dynamic gas function as "%w: %w" over ErrOutOfGas,
+		// so both match and write protection must take precedence.
+		return VMErrorCodeWriteProtection
 	case errors.Is(err, ErrOutOfGas):
 		return VMErrorCodeOutOfGas
 	case errors.Is(err, ErrCodeStoreOutOfGas):
@@ -190,8 +195,6 @@ func vmErrorCodeFromErr(err error) int {
 		return VMErrorCodeMaxCodeSizeExceeded
 	case errors.Is(err, ErrInvalidJump):
 		return VMErrorCodeInvalidJump
-	case errors.Is(err, ErrWriteProtection):
-		return VMErrorCodeWriteProtection
 	case errors.Is(err, ErrReturnDataOutOfBounds):
 		return VMErrorCodeReturnDataOutOfBounds
 	case errors.Is(err, ErrGasUintOverflow):

--- a/execution/vm/errors_test.go
+++ b/execution/vm/errors_test.go
@@ -1,0 +1,18 @@
+package vm
+
+import (
+	"fmt"
+	"testing"
+)
+
+// The interpreter wraps a dynamic-gas error that is not ErrOutOfGas as
+// fmt.Errorf("%w: %w", ErrOutOfGas, err). For static-context CREATE / CREATE2 /
+// SSTORE the underlying error is ErrWriteProtection, so the classification must
+// report write protection rather than the out-of-gas wrapper.
+func TestVMErrorCodeWriteProtectionWrappedAsOutOfGas(t *testing.T) {
+	t.Parallel()
+	wrapped := fmt.Errorf("%w: %w", ErrOutOfGas, ErrWriteProtection)
+	if got := vmErrorCodeFromErr(wrapped); got != VMErrorCodeWriteProtection {
+		t.Fatalf("vmErrorCodeFromErr(write protection wrapped as out-of-gas) = %d, want VMErrorCodeWriteProtection (%d)", got, VMErrorCodeWriteProtection)
+	}
+}

--- a/execution/vm/gas_table.go
+++ b/execution/vm/gas_table.go
@@ -292,10 +292,20 @@ var (
 	gasMLoad   = pureMemoryGascost
 	gasMStore8 = pureMemoryGascost
 	gasMStore  = pureMemoryGascost
-	gasCreate  = pureMemoryGascost
 )
 
-func gasCreate2(_ *EVM, callContext *CallContext, availableGas mdgas.MdGas, memorySize uint64) (mdgas.MdGas, error) {
+func gasCreate(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, memorySize uint64) (mdgas.MdGas, error) {
+	if evm.readOnly {
+		return mdgas.MdGas{}, ErrWriteProtection
+	}
+	g, err := memoryGasCost(callContext, memorySize)
+	return mdgas.MdGas{Regular: g}, err
+}
+
+func gasCreate2(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, memorySize uint64) (mdgas.MdGas, error) {
+	if evm.readOnly {
+		return mdgas.MdGas{}, ErrWriteProtection
+	}
 	gas, err := memoryGasCost(callContext, memorySize)
 	if err != nil {
 		return mdgas.MdGas{}, err
@@ -317,6 +327,9 @@ func gasCreate2(_ *EVM, callContext *CallContext, availableGas mdgas.MdGas, memo
 }
 
 func gasCreateEip3860(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, memorySize uint64) (gas mdgas.MdGas, err error) {
+	if evm.readOnly {
+		return mdgas.MdGas{}, ErrWriteProtection
+	}
 	gas.Regular, err = memoryGasCost(callContext, memorySize)
 	if err != nil {
 		return mdgas.MdGas{}, err
@@ -334,11 +347,17 @@ func gasCreateEip3860(evm *EVM, callContext *CallContext, availableGas mdgas.MdG
 	gas.Regular, overflow = math.SafeAdd(gas.Regular, wordGas)
 	if overflow {
 		return mdgas.MdGas{}, ErrGasUintOverflow
+	}
+	if evm.ChainRules().IsAmsterdam {
+		gas.State = params.StateGasNewAccount
 	}
 	return gas, nil
 }
 
 func gasCreate2Eip3860(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, memorySize uint64) (gas mdgas.MdGas, err error) {
+	if evm.readOnly {
+		return mdgas.MdGas{}, ErrWriteProtection
+	}
 	gas.Regular, err = memoryGasCost(callContext, memorySize)
 	if err != nil {
 		return mdgas.MdGas{}, err
@@ -357,53 +376,8 @@ func gasCreate2Eip3860(evm *EVM, callContext *CallContext, availableGas mdgas.Md
 	if overflow {
 		return mdgas.MdGas{}, ErrGasUintOverflow
 	}
-	return gas, nil
-}
-
-// gasCreateEip8037 is the dynamic gas function for CREATE under EIP-8037.
-// State gas is charged in execCreate after the static-context check (per execution-specs#2608).
-func gasCreateEip8037(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, memorySize uint64) (gas mdgas.MdGas, err error) {
-	gas.Regular, err = memoryGasCost(callContext, memorySize)
-	if err != nil {
-		return mdgas.MdGas{}, err
-	}
-	size, overflow := callContext.Stack.Back(2).Uint64WithOverflow()
-	if overflow {
-		return mdgas.MdGas{}, ErrGasUintOverflow
-	}
-	if err := CheckMaxInitCodeSize(size, evm.ChainRules().IsShanghai, evm.ChainRules().IsAmsterdam); err != nil {
-		return mdgas.MdGas{}, err
-	}
-	numWords := ToWordSize(size)
-	// Since size <= params.MaxInitCodeSizeAmsterdam, this multiplication cannot overflow
-	wordGas := params.InitCodeWordGas * numWords
-	gas.Regular, overflow = math.SafeAdd(gas.Regular, wordGas)
-	if overflow {
-		return mdgas.MdGas{}, ErrGasUintOverflow
-	}
-	return gas, nil
-}
-
-// gasCreate2Eip8037 is the dynamic gas function for CREATE2 under EIP-8037.
-// State gas is charged in execCreate after the static-context check (per execution-specs#2608).
-func gasCreate2Eip8037(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, memorySize uint64) (gas mdgas.MdGas, err error) {
-	gas.Regular, err = memoryGasCost(callContext, memorySize)
-	if err != nil {
-		return mdgas.MdGas{}, err
-	}
-	size, overflow := callContext.Stack.Back(2).Uint64WithOverflow()
-	if overflow {
-		return mdgas.MdGas{}, ErrGasUintOverflow
-	}
-	if err := CheckMaxInitCodeSize(size, evm.ChainRules().IsShanghai, evm.ChainRules().IsAmsterdam); err != nil {
-		return mdgas.MdGas{}, err
-	}
-	numWords := ToWordSize(size)
-	// Since size <= params.MaxInitCodeSizeAmsterdam, this multiplication cannot overflow
-	wordGas := (params.InitCodeWordGas + params.Keccak256WordGas) * numWords
-	gas.Regular, overflow = math.SafeAdd(gas.Regular, wordGas)
-	if overflow {
-		return mdgas.MdGas{}, ErrGasUintOverflow
+	if evm.ChainRules().IsAmsterdam {
+		gas.State = params.StateGasNewAccount
 	}
 	return gas, nil
 }

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -29,7 +29,6 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
-	"github.com/erigontech/erigon/execution/protocol/mdgas"
 	"github.com/erigontech/erigon/execution/protocol/misc"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/tracing"
@@ -984,9 +983,6 @@ func opSwap16(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 }
 
 func opCreate(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
-	if evm.readOnly {
-		return pc, nil, ErrWriteProtection
-	}
 	var (
 		value  = scope.Stack.pop()
 		offset = scope.Stack.pop()
@@ -1009,9 +1005,6 @@ func stCreate(_ uint64, scope *CallContext) string {
 }
 
 func opCreate2(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
-	if evm.readOnly {
-		return pc, nil, ErrWriteProtection
-	}
 	var (
 		endowment    = scope.Stack.pop()
 		offset, size = scope.Stack.pop(), scope.Stack.pop()
@@ -1023,15 +1016,6 @@ func opCreate2(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) 
 
 // execCreate is the shared implementation for opCreate (salt == nil) and opCreate2 (salt != nil).
 func execCreate(pc uint64, evm *EVM, scope *CallContext, value uint256.Int, input []byte, salt *uint256.Int) (uint64, []byte, error) {
-	if evm.ChainRules().IsAmsterdam {
-		// EIP-8037: charge state gas for account creation after the static-context
-		// check so that it is not consumed on early failures where no state is
-		// created (per execution-specs#2608).
-		if !scope.useMdGas(params.StateGasNewAccount, mdgas.StateGas, evm.Config().Tracer, tracing.GasChangeIgnored) {
-			return pc, nil, ErrOutOfGas
-		}
-	}
-
 	gas := scope.Gas()
 	if evm.ChainRules().IsTangerineWhistle {
 		gas.Regular -= gas.Regular / 64

--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -504,7 +504,7 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 			dynamicCost, err = operation.dynamicGas(evm, callContext, callContext.Gas(), memorySize)
 			if err != nil {
 				if !errors.Is(err, ErrOutOfGas) {
-					err = fmt.Errorf("%w: %v", ErrOutOfGas, err)
+					err = fmt.Errorf("%w: %w", ErrOutOfGas, err)
 				}
 				return nil, callContext.Gas(), mdgas.MdGasUsage{}, err
 			}


### PR DESCRIPTION
## Why

- **#20290** charges the EIP-8037 account-creation state gas inside `opCreate`/`opCreate2`.
  That charge belongs in the dynamic gas function, not the instruction handler.
- **#20038** added `gasCreateEip8037` / `gasCreate2Eip8037`, and after #20290 these had become
  exact duplicates of `gasCreateEip3860` / `gasCreate2Eip3860`. We remove them — rather than keep
  yet more per-EIP gas functions — because of planned work to condense the EIP variants of the
  execution/gas functions into single functions
  ([#15901](https://github.com/erigontech/erigon/issues/15901), "evm: attempt to condense eip
  variants of executionFunc-s and gasFunc-s"); adding parallel per-EIP variants moves against that
  consolidation.

## What

- Move the static-context (`readOnly`) check to be the first thing in the CREATE/CREATE2
  dynamic gas functions and remove it from `opCreate`/`opCreate2`, so the state gas can be
  charged in the gas function while still being skipped in a static context.
  (`gasCreate` was a `pureMemoryGascost` alias, so it becomes a real function to host the
  check; the check stays in all CREATE/CREATE2 gas functions to keep write-protection across
  every fork that has STATICCALL.)
- Charge the EIP-8037 state gas back in `gasCreateEip3860` / `gasCreate2Eip3860` behind a
  `rules.IsAmsterdam` guard, and delete `gasCreateEip8037` / `gasCreate2Eip8037` (`enable8037`
  now sets only `constantGas`).
