### PR TITLE
p2p: re-resolve STUN external IP on OS network-change events

### DIFF
--- a/p2p/external_ip.go
+++ b/p2p/external_ip.go
@@ -38,10 +38,11 @@ func usableExternalIP(ip net.IP) bool {
 // externalIPTracker re-resolves the external IP through a NAT mechanism and
 // applies it via set only when it changes to a usable value.
 type externalIPTracker struct {
-	nat    nat.Interface
-	set    func(net.IP)
-	logger log.Logger
-	last   net.IP
+	nat     nat.Interface
+	set     func(net.IP)
+	logger  log.Logger
+	last    net.IP
+	failing bool
 }
 
 // refresh resolves the external IP once and applies it on change. It reports
@@ -49,13 +50,14 @@ type externalIPTracker struct {
 func (t *externalIPTracker) refresh() bool {
 	ip, err := t.nat.ExternalIP()
 	if err != nil {
-		t.logger.Warn("NAT ExternalIP resolution has failed, try to pass a different --nat option", "err", err)
+		t.logFailure("NAT ExternalIP resolution has failed, try to pass a different --nat option", "err", err)
 		return false
 	}
 	if !usableExternalIP(ip) {
-		t.logger.Warn("NAT returned an unusable external IP, ignoring", "ip", ip)
+		t.logFailure("NAT returned an unusable external IP, ignoring", "ip", ip)
 		return false
 	}
+	t.failing = false
 	if ip.Equal(t.last) {
 		return false
 	}
@@ -65,18 +67,21 @@ func (t *externalIPTracker) refresh() bool {
 	return true
 }
 
-// run resolves immediately, then re-resolves every interval until stop closes.
-func (t *externalIPTracker) run(stop <-chan struct{}, interval time.Duration) {
-	t.refresh()
-	timer := time.NewTimer(interval)
-	defer timer.Stop()
-	for {
-		select {
-		case <-stop:
-			return
-		case <-timer.C:
-			t.refresh()
-			timer.Reset(interval)
-		}
+// logFailure reports a resolution failure loudly the first time, then quietly
+// while it persists, so a flapping link or a down STUN server cannot spam logs.
+func (t *externalIPTracker) logFailure(msg string, ctx ...interface{}) {
+	if t.failing {
+		t.logger.Debug(msg, ctx...)
+		return
 	}
+	t.failing = true
+	t.logger.Warn(msg, ctx...)
+}
+
+// run resolves immediately, then re-resolves on every interval and on every OS
+// network-change event until stop closes.
+func (t *externalIPTracker) run(stop <-chan struct{}, interval time.Duration) {
+	notifier := newNetChangeNotifier(t.logger)
+	defer notifier.Close()
+	t.runWithNotifier(stop, notifier, interval, defaultEventDebounce)
 }

--- a/p2p/external_ip.go
+++ b/p2p/external_ip.go
@@ -69,7 +69,7 @@ func (t *externalIPTracker) refresh() bool {
 
 // logFailure reports a resolution failure loudly the first time, then quietly
 // while it persists, so a flapping link or a down STUN server cannot spam logs.
-func (t *externalIPTracker) logFailure(msg string, ctx ...interface{}) {
+func (t *externalIPTracker) logFailure(msg string, ctx ...any) {
 	if t.failing {
 		t.logger.Debug(msg, ctx...)
 		return

--- a/p2p/external_ip_notify.go
+++ b/p2p/external_ip_notify.go
@@ -22,6 +22,13 @@ import "time"
 // interface flap emits many) into a single re-resolve once the link settles.
 const defaultEventDebounce = 3 * time.Second
 
+// Per-OS notifiers share these messages so logs read the same everywhere; the
+// "err" field carries the platform-specific cause.
+const (
+	notifierUnavailableMsg = "network-change notifier unavailable, using periodic external IP refresh only"
+	notifierReadFailedMsg  = "network-change notifier read failed, disabling event-driven external IP refresh"
+)
+
 // netChangeNotifier watches OS network-configuration changes. Events delivers a
 // coalesced signal to reconsider the external IP; it never carries an address,
 // so this path cannot be used to move the advertised endpoint. Platforms with

--- a/p2p/external_ip_notify.go
+++ b/p2p/external_ip_notify.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import "time"
+
+// defaultEventDebounce coalesces bursts of OS network-change events (an
+// interface flap emits many) into a single re-resolve once the link settles.
+const defaultEventDebounce = 3 * time.Second
+
+// netChangeNotifier watches OS network-configuration changes. Events delivers a
+// coalesced signal to reconsider the external IP; it never carries an address,
+// so this path cannot be used to move the advertised endpoint. Platforms with
+// no native implementation return a notifier whose channel never fires, leaving
+// periodic polling as the sole refresh path.
+type netChangeNotifier interface {
+	Events() <-chan struct{}
+	Close() error
+}
+
+// noopNotifier never fires. It backs platforms without a native event source
+// and is the runtime fallback when a native notifier fails to initialize.
+type noopNotifier struct{}
+
+func (noopNotifier) Events() <-chan struct{} { return nil }
+func (noopNotifier) Close() error            { return nil }
+
+// runWithNotifier re-resolves immediately, then on each interval tick and on
+// each debounced network-change event, until stop closes. An event only
+// triggers a re-resolution; the committed address is always the resolver's
+// validated answer, never anything carried by the event.
+func (t *externalIPTracker) runWithNotifier(stop <-chan struct{}, notifier netChangeNotifier, interval, debounce time.Duration) {
+	t.refresh()
+
+	tick := time.NewTimer(interval)
+	defer tick.Stop()
+
+	settle := time.NewTimer(debounce)
+	settle.Stop()
+	defer settle.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-tick.C:
+			t.refresh()
+			tick.Reset(interval)
+		case <-notifier.Events():
+			settle.Reset(debounce)
+		case <-settle.C:
+			t.refresh()
+		}
+	}
+}

--- a/p2p/external_ip_notify.go
+++ b/p2p/external_ip_notify.go
@@ -61,6 +61,12 @@ func (t *externalIPTracker) runWithNotifier(stop <-chan struct{}, notifier netCh
 			t.refresh()
 			tick.Reset(interval)
 		case <-notifier.Events():
+			if !settle.Stop() {
+				select {
+				case <-settle.C:
+				default:
+				}
+			}
 			settle.Reset(debounce)
 		case <-settle.C:
 			t.refresh()

--- a/p2p/external_ip_notify.go
+++ b/p2p/external_ip_notify.go
@@ -50,7 +50,7 @@ func (t *externalIPTracker) runWithNotifier(stop <-chan struct{}, notifier netCh
 	defer tick.Stop()
 
 	settle := time.NewTimer(debounce)
-	settle.Stop()
+	stopAndDrain(settle)
 	defer settle.Stop()
 
 	for {
@@ -61,15 +61,20 @@ func (t *externalIPTracker) runWithNotifier(stop <-chan struct{}, notifier netCh
 			t.refresh()
 			tick.Reset(interval)
 		case <-notifier.Events():
-			if !settle.Stop() {
-				select {
-				case <-settle.C:
-				default:
-				}
-			}
+			stopAndDrain(settle)
 			settle.Reset(debounce)
 		case <-settle.C:
 			t.refresh()
+		}
+	}
+}
+
+// stopAndDrain stops t and discards any pending tick, leaving it safe to Reset.
+func stopAndDrain(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
 		}
 	}
 }

--- a/p2p/external_ip_notify_bsd.go
+++ b/p2p/external_ip_notify_bsd.go
@@ -44,8 +44,13 @@ func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
 		return noopNotifier{}
 	}
 	unix.CloseOnExec(fd)
-	// A receive timeout lets the read wake periodically to observe Close.
-	_ = unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 1})
+	// A receive timeout lets the read wake periodically to observe Close;
+	// without it Close could block forever on a blocked read.
+	if err := unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 1}); err != nil {
+		_ = unix.Close(fd)
+		logger.Debug("p2p: route receive timeout setup failed, using periodic external IP refresh only", "err", err)
+		return noopNotifier{}
+	}
 
 	n := &routeNotifier{
 		fd:      fd,

--- a/p2p/external_ip_notify_bsd.go
+++ b/p2p/external_ip_notify_bsd.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build darwin || freebsd || netbsd || openbsd || dragonfly
+
+package p2p
+
+import (
+	"errors"
+	"sync"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+// routeNotifier signals on any message from a PF_ROUTE socket, which the kernel
+// emits on address, link and route changes.
+type routeNotifier struct {
+	fd        int
+	events    chan struct{}
+	done      chan struct{}
+	stopped   chan struct{}
+	closeOnce sync.Once
+}
+
+func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
+	fd, err := unix.Socket(unix.AF_ROUTE, unix.SOCK_RAW, unix.AF_UNSPEC)
+	if err != nil {
+		logger.Debug("p2p: route notifier unavailable, using periodic external IP refresh only", "err", err)
+		return noopNotifier{}
+	}
+	unix.CloseOnExec(fd)
+	// A receive timeout lets the read wake periodically to observe Close.
+	_ = unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 1})
+
+	n := &routeNotifier{
+		fd:      fd,
+		events:  make(chan struct{}, 1),
+		done:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	go n.loop()
+	return n
+}
+
+func (n *routeNotifier) Events() <-chan struct{} { return n.events }
+
+func (n *routeNotifier) Close() error {
+	n.closeOnce.Do(func() {
+		close(n.done)
+		<-n.stopped
+	})
+	return nil
+}
+
+func (n *routeNotifier) loop() {
+	defer close(n.stopped)
+	defer func() { _ = unix.Close(n.fd) }()
+
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-n.done:
+			return
+		default:
+		}
+
+		nr, err := unix.Read(n.fd, buf)
+		if err != nil {
+			if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return
+		}
+		if nr <= 0 {
+			continue
+		}
+		select {
+		case n.events <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/p2p/external_ip_notify_bsd.go
+++ b/p2p/external_ip_notify_bsd.go
@@ -58,7 +58,7 @@ func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
 		done:    make(chan struct{}),
 		stopped: make(chan struct{}),
 	}
-	go n.loop()
+	go n.loop(logger)
 	return n
 }
 
