### PR TITLE
docs(site): make version injection generic (versions.json-driven)

### DIFF
--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -4,6 +4,11 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const versionReplace = require('./src/remark/version-replace.js');
 
+// Archived doc versions (newest-first). Single source of truth: adding an entry
+// here (via `docusaurus docs:version`) is all that's needed — version injection
+// below derives everything from this list, no per-version config edits required.
+const archivedVersions: string[] = require('./versions.json');
+
 function githubHeaders(): Record<string, string> {
   const headers: Record<string, string> = {Accept: 'application/vnd.github.v3+json'};
   if (process.env.GITHUB_TOKEN) headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
@@ -24,7 +29,7 @@ async function fetchLatestVersion(): Promise<string> {
   }
 }
 
-async function fetchLatestV33Version(): Promise<string> {
+async function fetchLatestSeriesVersion(prefix: string): Promise<string> {
   try {
     const res = await fetch(
       'https://api.github.com/repos/erigontech/erigon/releases?per_page=50',
@@ -32,7 +37,7 @@ async function fetchLatestV33Version(): Promise<string> {
     );
     if (!res.ok) return 'latest';
     const releases = await res.json() as Array<{tag_name: string; prerelease: boolean}>;
-    const latest = releases.find((r) => !r.prerelease && r.tag_name.startsWith('v3.3.'));
+    const latest = releases.find((r) => !r.prerelease && r.tag_name.startsWith(prefix));
     return latest?.tag_name.replace(/^v/, '') ?? 'latest';
   } catch {
     return 'latest';
@@ -40,10 +45,14 @@ async function fetchLatestV33Version(): Promise<string> {
 }
 
 export default async function createConfig(): Promise<Config> {
-  const [latestVersion, v33Version] = await Promise.all([
+  const [latestVersion, ...archivedVersionStrings] = await Promise.all([
     fetchLatestVersion(),
-    fetchLatestV33Version(),
+    ...archivedVersions.map((v) => fetchLatestSeriesVersion(`${v}.`)),
   ]);
+  // Map each archived version id (e.g. "v3.4") to its latest patch release string.
+  const versionStrings: Record<string, string> = Object.fromEntries(
+    archivedVersions.map((v, i) => [v, archivedVersionStrings[i]]),
+  );
 
   return {
     title: 'Erigon Documentation',
@@ -127,7 +136,7 @@ export default async function createConfig(): Promise<Config> {
               badge: false,
             },
           },
-          remarkPlugins: [[versionReplace, {currentVersion: latestVersion, v33Version}]],
+          remarkPlugins: [[versionReplace, {currentVersion: latestVersion, versionStrings}]],
         },
         blog: false as false,
         theme: {customCss: './src/css/custom.css'},

--- a/docs/site/src/remark/version-replace.js
+++ b/docs/site/src/remark/version-replace.js
@@ -1,10 +1,11 @@
 // Remark plugin — replaces {ERIGON_VERSION} in text, inlineCode, code nodes,
 // and also in mdxTextExpression nodes (plain-text {ERIGON_VERSION} in MDX files).
-// Uses vfile.path to pick the right version: v3.3 versioned docs get v33Version,
-// everything else (current docs) gets currentVersion.
+// Uses vfile.path to pick the right version: a `version-vX.Y` path segment selects
+// versionStrings["vX.Y"]; everything else (current docs) gets currentVersion.
+// Adding a new archived version needs no change here — it's keyed off versions.json.
 function versionReplace(options) {
   const currentVersion = (options && options.currentVersion) || 'latest';
-  const v33Version = (options && options.v33Version) || 'latest';
+  const versionStrings = (options && options.versionStrings) || {};
 
   function visit(node, version) {
     if (
@@ -26,8 +27,11 @@ function versionReplace(options) {
   }
 
   return function (tree, vfile) {
-    const isV33 = vfile && vfile.path && vfile.path.split('/').includes('version-v3.3');
-    visit(tree, isV33 ? v33Version : currentVersion);
+    const segments = (vfile && vfile.path && vfile.path.split('/')) || [];
+    const versionSeg = segments.find((s) => s.startsWith('version-'));
+    const key = versionSeg && versionSeg.slice('version-'.length); // e.g. "v3.4"
+    const version = (key && versionStrings[key]) || currentVersion;
+    visit(tree, version);
   };
 }
 


### PR DESCRIPTION
Forward-ports the generic version-injection refactor (introduced on `release/3.5` in #22062) to **`main`**, so every release branch cut from main inherits it.

## Why on main
Release branches are cut from `main`. If this infra only lived on `release/3.5`, `release/3.6` would revert to the old hardcoded per-series resolver. Pairs with the Docs Version Bump workflow (#22066), which also lives on main.

## What changes
- Replaces the hardcoded `fetchLatestV33Version` / `v33Version` with a parametrized `fetchLatestSeriesVersion(prefix)` looped over `versions.json`, building a `{id -> latest patch}` map.
- The remark plugin routes by the `version-vX.Y` path segment instead of a hardcoded `version-v3.3` check.
- **Net effect:** adding an archived version (via `docusaurus docs:version`) needs zero edits to `docusaurus.config.ts` or `version-replace.js`.

## No behavior change here
`versions.json` is still `["v3.3"]` and the current label is still `v3.4` — verified the build injects `3.3.1` into the v3.3 archive and the latest release into current, exactly as before. This PR is purely the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)