### PR TITLE
[r3.5] execution/stagedsync: isolate commitment computes for blocks that own no changeset

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -607,8 +607,7 @@ func (sd *SharedDomains) StepSize() uint64 { return sd.stepSize }
 
 // IsUnfrozenStepEdge reports whether txNum is the last tx of a step whose
 // commitment is not yet frozen into files — where a step-boundary checkpoint
-// must be written. One predicate shared by the serial and parallel paths so
-// they can't silently diverge.
+// must be written.
 func (sd *SharedDomains) IsUnfrozenStepEdge(roTx kv.TemporalTx, txNum uint64) bool {
 	ss := sd.stepSize
 	if ss == 0 || dbg.DiscardCommitment() {

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -607,8 +607,8 @@ func (sd *SharedDomains) StepSize() uint64 { return sd.stepSize }
 
 // IsUnfrozenStepEdge reports whether txNum is the last tx of a step whose
 // commitment is not yet frozen into files — where a step-boundary checkpoint
-// must be written. Shared by serial CommitStepBoundary/ApplyStateWrites and the
-// parallel commitment calculator so the predicate can't silently diverge.
+// must be written. One predicate shared by the serial and parallel paths so
+// they can't silently diverge.
 func (sd *SharedDomains) IsUnfrozenStepEdge(roTx kv.TemporalTx, txNum uint64) bool {
 	ss := sd.stepSize
 	if ss == 0 || dbg.DiscardCommitment() {

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -8,12 +8,15 @@ import (
 	"runtime/pprof"
 	"sync"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
 // commitmentResult is the outcome of a single commitment computation.
@@ -42,9 +45,8 @@ type commitComputeRequest struct{}
 //   - Per-block mode (!BatchCommitments): computes at every blockResult.
 //     Used at chain tip or when shouldGenerateChangesets is true.
 //
-// The calculator owns its own commitment.Updates buffer. Writes from the
-// execLoop flow through VersionedWrites.TouchUpdates() which calls
-// TouchPlainKeyDirect() — no serialization round-trip.
+// The calculator owns its own commitment.Updates buffer, fed one aggregated
+// update per dirty key by calcState.FlushToUpdates — no serialization round-trip.
 //
 // It reads values from sd.mem (shared with the execLoop) via GetLatest.
 // The execLoop's Flush writes to sd.mem before sending the blockResult,
@@ -132,9 +134,8 @@ func newCommitmentCalculator(
 	in chan applyResult,
 	out chan commitmentResult,
 ) (*commitmentCalculator, error) {
-	// Create the calculator's own Updates buffer in ModeUpdate.
-	// ModeUpdate stores actual values (balance, nonce, storage) in the btree,
-	// so ComputeCommitment reads values from the Updates rather than sd.mem.
+	// ModeUpdate stores actual values (balance, nonce, storage) in the btree
+	// for the trie to read.
 	sdCtxUpdates := doms.GetCommitmentContext().GetUpdates()
 	calcUpdates := sdCtxUpdates.NewEmpty()
 	calcUpdates.SetMode(commitment.ModeUpdate)
@@ -206,6 +207,20 @@ func (cc *commitmentCalculator) loop(ctx context.Context) {
 	}
 }
 
+// perBlockCompute reports whether the given block computes commitment at its
+// own boundary (vs accumulating into a batch).
+func (cc *commitmentCalculator) perBlockCompute(blockNum uint64) bool {
+	return !dbg.BatchCommitments || cc.forcePerBlockCompute || blockNum >= cc.perBlockFrom
+}
+
+// ownsChangeset reports whether block n gets its own changeset (mirrors the exec
+// loop's accumulator eligibility: genesis excluded, window starts at perBlockFrom).
+// A block owning none must compute isolated — the calculator lags the exec loop,
+// so its writes would otherwise land in a later block's live changeset.
+func (cc *commitmentCalculator) ownsChangeset(n uint64) bool {
+	return n != 0 && n >= cc.perBlockFrom
+}
+
 // handleMessage contains the break logic — decides what to do with each
 // message in the stream.
 func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResult) {
@@ -266,7 +281,7 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		// required when changesets must record per-block branch deltas
 		// (reorg support, KeepExecutionProofs). Blocks from the changeset
 		// window (perBlockFrom) onward compute per-block for the same reason.
-		if !dbg.BatchCommitments || cc.forcePerBlockCompute || r.BlockNum >= cc.perBlockFrom {
+		if cc.perBlockCompute(r.BlockNum) {
 			if cc.lastComputedBlock == 0 && r.isPartial {
 				// First block is partial (resumed mid-block).
 				// Compute it (like serial does) to save trie state, then
@@ -329,183 +344,123 @@ func (cc *commitmentCalculator) shouldComputeOnRequest() bool {
 	return cc.lastBlockResult.BlockNum > cc.lastComputedBlock
 }
 
-func (cc *commitmentCalculator) computeAndPublish(ctx context.Context, br *blockResult) {
+// commitTarget is the block identity a compute needs; a mid-block checkpoint has
+// no StateRoot, so it carries a zero one and never sets checkRoot.
+type commitTarget struct {
+	blockNum  uint64
+	blockHash common.Hash
+	lastTxNum uint64
+	stateRoot common.Hash
+}
+
+func targetOf(br *blockResult) commitTarget {
+	return commitTarget{blockNum: br.BlockNum, blockHash: br.BlockHash, lastTxNum: br.lastTxNum, stateRoot: br.StateRoot}
+}
+
+// computeMode selects compute's per-call behaviour; isolation is otherwise
+// decided by ownsChangeset.
+type computeMode struct {
+	label            string // error-message context, e.g. "step-boundary "
+	resetFlags       bool   // ResetBlockFlags after FlushToUpdates (false only for a mid-block checkpoint)
+	isolateChangeset bool   // force isolation even for a block that owns a changeset (the pre-window fold)
+	checkRoot        bool   // compare the computed root against target.stateRoot
+	advance          bool   // advance lastComputedBlock/hasComputed
+	publishRoot      bool   // publish the successful root (batch-boundary request), not just mismatches
+}
+
+// compute is the shared prologue/compute/footer for every calculator commitment
+// path; the per-call differences live in m.
+func (cc *commitmentCalculator) compute(ctx context.Context, t commitTarget, m computeMode) {
 	if err := cc.state.LazyLoadErr(); err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: lazy-load failed: %w", err),
-		})
+		cc.publish(ctx, commitmentResult{blockNum: t.blockNum, txNum: t.lastTxNum,
+			err: fmt.Errorf("commitmentCalculator: %slazy-load failed: %w", m.label, err)})
 		return
 	}
 	cc.state.FlushToUpdates(cc.updates)
-	cc.state.ResetBlockFlags()
+	if m.resetFlags {
+		cc.state.ResetBlockFlags()
+	}
 
 	sdCtx := cc.doms.GetCommitmentContext()
 	sdCtx.SetUpdates(cc.updates)
 	cc.updates = cc.updates.NewEmpty()
 
-	cc.asOfReader.txNum = br.lastTxNum + 1
+	cc.asOfReader.txNum = t.lastTxNum + 1
 	sdCtx.SetStateReader(cc.asOfReader)
 
-	// Use hash-aware accumulator wrap — see computeWithBlockAccumulator
-	// docstring for why this is mandatory in reorg scenarios.
-	rh, err := cc.computeWithBlockAccumulator(ctx, br)
+	var rh []byte
+	var err error
+	if m.isolateChangeset || !cc.ownsChangeset(t.blockNum) {
+		rh, err = cc.computeIsolated(ctx, t)
+	} else {
+		rh, err = cc.computeWithBlockAccumulator(ctx, t)
+	}
 	if err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: %w", err),
-		})
+		cc.publish(ctx, commitmentResult{blockNum: t.blockNum, txNum: t.lastTxNum,
+			err: fmt.Errorf("commitmentCalculator: %scompute failed: %w", m.label, err)})
 		return
 	}
 
-	r := commitmentResult{
-		blockNum: br.BlockNum,
-		txNum:    br.lastTxNum,
-		rootHash: rh,
+	if m.advance {
+		cc.lastComputedBlock = t.blockNum
+		cc.hasComputed = true
 	}
 
-	// Check against expected root from the block header.
-	if !bytes.Equal(rh, br.StateRoot[:]) {
-		r.err = fmt.Errorf("%w: block %d root %x expected %x", ErrWrongTrieRoot, br.BlockNum, rh, br.StateRoot)
+	if !m.checkRoot {
+		return
 	}
-
-	cc.lastComputedBlock = br.BlockNum
-	cc.hasComputed = true
+	mismatch := !bytes.Equal(rh, t.stateRoot[:])
+	if !m.publishRoot && !mismatch {
+		return
+	}
+	r := commitmentResult{blockNum: t.blockNum, txNum: t.lastTxNum, rootHash: rh}
+	if mismatch {
+		r.err = fmt.Errorf("%w: block %d root %x expected %x", ErrWrongTrieRoot, t.blockNum, rh, t.stateRoot)
+	}
 	cc.publish(ctx, r)
 }
 
-// computeWithoutCheck computes commitment but doesn't verify the root.
-// Used for the first partial block where the trie state doesn't match the header.
-func (cc *commitmentCalculator) computeWithoutCheck(ctx context.Context, br *blockResult) {
-	if err := cc.state.LazyLoadErr(); err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: lazy-load failed: %w", err),
-		})
-		return
-	}
-	cc.state.FlushToUpdates(cc.updates)
-	cc.state.ResetBlockFlags()
+// computeIsolated computes and flushes its own deferred updates under a nil
+// changeset accumulator, so a block that owns no changeset records into none.
+func (cc *commitmentCalculator) computeIsolated(ctx context.Context, t commitTarget) ([]byte, error) {
+	cc.doms.LockChangesetAccumulator()
+	defer cc.doms.UnlockChangesetAccumulator()
+	prev := cc.doms.GetChangesetAccumulatorLocked()
+	cc.doms.SetChangesetAccumulatorLocked(nil)
+	defer cc.doms.SetChangesetAccumulatorLocked(prev)
 
-	sdCtx := cc.doms.GetCommitmentContext()
-	sdCtx.SetUpdates(cc.updates)
-	cc.updates = cc.updates.NewEmpty()
-
-	cc.asOfReader.txNum = br.lastTxNum + 1
-	sdCtx.SetStateReader(cc.asOfReader)
-
-	// Use the same hash-aware accumulator wrap as computeAndCheck — without
-	// it, the [state] write inside ComputeCommitment can land in a stale
-	// past-changeset entry chosen non-deterministically by GetChangesetByBlockNum
-	// when pastChangesAccumulator holds multiple changesets per block number
-	// (canonical + fork during reorg-bounce tests).
-	if _, err := cc.computeWithBlockAccumulator(ctx, br); err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: partial-block compute failed: %w", err),
-		})
-		return
-	}
-
-	cc.lastComputedBlock = br.BlockNum
-	cc.hasComputed = true
-}
-
-// computeStepBoundary checkpoints commitment at a mid-block step edge. It must
-// not advance lastComputedBlock (or the block/batch-end compute gets suppressed)
-// and must not ResetBlockFlags (or the block-end compute loses the pre-edge
-// dirty keys and folds a wrong block root).
-func (cc *commitmentCalculator) computeStepBoundary(ctx context.Context, br *blockResult) {
-	if err := cc.state.LazyLoadErr(); err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: step-boundary lazy-load failed: %w", err),
-		})
-		return
-	}
-	cc.state.FlushToUpdates(cc.updates)
-
-	sdCtx := cc.doms.GetCommitmentContext()
-	sdCtx.SetUpdates(cc.updates)
-	cc.updates = cc.updates.NewEmpty()
-
-	cc.asOfReader.txNum = br.lastTxNum + 1
-	sdCtx.SetStateReader(cc.asOfReader)
-
-	if _, err := cc.computeWithBlockAccumulator(ctx, br); err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: step-boundary compute failed: %w", err),
-		})
-	}
-}
-
-// computeAndCheck computes per-block commitment and validates the root.
-// Only publishes errors to the output channel — successful results are
-// tracked internally. This avoids filling the output channel buffer
-// (which would deadlock the pipeline when batch size > buffer size).
-// Uses the SharedDomains' roTx (not a separate DB connection) to ensure
-// consistency between sd.mem and the trie node reads.
-func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockResult) {
-	if err := cc.state.LazyLoadErr(); err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: lazy-load failed: %w", err),
-		})
-		return
-	}
-	// Flush accumulated local state to the trie's Updates buffer.
-	// This produces one Update per dirty account/slot with the final
-	// block-end values — not intermediate per-TX values.
-	cc.state.FlushToUpdates(cc.updates)
-	cc.state.ResetBlockFlags()
-
-	sdCtx := cc.doms.GetCommitmentContext()
-	sdCtx.SetUpdates(cc.updates)
-	cc.updates = cc.updates.NewEmpty()
-
-	// Install asOfStateReader so fold/unfold sibling reads see state at
-	// this block's txNum, not the apply loop's future state in sd.mem.
-	cc.asOfReader.txNum = br.lastTxNum + 1
-	sdCtx.SetStateReader(cc.asOfReader)
-
-	// In per-block compute mode, the exec loop has (or is about to)
-	// swap the changeset accumulator to block N+1 by the time this runs.
-	// Wrap ComputeCommitment so any branch writes (mid-process inline
-	// flushes from `pendingPrefixes` collisions, plus any writes via
-	// putBranch) go into block N's saved changeset, not whatever the
-	// exec loop has set as current. Without this wrap, block N's
-	// branch deltas leak into block N+1's CS, producing a wrong-trie-root
-	// chain on subsequent blocks (see TestTxLookupUnwind reproducer).
-	rh, err := cc.computeWithBlockAccumulator(ctx, br)
+	rh, err := cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 	if err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: %w", err),
-		})
-		return
+		return nil, err
 	}
