### PR TITLE
stagedsync: Fix logIndex reset and missing websocket notifications in parallel execution

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -574,9 +574,10 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 						blockValidatorWaiter = newBlockValidator(pe.cfg.engine, applyResult.BlockGasUsed, applyResult.BlobGasUsed, checkReceipts, checkBloom, applyResult.Receipts,
 							lastHeader, b.Transactions(), pe.cfg.chainConfig, pe.logger)
 
-						if !execStage.CurrentSyncCycle.IsInitialCycle {
-							pe.cfg.notifications.RecentReceipts.Add(applyResult.Receipts, b.Transactions(), lastHeader)
-						}
+					}
+
+					if applyResult.BlockNum > 0 && !execStage.CurrentSyncCycle.IsInitialCycle && applyResult.Header != nil {
+						pe.cfg.notifications.RecentReceipts.Add(applyResult.Receipts, applyResult.Txs, applyResult.Header)
 					}
 
 					if applyResult.BlockNum > lastBlockResult.BlockNum {

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2506,7 +2506,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 						if rawtemporaldb.ReceiptStoresFirstLogIdx(applyTx) {
 							return nil, fmt.Errorf("parallel execution is not supported on databases with legacy receipt domain schemas (ReceiptStoresFirstLogIdx == true)")
 						}
-						cumGasUsed, _, logIndexAfterTx, err := rawtemporaldb.ReceiptAsOf(applyTx, txVersion.TxNum)
+						cumGasUsed, cumBlobGasUsed, logIndexAfterTx, err := rawtemporaldb.ReceiptAsOf(applyTx, txVersion.TxNum)
 						if err != nil {
 							return nil, err
 						}
@@ -2521,6 +2521,8 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 							CumulativeGasUsed:        cumGasUsed,
 							FirstLogIndexWithinBlock: logIndexAfterTx,
 						}
