### PR TITLE
common/dbg: reduce TIP_TRIE_WARMUPERS default to estimate.HalfCPUs()

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -121,7 +121,7 @@ var (
 	TraceDeletion         = EnvBool("TRACE_DELETION", false)
 
 	RpcDropResponse  = EnvBool("RPC_DROP_RESPONSE", false)
-	TipTrieWarmupers = EnvInt("TIP_TRIE_WARMUPERS", runtime.NumCPU()*8) //io-bound (not cpu-bound). it's ok to have `io-threads > cpus`
+	TipTrieWarmupers = EnvInt("TIP_TRIE_WARMUPERS", estimate.HalfCPUs())
 
 	PerfProfiles = EnvBool("PERF_PROFILES", false)
 )


### PR DESCRIPTION
Reduce the default `TIP_TRIE_WARMUPERS` from `runtime.NumCPU()*8` to `estimate.HalfCPUs()`.

The previous default spawned 8× CPU count warmup goroutines for tip-trie warmup. This lowers the default to half the available CPUs to reduce contention and resource usage.

Same change as #22075 (against main).