### PR TITLE
execution: activate EIP-1283 for the Constantinople test fork

### DIFF
--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -348,11 +348,9 @@ func (c *Config) IsMuirGlacier(num uint64) bool {
 	return isForked(c.MuirGlacierBlock, num)
 }
 
-// IsPetersburg returns whether num is either
-// - equal to or greater than the PetersburgBlock fork block,
-// - OR is nil, and Constantinople is active
+// IsPetersburg returns whether num is either equal to the Petersburg fork block or greater.
 func (c *Config) IsPetersburg(num uint64) bool {
-	return isForked(c.PetersburgBlock, num) || c.PetersburgBlock == nil && isForked(c.ConstantinopleBlock, num)
+	return isForked(c.PetersburgBlock, num)
 }
 
 // IsIstanbul returns whether num is either equal to the Istanbul fork block or greater.

--- a/execution/state/database_test.go
+++ b/execution/state/database_test.go
@@ -61,6 +61,7 @@ func TestCreate2Revive(t *testing.T) {
 				SpuriousDragonBlock:   common.NewUint64(1),
 				ByzantiumBlock:        common.NewUint64(1),
 				ConstantinopleBlock:   common.NewUint64(1),
+				PetersburgBlock:       common.NewUint64(1),
 			},
 			Alloc: types.GenesisAlloc{
 				address.Value(): types.GenesisAccount{Balance: funds},
@@ -245,6 +246,7 @@ func TestCreate2Polymorth(t *testing.T) {
 				SpuriousDragonBlock:   common.NewUint64(1),
 				ByzantiumBlock:        common.NewUint64(1),
 				ConstantinopleBlock:   common.NewUint64(1),
+				PetersburgBlock:       common.NewUint64(1),
 			},
 			Alloc: types.GenesisAlloc{
 				address.Value(): types.GenesisAccount{Balance: funds},
@@ -509,6 +511,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 				SpuriousDragonBlock:   common.NewUint64(1),
 				ByzantiumBlock:        common.NewUint64(1),
 				ConstantinopleBlock:   common.NewUint64(1),
+				PetersburgBlock:       common.NewUint64(1),
 			},
 			Alloc: types.GenesisAlloc{
 				address.Value(): types.GenesisAccount{Balance: funds},
@@ -672,6 +675,7 @@ func TestReorgOverStateChange(t *testing.T) {
 				SpuriousDragonBlock:   common.NewUint64(1),
 				ByzantiumBlock:        common.NewUint64(1),
 				ConstantinopleBlock:   common.NewUint64(1),
+				PetersburgBlock:       common.NewUint64(1),
 			},
 			Alloc: types.GenesisAlloc{
 				address.Value(): {Balance: funds},
@@ -836,6 +840,7 @@ func TestCreateOnExistingStorage(t *testing.T) {
 				SpuriousDragonBlock:   common.NewUint64(1),
 				ByzantiumBlock:        common.NewUint64(1),
 				ConstantinopleBlock:   common.NewUint64(1),
+				PetersburgBlock:       common.NewUint64(1),
 			},
 			Alloc: types.GenesisAlloc{
 				address.Value(): {Balance: funds},
@@ -1706,6 +1711,7 @@ func TestTxLookupUnwind(t *testing.T) {
 				SpuriousDragonBlock:   common.NewUint64(1),
 				ByzantiumBlock:        common.NewUint64(1),
 				ConstantinopleBlock:   common.NewUint64(1),
+				PetersburgBlock:       common.NewUint64(1),
 			},
 			Alloc: types.GenesisAlloc{
 				address.Value(): types.GenesisAccount{Balance: funds},

--- a/execution/tests/state_test.go
+++ b/execution/tests/state_test.go
@@ -72,21 +72,6 @@ func TestLegacyCancunState(t *testing.T) {
 	// the 1h package timeout under -race instrumentation.
 	st.SkipLoad(`^VMTests/vmPerformance/`)
 
-	// Pre-existing Constantinople-only divergences from geth — see
-	// https://github.com/erigontech/erigon/issues/20894. Geth's local runner
-	// walks LegacyTests/Constantinople/GeneralStateTests (an older snapshot
-	// that doesn't include these fixtures) so it never exercises them
-	// locally even though it generated them. Skip-loading the whole file
-	// means we lose non-Constantinople coverage of these six fixtures, which
-	// is acceptable: the d3 RIPEMD-160 touch case this test was added to
-	// catch is in stRevertTest/RevertPrecompiledTouch.json, not these.
-	st.SkipLoad(`^stSStoreTest/sstoreGas\.json`)
-	st.SkipLoad(`^stCreateTest/CREATE_HighNonce\.json`)
-	st.SkipLoad(`^stCreate2/CREATE2_HighNonce\.json`)
-	st.SkipLoad(`^stCreate2/CREATE2_HighNonceDelegatecall\.json`)
-	st.SkipLoad(`^stPreCompiledContracts2/CallEcrecover_Overflow\.json`)
-	st.SkipLoad(`^stPreCompiledContracts2/ecrecoverShortBuff\.json`)
-
 	runStateTests(t, st, filepath.Join(legacyDir, "LegacyTests", "Cancun", "GeneralStateTests"))
 }
 

--- a/execution/tests/statedb_chain_test.go
+++ b/execution/tests/statedb_chain_test.go
@@ -53,6 +53,7 @@ func TestSelfDestructReceive(t *testing.T) {
 				HomesteadBlock:        new(uint64),
 				ByzantiumBlock:        new(uint64),
 				ConstantinopleBlock:   new(uint64),
+				PetersburgBlock:       new(uint64),
 				TangerineWhistleBlock: new(uint64),
 				SpuriousDragonBlock:   new(uint64),
 			},

--- a/execution/tests/statedb_insert_chain_transaction_test.go
+++ b/execution/tests/statedb_insert_chain_transaction_test.go
@@ -886,6 +886,7 @@ func getGenesis(funds ...*big.Int) initialData {
 				SpuriousDragonBlock:   common.NewUint64(1),
 				ByzantiumBlock:        common.NewUint64(1),
 				ConstantinopleBlock:   common.NewUint64(1),
+				PetersburgBlock:       common.NewUint64(1),
 			},
 			Alloc: allocs,
 		},

--- a/execution/tests/testforks/forks.go
+++ b/execution/tests/testforks/forks.go
@@ -106,7 +106,8 @@ func init() {
 
 	c = configCopy(c)
 	c.ConstantinopleBlock = common.NewUint64(0)
-	c.PetersburgBlock = nil
+	// A nil PetersburgBlock makes IsPetersburg fall back to ConstantinopleBlock, which would disable EIP-1283 net-metered SSTORE; keep Petersburg in the future so this fork actually exercises it.
+	c.PetersburgBlock = common.NewUint64(10_000_000)
 	Forks["Constantinople"] = c
 
 	c = configCopy(c)

--- a/execution/tests/testforks/forks.go
+++ b/execution/tests/testforks/forks.go
@@ -106,8 +106,7 @@ func init() {
 
 	c = configCopy(c)
 	c.ConstantinopleBlock = common.NewUint64(0)
-	// A nil PetersburgBlock makes IsPetersburg fall back to ConstantinopleBlock, which would disable EIP-1283 net-metered SSTORE; keep Petersburg in the future so this fork actually exercises it.
-	c.PetersburgBlock = common.NewUint64(10_000_000)
+	c.PetersburgBlock = nil
 	Forks["Constantinople"] = c
 
 	c = configCopy(c)

--- a/execution/vm/runtime/runtime_test.go
+++ b/execution/vm/runtime/runtime_test.go
@@ -203,6 +203,7 @@ func benchmarkEVM_Create(b *testing.B, code string) {
 			HomesteadBlock:        common.NewUint64(0),
 			ByzantiumBlock:        common.NewUint64(0),
 			ConstantinopleBlock:   common.NewUint64(0),
+			PetersburgBlock:       common.NewUint64(0),
 			TangerineWhistleBlock: common.NewUint64(0),
 			SpuriousDragonBlock:   common.NewUint64(0),
 		},


### PR DESCRIPTION
## Problem

#20894: six `TestLegacyCancunState` fixtures fail only on the **Constantinople** fork (the issue hypothesized three separate root causes — it's one).

## Root cause

`IsPetersburg` carried a fallback — a nil `PetersburgBlock` counts as Petersburg once Constantinople is set:

```go
return isForked(c.PetersburgBlock, num) || c.PetersburgBlock == nil && isForked(c.ConstantinopleBlock, num)
```

So the `testforks` `Constantinople` config (`PetersburgBlock=nil`) ran legacy/Petersburg SSTORE instead of EIP-1283. The six fixtures measure and store SSTORE gas, so the values diverged from geth's.

## Fix

Drop the fallback so `IsPetersburg` matches the other fork predicates (`isForked(c.PetersburgBlock, num)`). The Constantinople fork now runs EIP-1283 — `gasSStore`'s EIP-1283 path was already correct, just never reached — so the six `SkipLoad`s are removed. The few test `chain.Config`s that relied on the fallback for Petersburg behavior now set `PetersburgBlock` explicitly.

Verified: all six fixtures pass, full `stSStoreTest` and the affected `execution/state` / `execution/tests` packages green, `make lint` clean.

Fixes #20894
