### PR TITLE
[3.6] execution/stagedsync: checkpoint commitment at step boundaries in parallel exec

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -595,6 +595,21 @@ func (sd *SharedDomains) IndexAdd(table kv.InvertedIdx, key []byte, txNum uint64
 
 func (sd *SharedDomains) StepSize() uint64 { return sd.stepSize }
 
+// IsUnfrozenStepEdge reports whether txNum is the last tx of a step whose
+// commitment is not yet frozen into files — where a step-boundary checkpoint
+// must be written. Shared by serial CommitStepBoundary/ApplyStateWrites and the
+// parallel commitment calculator so the predicate can't silently diverge.
+func (sd *SharedDomains) IsUnfrozenStepEdge(roTx kv.TemporalTx, txNum uint64) bool {
+	ss := sd.stepSize
+	if ss == 0 || dbg.DiscardCommitment() {
+		return false
+	}
+	if (txNum+1)%ss != 0 {
+		return false
+	}
+	return txNum/ss >= uint64(roTx.StepsInFiles(kv.CommitmentDomain))
+}
+
 // SetTxNum sets txNum for all domains as well as common txNum for all domains
 // Requires for sd.rwTx because of commitment evaluation in shared domains if stepSize is reached
 func (sd *SharedDomains) SetTxNum(txNum uint64) {

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -54,6 +54,7 @@ type commitmentCalculator struct {
 	db        kv.TemporalRoDB
 	logPrefix string
 	logger    log.Logger
+	stepSize  uint64
 
 	// updates is the calculator's OWN buffer — never shared with the
 	// execLoop or apply loop. Only this goroutine reads/writes it.
@@ -155,6 +156,7 @@ func newCommitmentCalculator(
 		db:                   db,
 		logPrefix:            logPrefix,
 		logger:               logger,
+		stepSize:             doms.StepSize(),
 		updates:              calcUpdates,
 		state:                newCalcState(asOfReader, logger, logPrefix),
 		asOfReader:           asOfReader,
@@ -221,6 +223,16 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		if len(r.writes) > 0 {
 			cc.asOfReader.txNum = r.txNum
 			cc.state.ApplyWrites(r.writes)
+		}
+
+		// Step-end checkpoint on the calculator's own accumulator. Parallel
+		// exec disables the rs.domains step-boundary commitment, so without
+		// this a block straddling a step edge leaves the step's commitment
+		// .kv lagging its account/storage domain.
+		if cc.stepSize > 0 && (r.txNum+1)%cc.stepSize == 0 && !dbg.DiscardCommitment() {
+			if step := r.txNum / cc.stepSize; step >= uint64(cc.roTx.StepsInFiles(kv.CommitmentDomain)) {
+				cc.computeStepBoundary(ctx, &blockResult{BlockNum: r.blockNum, BlockHash: r.blockHash, lastTxNum: r.txNum})
+			}
 		}
 
 	case *blockResult:
@@ -386,6 +398,34 @@ func (cc *commitmentCalculator) computeWithoutCheck(ctx context.Context, br *blo
 
 	cc.lastComputedBlock = br.BlockNum
 	cc.hasComputed = true
+}
+
+// computeStepBoundary saves a commitment checkpoint at a mid-block step edge.
+// Mirrors computeWithoutCheck but must not advance lastComputedBlock — the
+// boundary sits inside the current block, so marking it computed would
+// suppress the real block/batch-end compute.
+func (cc *commitmentCalculator) computeStepBoundary(ctx context.Context, br *blockResult) {
+	if err := cc.state.LazyLoadErr(); err != nil {
+		cc.publish(ctx, commitmentResult{
+			blockNum: br.BlockNum,
+			txNum:    br.lastTxNum,
+			err:      fmt.Errorf("commitmentCalculator: step-boundary lazy-load failed: %w", err),
+		})
+		return
+	}
+	cc.state.FlushToUpdates(cc.updates)
+	cc.state.ResetBlockFlags()
+
+	sdCtx := cc.doms.GetCommitmentContext()
+	sdCtx.SetUpdates(cc.updates)
+	cc.updates = cc.updates.NewEmpty()
+
+	cc.asOfReader.txNum = br.lastTxNum + 1
+	sdCtx.SetStateReader(cc.asOfReader)
+
+	if _, err := cc.computeWithBlockAccumulator(ctx, br); err != nil && cc.logger != nil {
+		cc.logger.Warn("["+cc.logPrefix+"] commitmentCalculator: computeStepBoundary failed", "block", br.BlockNum, "txNum", br.lastTxNum, "err", err)
+	}
 }
 
 // computeAndCheck computes per-block commitment and validates the root.

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -93,11 +93,6 @@ type commitmentCalculator struct {
 	// stage progress instead of finding a commitment state).
 	hasComputed bool
 
-	// lastStepCheckpointTxNum is the txNum of the last step-boundary checkpoint,
-	// so the block-end-edge checkpoint on *blockResult doesn't double-fire when
-	// the edge txResult already triggered one.
-	lastStepCheckpointTxNum uint64
-
 	// in receives the same applyResult stream as the apply loop,
 	// plus commitComputeRequest messages for explicit compute triggers.
 	in chan applyResult
@@ -292,11 +287,6 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 			} else {
 				cc.computeAndCheck(ctx, r)
 			}
-		} else if cc.shouldCheckpointStepBoundary(r.lastTxNum) && cc.lastStepCheckpointTxNum != r.lastTxNum {
-			// Block ends exactly on a step edge but no edge txResult arrived
-			// (e.g. empty finalize) — serial's CommitStepBoundary checkpoints
-			// the block-end tx unconditionally, so checkpoint it here too.
-			cc.computeStepBoundary(ctx, &blockResult{BlockNum: r.BlockNum, BlockHash: r.BlockHash, lastTxNum: r.lastTxNum})
 		}
 		// In BatchCommitments mode (without forcePerBlockCompute): just
 		// accumulate — compute only on explicit commitComputeRequest from
@@ -453,7 +443,6 @@ func (cc *commitmentCalculator) computeStepBoundary(ctx context.Context, br *blo
 			err:      fmt.Errorf("commitmentCalculator: step-boundary compute failed: %w", err),
 		})
 	}
-	cc.lastStepCheckpointTxNum = br.lastTxNum
 }
 
 // computeAndCheck computes per-block commitment and validates the root.

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -205,11 +205,10 @@ func (cc *commitmentCalculator) perBlockCompute() bool {
 }
 
 // shouldCheckpointStepBoundary reports whether this tx sits on a not-yet-frozen
