### PR TITLE
[r3.4] db/state, cmd: default seg retire / stage_exec / stage_custom_trace to unbounded domain merge

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -38,13 +37,11 @@ import (
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cmd/hack/tool/fromdb"
-	"github.com/erigontech/erigon/cmd/utils"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/log/v3"
-	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/integrity"
 	"github.com/erigontech/erigon/db/kv"
@@ -336,6 +333,7 @@ func init() {
 	withPruneTo(cmdStageCustomTrace)
 	withTraceFlags(cmdStageCustomTrace)
 	withDomain(cmdStageCustomTrace)
+	withErigondbDomainStepsInFrozenFile(cmdStageCustomTrace)
 	rootCmd.AddCommand(cmdStageCustomTrace)
 
 	withStageBase(cmdStageTxLookup)
@@ -777,6 +775,9 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 	agg := (db.(dbstate.HasAgg).Agg()).(*dbstate.Aggregator)
 	blockSnapBuildSema := semaphore.NewWeighted(int64(runtime.NumCPU()))
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
+	if err := agg.SetDomainStepsInFrozenFile(erigondbDomainStepsInFrozenFile); err != nil {
+		return err
+	}
 	agg.PresetOfflineExecution()
 	agg.PeriodicalyPrintProcessSet(ctx)
 	agg.LockWorkersEditing()
@@ -860,6 +861,9 @@ func stageCustomTrace(db kv.TemporalRwDB, ctx context.Context, logger log.Logger
 
 	blockSnapBuildSema := semaphore.NewWeighted(int64(runtime.NumCPU()))
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
+	if err := agg.SetDomainStepsInFrozenFile(erigondbDomainStepsInFrozenFile); err != nil {
+		return err
+	}
 	agg.PresetOfflineExecution()
 	agg.PeriodicalyPrintProcessSet(ctx)
 
@@ -982,26 +986,6 @@ func allSnapshots(ctx context.Context, db kv.RoDB, logger log.Logger) (*freezebl
 			return
 		}
 		aggOpts := dbstate.New(dirs).Logger(logger).WithErigonDBSettings(erigonDBSettings)
-		if erigondbDomainStepsInFrozenFile != "" {
-			var v uint64
-			if strings.EqualFold(erigondbDomainStepsInFrozenFile, "inf") {
-				v = config3.UnboundedDomainMerge
-			} else {
-				parsed, perr := strconv.ParseUint(erigondbDomainStepsInFrozenFile, 10, 64)
-				if perr != nil || parsed == 0 {
-					err = fmt.Errorf("invalid --%s value %q: must be a positive integer or \"Inf\"",
-						utils.ErigondbDomainStepsInFrozenFileFlag.Name, erigondbDomainStepsInFrozenFile)
-					return
-				}
-				v = parsed
-			}
-			stepsStr := "Inf"
-			if v != config3.UnboundedDomainMerge {
-				stepsStr = fmt.Sprintf("%d", v)
-			}
-			logger.Info("domain merge cap overridden", "steps_in_frozen_file", stepsStr)
-			aggOpts = aggOpts.ErigondbDomainStepsInFrozenFile(v)
-		}
 		_aggSingleton = aggOpts.MustOpen(ctx, db)
 
 		_aggSingleton.SetProduceMod(snapCfg.ProduceE3)

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2951,25 +2951,8 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	defer br.MadvNormal().DisableReadAhead()
 	defer agg.MadvNormal().DisableReadAhead()
 
-	if cliCtx.IsSet(utils.ErigondbDomainStepsInFrozenFileFlag.Name) {
-		s := cliCtx.String(utils.ErigondbDomainStepsInFrozenFileFlag.Name)
-		var v uint64
-		if strings.EqualFold(s, "inf") {
-			v = config3.UnboundedDomainMerge
-		} else {
-			parsed, perr := strconv.ParseUint(s, 10, 64)
-			if perr != nil || parsed == 0 {
-				return fmt.Errorf("invalid --%s value %q: must be a positive integer or \"Inf\"",
-					utils.ErigondbDomainStepsInFrozenFileFlag.Name, s)
-			}
-			v = parsed
-		}
-		stepsStr := "Inf"
-		if v != config3.UnboundedDomainMerge {
-			stepsStr = fmt.Sprintf("%d", v)
-		}
-		logger.Info("domain merge cap overridden", "steps_in_frozen_file", stepsStr)
-		agg.SetErigondbDomainStepsInFrozenFile(v)
+	if err := agg.SetDomainStepsInFrozenFile(cliCtx.String(utils.ErigondbDomainStepsInFrozenFileFlag.Name)); err != nil {
+		return err
 	}
 
 	blockSnapBuildSema := semaphore.NewWeighted(int64(runtime.NumCPU()))

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -249,6 +250,21 @@ func (a *Aggregator) Logger() log.Logger        { return a.logger }
 // merge work begins.
 func (a *Aggregator) SetErigondbDomainStepsInFrozenFile(steps uint64) {
 	a.erigondbDomainStepsInFrozenFile = steps
+}
+
+// SetDomainStepsInFrozenFile sets the domain merge cap from a flag spec: empty or
+// "Inf" means unbounded, otherwise a positive integer step count.
+func (a *Aggregator) SetDomainStepsInFrozenFile(spec string) error {
+	v := config3.UnboundedDomainMerge
+	if spec != "" && !strings.EqualFold(spec, "inf") {
+		parsed, err := strconv.ParseUint(spec, 10, 64)
+		if err != nil || parsed == 0 {
+			return fmt.Errorf("invalid domain steps-in-frozen-file %q: must be a positive integer or \"Inf\"", spec)
+		}
+		v = parsed
+	}
+	a.SetErigondbDomainStepsInFrozenFile(v)
+	return nil
 }
 
 func (a *Aggregator) ForTestReplaceKeysInValues(domain kv.Domain, v bool) {


### PR DESCRIPTION
Cherry-pick of #22125 to release/3.4.

## r3.4-specific adaptations
- Import conflict in `cmd/integration/commands/stages.go`: kept the r3.4-only `cmd/hack/tool/fromdb` import while dropping the now-unused `cmd/utils` import.