### PR TITLE
[r3.5] execution/stagedsync: wire storage-subtree enumerator into calculator self-destruct

### DIFF
--- a/execution/stagedsync/calc_state.go
+++ b/execution/stagedsync/calc_state.go
@@ -67,6 +67,11 @@ func (r *calcDomainReader) ReadAccountStorage(addr accounts.Address, key account
 	return val, true, nil
 }
 
+// storageEnumerator lists every persisted storage slot under an address.
+type storageEnumerator interface {
+	EachStorageSlot(addr accounts.Address, fn func(key accounts.StorageKey) error) error
+}
+
 // calcState is the commitment calculator's local state accumulator.
 // It maintains the current state for every account/storage key that has been
 // touched. On first touch, values are lazy-loaded from the domain via the
@@ -81,6 +86,10 @@ type calcState struct {
 
 	// domainReader provides lazy-load from the domain via asOfStateReader.
 	domainReader *calcDomainReader
+
+	// storageEnum enumerates an account's persisted storage subtree for
+	// self-destruct; nil disables the on-disk subtree wipe.
+	storageEnum storageEnumerator
 
 	// lazyLoadErr captures the first error encountered during ensureAccount /
 	// ensureStorage. Sticky — never cleared — so the calculator can fail the
@@ -104,8 +113,48 @@ func newCalcState(reader *asOfStateReader, logger log.Logger, logPrefix string) 
 		storageState: make(map[accounts.Address]map[accounts.StorageKey]uint256.Int),
 		storageDirty: make(map[accounts.Address]map[accounts.StorageKey]bool),
 		domainReader: &calcDomainReader{reader: reader},
+		storageEnum:  &asOfStorageEnumerator{reader: reader},
 		logger:       logger,
 		logPrefix:    logPrefix,
+	}
+}
+
+// deleteStorageSubtree zeroes and dirties every storage slot under a
+// self-destructed account, including untouched on-disk slots pulled via
+// storageEnum, so FlushToUpdates emits a DeleteUpdate for each.
+func (cs *calcState) deleteStorageSubtree(addr accounts.Address) {
+	slots := cs.storageState[addr]
+	if slots == nil {
+		slots = make(map[accounts.StorageKey]uint256.Int)
+		cs.storageState[addr] = slots
+	}
+	dirty := cs.storageDirty[addr]
+	if dirty == nil {
+		dirty = make(map[accounts.StorageKey]bool)
+		cs.storageDirty[addr] = dirty
+	}
+	for key := range slots {
+		slots[key] = uint256.Int{}
+		dirty[key] = true
+	}
+	if cs.storageEnum == nil {
+		return
+	}
+	if err := cs.storageEnum.EachStorageSlot(addr, func(key accounts.StorageKey) error {
+		if _, ok := slots[key]; !ok {
+			slots[key] = uint256.Int{}
+			dirty[key] = true
+		}
+		return nil
+	}); err != nil {
+		// Sticky — a partial subtree wipe yields a wrong root, so fail the
+		// next compute rather than silently leaving stale slots.
+		if cs.lazyLoadErr == nil {
+			cs.lazyLoadErr = fmt.Errorf("deleteStorageSubtree(%x): %w", addr.Value(), err)
+		}
+		if cs.logger != nil {
+			cs.logger.Warn("["+cs.logPrefix+"] commitmentCalculator: SD storage enumeration failed", "addr", addr, "err", err)
+		}
 	}
 }
 
@@ -282,17 +331,7 @@ func (cs *calcState) ApplyWrites(writes state.VersionedWrites) {
 				acc.Nonce = 0
 				acc.CodeHash = empty.CodeHash
 				acc.Incarnation = 0
-				// Zero every tracked storage slot and mark dirty so
-				// FlushToUpdates emits DeleteUpdate per slot.
-				if slots, ok := cs.storageState[w.Address]; ok {
-					if cs.storageDirty[w.Address] == nil {
-						cs.storageDirty[w.Address] = make(map[accounts.StorageKey]bool)
-					}
-					for key := range slots {
-						slots[key] = uint256.Int{}
-						cs.storageDirty[w.Address][key] = true
-					}
-				}
+				cs.deleteStorageSubtree(w.Address)
 			}
 		case state.StoragePath:
 			v := w.Val.(uint256.Int)