-
-	cc.lastComputedBlock = br.BlockNum
-	cc.hasComputed = true
-
-	// Only publish on mismatch — success is silent.
-	if mismatch := !bytes.Equal(rh, br.StateRoot[:]); mismatch {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			rootHash: rh,
-			err:      fmt.Errorf("%w: block %d root %x expected %x", ErrWrongTrieRoot, br.BlockNum, rh, br.StateRoot),
-		})
+	if err := cc.doms.FlushPendingUpdatesLocked(ctx, cc.roTx); err != nil {
+		return nil, err
 	}
+	return rh, nil
+}
+
+func (cc *commitmentCalculator) computeAndPublish(ctx context.Context, br *blockResult) {
+	cc.compute(ctx, targetOf(br), computeMode{resetFlags: true, checkRoot: true, advance: true, publishRoot: true})
+}
+
+// computeWithoutCheck computes the first partial block's commitment without
+// verifying the root (its trie state doesn't match the header).
+func (cc *commitmentCalculator) computeWithoutCheck(ctx context.Context, br *blockResult) {
+	cc.compute(ctx, targetOf(br), computeMode{label: "partial-block ", resetFlags: true, advance: true})
+}
+
+// computeStepBoundary checkpoints commitment at a mid-block step edge without
+// advancing lastComputedBlock or resetting block flags — the block-end fold
+// still needs the pre-edge dirty keys.
+func (cc *commitmentCalculator) computeStepBoundary(ctx context.Context, br *blockResult) {
+	cc.compute(ctx, targetOf(br), computeMode{label: "step-boundary "})
+}
+
+// computeAndCheck computes per-block commitment and validates the root,
+// publishing only on mismatch (silent success keeps the bounded output channel
+// from deadlocking).
+func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockResult) {
+	cc.compute(ctx, targetOf(br), computeMode{resetFlags: true, checkRoot: true, advance: true})
 }
 
 // flushPendingUpdatesWithoutChangeset eagerly applies the pending deferred
