### PR TITLE
db/state: release commitment BranchCache on Aggregator.Close

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -557,6 +557,11 @@ func (a *Aggregator) Close() {
 	a.ctxCancel = nil
 	a.wg.Wait()
 
+	// Release the commitment BranchCache so a still-referenced closed Aggregator doesn't keep it reachable.
+	if cd := a.d[kv.CommitmentDomain]; cd != nil {
+		cd.branchCache = nil
+	}
+
 	a.dirtyFilesLock.Lock()
 	defer a.dirtyFilesLock.Unlock()
 	a.closeDirtyFiles()

--- a/db/state/aggregator_close_test.go
+++ b/db/state/aggregator_close_test.go
@@ -22,8 +22,10 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/mdbx"
 )
@@ -43,4 +45,27 @@ func TestAggregatorCloseWaitsForBackgroundMerge(t *testing.T) {
 		agg.Close()
 		db.Close()
 	}
+}
+
+// Close must release the commitment BranchCache so a closed-but-still-referenced
+// Aggregator doesn't keep the cache (and its entries) reachable.
+func TestAggregatorCloseReleasesBranchCache(t *testing.T) {
+	prev := dbg.UseStateCache
+	dbg.SetUseStateCache(true)
+	t.Cleanup(func() { dbg.SetUseStateCache(prev) })
+
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	defer db.Close()
+	agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
+	require.NoError(t, agg.OpenFolder())
+
+	cd := agg.d[kv.CommitmentDomain]
+	require.NotNil(t, cd)
+	require.NotNil(t, cd.branchCache, "precondition: BranchCache is set when USE_STATE_CACHE is on")
+
+	agg.Close()
+
+	require.Nil(t, cd.branchCache, "Close must drop the BranchCache reference")
 }


### PR DESCRIPTION
## What

`Aggregator.ConfigureDomains` attaches a per-aggregator commitment `BranchCache` (gated by `USE_STATE_CACHE`, on by default), but `Aggregator.Close` never released it. A closed-but-still-referenced `Aggregator` therefore kept its `BranchCache` reachable. This drops the reference in `Close`.

## Why it matters

On `main` this is benign: the cache's LRU tail (`maphash.LRU`, backed by `hashicorp/golang-lru`) allocates lazily, so an unused cache costs ~0 bytes and the retention is invisible.

It becomes fatal with #21982, which switches the tail to `freelru.ShardedLRU`. freelru **eagerly** allocates its full backing arrays on construction — ~3.3 MB per cache at the default capacity (50000), regardless of fill. The `execution/tests` suites create one aggregator (→ one cache) per fixture and fan thousands of fixtures out as parallel subtests; the closed aggregators linger, so the caches accumulate. Measured locally (Linux, 16 GB cap, `GOMAXPROCS=4`, running `./execution/tests`):

- **#21982 head:** memory climbs monotonically to 16 GB → OOM-killed (the cause of the red `tests`, `race-tests` execution-tests, `sonar`, and `eest-blocktests-devnet` jobs there).
- **with this fix:** flat ~1.25 GB, suite passes.

Split out of #21982 as an independent, mergeable fix; #21982 needs it to go green.

## Test

`TestAggregatorCloseReleasesBranchCache` (db/state) asserts the cache is set after open and released after `Close`. Written test-first — it fails on `main` (cache still attached after `Close`) and passes with the fix.

## Verification

`make lint` clean; `make erigon integration` builds; `go test -run TestAggregatorClose ./db/state/` passes.
