### PR TITLE
Update docker Go builder image version to 1.26-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 ##
 ##   5. DOCKER_BINARIES='erigon downloader rpcdaemon' make docker
 
-ARG BUILDER_IMAGE="golang:1.25-trixie" \
+ARG BUILDER_IMAGE="golang:1.26-trixie" \
     TARGET_BASE_IMAGE="debian:13-slim" \
     BINARIES="erigon" \
     BUILD_DBTOOLS="false" \


### PR DESCRIPTION
Bump default docker builder image to the latest 1.26-trixie .
It affects local docker builds and it does not affect release builds.