### PR TITLE
[wip] common/dbg, db: finalizer-based leak detection for unclosed resources

### DIFF
--- a/common/dbg/leak_detector.go
+++ b/common/dbg/leak_detector.go
@@ -18,6 +18,7 @@ package dbg
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -28,10 +29,40 @@ import (
 
 const FileCloseLogLevel = log.LvlTrace
 
+// gcLeakCheckEnabled - finalizer-based leak detection. Requires both ASSERT and SLOW_TX.
+var gcLeakCheckEnabled = AssertEnabled && SlowTx() > 0
+
+// ArmGCLeakCheck panics if obj is garbage-collected before DisarmGCLeakCheck(obj)
+// is called. No-op unless ASSERT and SLOW_TX are both enabled.
+func ArmGCLeakCheck(name string, obj any) {
+	if !gcLeakCheckEnabled {
+		return
+	}
+	armGCLeakFinalizer(name, StackSkip(2), obj)
+}
+
+// DisarmGCLeakCheck clears the finalizer set by ArmGCLeakCheck. Call it from the
+// resource's Close/Rollback path.
+func DisarmGCLeakCheck(obj any) {
+	if !gcLeakCheckEnabled {
+		return
+	}
+	runtime.SetFinalizer(obj, nil)
+}
+
+func armGCLeakFinalizer(name, stack string, obj any) {
+	typ := fmt.Sprintf("%T", obj)
+	runtime.SetFinalizer(obj, func(any) {
+		panic(fmt.Sprintf("[dbg.%s] %s garbage-collected without close — leak; created at:\n%s", name, typ, stack))
+	})
+}
+
 // LeakDetector - use it to find which resource was created but not closed (leaked)
 // periodically does print in logs resources which living longer than 1min with their creation stack trace
 // For example db transactions can call Add/Del from Begin/Commit/Rollback methods
 type LeakDetector struct {
+	name          string
+	panicOnLeak   bool
 	enabled       atomic.Bool
 	slowThreshold atomic.Pointer[time.Duration]
 	autoIncrement atomic.Uint64
@@ -50,7 +81,7 @@ func NewLeakDetector(name string, slowThreshold time.Duration) *LeakDetector {
 	if !enabled {
 		return nil
 	}
-	d := &LeakDetector{list: map[uint64]LeakDetectorItem{}}
+	d := &LeakDetector{name: name, panicOnLeak: AssertEnabled, list: map[uint64]LeakDetectorItem{}}
 	d.SetSlowThreshold(slowThreshold)
 
 	go func() {
@@ -88,15 +119,18 @@ func (d *LeakDetector) slowList() (res []string) {
 	return res
 }
 
-func (d *LeakDetector) Del(id uint64) {
+func (d *LeakDetector) Del(id uint64, obj any) {
 	if d == nil || !d.Enabled() {
 		return
+	}
+	if d.panicOnLeak {
+		runtime.SetFinalizer(obj, nil)
 	}
 	d.listLock.Lock()
 	defer d.listLock.Unlock()
 	delete(d.list, id)
 }
-func (d *LeakDetector) Add() uint64 {
+func (d *LeakDetector) Add(obj any) uint64 {
 	if d == nil || !d.Enabled() {
 		return 0
 	}
@@ -106,8 +140,11 @@ func (d *LeakDetector) Add() uint64 {
 	}
 	id := d.autoIncrement.Add(1)
 	d.listLock.Lock()
-	defer d.listLock.Unlock()
 	d.list[id] = ac
+	d.listLock.Unlock()
+	if d.panicOnLeak {
+		armGCLeakFinalizer(d.name, ac.stack, obj)
+	}
 	return id
 }
 

--- a/common/dbg/leak_detector_test.go
+++ b/common/dbg/leak_detector_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package dbg
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Each scenario runs in a re-exec'd child since a finalizer panic is fatal.
+func TestGCLeakCheck(t *testing.T) {
+	switch os.Getenv("DBG_LEAK_CHILD") {
+	case "leak":
+		runLeakChild(false)
+		return
+	case "disarm":
+		runLeakChild(true)
+		return
+	}
+
+	t.Run("panics when armed object is GC'd without close", func(t *testing.T) {
+		out, err := runLeakCheckChild(t, "leak", true)
+		if err == nil {
+			t.Fatalf("expected child to crash on leak, but it exited cleanly. output:\n%s", out)
+		}
+		if !strings.Contains(out, "garbage-collected without close") {
+			t.Fatalf("expected leak panic message, got:\n%s", out)
+		}
+	})
+
+	t.Run("no panic when disarmed before GC", func(t *testing.T) {
+		out, err := runLeakCheckChild(t, "disarm", true)
+		if err != nil {
+			t.Fatalf("expected clean exit after disarm, got %v. output:\n%s", err, out)
+		}
+	})
+
+	t.Run("no-op when ASSERT and SLOW_TX are not both set", func(t *testing.T) {
+		out, err := runLeakCheckChild(t, "leak", false)
+		if err != nil {
+			t.Fatalf("expected no-op when disabled, got %v. output:\n%s", err, out)
+		}
+	})
+}
+
+func runLeakCheckChild(t *testing.T, mode string, enabled bool) (string, error) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestGCLeakCheck")
+	env := append(os.Environ(), "DBG_LEAK_CHILD="+mode)
+	if enabled {
+		env = append(env, "ERIGON_ASSERT=true", "SLOW_TX=1m")
+	} else {
+		env = append(env, "ERIGON_ASSERT=false", "SLOW_TX=")
+	}
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+//go:noinline
+func armLeakedObject(disarm bool) {
+	obj := new([8]byte)
+	ArmGCLeakCheck("test-resource", obj)
+	if disarm {
+		DisarmGCLeakCheck(obj)
+	}
+}
+
+func runLeakChild(disarm bool) {
+	armLeakedObject(disarm)
+	for i := 0; i < 50; i++ {
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -581,6 +581,7 @@ func OpenBtreeIndexWithDecompressor(indexPath string, M uint64, kvGetter *seg.Re
 	idx.bplus.cursorGetter = idx.newCursor
 
 	validationPassed = true
+	dbg.ArmGCLeakCheck(idx.FileName(), idx)
 	return idx, nil
 }
 
@@ -645,6 +646,7 @@ func (b *BtIndex) Close() {
 	if b == nil {
 		return
 	}
+	dbg.DisarmGCLeakCheck(b)
 	if b.m != nil {
 		if err := b.m.Unmap(); err != nil {
 			log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", b.FileName(), "stack", dbg.Stack())

--- a/db/etl/collector.go
+++ b/db/etl/collector.go
@@ -28,6 +28,7 @@ import (
 	"github.com/c2h5oh/datasize"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 )
@@ -83,7 +84,9 @@ func NewCollectorWithAllocator(logPrefix, tmpdir string, allocator *Allocator, l
 	return c
 }
 func NewCollector(logPrefix, tmpdir string, sortableBuffer Buffer, logger log.Logger) *Collector {
-	return &Collector{bufType: getTypeByBuffer(sortableBuffer), buf: sortableBuffer, logPrefix: logPrefix, tmpdir: tmpdir, logLvl: log.LvlInfo, logger: logger}
+	c := &Collector{bufType: getTypeByBuffer(sortableBuffer), buf: sortableBuffer, logPrefix: logPrefix, tmpdir: tmpdir, logLvl: log.LvlInfo, logger: logger}
+	dbg.ArmGCLeakCheck(logPrefix, c)
+	return c
 }
 
 func (c *Collector) SortAndFlushInBackground(v bool) *Collector {
@@ -261,6 +264,7 @@ func (c *Collector) Load(db kv.RwTx, toBucket string, loadFunc LoadFunc, args Tr
 }
 
 func (c *Collector) Close() {
+	dbg.DisarmGCLeakCheck(c)
 	if c.buf != nil { //idempotency
 		if c.allocator != nil {
 			c.allocator.Put(c.buf)

--- a/db/kv/mdbx/kv_mdbx.go
+++ b/db/kv/mdbx/kv_mdbx.go
@@ -720,8 +720,8 @@ func (db *MdbxKV) BeginRo(ctx context.Context) (txn kv.Tx, err error) {
 		db:       db,
 		tx:       tx,
 		readOnly: true,
-		traceID:  db.leakDetector.Add(),
 	}
+	mt.traceID = db.leakDetector.Add(mt)
 	db.registerLiveTx(mt, true)
 	return mt, nil
 }
@@ -759,11 +759,11 @@ func (db *MdbxKV) beginRw(ctx context.Context, flags uint) (txn kv.RwTx, err err
 	}
 
 	mt := &MdbxTx{
-		db:      db,
-		tx:      tx,
-		ctx:     ctx,
-		traceID: db.leakDetector.Add(),
+		db:  db,
+		tx:  tx,
+		ctx: ctx,
 	}
+	mt.traceID = db.leakDetector.Add(mt)
 	db.registerLiveTx(mt, false)
 	return mt, nil
 }
@@ -1131,7 +1131,7 @@ func (tx *MdbxTx) Commit() error {
 		} else {
 			runtime.UnlockOSThread()
 		}
-		tx.db.leakDetector.Del(tx.traceID)
+		tx.db.leakDetector.Del(tx.traceID, tx)
 	}()
 	tx.closeCursors()
 
@@ -1198,7 +1198,7 @@ func (tx *MdbxTx) Rollback() {
 	} else {
 		runtime.UnlockOSThread()
 	}
-	tx.db.leakDetector.Del(tx.traceID)
+	tx.db.leakDetector.Del(tx.traceID, tx)
 }
 
 func (tx *MdbxTx) SpaceDirty() (uint64, uint64, error) {

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -163,6 +163,7 @@ func OpenIndex(indexFilePath string) (_ *Index, err error) {
 	//}
 
 	idx.sharedReader = NewIndexReader(idx)
+	dbg.ArmGCLeakCheck(fName, idx)
 	return idx, nil
 }
 
@@ -392,6 +393,7 @@ func (idx *Index) Close() {
 	if idx == nil || idx.f == nil {
 		return
 	}
+	dbg.DisarmGCLeakCheck(idx)
 	if err := mmap.Munmap(idx.mmapHandle1, idx.mmapHandle2); err != nil {
 		log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", idx.FileName(), "stack", dbg.Stack())
 	}

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -412,6 +412,7 @@ func NewDecompressorWithMetadata(compressedFilePath string, hasMetadata bool) (*
 	}
 
 	validationPassed = true
+	dbg.ArmGCLeakCheck(fName, d)
 	return d, nil
 }
 
@@ -570,6 +571,7 @@ func (d *Decompressor) Close() {
 	if d == nil || d.f == nil {
 		return
 	}
+	dbg.DisarmGCLeakCheck(d)
 	d.checkFileLenChange()
 	if err := mmap.Munmap(d.mmapHandle1, d.mmapHandle2); err != nil {
 		log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", d.FileName(), "stack", dbg.Stack())

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -506,7 +506,9 @@ func (s VisibleSegments) BeginRo() *RoTx {
 		}
 		seg.src.refcount.Add(1)
 	}
-	return &RoTx{Segments: s}
+	rotx := &RoTx{Segments: s}
+	dbg.ArmGCLeakCheck("snapshots.RoTx", rotx)
+	return rotx
 }
 
 type RoTx struct {
@@ -517,6 +519,7 @@ func (s *RoTx) Close() {
 	if s == nil || s.Segments == nil {
 		return
 	}
+	dbg.DisarmGCLeakCheck(s)
 	VisibleSegments := s.Segments
 	s.Segments = nil
 

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -2353,8 +2353,8 @@ func (a *Aggregator) BeginFilesRo() *AggregatorRoTx {
 		a:        a,
 		visible:  v,
 		iisCount: a.iisCount,
-		_leakID:  a.leakDetector.Add(),
 	}
+	ac._leakID = a.leakDetector.Add(ac)
 	for id, iv := range v.iis {
 		if iv == nil {
 			continue
@@ -2574,7 +2574,7 @@ func (at *AggregatorRoTx) Close() {
 		return
 	}
 	a := at.a
-	a.leakDetector.Del(at._leakID)
+	a.leakDetector.Del(at._leakID, at)
 	at.a = nil
 
 	for _, d := range at.d {


### PR DESCRIPTION
**WIP** — finalizer-based leak detection for resources that must be explicitly closed.

## What

Adds `dbg.ArmGCLeakCheck(name, obj)` / `dbg.DisarmGCLeakCheck(obj)`: a `runtime.SetFinalizer`-based detector that **panics** when a resource is garbage-collected without being closed. Armed on acquire, disarmed on close.

Gated on **both** `ERIGON_ASSERT` and `SLOW_TX` being set — a no-op (single bool check, no alloc) otherwise, so it costs nothing in production. This mirrors Pebble's `invariants`-tag leak checks: cheap no-op normally, loud failure only in assert builds.

The existing `dbg.LeakDetector` (the periodic "long-living resource" logger, gated on `SLOW_TX`) now also arms the finalizer when `ERIGON_ASSERT` is on, so `tx` and `aggrotx` get both: a time-based warning for held-too-long, and a hard panic for dropped-without-close.

## Wired into

- mdbx `tx` (`MdbxTx`)
- aggregator `aggrotx` (`AggregatorRoTx`)
- `seg.Decompressor`
- `recsplit.Index`
- `BtIndex`
- `etl.Collector` (leaks temp files on disk if dropped without `Close`)
- snapshot `RoTx` — the segment refcount holder behind `View`/`ViewType`/`ViewSingleFile`; a leak here pins dirty segments and blocks their deletion

## Notes

- A finalizer panic is fatal by design (loud, debug-only). The message carries the resource type and creation stack.
- The finalizer closure deliberately doesn't capture the object (that would keep it reachable and defeat the check).