-// step edge that the calculator must checkpoint itself. Only in batch mode:
-// per-block compute owns the boundary, and a mid-block checkpoint there corrupts
-// the straddling block's root.
+// step edge that the calculator must checkpoint itself, in every commitment mode
+// (the snapshot producer runs per-block and still needs step-aligned commitment).
 func (cc *commitmentCalculator) shouldCheckpointStepBoundary(r *txResult) bool {
-	if cc.perBlockCompute() || cc.stepSize == 0 || dbg.DiscardCommitment() {
+	if cc.stepSize == 0 || dbg.DiscardCommitment() {
 		return false
 	}
 	if (r.txNum+1)%cc.stepSize != 0 {
@@ -414,10 +413,10 @@ func (cc *commitmentCalculator) computeWithoutCheck(ctx context.Context, br *blo
 	cc.hasComputed = true
 }
 
-// computeStepBoundary saves a commitment checkpoint at a mid-block step edge.
-// Mirrors computeWithoutCheck but must not advance lastComputedBlock — the
-// boundary sits inside the current block, so marking it computed would
-// suppress the real block/batch-end compute.
+// computeStepBoundary checkpoints commitment at a mid-block step edge. It must
+// not advance lastComputedBlock (or the block/batch-end compute gets suppressed)
+// and must not ResetBlockFlags (or the block-end compute loses the pre-edge
+// dirty keys and folds a wrong block root).
 func (cc *commitmentCalculator) computeStepBoundary(ctx context.Context, br *blockResult) {
 	if err := cc.state.LazyLoadErr(); err != nil {
 		cc.publish(ctx, commitmentResult{
@@ -428,7 +427,6 @@ func (cc *commitmentCalculator) computeStepBoundary(ctx context.Context, br *blo
 		return
 	}
 	cc.state.FlushToUpdates(cc.updates)
-	cc.state.ResetBlockFlags()
 
 	sdCtx := cc.doms.GetCommitmentContext()
 	sdCtx.SetUpdates(cc.updates)

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -520,13 +520,14 @@ func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockRe
 
 func (cc *commitmentCalculator) publish(ctx context.Context, r commitmentResult) {
 	// The send is best-effort (it can drop on shutdown), so log genuine errors
-	// here; wrong-root is routine (apply loop logs it) and ctx cancel/timeout is
-	// expected on shutdown, so neither is worth an Error line.
+	// here as a breadcrumb — the apply loop surfaces the authoritative error.
+	// Wrong-root is routine (apply loop logs it) and ctx cancel/timeout is
+	// expected on shutdown, so skip both.
 	if r.err != nil && cc.logger != nil &&
 		!errors.Is(r.err, ErrWrongTrieRoot) &&
 		!errors.Is(r.err, context.Canceled) &&
 		!errors.Is(r.err, context.DeadlineExceeded) {
-		cc.logger.Error("["+cc.logPrefix+"] commitment compute failed", "block", r.blockNum, "txNum", r.txNum, "err", r.err)
+		cc.logger.Warn("["+cc.logPrefix+"] commitment compute failed", "block", r.blockNum, "txNum", r.txNum, "err", r.err)
 	}
 	select {
 	case cc.out <- r:

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -53,7 +53,6 @@ type commitmentCalculator struct {
 	doms      *execctx.SharedDomains
 	db        kv.TemporalRoDB
 	logPrefix string
-	logger    log.Logger
 	stepSize  uint64
 
 	// updates is the calculator's OWN buffer — never shared with the
@@ -155,7 +154,6 @@ func newCommitmentCalculator(
 		doms:                 doms,
 		db:                   db,
 		logPrefix:            logPrefix,
-		logger:               logger,
 		stepSize:             doms.StepSize(),
 		updates:              calcUpdates,
 		state:                newCalcState(asOfReader, logger, logPrefix),
@@ -401,12 +399,12 @@ func (cc *commitmentCalculator) computeWithoutCheck(ctx context.Context, br *blo
 	// when pastChangesAccumulator holds multiple changesets per block number
 	// (canonical + fork during reorg-bounce tests).
 	if _, err := cc.computeWithBlockAccumulator(ctx, br); err != nil {
-		// Partial-block compute is intentionally not verified (no header root
-		// to compare against), but a real ComputeCommitment failure leaves
-		// later trie state suspect — log so the failure isn't silent.
-		if cc.logger != nil {
-			cc.logger.Warn("["+cc.logPrefix+"] commitmentCalculator: computeWithoutCheck failed", "block", br.BlockNum, "txNum", br.lastTxNum, "err", err)
-		}
+		cc.publish(ctx, commitmentResult{
+			blockNum: br.BlockNum,
+			txNum:    br.lastTxNum,
+			err:      fmt.Errorf("commitmentCalculator: partial-block compute failed: %w", err),
+		})
+		return
 	}
 
 	cc.lastComputedBlock = br.BlockNum
@@ -435,8 +433,12 @@ func (cc *commitmentCalculator) computeStepBoundary(ctx context.Context, br *blo
 	cc.asOfReader.txNum = br.lastTxNum + 1
 	sdCtx.SetStateReader(cc.asOfReader)
 
-	if _, err := cc.computeWithBlockAccumulator(ctx, br); err != nil && cc.logger != nil {
-		cc.logger.Warn("["+cc.logPrefix+"] commitmentCalculator: computeStepBoundary failed", "block", br.BlockNum, "txNum", br.lastTxNum, "err", err)
+	if _, err := cc.computeWithBlockAccumulator(ctx, br); err != nil {
+		cc.publish(ctx, commitmentResult{
+			blockNum: br.BlockNum,
+			txNum:    br.lastTxNum,
+			err:      fmt.Errorf("commitmentCalculator: step-boundary compute failed: %w", err),
+		})
 	}
 }
 

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -93,6 +93,11 @@ type commitmentCalculator struct {
 	// stage progress instead of finding a commitment state).
 	hasComputed bool
 
+	// lastStepCheckpointTxNum is the txNum of the last step-boundary checkpoint,
+	// so the block-end-edge checkpoint on *blockResult doesn't double-fire when
+	// the edge txResult already triggered one.
+	lastStepCheckpointTxNum uint64
+
 	// in receives the same applyResult stream as the apply loop,
 	// plus commitComputeRequest messages for explicit compute triggers.
 	in chan applyResult
@@ -208,14 +213,14 @@ func (cc *commitmentCalculator) perBlockCompute() bool {
 // shouldCheckpointStepBoundary reports whether this tx sits on a not-yet-frozen
 // step edge that the calculator must checkpoint itself, in every commitment mode
 // (the snapshot producer runs per-block and still needs step-aligned commitment).
-func (cc *commitmentCalculator) shouldCheckpointStepBoundary(r *txResult) bool {
+func (cc *commitmentCalculator) shouldCheckpointStepBoundary(txNum uint64) bool {
 	if cc.stepSize == 0 || dbg.DiscardCommitment() {
 		return false
 	}
-	if (r.txNum+1)%cc.stepSize != 0 {
+	if (txNum+1)%cc.stepSize != 0 {
 		return false
 	}
-	return r.txNum/cc.stepSize >= uint64(cc.roTx.StepsInFiles(kv.CommitmentDomain))
+	return txNum/cc.stepSize >= uint64(cc.roTx.StepsInFiles(kv.CommitmentDomain))
 }
 
 // handleMessage contains the break logic — decides what to do with each
@@ -245,7 +250,7 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 			cc.state.ApplyWrites(r.writes)
 		}
 
-		if cc.shouldCheckpointStepBoundary(r) {
+		if cc.shouldCheckpointStepBoundary(r.txNum) {
 			cc.computeStepBoundary(ctx, &blockResult{BlockNum: r.blockNum, BlockHash: r.blockHash, lastTxNum: r.txNum})
 		}
 
@@ -287,6 +292,11 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 			} else {
 				cc.computeAndCheck(ctx, r)
 			}
+		} else if cc.shouldCheckpointStepBoundary(r.lastTxNum) && cc.lastStepCheckpointTxNum != r.lastTxNum {
+			// Block ends exactly on a step edge but no edge txResult arrived
+			// (e.g. empty finalize) — serial's CommitStepBoundary checkpoints
+			// the block-end tx unconditionally, so checkpoint it here too.
+			cc.computeStepBoundary(ctx, &blockResult{BlockNum: r.BlockNum, BlockHash: r.BlockHash, lastTxNum: r.lastTxNum})
 		}
 		// In BatchCommitments mode (without forcePerBlockCompute): just
 		// accumulate — compute only on explicit commitComputeRequest from
@@ -443,6 +453,7 @@ func (cc *commitmentCalculator) computeStepBoundary(ctx context.Context, br *blo
 			err:      fmt.Errorf("commitmentCalculator: step-boundary compute failed: %w", err),
 		})
 	}
+	cc.lastStepCheckpointTxNum = br.lastTxNum
 }
 
 // computeAndCheck computes per-block commitment and validates the root.

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -3,6 +3,7 @@ package stagedsync
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"runtime/pprof"
 	"sync"
@@ -53,6 +54,7 @@ type commitmentCalculator struct {
 	doms      *execctx.SharedDomains
 	db        kv.TemporalRoDB
 	logPrefix string
+	logger    log.Logger
 	stepSize  uint64
 
 	// updates is the calculator's OWN buffer — never shared with the
@@ -154,6 +156,7 @@ func newCommitmentCalculator(
 		doms:                 doms,
 		db:                   db,
 		logPrefix:            logPrefix,
+		logger:               logger,
 		stepSize:             doms.StepSize(),
 		updates:              calcUpdates,
 		state:                newCalcState(asOfReader, logger, logPrefix),
@@ -505,6 +508,11 @@ func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockRe
 }
 
 func (cc *commitmentCalculator) publish(ctx context.Context, r commitmentResult) {
+	// The send is best-effort (it can drop on shutdown), so log genuine errors
+	// here; wrong-root is routine and the apply loop already logs it.
+	if r.err != nil && cc.logger != nil && !errors.Is(r.err, ErrWrongTrieRoot) {
+		cc.logger.Error("["+cc.logPrefix+"] commitment compute failed", "block", r.blockNum, "txNum", r.txNum, "err", r.err)
+	}
 	select {
 	case cc.out <- r:
 	case <-ctx.Done():

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -55,7 +55,6 @@ type commitmentCalculator struct {
 	db        kv.TemporalRoDB
 	logPrefix string
 	logger    log.Logger
-	stepSize  uint64
 
 	// updates is the calculator's OWN buffer — never shared with the
 	// execLoop or apply loop. Only this goroutine reads/writes it.
@@ -157,7 +156,6 @@ func newCommitmentCalculator(
 		db:                   db,
 		logPrefix:            logPrefix,
 		logger:               logger,
-		stepSize:             doms.StepSize(),
 		updates:              calcUpdates,
 		state:                newCalcState(asOfReader, logger, logPrefix),
 		asOfReader:           asOfReader,
@@ -205,19 +203,6 @@ func (cc *commitmentCalculator) perBlockCompute() bool {
 	return !dbg.BatchCommitments || cc.forcePerBlockCompute
 }
 
-// shouldCheckpointStepBoundary reports whether this tx sits on a not-yet-frozen
-// step edge that the calculator must checkpoint itself, in every commitment mode
-// (the snapshot producer runs per-block and still needs step-aligned commitment).
-func (cc *commitmentCalculator) shouldCheckpointStepBoundary(txNum uint64) bool {
-	if cc.stepSize == 0 || dbg.DiscardCommitment() {
-		return false
-	}
-	if (txNum+1)%cc.stepSize != 0 {
-		return false
-	}
-	return txNum/cc.stepSize >= uint64(cc.roTx.StepsInFiles(kv.CommitmentDomain))
-}
-
 // handleMessage contains the break logic — decides what to do with each
 // message in the stream.
 func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResult) {
@@ -245,7 +230,7 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 			cc.state.ApplyWrites(r.writes)
 		}
 
-		if cc.shouldCheckpointStepBoundary(r.txNum) {
+		if cc.doms.IsUnfrozenStepEdge(cc.roTx, r.txNum) {
 			cc.computeStepBoundary(ctx, &blockResult{BlockNum: r.blockNum, BlockHash: r.blockHash, lastTxNum: r.txNum})
 		}
 

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -198,6 +198,26 @@ func (cc *commitmentCalculator) loop(ctx context.Context) {
 	}
 }
 
+// perBlockCompute reports whether commitment is computed at each block boundary
+// (vs accumulating into a batch).
+func (cc *commitmentCalculator) perBlockCompute() bool {
+	return !dbg.BatchCommitments || cc.forcePerBlockCompute
+}
+
+// shouldCheckpointStepBoundary reports whether this tx sits on a not-yet-frozen
+// step edge that the calculator must checkpoint itself. Only in batch mode:
+// per-block compute owns the boundary, and a mid-block checkpoint there corrupts
+// the straddling block's root.
+func (cc *commitmentCalculator) shouldCheckpointStepBoundary(r *txResult) bool {
+	if cc.perBlockCompute() || cc.stepSize == 0 || dbg.DiscardCommitment() {
+		return false
+	}
+	if (r.txNum+1)%cc.stepSize != 0 {
+		return false
+	}
+	return r.txNum/cc.stepSize >= uint64(cc.roTx.StepsInFiles(kv.CommitmentDomain))
+}
+
 // handleMessage contains the break logic — decides what to do with each
 // message in the stream.
 func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResult) {
@@ -225,14 +245,8 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 			cc.state.ApplyWrites(r.writes)
 		}
 
-		// Step-end checkpoint on the calculator's own accumulator. Parallel
-		// exec disables the rs.domains step-boundary commitment, so without
-		// this a block straddling a step edge leaves the step's commitment
-		// .kv lagging its account/storage domain.
-		if cc.stepSize > 0 && (r.txNum+1)%cc.stepSize == 0 && !dbg.DiscardCommitment() {
-			if step := r.txNum / cc.stepSize; step >= uint64(cc.roTx.StepsInFiles(kv.CommitmentDomain)) {
-				cc.computeStepBoundary(ctx, &blockResult{BlockNum: r.blockNum, BlockHash: r.blockHash, lastTxNum: r.txNum})
-			}
+		if cc.shouldCheckpointStepBoundary(r) {
+			cc.computeStepBoundary(ctx, &blockResult{BlockNum: r.blockNum, BlockHash: r.blockHash, lastTxNum: r.txNum})
 		}
 
 	case *blockResult:
@@ -263,7 +277,7 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		// || shouldGenerateChangesets || ...` check) — per-block compute is
 		// required when changesets must record per-block branch deltas
 		// (reorg support, KeepExecutionProofs).
-		if !dbg.BatchCommitments || cc.forcePerBlockCompute {
+		if cc.perBlockCompute() {
 			if cc.lastComputedBlock == 0 && r.isPartial {
 				// First block is partial (resumed mid-block).
 				// Compute it (like serial does) to save trie state, then

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -520,8 +520,12 @@ func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockRe
 
 func (cc *commitmentCalculator) publish(ctx context.Context, r commitmentResult) {
 	// The send is best-effort (it can drop on shutdown), so log genuine errors
-	// here; wrong-root is routine and the apply loop already logs it.
-	if r.err != nil && cc.logger != nil && !errors.Is(r.err, ErrWrongTrieRoot) {
+	// here; wrong-root is routine (apply loop logs it) and ctx cancel/timeout is
+	// expected on shutdown, so neither is worth an Error line.
+	if r.err != nil && cc.logger != nil &&
+		!errors.Is(r.err, ErrWrongTrieRoot) &&
+		!errors.Is(r.err, context.Canceled) &&
+		!errors.Is(r.err, context.DeadlineExceeded) {
 		cc.logger.Error("["+cc.logPrefix+"] commitment compute failed", "block", r.blockNum, "txNum", r.txNum, "err", r.err)
 	}
 	select {

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -141,6 +141,84 @@ func TestHandleMessage_StepBoundaryCheckpointMidBlock(t *testing.T) {
 	requireBranchesConsistentWithAccounts(t, doms, tx, accountValues)
 }
 
+// TestHandleMessage_NoStepCheckpointInPerBlockMode pins that in per-block compute
+// mode the calculator does not inject a mid-block step-boundary checkpoint — the
+// block-boundary compute owns commitment, and a mid-block checkpoint would corrupt
+// that block's root.
+func TestHandleMessage_NoStepCheckpointInPerBlockMode(t *testing.T) {
+	ctx := context.Background()
+	logger := log.New()
+	const stepSize = uint64(16)
+
+	dirs := datadir.New(t.TempDir())
+	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
+	defer rawDb.Close()
+
+	agg, err := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(ctx, rawDb)
+	require.NoError(t, err)
+	defer agg.Close()
+
+	db, err := temporal.New(rawDb, agg)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTemporalRw(ctx) //nolint:gocritic
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	defer doms.Close()
+
+	in := make(chan applyResult, 64)
+	out := make(chan commitmentResult, 64)
+	// forcePerBlockCompute => every block computes per-block.
+	cc, err := newCommitmentCalculator(ctx, doms, db, "test", logger, true, in, out)
+	require.NoError(t, err)
+
+	const block1End = uint64(10)
+	const stepEdgeTxNum = stepSize - 1 // 15
+
+	rnd := rand.New(rand.NewSource(42))
+	writeAccount := func(txNum, blockNum uint64) {
+		addrBytes := make([]byte, length.Addr)
+		rnd.Read(addrBytes)
+		addr := accounts.InternAddress([20]byte(addrBytes))
+		bal := *uint256.NewInt(txNum * 1000)
+		acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
+		buf := accounts.SerialiseV3(&acc)
+		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
+		cc.handleMessage(ctx, &txResult{
+			blockNum: blockNum,
+			txNum:    txNum,
+			writes: state.VersionedWrites{
+				&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: txNum},
+				&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: bal},
+			},
+		})
+	}
+
+	for txNum := uint64(1); txNum <= block1End; txNum++ {
+		writeAccount(txNum, 1)
+	}
+	cc.handleMessage(ctx, &blockResult{BlockNum: 1, BlockHash: common.Hash{0x01}, lastTxNum: block1End})
+
+	// Block 2 runs only up to the step edge — no block-2 boundary is sent.
+	for txNum := block1End + 1; txNum <= stepEdgeTxNum; txNum++ {
+		writeAccount(txNum, 2)
+	}
+
+	cc.Stop()
+
+	stateBlob, _, err := doms.GetLatest(kv.CommitmentDomain, tx, commitmentdb.KeyCommitmentState)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(stateBlob), 16, "block 1's per-block compute should have saved a commitment state")
+	gotTxNum, gotBlockNum := commitmentdb.DecodeTxBlockNums(stateBlob)
+	require.Equal(t, block1End, gotTxNum,
+		"per-block mode must not checkpoint at the mid-block step edge — latest state must stay at block 1's boundary")
+	require.Equal(t, uint64(1), gotBlockNum,
+		"per-block mode must not advance commitment into the straddling block before its boundary")
+}
+
 // requireBranchesConsistentWithAccounts flushes the calculator's commitment
 // branches and verifies every one hashes consistently with the account values
 // written through the step edge — the integrity oracle proving the step-0

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -141,11 +141,11 @@ func TestHandleMessage_StepBoundaryCheckpointMidBlock(t *testing.T) {
 	requireBranchesConsistentWithAccounts(t, doms, tx, accountValues)
 }
 
-// TestHandleMessage_NoStepCheckpointInPerBlockMode pins that in per-block compute
-// mode the calculator does not inject a mid-block step-boundary checkpoint — the
-// block-boundary compute owns commitment, and a mid-block checkpoint would corrupt
-// that block's root.
-func TestHandleMessage_NoStepCheckpointInPerBlockMode(t *testing.T) {
+// TestHandleMessage_StepCheckpointInPerBlockMode pins that the step-boundary
+// checkpoint still fires in per-block compute mode (forcePerBlockCompute), which
+// is how the archive snapshot producer runs — it needs step-aligned commitment
+// just like batch mode.
+func TestHandleMessage_StepCheckpointInPerBlockMode(t *testing.T) {
 	ctx := context.Background()
 	logger := log.New()
 	const stepSize = uint64(16)
@@ -171,7 +171,7 @@ func TestHandleMessage_NoStepCheckpointInPerBlockMode(t *testing.T) {
 
 	in := make(chan applyResult, 64)
 	out := make(chan commitmentResult, 64)
-	// forcePerBlockCompute => every block computes per-block.
+	// forcePerBlockCompute=true => snapshot-producer mode (per-block at every block).
 	cc, err := newCommitmentCalculator(ctx, doms, db, "test", logger, true, in, out)
 	require.NoError(t, err)
 
@@ -211,12 +211,12 @@ func TestHandleMessage_NoStepCheckpointInPerBlockMode(t *testing.T) {
 
 	stateBlob, _, err := doms.GetLatest(kv.CommitmentDomain, tx, commitmentdb.KeyCommitmentState)
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(stateBlob), 16, "block 1's per-block compute should have saved a commitment state")
+	require.GreaterOrEqual(t, len(stateBlob), 16, "a commitment checkpoint must exist at the mid-block step edge")
 	gotTxNum, gotBlockNum := commitmentdb.DecodeTxBlockNums(stateBlob)
-	require.Equal(t, block1End, gotTxNum,
-		"per-block mode must not checkpoint at the mid-block step edge — latest state must stay at block 1's boundary")
-	require.Equal(t, uint64(1), gotBlockNum,
-		"per-block mode must not advance commitment into the straddling block before its boundary")
+	require.Equal(t, stepEdgeTxNum, gotTxNum,
+		"per-block mode must still checkpoint at the mid-block step edge (snapshot producer needs step-aligned commitment)")
+	require.Equal(t, uint64(2), gotBlockNum,
+		"the step checkpoint sits inside the straddling block")
 }
 
 // requireBranchesConsistentWithAccounts flushes the calculator's commitment

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package stagedsync
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/mdbx"
+	"github.com/erigontech/erigon/db/kv/order"
+	"github.com/erigontech/erigon/db/kv/temporal"
+	dbstate "github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// TestHandleMessage_StepBoundaryCheckpointMidBlock pins the parallel-exec
+// step-boundary commitment bug: a block whose txNum range straddles a step
+// edge must leave a commitment checkpoint at that edge, otherwise the step's
+// commitment .kv lags its account/storage domain .kv. The calculator runs in
+// pure batch mode (no per-block compute), so without the step-boundary hook in
+// handleMessage's txResult case NO commitment state is written at the mid-block
+// step edge: the checkpoint never advances to stepEnd and no step-0 branches
+// are produced to verify against the account domain written through that step.
+func TestHandleMessage_StepBoundaryCheckpointMidBlock(t *testing.T) {
+	ctx := context.Background()
+	logger := log.New()
+	const stepSize = uint64(16)
+
+	dirs := datadir.New(t.TempDir())
+	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
+	defer rawDb.Close()
+
+	agg, err := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(ctx, rawDb)
+	require.NoError(t, err)
+	defer agg.Close()
+
+	db, err := temporal.New(rawDb, agg)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTemporalRw(ctx) //nolint:gocritic
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	defer doms.Close()
+
+	in := make(chan applyResult, 64)
+	out := make(chan commitmentResult, 64)
+	cc, err := newCommitmentCalculator(ctx, doms, db, "test", logger, false, in, out)
+	require.NoError(t, err)
+
+	// Block 1: txNums 1..10, fully before the step-0 edge (txNum 15).
+	// Block 2: txNums 11..20, straddling the edge at txNum 15.
+	const block1End = uint64(10)
+	const block2End = uint64(20)
+	const stepEdgeTxNum = stepSize - 1 // 15, where (txNum+1)%stepSize==0
+
+	rnd := rand.New(rand.NewSource(42))
+	accountValues := make(map[string][]byte)
+
+	writeAccount := func(txNum uint64) {
+		addrBytes := make([]byte, length.Addr)
+		rnd.Read(addrBytes)
+		addr := accounts.InternAddress([20]byte(addrBytes))
+		bal := *uint256.NewInt(txNum * 1000)
+		acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
+		buf := accounts.SerialiseV3(&acc)
+		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
+		if txNum <= stepEdgeTxNum {
+			accountValues[string(addrBytes)] = buf
+		}
+		blockNum := uint64(1)
+		if txNum > block1End {
+			blockNum = 2
+		}
+		cc.handleMessage(ctx, &txResult{
+			blockNum: blockNum,
+			txNum:    txNum,
+			writes: state.VersionedWrites{
+				&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: txNum},
+				&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: bal},
+			},
+		})
+	}
+
+	for txNum := uint64(1); txNum <= block1End; txNum++ {
+		writeAccount(txNum)
+	}
+	cc.handleMessage(ctx, &blockResult{BlockNum: 1, BlockHash: common.Hash{0x01}, lastTxNum: block1End})
+
+	for txNum := block1End + 1; txNum <= block2End; txNum++ {
+		writeAccount(txNum)
+	}
+	cc.handleMessage(ctx, &blockResult{BlockNum: 2, BlockHash: common.Hash{0x02}, lastTxNum: block2End})
+
+	cc.Stop()
+
+	// Batch mode computes commitment only on an explicit request, which this
+	// stream never sends; the sole writer of a checkpoint is the step-boundary
+	// hook at txNum 15, so the latest checkpoint must decode to that edge.
+	stateBlob, _, err := doms.GetLatest(kv.CommitmentDomain, tx, commitmentdb.KeyCommitmentState)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(stateBlob), 16,
+		"no commitment checkpoint was saved at the mid-block step edge — the step-boundary hook in handleMessage's txResult case never ran")
+	gotTxNum, gotBlockNum := commitmentdb.DecodeTxBlockNums(stateBlob)
+	require.Equal(t, stepEdgeTxNum, gotTxNum,
+		"step-boundary checkpoint must reflect the straddling step's last txNum (stepEnd-1), not the last complete block before the edge")
+	require.Equal(t, uint64(2), gotBlockNum,
+		"the checkpoint sits inside block 2 (the straddling block)")
+
+	requireBranchesConsistentWithAccounts(t, doms, tx, accountValues)
+}
+
+// requireBranchesConsistentWithAccounts flushes the calculator's commitment
+// branches and verifies every one hashes consistently with the account values
+// written through the step edge — the integrity oracle proving the step-0
+// commitment .kv matches the step-0 account domain .kv.
+func requireBranchesConsistentWithAccounts(t *testing.T, doms *execctx.SharedDomains, tx kv.TemporalRwTx, accountValues map[string][]byte) {
+	t.Helper()
+	require.NoError(t, doms.Flush(t.Context(), tx))
+
+	it, err := tx.RangeAsOf(kv.CommitmentDomain, nil, nil, 1000, order.Asc, -1)
+	require.NoError(t, err)
+	defer it.Close()
+
+	storageValues := map[string][]byte{}
+	checked := 0
+	for it.HasNext() {
+		k, v, err := it.Next()
+		require.NoError(t, err)
+		if bytes.Equal(k, commitmentdb.KeyCommitmentState) {
+			continue
+		}
+		require.NoError(t, commitment.VerifyBranchHashes(k, commitment.BranchData(v), accountValues, storageValues),
+			"branch %x at the step edge disagrees with the account domain written through that step", k)
+		checked++
+	}
+	require.Positive(t, checked, "expected at least one commitment branch to verify at the step edge")
+}

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -55,24 +55,7 @@ func TestHandleMessage_StepBoundaryCheckpointMidBlock(t *testing.T) {
 	logger := log.New()
 	const stepSize = uint64(16)
 
-	dirs := datadir.New(t.TempDir())
-	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
-	defer rawDb.Close()
-
-	agg, err := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(ctx, rawDb)
-	require.NoError(t, err)
-	defer agg.Close()
-
-	db, err := temporal.New(rawDb, agg)
-	require.NoError(t, err)
-
-	tx, err := db.BeginTemporalRw(ctx) //nolint:gocritic
-	require.NoError(t, err)
-	defer tx.Rollback()
-
-	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
-	require.NoError(t, err)
-	defer doms.Close()
+	db, tx, doms := setupStepTest(t)
 
 	in := make(chan applyResult, 64)
 	out := make(chan commitmentResult, 64)
@@ -150,24 +133,7 @@ func TestHandleMessage_StepCheckpointInPerBlockMode(t *testing.T) {
 	logger := log.New()
 	const stepSize = uint64(16)
 
-	dirs := datadir.New(t.TempDir())
-	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
-	defer rawDb.Close()
-
-	agg, err := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(ctx, rawDb)
-	require.NoError(t, err)
-	defer agg.Close()
-
-	db, err := temporal.New(rawDb, agg)
-	require.NoError(t, err)
-
-	tx, err := db.BeginTemporalRw(ctx) //nolint:gocritic
-	require.NoError(t, err)
-	defer tx.Rollback()
-
-	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
-	require.NoError(t, err)
-	defer doms.Close()
+	db, tx, doms := setupStepTest(t)
 
 	in := make(chan applyResult, 64)
 	out := make(chan commitmentResult, 64)
@@ -228,24 +194,7 @@ func TestHandleMessage_PartialBlockComputeFailureNotSwallowed(t *testing.T) {
 	logger := log.New()
 	const stepSize = uint64(16)
 
-	dirs := datadir.New(t.TempDir())
-	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
-	defer rawDb.Close()
-
-	agg, err := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(ctx, rawDb)
-	require.NoError(t, err)
-	defer agg.Close()
-
-	db, err := temporal.New(rawDb, agg)
-	require.NoError(t, err)
-
-	tx, err := db.BeginTemporalRw(ctx) //nolint:gocritic
-	require.NoError(t, err)
-	defer tx.Rollback()
-
-	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
-	require.NoError(t, err)
-	defer doms.Close()
+	db, tx, doms := setupStepTest(t)
 
 	in := make(chan applyResult, 64)
 	out := make(chan commitmentResult, 64)
@@ -332,24 +281,7 @@ func runBlockEndingOnStepEdge(t *testing.T, edgeTxHasWrites bool) stepEdgeOutcom
 	const stepSize = uint64(16)
 	const edgeTxNum = stepSize - 1 // 15: (txNum+1)%stepSize == 0
 
-	dirs := datadir.New(t.TempDir())
-	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
-	defer rawDb.Close()
-
-	agg, err := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(ctx, rawDb)
-	require.NoError(t, err)
-	defer agg.Close()
-
-	db, err := temporal.New(rawDb, agg)
-	require.NoError(t, err)
-
-	tx, err := db.BeginTemporalRw(ctx) //nolint:gocritic
-	require.NoError(t, err)
-	defer tx.Rollback()
-
-	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
-	require.NoError(t, err)
-	defer doms.Close()
+	db, tx, doms := setupStepTest(t)
 
 	in := make(chan applyResult, 64)
 	out := make(chan commitmentResult, 64)
@@ -433,4 +365,32 @@ func TestHandleMessage_StepEdgeAtBlockEnd(t *testing.T) {
 		require.Equal(t, uint64(15), gotTxNum)
 		require.Equal(t, uint64(1), gotBlockNum)
 	})
+}
+
+// setupStepTest builds the shared in-memory temporal stack (stepSize 16) for the
+// step-boundary tests — like setup2CacheTest, but also returns the db the
+// commitment calculator needs for its own read tx.
+func setupStepTest(t *testing.T) (kv.TemporalRwDB, kv.TemporalRwTx, *execctx.SharedDomains) {
+	t.Helper()
+	ctx := context.Background()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
+	t.Cleanup(rawDb.Close)
+
+	agg, err := dbstate.NewTest(dirs).StepSize(16).Logger(logger).Open(ctx, rawDb)
+	require.NoError(t, err)
+	t.Cleanup(agg.Close)
+
+	db, err := temporal.New(rawDb, agg)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTemporalRw(ctx) //nolint:gocritic
+	require.NoError(t, err)
+	t.Cleanup(func() { tx.Rollback() })
+
+	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	t.Cleanup(doms.Close)
+	return db, tx, doms
 }

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -219,6 +219,73 @@ func TestHandleMessage_StepCheckpointInPerBlockMode(t *testing.T) {
 		"the step checkpoint sits inside the straddling block")
 }
 
+// TestHandleMessage_PartialBlockComputeFailureNotSwallowed pins that when the
+// first partial block's commitment computation fails, the calculator does not
+// mark the block computed. A swallowed compute error there would let exec
+// proceed past a block whose commitment never landed.
+func TestHandleMessage_PartialBlockComputeFailureNotSwallowed(t *testing.T) {
+	ctx := context.Background()
+	logger := log.New()
+	const stepSize = uint64(16)
+
+	dirs := datadir.New(t.TempDir())
+	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
+	defer rawDb.Close()
+
+	agg, err := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(ctx, rawDb)
+	require.NoError(t, err)
+	defer agg.Close()
+
+	db, err := temporal.New(rawDb, agg)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTemporalRw(ctx) //nolint:gocritic
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	defer doms.Close()
+
+	in := make(chan applyResult, 64)
+	out := make(chan commitmentResult, 64)
+	// forcePerBlockCompute=true routes the first partial block to computeWithoutCheck.
+	cc, err := newCommitmentCalculator(ctx, doms, db, "test", logger, true, in, out)
+	require.NoError(t, err)
+	defer cc.Stop()
+
+	rnd := rand.New(rand.NewSource(42))
+	for txNum := uint64(1); txNum <= 5; txNum++ {
+		addrBytes := make([]byte, length.Addr)
+		rnd.Read(addrBytes)
+		addr := accounts.InternAddress([20]byte(addrBytes))
+		bal := *uint256.NewInt(txNum * 1000)
+		acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
+		buf := accounts.SerialiseV3(&acc)
+		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
+		cc.handleMessage(ctx, &txResult{
+			blockNum: 1,
+			txNum:    txNum,
+			writes: state.VersionedWrites{
+				&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: txNum},
+				&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: bal},
+			},
+		})
+	}
+	require.False(t, cc.hasComputed)
+
+	// A cancelled context makes the partial-block ComputeCommitment fail
+	// deterministically (the per-key ctx check in the trie fold, with >=1 update).
+	failCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	cc.handleMessage(failCtx, &blockResult{BlockNum: 1, BlockHash: common.Hash{0x01}, lastTxNum: 5, isPartial: true})
+
+	require.False(t, cc.hasComputed,
+		"a failed partial-block commitment must not be marked computed — the error must halt exec, not be swallowed")
+	require.Zero(t, cc.lastComputedBlock,
+		"lastComputedBlock must not advance past a block whose commitment failed")
+}
+
 // requireBranchesConsistentWithAccounts flushes the calculator's commitment
 // branches and verifies every one hashes consistently with the account values
 // written through the step edge — the integrity oracle proving the step-0

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -312,3 +312,129 @@ func requireBranchesConsistentWithAccounts(t *testing.T, doms *execctx.SharedDom
 	}
 	require.Positive(t, checked, "expected at least one commitment branch to verify at the step edge")
 }
+
+type stepEdgeOutcome struct {
+	commitmentState  []byte
+	accountsThruEdge int
+}
+
+// runBlockEndingOnStepEdge drives one block, in pure batch mode, whose finalize
+// (block-end) txNum is exactly the step-0 edge (txNum 15, stepSize 16). Regular
+// txs 1..14 each emit a txResult; none lands on the edge. The block-end txNum 15
+// IS the step edge, and deliverEdgeTxResult models whether the exec loop emits a
+// txResult there — in production that send is gated on `len(finalizeWrites) > 0`
+// in blockExecutor.nextResult (exec3_parallel.go), so an empty-finalize block
+// delivers only the blockResult. The blockResult (lastTxNum=15) always arrives.
+func runBlockEndingOnStepEdge(t *testing.T, deliverEdgeTxResult bool) stepEdgeOutcome {
+	t.Helper()
+	ctx := context.Background()
+	logger := log.New()
+	const stepSize = uint64(16)
+	const edgeTxNum = stepSize - 1 // 15: (txNum+1)%stepSize == 0
+
+	dirs := datadir.New(t.TempDir())
+	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
+	defer rawDb.Close()
+
+	agg, err := dbstate.NewTest(dirs).StepSize(stepSize).Logger(logger).Open(ctx, rawDb)
+	require.NoError(t, err)
+	defer agg.Close()
+
+	db, err := temporal.New(rawDb, agg)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTemporalRw(ctx) //nolint:gocritic
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	doms, err := execctx.NewSharedDomains(ctx, tx, logger)
+	require.NoError(t, err)
+	defer doms.Close()
+
+	in := make(chan applyResult, 64)
+	out := make(chan commitmentResult, 64)
+	// forcePerBlockCompute=false + huge perBlockFrom => pure batch mode: the
+	// blockResult never triggers a per-block compute, so the only thing that can
+	// checkpoint the step edge is the step-boundary hook.
+	cc, err := newCommitmentCalculator(ctx, doms, db, "test", logger, false, in, out)
+	require.NoError(t, err)
+
+	rnd := rand.New(rand.NewSource(42))
+	writeAccount := func(txNum uint64) {
+		addrBytes := make([]byte, length.Addr)
+		rnd.Read(addrBytes)
+		addr := accounts.InternAddress([20]byte(addrBytes))
+		bal := *uint256.NewInt(txNum * 1000)
+		acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
+		buf := accounts.SerialiseV3(&acc)
+		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
+		cc.handleMessage(ctx, &txResult{
+			blockNum: 1,
+			txNum:    txNum,
+			writes: state.VersionedWrites{
+				&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: txNum},
+				&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: bal},
+			},
+		})
+	}
+
+	for txNum := uint64(1); txNum < edgeTxNum; txNum++ {
+		writeAccount(txNum)
+	}
+	if deliverEdgeTxResult {
+		writeAccount(edgeTxNum)
+	}
+	cc.handleMessage(ctx, &blockResult{BlockNum: 1, BlockHash: common.Hash{0x01}, lastTxNum: edgeTxNum})
+	cc.Stop()
+
+	stateBlob, _, err := doms.GetLatest(kv.CommitmentDomain, tx, commitmentdb.KeyCommitmentState)
+	require.NoError(t, err)
+
+	require.NoError(t, doms.Flush(ctx, tx))
+	it, err := tx.RangeAsOf(kv.AccountsDomain, nil, nil, edgeTxNum+1, order.Asc, -1)
+	require.NoError(t, err)
+	defer it.Close()
+	accCount := 0
+	for it.HasNext() {
+		_, v, err := it.Next()
+		require.NoError(t, err)
+		if len(v) > 0 {
+			accCount++
+		}
+	}
+	return stepEdgeOutcome{commitmentState: stateBlob, accountsThruEdge: accCount}
+}
+
+// TestHandleMessage_StepEdgeAtBlockEnd pins parity with serial when a step edge
+// lands exactly on a block's finalize (block-end) txNum. Serial runs
+// CommitStepBoundary on the block-end tx task unconditionally (exec3_serial.go),
+// so it always checkpoints the edge. In parallel the calculator only consults
+// shouldCheckpointStepBoundary in handleMessage's *txResult case, and the exec
+// loop suppresses the finalize txResult when the block produced no finalize
+// writes (`if len(finalizeWrites) > 0`). The two sub-cases differ ONLY by whether
+// a txResult is delivered at the edge txNum; both must leave a step-aligned
+// commitment checkpoint, else the step's commitment .kv lags its account-domain
+// .kv (the inconsistency fixed for the mid-block case).
+func TestHandleMessage_StepEdgeAtBlockEnd(t *testing.T) {
+	t.Run("with_finalize_writes", func(t *testing.T) {
+		res := runBlockEndingOnStepEdge(t, true)
+		require.GreaterOrEqual(t, len(res.commitmentState), 16,
+			"edge txResult delivered → step-boundary checkpoint written")
+		gotTxNum, gotBlockNum := commitmentdb.DecodeTxBlockNums(res.commitmentState)
+		require.Equal(t, uint64(15), gotTxNum)
+		require.Equal(t, uint64(1), gotBlockNum)
+	})
+
+	t.Run("empty_finalize", func(t *testing.T) {
+		res := runBlockEndingOnStepEdge(t, false)
+		require.Positive(t, res.accountsThruEdge,
+			"sanity: the account domain holds the block's writes through the step edge")
+		require.GreaterOrEqual(t, len(res.commitmentState), 16,
+			"a block ending on a step edge with empty finalize must still leave a step-aligned "+
+				"commitment checkpoint (serial does via CommitStepBoundary); otherwise step-0 "+
+				"commitment .kv lags its account .kv")
+		gotTxNum, gotBlockNum := commitmentdb.DecodeTxBlockNums(res.commitmentState)
+		require.Equal(t, uint64(15), gotTxNum)
+		require.Equal(t, uint64(1), gotBlockNum)
+	})
+}

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -318,14 +318,14 @@ type stepEdgeOutcome struct {
 	accountsThruEdge int
 }
 
-// runBlockEndingOnStepEdge drives one block, in pure batch mode, whose finalize
-// (block-end) txNum is exactly the step-0 edge (txNum 15, stepSize 16). Regular
-// txs 1..14 each emit a txResult; none lands on the edge. The block-end txNum 15
-// IS the step edge, and deliverEdgeTxResult models whether the exec loop emits a
-// txResult there — in production that send is gated on `len(finalizeWrites) > 0`
-// in blockExecutor.nextResult (exec3_parallel.go), so an empty-finalize block
-// delivers only the blockResult. The blockResult (lastTxNum=15) always arrives.
-func runBlockEndingOnStepEdge(t *testing.T, deliverEdgeTxResult bool) stepEdgeOutcome {
+// runBlockEndingOnStepEdge drives one block, in pure batch mode, whose block-end
+// txNum is exactly the step-0 edge (txNum 15, stepSize 16). Regular txs 1..14
+// emit a txResult with writes; the block-end system task at txNum 15 is always
+// emitted as a regular txResult by the producer (exec3_parallel.go nextResult
+// sends every task unconditionally), carrying writes only when the block
+// finalizes some — edgeTxHasWrites models that. The step-boundary hook in
+// handleMessage's txResult case must checkpoint the edge in both cases.
+func runBlockEndingOnStepEdge(t *testing.T, edgeTxHasWrites bool) stepEdgeOutcome {
 	t.Helper()
 	ctx := context.Background()
 	logger := log.New()
@@ -360,30 +360,30 @@ func runBlockEndingOnStepEdge(t *testing.T, deliverEdgeTxResult bool) stepEdgeOu
 	require.NoError(t, err)
 
 	rnd := rand.New(rand.NewSource(42))
-	writeAccount := func(txNum uint64) {
-		addrBytes := make([]byte, length.Addr)
-		rnd.Read(addrBytes)
-		addr := accounts.InternAddress([20]byte(addrBytes))
-		bal := *uint256.NewInt(txNum * 1000)
-		acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
-		buf := accounts.SerialiseV3(&acc)
-		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
-		cc.handleMessage(ctx, &txResult{
-			blockNum: 1,
-			txNum:    txNum,
-			writes: state.VersionedWrites{
+	writeAccount := func(txNum uint64, hasWrites bool) {
+		var writes state.VersionedWrites
+		if hasWrites {
+			addrBytes := make([]byte, length.Addr)
+			rnd.Read(addrBytes)
+			addr := accounts.InternAddress([20]byte(addrBytes))
+			bal := *uint256.NewInt(txNum * 1000)
+			acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
+			buf := accounts.SerialiseV3(&acc)
+			require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
+			writes = state.VersionedWrites{
 				&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: txNum},
 				&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: bal},
-			},
-		})
+			}
+		}
+		cc.handleMessage(ctx, &txResult{blockNum: 1, txNum: txNum, writes: writes})
 	}
 
 	for txNum := uint64(1); txNum < edgeTxNum; txNum++ {
-		writeAccount(txNum)
+		writeAccount(txNum, true)
 	}
-	if deliverEdgeTxResult {
-		writeAccount(edgeTxNum)
-	}
+	// The block-end system task is always published at the block-end txNum, with
+	// empty writes when the block has no finalize writes.
+	writeAccount(edgeTxNum, edgeTxHasWrites)
 	cc.handleMessage(ctx, &blockResult{BlockNum: 1, BlockHash: common.Hash{0x01}, lastTxNum: edgeTxNum})
 	cc.Stop()
 
@@ -405,21 +405,17 @@ func runBlockEndingOnStepEdge(t *testing.T, deliverEdgeTxResult bool) stepEdgeOu
 	return stepEdgeOutcome{commitmentState: stateBlob, accountsThruEdge: accCount}
 }
 
-// TestHandleMessage_StepEdgeAtBlockEnd pins parity with serial when a step edge
-// lands exactly on a block's finalize (block-end) txNum. Serial runs
-// CommitStepBoundary on the block-end tx task unconditionally (exec3_serial.go),
-// so it always checkpoints the edge. In parallel the calculator only consults
-// shouldCheckpointStepBoundary in handleMessage's *txResult case, and the exec
-// loop suppresses the finalize txResult when the block produced no finalize
-// writes (`if len(finalizeWrites) > 0`). The two sub-cases differ ONLY by whether
-// a txResult is delivered at the edge txNum; both must leave a step-aligned
-// commitment checkpoint, else the step's commitment .kv lags its account-domain
-// .kv (the inconsistency fixed for the mid-block case).
+// TestHandleMessage_StepEdgeAtBlockEnd pins that a block whose block-end txNum is
+// a step edge leaves a step-aligned commitment checkpoint. The producer always
+// emits the block-end system task as a regular txResult, so the step-boundary
+// hook in handleMessage's *txResult case checkpoints the edge whether or not that
+// task carries finalize writes (it ignores len(writes)). Without it the step's
+// commitment .kv lags its account-domain .kv (the mid-block inconsistency).
 func TestHandleMessage_StepEdgeAtBlockEnd(t *testing.T) {
 	t.Run("with_finalize_writes", func(t *testing.T) {
 		res := runBlockEndingOnStepEdge(t, true)
 		require.GreaterOrEqual(t, len(res.commitmentState), 16,
-			"edge txResult delivered → step-boundary checkpoint written")
+			"block-end txResult at the step edge → step-boundary checkpoint written")
 		gotTxNum, gotBlockNum := commitmentdb.DecodeTxBlockNums(res.commitmentState)
 		require.Equal(t, uint64(15), gotTxNum)
 		require.Equal(t, uint64(1), gotBlockNum)
@@ -430,9 +426,9 @@ func TestHandleMessage_StepEdgeAtBlockEnd(t *testing.T) {
 		require.Positive(t, res.accountsThruEdge,
 			"sanity: the account domain holds the block's writes through the step edge")
 		require.GreaterOrEqual(t, len(res.commitmentState), 16,
-			"a block ending on a step edge with empty finalize must still leave a step-aligned "+
-				"commitment checkpoint (serial does via CommitStepBoundary); otherwise step-0 "+
-				"commitment .kv lags its account .kv")
+			"a block-end task with empty finalize writes must still leave a step-aligned "+
+				"checkpoint — the hook ignores len(writes); otherwise step-0 commitment .kv "+
+				"lags its account .kv")
 		gotTxNum, gotBlockNum := commitmentdb.DecodeTxBlockNums(res.commitmentState)
 		require.Equal(t, uint64(15), gotTxNum)
 		require.Equal(t, uint64(1), gotBlockNum)

--- a/execution/stagedsync/committer_test.go
+++ b/execution/stagedsync/committer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/state"
 )
 
@@ -142,6 +143,9 @@ func TestHandleMessage_TxResultPinsAsOfReaderTxNum(t *testing.T) {
 	cc := &commitmentCalculator{
 		asOfReader: asOfReader,
 		state:      cs,
+		// Non-nil doms with stepSize 0 so the step-boundary hook short-circuits;
+		// this test pins asOfReader.txNum, not the checkpoint path.
+		doms: &execctx.SharedDomains{},
 	}
 
 	// A txResult must carry at least one write to enter the fix's

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1492,6 +1492,7 @@ type blockResult struct {
 
 type txResult struct {
 	blockNum              uint64
+	blockHash             common.Hash
 	txNum                 uint64
 	blockGasUsed          int64
 	blobGasUsed           uint64
@@ -2624,6 +2625,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 			applyResult := txResult{
 				blockNum:              be.blockNum,
+				blockHash:             be.blockHash,
 				traceFroms:            map[accounts.Address]struct{}{},
 				traceTos:              map[accounts.Address]struct{}{},
 				txNum:                 task.Version().TxNum,
@@ -2814,6 +2816,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			lastResult := be.results[len(be.results)-1]
 			if err := be.sendResult(ctx, &txResult{
 				blockNum:              be.blockNum,
+				blockHash:             be.blockHash,
 				txNum:                 txTask.Version().TxNum,
 				rules:                 lastResult.Rules(),
 				writes:                finalizeWrites,

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -385,16 +385,11 @@ func (rs *StateV3) ApplyStateWrites(ctx context.Context,
 	// Skip when the commitment calculator goroutine is active (it owns
 	// the Updates buffer and handles all commitment computation).
 	// Also skip if the step is already frozen (nothing to commit).
-	stepSize := rs.domains.StepSize()
-	if (txNum+1)%stepSize == 0 && !dbg.DiscardCommitment() && !rs.domains.InlineTouchKeyDisabled() && !rs.skipStepBoundaryCommitment {
-		step := txNum / stepSize
-		lastFrozenStep := uint64(roTx.StepsInFiles(kv.CommitmentDomain))
-		if step >= lastFrozenStep {
-			_, err := rs.domains.ComputeCommitment(ctx, roTx, true, blockNum, txNum,
-				fmt.Sprintf("applying step %d", step), nil)
-			if err != nil {
-				return fmt.Errorf("StateV3.ApplyStateWrites: step boundary: %w", err)
-			}
+	if rs.domains.IsUnfrozenStepEdge(roTx, txNum) && !rs.domains.InlineTouchKeyDisabled() && !rs.skipStepBoundaryCommitment {
+		_, err := rs.domains.ComputeCommitment(ctx, roTx, true, blockNum, txNum,
+			fmt.Sprintf("applying step %d", txNum/rs.domains.StepSize()), nil)
+		if err != nil {
+			return fmt.Errorf("StateV3.ApplyStateWrites: step boundary: %w", err)
 		}
 	}
 	return nil
@@ -427,7 +422,7 @@ func (rs *StateV3) ApplyTxIndexes(
 // contain a commitment state at each step end, even when the boundary falls
 // mid-block.
 func (rs *StateV3) CommitStepBoundary(ctx context.Context, roTx kv.TemporalTx, blockNum, txNum uint64) error {
-	if (txNum+1)%rs.domains.StepSize() == 0 && !dbg.DiscardCommitment() && !rs.domains.InlineTouchKeyDisabled() && !rs.skipStepBoundaryCommitment {
+	if rs.domains.IsUnfrozenStepEdge(roTx, txNum) && !rs.domains.InlineTouchKeyDisabled() && !rs.skipStepBoundaryCommitment {
 		_, err := rs.domains.ComputeCommitment(ctx, roTx, true, blockNum, txNum,
 			fmt.Sprintf("applying step %d", txNum/rs.domains.StepSize()), nil)
 		if err != nil {


### PR DESCRIPTION
Step-boundary commitment checkpoint fix for the performance-v36 lineage. Regression introduced by #20805; same change as #22092 (to main), adapted to performance-v36's calculator. Relates to #21992.