### PR TITLE
execution/stagedsync, commitment: restore commitment state reader after parallel exec batch

### DIFF
--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -70,6 +70,12 @@ func (sdc *SharedDomainsCommitmentContext) SetStateReader(stateReader StateReade
 	sdc.stateReader = stateReader
 }
 
+// StateReader returns the currently installed custom state reader, or nil when
+// none is set (trieContext then builds the default latest-state reader).
+func (sdc *SharedDomainsCommitmentContext) StateReader() StateReader {
+	return sdc.stateReader
+}
+
 func (sdc *SharedDomainsCommitmentContext) EnableParaTrieDB(db kv.TemporalRoDB) {
 	sdc.paraTrieDB = db
 }

--- a/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
+++ b/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
@@ -145,19 +145,10 @@ func runFromZeroGenesisAllocPreservedAfterResetReExec(t *testing.T) {
 		"BUG #21138: after reset + integration-path re-exec, genesis-allocated balance dropped (mainnet block 46147)")
 }
 
-// reExecViaIntegrationPath drives execution the way cmd/integration/commands/
-// stages.go does: SpawnExecuteBlocksStage one batch per rwtx, committing each
-// with doms.Commit + ClearRam and reusing the SharedDomains. This bypasses the
-// engine API. doms.Commit (not Flush) is load-bearing: it refreshes the
-// aggregator BranchCache to match committed state — Flush leaves it stale and
-// corrupts the next batch's trie root.
-func reExecViaIntegrationPath(t *testing.T, ctx context.Context, emt *ExecModuleTester, toBlock uint64, batchSize datasize.ByteSize, badBlockHalt bool, logger log.Logger) error {
-	t.Helper()
-
-	// The exec stage cfg execmoduletester built sits inside emt.Sync; we
-	// rebuild it with the same arguments so we can invoke
-	// SpawnExecuteBlocksStage directly without coupling to internal stage
-	// indices.
+// newOfflineExecCfg rebuilds the exec-stage cfg directly (execmoduletester's own
+// copy is buried in emt.Sync) and locks the offline-execution writers like the
+// integration tool does, so periodic snapshot retiring doesn't fight the re-exec.
+func newOfflineExecCfg(emt *ExecModuleTester, batchSize datasize.ByteSize, badBlockHalt bool) stagedsync.ExecuteBlockCfg {
 	cfg := stagedsync.StageExecuteBlocksCfg(
 		emt.DB,
 		emt.cfg.Prune,
@@ -175,14 +166,24 @@ func reExecViaIntegrationPath(t *testing.T, ctx context.Context, emt *ExecModule
 		false, /*experimentalBAL*/
 		exec.NewBlockReadAheader(),
 	)
-
-	// Lock the offline-execution writers like the integration tool does so
-	// the periodic snapshot retiring doesn't fight us.
 	if agg, ok := emt.DB.(dbstate.HasAgg); ok {
 		if aggT, okT := agg.Agg().(*dbstate.Aggregator); okT {
 			aggT.PresetOfflineExecution()
 		}
 	}
+	return cfg
+}
+
+// reExecViaIntegrationPath drives execution the way cmd/integration/commands/
+// stages.go does: SpawnExecuteBlocksStage one batch per rwtx, committing each
+// with doms.Commit + ClearRam and reusing the SharedDomains. This bypasses the
+// engine API. doms.Commit (not Flush) is load-bearing: it refreshes the
+// aggregator BranchCache to match committed state — Flush leaves it stale and
+// corrupts the next batch's trie root.
+func reExecViaIntegrationPath(t *testing.T, ctx context.Context, emt *ExecModuleTester, toBlock uint64, batchSize datasize.ByteSize, badBlockHalt bool, logger log.Logger) error {
+	t.Helper()
+
+	cfg := newOfflineExecCfg(emt, batchSize, badBlockHalt)
 
 	doms, err := newReusedDomains(ctx, emt, logger)
 	if err != nil {
@@ -356,15 +357,7 @@ func TestExec_RestoresCommitmentStateReader(t *testing.T) {
 	logger := log.New()
 	require.NoError(t, rawdbreset.ResetExec(ctx, emt.DB))
 
-	cfg := stagedsync.StageExecuteBlocksCfg(
-		emt.DB, emt.cfg.Prune, emt.cfg.BatchSize, emt.ChainConfig, emt.Engine,
-		&vm.Config{}, emt.Notifications, emt.cfg.StateStream, false /*badBlockHalt*/, emt.Dirs,
-		emt.BlockReader, emt.cfg.Genesis, emt.cfg.Sync, false /*experimentalBAL*/, exec.NewBlockReadAheader())
-	if agg, ok := emt.DB.(dbstate.HasAgg); ok {
-		if aggT, okT := agg.Agg().(*dbstate.Aggregator); okT {
-			aggT.PresetOfflineExecution()
-		}
-	}
+	cfg := newOfflineExecCfg(emt, emt.cfg.BatchSize, false /*badBlockHalt*/)
 
 	doms, err := newReusedDomains(ctx, emt, logger)
 	require.NoError(t, err)

--- a/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
+++ b/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
@@ -322,30 +322,14 @@ func runBranchCacheCoherentAcrossBatches(t *testing.T) {
 }
 
 // TestExec_RestoresCommitmentStateReader checks that an execution batch leaves
-// the commitment state reader as it found it, in both serial and parallel mode.
-// Parallel installs a GetAsOf-based asOfStateReader (via the commitment
-// calculator); leaving it on the shared context makes a later foreground
-// SeekCommitment in the offline re-exec path (in-mem history reads disabled)
-// fail with "GetAsOf called on TemporalMemBatch with inMemHistoryReads disabled".
-// Serial installs no custom reader and is the control for the same invariant.
+// the commitment state reader as it found it. The exec mode is whatever the
+// suite selects — the serial/parallel CI matrix (and the EXEC3_PARALLEL default)
+// cover both. It bites in parallel: the commitment calculator installs a
+// GetAsOf-based asOfStateReader on the shared context, and leaving it there
+// makes a later foreground SeekCommitment in the offline re-exec path (in-mem
+// history reads disabled) fail with "GetAsOf called on TemporalMemBatch with
+// inMemHistoryReads disabled". Serial installs no custom reader.
 func TestExec_RestoresCommitmentStateReader(t *testing.T) {
-	for _, mode := range []struct {
-		name     string
-		parallel bool
-	}{
-		{"serial", false},
-		{"parallel", true},
-	} {
-		t.Run(mode.name, func(t *testing.T) {
-			prev := dbg.Exec3Parallel
-			dbg.Exec3Parallel = mode.parallel
-			t.Cleanup(func() { dbg.Exec3Parallel = prev })
-			runExecRestoresCommitmentStateReader(t)
-		})
-	}
-}
-
-func runExecRestoresCommitmentStateReader(t *testing.T) {
 	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	keyAddr := crypto.PubkeyToAddress(key.PublicKey)
 	keyFunds := new(big.Int).Mul(big.NewInt(1_000_000), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))

--- a/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
+++ b/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
@@ -145,10 +145,10 @@ func runFromZeroGenesisAllocPreservedAfterResetReExec(t *testing.T) {
 		"BUG #21138: after reset + integration-path re-exec, genesis-allocated balance dropped (mainnet block 46147)")
 }
 
-// newOfflineExecCfg rebuilds the exec-stage cfg directly (execmoduletester's own
+// setupOfflineExec rebuilds the exec-stage cfg directly (execmoduletester's own
 // copy is buried in emt.Sync) and locks the offline-execution writers like the
 // integration tool does, so periodic snapshot retiring doesn't fight the re-exec.
-func newOfflineExecCfg(emt *ExecModuleTester, batchSize datasize.ByteSize, badBlockHalt bool) stagedsync.ExecuteBlockCfg {
+func setupOfflineExec(emt *ExecModuleTester, batchSize datasize.ByteSize, badBlockHalt bool) stagedsync.ExecuteBlockCfg {
 	cfg := stagedsync.StageExecuteBlocksCfg(
 		emt.DB,
 		emt.cfg.Prune,
@@ -183,7 +183,7 @@ func newOfflineExecCfg(emt *ExecModuleTester, batchSize datasize.ByteSize, badBl
 func reExecViaIntegrationPath(t *testing.T, ctx context.Context, emt *ExecModuleTester, toBlock uint64, batchSize datasize.ByteSize, badBlockHalt bool, logger log.Logger) error {
 	t.Helper()
 
-	cfg := newOfflineExecCfg(emt, batchSize, badBlockHalt)
+	cfg := setupOfflineExec(emt, batchSize, badBlockHalt)
 
 	doms, err := newReusedDomains(ctx, emt, logger)
 	if err != nil {
@@ -357,7 +357,7 @@ func TestExec_RestoresCommitmentStateReader(t *testing.T) {
 	logger := log.New()
 	require.NoError(t, rawdbreset.ResetExec(ctx, emt.DB))
 
-	cfg := newOfflineExecCfg(emt, emt.cfg.BatchSize, false /*badBlockHalt*/)
+	cfg := setupOfflineExec(emt, emt.cfg.BatchSize, false /*badBlockHalt*/)
 
 	doms, err := newReusedDomains(ctx, emt, logger)
 	require.NoError(t, err)

--- a/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
+++ b/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
@@ -320,3 +320,63 @@ func runBranchCacheCoherentAcrossBatches(t *testing.T) {
 		reExecViaIntegrationPath(t, ctx, emt, gen.TopBlock.NumberU64(), 1*datasize.KB, true /*badBlockHalt*/, logger),
 		"re-exec from 0 in tiny batches must reproduce each block's trie root; a stale BranchCache corrupts it")
 }
+
+// TestParallelExec_RestoresCommitmentStateReader checks that a parallel-exec
+// batch leaves the commitment state reader as it found it. The commitment
+// calculator installs its own GetAsOf-based asOfStateReader on the shared
+// commitment context; if that reader is left installed, a later foreground
+// SeekCommitment in the offline re-exec path (which runs with in-mem history
+// reads disabled) routes account reads through GetAsOf on sd.mem and fails
+// with "GetAsOf called on TemporalMemBatch with inMemHistoryReads disabled".
+func TestParallelExec_RestoresCommitmentStateReader(t *testing.T) {
+	prev := dbg.Exec3Parallel
+	dbg.Exec3Parallel = true
+	t.Cleanup(func() { dbg.Exec3Parallel = prev })
+
+	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	keyAddr := crypto.PubkeyToAddress(key.PublicKey)
+	keyFunds := new(big.Int).Mul(big.NewInt(1_000_000), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+	gspec := &types.Genesis{
+		Config: chain.TestChainBerlinConfig,
+		Alloc:  types.GenesisAlloc{keyAddr: types.GenesisAccount{Balance: keyFunds}},
+	}
+	emt := New(t, WithGenesisSpec(gspec), WithKey(key))
+
+	signer := types.LatestSignerForChainID(emt.ChainConfig.ChainID)
+	gen, err := blockgen.GenerateChain(emt.ChainConfig, emt.Genesis, emt.Engine, emt.DB, 4, func(i int, b *blockgen.BlockGen) {
+		b.SetCoinbase(common.Address{1})
+		to := common.BytesToAddress([]byte{byte(i + 1), 0xab})
+		tx, txErr := types.SignTx(
+			types.NewTransaction(b.TxNonce(keyAddr), to, uint256.NewInt(1_000_000), params.TxGas, uint256.NewInt(1), nil),
+			*signer, key)
+		require.NoError(t, txErr)
+		b.AddTx(tx)
+	})
+	require.NoError(t, err)
+	require.NoError(t, emt.InsertChain(gen))
+
+	ctx := context.Background()
+	logger := log.New()
+	require.NoError(t, rawdbreset.ResetExec(ctx, emt.DB))
+
+	cfg := stagedsync.StageExecuteBlocksCfg(
+		emt.DB, emt.cfg.Prune, emt.cfg.BatchSize, emt.ChainConfig, emt.Engine,
+		&vm.Config{}, emt.Notifications, emt.cfg.StateStream, false /*badBlockHalt*/, emt.Dirs,
+		emt.BlockReader, emt.cfg.Genesis, emt.cfg.Sync, false /*experimentalBAL*/, exec.NewBlockReadAheader())
+	if agg, ok := emt.DB.(dbstate.HasAgg); ok {
+		if aggT, okT := agg.Agg().(*dbstate.Aggregator); okT {
+			aggT.PresetOfflineExecution()
+		}
+	}
+
+	doms, err := newReusedDomains(ctx, emt, logger)
+	require.NoError(t, err)
+	defer doms.Close()
+
+	readerBefore := doms.GetCommitmentContext().StateReader()
+	_, err = execOneBatch(ctx, emt, doms, cfg, gen.TopBlock.NumberU64(), logger)
+	require.NoError(t, err)
+
+	require.Equal(t, readerBefore, doms.GetCommitmentContext().StateReader(),
+		"parallel exec must restore the commitment state reader it found; leaving the calculator's asOfStateReader installed breaks a later foreground SeekCommitment with in-mem history reads disabled")
+}

--- a/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
+++ b/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
@@ -321,18 +321,31 @@ func runBranchCacheCoherentAcrossBatches(t *testing.T) {
 		"re-exec from 0 in tiny batches must reproduce each block's trie root; a stale BranchCache corrupts it")
 }
 
-// TestParallelExec_RestoresCommitmentStateReader checks that a parallel-exec
-// batch leaves the commitment state reader as it found it. The commitment
-// calculator installs its own GetAsOf-based asOfStateReader on the shared
-// commitment context; if that reader is left installed, a later foreground
-// SeekCommitment in the offline re-exec path (which runs with in-mem history
-// reads disabled) routes account reads through GetAsOf on sd.mem and fails
-// with "GetAsOf called on TemporalMemBatch with inMemHistoryReads disabled".
-func TestParallelExec_RestoresCommitmentStateReader(t *testing.T) {
-	prev := dbg.Exec3Parallel
-	dbg.Exec3Parallel = true
-	t.Cleanup(func() { dbg.Exec3Parallel = prev })
+// TestExec_RestoresCommitmentStateReader checks that an execution batch leaves
+// the commitment state reader as it found it, in both serial and parallel mode.
+// Parallel installs a GetAsOf-based asOfStateReader (via the commitment
+// calculator); leaving it on the shared context makes a later foreground
+// SeekCommitment in the offline re-exec path (in-mem history reads disabled)
+// fail with "GetAsOf called on TemporalMemBatch with inMemHistoryReads disabled".
+// Serial installs no custom reader and is the control for the same invariant.
+func TestExec_RestoresCommitmentStateReader(t *testing.T) {
+	for _, mode := range []struct {
+		name     string
+		parallel bool
+	}{
+		{"serial", false},
+		{"parallel", true},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			prev := dbg.Exec3Parallel
+			dbg.Exec3Parallel = mode.parallel
+			t.Cleanup(func() { dbg.Exec3Parallel = prev })
+			runExecRestoresCommitmentStateReader(t)
+		})
+	}
+}
 
+func runExecRestoresCommitmentStateReader(t *testing.T) {
 	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	keyAddr := crypto.PubkeyToAddress(key.PublicKey)
 	keyFunds := new(big.Int).Mul(big.NewInt(1_000_000), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
@@ -378,5 +391,5 @@ func TestParallelExec_RestoresCommitmentStateReader(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, readerBefore, doms.GetCommitmentContext().StateReader(),
-		"parallel exec must restore the commitment state reader it found; leaving the calculator's asOfStateReader installed breaks a later foreground SeekCommitment with in-mem history reads disabled")
+		"exec must restore the commitment state reader it found; leaving the parallel calculator's asOfStateReader installed breaks a later foreground SeekCommitment with in-mem history reads disabled")
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -250,6 +250,13 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 	pe.rs.StateV3.SetSkipStepBoundaryCommitment(true)
 	defer pe.rs.StateV3.SetSkipStepBoundaryCommitment(false)
 
+	// The calculator installs its own asOfStateReader on the shared commitment
+	// context; restore the prior reader on exit so it doesn't leak GetAsOf reads
+	// into later foreground commitment reads (which break when the caller runs
+	// with in-mem history reads disabled, e.g. offline re-exec).
+	prevStateReader := pe.rs.Domains().GetCommitmentContext().StateReader()
+	defer pe.rs.Domains().GetCommitmentContext().SetStateReader(prevStateReader)
+
 	// Store channels and limits on pe so execLoop can access them.
 	pe.applyResultsCh = applyResults
 	pe.commitResultsCh = commitResults

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -254,8 +254,9 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 	// context; restore the prior reader on exit so it doesn't leak GetAsOf reads
 	// into later foreground commitment reads (which break when the caller runs
 	// with in-mem history reads disabled, e.g. offline re-exec).
-	prevStateReader := pe.rs.Domains().GetCommitmentContext().StateReader()
-	defer pe.rs.Domains().GetCommitmentContext().SetStateReader(prevStateReader)
+	sdCtx := pe.rs.Domains().GetCommitmentContext()
+	prevStateReader := sdCtx.StateReader()
+	defer sdCtx.SetStateReader(prevStateReader)
 
 	// Store channels and limits on pe so execLoop can access them.
 	pe.applyResultsCh = applyResults


### PR DESCRIPTION
## Summary

Fixes a latent correctness bug in parallel execution that surfaced as a rare flake in `TestFromZero_BranchCacheCoherentAcrossBatches/parallel` — the test that dequeued #22007 from the merge queue (and can hit any PR). The bug is on `main`, independent of #22007.

## Root cause

The parallel commitment calculator installs its own `GetAsOf`-based `asOfStateReader` onto the **shared** `SharedDomainsCommitmentContext.stateReader` (`committer.go`), and **nothing ever reset it**. Once installed, it leaked into every later *foreground* commitment read: `trieContext()` clones `sdc.stateReader` when non-nil instead of building a fresh latest-state reader.

In the offline from-0 re-exec path, `newReusedDomains` sets `inMemHistoryReads=false` (history reads come from disk). A foreground `SeekCommitment` that restores a **single-account (leaf-root)** commitment state then reads the root account through the leftover reader → `GetAsOf` on the in-memory `TemporalMemBatch` → hard error:

```
failed restore state : GetAsOf called on TemporalMemBatch with inMemHistoryReads disabled
```

The failure needs two conditions to coincide — (a) the leftover reader is installed, and (b) a `SeekCommitment` restores a leaf-root state — which only happens under some parallel-pipeline schedules, hence the flakiness. Instrumentation on a *passing* run confirmed the foreground seek already uses the leftover `*stagedsync.asOfStateReader` (`withHistory=false`); only the trie shape (non-leaf roots at those seeks) kept it from firing.

## Fix

`parallelExecutor.execImpl` now captures the prior state reader and restores it on exit, symmetric to the existing `inMemHistoryReads` save/restore right above it. This scopes the calculator's reader to the batch and matches the serial path, which never installs a custom reader. A `StateReader()` getter exposes the current reader.

## Test

`TestExec_RestoresCommitmentStateReader` drives one real exec batch through the integration path and asserts the commitment state reader is restored. It runs in whichever exec mode the suite selects — the serial/parallel CI matrix (`ERIGON_EXEC3_PARALLEL`) and the `EXEC3_PARALLEL` default cover both — so no per-test mode loop is needed. Parallel is the regression (and the local default); serial is a control, since it never installs a custom reader.

- **Parallel, without the fix**: fails every run — `expected <nil>, actual *stagedsync.asOfStateReader{...}`.
- **With the fix**: passes (parallel and serial).

(The test is intentionally not `testing.Short()`-guarded — it runs in ~0.07s and should run wherever the original failure was caught. It is unguarded rather than skipped per the repo's automated-agent no-skip rule.)

## Verification

- New test: red without the fix (parallel), green with it; passes in both serial and parallel exec modes.
- `TestFromZero_BranchCacheCoherentAcrossBatches` + `TestFromZero_GenesisAllocPreservedAfterResetReExec`: pass (serial + parallel), including 12× under `-race`.
- `go test ./execution/stagedsync/... ./execution/commitment/...`: pass.
- `make lint`: 0 issues. `make erigon integration`: builds.
