### PR TITLE
db/state: remove FilesItem.frozen field

### DIFF
--- a/db/state/aggregator_files.go
+++ b/db/state/aggregator_files.go
@@ -104,7 +104,7 @@ func (mf MergeResult) FilePaths(relative string) (fPaths []string) {
 		if mf.dHist[id] != nil {
 			fPaths = append(fPaths, mf.dHist[id].FilePaths(relative)...)
 		}
-		if mf.dIdx[id] != nil && mf.dIdx[id].frozen {
+		if mf.dIdx[id] != nil {
 			fPaths = append(fPaths, mf.dIdx[id].FilePaths(relative)...)
 		}
 	}

--- a/db/state/deduplicate.go
+++ b/db/state/deduplicate.go
@@ -381,7 +381,7 @@ func (iit *InvertedIndexRoTx) deduplicateFiles(ctx context.Context, files []*Fil
 	comp.Close()
 	comp = nil
 
-	outItem = newFilesItem(startTxNum, endTxNum, iit.stepSize, iit.stepsInFrozenFile)
+	outItem = newFilesItem(startTxNum, endTxNum)
 	if outItem.decompressor, err = seg.NewDecompressor(datPath); err != nil {
 		return nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", iit.ii.FilenameBase, startTxNum, endTxNum, err)
 	}

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -122,8 +122,8 @@ type FilesItem struct {
 
 	refcount atomic.Int32
 
-	// file can be deleted in 2 cases: 1. when `refcount == 0 && canDelete == true` 2. on app startup when `file.isProperSubsetOf()` a bigger file
-	// other processes (which also reading files, may have same logic)
+	// Deprecated: only the not-yet-migrated forkable subsystem still uses this (with
+	// refcount); the aggregator reclaims via aggregatorVisible generations (retired + refcnt).
 	canDelete atomic.Bool
 }
 

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -120,26 +120,15 @@ type FilesItem struct {
 	existence            *existence.Filter
 	startTxNum, endTxNum uint64 //[startTxNum, endTxNum)
 
-	// Frozen: file containing Aggregator.stepsInFrozenFile steps. Completely immutable.
-	// Cold: file containing < Aggregator.stepsInFrozenFile steps. Immutable, but can be closed/removed after merge to bigger file.
-	// Hot: Stored in DB. Providing Snapshot-Isolation by CopyOnWrite.
-	frozen   bool         // immutable, don't need atomic
-	refcount atomic.Int32 // only for `frozen=false`
+	refcount atomic.Int32
 
-	// file can be deleted in 2 cases: 1. when `refcount == 0 && canDelete == true` 2. on app startup when `file.isSubsetOfFrozenFile()`
+	// file can be deleted in 2 cases: 1. when `refcount == 0 && canDelete == true` 2. on app startup when `file.isProperSubsetOf()` a bigger file
 	// other processes (which also reading files, may have same logic)
 	canDelete atomic.Bool
 }
 
-func newFilesItemWithSnapConfig(startTxNum, endTxNum uint64, snapConfig *SnapshotConfig) *FilesItem {
-	return newFilesItem(startTxNum, endTxNum, snapConfig.RootNumPerStep, snapConfig.StepsInFrozenFile())
-}
-
-func newFilesItem(startTxNum, endTxNum, stepSize uint64, stepsInFrozenFile uint64) *FilesItem {
-	startStep := startTxNum / stepSize
-	endStep := endTxNum / stepSize
-	frozen := endStep-startStep >= stepsInFrozenFile
-	return &FilesItem{startTxNum: startTxNum, endTxNum: endTxNum, frozen: frozen}
+func newFilesItem(startTxNum, endTxNum uint64) *FilesItem {
+	return &FilesItem{startTxNum: startTxNum, endTxNum: endTxNum}
 }
 
 func (i *FilesItem) Segment() *seg.Decompressor { return i.decompressor }
@@ -258,14 +247,11 @@ func (i *FilesItem) closeFilesAndRemove() {
 	// permanently orphaned.
 	if i.index != nil {
 		i.index.Close()
-		// paranoic-mode on: don't delete frozen files
-		if !i.frozen {
-			if err := dir.RemoveFile(i.index.FilePath()); err != nil {
-				log.Trace("remove after close", "err", err, "file", i.index.FileName())
-			}
-			if err := dir.RemoveFile(i.index.FilePath() + ".torrent"); err != nil {
-				log.Trace("remove after close", "err", err, "file", i.index.FileName())
-			}
+		if err := dir.RemoveFile(i.index.FilePath()); err != nil {
+			log.Trace("remove after close", "err", err, "file", i.index.FileName())
+		}
+		if err := dir.RemoveFile(i.index.FilePath() + ".torrent"); err != nil {
+			log.Trace("remove after close", "err", err, "file", i.index.FileName())
 		}
 		i.index = nil
 	}
@@ -291,14 +277,11 @@ func (i *FilesItem) closeFilesAndRemove() {
 	}
 	if i.decompressor != nil {
 		i.decompressor.Close()
-		// paranoic-mode on: don't delete frozen files
-		if !i.frozen {
-			if err := dir.RemoveFile(i.decompressor.FilePath()); err != nil {
-				log.Trace("remove after close", "err", err, "file", i.decompressor.FileName())
-			}
-			if err := dir.RemoveFile(i.decompressor.FilePath() + ".torrent"); err != nil {
-				log.Trace("remove after close", "err", err, "file", i.decompressor.FileName()+".torrent")
-			}
+		if err := dir.RemoveFile(i.decompressor.FilePath()); err != nil {
+			log.Trace("remove after close", "err", err, "file", i.decompressor.FileName())
+		}
+		if err := dir.RemoveFile(i.decompressor.FilePath() + ".torrent"); err != nil {
+			log.Trace("remove after close", "err", err, "file", i.decompressor.FileName()+".torrent")
 		}
 		i.decompressor = nil
 	}
@@ -306,7 +289,7 @@ func (i *FilesItem) closeFilesAndRemove() {
 
 var filterDirtyFilesReCache sync.Map // pattern string → *regexp.Regexp
 
-func filterDirtyFiles(fileNames []string, stepSize, stepsInFrozenFile uint64, filenameBase, ext string, logger log.Logger) (res []*FilesItem) {
+func filterDirtyFiles(fileNames []string, stepSize uint64, filenameBase, ext string, logger log.Logger) (res []*FilesItem) {
 	pattern := `^v(\d+(?:\.\d+)?)-` + filenameBase + `\.(\d+)-(\d+)\.` + ext + `$`
 	reVal, ok := filterDirtyFilesReCache.Load(pattern)
 	if !ok {
@@ -346,7 +329,7 @@ func filterDirtyFiles(fileNames []string, stepSize, stepsInFrozenFile uint64, fi
 		//   1-2.kv: [8, 16)
 		startTxNum, endTxNum := startStep*stepSize, endStep*stepSize
 
-		var newFile = newFilesItem(startTxNum, endTxNum, stepSize, stepsInFrozenFile)
+		var newFile = newFilesItem(startTxNum, endTxNum)
 		res = append(res, newFile)
 	}
 	return res

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -353,10 +353,8 @@ func (d *Domain) scanDirtyFiles(fileNames []string) (garbageFiles []*FilesItem) 
 	if d.FilenameBase == "" {
 		panic("assert: empty `filenameBase`")
 	}
-	l := filterDirtyFiles(fileNames, d.stepSize, d.stepsInFrozenFile, d.FilenameBase, "kv", d.logger)
+	l := filterDirtyFiles(fileNames, d.stepSize, d.FilenameBase, "kv", d.logger)
 	for _, dirtyFile := range l {
-		dirtyFile.frozen = false
-
 		if _, has := d.dirtyFiles.Get(dirtyFile); !has {
 			d.dirtyFiles.Set(dirtyFile)
 		}
@@ -1287,8 +1285,7 @@ func (d *Domain) integrateDirtyFiles(sf StaticFiles, txNumFrom, txNumTo uint64) 
 
 	d.History.integrateDirtyFiles(sf.HistoryFiles, txNumFrom, txNumTo)
 
-	fi := newFilesItem(txNumFrom, txNumTo, d.stepSize, d.stepsInFrozenFile)
-	fi.frozen = false
+	fi := newFilesItem(txNumFrom, txNumTo)
 	fi.decompressor = sf.valuesDecomp
 	fi.index = sf.valuesIdx
 	fi.bindex = sf.valuesBt

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -540,7 +540,7 @@ func checkHistory(t *testing.T, db kv.RwDB, d *Domain, txs uint64) {
 
 	// Structural invariants: no duplicates, monotonic txNums, index-history consistency, etc.
 	checkHistoryProperties(t, domainRoTx.ht)
-	// Domain file invariants: key-count, accessor presence, frozen flag, sort order, alignment, bloom.
+	// Domain file invariants: key-count, accessor presence, sort order, alignment, bloom.
 	checkDomainFileProperties(t, domainRoTx)
 }
 
@@ -549,7 +549,6 @@ func checkDomainFileProperties(t *testing.T, dt *DomainRoTx) {
 	t.Helper()
 	checkDomainFileKeyCountConsistency(t, dt)
 	checkDomainFileAccessorsPresent(t, dt)
-	checkDomainFileFrozenFlagConsistency(t, dt)
 	checkDomainFileSortedKeyOrder(t, dt)
 	checkDomainHistoryRangeAlignment(t, dt)
 	checkDomainExistenceFilterNoFalseNegatives(t, dt)
@@ -599,20 +598,6 @@ func checkDomainFileAccessorsPresent(t *testing.T, dt *DomainRoTx) {
 				"file %d [%d-%d): AccessorExistence configured but existence is nil",
 				i, f.startTxNum, f.endTxNum)
 		}
-	}
-}
-
-// checkDomainFileFrozenFlagConsistency verifies (property 7):
-// file.frozen == (endStep - startStep >= stepsInFrozenFile).
-func checkDomainFileFrozenFlagConsistency(t *testing.T, dt *DomainRoTx) {
-	t.Helper()
-	for i, f := range dt.files {
-		startStep := f.startTxNum / dt.stepSize
-		endStep := f.endTxNum / dt.stepSize
-		expectedFrozen := (endStep - startStep) >= dt.stepsInFrozenFile
-		require.Equal(t, expectedFrozen, f.src.frozen,
-			"file %d [%d-%d): frozen=%v but expected frozen=%v (steps=%d, stepsInFrozenFile=%d)",
-			i, f.startTxNum, f.endTxNum, f.src.frozen, expectedFrozen, endStep-startStep, dt.stepsInFrozenFile)
 	}
 }
 

--- a/db/state/forkable_debug.go
+++ b/db/state/forkable_debug.go
@@ -19,11 +19,9 @@ func (f *forkableDirtyFilesRoTx) Close() {
 	}
 	f.p = nil
 	for _, item := range f.files {
-		if !item.frozen {
-			refCnt := item.refcount.Add(-1)
-			if refCnt == 0 && item.canDelete.Load() {
-				item.closeFilesAndRemove()
-			}
+		refCnt := item.refcount.Add(-1)
+		if refCnt == 0 && item.canDelete.Load() {
+			item.closeFilesAndRemove()
 		}
 	}
 	f.files = nil

--- a/db/state/forkable_merge.go
+++ b/db/state/forkable_merge.go
@@ -145,7 +145,7 @@ func (f *ProtoForkable) MergeFiles(ctx context.Context, _filesToMerge []visibleF
 		ps.Delete(p)
 	}
 
-	mergedFile = newFilesItemWithSnapConfig(from.Uint64(), to.Uint64(), f.snapCfg)
+	mergedFile = newFilesItem(from.Uint64(), to.Uint64())
 	if mergedFile.decompressor, err = seg.NewDecompressorWithMetadata(segPath, f.snapCfg.HasMetadata); err != nil {
 		return
 	}

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -149,7 +149,7 @@ func (h *History) scanDirtyFiles(fileNames []string) {
 	if h.stepSize == 0 {
 		panic("assert: empty `stepSize`")
 	}
-	for _, dirtyFile := range filterDirtyFiles(fileNames, h.stepSize, h.stepsInFrozenFile, h.FilenameBase, "v", h.logger) {
+	for _, dirtyFile := range filterDirtyFiles(fileNames, h.stepSize, h.FilenameBase, "v", h.logger) {
 		if _, has := h.dirtyFiles.Get(dirtyFile); !has {
 			h.dirtyFiles.Set(dirtyFile)
 		}
@@ -853,7 +853,7 @@ func (h *History) integrateDirtyFiles(sf HistoryFiles, txNumFrom, txNumTo uint64
 		existence: sf.efExistence,
 	}, txNumFrom, txNumTo)
 
-	fi := newFilesItem(txNumFrom, txNumTo, h.stepSize, h.stepsInFrozenFile)
+	fi := newFilesItem(txNumFrom, txNumTo)
 	fi.decompressor = sf.historyDecomp
 	fi.index = sf.historyIdx
 	h.dirtyFiles.Set(fi)

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -209,7 +209,7 @@ func (ii *InvertedIndex) scanDirtyFiles(fileNames []string) {
 	if ii.stepSize == 0 {
 		panic("assert: empty `stepSize`")
 	}
-	for _, dirtyFile := range filterDirtyFiles(fileNames, ii.stepSize, ii.stepsInFrozenFile, ii.FilenameBase, "ef", ii.logger) {
+	for _, dirtyFile := range filterDirtyFiles(fileNames, ii.stepSize, ii.FilenameBase, "ef", ii.logger) {
 		if _, has := ii.dirtyFiles.Get(dirtyFile); !has {
 			ii.dirtyFiles.Set(dirtyFile)
 		}
@@ -1196,7 +1196,7 @@ func (ii *InvertedIndex) integrateDirtyFiles(sf InvertedFiles, txNumFrom, txNumT
 	if sf.decomp == nil {
 		return // build was skipped — don't overwrite existing dirty files
 	}
-	fi := newFilesItem(txNumFrom, txNumTo, ii.stepSize, ii.stepsInFrozenFile)
+	fi := newFilesItem(txNumFrom, txNumTo)
 	fi.decompressor = sf.decomp
 	fi.index = sf.index
 	fi.existence = sf.existence

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -534,8 +534,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	kvWriter = nil
 	ps.Delete(p)
 
-	valuesIn = newFilesItem(r.values.from, r.values.to, dt.stepSize, dt.stepsInFrozenFile)
-	valuesIn.frozen = false
+	valuesIn = newFilesItem(r.values.from, r.values.to)
 	if valuesIn.decompressor, err = seg.NewDecompressor(kvFilePath); err != nil {
 		return nil, nil, nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", dt.d.FilenameBase, r.values.from, r.values.to, err)
 	}
@@ -710,7 +709,7 @@ func (iit *InvertedIndexRoTx) mergeFiles(ctx context.Context, files []*FilesItem
 	comp.Close()
 	comp = nil
 
-	outItem = newFilesItem(startTxNum, endTxNum, iit.stepSize, iit.stepsInFrozenFile)
+	outItem = newFilesItem(startTxNum, endTxNum)
 	if outItem.decompressor, err = seg.NewDecompressor(datPath); err != nil {
 		return nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", iit.ii.FilenameBase, startTxNum, endTxNum, err)
 	}
@@ -888,7 +887,7 @@ func (ht *HistoryRoTx) mergeFiles(ctx context.Context, indexFiles, historyFiles 
 		if index, err = ht.h.openHashMapAccessor(idxPath); err != nil {
 			return nil, nil, fmt.Errorf("open %s idx: %w", ht.h.FilenameBase, err)
 		}
-		historyIn = newFilesItem(r.history.from, r.history.to, ht.stepSize, ht.stepsInFrozenFile)
+		historyIn = newFilesItem(r.history.from, r.history.to)
 		historyIn.decompressor = decomp
 		historyIn.index = index
 
@@ -1002,10 +1001,6 @@ func garbage(dirtyFiles *DirtyFiles, visibleFiles []visibleFile, merged *FilesIt
 	defer iter.Release()
 	for ok := iter.First(); ok; ok = iter.Next() {
 		item := iter.Item()
-		if item.frozen {
-			continue
-		}
-
 		if merged == nil {
 			if hasCoverVisibleFile(visibleFiles, item) {
 				outs = append(outs, item)

--- a/db/state/proto_forkable.go
+++ b/db/state/proto_forkable.go
@@ -147,7 +147,7 @@ func (a *ProtoForkable) BuildFile(ctx context.Context, from, to RootNum, db kv.R
 		return nil, false, err
 	}
 
-	df := newFilesItemWithSnapConfig(uint64(calcFrom), uint64(calcTo), cfg)
+	df := newFilesItem(uint64(calcFrom), uint64(calcTo))
 	df.decompressor = valuesDecomp
 
 	indexes, err := a.BuildIndexes(ctx, df.decompressor, calcFrom, calcTo, ps)
@@ -257,10 +257,7 @@ type ProtoForkableTx struct {
 func (a *ProtoForkable) BeginFilesRo() *ProtoForkableTx {
 	visibleFiles := a.snaps.visibleFiles()
 	for i := range visibleFiles {
-		src := visibleFiles[i].src
-		if !src.frozen {
-			src.refcount.Add(1)
-		}
+		visibleFiles[i].src.refcount.Add(1)
 	}
 
 	return &ProtoForkableTx{
@@ -280,9 +277,7 @@ func (a *ProtoForkable) DebugBeginDirtyFilesRo() *forkableDirtyFilesRoTx {
 	for ok := iter.First(); ok; ok = iter.Next() {
 		item := iter.Item()
 		files = append(files, item)
-		if !item.frozen {
-			item.refcount.Add(1)
-		}
+		item.refcount.Add(1)
 	}
 	return &forkableDirtyFilesRoTx{
 		p:     a,
@@ -326,7 +321,7 @@ func (a *ProtoForkableTx) Close() {
 	a.files = nil
 	for i := range files {
 		src := files[i].src
-		if src == nil || src.frozen {
+		if src == nil {
 			continue
 		}
 		refCnt := src.refcount.Add(-1)

--- a/db/state/snap_config.go
+++ b/db/state/snap_config.go
@@ -74,14 +74,6 @@ func (s *SnapshotConfig) validate() {
 	}
 }
 
-func (s *SnapshotConfig) StepsInFrozenFile() uint64 {
-	if len(s.MergeStages) == 0 {
-		return s.MinimumSize / s.RootNumPerStep
-	}
-
-	return s.MergeStages[len(s.MergeStages)-1] / s.RootNumPerStep
-}
-
 func (s *SnapshotConfig) LoadPreverified(pre snapcfg.PreverifiedItems) {
 	if s.PreverifiedParsed != nil {
 		return

--- a/db/state/snap_repo.go
+++ b/db/state/snap_repo.go
@@ -434,7 +434,7 @@ func (f *SnapshotRepo) loadDirtyFiles(aps []string) {
 			f.logger.Trace("can't parse file name", "file", ap)
 			continue
 		}
-		dirtyFile := newFilesItemWithSnapConfig(fileInfo.From, fileInfo.To, f.cfg)
+		dirtyFile := newFilesItem(fileInfo.From, fileInfo.To)
 
 		if _, has := f.dirtyFiles.Get(dirtyFile); !has {
 			f.dirtyFiles.Set(dirtyFile)

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -161,7 +161,7 @@ func TestIntegrateDirtyFile(t *testing.T) {
 	err := repo.OpenFolder()
 	require.NoError(t, err)
 
-	filesItem := newFilesItemWithSnapConfig(0, 1024, repo.cfg)
+	filesItem := newFilesItem(0, 1024)
 	filename, _ := repo.schema.DataFile(version.V1_0, 0, 1024)
 	comp, err := seg.NewCompressor(t.Context(), t.Name(), filename, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 	require.NoError(t, err)
@@ -495,7 +495,7 @@ func TestRecalcVisibleFilesAfterMerge(t *testing.T) {
 		items := repo.FilesInRange(mr, vf) // vf passed should ideally from rotx, but doesn't matter here
 		require.Len(t, items, nFilesInRange)
 
-		merged := newFilesItemWithSnapConfig(mr.from, mr.to, repo.cfg)
+		merged := newFilesItem(mr.from, mr.to)
 		repo.IntegrateDirtyFile(merged)
 		dirEntries, err := filesFromDir(repo.schema.DataDirectory())
 		require.NoError(t, err)

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -287,7 +287,6 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 				return err
 			}
 			sizeDelta += delta
-			cf.frozen = false
 			cf.closeFilesAndRemove()
 
 			squeezedPath := originalPath + sqExt


### PR DESCRIPTION
Step 2 of #21306 (prune frozen files).

`frozen` (a cached `stepCount >= stepsInFrozenFile`) existed only to skip per-file refcount atomics in `BeginFilesRo()`. #21397 moved reader pinning to a single bundle-level refcount (`aggregatorVisible`) — "one atomic add instead of dozens of per-file adds" — so the field is no longer needed for that optimization.

### Removed
- the `frozen` field on `FilesItem`
- the per-file refcount `!frozen` skip in the forkable / snapshot begin+close paths (files are now always refcounted)
- the "paranoic-mode: don't delete frozen files" guard in `closeFilesAndRemove` and the `frozen` skip in `garbage()` — this is the unprotection Step 3 (prune state history files) needs
- `newFilesItem()`'s now-unused `stepSize`/`stepsInFrozenFile` params, `newFilesItemWithSnapConfig`, and the orphaned `SnapshotConfig.StepsInFrozenFile()`

### Behavior note
The merged domain-II (`dIdx`) downloader-seed filter in `MergeResult.FilePaths` previously depended on `frozen`; it is now unconditional, matching how domain-value and domain-history merged files were already announced.

### Out of scope (follow-ups)
- The RoTx/entity `stepsInFrozenFile` fields are now write-only; removing them cleanly unwinds the exported `NewDomain`/`NewHistory`/`NewInvertedIndex` signatures (external caller in `cmd/integration` + tests), so it is left for a separate change.
- `db/snapshotsync`'s own `frozen` (on `DirtySegment`) is untouched — its begin path still uses per-file refcounting (Step 1 not yet done there).
