### PR TITLE
db/snapshotsync: fix race between concurrent merge and index build

### DIFF
--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -204,7 +204,23 @@ func NewBlockRetire(
 		borDataNotReadyBefore: time.Now(),
 	}
 	r.workers.Store(int32(compressWorkers))
+	cleanupStaleTmpFiles(dirs.Snap, logger)
 	return r
+}
+
+// cleanupStaleTmpFiles removes .tmp index files left by a previous run that
+// was killed before the atomic rename; safe only at startup before concurrent builds.
+func cleanupStaleTmpFiles(snapDir string, logger log.Logger) {
+	tmpFiles, err := snaptype.TmpFiles(snapDir)
+	if err != nil {
+		logger.Warn("[snapshots] cleanup stale tmp files", "err", err)
+		return
+	}
+	for _, f := range tmpFiles {
+		if err := dir2.RemoveFile(f); err != nil {
+			logger.Warn("[snapshots] remove stale tmp file", "file", f, "err", err)
+		}
+	}
 }
 
 func (br *BlockRetire) SetWorkers(workers int) { br.workers.Store(int32(workers)) }

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -1394,16 +1394,6 @@ func (s *RoSnapshots) RemoveOverlaps(onDelete func(l []string) error) error {
 	}
 
 	removeOldFiles(toRemove)
-
-	// remove .tmp files
-	//TODO: it may remove Caplin's useful .tmp files - re-think. Keep it here for backward-compatibility for now.
-	tmpFiles, err := snaptype.TmpFiles(s.dir)
-	if err != nil {
-		return err
-	}
-	for _, f := range tmpFiles {
-		_ = dir.RemoveFile(f)
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Root cause

PR #21526 moved the block-snapshot merge goroutine off the shared semaphore so it can run concurrently with the next retirement cycle. The retirement cycle (`DumpBlocks`) calls `recsplit.Build()`, which creates a `.idx.*.tmp` file in the snapshot directory for an atomic temp-then-rename. Concurrently, the merge calls `RemoveOverlaps()` which contains a sweep that deletes **all** `.tmp` files in the snapshot directory. The sweep races with the active index build, deletes the live `.tmp` file, and the subsequent `os.Rename` fails with `ENOENT`.

```
[WARN] [index] rename  file=…/v2.0-025350-025351-transactions.idx.3024714354.tmp
                        err="…/transactions.idx.3024714354.tmp …/transactions.idx: no such file or directory"
[EROR] [snapshots] retire blocks  err="DumpBlocks: txnHashIdx: rename …"
```

Closes #21960.

## Change

- **Remove** the `.tmp` sweep from `RemoveOverlaps`. `RemoveOverlaps` is called from `MergeBlocks`, which now runs without the semaphore and therefore concurrently with active index builds. Sweeping `.tmp` files there is not safe.

- **Move** the cleanup to `NewBlockRetire` (startup), called once before any concurrent builds or merges can start. Leftover `.tmp` files from a previous crash are cleaned there instead.

The comment in the old code already said _"it may remove Caplin's useful .tmp files — re-think"_; this change resolves that TODO.

## Testing

The race requires #21526's concurrent merge to reproduce. The existing `TestBlockMergeRunsWithoutSemaphore` / `TestRetireBlocksInBackgroundReleasesSemaphore` tests cover the concurrency invariants; the `.tmp` deletion race is exercised by the QA sync tests cited in #21960.

/cc @yperbasis