@@ -72,7 +72,7 @@ func (n *routeNotifier) Close() error {
 	return nil
 }
 
-func (n *routeNotifier) loop() {
+func (n *routeNotifier) loop(logger log.Logger) {
 	defer close(n.stopped)
 	defer func() { _ = unix.Close(n.fd) }()
 
@@ -89,6 +89,7 @@ func (n *routeNotifier) loop() {
 			if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EINTR) {
 				continue
 			}
+			logger.Debug("p2p: route read failed, disabling event-driven external IP refresh", "err", err)
 			return
 		}
 		if nr <= 0 {

--- a/p2p/external_ip_notify_bsd.go
+++ b/p2p/external_ip_notify_bsd.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
@@ -40,7 +41,7 @@ type routeNotifier struct {
 func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
 	fd, err := unix.Socket(unix.AF_ROUTE, unix.SOCK_RAW, unix.AF_UNSPEC)
 	if err != nil {
-		logger.Debug("p2p: route notifier unavailable, using periodic external IP refresh only", "err", err)
+		logger.Debug(notifierUnavailableMsg, "err", err)
 		return noopNotifier{}
 	}
 	unix.CloseOnExec(fd)
@@ -48,7 +49,7 @@ func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
 	// without it Close could block forever on a blocked read.
 	if err := unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 1}); err != nil {
 		_ = unix.Close(fd)
-		logger.Debug("p2p: route receive timeout setup failed, using periodic external IP refresh only", "err", err)
+		logger.Debug(notifierUnavailableMsg, "err", err)
 		return noopNotifier{}
 	}
 
@@ -73,6 +74,7 @@ func (n *routeNotifier) Close() error {
 }
 
 func (n *routeNotifier) loop(logger log.Logger) {
+	defer dbg.LogPanic()
 	defer close(n.stopped)
 	defer func() { _ = unix.Close(n.fd) }()
 
@@ -89,7 +91,17 @@ func (n *routeNotifier) loop(logger log.Logger) {
 			if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EINTR) {
 				continue
 			}
-			logger.Debug("p2p: route read failed, disabling event-driven external IP refresh", "err", err)
+			if errors.Is(err, unix.ENOBUFS) {
+				// The kernel dropped route messages because we fell behind. A
+				// drop means state we didn't see changed, so signal a refresh
+				// and keep watching rather than reverting to poll-only.
+				select {
+				case n.events <- struct{}{}:
+				default:
+				}
+				continue
+			}
+			logger.Debug(notifierReadFailedMsg, "err", err)
 			return
 		}
 		if nr <= 0 {

--- a/p2p/external_ip_notify_linux.go
+++ b/p2p/external_ip_notify_linux.go
@@ -66,7 +66,7 @@ func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
 		done:    make(chan struct{}),
 		stopped: make(chan struct{}),
 	}
-	go n.loop()
+	go n.loop(logger)
 	return n
 }
 
