### PR TITLE
docs: correct MAX_REORG_DEPTH default (512 → 96)

### DIFF
--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -558,7 +558,7 @@ Erigon supports configuration through environment variables, primarily for exper
 * `NO_PRUNE` - Disables pruning when set to true (flag equivalent: `--exec.no-prune`)
 * `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
 * `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
-* `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `512`)
+* `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
 
 **Execution and Processing:**
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2424,7 +2424,7 @@ Erigon supports configuration through environment variables, primarily for exper
 * `NO_PRUNE` - Disables pruning when set to true (flag equivalent: `--exec.no-prune`)
 * `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
 * `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
-* `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `512`)
+* `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
 
 **Execution and Processing:**
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2424,7 +2424,7 @@ Erigon supports configuration through environment variables, primarily for exper
 * `NO_PRUNE` - Disables pruning when set to true (flag equivalent: `--exec.no-prune`)
 * `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
 * `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
-* `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `512`)
+* `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
 
 **Execution and Processing:**
 


### PR DESCRIPTION
The `configuring-erigon` env-var reference documents `MAX_REORG_DEPTH` with `default: 512`, but the actual code default on `main` is **96**:

```
common/dbg/experiments.go:39
MaxReorgDepth = EnvUint("MAX_REORG_DEPTH", 96)
```

The `512` value only appears in test fixtures. Corrects the documented default and regenerates the `llms.txt` / `llms-full.txt` artifacts.

Verified against `origin/main` source. `docs/site` build is green; `generate-llms.py --check` passes. The matching `release/3.5` fix is #22068 (dual-commit rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)