### PR TITLE
p2p: re-resolve STUN external IP at runtime

### DIFF
--- a/p2p/external_ip.go
+++ b/p2p/external_ip.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"net"
+	"time"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/p2p/nat"
+)
+
+// externalIPRefreshInterval is how often the public IP is re-resolved for NAT
+// mechanisms whose external address can change while the node runs (STUN).
+const externalIPRefreshInterval = 10 * time.Minute
+
+// usableExternalIP reports whether ip can be advertised as the node's public
+// address. It rejects the non-routable values a misbehaving resolver might hand
+// back so they never reach the local node record.
+func usableExternalIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return !ip.IsUnspecified() &&
+		!ip.IsLoopback() &&
+		!ip.IsPrivate() &&
+		!ip.IsLinkLocalUnicast() &&
+		!ip.IsLinkLocalMulticast() &&
+		!ip.IsMulticast()
+}
+
+// externalIPTracker re-resolves the external IP through a NAT mechanism and
+// applies it via set only when it changes to a usable value.
+type externalIPTracker struct {
+	nat    nat.Interface
+	set    func(net.IP)
+	logger log.Logger
+	last   net.IP
+}
+
+// refresh resolves the external IP once and applies it on change. It reports
+// whether the address was updated.
+func (t *externalIPTracker) refresh() bool {
+	ip, err := t.nat.ExternalIP()
+	if err != nil {
+		t.logger.Warn("NAT ExternalIP resolution has failed, try to pass a different --nat option", "err", err)
+		return false
+	}
+	if !usableExternalIP(ip) {
+		t.logger.Warn("NAT returned an unusable external IP, ignoring", "ip", ip)
+		return false
+	}
+	if ip.Equal(t.last) {
+		return false
+	}
+	t.last = ip
+	t.set(ip)
+	t.logger.Info("NAT ExternalIP resolved", "ip", ip)
+	return true
+}
+
+// run resolves immediately, then re-resolves every interval until stop closes.
+func (t *externalIPTracker) run(stop <-chan struct{}, interval time.Duration) {
+	t.refresh()
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-timer.C:
+			t.refresh()
+			timer.Reset(interval)
+		}
+	}
+}

--- a/p2p/external_ip.go
+++ b/p2p/external_ip.go
@@ -32,15 +32,7 @@ const externalIPRefreshInterval = 10 * time.Minute
 // address. It rejects the non-routable values a misbehaving resolver might hand
 // back so they never reach the local node record.
 func usableExternalIP(ip net.IP) bool {
-	if ip == nil {
-		return false
-	}
-	return !ip.IsUnspecified() &&
-		!ip.IsLoopback() &&
-		!ip.IsPrivate() &&
-		!ip.IsLinkLocalUnicast() &&
-		!ip.IsLinkLocalMulticast() &&
-		!ip.IsMulticast()
+	return ip.IsGlobalUnicast() && !ip.IsPrivate()
 }
 
 // externalIPTracker re-resolves the external IP through a NAT mechanism and

--- a/p2p/external_ip_test.go
+++ b/p2p/external_ip_test.go
@@ -39,6 +39,7 @@ func TestUsableExternalIP(t *testing.T) {
 		{net.ParseIP("172.16.4.4"), false},
 		{net.ParseIP("169.254.1.1"), false},
 		{net.ParseIP("224.0.0.1"), false},
+		{net.IPv4bcast, false},
 		{net.ParseIP("203.0.113.7"), true},
 		{net.ParseIP("8.8.8.8"), true},
 	}