@@ -80,7 +80,7 @@ func (n *netlinkNotifier) Close() error {
 	return nil
 }
 
-func (n *netlinkNotifier) loop() {
+func (n *netlinkNotifier) loop(logger log.Logger) {
 	defer close(n.stopped)
 	defer func() { _ = unix.Close(n.fd) }()
 
@@ -97,6 +97,7 @@ func (n *netlinkNotifier) loop() {
 			if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EINTR) {
 				continue
 			}
+			logger.Debug("p2p: netlink read failed, disabling event-driven external IP refresh", "err", err)
 			return
 		}
 		if nr < unix.NLMSG_HDRLEN {

--- a/p2p/external_ip_notify_linux.go
+++ b/p2p/external_ip_notify_linux.go
@@ -24,6 +24,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
@@ -40,7 +41,7 @@ type netlinkNotifier struct {
 func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
 	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW|unix.SOCK_CLOEXEC, unix.NETLINK_ROUTE)
 	if err != nil {
-		logger.Debug("p2p: netlink notifier unavailable, using periodic external IP refresh only", "err", err)
+		logger.Debug(notifierUnavailableMsg, "err", err)
 		return noopNotifier{}
 	}
 	addr := &unix.SockaddrNetlink{
@@ -49,14 +50,14 @@ func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
 	}
 	if err := unix.Bind(fd, addr); err != nil {
 		_ = unix.Close(fd)
-		logger.Debug("p2p: netlink bind failed, using periodic external IP refresh only", "err", err)
+		logger.Debug(notifierUnavailableMsg, "err", err)
 		return noopNotifier{}
 	}
 	// A receive timeout lets the read wake periodically to observe Close;
 	// without it Close could block forever on a blocked read.
 	if err := unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 1}); err != nil {
 		_ = unix.Close(fd)
-		logger.Debug("p2p: netlink receive timeout setup failed, using periodic external IP refresh only", "err", err)
+		logger.Debug(notifierUnavailableMsg, "err", err)
 		return noopNotifier{}
 	}
 