@@ -527,58 +482,11 @@ func (cc *commitmentCalculator) flushPendingUpdatesWithoutChangeset(ctx context.
 	}
 }
 
-// computeTransition folds all batch-mode blocks at the last pre-window block
-// so the first window block's compute (and changeset) covers only its own
-// deltas. Branch writes and the deferred-update flush run under a nil
-// accumulator — pre-window deltas must not land in any block's changeset.
+// computeTransition folds all accumulated batch-mode blocks at the last
+// pre-window block, isolated so their deltas don't leak into the first window
+// block's changeset.
 func (cc *commitmentCalculator) computeTransition(ctx context.Context, br *blockResult) {
-	if err := cc.state.LazyLoadErr(); err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: lazy-load failed: %w", err),
-		})
-		return
-	}
-	cc.state.FlushToUpdates(cc.updates)
-	cc.state.ResetBlockFlags()
-
-	sdCtx := cc.doms.GetCommitmentContext()
-	sdCtx.SetUpdates(cc.updates)
-	cc.updates = cc.updates.NewEmpty()
-
-	cc.asOfReader.txNum = br.lastTxNum + 1
-	sdCtx.SetStateReader(cc.asOfReader)
-
-	cc.doms.LockChangesetAccumulator()
-	prev := cc.doms.GetChangesetAccumulatorLocked()
-	cc.doms.SetChangesetAccumulatorLocked(nil)
-	rh, err := cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, br.BlockNum, br.lastTxNum, cc.logPrefix, nil)
-	if err == nil {
-		err = cc.doms.FlushPendingUpdatesLocked(ctx, cc.roTx)
-	}
-	cc.doms.SetChangesetAccumulatorLocked(prev)
-	cc.doms.UnlockChangesetAccumulator()
-	if err != nil {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			err:      fmt.Errorf("commitmentCalculator: %w", err),
-		})
-		return
-	}
-
-	cc.lastComputedBlock = br.BlockNum
-	cc.hasComputed = true
-
-	if !bytes.Equal(rh, br.StateRoot[:]) {
-		cc.publish(ctx, commitmentResult{
-			blockNum: br.BlockNum,
-			txNum:    br.lastTxNum,
-			rootHash: rh,
-			err:      fmt.Errorf("%w: block %d root %x expected %x", ErrWrongTrieRoot, br.BlockNum, rh, br.StateRoot),
-		})
-	}
+	cc.compute(ctx, targetOf(br), computeMode{resetFlags: true, isolateChangeset: true, checkRoot: true, advance: true})
 }
 
 func (cc *commitmentCalculator) publish(ctx context.Context, r commitmentResult) {
@@ -623,18 +531,18 @@ func (cc *commitmentCalculator) publish(ctx context.Context, r commitmentResult)
 // Also annotates the pending deferred update (set inside ComputeCommitment
 // when defer mode is on) with the block's hash, so the next call's
 // FlushPendingUpdates uses the same hash-aware routing.
-func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context, br *blockResult) ([]byte, error) {
+func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context, t commitTarget) ([]byte, error) {
 	defer func() {
 		// Stamp the pending update (if any was set during ComputeCommitment)
 		// with this block's hash so FlushPendingUpdates on the next call
 		// routes to the exact (BlockNum, BlockHash) entry rather than
 		// guessing among ambiguous block-number-only matches.
-		if upd := cc.doms.GetCommitmentContext().PeekPendingUpdate(); upd != nil && upd.BlockNum == br.BlockNum {
-			upd.BlockHash = br.BlockHash
+		if upd := cc.doms.GetCommitmentContext().PeekPendingUpdate(); upd != nil && upd.BlockNum == t.blockNum {
+			upd.BlockHash = t.blockHash
 		}
 	}()
 
-	cs := cc.doms.GetChangesetByHash(br.BlockNum, br.BlockHash)
+	cs := cc.doms.GetChangesetByHash(t.blockNum, t.blockHash)
 	// Always take the lock around ComputeCommitment, even on the cs==nil
 	// fast path: the FlushPendingUpdates that ComputeCommitment runs
 	// internally still mutates the global accumulator pointer + per-domain
@@ -644,7 +552,7 @@ func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context,
 	cc.doms.LockChangesetAccumulator()
 	defer cc.doms.UnlockChangesetAccumulator()
 	if cs == nil {
-		return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, br.BlockNum, br.lastTxNum, cc.logPrefix, nil)
+		return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 	}
 	// LOAD-BEARING swap under the outer lock (already taken above). The
 	// Set/restore dance below mutates the global current-accumulator
@@ -660,7 +568,7 @@ func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context,
 	prev := cc.doms.GetChangesetAccumulatorLocked()
 	cc.doms.SetChangesetAccumulatorLocked(cs)
 	defer cc.doms.SetChangesetAccumulatorLocked(prev)
-	return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, br.BlockNum, br.lastTxNum, cc.logPrefix, nil)
+	return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 }
 
 // asOfStateReader reads account/storage/code at a specific txNum via
