### PR TITLE
build: bump protoc to v35.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,7 +494,7 @@ $(GOBINREL):
 
 $(GOBINREL)/protoc: | $(GOBINREL)
 	$(eval PROTOC_TMP := $(shell mktemp -d))
-	curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v35.0/protoc-35.0-$(PROTOC_OS)-$(ARCH).zip -o "$(PROTOC_TMP)/protoc.zip"
+	curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v35.1/protoc-35.1-$(PROTOC_OS)-$(ARCH).zip -o "$(PROTOC_TMP)/protoc.zip"
 	cd "$(PROTOC_TMP)" && unzip protoc.zip
 	cp "$(PROTOC_TMP)/bin/protoc" "$(GOBIN)"
 	mkdir -p "$(PROTOC_INCLUDE)"

--- a/txnprovider/shutter/Makefile
+++ b/txnprovider/shutter/Makefile
@@ -24,7 +24,7 @@ $(GOBINREL):
 
 $(GOBINREL)/protoc: $(GOBINREL)
 	$(eval PROTOC_TMP := $(shell mktemp -d))
-	curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v35.0/protoc-35.0-$(PROTOC_OS)-$(ARCH).zip -o "$(PROTOC_TMP)/protoc.zip"
+	curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v35.1/protoc-35.1-$(PROTOC_OS)-$(ARCH).zip -o "$(PROTOC_TMP)/protoc.zip"
 	cd "$(PROTOC_TMP)" && unzip protoc.zip
 	cp "$(PROTOC_TMP)/bin/protoc" "$(GOBIN)"
 	mkdir -p "$(PROTOC_INCLUDE)"


### PR DESCRIPTION
Bumps the `protoc` compiler downloaded by `make protoc` from v35.0 to v35.1 (latest release, published 2026-06-11).

Updated in both Makefiles that fetch the compiler:
- `Makefile`
- `txnprovider/shutter/Makefile`

Asset naming is unchanged (`protoc-35.1-$(PROTOC_OS)-$(ARCH).zip`), so only the version numbers change. The new download URL was verified to resolve (HTTP 200). No proto regeneration needed — generated `.pb.go` output is driven by `protoc-gen-go`, not the `protoc` patch release.