@@ -81,6 +82,7 @@ func (n *netlinkNotifier) Close() error {
 }
 
 func (n *netlinkNotifier) loop(logger log.Logger) {
+	defer dbg.LogPanic()
 	defer close(n.stopped)
 	defer func() { _ = unix.Close(n.fd) }()
 
@@ -97,7 +99,17 @@ func (n *netlinkNotifier) loop(logger log.Logger) {
 			if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EINTR) {
 				continue
 			}
-			logger.Debug("p2p: netlink read failed, disabling event-driven external IP refresh", "err", err)
+			if errors.Is(err, unix.ENOBUFS) {
+				// The kernel dropped multicast messages because we fell behind.
+				// A drop means state we didn't see changed, so signal a refresh
+				// and keep watching rather than reverting to poll-only.
+				select {
+				case n.events <- struct{}{}:
+				default:
+				}
+				continue
+			}
+			logger.Debug(notifierReadFailedMsg, "err", err)
 			return
 		}
 		if nr < unix.NLMSG_HDRLEN {

--- a/p2p/external_ip_notify_linux.go
+++ b/p2p/external_ip_notify_linux.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package p2p
+
+import (
+	"errors"
+	"sync"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+// netlinkNotifier signals on address, link and route changes via an
+// RTNETLINK multicast socket.
+type netlinkNotifier struct {
+	fd        int
+	events    chan struct{}
+	done      chan struct{}
+	stopped   chan struct{}
+	closeOnce sync.Once
+}
+
+func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
+	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW|unix.SOCK_CLOEXEC, unix.NETLINK_ROUTE)
+	if err != nil {
+		logger.Debug("p2p: netlink notifier unavailable, using periodic external IP refresh only", "err", err)
+		return noopNotifier{}
+	}
+	addr := &unix.SockaddrNetlink{
+		Family: unix.AF_NETLINK,
+		Groups: unix.RTMGRP_IPV4_IFADDR | unix.RTMGRP_IPV6_IFADDR | unix.RTMGRP_LINK,
+	}
+	if err := unix.Bind(fd, addr); err != nil {
+		_ = unix.Close(fd)
+		logger.Debug("p2p: netlink bind failed, using periodic external IP refresh only", "err", err)
+		return noopNotifier{}
+	}
+	// A receive timeout lets the read wake periodically to observe Close.
+	_ = unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 1})
+
+	n := &netlinkNotifier{
+		fd:      fd,
+		events:  make(chan struct{}, 1),
+		done:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	go n.loop()
+	return n
+}
+
+func (n *netlinkNotifier) Events() <-chan struct{} { return n.events }
+
+func (n *netlinkNotifier) Close() error {
+	n.closeOnce.Do(func() {
+		close(n.done)
+		<-n.stopped
+	})
+	return nil
+}
+
+func (n *netlinkNotifier) loop() {
+	defer close(n.stopped)
+	defer func() { _ = unix.Close(n.fd) }()
+
+	buf := make([]byte, 8192)
+	for {
+		select {
+		case <-n.done:
+			return
+		default:
+		}
+
+		nr, _, err := unix.Recvfrom(n.fd, buf, 0)
+		if err != nil {
+			if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return
+		}
+		if nr < unix.NLMSG_HDRLEN {
+			continue
+		}
+		select {
+		case n.events <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/p2p/external_ip_notify_linux.go
+++ b/p2p/external_ip_notify_linux.go
@@ -27,7 +27,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
-// netlinkNotifier signals on address, link and route changes via an
+// netlinkNotifier signals on interface address and link changes via an
 // RTNETLINK multicast socket.
 type netlinkNotifier struct {
 	fd        int

--- a/p2p/external_ip_notify_linux.go
+++ b/p2p/external_ip_notify_linux.go
@@ -52,8 +52,13 @@ func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
 		logger.Debug("p2p: netlink bind failed, using periodic external IP refresh only", "err", err)
 		return noopNotifier{}
 	}
-	// A receive timeout lets the read wake periodically to observe Close.
-	_ = unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 1})
+	// A receive timeout lets the read wake periodically to observe Close;
+	// without it Close could block forever on a blocked read.
+	if err := unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 1}); err != nil {
+		_ = unix.Close(fd)
+		logger.Debug("p2p: netlink receive timeout setup failed, using periodic external IP refresh only", "err", err)
+		return noopNotifier{}
+	}
 
 	n := &netlinkNotifier{
 		fd:      fd,

--- a/p2p/external_ip_notify_other.go
+++ b/p2p/external_ip_notify_other.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !linux
+//go:build !linux && !windows && !darwin && !freebsd && !netbsd && !openbsd && !dragonfly
 
 package p2p
 

--- a/p2p/external_ip_notify_other.go
+++ b/p2p/external_ip_notify_other.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !linux
+
+package p2p
+
+import "github.com/erigontech/erigon/common/log/v3"
+
+// newNetChangeNotifier has no native event source on this platform; the node
+// relies on periodic re-resolution only.
+func newNetChangeNotifier(log.Logger) netChangeNotifier {
+	return noopNotifier{}
+}

--- a/p2p/external_ip_notify_test.go
+++ b/p2p/external_ip_notify_test.go
@@ -118,17 +118,33 @@ func TestNetworkChangeEventsCoalesce(t *testing.T) {
 
 	expectApplied(t, applied, ip1) // initial resolve -> 1 call
 
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 8; i++ { // burst, buffered, no inter-event sleeps
 		fn.ch <- struct{}{}
-		time.Sleep(2 * time.Millisecond)
 	}
-	time.Sleep(120 * time.Millisecond) // let the debounce settle and fire once
+	waitForCount(t, nat, 2) // the burst coalesces into a single extra resolve
+
+	// No further events arrive, so the count must stay at 2 (coalesced, not per-event).
+	time.Sleep(80 * time.Millisecond)
+	if got := nat.callCount(); got != 2 {
+		t.Fatalf("expected a burst to coalesce into 1 extra resolve (2 calls total), got %d", got)
+	}
 
 	close(stop)
 	expectClosed(t, done)
+}
 
-	if got := nat.callCount(); got != 2 {
-		t.Fatalf("expected a burst to coalesce into 1 extra resolve (2 calls total), got %d", got)
+func waitForCount(t *testing.T, nat *countingNAT, want int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if nat.callCount() >= want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d resolves, got %d", want, nat.callCount())
+		case <-time.After(time.Millisecond):
+		}
 	}
 }
 

