### PR TITLE
execution: read-ahead warmup must not clobber fresher StateCache entries

### DIFF
--- a/execution/cache/cache.go
+++ b/execution/cache/cache.go
@@ -30,6 +30,11 @@ type Cache interface {
 	// reflects (used for txNum/epoch unwind invalidation).
 	Put(key []byte, value []byte, txNum uint64)
 
+	// PutIfAbsent is Put except that a live entry for key is left untouched
+	// (a stale one is replaced) — for prefetch writers, whose snapshot may
+	// already be superseded by an authoritative Put.
+	PutIfAbsent(key []byte, value []byte, txNum uint64)
+
 	// Delete removes the data for the given key.
 	Delete(key []byte)
 

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -855,4 +856,26 @@ func TestCodeCache_PutWithCodeHashIfAbsent(t *testing.T) {
 	size, ok := cc.GetCodeSizeByCodeHash(staleHash)
 	require.True(t, ok)
 	assert.Equal(t, len(stale), size)
+}
+
+// A conditional put must be atomic w.r.t. a concurrent unconditional Put of
+// the same key: without a shared critical section the conditional writer can
+// check (absent), lose the CPU to the authoritative writer's insert, then
+// clobber it — the prefetch-vs-flush staleness this cache guards against.
+func TestDomainCache_PutIfAbsentAtomicWithPut(t *testing.T) {
+	c := NewDomainCacheMode(1*datasize.MB, ModeEvictLRU)
+	addr := makeAddr(1)
+	fresh := []byte("fresh")
+	stale := []byte("stale")
+	for round := 0; round < 20000; round++ {
+		c.Delete(addr)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); c.Put(addr, fresh, 20) }()
+		go func() { defer wg.Done(); c.PutIfAbsent(addr, stale, 10) }()
+		wg.Wait()
+		v, ok := c.Get(addr)
+		require.True(t, ok)
+		require.Equal(t, fresh, v, "round %d: PutIfAbsent raced past a concurrent Put", round)
+	}
 }

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/db/kv"
 )
 