@@ -711,6 +619,40 @@ func (r *asOfStateReader) Read(d kv.Domain, plainKey []byte, stepSize uint64) (e
 
 func (r *asOfStateReader) Clone(tx kv.TemporalTx) commitmentdb.StateReader {
 	return &asOfStateReader{sd: r.sd, roTx: tx, txNum: r.txNum}
+}
+
+// asOfStorageEnumerator lists the persisted storage slots under an address via
+// the calculator's stable roTx snapshot (the pre-cycle baseline the trie was
+// built from), so a self-destruct deletes the whole subtree. The exec loop's
+// DomainDelPrefix runs with inline TouchKey disabled in parallel mode, so this
+// is the parallel path's equivalent of serial's per-slot delete touches.
+type asOfStorageEnumerator struct {
+	reader *asOfStateReader
+}
+
+func (e *asOfStorageEnumerator) EachStorageSlot(addr accounts.Address, fn func(key accounts.StorageKey) error) error {
+	addrVal := addr.Value()
+	toKey, _ := kv.NextSubtree(addrVal[:])
+	it, err := e.reader.roTx.RangeAsOf(kv.StorageDomain, addrVal[:], toKey, e.reader.txNum, order.Asc, kv.Unlim)
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+	for it.HasNext() {
+		k, v, err := it.Next()
+		if err != nil {
+			return err
+		}
+		if len(v) == 0 || len(k) != 52 || !bytes.HasPrefix(k, addrVal[:]) {
+			continue
+		}
+		var h common.Hash
+		copy(h[:], k[20:])
+		if err := fn(accounts.InternKey(h)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Keep imports used.

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -213,10 +213,8 @@ func (cc *commitmentCalculator) perBlockCompute(blockNum uint64) bool {
 	return !dbg.BatchCommitments || cc.forcePerBlockCompute || blockNum >= cc.perBlockFrom
 }
 
-// ownsChangeset reports whether block n gets its own changeset (mirrors the exec
-// loop's accumulator eligibility: genesis excluded, window starts at perBlockFrom).
-// A block owning none must compute isolated — the calculator lags the exec loop,
-// so its writes would otherwise land in a later block's live changeset.
+// ownsChangeset reports whether block n gets its own changeset: genesis excluded,
+// window starts at perBlockFrom. A block owning none must compute isolated.
 func (cc *commitmentCalculator) ownsChangeset(n uint64) bool {
 	return n != 0 && n >= cc.perBlockFrom
 }
@@ -489,10 +487,8 @@ func (cc *commitmentCalculator) computeTransition(ctx context.Context, br *block
 }
 
 func (cc *commitmentCalculator) publish(ctx context.Context, r commitmentResult) {
-	// The send is best-effort (it can drop on shutdown), so log genuine errors
-	// here as a breadcrumb — the apply loop surfaces the authoritative error.
-	// Wrong-root is routine (apply loop logs it) and ctx cancel/timeout is
-	// expected on shutdown, so skip both.
+	// Best-effort send; log only genuine errors as a breadcrumb (the apply loop
+	// surfaces the authoritative one). Wrong-root and shutdown cancels are expected.
 	if r.err != nil && cc.logger != nil &&
 		!errors.Is(r.err, ErrWrongTrieRoot) &&
 		!errors.Is(r.err, context.Canceled) &&

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -361,11 +361,10 @@ func targetOf(br *blockResult) commitTarget {
 // decided by ownsChangeset.
 type computeMode struct {
 	label            string // error-message context, e.g. "step-boundary "
-	resetFlags       bool   // ResetBlockFlags after FlushToUpdates (false only for a mid-block checkpoint)
+	midBlock         bool   // mid-block checkpoint: keep block flags dirty and don't advance lastComputedBlock (block-end otherwise)
 	isolateChangeset bool   // force isolation even for a block that owns a changeset (the pre-window fold)
 	checkRoot        bool   // compare the computed root against target.stateRoot
-	advance          bool   // advance lastComputedBlock/hasComputed
-	publishRoot      bool   // publish the successful root (batch-boundary request), not just mismatches
+	publishRoot      bool   // with checkRoot, publish the successful root too (batch-boundary request), not just mismatches
 }
 
 // compute is the shared prologue/compute/footer for every calculator commitment
@@ -377,7 +376,7 @@ func (cc *commitmentCalculator) compute(ctx context.Context, t commitTarget, m c
 		return
 	}
 	cc.state.FlushToUpdates(cc.updates)
-	if m.resetFlags {
+	if !m.midBlock {
 		cc.state.ResetBlockFlags()
 	}
 
@@ -401,7 +400,7 @@ func (cc *commitmentCalculator) compute(ctx context.Context, t commitTarget, m c
 		return
 	}
 
-	if m.advance {
+	if !m.midBlock {
 		cc.lastComputedBlock = t.blockNum
 		cc.hasComputed = true
 	}
@@ -440,27 +439,27 @@ func (cc *commitmentCalculator) computeIsolated(ctx context.Context, t commitTar
 }
 
 func (cc *commitmentCalculator) computeAndPublish(ctx context.Context, br *blockResult) {
-	cc.compute(ctx, targetOf(br), computeMode{resetFlags: true, checkRoot: true, advance: true, publishRoot: true})
+	cc.compute(ctx, targetOf(br), computeMode{checkRoot: true, publishRoot: true})
 }
 
 // computeWithoutCheck computes the first partial block's commitment without
 // verifying the root (its trie state doesn't match the header).
 func (cc *commitmentCalculator) computeWithoutCheck(ctx context.Context, br *blockResult) {
-	cc.compute(ctx, targetOf(br), computeMode{label: "partial-block ", resetFlags: true, advance: true})
+	cc.compute(ctx, targetOf(br), computeMode{label: "partial-block "})
 }
 
 // computeStepBoundary checkpoints commitment at a mid-block step edge without
 // advancing lastComputedBlock or resetting block flags — the block-end fold
 // still needs the pre-edge dirty keys.
 func (cc *commitmentCalculator) computeStepBoundary(ctx context.Context, br *blockResult) {
-	cc.compute(ctx, targetOf(br), computeMode{label: "step-boundary "})
+	cc.compute(ctx, targetOf(br), computeMode{label: "step-boundary ", midBlock: true})
 }
 
 // computeAndCheck computes per-block commitment and validates the root,
 // publishing only on mismatch (silent success keeps the bounded output channel
 // from deadlocking).
 func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockResult) {
-	cc.compute(ctx, targetOf(br), computeMode{resetFlags: true, checkRoot: true, advance: true})
+	cc.compute(ctx, targetOf(br), computeMode{checkRoot: true})
 }
 
 // flushPendingUpdatesWithoutChangeset eagerly applies the pending deferred
@@ -486,7 +485,7 @@ func (cc *commitmentCalculator) flushPendingUpdatesWithoutChangeset(ctx context.
 // pre-window block, isolated so their deltas don't leak into the first window
 // block's changeset.
 func (cc *commitmentCalculator) computeTransition(ctx context.Context, br *blockResult) {
-	cc.compute(ctx, targetOf(br), computeMode{resetFlags: true, isolateChangeset: true, checkRoot: true, advance: true})
+	cc.compute(ctx, targetOf(br), computeMode{isolateChangeset: true, checkRoot: true})
 }
 
 func (cc *commitmentCalculator) publish(ctx context.Context, r commitmentResult) {
@@ -524,9 +523,9 @@ func (cc *commitmentCalculator) publish(ctx context.Context, r commitmentResult)
 // reproducer, leaving canonical block 1's CS without [state] and producing
 // off-by-one wrong-trie-root chains on the next iteration's re-execution.
 //
-// If block N's CS hasn't been saved yet (rare race with the exec loop's
-// SavePastChangesetAccumulator), falls through to whatever current is
-// installed — same as the pre-fix behavior.
+// If block N's CS hasn't been saved yet it falls through to the live
+// accumulator, which — because the lookup is under changesetMu — is still N's
+// own (the apply loop can't rotate it while the lock is held).
 //
 // Also annotates the pending deferred update (set inside ComputeCommitment
 // when defer mode is on) with the block's hash, so the next call's
@@ -542,15 +541,14 @@ func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context,
 		}
 	}()
 
-	cs := cc.doms.GetChangesetByHash(t.blockNum, t.blockHash)
-	// Always take the lock around ComputeCommitment, even on the cs==nil
-	// fast path: the FlushPendingUpdates that ComputeCommitment runs
-	// internally still mutates the global accumulator pointer + per-domain
-	// diff fields, racing with the apply loop's SetChangesetAccumulator if
-	// we don't serialize. Without this, race detector flags ~73 SetDiff vs
-	// PutWithPrev hits on the cs==nil path (genesis, missing-CS edge cases).
+	// Look up cs AND compute under changesetMu: reading cs before the lock races
+	// the apply loop's SavePastChangesetAccumulator + accumulator rotation, which
+	// would route this block's [state] write into the next block's changeset. The
+	// lock is required even on the cs==nil path — the internal FlushPendingUpdates
+	// mutates the same global accumulator pointer.
 	cc.doms.LockChangesetAccumulator()
 	defer cc.doms.UnlockChangesetAccumulator()
+	cs := cc.doms.GetChangesetByHash(t.blockNum, t.blockHash)
 	if cs == nil {
 		return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 	}

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -358,11 +358,10 @@ func targetOf(br *blockResult) commitTarget {
 // computeMode selects compute's per-call behaviour; isolation is otherwise
 // decided by ownsChangeset.
 type computeMode struct {
-	label            string // error-message context, e.g. "step-boundary "
-	midBlock         bool   // mid-block checkpoint: keep block flags dirty and don't advance lastComputedBlock (block-end otherwise)
-	isolateChangeset bool   // force isolation even for a block that owns a changeset (the pre-window fold)
-	checkRoot        bool   // compare the computed root against target.stateRoot
-	publishRoot      bool   // with checkRoot, publish the successful root too (batch-boundary request), not just mismatches
+	label       string // error-message context, e.g. "step-boundary "
+	midBlock    bool   // mid-block checkpoint: keep block flags dirty and don't advance lastComputedBlock (block-end otherwise)
+	checkRoot   bool   // compare the computed root against target.stateRoot
+	publishRoot bool   // with checkRoot, publish the successful root too (batch-boundary request), not just mismatches
 }
 
 // compute is the shared prologue/compute/footer for every calculator commitment
@@ -387,7 +386,7 @@ func (cc *commitmentCalculator) compute(ctx context.Context, t commitTarget, m c
 
 	var rh []byte
 	var err error
-	if m.isolateChangeset || !cc.ownsChangeset(t.blockNum) {
+	if !cc.ownsChangeset(t.blockNum) {
 		rh, err = cc.computeIsolated(ctx, t)
 	} else {
 		rh, err = cc.computeWithBlockAccumulator(ctx, t)
@@ -483,7 +482,7 @@ func (cc *commitmentCalculator) flushPendingUpdatesWithoutChangeset(ctx context.
 // pre-window block, isolated so their deltas don't leak into the first window
 // block's changeset.
 func (cc *commitmentCalculator) computeTransition(ctx context.Context, br *blockResult) {
-	cc.compute(ctx, targetOf(br), computeMode{isolateChangeset: true, checkRoot: true})
+	cc.compute(ctx, targetOf(br), computeMode{checkRoot: true})
 }
 
 func (cc *commitmentCalculator) publish(ctx context.Context, r commitmentResult) {

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -423,23 +423,30 @@ func TestHandleMessage_StepBoundaryDoesNotPolluteLiveChangeset(t *testing.T) {
 	require.Equal(t, stepEdgeTxNum, gotTxNum)
 }
 
-// TestHandleMessage_StepBoundaryRecordsIntoOwnChangesetInWindow is the in-window
-// mirror: the checkpoint MUST record into the block's own changeset, else the
-// block-end recompute stores mid-block prevData and the block's unwind is wrong.
-// Pins that isolation is window-aware, not unconditional.
+// TestHandleMessage_StepBoundaryRecordsIntoOwnChangesetInWindow pins the cs!=nil
+// hash-routing path: with block N's changeset saved and a DIFFERENT accumulator
+// live, the mid-block checkpoint must record its commitment writes into N's own
+// changeset, not the live one. (The stale-cs==nil TOCTOU itself needs concurrent
+// interleaving to trigger and isn't reproducible in this single-goroutine test.)
 func TestHandleMessage_StepBoundaryRecordsIntoOwnChangesetInWindow(t *testing.T) {
 	ctx := context.Background()
 	logger := log.New()
 	const stepSize = uint64(16)
+	blockHash := common.Hash{0xAB}
 
 	db, tx, doms := setupStepTest(t)
 
+	// Save block 1's own changeset (keyed by its hash) and install a DIFFERENT
+	// accumulator as the live one.
 	ownCS := &changeset.StateChangeSet{}
-	doms.SetChangesetAccumulator(ownCS)
+	liveCS := &changeset.StateChangeSet{}
+	doms.SavePastChangesetAccumulator(blockHash, 1, ownCS)
+	doms.SetChangesetAccumulator(liveCS)
 
 	in := make(chan applyResult, 64)
 	out := make(chan commitmentResult, 64)
-	// perBlockFrom=1 => block 1 is an in-window block (blockNum >= perBlockFrom).
+	// perBlockFrom=1 => block 1 is in-window, so it routes through the hash-aware
+	// wrap (ownsChangeset(1)=true) rather than the isolated path.
 	cc, err := newCommitmentCalculator(ctx, doms, db, "test", logger, false, 1, in, out)
 	require.NoError(t, err)
 	defer cc.Stop()
@@ -455,8 +462,9 @@ func TestHandleMessage_StepBoundaryRecordsIntoOwnChangesetInWindow(t *testing.T)
 		buf := accounts.SerialiseV3(&acc)
 		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
 		cc.handleMessage(ctx, &txResult{
-			blockNum: 1,
-			txNum:    txNum,
+			blockNum:  1,
+			blockHash: blockHash,
+			txNum:     txNum,
 			writes: state.VersionedWrites{
 				&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: txNum},
 				&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: bal},
@@ -465,8 +473,9 @@ func TestHandleMessage_StepBoundaryRecordsIntoOwnChangesetInWindow(t *testing.T)
 	}
 
 	require.Positive(t, ownCS.Diffs[kv.CommitmentDomain].Len(),
-		"an in-window block's mid-block step checkpoint must record into its own live "+
-			"changeset — isolating it would corrupt the block's post-unwind commitment state")
+		"the checkpoint must hash-route its commitment writes into block N's own saved changeset")
+	require.Zero(t, liveCS.Diffs[kv.CommitmentDomain].Len(),
+		"the checkpoint must NOT record commitment writes into the different live accumulator")
 }
 
 // TestHandleMessage_PreWindowPerBlockComputeDoesNotPolluteLiveChangeset guards

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/temporal"
 	dbstate "github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
@@ -363,6 +364,172 @@ func TestHandleMessage_StepEdgeAtBlockEnd(t *testing.T) {
 		require.Equal(t, uint64(15), gotTxNum)
 		require.Equal(t, uint64(1), gotBlockNum)
 	})
+}
+
+// TestHandleMessage_StepBoundaryDoesNotPolluteLiveChangeset pins that a
+// pre-window mid-block step checkpoint records into NO changeset: the lagging
+// calculator's live accumulator can be a later block's, and leaking there
+// corrupts that block's unwind.
+func TestHandleMessage_StepBoundaryDoesNotPolluteLiveChangeset(t *testing.T) {
+	ctx := context.Background()
+	logger := log.New()
+	const stepSize = uint64(16)
+
+	db, tx, doms := setupStepTest(t)
+
+	// Stand in for the exec loop having advanced into the changeset window and
+	// installed a later block's accumulator as live, while the calculator is
+	// still on an earlier block whose own changeset was never saved.
+	liveCS := &changeset.StateChangeSet{}
+	doms.SetChangesetAccumulator(liveCS)
+
+	in := make(chan applyResult, 64)
+	out := make(chan commitmentResult, 64)
+	cc, err := newCommitmentCalculator(ctx, doms, db, "test", logger, false, 1<<62, in, out)
+	require.NoError(t, err)
+	defer cc.Stop()
+
+	const stepEdgeTxNum = stepSize - 1 // 15: (txNum+1)%stepSize == 0
+	rnd := rand.New(rand.NewSource(42))
+	for txNum := uint64(1); txNum <= stepEdgeTxNum; txNum++ {
+		addrBytes := make([]byte, length.Addr)
+		rnd.Read(addrBytes)
+		addr := accounts.InternAddress([20]byte(addrBytes))
+		bal := *uint256.NewInt(txNum * 1000)
+		acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
+		buf := accounts.SerialiseV3(&acc)
+		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
+		cc.handleMessage(ctx, &txResult{
+			blockNum: 1,
+			txNum:    txNum,
+			writes: state.VersionedWrites{
+				&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: txNum},
+				&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: bal},
+			},
+		})
+	}
+
+	require.Zero(t, liveCS.Diffs[kv.CommitmentDomain].Len(),
+		"mid-block step-boundary compute leaked CommitmentDomain diffs into the live "+
+			"changeset accumulator — on that block's unwind they corrupt commitment state")
+
+	// The checkpoint must still advance to the step edge: the fix isolates the
+	// changeset, it does not suppress the checkpoint.
+	stateBlob, _, err := doms.GetLatest(kv.CommitmentDomain, tx, commitmentdb.KeyCommitmentState)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(stateBlob), 16,
+		"step-boundary checkpoint must still be written to sd, only kept out of the changeset")
+	gotTxNum, _ := commitmentdb.DecodeTxBlockNums(stateBlob)
+	require.Equal(t, stepEdgeTxNum, gotTxNum)
+}
+
+// TestHandleMessage_StepBoundaryRecordsIntoOwnChangesetInWindow is the in-window
+// mirror: the checkpoint MUST record into the block's own changeset, else the
+// block-end recompute stores mid-block prevData and the block's unwind is wrong.
+// Pins that isolation is window-aware, not unconditional.
+func TestHandleMessage_StepBoundaryRecordsIntoOwnChangesetInWindow(t *testing.T) {
+	ctx := context.Background()
+	logger := log.New()
+	const stepSize = uint64(16)
+
+	db, tx, doms := setupStepTest(t)
+
+	ownCS := &changeset.StateChangeSet{}
+	doms.SetChangesetAccumulator(ownCS)
+
+	in := make(chan applyResult, 64)
+	out := make(chan commitmentResult, 64)
+	// perBlockFrom=1 => block 1 is an in-window block (blockNum >= perBlockFrom).
+	cc, err := newCommitmentCalculator(ctx, doms, db, "test", logger, false, 1, in, out)
+	require.NoError(t, err)
+	defer cc.Stop()
+
+	const stepEdgeTxNum = stepSize - 1 // 15
+	rnd := rand.New(rand.NewSource(42))
+	for txNum := uint64(1); txNum <= stepEdgeTxNum; txNum++ {
+		addrBytes := make([]byte, length.Addr)
+		rnd.Read(addrBytes)
+		addr := accounts.InternAddress([20]byte(addrBytes))
+		bal := *uint256.NewInt(txNum * 1000)
+		acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
+		buf := accounts.SerialiseV3(&acc)
+		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
+		cc.handleMessage(ctx, &txResult{
+			blockNum: 1,
+			txNum:    txNum,
+			writes: state.VersionedWrites{
+				&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: txNum},
+				&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: bal},
+			},
+		})
+	}
+
+	require.Positive(t, ownCS.Diffs[kv.CommitmentDomain].Len(),
+		"an in-window block's mid-block step checkpoint must record into its own live "+
+			"changeset — isolating it would corrupt the block's post-unwind commitment state")
+}
+
+// TestHandleMessage_PreWindowPerBlockComputeDoesNotPolluteLiveChangeset guards
+// the block-boundary variant: forcePerBlockCompute makes even a pre-window block
+// compute per-block, so that compute must isolate or it leaks into a later
+// block's live changeset.
+func TestHandleMessage_PreWindowPerBlockComputeDoesNotPolluteLiveChangeset(t *testing.T) {
+	ctx := context.Background()
+	logger := log.New()
+
+	db, tx, doms := setupStepTest(t)
+
+	liveCS := &changeset.StateChangeSet{}
+	doms.SetChangesetAccumulator(liveCS)
+
+	in := make(chan applyResult, 64)
+	out := make(chan commitmentResult, 64)
+	// forcePerBlockCompute=true + perBlockFrom=5 => block 1 is pre-window yet
+	// still computes per-block.
+	cc, err := newCommitmentCalculator(ctx, doms, db, "test", logger, true, 5, in, out)
+	require.NoError(t, err)
+	defer cc.Stop()
+
+	rnd := rand.New(rand.NewSource(42))
+	for txNum := uint64(1); txNum <= 5; txNum++ {
+		addrBytes := make([]byte, length.Addr)
+		rnd.Read(addrBytes)
+		addr := accounts.InternAddress([20]byte(addrBytes))
+		bal := *uint256.NewInt(txNum * 1000)
+		acc := accounts.Account{Nonce: txNum, Balance: bal, CodeHash: accounts.EmptyCodeHash}
+		buf := accounts.SerialiseV3(&acc)
+		require.NoError(t, doms.DomainPut(kv.AccountsDomain, tx, addrBytes, buf, txNum, nil))
+		cc.handleMessage(ctx, &txResult{
+			blockNum: 1,
+			txNum:    txNum,
+			writes: state.VersionedWrites{
+				&state.VersionedWrite{Address: addr, Path: state.NoncePath, Val: txNum},
+				&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: bal},
+			},
+		})
+	}
+	// First partial block => computeWithoutCheck, a per-block compute with no
+	// root check; pre-window, so it must isolate its commitment writes.
+	cc.handleMessage(ctx, &blockResult{BlockNum: 1, BlockHash: common.Hash{0x01}, lastTxNum: 5, isPartial: true})
+
+	require.Zero(t, liveCS.Diffs[kv.CommitmentDomain].Len(),
+		"pre-window per-block compute leaked CommitmentDomain diffs into the live changeset accumulator")
+}
+
+// TestOwnsChangeset pins the isolation predicate at the window boundary — a wrong
+// answer either leaks a pre-window compute or over-isolates an in-window block.
+func TestOwnsChangeset(t *testing.T) {
+	cc := &commitmentCalculator{perBlockFrom: 100}
+	require.False(t, cc.ownsChangeset(0), "genesis owns no changeset")
+	require.False(t, cc.ownsChangeset(99), "pre-window block owns no changeset")
+	require.True(t, cc.ownsChangeset(100), "first in-window block owns its changeset")
+	require.True(t, cc.ownsChangeset(101), "in-window block owns its changeset")
+
+	// AlwaysGenerateChangesets from genesis => perBlockFrom == startBlockNum (0),
+	// but block 0 is still excluded by the exec loop.
+	genesisStart := &commitmentCalculator{perBlockFrom: 0}
+	require.False(t, genesisStart.ownsChangeset(0), "block 0 is always excluded")
+	require.True(t, genesisStart.ownsChangeset(1), "block 1 owns its changeset when the window starts at genesis")
 }
 
 // setupStepTest builds the shared in-memory temporal stack (stepSize 16) for the

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -250,10 +250,6 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 	// (block 24358306) by letting the Warmuper pre-fetch branch data while
 	// EVM execution runs. See #20920 for the canonical perf measurement.
 
-	// Skip step-boundary commitment — the calculator handles this.
-	pe.rs.StateV3.SetSkipStepBoundaryCommitment(true)
-	defer pe.rs.StateV3.SetSkipStepBoundaryCommitment(false)
-
 	// Store channels and limits on pe so execLoop can access them.
 	pe.applyResultsCh = applyResults
 	pe.commitResultsCh = commitResults

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -42,12 +42,11 @@ import (
 )
 
 type StateV3 struct {
-	domains                    *execctx.SharedDomains
-	logger                     log.Logger
-	persistReceiptsCacheV2     bool
-	txNum                      uint64
-	trace                      atomic.Bool
-	skipStepBoundaryCommitment bool
+	domains                *execctx.SharedDomains
+	logger                 log.Logger
+	persistReceiptsCacheV2 bool
+	txNum                  uint64
+	trace                  atomic.Bool
 }
 
 func NewStateV3(domains *execctx.SharedDomains, persistReceiptsCacheV2 bool, logger log.Logger) *StateV3 {
@@ -365,7 +364,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 // TouchKey is called for per-TX commitment tracking. The cache is flushed to
 // SharedDomains at block boundary. When blockCache is nil (serial executor),
 // writes go directly to SharedDomains via DomainPut.
-func (rs *StateV3) ApplyStateWrites(ctx context.Context,
+func (rs *StateV3) ApplyStateWrites(_ context.Context,
 	roTx kv.TemporalTx,
 	blockNum uint64,
 	txNum uint64,
@@ -380,17 +379,8 @@ func (rs *StateV3) ApplyStateWrites(ctx context.Context,
 	if err := rs.applyVersionedWrites(roTx, blockNum, txNum, writes, balanceIncreases, rules, blockCache); err != nil {
 		return fmt.Errorf("StateV3.ApplyStateWrites: %w", err)
 	}
-	// Compute commitment at step boundaries — must follow state writes.
-	// Skip when the commitment calculator goroutine is active (it owns
-	// the Updates buffer and handles all commitment computation).
-	// Also skip if the step is already frozen (nothing to commit).
-	if rs.domains.IsUnfrozenStepEdge(roTx, txNum) && !rs.domains.InlineTouchKeyDisabled() && !rs.skipStepBoundaryCommitment {
-		_, err := rs.domains.ComputeCommitment(ctx, roTx, true, blockNum, txNum,
-			fmt.Sprintf("applying step %d", txNum/rs.domains.StepSize()), nil)
-		if err != nil {
-			return fmt.Errorf("StateV3.ApplyStateWrites: step boundary: %w", err)
-		}
-	}
+	// Step-boundary commitment is computed by the explicit CommitStepBoundary
+	// call (serial) or the commitment calculator (parallel), not here.
 	return nil
 }
 
@@ -421,7 +411,7 @@ func (rs *StateV3) ApplyTxIndexes(
 // contain a commitment state at each step end, even when the boundary falls
 // mid-block.
 func (rs *StateV3) CommitStepBoundary(ctx context.Context, roTx kv.TemporalTx, blockNum, txNum uint64) error {
-	if rs.domains.IsUnfrozenStepEdge(roTx, txNum) && !rs.domains.InlineTouchKeyDisabled() && !rs.skipStepBoundaryCommitment {
+	if rs.domains.IsUnfrozenStepEdge(roTx, txNum) && !rs.domains.InlineTouchKeyDisabled() {
 		_, err := rs.domains.ComputeCommitment(ctx, roTx, true, blockNum, txNum,
 			fmt.Sprintf("applying step %d", txNum/rs.domains.StepSize()), nil)
 		if err != nil {
@@ -429,13 +419,6 @@ func (rs *StateV3) CommitStepBoundary(ctx context.Context, roTx kv.TemporalTx, b
 		}
 	}
 	return nil
-}
-
-// SetSkipStepBoundaryCommitment disables step-boundary commitment computation.
-// Used by the parallel executor where step-boundary commitment would clear
-// the Updates buffer mid-batch, corrupting the batch-end commitment.
-func (rs *StateV3) SetSkipStepBoundaryCommitment(skip bool) {
-	rs.skipStepBoundaryCommitment = skip
 }
 
 func (rs *StateV3) applyLogsAndTraces4(tx kv.TemporalTx, txNum uint64, receipt *types.Receipt, cummulativeBlobGas uint64, logs []*types.Log, traceFroms map[accounts.Address]struct{}, traceTos map[accounts.Address]struct{}, historyExecution bool, skipReceiptCache bool) error {


### PR DESCRIPTION
Brings the changeset-isolation fix from #22092 (still open on `main`) to release/3.5, which has an earlier snapshot of this feature via #22111 (branch `awskii/commitment-fail-fast-35`). Pulls in the fix plus the compute-path refactor it builds on.

The calculator goroutine lags the exec loop that owns the changeset accumulator. On the `cs == nil` fall-through a step checkpoint's `[state]` marker + branches were recorded into whatever accumulator was live — for a pre-window block, that's a later in-window block's. Unwind replays those diffs and corrupts that block's post-unwind commitment state and the `SeekCommitment` resume marker. Reachable via `computeStepBoundary` (mid-block step edge) and, under `forcePerBlockCompute` (`--prune.include-commitment-history`), pre-window per-block computes.

`ownsChangeset(n)` (genesis excluded, window starts at `perBlockFrom == changesetWindowStart`) now decides isolation: a block owning no changeset computes under a nil accumulator; an in-window block keeps the hash-aware wrap so its checkpoint records into its own changeset with the correct pre-block prevData.

## r3.5-specific adaptations

- `newCommitmentCalculator` sets `commitment.ModeUpdate` unconditionally — release/3.5 has no `commitment.ModeParallel`.

Fixes #21992
