### PR TITLE
QA: repin rpc-tests to v2.20.0

### DIFF
--- a/.github/workflows/scripts/rpc_version.env
+++ b/.github/workflows/scripts/rpc_version.env
@@ -1,2 +1,2 @@
 
-RPC_VERSION=fix_expected_bn_as_hex_string
+RPC_VERSION=v2.20.0


### PR DESCRIPTION
## Summary
`rpc_version.env` pins the rpc-tests suite to branch `fix_expected_bn_as_hex_string`, which has since merged and been deleted from `erigontech/rpc-tests`. On a cold rpc-tests cache the QA RPC workflows fail to clone that branch and die during setup before any test runs (e.g. run 28475730212).

Repin to the released tag `v2.20.0`, which includes the same block-number-as-hex test changes (`erigontech/rpc-tests#581`) the branch carried, and restores the version-pin convention (the prior pin was `v2.19.0`).

## Changes
- `.github/workflows/scripts/rpc_version.env`: `RPC_VERSION` `fix_expected_bn_as_hex_string` → `v2.20.0`.

## Notes
Affects every workflow and script that sources `rpc_version.env`: the QA RPC integration workflows (mainnet, gnosis, latest, remote, clients) and `qa-sync-from-scratch`. `v2.20.0` also emits `results/test_report.json`.
