### PR TITLE
ci: isolate per-shard state in hive + hive-eest to stop concurrent-shard clobbering

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -287,6 +287,7 @@ jobs:
       # Currently, we fail even if suites and tests are too few, indicating the tests did not run
       # We also fail if more than half the tests fail
       - name: Run hive tests and parse output
+        id: run_eest
         run: |
           branch=$(jq -r --arg t '${{ matrix.fixtures-tarball }}' '.[$t].branch // empty' "$ERIGON_DIR"/test-fixtures.json)
           branch_arg=""
@@ -348,6 +349,13 @@ jobs:
       - name: Test Results
         if: always()
         run: |
+          # if: always() runs this even when the hive step was skipped/failed,
+          # so gate on its real outcome — an early crash (before result.log /
+          # failed.log are written) must fail the job, not read as green.
+          if [ "${{ steps.run_eest.outcome }}" != "success" ]; then
+            echo "Hive test step did not succeed (outcome=${{ steps.run_eest.outcome }})."
+            exit 1
+          fi
           cat "$HIVE_DIR/result.log"
           if grep -q "failed" "$HIVE_DIR/failed.log"; then
             echo "One or more tests failed."

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -137,14 +137,28 @@ jobs:
           fi
           echo "Pruning docker system..."
           docker system prune -af --volumes
+
+      # Matrix shards share the self-hosted host's workspace with their siblings
+      # (the docker daemon is per-runner). Give each shard unique checkout dirs
+      # and image tag so a sibling's cleanup can't delete the checkout out from
+      # under a still-running shard.
+      - name: Compute per-shard identifiers
+        run: |
+          slug="${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}"
+          {
+            echo "ERIGON_DIR=erigon-full-$slug"
+            echo "HIVE_DIR=hive-$slug"
+            echo "IMAGE_TAG=hive/erigon:cilocal-$slug"
+          } >> "$GITHUB_ENV"
+
       - name: Checkout Erigon
         uses: actions/checkout@v7
         with:
-          path: erigon-full
+          path: ${{ env.ERIGON_DIR }}
 
       - name: Read pinned Hive ref
         id: hive-version
-        run: echo "ref=$(jq -r .hive_ref erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
+        run: echo "ref=$(jq -r .hive_ref "$ERIGON_DIR"/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
         uses: actions/checkout@v7
@@ -156,7 +170,7 @@ jobs:
           # Revert to ethereum/hive + steps.hive-version.outputs.ref once upstream.
           repository: erigontech/hive
           ref: 9afe5f15a37136fa57f2b2055d1d6c69c681aa16
-          path: hive
+          path: ${{ env.HIVE_DIR }}
 
       - name: Conditional Docker Login
         # Only login if we can. Workflow works without it but we want to avoid
@@ -197,7 +211,7 @@ jobs:
               sleep $((n*15)); n=$((n+1))
             done
           }
-          retry 3 docker build -t hive/erigon:cilocal erigon-full
+          retry 3 docker build -t "$IMAGE_TAG" "$ERIGON_DIR"
 
       - name: Get dependencies and build hive
         env:
@@ -206,7 +220,9 @@ jobs:
           # erigon instance hive launches inherits it.
           ERIGON_EXEC3_PARALLEL: ${{ matrix.exec_mode == 'parallel' && 'true' || 'false' }}
         run: |
