### PR TITLE
ChangeLog: reformat version headers and update 3.5.0 release notes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,3 @@
-# Changelog
-
 # Erigon v3.6.0 — Upstream Underbelly — TBD
 
 ### Breaking Changes
@@ -93,12 +91,10 @@ Aligns Erigon with the execution-apis specification ([ethereum/execution-apis#76
 
 Both the key and its default changed: `disable*` → `enable*`, and memory and return data are now **excluded** unless explicitly enabled — matching the spec and Geth.
 
-**Migration:**
+**Migration:** memory and return data are now excluded by default. To include them, add the new opt-in key (omit it to keep the default):
 
-```jsonc
-{ "disableMemory": true }  // before: opt out of memory (on by default)
-{ "enableMemory": true }   // after:  opt in to memory (off by default)
-```
+- Memory: `{ "enableMemory": true }`
+- Return data: `{ "enableReturnData": true }`
 
 Affected RPC methods: `debug_traceTransaction`, `debug_traceBlockByHash`, `debug_traceBlockByNumber`, `debug_traceCall`.
 
@@ -551,7 +547,7 @@ Gnosis hardfork support.
 
 ---
 
-# Erigon v3.3.0 — 2025-11-27
+# Erigon v3.3.0 — Rocky Romp — 2025-11-27
 
 ### Added
 
@@ -689,7 +685,3 @@ test nets (#17197):
 - RPC: impl admin_RemovePeer (#16292) by @lupin012
 
 **Full Changelog**: https://github.com/erigontech/erigon/compare/v3.1.0...v3.2.0
- 
------
-
-File following Keep a Changelog spec: https://keepachangelog.com/en/1.1.0/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -45,11 +45,13 @@ Full mode now retains state and block data for the last `262,144` blocks (~36.4 
 | State history retention | last 100,000 blocks | last 262,144 blocks |
 | Block data retention | pre-merge pruned, all post-merge kept (EIP-4444) | last 262,144 blocks |
 
-`--prune.mode=blocks` keeps the same shape (all block data retained) but its `History` retention also bumps from 100,000 to 262,144 blocks. `--prune.mode=minimal` is unchanged — both `Blocks` and `History` retain the 100,000-block window, deliberately sub-EIP-8252 for disk-constrained operators. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
+`--prune.mode=blocks` keeps the same shape as before (all block data retained) but its state history retention also bumps from 100,000 to 262,144 blocks. `--prune.mode=minimal` is unchanged — both block and state history retain the 100,000-block window, deliberately sub-EIP-8252 for disk-constrained operators. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
 
 **Migration:** existing datadirs upgrade automatically and silently. To keep the old "retain all post-merge block data" behavior, switch to `--prune.mode=blocks`; the auto-upgrade is reversible with `--prune.distance.blocks=18446744073709551615`.
 
-Note: physical deletion of frozen `.seg` files is gated by [#21306](https://github.com/erigontech/erigon/issues/21306) — existing on-disk segments persist until it lands, though the new cutoff is already recorded at the config level.
+Note: physical deletion of frozen snapshot files is not implemented yet (see [#21306](https://github.com/erigontech/erigon/issues/21306)), so existing on-disk historical blocks persist for now, though the new cutoff is already recorded at the config level.
+
+_In practice, this means only freshly synced `full` nodes will have a reduced disk footprint._
 
 ---
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -179,6 +179,7 @@ The optional Silkworm C++ execution-backend integration and its `--silkworm.*` f
 
 - Unified Engine API client for standalone mode (#20035) — by @mh0lt
 - Fork-choice and ENR-stability fixes — recovery from a post-GLOAS fork-choice stall and a persistent node key for stable ENR across restarts (#21228, #21276) — by @domiwei
+- Block production: give the EL builder a build window before stopping it, fixing near-empty proposed blocks (~0–2% gas) on otherwise-healthy validators (#21990) — by @lystopad
 
 #### Storage & Performance
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.6.0] 
+# Erigon v3.6.0 — Upstream Underbelly — TBD
 
 ### Breaking Changes
 
@@ -20,7 +20,7 @@ Aligns Erigon with the `eth_simulateV1` error code specification ([NethermindEth
 
 ---
 
-## [3.5.0] "Tidal Tails" – TBD
+# Erigon v3.5.0 — Tidal Tails — 2026-06-26
 
 Erigon 3.5.0 is a major release headlined by **parallel block execution becoming the default** and **initial support for Ethereum's upcoming Glamsterdam hardfork**. It is a drop-in upgrade for 3.4.x users — no re-sync required; existing datadirs upgrade their prune configuration automatically (see Breaking Changes).
 
@@ -189,7 +189,7 @@ The optional Silkworm C++ execution-backend integration and its `--silkworm.*` f
 
 ---
 
-## [3.4.4] "Splashing Saga" – 2026-06-18
+# Erigon v3.4.4 — Splashing Saga — 2026-06-18
 
 v3.4.4 is a bugfix release recommended for all users.
 
@@ -202,7 +202,7 @@ v3.4.4 is a bugfix release recommended for all users.
 
 ---
 
-## [3.4.3] "Splashing Saga" – 2026-06-02
+# Erigon v3.4.3 — Splashing Saga — 2026-06-02
 
 v3.4.3 is a bugfix release recommended for all users.
 
@@ -231,7 +231,7 @@ v3.4.3 is a bugfix release recommended for all users.
 
 ---
 
-## [3.4.2] "Splashing Saga" – 2026-05-22
+# Erigon v3.4.2 — Splashing Saga — 2026-05-22
 
 v3.4.2 is a bugfix release recommended for all users.
 
@@ -254,7 +254,7 @@ v3.4.2 is a bugfix release recommended for all users.
 
 ---
 
-## [3.4.1] "Splashing Saga" – 2026-05-11
+# Erigon v3.4.1 — Splashing Saga — 2026-05-11
 
 **Bugfixes**
 
@@ -264,7 +264,7 @@ v3.4.2 is a bugfix release recommended for all users.
 
 ---
 
-## [3.4.0] "Splashing Saga" – 2026-04-28
+# Erigon v3.4.0 — Splashing Saga — 2026-04-28
 
 Erigon 3.4.0 is a major update for node operators and validators, focused on stability, performance, and
 efficiency at ChainTip. It is a drop-in upgrade for 3.3.x users — no data migration or re-sync required.
@@ -388,7 +388,7 @@ efficiency at ChainTip. It is a drop-in upgrade for 3.3.x users — no data migr
 
 ---
 
-## [3.3.10] "Rocky Romp" – 2026-03-27
+# Erigon v3.3.10 — Rocky Romp — 2026-03-27
 
 This release schedules Fusaka on **Gnosis Chain mainnet** at **Tue 14 April 2026, 12:06:20 UTC** and
 thus is **mandatory for all Gnosis users**. It is also recommended for all users in general.
@@ -407,7 +407,7 @@ thus is **mandatory for all Gnosis users**. It is also recommended for all users
 
 ---
 
-## [3.3.9] "Rocky Romp" – 2026-03-09
+# Erigon v3.3.9 — Rocky Romp — 2026-03-09
 
 This release schedules Fusaka on Chiado on **Mon 16 March 2026, 09:33:00 UTC** and thus is mandatory
 for all Chiado users.
@@ -425,7 +425,7 @@ for all Chiado users.
 
 ---
 
-## [3.3.8] "Rocky Romp" – 2026-02-20
+# Erigon v3.3.8 — Rocky Romp — 2026-02-20
 
 **Changes**
 
@@ -452,7 +452,7 @@ for all Chiado users.
 
 ---
 
-## [3.3.7] "Rocky Romp" – 2026-01-30
+# Erigon v3.3.7 — Rocky Romp — 2026-01-30
 
 P2P stability. Prune performance.
 
@@ -470,7 +470,7 @@ P2P stability. Prune performance.
 
 ---
 
-## [3.3.4] "Rocky Romp" – 2026-01-23
+# Erigon v3.3.4 — Rocky Romp — 2026-01-23
 
 v3.3.4 is a bugfix release recommended for all users.
 
@@ -487,7 +487,7 @@ v3.3.4 is a bugfix release recommended for all users.
 
 ---
 
-## [3.3.3] "Rocky Romp" – 2026-01-14
+# Erigon v3.3.3 — Rocky Romp — 2026-01-14
 
 v3.3.3 is a bugfix release recommended for all users.
 
@@ -507,7 +507,7 @@ v3.3.3 is a bugfix release recommended for all users.
 
 ---
 
-## [3.3.2] "Rocky Romp" – 2025-12-13
+# Erigon v3.3.2 — Rocky Romp — 2025-12-13
 
 Gnosis hardfork support.
 
@@ -523,7 +523,7 @@ Gnosis hardfork support.
 
 ---
 
-## [3.3.1] "Rocky Romp" – 2025-12-07
+# Erigon v3.3.1 — Rocky Romp — 2025-12-07
 
 - We have new Docs and HelpCenter: https://docs.erigon.tech/
 - Support of historical `eth_getProof` (https://github.com/erigontech/erigon/issues/12984). It requires
@@ -549,7 +549,7 @@ Gnosis hardfork support.
 
 ---
 
-## [3.3.0] – 2025-11-27
+# Erigon v3.3.0 — 2025-11-27
 
 ### Added
 
@@ -606,7 +606,7 @@ Gnosis hardfork support.
 
 ---
 
-## [3.2.3] "Quirky Quests" – 2025-11-25
+# Erigon v3.2.3 — Quirky Quests — 2025-11-25
 
 **Changes**
 
@@ -616,7 +616,7 @@ Gnosis hardfork support.
 
 ---
 
-## [3.2.2] "Quirky Quests" – 2025-11-03
+# Erigon v3.2.2 — Quirky Quests — 2025-11-03
 
 v3.2.2 schedules Fusaka on Ethereum mainnet on December 3, 2025 at 09:49:11pm UTC. Thus it is a mandatory update for all Ethereum mainnet users.
 
@@ -629,7 +629,7 @@ v3.2.2 schedules Fusaka on Ethereum mainnet on December 3, 2025 at 09:49:11pm UT
 
 ---
 
-## [3.2.1] "Quirky Quests" – 2025-10-20
+# Erigon v3.2.1 — Quirky Quests — 2025-10-20
 
 v3.2.1 is a bugfix release recommended for all users, especially validators.
 
@@ -650,7 +650,7 @@ v3.2.1 is a bugfix release recommended for all users, especially validators.
 
 ---
 
-## [3.2.0] "Quirky Quests" – 2025-10-02
+# Erigon v3.2.0 — Quirky Quests — 2025-10-02
 
 Erigon 3.2.0 has a complete implementation of [Fusaka](https://eips.ethereum.org/EIPS/eip-7607) and schedules it on the
 test nets (#17197):

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -138,7 +138,6 @@ The optional Silkworm C++ execution-backend integration and its `--silkworm.*` f
 
 #### CLI & Operations
 
-- `--snap.p2p-manifest` (experimental, opt-in): decentralized snapshot distribution over P2P — peers advertise their `chain.toml` manifest via ENR, instead of the centralized `preverified.toml` (#20526, #20615) — by @mh0lt
 - `--exec.no-prune` (disable all DB pruning), `--exec.serial` (force single-threaded execution), and `--exec.*` executor-tuning flags (#20915, #20853, #20797) — by @mh0lt
 - `seg du` (snapshot disk-usage analysis, #20104) and `seg rm-blocks` (remove latest block snapshots, #20554) — by @awskii, @sudeepdino008
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,7 +27,7 @@ Erigon 3.5.0 is a major release headlined by **parallel block execution becoming
 ### Key Features
 
 - **Parallel block execution, on by default.** Erigon now executes EVM transactions across multiple cores by default, using the Block-STM (software transactional memory) design pioneered by Aptos: transactions run optimistically in parallel and are re-validated against a multi-version state, re-executing only on conflict (#21591 by @mh0lt, closes #17630). Revert to serial with `EXEC3_PARALLEL=false` or `--exec.serial`.
-- **Glamsterdam devnet support.** Initial implementation of Ethereum's next hardfork: Block-Level Access Lists (EIP-7928), enshrined Proposer-Builder Separation / "GLOAS" (EIP-7732) in Caplin, gas repricings (EIP-8037, EIP-7976, EIP-7981), larger contracts (EIP-7954), transfer logs (EIP-7708), and the `eth/71` Block Access List wire protocol (EIP-8159). **Devnet/testing only — not scheduled on mainnet or any public testnet.**
+- **Glamsterdam devnet support.** Initial implementation of Ethereum's next hardfork: Block-Level Access Lists (EIP-7928), enshrined Proposer-Builder Separation / "Gloas" (EIP-7732) in Caplin, gas repricings (EIP-8037, EIP-7976, EIP-7981), larger contracts (EIP-7954), transfer logs (EIP-7708), and the `eth/71` Block Access List wire protocol (EIP-8159). **Devnet/testing only — not scheduled on mainnet or any public testnet.**
 - **`debug_executionWitness`.** Stateless execution-witness generation (EIP-7928/8025) with reth-compatible output, for zkEVM and stateless clients (#20205 by @antonis19, #21629 by @awskii).
 - **More aggressive history pruning by default.** `--prune.mode=full` now follows the EIP-8252 reorg-retention window (~36 days / 262,144 blocks) — see Breaking Changes.
 - **GraphQL API revival.** Broad resolver coverage restored — queries, logs, `call`, `sendRawTransaction`, `estimateGas`, `gasPrice`, storage, and EIP-4844 fields.
@@ -45,7 +45,7 @@ Full mode now retains state and block data for the last `262,144` blocks (~36.4 
 | State history retention | last 100,000 blocks | last 262,144 blocks |
 | Block data retention | pre-merge pruned, all post-merge kept (EIP-4444) | last 262,144 blocks |
 
-`--prune.mode=blocks` keeps the same shape as before (all block data retained) but its state history retention also bumps from 100,000 to 262,144 blocks. `--prune.mode=minimal` is unchanged — both block and state history retain the 100,000-block window, deliberately sub-EIP-8252 for disk-constrained operators. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
+`--prune.mode=blocks` keeps the same shape as before (all block data retained), but its state history retention also bumps from 100,000 to 262,144 blocks. `--prune.mode=minimal` is unchanged — both block and state history retain the 100,000-block window, deliberately sub-EIP-8252 for disk-constrained operators. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
 
 **Migration:** existing datadirs upgrade automatically and silently. To keep the old "retain all post-merge block data" behavior, switch to `--prune.mode=blocks`; the auto-upgrade is reversible with `--prune.distance.blocks=18446744073709551615`.
 
@@ -121,10 +121,10 @@ The optional Silkworm C++ execution-backend integration and its `--silkworm.*` f
 3.5.0 adds an initial implementation of Ethereum's next hardfork — **Glamsterdam** (consensus-layer "Gloas" + execution-layer "Amsterdam") — for devnet testing and validation. **It is not scheduled on mainnet or any public testnet**, and these code paths are inert on production networks until an activation time is configured.
 
 - **EIP-7928 — Block-Level Access Lists (BAL):** records every account and storage slot a block touches, enabling deterministic parallel validation. Full builder, validator, and strict-validation support (#19627, #19656, #20602, #20776), plus the `eth_getBlockAccessList` RPC method (#19929) — by @mh0lt, @yperbasis, @Sahil-4555
-- **EIP-7732 — Enshrined Proposer-Builder Separation (ePBS / "GLOAS"):** implemented in Caplin — execution-payload envelope, PTC, and builder payments (#18956) — with follow-up audit and fork-choice fixes (#21248, #21228) — by @domiwei
+- **EIP-7732 — Enshrined Proposer-Builder Separation (ePBS / "Gloas"):** implemented in Caplin — execution-payload envelope, PTC, and builder payments (#18956) — with follow-up audit and fork-choice fixes (#21248, #21228) — by @domiwei
 - **Gas repricings:** EIP-8037 State Creation Gas Cost Increase (#19596), EIP-7976 calldata floor cost (#20613), EIP-7981 access-list cost (#20671) — by @taratorio
 - **EIP-7954 — Increase Maximum Contract Size** (#19624) — by @yperbasis
-- **EIP-7843 — slot-number system contract**, wired into Caplin block production and `engine_forkchoiceUpdatedV4` (#20175) — by @yperbasis
+- **EIP-7843 — slot-number opcode (`SLOTNUM`)**, wired into Caplin block production and `engine_forkchoiceUpdatedV4` (#20175) — by @yperbasis
 - **Networking:** `eth/71` Block Access List exchange (EIP-8159, #20793, #20794, #20795) — by @mh0lt
 
 ### Added
@@ -169,7 +169,7 @@ The optional Silkworm C++ execution-backend integration and its `--silkworm.*` f
 #### Caplin (Consensus Layer)
 
 - Unified Engine API client for standalone mode (#20035) — by @mh0lt
-- Fork-choice and ENR-stability fixes — recovery from a post-GLOAS fork-choice stall and a persistent node key for stable ENR across restarts (#21228, #21276) — by @domiwei
+- Fork-choice and ENR-stability fixes — recovery from a post-Gloas fork-choice stall and a persistent node key for stable ENR across restarts (#21228, #21276) — by @domiwei
 - Block production: give the EL builder a build window before stopping it, fixing near-empty proposed blocks (~0–2% gas) on otherwise-healthy validators (#21990) — by @lystopad
 
 #### Storage & Performance

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,13 +43,15 @@ Full mode now retains state and block data for the last `262,144` blocks (~36.4 
 | State history retention | last 100,000 blocks | last 262,144 blocks |
 | Block data retention | pre-merge pruned, all post-merge kept (EIP-4444) | last 262,144 blocks |
 
-`--prune.mode=blocks` keeps the same shape as before (all block data retained), but its state history retention also bumps from 100,000 to 262,144 blocks. `--prune.mode=minimal` is unchanged — both block and state history retain the 100,000-block window, deliberately sub-EIP-8252 for disk-constrained operators. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
-
 **Migration:** existing datadirs upgrade automatically and silently. To keep the old "retain all post-merge block data" behavior, set `--prune.distance.blocks=18446744073709551615`.
 
 Note: physical deletion of frozen snapshot files is not implemented yet (see [#21306](https://github.com/erigontech/erigon/issues/21306)), so existing on-disk historical blocks persist for now, though the new cutoff is already recorded at the config level.
 
 _In practice, this means only freshly synced `full` nodes will have a reduced disk footprint._
+
+#### `--prune.mode=blocks`: state history retention bumped to 262,144 blocks
+
+`--prune.mode=blocks` keeps the same shape as before (all block data retained), but its state history retention also bumps from 100,000 to 262,144 blocks. `--prune.mode=minimal` is unchanged — both block and state history retain the 100,000-block window, deliberately sub-EIP-8252 for disk-constrained operators. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
 
 ---
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -45,7 +45,7 @@ Full mode now retains state and block data for the last `262,144` blocks (~36.4 
 
 `--prune.mode=blocks` keeps the same shape as before (all block data retained), but its state history retention also bumps from 100,000 to 262,144 blocks. `--prune.mode=minimal` is unchanged — both block and state history retain the 100,000-block window, deliberately sub-EIP-8252 for disk-constrained operators. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
 
-**Migration:** existing datadirs upgrade automatically and silently. To keep the old "retain all post-merge block data" behavior, switch to `--prune.mode=blocks`; the auto-upgrade is reversible with `--prune.distance.blocks=18446744073709551615`.
+**Migration:** existing datadirs upgrade automatically and silently. To keep the old "retain all post-merge block data" behavior, set `--prune.distance.blocks=18446744073709551615`.
 
 Note: physical deletion of frozen snapshot files is not implemented yet (see [#21306](https://github.com/erigontech/erigon/issues/21306)), so existing on-disk historical blocks persist for now, though the new cutoff is already recorded at the config level.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -34,7 +34,7 @@ Erigon 3.5.0 is a major release headlined by **parallel block execution becoming
 
 #### `--prune.mode=full`: EIP-8252 retention window replaces pre-merge history-expiry
 
-Full mode now retains state and block data for the last `262,144` blocks (~36.4 days), matching [EIP-8252](https://github.com/ethereum/EIPs/pull/11601)'s `REORG_RETENTION_WINDOW`. Previously full mode pruned only pre-merge block data ([EIP-4444](https://eips.ethereum.org/EIPS/eip-4444) history-expiry) and kept the last 100,000 blocks of state history.
+Full mode now retains state and block data for the last `262,144` blocks (~36.4 days), matching [EIP-8252](https://github.com/ethereum/EIPs/pull/11601)'s `REORG_RETENTION_WINDOW` ([#21342](https://github.com/erigontech/erigon/pull/21342)). Previously full mode pruned only pre-merge block data ([EIP-4444](https://eips.ethereum.org/EIPS/eip-4444) history-expiry) and kept the last 100,000 blocks of state history.
 
 **What changed:**
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,7 +26,7 @@ Erigon 3.5.0 is a major release headlined by **parallel block execution becoming
 
 ### Key Features
 
-- **Parallel block execution, on by default.** Erigon now executes EVM transactions across multiple cores by default, using the Block-STM (software transactional memory) design pioneered by Aptos: transactions run optimistically in parallel and are re-validated against a multi-version state, re-executing only on conflict (#21591 by @mh0lt, closes #17630). Revert to the serial path with `EXEC3_PARALLEL=false` or `--exec.serial`.
+- **Parallel block execution, on by default.** Erigon now executes EVM transactions across multiple cores by default, using the Block-STM (software transactional memory) design pioneered by Aptos: transactions run optimistically in parallel and are re-validated against a multi-version state, re-executing only on conflict (#21591 by @mh0lt, closes #17630). Revert to serial with `EXEC3_PARALLEL=false` or `--exec.serial`.
 - **Glamsterdam devnet support.** Initial implementation of Ethereum's next hardfork: Block-Level Access Lists (EIP-7928), enshrined Proposer-Builder Separation / "GLOAS" (EIP-7732) in Caplin, gas repricings (EIP-8037, EIP-7976, EIP-7981), larger contracts (EIP-7954), transfer logs (EIP-7708), and the `eth/71` Block Access List wire protocol (EIP-8159). **Devnet/testing only — not scheduled on mainnet or any public testnet.**
 - **`debug_executionWitness`.** Stateless execution-witness generation (EIP-7928/8025) with reth-compatible output, for zkEVM and stateless clients (#20205 by @antonis19, #21629 by @awskii).
 - **More aggressive history pruning by default.** `--prune.mode=full` now follows the EIP-8252 reorg-retention window (~36 days / 262,144 blocks) — see Breaking Changes.
@@ -36,7 +36,7 @@ Erigon 3.5.0 is a major release headlined by **parallel block execution becoming
 
 #### `--prune.mode=full`: EIP-8252 retention window replaces pre-merge history-expiry
 
-Full mode now retains state and block data for the last `262,144` blocks (~36.4 days), matching [EIP-8252](https://github.com/ethereum/EIPs/pull/11601)'s `REORG_RETENTION_WINDOW` — the inactivity-leak-bounded non-finality window across which an EL must be able to reconstruct state to handle any reorg without external sync. Previously full mode pruned only pre-merge block data ([EIP-4444](https://eips.ethereum.org/EIPS/eip-4444) history-expiry) and kept the last 100,000 blocks of state history.
+Full mode now retains state and block data for the last `262,144` blocks (~36.4 days), matching [EIP-8252](https://github.com/ethereum/EIPs/pull/11601)'s `REORG_RETENTION_WINDOW`. Previously full mode pruned only pre-merge block data ([EIP-4444](https://eips.ethereum.org/EIPS/eip-4444) history-expiry) and kept the last 100,000 blocks of state history.
 
 **What changed:**
 
@@ -47,15 +47,15 @@ Full mode now retains state and block data for the last `262,144` blocks (~36.4 
 
 `--prune.mode=blocks` keeps the same shape (all block data retained) but its `History` retention also bumps from 100,000 to 262,144 blocks. `--prune.mode=minimal` is unchanged — both `Blocks` and `History` retain the 100,000-block window, deliberately sub-EIP-8252 for disk-constrained operators. See [#21342](https://github.com/erigontech/erigon/pull/21342) for details.
 
-**Migration:** existing datadirs upgrade automatically. The prune-config guard now accepts finite distance changes on `History`/`Blocks` in either direction, plus either-direction transitions between a finite Distance and the `KeepPostMergeBlocksPruneMode` chain-history-expiry sentinel on `Blocks` (so the upgrade is silent, and operators can revert with `--prune.distance.blocks=18446744073709551615` even after the auto-upgrade has rewritten the persisted value). Operators who want to keep the old "retain all post-merge block data" behavior can switch to `--prune.mode=blocks` or pass the override flag.
+**Migration:** existing datadirs upgrade automatically and silently. To keep the old "retain all post-merge block data" behavior, switch to `--prune.mode=blocks`; the auto-upgrade is reversible with `--prune.distance.blocks=18446744073709551615`.
 
-Note: physical deletion of frozen `.seg` files is gated by [#21306](https://github.com/erigontech/erigon/issues/21306); existing on-disk segments persist until that lands. The config-level transition is still recorded so the new cutoff takes effect once the deletion path exists.
+Note: physical deletion of frozen `.seg` files is gated by [#21306](https://github.com/erigontech/erigon/issues/21306) — existing on-disk segments persist until it lands, though the new cutoff is already recorded at the config level.
 
 ---
 
 #### Single p2p listener: `--p2p.allowed-ports` removed, all eth versions multiplex on `--port`
 
-Erigon now opens a single TCP listener on `--port` (default 30303) carrying every configured eth protocol version, instead of one listener per protocol on 30303/30304/30305. This fixes a discovery-DHT race that left inbound peers stuck at a fraction of `--maxpeers` for multi-protocol deployments — per-protocol Servers each signed an ENR under the same Node ID, and only the highest-`seq` one survived in the DHT, so peers dialed the wrong listener (#21335).
+Erigon now opens a single TCP listener on `--port` (default 30303) carrying every configured eth protocol version, instead of one listener per protocol on 30303/30304/30305. This fixes a discovery-DHT race that left inbound peers stuck at a fraction of `--maxpeers` for multi-protocol deployments: per-protocol ENRs collided under one Node ID, so only one survived in the DHT and peers dialed the wrong listener (#21335).
 
 **What changed:**
 
@@ -89,24 +89,13 @@ Aligns Erigon with the execution-apis specification ([ethereum/execution-apis#76
 | Memory in trace | `disableMemory` (default: included) | `enableMemory` (default: excluded) |
 | Return data in trace | `disableReturnData` (default: included) | `enableReturnData` (default: excluded) |
 
-The change is **twofold**:
-1. The JSON key is renamed (`disable*` → `enable*`).
-2. The default value is inverted: previously memory and return data were **included** by default (opt-out model); now they are **excluded** by default (opt-in model), matching the spec and Geth.
+Both the key and its default changed: `disable*` → `enable*`, and memory and return data are now **excluded** unless explicitly enabled — matching the spec and Geth.
 
 **Migration:**
 
 ```jsonc
-// Before — disable memory explicitly
-{ "disableMemory": true }
-
-// After — enable memory explicitly
-{ "enableMemory": true }
-
-// Before — memory included by default (no flag needed)
-{}
-
-// After — must opt in
-{ "enableMemory": true }
+{ "disableMemory": true }  // before: opt out of memory (on by default)
+{ "enableMemory": true }   // after:  opt in to memory (off by default)
 ```
 
 Affected RPC methods: `debug_traceTransaction`, `debug_traceBlockByHash`, `debug_traceBlockByNumber`, `debug_traceCall`.


### PR DESCRIPTION
Changelog-only (no code touched; `make lint` N/A).

**Unified release-header format (all versions).** Every release header is now `# Erigon vX.Y.Z — Codename — Date` (em-dash separators), replacing `## [X.Y.Z] "Codename" – Date`. Removes the redundant `# Changelog` title and the "Keep a Changelog" footer; 3.3.0 gets its previously-missing "Rocky Romp" codename.

**3.5.0 finalized.**
- Release date **2026-06-26**.
- Adds the EL builder-window fix (#21990) under *Changed → Caplin (Consensus Layer)*.
- Prune breaking change split into separate `--prune.mode=full` and `--prune.mode=blocks` subsections; the revert instruction points to `--prune.distance.blocks=18446744073709551615` (the keep-post-merge sentinel).
- `debug_trace*` migration uses self-contained inline JSON; EIP-7843 is described as the `SLOTNUM` opcode; plus minor wording/consistency fixes.

**3.6.0 stub.** Codename **Upstream Underbelly**, date TBD.

Follow-up: #22055 (human-readable alias for the prune-distance sentinel).