@@ -770,4 +771,88 @@ func TestUnwind_FloorOnlyMovesDown(t *testing.T) {
 
 	_, ok := c.Get(k)
 	assert.False(t, ok, "deeper unwind's floor must not be raised by a later shallower one")
+}
+
+func TestDomainCache_PutIfAbsent(t *testing.T) {
+	c := NewDomainCacheMode(1*datasize.KB, ModeEvictLRU)
+	addr := makeAddr(1)
+	fresh := []byte("fresh")
+	stale := []byte("stale")
+
+	// Absent → inserts.
+	c.PutIfAbsent(addr, stale, 10)
+	v, ok := c.Get(addr)
+	require.True(t, ok)
+	assert.Equal(t, stale, v)
+
+	// Live entry → left untouched.
+	c.Put(addr, fresh, 20)
+	c.PutIfAbsent(addr, stale, 10)
+	v, ok = c.Get(addr)
+	require.True(t, ok)
+	assert.Equal(t, fresh, v, "PutIfAbsent must not replace a live entry")
+
+	// Entry below the unwind floor survives the unwind and still blocks PutIfAbsent.
+	low := makeAddr(2)
+	c.Put(low, fresh, 3)
+	c.Unwind(5)
+	c.PutIfAbsent(low, stale, 4)
+	v, ok = c.Get(low)
+	require.True(t, ok)
+	assert.Equal(t, fresh, v)
+
+	// Stale entry (at/above the floor, superseded epoch) → replaced.
+	c.PutIfAbsent(addr, stale, 10) // addr's entry was stamped txNum 20 >= floor 5
+	v, ok = c.Get(addr)
+	require.True(t, ok)
+	assert.Equal(t, stale, v, "PutIfAbsent must replace a stale entry")
+}
+
+func TestCodeCache_PutIfAbsentKeepsLiveAddrBinding(t *testing.T) {
+	cc := NewCodeCache(1*datasize.MB, 1*datasize.MB)
+	addr := makeAddr(1)
+	fresh := []byte{0xaa, 1, 2, 3}
+	stale := []byte{0xbb, 4, 5, 6}
+
+	cc.PutIfAbsent(addr, stale, 10)
+	v, ok := cc.Get(addr)
+	require.True(t, ok)
+	assert.Equal(t, stale, v)
+
+	cc.Put(addr, fresh, 20)
+	cc.PutIfAbsent(addr, stale, 10)
+	v, ok = cc.Get(addr)
+	require.True(t, ok)
+	assert.Equal(t, fresh, v, "PutIfAbsent must not rebind a live addr entry")
+
+	// After an unwind marks the binding stale, PutIfAbsent may rebind.
+	cc.Unwind(5)
+	cc.PutIfAbsent(addr, stale, 4)
+	v, ok = cc.Get(addr)
+	require.True(t, ok)
+	assert.Equal(t, stale, v)
+}
+
+func TestCodeCache_PutWithCodeHashIfAbsent(t *testing.T) {
+	cc := NewCodeCache(1*datasize.MB, 1*datasize.MB)
+	addr := makeAddr(1)
+	fresh := []byte{0xaa, 1, 2, 3}
+	stale := []byte{0xbb, 4, 5, 6}
+	freshHash := crypto.Keccak256(fresh)
+	staleHash := crypto.Keccak256(stale)
+
+	cc.PutWithCodeHash(addr, fresh, freshHash, 20)
+	cc.PutWithCodeHashIfAbsent(addr, stale, staleHash, 10)
+
+	v, ok := cc.Get(addr)
+	require.True(t, ok)
+	assert.Equal(t, fresh, v, "addr must stay bound to the fresher code")
+
+	// The content-addressed layers are per-key-immutable and still populated.
+	v, ok = cc.GetByCodeHash(staleHash)
+	require.True(t, ok)
+	assert.Equal(t, stale, v)
+	size, ok := cc.GetCodeSizeByCodeHash(staleHash)
+	require.True(t, ok)
+	assert.Equal(t, len(stale), size)
 }

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -310,7 +310,14 @@ func (c *CodeCache) GetWithTxNum(addr []byte) ([]byte, uint64, bool) {
 func (c *CodeCache) Put(addr []byte, code []byte, txNum uint64) {
 	// No codeHash in hand here, so the entry is left unverified against maphash
 	// collisions. The EVM read path uses PutWithCodeHash, which records it.
-	c.putCode(addr, code, [32]byte{}, txNum)
+	c.putCode(addr, code, [32]byte{}, txNum, true)
+}
+
+// PutIfAbsent is Put except that a live addr→code binding is kept — for
+// prefetch writers, whose snapshot may already be superseded. The
+// content-addressed layers are per-key-immutable and skip live entries anyway.
+func (c *CodeCache) PutIfAbsent(addr []byte, code []byte, txNum uint64) {
+	c.putCode(addr, code, [32]byte{}, txNum, false)
 }
 
 // putCode populates the addr→codeID and codeID→code layers. keyHash is the
@@ -318,14 +325,22 @@ func (c *CodeCache) Put(addr []byte, code []byte, txNum uint64) {
 // a 64-bit maphash collision. Size is accounted only on the goroutine that
 // actually inserts (LoadOrStore is atomic), so concurrent Puts of the same
 // cold code can't both Add and permanently inflate codeSize.
-func (c *CodeCache) putCode(addr []byte, code []byte, keyHash [32]byte, txNum uint64) {
+func (c *CodeCache) putCode(addr []byte, code []byte, keyHash [32]byte, txNum uint64, overwriteAddr bool) {
 	if len(code) == 0 {
 		return
 	}
 	ep := c.coh.Epoch()
 	codeID := maphash.Hash(code)
 
-	c.addrToHash.Add(common.BytesToAddress(addr), versionedAddressID{addrID: codeID, codeHash: keyHash, txNum: txNum, epoch: ep})
+	a := common.BytesToAddress(addr)
+	bindAddr := overwriteAddr
+	if !bindAddr {
+		e, ok := c.addrToHash.Get(a)
+		bindAddr = !ok || c.isStale(e.txNum, e.epoch)
+	}
+	if bindAddr {
+		c.addrToHash.Add(a, versionedAddressID{addrID: codeID, codeHash: keyHash, txNum: txNum, epoch: ep})
+	}
 
 	hashKey := uint64AsBytes(&codeID)
 	entry := codeEntry{code: code, keyHash: keyHash, txNum: txNum, epoch: ep}
@@ -405,6 +420,17 @@ func (c *CodeCache) GetByCodeHash(codeHash []byte) ([]byte, bool) {
 // addr may be empty to populate only codeHashToCode (e.g. when populating from a
 // codehash-only path that hasn't seen the addr yet).
 func (c *CodeCache) PutWithCodeHash(addr []byte, code []byte, codeHash []byte, txNum uint64) {
+	c.putWithCodeHash(addr, code, codeHash, txNum, true)
+}
+
+// PutWithCodeHashIfAbsent is PutWithCodeHash except that a live addr→code
+// binding is kept — for prefetch writers, whose snapshot may already be
+// superseded.
+func (c *CodeCache) PutWithCodeHashIfAbsent(addr []byte, code []byte, codeHash []byte, txNum uint64) {
+	c.putWithCodeHash(addr, code, codeHash, txNum, false)
+}
+
+func (c *CodeCache) putWithCodeHash(addr []byte, code []byte, codeHash []byte, txNum uint64, overwriteAddr bool) {
 	if len(code) == 0 || len(codeHash) == 0 {
 		return
 	}
@@ -412,7 +438,7 @@ func (c *CodeCache) PutWithCodeHash(addr []byte, code []byte, codeHash []byte, t
 	kh := hash32(codeHash)
 
 	if len(addr) > 0 {
-		c.putCode(addr, code, kh, txNum)
+		c.putCode(addr, code, kh, txNum, overwriteAddr)
 	}
 
 	// Populate the size-only layer alongside the bytes layer — every time

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -318,9 +318,8 @@ func (c *CodeCache) Put(addr []byte, code []byte, txNum uint64) {
 	c.putCode(addr, code, [32]byte{}, txNum, true)
 }
 
-// PutIfAbsent is Put except that a live addr→code binding is kept — for
-// prefetch writers, whose snapshot may already be superseded. The
-// content-addressed layers are per-key-immutable and skip live entries anyway.
+// PutIfAbsent implements Cache.PutIfAbsent for the addr→code binding; the
+// content-addressed layers skip live entries regardless.
 func (c *CodeCache) PutIfAbsent(addr []byte, code []byte, txNum uint64) {
 	c.putCode(addr, code, [32]byte{}, txNum, false)
 }
@@ -430,9 +429,8 @@ func (c *CodeCache) PutWithCodeHash(addr []byte, code []byte, codeHash []byte, t
 	c.putWithCodeHash(addr, code, codeHash, txNum, true)
 }
 
-// PutWithCodeHashIfAbsent is PutWithCodeHash except that a live addr→code
-// binding is kept — for prefetch writers, whose snapshot may already be
-// superseded.
+// PutWithCodeHashIfAbsent is PutWithCodeHash with if-absent binding semantics
+// (see Cache.PutIfAbsent).
 func (c *CodeCache) PutWithCodeHashIfAbsent(addr []byte, code []byte, codeHash []byte, txNum uint64) {
 	c.putWithCodeHash(addr, code, codeHash, txNum, false)
 }

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -17,6 +17,7 @@
 package cache
 
 import (
+	"sync"
 	"sync/atomic"
 	"unsafe"
 
@@ -149,6 +150,10 @@ type CodeCache struct {
 	// an entry is valid iff written in the current epoch OR its txNum is below
 	// the unwind floor. See execution/cache/coherence.
 	coh coherence.Gen
+
+	// addrBindMu serializes addr→code binding writers so PutIfAbsent's
+	// check+bind is atomic w.r.t. a concurrent authoritative rebind.
+	addrBindMu sync.Mutex
 
 	// Stats counters (atomic for concurrent access)
 	addrHits       atomic.Uint64
@@ -333,6 +338,7 @@ func (c *CodeCache) putCode(addr []byte, code []byte, keyHash [32]byte, txNum ui
 	codeID := maphash.Hash(code)
 
 	a := common.BytesToAddress(addr)
+	c.addrBindMu.Lock()
 	bindAddr := overwriteAddr
 	if !bindAddr {
 		e, ok := c.addrToHash.Get(a)
@@ -341,6 +347,7 @@ func (c *CodeCache) putCode(addr []byte, code []byte, keyHash [32]byte, txNum ui
 	if bindAddr {
 		c.addrToHash.Add(a, versionedAddressID{addrID: codeID, codeHash: keyHash, txNum: txNum, epoch: ep})
 	}
+	c.addrBindMu.Unlock()
 
 	hashKey := uint64AsBytes(&codeID)
 	entry := codeEntry{code: code, keyHash: keyHash, txNum: txNum, epoch: ep}

--- a/execution/cache/code_cache_concurrency_test.go
+++ b/execution/cache/code_cache_concurrency_test.go
@@ -118,3 +118,25 @@ func TestCodeCache_ConcurrentDistinctPuts_RespectCap(t *testing.T) {
 	require.GreaterOrEqual(t, cc.codeHashCodeSize.Load(), int64(0),
 		"codeHashToCode size must stay non-negative (no double back-out)")
 }
+
+// Same atomicity requirement for the addr→code binding: a concurrent
+// authoritative Put must win over a conditional prefetch put in every
+// interleaving.
+func TestCodeCache_PutIfAbsentAtomicWithPut(t *testing.T) {
+	cc := NewCodeCache(64*datasize.MB, 16*datasize.MB)
+	addr := make([]byte, 20)
+	addr[0] = 0xcd
+	fresh := []byte{0xaa, 1, 2, 3}
+	stale := []byte{0xbb, 4, 5, 6}
+	for round := 0; round < 20000; round++ {
+		cc.Delete(addr)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); cc.Put(addr, fresh, 20) }()
+		go func() { defer wg.Done(); cc.PutIfAbsent(addr, stale, 10) }()
+		wg.Wait()
+		v, ok := cc.Get(addr)
+		require.True(t, ok)
+		require.Equal(t, fresh, v, "round %d: PutIfAbsent raced past a concurrent Put", round)
+	}
+}

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"bytes"
+	"sync"
 	"sync/atomic"
 
 	"github.com/c2h5oh/datasize"
@@ -28,6 +29,10 @@ import (
 	"github.com/erigontech/erigon/common/maphash"
 	"github.com/erigontech/erigon/execution/cache/coherence"
 )
+
+// putStripeCount sizes the same-key write-serialization stripes; power of two
+// so the stripe index is a mask of the key hash.
+const putStripeCount = 256
 
 // avgBytesPerEntry is the assumption used to translate a byte budget into
 // the entry-count cap that freelru.ShardedLRU is sized against. 256 B
@@ -63,6 +68,10 @@ type GenericCache[T any] struct {
 	// valid iff written in the current epoch OR its txNum is below the unwind
 	// floor. See execution/cache/coherence.
 	coh coherence.Gen
+
+	// putStripes serialize same-key writers so PutIfAbsent's check+insert is
+	// atomic w.r.t. a concurrent Put (freelru offers no conditional insert).
+	putStripes [putStripeCount]sync.Mutex
 
 	hits         atomic.Uint64
 	misses       atomic.Uint64
@@ -208,6 +217,10 @@ func (c *GenericCache[T]) put(key []byte, value T, txNum uint64, overwrite bool)
 	valBytes := c.sizeFunc(value)
 	newSize := len(key) + valBytes + 24
 	ep := c.coh.Epoch()
+
+	mu := &c.putStripes[h&(putStripeCount-1)]
+	mu.Lock()
+	defer mu.Unlock()
 
 	existing, hasExisting := c.data.Get(h)
 

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -192,6 +192,18 @@ func (c *GenericCache[T]) GetWithTxNum(key []byte) (T, uint64, bool) {
 // In ModeNoOp inserts that would overflow the byte budget are dropped
 // (and counted via the dropped metric).
 func (c *GenericCache[T]) Put(key []byte, value T, txNum uint64) {
+	c.put(key, value, txNum, true)
+}
+
+// PutIfAbsent is Put except that a live entry for key is left untouched (a
+// stale one is replaced). Prefetch writers must use this: they read an older
+// snapshot, so an unconditional Put racing an authoritative one could pin
+// superseded state in the cache.
+func (c *GenericCache[T]) PutIfAbsent(key []byte, value T, txNum uint64) {
+	c.put(key, value, txNum, false)
+}
+
+func (c *GenericCache[T]) put(key []byte, value T, txNum uint64, overwrite bool) {
 	h := maphash.Hash(key)
 	valBytes := c.sizeFunc(value)
 	newSize := len(key) + valBytes + 24
@@ -203,6 +215,9 @@ func (c *GenericCache[T]) Put(key []byte, value T, txNum uint64) {
 	// avoid an extra allocation; the freshly-decoded value replaces the
 	// old one.
 	if hasExisting && bytes.Equal(existing.key, key) {
+		if !overwrite && !c.coh.IsStale(existing.txNum, existing.epoch) {
+			return
+		}
 		c.data.Add(h, entry[T]{key: existing.key, val: value, size: newSize, txNum: txNum, epoch: ep})
 		c.currentSize.Add(int64(newSize - existing.size))
 		return

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -204,10 +204,8 @@ func (c *GenericCache[T]) Put(key []byte, value T, txNum uint64) {
 	c.put(key, value, txNum, true)
 }
 
-// PutIfAbsent is Put except that a live entry for key is left untouched (a
-// stale one is replaced). Prefetch writers must use this: they read an older
-// snapshot, so an unconditional Put racing an authoritative one could pin
-// superseded state in the cache.
+// PutIfAbsent implements Cache.PutIfAbsent (live entry kept, stale one
+// replaced).
 func (c *GenericCache[T]) PutIfAbsent(key []byte, value T, txNum uint64) {
 	c.put(key, value, txNum, false)
 }

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -158,22 +158,25 @@ func (c *StateCache) GetCodeByHash(codeHash []byte) ([]byte, bool) {
 // codeHash-keyed codeHashToCode layer. Callers should prefer this over Put when they
 // have the codeHash from the account record — avoids a redundant keccak.
 func (c *StateCache) PutCodeWithHash(addr, code, codeHash []byte, txNum uint64) {
-	cc, ok := c.caches[kv.CodeDomain].(*CodeCache)
-	if !ok {
-		return
-	}
-	cc.PutWithCodeHash(addr, common.Copy(code), codeHash, txNum)
+	c.putCodeWithHash(addr, code, codeHash, txNum, true)
 }
 
-// PutCodeWithHashIfAbsent is PutCodeWithHash except that a live addr→code
-// binding is kept — for prefetch writers, whose snapshot may already be
-// superseded.
+// PutCodeWithHashIfAbsent is PutCodeWithHash with if-absent binding semantics
+// (see Cache.PutIfAbsent).
 func (c *StateCache) PutCodeWithHashIfAbsent(addr, code, codeHash []byte, txNum uint64) {
+	c.putCodeWithHash(addr, code, codeHash, txNum, false)
+}
+
+func (c *StateCache) putCodeWithHash(addr, code, codeHash []byte, txNum uint64, overwrite bool) {
 	cc, ok := c.caches[kv.CodeDomain].(*CodeCache)
 	if !ok {
 		return
 	}
-	cc.PutWithCodeHashIfAbsent(addr, common.Copy(code), codeHash, txNum)
+	if overwrite {
+		cc.PutWithCodeHash(addr, common.Copy(code), codeHash, txNum)
+	} else {
+		cc.PutWithCodeHashIfAbsent(addr, common.Copy(code), codeHash, txNum)
+	}
 }
 
 // GetCodeSizeByHash returns the size of code by its Ethereum codeHash
@@ -234,19 +237,15 @@ func (c *StateCache) DeleteAddrCodeHash(addr []byte) {
 // Put stores data for the given domain and key, stamped with the txNum the
 // value reflects (for txNum/epoch unwind invalidation).
 func (c *StateCache) Put(domain kv.Domain, key []byte, value []byte, txNum uint64) {
-	cache := c.caches[domain]
-	if cache == nil {
-		return
-	}
-	if domain == kv.CommitmentDomain && bytes.Equal(key, commitmentdb.KeyCommitmentState) {
-		return
-	}
-	cache.Put(key, common.Copy(value), txNum)
+	c.put(domain, key, value, txNum, true)
 }
 
-// PutIfAbsent is Put except that a live entry is left untouched — for prefetch
-// writers, whose snapshot may already be superseded by an authoritative Put.
+// PutIfAbsent is Put with if-absent semantics (see Cache.PutIfAbsent).
 func (c *StateCache) PutIfAbsent(domain kv.Domain, key []byte, value []byte, txNum uint64) {
+	c.put(domain, key, value, txNum, false)
+}
+
+func (c *StateCache) put(domain kv.Domain, key []byte, value []byte, txNum uint64, overwrite bool) {
 	cache := c.caches[domain]
 	if cache == nil {
 		return
@@ -254,7 +253,11 @@ func (c *StateCache) PutIfAbsent(domain kv.Domain, key []byte, value []byte, txN
 	if domain == kv.CommitmentDomain && bytes.Equal(key, commitmentdb.KeyCommitmentState) {
 		return
 	}
-	cache.PutIfAbsent(key, common.Copy(value), txNum)
+	if overwrite {
+		cache.Put(key, common.Copy(value), txNum)
+	} else {
+		cache.PutIfAbsent(key, common.Copy(value), txNum)
+	}
 }
 
 // Delete removes the data for the given domain and key.

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -165,6 +165,17 @@ func (c *StateCache) PutCodeWithHash(addr, code, codeHash []byte, txNum uint64) 
 	cc.PutWithCodeHash(addr, common.Copy(code), codeHash, txNum)
 }
 
+// PutCodeWithHashIfAbsent is PutCodeWithHash except that a live addr→code
+// binding is kept — for prefetch writers, whose snapshot may already be
+// superseded.
+func (c *StateCache) PutCodeWithHashIfAbsent(addr, code, codeHash []byte, txNum uint64) {
+	cc, ok := c.caches[kv.CodeDomain].(*CodeCache)
+	if !ok {
+		return
+	}
+	cc.PutWithCodeHashIfAbsent(addr, common.Copy(code), codeHash, txNum)
+}
+
 // GetCodeSizeByHash returns the size of code by its Ethereum codeHash
 // without loading the bytes. Returns (0, false) when the size-only layer
 // is not populated for this hash.
@@ -231,6 +242,19 @@ func (c *StateCache) Put(domain kv.Domain, key []byte, value []byte, txNum uint6
 		return
 	}
 	cache.Put(key, common.Copy(value), txNum)
+}
+
+// PutIfAbsent is Put except that a live entry is left untouched — for prefetch
+// writers, whose snapshot may already be superseded by an authoritative Put.
+func (c *StateCache) PutIfAbsent(domain kv.Domain, key []byte, value []byte, txNum uint64) {
+	cache := c.caches[domain]
+	if cache == nil {
+		return
+	}
+	if domain == kv.CommitmentDomain && bytes.Equal(key, commitmentdb.KeyCommitmentState) {
+		return
+	}
+	cache.PutIfAbsent(key, common.Copy(value), txNum)
 }
 
 // Delete removes the data for the given domain and key.

--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -103,7 +103,8 @@ func (cpg *cachePopulatingGetter) GetLatest(name kv.Domain, k []byte) ([]byte, k
 		} else {
 			// Cache including nil/empty results: a probe returning no
 			// bytes is a valid negative answer (missing account, empty
-			// storage slot, no code) and caching it lets repeated probes
+			// storage slot; empty code lands here too but CodeCache drops
+			// zero-length puts) and caching it lets repeated probes
 			// skip the file accessor stack. Mirrors revm's CacheAccount
 			// { account: None, status: LoadedNotExisting } pattern.
 			// Stamp with an upper bound on the value's write txNum (last txNum

--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -90,13 +90,16 @@ type cachePopulatingGetter struct {
 func (cpg *cachePopulatingGetter) GetLatest(name kv.Domain, k []byte) ([]byte, kv.Step, error) {
 	v, step, err := cpg.g.GetLatest(name, k)
 	if err == nil && cpg.sc != nil {
+		// If-absent writes only: this runs in a fire-and-forget goroutine over a
+		// committed snapshot, so an unconditional Put racing an FCU flush's
+		// cache-apply could replace the flushed value with the pre-flush one.
 		if name == kv.CodeDomain && len(v) > 0 {
 			// Key the content cache by the code's OWN hash, never a separately
 			// read account codeHash: under parallel/speculative exec that hash
 			// can be skewed or cross-account, and a (hash, code) pair that
 			// doesn't satisfy keccak(code)==hash poisons every account sharing
 			// the hash. keccak(v) makes each entry self-consistent.
-			cpg.sc.PutCodeWithHash(k, v, crypto.Keccak256(v), (uint64(step)+1)*cpg.stepSize-1)
+			cpg.sc.PutCodeWithHashIfAbsent(k, v, crypto.Keccak256(v), (uint64(step)+1)*cpg.stepSize-1)
 		} else {
 			// Cache including nil/empty results: a probe returning no
 			// bytes is a valid negative answer (missing account, empty
@@ -105,7 +108,7 @@ func (cpg *cachePopulatingGetter) GetLatest(name kv.Domain, k []byte) ([]byte, k
 			// { account: None, status: LoadedNotExisting } pattern.
 			// Stamp with an upper bound on the value's write txNum (last txNum
 			// of the step it came from) so unwind invalidation is correct.
-			cpg.sc.Put(name, k, v, (uint64(step)+1)*cpg.stepSize-1)
+			cpg.sc.PutIfAbsent(name, k, v, (uint64(step)+1)*cpg.stepSize-1)
 		}
 	}
 	return v, step, err

--- a/execution/exec/blocks_read_ahead_test.go
+++ b/execution/exec/blocks_read_ahead_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package exec
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/cache"
+)
+
+// stubTemporalGetter stands in for the committed-state snapshot a warmup
+// goroutine reads: every GetLatest returns the same fixed value.
+type stubTemporalGetter struct {
+	v    []byte
+	step kv.Step
+}
+
+func (s stubTemporalGetter) GetLatest(kv.Domain, []byte) ([]byte, kv.Step, error) {
+	return s.v, s.step, nil
+}
+
+func (s stubTemporalGetter) HasPrefix(kv.Domain, []byte) ([]byte, []byte, bool, error) {
+	return nil, nil, false, nil
+}
+
+func (s stubTemporalGetter) StepsInFiles(...kv.Domain) kv.Step { return 0 }
+
+func newTestStateCache() *cache.StateCache {
+	b := 1 * datasize.MB
+	return cache.NewStateCache(b, b, b, b)
+}
+
+// A warmup read-through must never replace a fresher entry an authoritative
+// writer (the FCU flush cache-apply) has already put: the warmup reads a
+// pre-flush snapshot, so a laggard Put landing after the flush would pin stale
+// state in the cache and corrupt the next block's execution.
+func TestCachePopulatingGetterKeepsFresherEntry(t *testing.T) {
+	key := []byte("\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff\x00\x11\x22\x33\x44")
+	fresh := []byte("account-record-nonce-5")
+	stale := []byte("account-record-nonce-4")
+	for _, domain := range []kv.Domain{kv.AccountsDomain, kv.StorageDomain} {
+		sc := newTestStateCache()
+		sc.Put(domain, key, fresh, 54)
+		cpg := &cachePopulatingGetter{g: stubTemporalGetter{v: stale}, sc: sc, stepSize: 1_562_500}
+
+		v, _, err := cpg.GetLatest(domain, key)
+		require.NoError(t, err)
+		require.Equal(t, stale, v, "read-through must still return the snapshot value")
+
+		got, ok := sc.Get(domain, key)
+		require.True(t, ok, "domain %s", domain)
+		require.Equal(t, fresh, got, "domain %s: warmup must not clobber the fresher entry", domain)
+	}
+}
+
+// Same invariant for the code addr→code binding, which is rebound when an
+// account's code changes and is therefore just as clobber-able as accounts.
+func TestCachePopulatingGetterKeepsFresherCodeBinding(t *testing.T) {
+	addr := []byte("\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff\x00\x11\x22\x33\x44")
+	freshCode := []byte{0xaa, 0x01, 0x02, 0x03}
+	staleCode := []byte{0xbb, 0x04, 0x05, 0x06}
+	sc := newTestStateCache()
+	sc.PutCodeWithHash(addr, freshCode, crypto.Keccak256(freshCode), 54)
+	cpg := &cachePopulatingGetter{g: stubTemporalGetter{v: staleCode}, sc: sc, stepSize: 1_562_500}
+
+	_, _, err := cpg.GetLatest(kv.CodeDomain, addr)
+	require.NoError(t, err)
+
+	got, ok := sc.Get(kv.CodeDomain, addr)
+	require.True(t, ok)
+	require.Equal(t, freshCode, got, "warmup must not rebind addr to older code")
+}
+
+// Cold keys must still be warmed — that is the prefetcher's purpose.
+func TestCachePopulatingGetterWarmsColdKeys(t *testing.T) {
+	key := []byte("\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff\x00\x11\x22\x33\x44")
+	val := []byte("account-record")
+	code := []byte{0xaa, 0x01, 0x02, 0x03}
+
+	for _, domain := range []kv.Domain{kv.AccountsDomain, kv.StorageDomain} {
+		sc := newTestStateCache()
+		cpg := &cachePopulatingGetter{g: stubTemporalGetter{v: val}, sc: sc, stepSize: 1_562_500}
+		_, _, err := cpg.GetLatest(domain, key)
+		require.NoError(t, err)
+		got, ok := sc.Get(domain, key)
+		require.True(t, ok, "domain %s", domain)
+		require.Equal(t, val, got, "domain %s", domain)
+	}
+
+	sc := newTestStateCache()
+	cpg := &cachePopulatingGetter{g: stubTemporalGetter{v: code}, sc: sc, stepSize: 1_562_500}
+	_, _, err := cpg.GetLatest(kv.CodeDomain, key)
+	require.NoError(t, err)
+	got, ok := sc.Get(kv.CodeDomain, key)
+	require.True(t, ok)
+	require.Equal(t, code, got)
+
+	// Negative results (missing account, empty slot) are cached as nil hits.
+	sc = newTestStateCache()
+	cpg = &cachePopulatingGetter{g: stubTemporalGetter{v: nil}, sc: sc, stepSize: 1_562_500}
+	_, _, err = cpg.GetLatest(kv.AccountsDomain, key)
+	require.NoError(t, err)
+	got, ok = sc.Get(kv.AccountsDomain, key)
+	require.True(t, ok)
+	require.Empty(t, got)
+}

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -383,8 +383,9 @@ func (e *ExecModule) canonicalHash(ctx context.Context, tx kv.Tx, blockNumber ui
 // warmBody is fire-and-forget and populates the shared state/branch caches; if
 // it is still running when an unwind bumps the cache epoch, it can Put a
 // pre-unwind (dead-fork) value stamped with the post-unwind epoch — IsStale then
-// returns false and the stale value is served as canonical (wrong root). Call
-// before every UnwindTo that invalidates the cache.
+// returns false and the stale value is served as canonical (wrong root). A
+// laggard Put can likewise land after a flush's cache-apply and pin the
+// pre-flush snapshot. Call before any unwind epoch-bump or flush cache-apply.
 func (e *ExecModule) drainReadAhead() {
 	if e.readAheader == nil {
 		return

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -179,6 +179,12 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	})
 	defer cleanupBeforeSemaRelease()
 
+	// Drain any warmup a preceding newPayload spawned: its Puts reflect a
+	// pre-FCU snapshot and must land before this FCU's unwind epoch-bump and
+	// flush cache-apply, not after them (no new warmup starts while we hold
+	// the semaphore).
+	e.drainReadAhead()
+
 	var validationError string
 	type canonicalEntry struct {
 		hash   common.Hash
@@ -410,9 +416,6 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 				}, false)
 			}
 
-			// Drain in-flight warmup before the unwind bumps the cache epoch
-			// (cross-fork contamination — see drainReadAhead).
-			e.drainReadAhead()
 			if err := e.pipelineExecutor.UnwindTo(unwindTarget, stagedsync.ForkChoice, tx); err != nil {
 				return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 			}


### PR DESCRIPTION
Fixes #22151.

## Problem

Since #21386 merged (2026-06-30), `eest-spec-enginextests-stable-sequential` has been flaking in the merge queue: three of the four queue evictions on 2026-07-01 (PRs #22133, #22125, #22119) were this job failing exactly 1 of 63,920 tests with `payload status is not valid: INVALID`, always accompanied by a single

```
[EROR] [5/5 Execution] Wrong trie root of block N: <computed>, expected (from header): <expected>
```

and always in a `tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py::test_fork_transition_excess_blob_gas_post_blob_genesis[...]` parametrization — a different one each time. I verified for all three CI failures that the wrong-root block hash belongs to block N of the named test in the EEST v5.4.0 fixtures.

## Root cause

A stale-read race between the block read-ahead warmup and the FCU flush, introduced by #21386's "same hashmap" prefetch wiring:

1. Every `newPayload` spawns a fire-and-forget `warmBody` goroutine (`AddHeaderAndBody`, `execution/exec/blocks_read_ahead.go`). It opens its own RO tx on **committed canonical state** — i.e. the *parent* block's post-state — and `Put`s every touched account/storage/code value into the per-node `StateCache` via `cachePopulatingGetter`.
2. The subsequent FCU commits the new block and, post-commit, `Put`s the block's **new** values into the same cache (`SharedDomains` flush callbacks).
3. Nothing orders the two writers on the extending-head path. `drainReadAhead` — whose own doc comment describes exactly this staleness hazard — was called only on the *unwind* paths. A laggard warmup `Put` landing after the flush overwrites fresh state with parent-block state: `GenericCache.Put` replaces unconditionally and stamps the **current** epoch, so the lazy-unwind staleness check (`epoch != current && txNum >= floor`) considers the stale entry fresh from then on.
4. The next block's execution reads the stale nonce/balance/slot through the cache → wrong post-state → wrong trie root → `INVALID`.

The blob fork-transition fixtures are simply the most exposed corpus: they combine a transaction in every block (the same sender rewritten and re-read every block), long *extending* chains (~25 payload+FCU cycles with no reorg, so no epoch bump ever rescues the cache), and 6 tests sharing one node. The parallel shard runs the same code and is equally exposed. This also affects any `main`-based node at chain tip (same `newPayload` → FCU sequence; mainnet's 12s cadence narrows but does not close the window). No release branch is affected.

### Evidence

- Reproduced the CI signature locally at `f1d79d69` by looping `evm enginextest` over `test_fork_transition_excess_blob_gas_post_blob_genesis.json` (`ERIGON_EXEC3_PARALLEL=false`, `GOMAXPROCS=4`, 8 workers).
- With `ERIGON_ASSERT_STATE_CACHE=true` the assert panics within 1–3 file-runs, during `ValidatePayload` of the next block:

  ```
  stateCache divergence: domain=accounts key=9aaa…3c75 cached=00010c0000 db=00010d0000 txNum=54
  ```

  cached nonce **12** vs authoritative nonce **13** — stale by exactly one block, i.e. the warmup's parent-state value sitting on top of the flushed head-state value.
- Differential: the identical loop with `ERIGON_READ_AHEAD=false` ran 40/40 clean; with read-ahead enabled it failed at iterations 1 and 3.

## Fix

Two complementary layers:

1. **Prefetch writes can no longer clobber authoritative ones.** New `PutIfAbsent` (and `PutCodeWithHashIfAbsent` for the code addr→code binding): a live entry is left untouched, a stale one (superseded epoch, txNum at/above the unwind floor) is replaced. `cachePopulatingGetter` now uses only these. With this semantic, either ordering converges to the fresh value: if the flush lands first the warmup no-ops; if the warmup lands first the flush (unconditional `Put`) overwrites it. The check+insert is atomic w.r.t. concurrent same-key writers — striped mutexes in `GenericCache`, a bind mutex around the `CodeCache` addr→code binding — so there is no window where a conditional writer checks (absent), loses the CPU to an authoritative insert, then clobbers it. The content-addressed code layers already skip live entries and are unchanged.
2. **Ordering.** `updateForkChoice` drains any in-flight warmup at entry — before the unwind epoch-bump *and* the flush cache-apply — subsuming the previous unwind-path-only drain. No new warmup can start while the engine semaphore is held (`AddHeaderAndBody` is only reached from `ValidateChain`).

Layer two alone closes the observed race; layer one hardens the prefetcher against a future path without the semaphore invariant (e.g. reviving `FcuBackgroundCommit`, or a new warmup call site). Layer one also matters for #22116's drain-free direction: getter-level epoch capture covers the unwind race but not this flush race (no epoch bump on the extending-head path), so if the drains are later removed per #22116, the if-absent guarantee is what keeps this bug closed. One scoping caveat for such a future design: if-absent semantics — however atomic — cannot protect against authoritative *deletions*. The flush cache-apply expresses account/slot deletion as `Delete(key)`, and a laggard prefetch running truly concurrently could then re-insert the key from its older snapshot ("absent" cannot distinguish never-cached from just-deleted). Under this PR that cannot happen because of layer two; a design that runs prefetch concurrently with flushes must add tombstone handling rather than rely on if-absent alone.

Note for reviewers: a "put if newer txNum" variant would be wrong — warmup entries are stamped with a step-granularity *upper bound* (last txNum of the step, ~1.56M for step 0) while flush entries carry exact write txNums, so newer-wins would always prefer the stale warmup value.

## Testing

TDD: `TestCachePopulatingGetterKeepsFresherEntry` / `...KeepsFresherCodeBinding` were written first and failed on the pre-fix code with the stale value clobbering the fresh one; they pass with the fix. `TestCachePopulatingGetterWarmsColdKeys` pins the prefetcher's intended behavior (cold keys, including nil negative results, still get warmed). Unit tests cover `PutIfAbsent` semantics on both cache types, including keep-below-floor-survivors and replace-stale-after-unwind. `TestDomainCache_PutIfAbsentAtomicWithPut` / `TestCodeCache_PutIfAbsentAtomicWithPut` hammer a single key with a concurrent `Put`+`PutIfAbsent` pair and assert the authoritative value wins in every interleaving — red before the striped locks (stale value won within a few thousand rounds), green and `-race`-clean after. The drain reordering has no isolated unit test (it needs the full engine flow); it is covered by the end-to-end validation below.

- `go test ./execution/cache/... ./execution/exec/ ./execution/execmodule/...` clean.
- End-to-end: 40/40 clean iterations of the repro loop (fixed binary, read-ahead **enabled**, `ERIGON_ASSERT_STATE_CACHE=true`, `GOMAXPROCS=4`, 8 workers) vs failures at iterations 1–3 before the fix.
- `make lint` clean.