--- a/p2p/external_ip_notify_test.go
+++ b/p2p/external_ip_notify_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+func TestNoopNotifierNeverFires(t *testing.T) {
+	t.Parallel()
+	n := noopNotifier{}
+	select {
+	case <-n.Events():
+		t.Fatal("noop notifier must never fire")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := n.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+type fakeNotifier struct{ ch chan struct{} }
+
+func (f *fakeNotifier) Events() <-chan struct{} { return f.ch }
+func (f *fakeNotifier) Close() error            { return nil }
+
+// countingNAT is concurrency-safe and counts ExternalIP calls.
+type countingNAT struct {
+	mu    sync.Mutex
+	ips   []net.IP
+	calls int
+}
+
+func (c *countingNAT) ExternalIP() (net.IP, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	i := c.calls
+	if i >= len(c.ips) {
+		i = len(c.ips) - 1
+	}
+	c.calls++
+	return c.ips[i], nil
+}
+
+func (c *countingNAT) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+func (c *countingNAT) AddMapping(string, int, int, string, time.Duration) error { return nil }
+func (c *countingNAT) DeleteMapping(string, int, int) error                     { return nil }
+func (c *countingNAT) SupportsMapping() bool                                    { return false }
+func (c *countingNAT) String() string                                           { return "countingNAT" }
+
+func TestNetworkChangeEventTriggersRefresh(t *testing.T) {
+	t.Parallel()
+	ip1 := net.ParseIP("203.0.113.7")
+	ip2 := net.ParseIP("198.51.100.9")
+	applied := make(chan net.IP, 4)
+	tr := &externalIPTracker{
+		nat:    &countingNAT{ips: []net.IP{ip1, ip2}},
+		set:    func(ip net.IP) { applied <- ip },
+		logger: log.New(),
+	}
+	fn := &fakeNotifier{ch: make(chan struct{}, 1)}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		tr.runWithNotifier(stop, fn, time.Hour, 10*time.Millisecond)
+		close(done)
+	}()
+
+	expectApplied(t, applied, ip1) // initial resolve
+	fn.ch <- struct{}{}
+	expectApplied(t, applied, ip2) // event-driven resolve, after debounce
+
+	close(stop)
+	expectClosed(t, done)
+}
+
+func TestNetworkChangeEventsCoalesce(t *testing.T) {
+	t.Parallel()
+	ip1 := net.ParseIP("203.0.113.7")
+	nat := &countingNAT{ips: []net.IP{ip1}}
+	applied := make(chan net.IP, 1)
+	tr := &externalIPTracker{
+		nat:    nat,
+		set:    func(ip net.IP) { applied <- ip },
+		logger: log.New(),
+	}
+	fn := &fakeNotifier{ch: make(chan struct{}, 16)}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		tr.runWithNotifier(stop, fn, time.Hour, 40*time.Millisecond)
+		close(done)
+	}()
+
+	expectApplied(t, applied, ip1) // initial resolve -> 1 call
+
+	for i := 0; i < 8; i++ {
+		fn.ch <- struct{}{}
+		time.Sleep(2 * time.Millisecond)
+	}
+	time.Sleep(120 * time.Millisecond) // let the debounce settle and fire once
+
+	close(stop)
+	expectClosed(t, done)
+
+	if got := nat.callCount(); got != 2 {
+		t.Fatalf("expected a burst to coalesce into 1 extra resolve (2 calls total), got %d", got)
+	}
+}
+
+func expectApplied(t *testing.T, ch <-chan net.IP, want net.IP) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		if !got.Equal(want) {
+			t.Fatalf("applied %v, want %v", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %v to be applied", want)
+	}
+}
+
+func expectClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWithNotifier did not return after stop")
+	}
+}

