### PR TITLE
[r3.5] db/state/statecfg: bump rcache domain kv/.v to v3.1 (#21974)

### DIFF
--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -33,9 +33,9 @@ func InitSchemasGen() {
 	Schema.LogAddrIdx.FileVersion.AccessorEFI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.LogTopicIdx.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.LogTopicIdx.FileVersion.AccessorEFI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
-	Schema.RCacheDomain.FileVersion.DataKV = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
+	Schema.RCacheDomain.FileVersion.DataKV = version.Versions{version.Version{3, 1}, version.Version{1, 0}}
 	Schema.RCacheDomain.FileVersion.AccessorKVI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.RCacheDomain.Hist.FileVersion.DataV = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
+	Schema.RCacheDomain.Hist.FileVersion.DataV = version.Versions{version.Version{3, 1}, version.Version{1, 0}}
 	Schema.RCacheDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.RCacheDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.RCacheDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -105,14 +105,14 @@ logtopics:
 rcache:
     domain:
         kv:
-            current: v3.0
+            current: v3.1
             min: v1.0
         kvi:
             current: v2.0
             min: v1.0
     hist:
         v:
-            current: v3.0
+            current: v3.1
             min: v1.0
         vi:
             current: v1.1


### PR DESCRIPTION
Cherry-pick of #21974 to release/3.5.

Bumps rcache **data** file versions `.kv` (`DataKV`) and `.v` (`Hist.DataV`) `v3.0` → `v3.1`, `min` unchanged. Indexes untouched. Raises the schema ceiling so a node doesn't panic on startup when it encounters `v3.1-rcache.*.kv`/`.v` files. Same shape as #21780.

Two files: `versions.yaml` + generated `version_schema_gen.go`.