+						// Initialize cumulative blob gas used so far in this block
+						be.blobGasUsed = cumBlobGasUsed
 					}
 				}
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -23,6 +23,7 @@ import (
 	"github.com/erigontech/erigon/db/consensuschain"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/diagnostics/metrics"
 	"github.com/erigontech/erigon/execution/chain"
@@ -573,7 +574,7 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 						blockValidatorWaiter = newBlockValidator(pe.cfg.engine, applyResult.BlockGasUsed, applyResult.BlobGasUsed, checkReceipts, checkBloom, applyResult.Receipts,
 							lastHeader, b.Transactions(), pe.cfg.chainConfig, pe.logger)
 
-						if !applyResult.isPartial && !execStage.CurrentSyncCycle.IsInitialCycle {
+						if !execStage.CurrentSyncCycle.IsInitialCycle {
 							pe.cfg.notifications.RecentReceipts.Add(applyResult.Receipts, b.Transactions(), lastHeader)
 						}
 					}
@@ -2494,9 +2495,21 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				be.finalizedResults[tx] = txResult
 
 				var prevReceipt *types.Receipt
-				if txVersion.TxIndex > 0 && tx > 0 {
-					if prev := be.finalizedResults[tx-1]; prev != nil {
-						prevReceipt = prev.Receipt
+				if txVersion.TxIndex > 0 {
+					if tx > 0 {
+						if prev := be.finalizedResults[tx-1]; prev != nil {
+							prevReceipt = prev.Receipt
+						}
+					}
+					if prevReceipt == nil {
+						cumGasUsed, _, logIndexAfterTx, err := rawtemporaldb.ReceiptAsOf(applyTx, txVersion.TxNum)
+						if err != nil {
+							return nil, err
+						}
+						prevReceipt = &types.Receipt{
+							CumulativeGasUsed:        cumGasUsed,
+							FirstLogIndexWithinBlock: logIndexAfterTx,
+						}
 					}
 				}
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2502,9 +2502,9 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				var firstLogIndex uint32
 				if txVersion.TxIndex > 0 && !txTask.IsBlockEnd() {
 					if tx > 0 && be.tasks[tx-1].Task.Version().TxIndex >= 0 {
-						if prev := be.finalizedResults[tx-1].Receipt; prev != nil {
-							cumulativeGasUsed = prev.CumulativeGasUsed
-							firstLogIndex = prev.FirstLogIndexWithinBlock + uint32(len(prev.Logs))
+						if prevRes := be.finalizedResults[tx-1]; prevRes != nil && prevRes.Receipt != nil {
+							cumulativeGasUsed = prevRes.Receipt.CumulativeGasUsed
+							firstLogIndex = prevRes.Receipt.FirstLogIndexWithinBlock + uint32(len(prevRes.Receipt.Logs))
 						}
 					} else {
 						cumGasUsed, cumBlobGasUsed, logIndexAfterTx, err := rawtemporaldb.ReceiptAsOf(applyTx, txVersion.TxNum)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2503,6 +2503,9 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 						}
 					}
 					if prevReceipt == nil {
+						if rawtemporaldb.ReceiptStoresFirstLogIdx(applyTx) {
+							return nil, fmt.Errorf("parallel execution is not supported on databases with legacy receipt domain schemas (ReceiptStoresFirstLogIdx == true)")
+						}
 						cumGasUsed, _, logIndexAfterTx, err := rawtemporaldb.ReceiptAsOf(applyTx, txVersion.TxNum)
 						if err != nil {
 							return nil, err

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -576,7 +576,7 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 
 					}
 
-					if applyResult.BlockNum > 0 && !execStage.CurrentSyncCycle.IsInitialCycle && applyResult.Header != nil {
+					if applyResult.BlockNum > 0 && !applyResult.isPartial && !execStage.CurrentSyncCycle.IsInitialCycle && applyResult.Header != nil {
 						pe.cfg.notifications.RecentReceipts.Add(applyResult.Receipts, applyResult.Txs, applyResult.Header)
 					}
 
@@ -1546,10 +1546,11 @@ type execTask struct {
 
 type execResult struct {
 	*exec.TxResult
-	writes state.VersionedWrites
+	writes                state.VersionedWrites
+	cumulativeBlobGasUsed uint64
 }
 
-func (result *execResult) finalize(prevReceipt *types.Receipt, engine rules.Engine, vm *state.VersionMap, stateReader state.StateReader, stateWriter state.StateWriter) (*types.Receipt, state.ReadSet, state.VersionedWrites, error) {
+func (result *execResult) finalize(cumulativeGasUsed uint64, firstLogIndex uint32, engine rules.Engine, vm *state.VersionMap, stateReader state.StateReader, stateWriter state.StateWriter) (*types.Receipt, state.ReadSet, state.VersionedWrites, error) {
 	task, ok := result.Task.(*taskVersion)
 
 	if !ok {
@@ -1591,7 +1592,7 @@ func (result *execResult) finalize(prevReceipt *types.Receipt, engine rules.Engi
 		return result.finalizeSystemTx(task, txTask, rules, vm, stateReader, stateWriter)
 	}
 
-	return result.finalizeTx(task, txTask, prevReceipt, engine, vm, stateReader)
+	return result.finalizeTx(task, txTask, cumulativeGasUsed, firstLogIndex, engine, vm, stateReader)
 }
 
 // finalizeSystemTx handles block-end and system TXs (txIndex < 0) via full
@@ -1827,7 +1828,8 @@ func (result *execResult) calcFees(
 func (result *execResult) finalizeTx(
 	task *taskVersion,
 	txTask *exec.TxTask,
-	prevReceipt *types.Receipt,
+	cumulativeGasUsed uint64,
+	firstLogIndex uint32,
 	engine rules.Engine,
 	vm *state.VersionMap,
 	stateReader state.StateReader,
@@ -1840,10 +1842,11 @@ func (result *execResult) finalizeTx(
 		return nil, nil, nil, err
 	}
 
-	receipt, err := result.CreateNextReceipt(prevReceipt)
+	receipt, err := result.CreateReceipt(task.Version().TxIndex, cumulativeGasUsed+result.ExecutionResult.ReceiptGasUsed, firstLogIndex)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	result.Receipt = receipt
 	return receipt, nil, nil, nil
 }
 
@@ -2229,7 +2232,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 	}
 
 	tx := task.index
-	be.results[tx] = &execResult{res, nil}
+	be.results[tx] = &execResult{TxResult: res}
 	if res.Err != nil {
 		if execErr, ok := res.Err.(protocol.ErrExecAbortError); ok {
 			if res.Version().Incarnation > len(be.tasks) {
@@ -2495,33 +2498,21 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 				be.finalizedResults[tx] = txResult
 
-				var prevReceipt *types.Receipt
-				if txVersion.TxIndex > 0 {
-					if tx > 0 {
-						if prev := be.finalizedResults[tx-1]; prev != nil {
-							prevReceipt = prev.Receipt
+				var cumulativeGasUsed uint64
+				var firstLogIndex uint32
+				if txVersion.TxIndex > 0 && !txTask.IsBlockEnd() {
+					if tx > 0 && be.tasks[tx-1].Task.Version().TxIndex >= 0 {
+						if prev := be.finalizedResults[tx-1].Receipt; prev != nil {
+							cumulativeGasUsed = prev.CumulativeGasUsed
+							firstLogIndex = prev.FirstLogIndexWithinBlock + uint32(len(prev.Logs))
 						}
-					}
-					if prevReceipt == nil {
-						if rawtemporaldb.ReceiptStoresFirstLogIdx(applyTx) {
-							return nil, fmt.Errorf("parallel execution is not supported on databases with legacy receipt domain schemas (ReceiptStoresFirstLogIdx == true)")
-						}
+					} else {
 						cumGasUsed, cumBlobGasUsed, logIndexAfterTx, err := rawtemporaldb.ReceiptAsOf(applyTx, txVersion.TxNum)
 						if err != nil {
 							return nil, err
 						}
-						// Actually, when we reconstruct prevReceipt from the DB, it does not have any logs.
-						// The logIndexAfterTx we got from the DB is already the index after adding all logs of the previous tx.
-						// So we are setting FirstLogIndexWithinBlock to logIndexAfterTx and keeping prevReceipt.Logs as nil (len is 0).
-						// Because of this, the calculation in CreateNextReceipt:
-						// currentReceipt.FirstLogIndexWithinBlock = prevReceipt.FirstLogIndexWithinBlock + len(prevReceipt.Logs)
-						// becomes logIndexAfterTx + 0, which correctly gives the starting index of the current tx.
-						// So this math works out perfectly without needing to fetch or re-execute the previous tx logs.
-						prevReceipt = &types.Receipt{
-							CumulativeGasUsed:        cumGasUsed,
-							FirstLogIndexWithinBlock: logIndexAfterTx,
-						}
-						// Initialize cumulative blob gas used so far in this block
+						cumulativeGasUsed = cumGasUsed
+						firstLogIndex = logIndexAfterTx
 						be.blobGasUsed = cumBlobGasUsed
 					}
 				}
@@ -2563,7 +2554,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 				collector := state.NewVersionedWriteCollector(pe.rs)
 
-				_, addReads, finalizeWrites, err := txResult.finalize(prevReceipt, pe.cfg.engine, be.versionMap, stateReader, collector)
+				_, addReads, finalizeWrites, err := txResult.finalize(cumulativeGasUsed, firstLogIndex, pe.cfg.engine, be.versionMap, stateReader, collector)
 				if err != nil {
 					return nil, err
 				}
@@ -2662,6 +2653,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				// the publish loop from seeing a later incarnation if
 				// be.results[tx] is overwritten by a concurrent worker.
 				be.finalizedResults[tx] = txResult
+				txResult.cumulativeBlobGasUsed = be.blobGasUsed
 				be.publishTasks.pushPending(tx)
 			}
 		} else {
@@ -2712,7 +2704,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				traceTos:              map[accounts.Address]struct{}{},
 				txNum:                 task.Version().TxNum,
 				rules:                 task.Rules(),
-				cumulativeBlobGasUsed: be.blobGasUsed,
+				cumulativeBlobGasUsed: result.cumulativeBlobGasUsed,
 			}
 
 			if tx := result.Tx(); tx != nil {
@@ -2763,7 +2755,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			// exec loop, on the SAME goroutine that owns sd.mem mutations.
 			// Doing this in the apply loop instead used to race with the next
 			// tx / block-end ApplyStateWrites on SharedDomains.mem.
-			if err := pe.rs.ApplyTxIndexes(applyTx, applyResult.txNum, applyResult.receipt, applyResult.blobGasUsed,
+			if err := pe.rs.ApplyTxIndexes(applyTx, applyResult.txNum, applyResult.receipt, applyResult.cumulativeBlobGasUsed,
 				applyResult.logs, applyResult.traceFroms, applyResult.traceTos); err != nil {
 				return nil, fmt.Errorf("ApplyTxIndexes block=%d txNum=%d: %w", applyResult.blockNum, applyResult.txNum, err)
 			}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2510,6 +2510,13 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 						if err != nil {
 							return nil, err
 						}
+						// Actually, when we reconstruct prevReceipt from the DB, it does not have any logs.
+						// The logIndexAfterTx we got from the DB is already the index after adding all logs of the previous tx.
+						// So we are setting FirstLogIndexWithinBlock to logIndexAfterTx and keeping prevReceipt.Logs as nil (len is 0).
+						// Because of this, the calculation in CreateNextReceipt:
+						// currentReceipt.FirstLogIndexWithinBlock = prevReceipt.FirstLogIndexWithinBlock + len(prevReceipt.Logs)
+						// becomes logIndexAfterTx + 0, which correctly gives the starting index of the current tx.
+						// So this math works out perfectly without needing to fetch or re-execute the previous tx logs.
 						prevReceipt = &types.Receipt{
 							CumulativeGasUsed:        cumGasUsed,
 							FirstLogIndexWithinBlock: logIndexAfterTx,

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/mdbx"
 	"github.com/erigontech/erigon/db/kv/temporal"
+	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain"
@@ -29,10 +31,12 @@ import (
 	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/protocol/rules/ethash"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/execution/vm"
+	"github.com/erigontech/erigon/execution/vm/evmtypes"
 )
 
 type OpType int
@@ -1348,4 +1352,132 @@ func BenchmarkDexScenarioWithMetadata(b *testing.B) {
 	}
 
 	testExecutorCombWithMetadata(b, totalTxs, numReads, numWrites, numNonIO, taskRunner, logger)
+}
+
+func TestParallelResumeBoundaryAndNotifications(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	assert := assert.New(t)
+	logger := log.New()
+	tmpDir, err := os.MkdirTemp("", "erigon-parallel-test-*")
+	assert.NoError(err)
+	defer dir.RemoveAll(tmpDir)
+
+	dirs := datadir.New(tmpDir)
+	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
+	defer rawDb.Close()
+
+	agg, err := dbstate.NewTest(dirs).StepSize(16).Logger(logger).Open(context.Background(), rawDb)
+	assert.NoError(err)
+	defer agg.Close()
+
+	db, err := temporal.New(rawDb, agg)
+	assert.NoError(err)
+
+	// Write mock receipt for transaction 0 in the database at txNum = 1
+	err = db.UpdateTemporal(context.Background(), func(rwTx kv.TemporalRwTx) error {
+		domains, err := execctx.NewSharedDomains(context.Background(), rwTx, logger)
+		if err != nil {
+			return err
+		}
+		defer domains.Close()
+		putter := domains.AsPutDel(rwTx)
+		if err := rawtemporaldb.AppendReceipt(putter, 5, 21000, 12000, 1); err != nil {
+			return err
+		}
+		return domains.Flush(context.Background(), rwTx)
+	})
+	assert.NoError(err)
+
+	chainSpec, _ := chainspec.ChainSpecByName(networkname.Mainnet)
+
+	signedTx := signSelfSendTx(t, 0, 0, 1, 21000, chainSpec.Config, 0)
+
+	// Create a task list that resumes mid-block
+	// First task has TxIndex = 1 (not -1/0), so isPartial will be true
+	txTask := &exec.TxTask{
+		Header: &types.Header{
+			Number: *uint256.NewInt(1),
+		},
+		TxNum:   2,
+		TxIndex: 1,
+		Config:  chainSpec.Config,
+		Txs: []types.Transaction{
+			signedTx,
+			signedTx,
+		},
+	}
+
+	// Open read transaction for execution
+	roTx, err := db.BeginTemporalRo(context.Background())
+	assert.NoError(err)
+	defer roTx.Rollback()
+
+	domains, err := execctx.NewSharedDomains(context.Background(), roTx, logger)
+	assert.NoError(err)
+	defer domains.Close()
+
+	pe := &parallelExecutor{
+		txExecutor: txExecutor{
+			cfg: ExecuteBlockCfg{
+				chainConfig: chainSpec.Config,
+				db:          db,
+				engine:      ethash.NewFaker(),
+			},
+			doms:   domains,
+			rs:     state.NewStateV3Buffered(state.NewStateV3(domains, false, logger)),
+			logger: logger,
+		},
+		workerCount: runtime.NumCPU() - 1,
+	}
+
+	gasPool := new(protocol.GasPool).AddGas(10_000_000)
+
+	// Run nextResult
+	be := newBlockExec(0, common.Hash{}, gasPool, nil, make(chan applyResult, 1), nil, false, nil)
+	eTask := &execTask{
+		Task:  txTask,
+		index: 0,
+	}
+	be.tasks = []*execTask{eTask}
+	be.results = []*execResult{nil}
+	be.execTasks.inProgress = []int{0}
+	be.validateTasks.inProgress = []int{0}
+	be.publishTasks.pending = []int{0}
+
+	tVersion := &taskVersion{
+		execTask: eTask,
+		version: state.Version{
+			BlockNum:    0,
+			TxIndex:     1,
+			Incarnation: 1,
+			TxNum:       2,
+		},
+	}
+
+	// Populate a mock test result in be.results[0]
+	txResult := &exec.TxResult{
+		Task: tVersion,
+		ExecutionResult: evmtypes.ExecutionResult{
+			ReceiptGasUsed: 10000,
+		},
+	}
+	be.results[0] = &execResult{TxResult: txResult}
+
+	// execute nextResult sequentially
+	res, err := be.nextResult(context.Background(), pe, txResult, roTx)
+	assert.NoError(err)
+	assert.NotNil(res)
+
+	// Verify that the fallback database query ran and set the correct offset values:
+	// cumulativeGasUsed should be cumGasUsed (21000) + current receipt gas used (10000) = 31000
+	// firstLogIndex should be logIndexAfterTx from DB = 5
+	assert.NotNil(txResult.Receipt)
+	assert.Equal(uint64(31000), txResult.Receipt.CumulativeGasUsed)
+	assert.Equal(uint32(5), txResult.Receipt.FirstLogIndexWithinBlock)
+	assert.Equal(uint64(12000), be.blobGasUsed)
+
+	// Verify notification behavior: since it's a partial block, it should be marked as partial
+	assert.True(res.isPartial)
 }


### PR DESCRIPTION
### Issue

When Erigon is doing parallel block execution (`EXEC3_PARALLEL=true`), the state snapshots can end at step boundaries which fall mid-block. So when we restart the node or resume sync from these snapshots, the execution stage needs to start/resume execution from the middle of the block (running only the remaining transactions of that block).

While finalizing the transaction receipts for this partial block execution, the code in `exec3_parallel.go` was checking `if txVersion.TxIndex > 0 && tx > 0` to fetch the previous transaction's receipt from the memory results map. But for the first transaction task of this new batch (where the local slice task index `tx` is `0`, but the actual block-level index `txVersion.TxIndex` is `> 0`), this check was failing and `prevReceipt` remained `nil`. Because of this, it called `CreateNextReceipt(nil)` and the starting log index and cumulative gas for that mid-block transaction got reset to `0`. This wrong log index got written directly to the database `ReceiptDomain` and caused inconsistent `logIndex` values when clients queried `eth_getLogs`.

Additionally, for partial blocks the websocket notification path was publishing tail-only receipts (only the resumed portion) via `RecentReceipts.Add`, which `eth_subscribe` log/receipt clients would receive as the complete block — diverging from `eth_getLogs` results.

### Fix

The main fix is in the parallel executor's receipt finalization loop in `exec3_parallel.go`. We changed the `finalize` function signature to accept `cumulativeGasUsed` and `firstLogIndex` directly instead of a `prevReceipt` pointer, and it now calls `CreateReceipt` instead of `CreateNextReceipt`. This matches how the serial executor handles receipt creation. We also branch explicitly on `tx == 0` (batch boundary) instead of checking `prevReceipt == nil`. When the first task in a batch has `TxIndex > 0` (meaning we are resuming mid-block), we query the temporal database using`rawtemporaldb.ReceiptAsOf` to fetch the previous transaction's cumulative gas used, cumulative blob gas used, and log index offset. We excluded `IsBlockEnd` tasks from this fallback since `finalizeSystemTx` never consumes `prevReceipt` anyway. Also added a two-step nil check on `be.finalizedResults[tx-1]` before accessing `.Receipt` since `finalizedResults` is a map and a missing key would return nil and cause a panic.

For the notification issue, we gated `RecentReceipts.Add` behind `!applyResult.isPartial` and moved it outside the block validation scope so that incomplete tail-only receipts are not published for partial blocks. We now use `applyResult.Txs` and `applyResult.Header` directly instead of fetching from the database. This is consistent with how the serial path gates behind `startTxIndex == 0` in `exec3_serial.go:421`.

For the blob gas issue, we added a `cumulativeBlobGasUsed` field to `execResult` and snapshot `be.blobGasUsed` into it at finalization time. The publish loop now uses this per-result snapshot instead of reading `be.blobGasUsed` directly, which could have been overwritten by a later transaction. We also initialize `be.blobGasUsed` from the database `cumBlobGasUsed` value at the resume boundary.

Added `TestParallelResumeBoundaryAndNotifications` unit test to pin theresume boundary receipt reconstruction (first task with `TxIndex > 0` at slice index 0 → correct offsets from DB) and the `isPartial` flag that controls notification skipping.

Closes: https://github.com/erigontech/erigon/issues/22106