--- a/p2p/external_ip_notify_test.go
+++ b/p2p/external_ip_notify_test.go
@@ -112,13 +112,13 @@ func TestNetworkChangeEventsCoalesce(t *testing.T) {
 	stop := make(chan struct{})
 	done := make(chan struct{})
 	go func() {
-		tr.runWithNotifier(stop, fn, time.Hour, 40*time.Millisecond)
+		tr.runWithNotifier(stop, fn, time.Hour, 250*time.Millisecond)
 		close(done)
 	}()
 
 	expectApplied(t, applied, ip1) // initial resolve -> 1 call
 
-	for i := 0; i < 8; i++ { // burst, buffered, no inter-event sleeps
+	for range 8 { // burst, buffered, no inter-event sleeps
 		fn.ch <- struct{}{}
 	}
 	waitForCount(t, nat, 2) // the burst coalesces into a single extra resolve

--- a/p2p/external_ip_notify_windows.go
+++ b/p2p/external_ip_notify_windows.go
@@ -19,6 +19,7 @@
 package p2p
 
 import (
+	"runtime"
 	"sync"
 	"unsafe"
 
@@ -27,33 +28,34 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
-var (
-	modiphlpapi          = windows.NewLazySystemDLL("iphlpapi.dll")
-	procNotifyAddrChange = modiphlpapi.NewProc("NotifyAddrChange")
-	procCancelIPChange   = modiphlpapi.NewProc("CancelIPChangeNotify")
-)
+// addrChangeCallback is registered once for the whole process. A
+// windows.NewCallback trampoline is never freed, so it must not be allocated
+// per notifier; the owning notifier is recovered from the caller context.
+var addrChangeCallback = windows.NewCallback(onUnicastIPAddressChange)
 
-// addrChangeNotifier signals on IP address changes via the IP Helper
-// NotifyAddrChange API, cancelled through a manual-reset event.
+// addrChangeNotifier signals on unicast IP address changes via the IP Helper
+// NotifyUnicastIpAddressChange API. Cancellation is synchronous —
+// CancelMibChangeNotify2 waits for any in-flight callback to return and
+// guarantees none fires afterwards — so no OVERLAPPED buffer or manual event
+// handshake is needed.
 type addrChangeNotifier struct {
-	events      chan struct{}
-	cancelEvent windows.Handle
-	stopped     chan struct{}
-	closeOnce   sync.Once
+	events    chan struct{}
+	handle    windows.Handle
+	pinner    runtime.Pinner
+	closeOnce sync.Once
 }
 
 func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
-	cancelEvent, err := windows.CreateEvent(nil, 1, 0, nil) // manual-reset, nonsignaled
+	n := &addrChangeNotifier{events: make(chan struct{}, 1)}
+	// The OS retains the caller context until CancelMibChangeNotify2, so pin n
+	// to keep it alive and unmoved for the callback to dereference.
+	n.pinner.Pin(n)
+	err := windows.NotifyUnicastIpAddressChange(windows.AF_UNSPEC, addrChangeCallback, unsafe.Pointer(n), false, &n.handle)
 	if err != nil {
-		logger.Debug("p2p: address-change notifier unavailable, using periodic external IP refresh only", "err", err)
+		n.pinner.Unpin()
+		logger.Debug(notifierUnavailableMsg, "err", err)
 		return noopNotifier{}
 	}
-	n := &addrChangeNotifier{
-		events:      make(chan struct{}, 1),
-		cancelEvent: cancelEvent,
-		stopped:     make(chan struct{}),
-	}
-	go n.loop(logger)
 	return n
 }
 
@@ -61,46 +63,20 @@ func (n *addrChangeNotifier) Events() <-chan struct{} { return n.events }
 
 func (n *addrChangeNotifier) Close() error {
 	n.closeOnce.Do(func() {
-		windows.SetEvent(n.cancelEvent)
-		<-n.stopped
-		windows.CloseHandle(n.cancelEvent)
+		windows.CancelMibChangeNotify2(n.handle)
+		n.pinner.Unpin()
 	})
 	return nil
 }
 
-func (n *addrChangeNotifier) loop(logger log.Logger) {
-	defer close(n.stopped)
-
-	notifyEvent, err := windows.CreateEvent(nil, 0, 0, nil) // auto-reset, nonsignaled
-	if err != nil {
-		logger.Debug("p2p: address-change event creation failed, using periodic external IP refresh only", "err", err)
-		return
+// onUnicastIPAddressChange is the process-wide notify callback. It runs on an OS
+// thread-pool thread, so it does nothing but a non-blocking send to the owning
+// notifier's channel; the debounced refresh loop does the real work.
+func onUnicastIPAddressChange(callerContext, row, notificationType uintptr) uintptr {
+	n := (*addrChangeNotifier)(unsafe.Pointer(callerContext))
+	select {
+	case n.events <- struct{}{}:
+	default:
 	}
-	defer windows.CloseHandle(notifyEvent)
-
-	for {
-		var handle windows.Handle
-		overlapped := &windows.Overlapped{HEvent: notifyEvent}
-		r, _, _ := procNotifyAddrChange.Call(uintptr(unsafe.Pointer(&handle)), uintptr(unsafe.Pointer(overlapped)))
-		if errno := windows.Errno(r); errno != 0 && errno != windows.ERROR_IO_PENDING {
-			logger.Debug("p2p: NotifyAddrChange failed, using periodic external IP refresh only", "err", errno)
-			return
-		}
-
-		s, err := windows.WaitForMultipleObjects([]windows.Handle{n.cancelEvent, notifyEvent}, false, windows.INFINITE)
-		// Only an address change (second handle) continues the loop; a Close
-		// cancel (first handle), an error, or any unexpected result tears down
-		// the pending notification and stops.
-		if err != nil || s != windows.WAIT_OBJECT_0+1 {
-			if err != nil {
-				logger.Debug("p2p: address-change wait failed", "err", err)
-			}
-			procCancelIPChange.Call(uintptr(unsafe.Pointer(overlapped)))
-			return
-		}
-		select {
-		case n.events <- struct{}{}:
-		default:
-		}
-	}
+	return 0
 }

--- a/p2p/external_ip_notify_windows.go
+++ b/p2p/external_ip_notify_windows.go
@@ -88,23 +88,19 @@ func (n *addrChangeNotifier) loop(logger log.Logger) {
 		}
 
 		s, err := windows.WaitForMultipleObjects([]windows.Handle{n.cancelEvent, notifyEvent}, false, windows.INFINITE)
-		if err != nil {
-			logger.Debug("p2p: address-change wait failed", "err", err)
+		// Only an address change (second handle) continues the loop; a Close
+		// cancel (first handle), an error, or any unexpected result tears down
+		// the pending notification and stops.
+		if err != nil || s != windows.WAIT_OBJECT_0+1 {
+			if err != nil {
+				logger.Debug("p2p: address-change wait failed", "err", err)
+			}
 			procCancelIPChange.Call(uintptr(unsafe.Pointer(overlapped)))
 			return
 		}
-		switch s {
-		case windows.WAIT_OBJECT_0: // cancelled by Close
-			procCancelIPChange.Call(uintptr(unsafe.Pointer(overlapped)))
-			return
-		case windows.WAIT_OBJECT_0 + 1: // address changed
-			select {
-			case n.events <- struct{}{}:
-			default:
-			}
+		select {
+		case n.events <- struct{}{}:
 		default:
-			procCancelIPChange.Call(uintptr(unsafe.Pointer(overlapped)))
-			return
 		}
 	}
 }

--- a/p2p/external_ip_notify_windows.go
+++ b/p2p/external_ip_notify_windows.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package p2p
+
+import (
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+var (
+	modiphlpapi          = windows.NewLazySystemDLL("iphlpapi.dll")
+	procNotifyAddrChange = modiphlpapi.NewProc("NotifyAddrChange")
+	procCancelIPChange   = modiphlpapi.NewProc("CancelIPChangeNotify")
+)
+
+// addrChangeNotifier signals on IP address changes via the IP Helper
+// NotifyAddrChange API, cancelled through a manual-reset event.
+type addrChangeNotifier struct {
+	events      chan struct{}
+	cancelEvent windows.Handle
+	stopped     chan struct{}
+	closeOnce   sync.Once
+}
+
+func newNetChangeNotifier(logger log.Logger) netChangeNotifier {
+	cancelEvent, err := windows.CreateEvent(nil, 1, 0, nil) // manual-reset, nonsignaled
+	if err != nil {
+		logger.Debug("p2p: address-change notifier unavailable, using periodic external IP refresh only", "err", err)
+		return noopNotifier{}
+	}
+	n := &addrChangeNotifier{
+		events:      make(chan struct{}, 1),
+		cancelEvent: cancelEvent,
+		stopped:     make(chan struct{}),
+	}
+	go n.loop(logger)
+	return n
+}
+
+func (n *addrChangeNotifier) Events() <-chan struct{} { return n.events }
+
+func (n *addrChangeNotifier) Close() error {
+	n.closeOnce.Do(func() {
+		windows.SetEvent(n.cancelEvent)
+		<-n.stopped
+		windows.CloseHandle(n.cancelEvent)
+	})
+	return nil
+}
+
+func (n *addrChangeNotifier) loop(logger log.Logger) {
+	defer close(n.stopped)
+
+	notifyEvent, err := windows.CreateEvent(nil, 0, 0, nil) // auto-reset, nonsignaled
+	if err != nil {
+		logger.Debug("p2p: address-change event creation failed, using periodic external IP refresh only", "err", err)
+		return
+	}
+	defer windows.CloseHandle(notifyEvent)
+
+	for {
+		var handle windows.Handle
+		overlapped := &windows.Overlapped{HEvent: notifyEvent}
+		r, _, _ := procNotifyAddrChange.Call(uintptr(unsafe.Pointer(&handle)), uintptr(unsafe.Pointer(overlapped)))
+		if errno := windows.Errno(r); errno != 0 && errno != windows.ERROR_IO_PENDING {
+			logger.Debug("p2p: NotifyAddrChange failed, using periodic external IP refresh only", "err", errno)
+			return
+		}
+
+		s, err := windows.WaitForMultipleObjects([]windows.Handle{n.cancelEvent, notifyEvent}, false, windows.INFINITE)
+		if err != nil {
+			logger.Debug("p2p: address-change wait failed", "err", err)
+			procCancelIPChange.Call(uintptr(unsafe.Pointer(overlapped)))
+			return
+		}
+		switch s {
+		case windows.WAIT_OBJECT_0: // cancelled by Close
+			procCancelIPChange.Call(uintptr(unsafe.Pointer(overlapped)))
+			return
+		case windows.WAIT_OBJECT_0 + 1: // address changed
+			select {
+			case n.events <- struct{}{}:
+			default:
+			}
+		default:
+			procCancelIPChange.Call(uintptr(unsafe.Pointer(overlapped)))
+			return
+		}
+	}
+}

--- a/p2p/external_ip_test.go
+++ b/p2p/external_ip_test.go
@@ -17,6 +17,7 @@
 package p2p
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
@@ -138,6 +139,45 @@ func TestExternalIPTrackerIgnoresError(t *testing.T) {
 	}
 	if len(*applied) != 0 {
 		t.Fatalf("expected no apply, got %v", *applied)
+	}
+}
+
+type levelCaptureHandler struct{ levels []log.Lvl }
+
+func (h *levelCaptureHandler) Log(r *log.Record) error {
+	h.levels = append(h.levels, r.Lvl)
+	return nil
+}
+func (h *levelCaptureHandler) Enabled(context.Context, log.Lvl) bool { return true }
+
+func TestExternalIPTrackerFailureLogIsDeduped(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+	h := &levelCaptureHandler{}
+	logger.SetHandler(h)
+	tr := &externalIPTracker{
+		nat: &fakeNAT{results: []fakeResult{
+			{err: errors.New("down")},
+			{err: errors.New("down")},
+			{ip: net.ParseIP("203.0.113.7")},
+			{err: errors.New("down")},
+		}},
+		set:    func(net.IP) {},
+		logger: logger,
+	}
+	tr.refresh() // failure -> WARN (first)
+	tr.refresh() // failure -> DEBUG (deduped)
+	tr.refresh() // success -> INFO
+	tr.refresh() // failure after recovery -> WARN again
+
+	want := []log.Lvl{log.LvlWarn, log.LvlDebug, log.LvlInfo, log.LvlWarn}
+	if len(h.levels) != len(want) {
+		t.Fatalf("levels = %v, want %v", h.levels, want)
+	}
+	for i := range want {
+		if h.levels[i] != want[i] {
+			t.Fatalf("levels = %v, want %v", h.levels, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Background

Follow-up to #22105, which re-resolves the `nat=stun` public IP on a 10-minute timer. This adds an OS network-change **trigger** so a re-resolve also fires promptly when the host's network configuration changes — cutting detection latency for directly-connected hosts whose own interface gets a dynamic public IP (PPPoE/DHCP). It implements the same idea for the STUN path as the latent `// TODO: monitor network configuration and rerun doit when it changes` in `p2p/nat/nat.go` (that TODO is in `startautodisc` — UPnP/PMP gateway re-discovery, which this PR doesn't touch — so it stays).

This is a **latency optimization only** — correctness is already provided by the poll in #22105.

## Design

A per-platform `netChangeNotifier` whose `Events()` channel delivers a *coalesced signal to reconsider the external IP*. It never carries an address, so this path cannot be used to move the advertised endpoint — the committed value is always the resolver's validated answer (`SetStaticIP`, same as #22105).

| GOOS | Source |
| --- | --- |
| `linux` | RTNETLINK socket (`RTMGRP_IPV4_IFADDR \| _IPV6_IFADDR \| _LINK`) |
| `darwin`, `freebsd`, `netbsd`, `openbsd`, `dragonfly` | `PF_ROUTE` socket |
| `windows` | IP Helper `NotifyUnicastIpAddressChange` callback, cancelled synchronously via `CancelMibChangeNotify2` |
| everything else (`plan9`, `solaris`, `illumos`, `aix`, `wasm`, …) | **no-op** notifier → periodic poll only |

The no-op fallback (inverse build tag) guarantees the build and behavior are safe on **every** `GOOS` with no per-platform enumeration. A native notifier that fails to initialize at runtime also degrades to the no-op + a one-shot debug log, so a node never loses the poll baseline. No new dependencies (`golang.org/x/sys` was already vendored).

### Safety properties
- **Debounced/coalesced**: an interface flap emits bursts of events; they collapse into a single re-resolve once the link settles. No STUN-query storm; the poll remains the backstop if a link flaps continuously.
- **Events carry no IP**: not attacker-influenceable into changing the endpoint.
- **Clean shutdown**: `Close()` stops and waits for the Unix watcher goroutine (receive-timeout wake); on Windows, it synchronously cancels the callback registration with `CancelMibChangeNotify2`.

## Logging
No steady-state log growth. Notifiers log only a one-shot debug line if their native source is unavailable. Separately, resolution-failure logs are now deduped (warn once on entering a failing state, debug while it persists, warn again after recovery) so the new event triggers can't turn a flapping link / down STUN server into log spam.

## Tests
Platform-agnostic, deterministic (fake notifier): no-op never fires; an event triggers a debounced re-resolve; an event burst coalesces into one resolve; failure-log levels (`WARN, DEBUG, INFO, WARN`) via a capturing handler. Pass under `-race`.

## Verification
- `go test ./p2p/ -race` — pass (darwin path exercises a real `PF_ROUTE` socket via `run()`)
- Linux + Windows notifier code type-checked in isolation (full cgo cross-build unavailable locally)
- `make lint` — 0 issues
- `make erigon` — builds