--- a/execution/stagedsync/calc_state_test.go
+++ b/execution/stagedsync/calc_state_test.go
@@ -533,6 +533,63 @@ func TestSDStorageCascade_EmitsPerSlotDeletes(t *testing.T) {
 		"both pre-loaded slots must emit DeleteUpdate after the cascade")
 }
 
+// mockStorageEnum returns a fixed persisted-slot set per address.
+type mockStorageEnum struct {
+	slots map[accounts.Address][]accounts.StorageKey
+}
+
+func (m *mockStorageEnum) EachStorageSlot(addr accounts.Address, fn func(key accounts.StorageKey) error) error {
+	for _, k := range m.slots[addr] {
+		if err := fn(k); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestSDOfPreExistingContract_DeletesUntouchedSlots checks that a self-destruct
+// deletes the whole persisted storage subtree, not just the EVM-touched slots.
+func TestSDOfPreExistingContract_DeletesUntouchedSlots(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0x40, 0x55, 0xca, 0xe5})
+	// On-disk slots never read/written this block, so they never enter storageState.
+	untouched1 := accounts.InternKey(common.Hash{0x11})
+	untouched2 := accounts.InternKey(common.Hash{0x22})
+
+	cs := newTestCalcState()
+	cs.storageEnum = &mockStorageEnum{slots: map[accounts.Address][]accounts.StorageKey{
+		addr: {untouched1, untouched2},
+	}}
+
+	cs.ApplyWrites(state.VersionedWrites{
+		&state.VersionedWrite{Address: addr, Path: state.IncarnationPath, Val: uint64(3)},
+		&state.VersionedWrite{Address: addr, Path: state.SelfDestructPath, Val: true},
+		&state.VersionedWrite{Address: addr, Path: state.BalancePath, Val: uint256.Int{}},
+	})
+
+	updates := newTestUpdates()
+	cs.FlushToUpdates(updates)
+
+	addrBytes := addr.Value()
+	gotSlots := map[common.Hash]commitment.Update{}
+	require.NoError(t, updates.HashSort(t.Context(), nil, func(_, k []byte, u *commitment.Update) error {
+		if len(k) == 52 && bytes.Equal(k[:20], addrBytes[:]) {
+			var h common.Hash
+			copy(h[:], k[20:])
+			gotSlots[h] = *u
+		}
+		return nil
+	}))
+
+	require.Len(t, gotSlots, 2,
+		"both untouched on-disk slots must be deleted on SD (matches serial's DomainDelPrefix)")
+	for _, sk := range []accounts.StorageKey{untouched1, untouched2} {
+		u, ok := gotSlots[sk.Value()]
+		require.True(t, ok, "untouched slot %x must emit a delete", sk.Value())
+		assert.Equal(t, commitment.DeleteUpdate, u.Flags,
+			"untouched slot %x must emit DeleteUpdate", sk.Value())
+	}
+}
+
 func lookupKeyUpdate(t *testing.T, updates *commitment.Updates, plainKey string) *commitment.Update {
 	t.Helper()
 	var found *commitment.Update


### PR DESCRIPTION
Follow-up to #22135, which merged before this fix landed.

On release/3.5 the parallel commitment calculator zeroed only EVM-touched
storage slots on self-destruct. The exec loop's `DomainDelPrefix` wipes the
whole subtree, but with inline TouchKey disabled the calculator never sees
those deletions, so untouched on-disk slots survived in commitment — a wrong
storage/state root when a pre-existing contract self-destructs under
`--experimental.parallel-commitment`.

`asOfStorageEnumerator` was already present on the branch but unwired. This
connects it:

- add `storageEnum` to `calcState` + `deleteStorageSubtree`, called from the
  `SelfDestructPath` handler
- enumerate and delete the full persisted storage subtree, matching main and
  serial's `DomainDelPrefix`
- port `TestSDOfPreExistingContract_DeletesUntouchedSlots` from main

Only the experimental parallel-commitment path is affected; default
single-trie/serial is unchanged.
