### PR TITLE
ci(docs): one-click Docs Version Bump workflow

### DIFF
--- a/.github/workflows/docs-version-bump.yml
+++ b/.github/workflows/docs-version-bump.yml
@@ -1,0 +1,119 @@
+name: Docs Version Bump
+
+# One-click docs versioning for a new major/minor release.
+#
+# Run this ON THE DOCS SOURCE BRANCH for the new release (e.g. on `release/3.6`,
+# right after it is cut from the previous release branch), where `docs/site/docs`
+# still holds the about-to-be-archived version's content.
+#
+# It snapshots the current docs as an archived version, bumps the "current"
+# version label, enforces the 3-archived-version cap, regenerates the llms.txt
+# artifacts, verifies the build, and opens a PR. Version injection is driven by
+# versions.json, so no docusaurus.config.ts / remark-plugin edits are needed.
+#
+# NOTE: this does NOT move the Pages deploy trigger. If the docs deploy still
+# lives on a per-release branch (docs-deploy.yml), update that branch separately.
+
+on:
+  workflow_dispatch:
+    inputs:
+      archive_version:
+        description: 'Version id to freeze from the CURRENT docs, e.g. "v3.5". Creates versioned_docs/version-<id>.'
+        required: true
+        type: string
+      new_label:
+        description: 'New label for the current (unreleased) docs, e.g. "v3.6".'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs/site
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate inputs
+        run: |
+          for v in "${{ inputs.archive_version }}" "${{ inputs.new_label }}"; do
+            if ! printf '%s' "$v" | grep -qE '^v[0-9]+\.[0-9]+$'; then
+              echo "::error::Version '$v' must look like vMAJOR.MINOR (e.g. v3.6)"; exit 1
+            fi
+          done
+          if grep -q "\"${{ inputs.archive_version }}\"" versions.json; then
+            echo "::error::${{ inputs.archive_version }} is already an archived version"; exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: docs/site/package-lock.json
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Snapshot current docs as ${{ inputs.archive_version }}
+        run: npx docusaurus docs:version "${{ inputs.archive_version }}"
+
+      - name: Bump current version label to ${{ inputs.new_label }}
+        run: |
+          sed -i -E "s/label: 'v[0-9]+\.[0-9]+'/label: '${{ inputs.new_label }}'/" docusaurus.config.ts
+          grep -q "label: '${{ inputs.new_label }}'" docusaurus.config.ts \
+            || { echo "::error::failed to update current version label"; exit 1; }
+
+      - name: Enforce 3-archived-version cap (prune oldest)
+        run: |
+          count=$(jq 'length' versions.json)
+          if [ "$count" -gt 3 ]; then
+            # versions.json is newest-first; everything past index 2 is pruned.
+            for v in $(jq -r '.[3:][]' versions.json); do
+              echo "Pruning archived version $v"
+              rm -rf "versioned_docs/version-$v"
+              rm -f  "versioned_sidebars/version-$v-sidebars.json"
+            done
+            jq '.[:3]' versions.json > versions.json.tmp && mv versions.json.tmp versions.json
+          fi
+
+      - name: Regenerate llms.txt artifacts
+        run: python3 scripts/generate-llms.py
+
+      - name: Verify build
+        run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}
+        run: |
+          branch="docs/version-bump-${{ inputs.new_label }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add -A
+          git commit -m "docs(site): archive ${{ inputs.archive_version }}, bump current to ${{ inputs.new_label }}"
+          git push -u origin "$branch"
+          gh pr create \
+            --base "${{ github.ref_name }}" \
+            --head "$branch" \
+            --title "docs(site): archive ${{ inputs.archive_version }}, publish ${{ inputs.new_label }}" \
+            --body "Automated docs version bump (\`docs-version-bump.yml\`).
+
+          - Snapshotted the current docs as **${{ inputs.archive_version }}** (\`versioned_docs/version-${{ inputs.archive_version }}\`).
+          - Bumped the current version label to **${{ inputs.new_label }}**.
+          - Enforced the 3-archived-version cap and regenerated llms.txt artifacts.
+          - \`npm run build\` passed in CI before this PR was opened.
+
+          If the Pages deploy still lives on a per-release branch, move \`docs-deploy.yml\` to this branch separately."


### PR DESCRIPTION
Adds `.github/workflows/docs-version-bump.yml` — `workflow_dispatch` tooling to automate docs versioning when a new major/minor releases, so we don't hand-edit config every time.

## What it does
Given two inputs — `archive_version` (e.g. `v3.5`) and `new_label` (e.g. `v3.6`) — it:
1. Snapshots the current docs as the archived version (`docusaurus docs:version`).
2. Bumps the current version label.
3. Enforces the 3-archived-version cap (prunes the oldest).
4. Regenerates the `llms.txt` artifacts.
5. Verifies `npm run build`.
6. Opens a PR with the result.

## How to use
Run it **on the new release branch, right after it's cut** (where `docs/site/docs` still holds the about-to-be-archived content). Version injection is driven by `versions.json`, so no `docusaurus.config.ts` / remark-plugin edits are needed.

## Depends on / notes
- Builds on the `versions.json`-driven version injection introduced in #22062 — merge that first.
- Does **not** move the Pages deploy trigger. While docs deploy from a per-release branch (`docs-deploy.yml`), that move stays manual (as in #22062 / #22063).
- Requires the repo setting *"Allow GitHub Actions to create and approve pull requests"* for the final PR-open step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)