-          cd hive
+          cd "$HIVE_DIR"
+          image_repo="${IMAGE_TAG%:*}"
+          image_version="${IMAGE_TAG#*:}"
           retry() {
             local max=$1 n=1; shift
             until "$@"; do
@@ -218,13 +234,13 @@ jobs:
           retry 3 go get . >> buildlogs.log
           # Point hive's default (prebuilt-image) erigon client at the image we
           # built locally above, instead of cloning erigon inside the builder.
-          sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=hive/erigon|" clients/erigon/Dockerfile
-          sed -i "s|^ARG tag=main-latest$|ARG tag=cilocal|" clients/erigon/Dockerfile
+          sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=${image_repo}|" clients/erigon/Dockerfile
+          sed -i "s|^ARG tag=main-latest$|ARG tag=${image_version}|" clients/erigon/Dockerfile
           # Fail fast if the sed didn't apply (upstream Dockerfile ARGs changed),
           # otherwise hive would silently use the remote erigontech/erigon image.
-          if ! grep -q "^ARG baseimage=hive/erigon$" clients/erigon/Dockerfile \
-             || ! grep -q "^ARG tag=cilocal$" clients/erigon/Dockerfile; then
-            echo "ERROR: failed to repoint hive's erigon client Dockerfile at hive/erigon:cilocal"
+          if ! grep -q "^ARG baseimage=${image_repo}$" clients/erigon/Dockerfile \
+             || ! grep -q "^ARG tag=${image_version}$" clients/erigon/Dockerfile; then
+            echo "ERROR: failed to repoint hive's erigon client Dockerfile at ${IMAGE_TAG}"
             exit 1
           fi
           # Inject ERIGON_EXEC3_PARALLEL into the runtime image so the
@@ -256,28 +272,28 @@ jobs:
             test-fixtures-cache/eest_devnet.tar.gz
             test-fixtures-cache/eest_benchmark.tar.gz
             test-fixtures-cache/eest_zkevm.tar.gz
-          key: test-fixtures-eest-${{ runner.os }}-${{ hashFiles('erigon-full/test-fixtures.json') }}
+          key: test-fixtures-eest-${{ runner.os }}-${{ hashFiles(format('{0}/test-fixtures.json', env.ERIGON_DIR)) }}
           restore-keys: |
             test-fixtures-eest-${{ runner.os }}-
 
       - name: Download EEST fixtures on cache miss
         if: steps.eest-cache.outputs.cache-hit != 'true'
-        run: bash erigon-full/tools/test-fixtures.sh --download-only erigon-full/test-fixtures.json test-fixtures-cache ${{ matrix.fixtures-tarball }}
+        run: bash "$ERIGON_DIR"/tools/test-fixtures.sh --download-only "$ERIGON_DIR"/test-fixtures.json test-fixtures-cache ${{ matrix.fixtures-tarball }}
 
       - name: Stage fixtures into hive eels sim build context
-        run: cp "test-fixtures-cache/${{ matrix.fixtures-tarball }}.tar.gz" "hive/simulators/ethereum/eels/${{ matrix.sim }}/fixtures.tar.gz"
+        run: cp "test-fixtures-cache/${{ matrix.fixtures-tarball }}.tar.gz" "$HIVE_DIR/simulators/ethereum/eels/${{ matrix.sim }}/fixtures.tar.gz"
 
       # Depends on the last line of hive output that prints the number of suites, tests and failed
       # Currently, we fail even if suites and tests are too few, indicating the tests did not run
       # We also fail if more than half the tests fail
       - name: Run hive tests and parse output
         run: |
-          branch=$(jq -r --arg t '${{ matrix.fixtures-tarball }}' '.[$t].branch // empty' erigon-full/test-fixtures.json)
+          branch=$(jq -r --arg t '${{ matrix.fixtures-tarball }}' '.[$t].branch // empty' "$ERIGON_DIR"/test-fixtures.json)
           branch_arg=""
           if [ -n "$branch" ]; then
             branch_arg="--sim.buildarg branch=$branch"
           fi
-          cd hive
+          cd "$HIVE_DIR"
           docker ps
           run_suite() {
             echo -e "\n\n============================================================"
@@ -327,13 +343,13 @@ jobs:
           # exec_mode in the artifact name keeps the two matrix entries from
           # clobbering each other's logs on the same artifact key.
           name: hive-workspace-log-${{ matrix.shard }}-${{ matrix.exec_mode }}
-          path: hive/workspace/logs
+          path: ${{ env.HIVE_DIR }}/workspace/logs
           if-no-files-found: ignore
       - name: Test Results
         if: always()
         run: |
-          cat hive/result.log
-          if grep -q "failed" hive/failed.log; then
+          cat "$HIVE_DIR/result.log"
+          if grep -q "failed" "$HIVE_DIR/failed.log"; then
             echo "One or more tests failed."
             exit 1
           fi
@@ -341,16 +357,16 @@ jobs:
 
 
 
-      # This step is not required UNTIL the github-managed runners are dismissed in favor of self-hosted ones (which is planned)
-      # So it is good to PROACTIVELY run it (it should not cause any issues within github-managed runners either)
-      - name: Remove Hive directory
+      # Scoped to this shard's own dirs: siblings share the workspace, so a
+      # blanket `rm -rf hive` would delete a still-running shard's checkout.
+      - name: Remove this shard's checkout dirs
         run: |
-          echo "Removing the Hive directory..."
-          rm -rf hive
+          echo "Removing this shard's checkout dirs..."
+          rm -rf "$ERIGON_DIR" "$HIVE_DIR"
         if: always()
 
-      # This step is not required UNTIL the github-managed runners are dismissed in favor of self-hosted ones (which is planned)
-      # So it is good to PROACTIVELY run it (it should not cause any issues within github-managed runners either)  
+      # Per-runner docker daemon: a host-global prune is safe (no sibling
+      # shares it) and reclaims disk on this reused runner between jobs.
       - name: Prune docker
         run: |
           echo "Stopping and removing all containers..."

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -85,16 +85,29 @@ jobs:
             max-allowed-failures: 0
             exec_mode: parallel
     steps:
+      # Every matrix shard shares the self-hosted host's workspace and docker
+      # daemon, so a sibling's end-of-job cleanup can delete files or images a
+      # still-running shard depends on. Give each shard unique checkout dirs and
+      # image tag so cleanup only ever touches that shard's own state.
+      - name: Compute per-shard identifiers
+        run: |
+          slug="${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}"
+          {
+            echo "ERIGON_DIR=erigon-full-$slug"
+            echo "HIVE_DIR=hive-$slug"
+            echo "IMAGE_TAG=hive/erigon:cilocal-$slug"
+          } >> "$GITHUB_ENV"
+
       - name: Checkout Erigon
         uses: actions/checkout@v7
         with:
-          path: erigon-full
+          path: ${{ env.ERIGON_DIR }}
 
       - name: Read pinned versions
         id: hive-version
         run: |
-          echo "ref=$(jq -r .hive_ref erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
-          echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
+          echo "ref=$(jq -r .hive_ref "$ERIGON_DIR"/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
+          echo "execution_apis_ref=$(jq -r '.execution_apis_ref // empty' "$ERIGON_DIR"/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
         uses: actions/checkout@v7
@@ -102,13 +115,13 @@ jobs:
           repository: ethereum/hive
           # version hive and update periodically/on-demand to prevent upstream changes in Hive affecting us with red CI
           ref: ${{ steps.hive-version.outputs.ref }}
-          path: hive
+          path: ${{ env.HIVE_DIR }}
 
       - name: Setup go env and cache
         uses: actions/setup-go@v6
         with:
           go-version: '>=1.25'
-          go-version-file: 'hive/go.mod'
+          go-version-file: ${{ env.HIVE_DIR }}/go.mod
 
       - name: Conditional Docker Login
         # Only login if we can. Workflow works without it but we want to avoid
@@ -144,7 +157,7 @@ jobs:
               sleep $((n*15)); n=$((n+1))
             done
           }
-          retry 3 docker build -t hive/erigon:cilocal erigon-full
+          retry 3 docker build -t "$IMAGE_TAG" "$ERIGON_DIR"
 
       - name: Get dependencies and build hive
         env:
@@ -154,7 +167,9 @@ jobs:
           # every erigon instance hive launches inherits it.
           ERIGON_EXEC3_PARALLEL: ${{ matrix.exec_mode == 'parallel' && 'true' || 'false' }}
         run: |
-          cd hive
+          cd "$HIVE_DIR"
+          image_repo="${IMAGE_TAG%:*}"
+          image_version="${IMAGE_TAG#*:}"
           retry() {
             local max=$1 n=1; shift
             until "$@"; do
@@ -166,13 +181,13 @@ jobs:
           retry 3 go get . >> buildlogs.log
           # Point hive's default (prebuilt-image) erigon client at the image we
           # built locally above, instead of cloning erigon inside the builder.
-          sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=hive/erigon|" clients/erigon/Dockerfile
-          sed -i "s|^ARG tag=main-latest$|ARG tag=cilocal|" clients/erigon/Dockerfile
+          sed -i "s|^ARG baseimage=erigontech/erigon$|ARG baseimage=${image_repo}|" clients/erigon/Dockerfile
+          sed -i "s|^ARG tag=main-latest$|ARG tag=${image_version}|" clients/erigon/Dockerfile
           # Fail fast if the sed didn't apply (upstream Dockerfile ARGs changed),
           # otherwise hive would silently use the remote erigontech/erigon image.
-          if ! grep -q "^ARG baseimage=hive/erigon$" clients/erigon/Dockerfile \
-             || ! grep -q "^ARG tag=cilocal$" clients/erigon/Dockerfile; then
-            echo "ERROR: failed to repoint hive's erigon client Dockerfile at hive/erigon:cilocal"
+          if ! grep -q "^ARG baseimage=${image_repo}$" clients/erigon/Dockerfile \
+             || ! grep -q "^ARG tag=${image_version}$" clients/erigon/Dockerfile; then
+            echo "ERROR: failed to repoint hive's erigon client Dockerfile at ${IMAGE_TAG}"
             exit 1
           fi
           # Inject ERIGON_EXEC3_PARALLEL into the runtime image so the
@@ -197,7 +212,7 @@ jobs:
       # We also fail if more than half the tests fail
       - name: Run hive tests and parse output
         run: |
-          cd hive
+          cd "$HIVE_DIR"
           run_suite() {
             if [ $# -ne 3 ]; then
               echo "Error: run_suite requires exactly 3 parameters"
@@ -263,31 +278,32 @@ jobs:
           # exec_mode in the artifact name keeps the two matrix entries from
           # clobbering each other's logs on the same artifact key.
           name: ${{ steps.artifact-name.outputs.name }}
-          path: hive/workspace/logs
+          path: ${{ env.HIVE_DIR }}/workspace/logs
         continue-on-error: true
 
       - name: Check for failures
         run: |
-          if grep -q "failed" hive/failed.log; then
+          if grep -q "failed" "$HIVE_DIR/failed.log"; then
             echo "One or more tests failed."
             exit 1
           fi
           echo "All tests passed successfully."
 
-      # This step is not required UNTIL the github-managed runners are dismissed in favor of self-hosted ones (which is planned)
-      # So it is good to PROACTIVELY run it (it should not cause any issues within github-managed runners either)
-      - name: Remove Hive directory
+      # Scoped to this shard's own dirs: siblings share the workspace, so a
+      # blanket `rm -rf hive` would delete a still-running shard's checkout.
+      - name: Remove this shard's checkout dirs
         run: |
-          echo "Removing the Hive directory..."
-          rm -rf hive
+          echo "Removing this shard's checkout dirs..."
+          rm -rf "$ERIGON_DIR" "$HIVE_DIR"
         if: always()
 
-      # This step is not required UNTIL the github-managed runners are dismissed in favor of self-hosted ones (which is planned)
-      # So it is good to PROACTIVELY run it (it should not cause any issues within github-managed runners either)  
-      - name: Prune docker
+      # Scoped to this shard's own image: siblings share the docker daemon, so a
+      # host-global `docker system prune -af --volumes` would wipe images and
+      # build cache out from under still-running shards.
+      - name: Remove this shard's docker image
         run: |
-          echo "Pruning docker..."
-          docker system prune -af --volumes
+          echo "Removing this shard's erigon image..."
+          docker rmi -f "$IMAGE_TAG" 2>/dev/null || true
         if: always()
 
       # In the merge queue, cancel the run on first failure so the gate

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -85,10 +85,10 @@ jobs:
             max-allowed-failures: 0
             exec_mode: parallel
     steps:
-      # Every matrix shard shares the self-hosted host's workspace and docker
-      # daemon, so a sibling's end-of-job cleanup can delete files or images a
-      # still-running shard depends on. Give each shard unique checkout dirs and
-      # image tag so cleanup only ever touches that shard's own state.
+      # Matrix shards share the self-hosted host's workspace with their siblings
+      # (the docker daemon is per-runner). Give each shard unique checkout dirs
+      # and image tag so a sibling's cleanup can't delete the checkout out from
+      # under a still-running shard.
       - name: Compute per-shard identifiers
         run: |
           slug="${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}"
@@ -297,13 +297,12 @@ jobs:
           rm -rf "$ERIGON_DIR" "$HIVE_DIR"
         if: always()
 
-      # Scoped to this shard's own image: siblings share the docker daemon, so a
-      # host-global `docker system prune -af --volumes` would wipe images and
-      # build cache out from under still-running shards.
-      - name: Remove this shard's docker image
+      # Per-runner docker daemon: a host-global prune is safe (no sibling shares
+      # it) and reclaims disk on this reused runner between jobs.
+      - name: Prune docker
         run: |
-          echo "Removing this shard's erigon image..."
-          docker rmi -f "$IMAGE_TAG" 2>/dev/null || true
+          echo "Pruning docker..."
+          docker system prune -af --volumes
         if: always()
 
       # In the merge queue, cancel the run on first failure so the gate

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -211,6 +211,7 @@ jobs:
       # Currently, we fail even if suites and tests are too few, indicating the tests did not run
       # We also fail if more than half the tests fail
       - name: Run hive tests and parse output
+        id: run_hive
         run: |
           cd "$HIVE_DIR"
           run_suite() {
@@ -283,6 +284,12 @@ jobs:
 
       - name: Check for failures
         run: |
+          # The hive step is continue-on-error, so gate on its real outcome —
+          # otherwise an early crash (before failed.log is written) reads as green.
+          if [ "${{ steps.run_hive.outcome }}" != "success" ]; then
+            echo "Hive test step did not succeed (outcome=${{ steps.run_hive.outcome }})."
+            exit 1
+          fi
           if grep -q "failed" "$HIVE_DIR/failed.log"; then
             echo "One or more tests failed."
             exit 1


### PR DESCRIPTION
## Problem

`hive / test-hive (ethereum/engine, withdrawals, serial)` intermittently fails with:

```
cd: hive: No such file or directory
##[error]Process completed with exit code 1.
```

right *after* "Build erigon image from local source" succeeded — erigon builds fine, but the Hive checkout directory has vanished mid-job. (Seen on the CI Gate run for #22119.) `test-hive-eest` has the identical structure and is exposed to the same flake.

## Root cause

Both hive workflows run their matrix (~12 / ~11 shards) **concurrently** on the self-hosted `hive` runner group, and every shard uses **identical filesystem paths**: checkout dirs `erigon-full` / `hive`. Each shard ends with `if: always()` cleanup including `rm -rf hive`. Concurrent shards **share the host's `_work` filesystem**, so when the first shard finishes, its `rm -rf hive` deletes the shared checkout out from under a still-running sibling → that sibling hits `cd hive: No such file or directory`.

This matches the intermittency exactly: only the shard still building when a fast sibling finishes is hit. In the triggering run only `withdrawals/serial` died while its `parallel` twin and every other hive shard passed.

**Runner topology (confirmed):** the `_work` filesystem is shared across concurrent shards, but the **docker daemon is per-runner**. So the host-global `docker system prune -af --volumes` is legitimate per-runner disk hygiene, **not** a cross-shard hazard — only the shared filesystem needs isolating.

## Fix

Give each shard a unique slug (`<run_id>-<run_attempt>-<job_index>`) and use it for the per-shard checkout dirs (`erigon-full-<slug>`, `hive-<slug>`) and image tag (`hive/erigon:cilocal-<slug>`), in **both** `test-hive.yml` and `test-hive-eest.yml`. End-of-job `rm -rf` is scoped to that shard's own dirs. The host-global `docker system prune` is left as-is (correct for per-runner daemons).

Also hardens the job verdict (from the Copilot review): the `Run hive tests` step is `continue-on-error` and pass/fail was gated **only** on `failed.log`, so an early crash of that step — before `failed.log` is written (e.g. `cd` / `./hive` failing) — read as green. The step now carries an `id` and the results step fails when `steps.<id>.outcome != 'success'` (keeping the `failed.log` content check), in both workflows. Pre-existing gap, but the shard-isolation change turned the `cd` target into a variable, so it's fixed here.

## Notes

- `test-hive-eest` also shares `test-fixtures-cache/` across shards, but that dir is populated by the `actions/cache` restore (whose extraction path is fixed by the warming workflow), so isolating it would need a cross-workflow change — out of scope here and a much lower-severity race (identical, content-addressed tarballs). Called out for a possible follow-up.
- `actionlint` (as CI runs it, `-shellcheck ''`) is clean on both files.

## Validation

- **`test-hive`** runs on this PR via ci-gate, so its changes (both the shard isolation and the verdict gate) are exercised by the PR checks.
- **`test-hive-eest`** is gated `if: github.event_name != 'pull_request'` in `ci-gate.yml`, so it does **not** run on PRs (only in the merge queue). I validated its shard-isolation plumbing by dispatching it on this branch — [run 28548787480](https://github.com/erigontech/erigon/actions/runs/28548787480): the `prague, serial` shard cleared all the per-shard path/tag/fixture steps (`Compute per-shard identifiers`, both slugged checkouts, `Build erigon image` with the slugged tag, `Get dependencies and build hive` incl. the Dockerfile repoint + fail-fast `ARG tag=…` check, and `Stage fixtures`) and reached the test phase. Remaining shards were cancelled since this is a workflow-only change off `main` and they were contending with this PR's own `test-hive` shards for the `hive` group.
- The verdict-hardening commit (step `id` + `outcome != 'success'` gate) landed **after** that dispatch, so it isn't covered by run 28548787480; it's trivial shell logic, `actionlint`-clean, doesn't touch the setup/build path, and `test-hive`'s copy of it is exercised by this PR's own checks.

Hardens the current self-hosted path; complements the hosted-runner experiment (#21576) and base-image caching (#21115).