--- a/p2p/external_ip_test.go
+++ b/p2p/external_ip_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+func TestUsableExternalIP(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		ip   net.IP
+		want bool
+	}{
+		{nil, false},
+		{net.IPv4zero, false},
+		{net.ParseIP("127.0.0.1"), false},
+		{net.ParseIP("10.0.0.1"), false},
+		{net.ParseIP("192.168.1.5"), false},
+		{net.ParseIP("172.16.4.4"), false},
+		{net.ParseIP("169.254.1.1"), false},
+		{net.ParseIP("224.0.0.1"), false},
+		{net.ParseIP("203.0.113.7"), true},
+		{net.ParseIP("8.8.8.8"), true},
+	}
+	for _, c := range cases {
+		if got := usableExternalIP(c.ip); got != c.want {
+			t.Errorf("usableExternalIP(%v) = %v, want %v", c.ip, got, c.want)
+		}
+	}
+}
+
+// fakeNAT returns a scripted sequence of ExternalIP results, repeating the last
+// entry once exhausted.
+type fakeNAT struct {
+	results []fakeResult
+	calls   int
+}
+
+type fakeResult struct {
+	ip  net.IP
+	err error
+}
+
+func (f *fakeNAT) ExternalIP() (net.IP, error) {
+	i := f.calls
+	if i >= len(f.results) {
+		i = len(f.results) - 1
+	}
+	f.calls++
+	return f.results[i].ip, f.results[i].err
+}
+
+func (f *fakeNAT) AddMapping(string, int, int, string, time.Duration) error { return nil }
+func (f *fakeNAT) DeleteMapping(string, int, int) error                     { return nil }
+func (f *fakeNAT) SupportsMapping() bool                                    { return false }
+func (f *fakeNAT) String() string                                           { return "fakeNAT" }
+
+func newTracker(results []fakeResult) (*externalIPTracker, *[]net.IP) {
+	var applied []net.IP
+	tr := &externalIPTracker{
+		nat:    &fakeNAT{results: results},
+		set:    func(ip net.IP) { applied = append(applied, ip) },
+		logger: log.New(),
+	}
+	return tr, &applied
+}
+
+func TestExternalIPTrackerDetectsChange(t *testing.T) {
+	t.Parallel()
+	ip1 := net.ParseIP("203.0.113.7")
+	ip2 := net.ParseIP("198.51.100.9")
+	tr, applied := newTracker([]fakeResult{{ip: ip1}, {ip: ip2}})
+
+	if !tr.refresh() {
+		t.Fatal("first refresh should apply the resolved IP")
+	}
+	if !tr.refresh() {
+		t.Fatal("second refresh should apply the changed IP")
+	}
+	if len(*applied) != 2 || !(*applied)[0].Equal(ip1) || !(*applied)[1].Equal(ip2) {
+		t.Fatalf("expected [%v %v], got %v", ip1, ip2, *applied)
+	}
+}
+
+func TestExternalIPTrackerSkipsUnchanged(t *testing.T) {
+	t.Parallel()
+	ip1 := net.ParseIP("203.0.113.7")
+	tr, applied := newTracker([]fakeResult{{ip: ip1}, {ip: ip1}})
+
+	if !tr.refresh() {
+		t.Fatal("first refresh should apply the resolved IP")
+	}
+	if tr.refresh() {
+		t.Fatal("second refresh with same IP must not re-apply")
+	}
+	if len(*applied) != 1 {
+		t.Fatalf("expected a single apply, got %v", *applied)
+	}
+}
+
+func TestExternalIPTrackerRejectsUnusable(t *testing.T) {
+	t.Parallel()
+	tr, applied := newTracker([]fakeResult{{ip: net.ParseIP("192.168.1.5")}})
+	if tr.refresh() {
+		t.Fatal("a private IP must not be applied")
+	}
+	if len(*applied) != 0 {
+		t.Fatalf("expected no apply, got %v", *applied)
+	}
+}
+
+func TestExternalIPTrackerIgnoresError(t *testing.T) {
+	t.Parallel()
+	tr, applied := newTracker([]fakeResult{{err: errors.New("stun unreachable")}})
+	if tr.refresh() {
+		t.Fatal("a resolution error must not be applied")
+	}
+	if len(*applied) != 0 {
+		t.Fatalf("expected no apply, got %v", *applied)
+	}
+}
+
+func TestExternalIPTrackerRunStops(t *testing.T) {
+	t.Parallel()
+	ip1 := net.ParseIP("203.0.113.7")
+	applied := make(chan net.IP, 1)
+	tr := &externalIPTracker{
+		nat:    &fakeNAT{results: []fakeResult{{ip: ip1}}},
+		set:    func(ip net.IP) { applied <- ip },
+		logger: log.New(),
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		tr.run(stop, time.Hour)
+		close(done)
+	}()
+
+	select {
+	case got := <-applied:
+		if !got.Equal(ip1) {
+			t.Fatalf("run applied %v, want %v", got, ip1)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not resolve the initial IP")
+	}
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not return after stop")
+	}
+}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -473,6 +473,22 @@ func (srv *Server) setupLocalNode() error {
 		ip, _ := srv.NAT.ExternalIP()
 		srv.localnode.SetStaticIP(ip)
 		srv.updateLocalNodeStaticAddrCache()
+	case nat.STUN:
+		// STUN-discovered IPs can change while running, so keep re-resolving.
+		tracker := &externalIPTracker{
+			nat: srv.NAT,
+			set: func(ip net.IP) {
+				srv.localnode.SetStaticIP(ip)
+				srv.updateLocalNodeStaticAddrCache()
+			},
+			logger: srv.logger,
+		}
+		srv.loopWG.Add(1)
+		go func() {
+			defer dbg.LogPanic()
+			defer srv.loopWG.Done()
+			tracker.run(srv.quit, externalIPRefreshInterval)
+		}()
 	default:
 		// Ask the router about the IP. This takes a while and blocks startup,
 		// do it in the background.


### PR DESCRIPTION
## Problem

Fixes #22104. With `nat = "stun"`, Erigon resolves the public IP **once** at startup (a one-shot goroutine in `setupLocalNode`) and never again. A node whose public IP changes while running keeps advertising a stale enode/ENR. This affects both common dynamic-IP topologies:

- behind a NAT router whose ISP-assigned WAN IP changes (DHCP/PPPoE renewal), and
- a directly-connected host whose own interface gets a dynamic public IP (PPPoE/DHCP).

## Change

Add an `externalIPTracker` scoped to the `nat.STUN` case only. It resolves immediately, then re-resolves every `externalIPRefreshInterval` (10m) and applies the address **only when it changes** to a usable value.

- Keeps `SetStaticIP` (authoritative) rather than switching to the discovery endpoint predictor. The predictor is fed by `UDPEndpointStatement` from attacker-controlled ping fields keyed by spoofable UDP source addresses; using a fallback/prediction path would let a spoofing attacker who reaches quorum move the advertised endpoint. Keeping STUN authoritative does not widen that surface.
- Validates the resolved IP (`usableExternalIP`) before it reaches the local record — rejects unspecified/loopback/private/link-local/multicast. The previous one-shot did no validation, so this also hardens against a misbehaving STUN server.
- Fixed internal timer, no externally-triggerable lever — an outsider cannot induce extra STUN queries (no self-DoS/amplification).

### Unaffected modes
`none`/nil, `extip:<ip>` (one-shot static, user-pinned), and `upnp`/`pmp`/`any` (the `default` branch) are byte-for-byte unchanged. Only `nat=stun` gets the refresh loop.

## Tests

TDD (Red → Green). `p2p/external_ip_test.go` covers: IP validation table, change detection, no-op on unchanged IP, rejection of unusable IPs, resolution-error tolerance, and clean loop shutdown. Passes under `-race`.

## Verification
- `go test ./p2p/ -race` — pass
- `make lint` — 0 issues
- `make erigon` — builds

## Follow-up (separate PR)
Trigger an immediate, **rate-limited** re-resolve from OS network-change events (Linux netlink / Darwin route socket / Windows IP Helper) to cut detection latency below the poll interval on directly-connected dynamic-IP hosts. This is the latent `// TODO: monitor network configuration and rerun doit when it changes` in `p2p/nat/nat.go`. It only improves latency — correctness is already covered here — and is cross-platform per-OS work that warrants its own PR + tests. The event would remain a trigger that still commits STUN's validated answer (never the raw interface IP).

## Note on inbound reachability
STUN reports `SupportsMapping() == false`: it fixes the advertised IP, not NAT hole-punching. Behind-NAT operators still need a port-forward (or `upnp`/`pmp`); the forward is LAN-based so it survives the WAN-IP change while this loop refreshes the advertised IP to match.