### PR TITLE
execution: enlarge parallel-exec dispatch & results queues

### DIFF
--- a/execution/exec/state.go
+++ b/execution/exec/state.go
@@ -577,7 +577,7 @@ func NewWorkersPool(ctx context.Context, accumulator *shards.Accumulator, backgr
 	engine rules.Engine, workerCount int, metrics *WorkerMetrics, dirs datadir.Dirs, logger log.Logger) (reconWorkers []*Worker, applyWorker *Worker, rws *ResultsQueue, clear func(), wait func(), err error) {
 	reconWorkers = make([]*Worker, workerCount)
 
-	resultsSize := workerCount * 8
+	resultsSize := workerCount * 512
 	rws = NewResultsQueue(resultsSize, workerCount)
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1430,7 +1430,7 @@ func (pe *parallelExecutor) run(ctx context.Context) (context.Context, context.C
 	pe.blockExecutors = nil
 	// in is the per-transaction work queue consumed by OCC workers.
 	// 2048 entries keeps all workers saturated without unbounded accumulation.
-	pe.in = exec.NewQueueWithRetry(2_048)
+	pe.in = exec.NewQueueWithRetry(32_768)
 
 	pe.taskExecMetrics = exec.NewWorkerMetrics()
 	pe.blockExecMetrics = newBlockExecMetrics()


### PR DESCRIPTION
## Motivation
The parallel executor's coordinator goroutine both refills the dispatch queue (`pe.in`) and drains the results queue (`rws`). With `pe.in` capped at **2048** and `rws` at **workerCount*8**, worker goroutines starve on `QueueWithRetry.Next` waiting for the single coordinator to refill/drain — so effective throughput stays well below the worker count (block-profile shows workers parked in `QueueWithRetry.popWait`).

This happens because with BAL, worker's execution is purely in-CPU. So the 2048 workers finish much faster than a single result processing can be done.

**caveat**

This PR is probably not the proper solution. I think there has to be a different way to do this - like offload the result processing to a different goroutine, and accept the output of that (via a channel) in coordinator. This allows coordinator to be free of result processing. 

## Change
| queue | before | after |
|---|---|---|
| dispatch `pe.in` (`exec3_parallel.go`) | `NewQueueWithRetry(2_048)` | `NewQueueWithRetry(32_768)` |
| results `rws` size (`exec/state.go`) | `workerCount * 8` | `workerCount * 512` |

Two-line change; no behavior change beyond buffering. Keeps workers fed so the coordinator is no longer the bottleneck.

## Impact
Isolated by toggling only the two queue sizes, everything else held constant (jochemnet Amsterdam repricing bench, MGas/s):

| regime | before | after | speedup |
|---|---|---|---|
| ether_transfers[amt_0] | 40 | 100 | **2.5x** |
| ether_transfers[amt_1] | 27 | 47 | **1.7x** |
| sload_bloated[existing_slots_True] | 157 | 200 | 1.3x |
| sstore_bloated[existing_slots_False] | 353 | 408 | 1.2x |
| sload_bloated[existing_slots_False] | 195 | 197 | — |
| sstore_bloated[existing_slots_True] | 32 | 33 | — |
| storage_sload_same_key | 607–622 | 573–631 | — (noise) |
| ext_account_query_warm | 700 | 623 | — (noise) |

The win concentrates on **dispatch-bound, high-txn-count regimes** (ether_transfers): up to 2.5x. Regimes bound by something other than exec dispatch — commitment fold (sstore_bloated[True]) or warm-cache lookups — are unmoved, as expected.

## Notes
- Memory cost is bounded: the queues hold lightweight task/result handles.
- Isolated from any commitment/BAL work — purely the exec dispatch/results sizing.