### PR TITLE
[r3.5] execution/stagedsync: fix pruning in stage_custom_trace

### DIFF
--- a/execution/stagedsync/stage_custom_trace.go
+++ b/execution/stagedsync/stage_custom_trace.go
@@ -248,10 +248,6 @@ func customTraceBatchProduce(ctx context.Context, produce Produce, cfg *exec.Exe
 			}
 		}
 
-		lastTxNum, _, err = doms.SeekCommitment(ctx, tx)
-		if err != nil {
-			return err
-		}
 		if err := tx.Commit(); err != nil {
 			return err
 		}
@@ -262,6 +258,14 @@ func customTraceBatchProduce(ctx context.Context, produce Produce, cfg *exec.Exe
 	var fromStep, toStep kv.Step
 	if err := db.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
 		fromStep = firstStepNotInFiles(tx, produce)
+		// toStep must reflect what this batch actually re-derived, not the commitment
+		// frontier: when rebuilding a subset of domains, commitment can be ahead, which
+		// would build empty files past the domain's data and desync pruning.
+		var err error
+		lastTxNum, err = cfg.BlockReader.TxnumReader().Max(ctx, tx, toBlock-1)
+		if err != nil {
+			return err
+		}
 		if lastTxNum/agg.StepSize() > 0 {
 			toStep = kv.Step(lastTxNum / agg.StepSize())
 		}
@@ -502,6 +506,14 @@ func StageCustomTraceReset(ctx context.Context, db kv.TemporalRwDB, produce Prod
 	}
 	if err := backup.ClearTables(ctx, tx, tables...); err != nil {
 		return err
+	}
+	// Clearing the data tables alone is not enough: the prune-progress bookmark in
+	// TblPruningValsProg survives and would make the post-rebuild prune short-circuit
+	// (prs.TxTo >= txTo && Done), so the re-written history never gets pruned.
+	for _, table := range tables {
+		if err := dbstate.InvalidatePruneProgress(tx, table); err != nil {
+			return err
+		}
 	}
 	return tx.Commit()
 }


### PR DESCRIPTION
Cherry-pick of #22049 to release/3.5.

Fixes #22013.

`stage_custom_trace` didn't prune the data from db, causing all the regened domains to accumulate in db.

## Root cause (two parts, both in `stage_custom_trace`)

1. **`toStep` came from the latest commitment state, not the rebuild'd progress.** 
So it builds empty files, and prunes empty stuff from db -- and then never prunes those ranges again because of pruning progress caching. So even if later those steps are populated, pruning doesn't happen on it.
2. **Reset left a stale prune-progress bookmark.** `stage_custom_trace --reset` cleared the data tables but not `TblPruningValsProg`, so table scanning prune turns out to be no-op.

## verification

on a chiado archive node