### PR TITLE
docs/site: bump http-proxy-middleware to 2.0.10 (Dependabot #105)

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -11086,9 +11086,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -53,6 +53,7 @@
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "@babel/core": "^7.29.6",
     "fast-uri": "^3.1.2",
+    "http-proxy-middleware": "^2.0.10",
     "joi": "^17.13.4",
     "js-yaml": "^4.2.0",
     "gray-matter": {


### PR DESCRIPTION
Resolves Dependabot alert [#105](https://github.com/erigontech/erigon/security/dependabot/105) — `http-proxy-middleware` Host-header routing-bypass.

## Fix

Adds an npm `override` pinning `http-proxy-middleware` to `^2.0.10` (the earliest patched release). The lockfile now resolves `2.0.10` instead of the vulnerable `2.0.9`.

`webpack-dev-server@5.2.5` already requires `http-proxy-middleware@^2.0.9`, a range that permits `2.0.10` — only a manual override was needed because Dependabot's transitive updater could not reason that the existing range already allows the patched version.

## Verification — does not change the published site

`http-proxy-middleware` runs only inside `webpack-dev-server` (active during `npm start` for local authoring); it is absent from the deployed static site at https://docs.erigon.tech. Confirmed with a before/after production build:

| Check | Result |
|-------|--------|
| Baseline `npm ci` + `npm run build` | 367 files |
| Post-fix build | 367 files |
| Aggregate SHA-256 of all output | identical (`4df23297…`) |
| Per-file diff | 0 differences |
| `http-proxy-middleware` in build output | absent |
| Local serve, key pages (`/`, `/get-started`, `/fundamentals`, `/about`) | all HTTP 200, render correctly |

## Not included: Dependabot #91 (js-yaml)

Alert [#91](https://github.com/erigontech/erigon/security/dependabot/91) (`js-yaml` quadratic-complexity DoS) is also in this lockfile but is **not** fixed here, intentionally:

- `node_modules/js-yaml` is already on the patched `4.2.0`. The remaining flag is `gray-matter`'s pinned copy at `3.14.2`.
- The advisory marks all `<= 4.1.1` vulnerable with **no patched 3.x release** — only `4.2.0`.
- `gray-matter@4.0.3` calls `yaml.safeLoad`/`yaml.safeDump`, both removed in js-yaml 4.x, so forcing `4.2.0` there would break the docs build (that is why the `3.14.2` pin exists).
- Exposure is negligible: it parses trusted in-repo markdown front-matter at build time, not untrusted input.

Recommend dismissing #91 (dev/build-time, trusted input, no upstream fix) or tracking it against a future Docusaurus bump off `gray-matter@4.0.3`.