### PR TITLE
execution/exec, execmodule: don't seed state cache from async read-ahead (fixes wrong trie root on reorg)

### DIFF
--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -10,14 +10,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/db/services"
-	"github.com/erigontech/erigon/execution/cache"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types"
@@ -33,14 +31,6 @@ type BlockReadAheader struct {
 	// this is for warming state
 	warming atomic.Bool // only one warmBody can run at a time
 	warmWg  sync.WaitGroup
-
-	// stateCache is the process-global state cache that SharedDomains.GetLatest
-	// consults on the EVM hot path. When set, warmBody routes its prefetches
-	// through a cache-populating getter so the same hashmap the EVM probes is
-	// pre-warmed. Without it, prefetches only warm OS page cache + RoTx
-	// cursors — disconnected from the cache layer the EVM actually reads.
-	// Mirrors reth's CachedReads / ExecutionCache "same hashmap" property.
-	stateCache *cache.StateCache
 }
 
 func NewBlockReadAheader() *BlockReadAheader {
@@ -61,62 +51,6 @@ func NewBlockReadAheader() *BlockReadAheader {
 		bodies:  bodies,
 		senders: senders,
 	}
-}
-
-// SetStateCache wires the process-global state cache so warmBody's
-// prefetches land in the same hashmap that SharedDomains.GetLatest probes
-// on the EVM hot path. Without this, prefetches warm OS page cache only —
-// the EVM still pays the file accessor stack on its first per-address read.
-// Idempotent; safe to call before the first AddHeaderAndBody.
-func (bra *BlockReadAheader) SetStateCache(sc *cache.StateCache) {
-	bra.stateCache = sc
-}
-
-// cachePopulatingGetter wraps a kv.TemporalGetter and writes successful
-// reads through to a cache.StateCache as a side effect. Used by warmBody
-// to make read-ahead prefetches populate the same in-process cache layer
-// that SharedDomains.GetLatest consults — eliminating the file-accessor
-// stack cost on the EVM's first touch of any prefetched address.
-//
-// For the CodeDomain the wrapper also populates the codeHashToCode
-// (codeHash→bytes) + size-cache layers via PutCodeWithHash, keyed by the
-// code's own keccak hash so every cached pair is self-consistent.
-type cachePopulatingGetter struct {
-	g        kv.TemporalGetter
-	sc       *cache.StateCache
-	stepSize uint64 // for the read txNum upper bound (last txNum of the read's step)
-}
-
-func (cpg *cachePopulatingGetter) GetLatest(name kv.Domain, k []byte) ([]byte, kv.Step, error) {
-	v, step, err := cpg.g.GetLatest(name, k)
-	if err == nil && cpg.sc != nil {
-		if name == kv.CodeDomain && len(v) > 0 {
-			// Key the content cache by the code's OWN hash, never a separately
-			// read account codeHash: under parallel/speculative exec that hash
-			// can be skewed or cross-account, and a (hash, code) pair that
-			// doesn't satisfy keccak(code)==hash poisons every account sharing
-			// the hash. keccak(v) makes each entry self-consistent.
-			cpg.sc.PutCodeWithHash(k, v, crypto.Keccak256(v), (uint64(step)+1)*cpg.stepSize-1)
-		} else {
-			// Cache including nil/empty results: a probe returning no
-			// bytes is a valid negative answer (missing account, empty
-			// storage slot, no code) and caching it lets repeated probes
-			// skip the file accessor stack. Mirrors revm's CacheAccount
-			// { account: None, status: LoadedNotExisting } pattern.
-			// Stamp with an upper bound on the value's write txNum (last txNum
-			// of the step it came from) so unwind invalidation is correct.
-			cpg.sc.Put(name, k, v, (uint64(step)+1)*cpg.stepSize-1)
-		}
-	}
-	return v, step, err
-}
-
-func (cpg *cachePopulatingGetter) HasPrefix(name kv.Domain, prefix []byte) ([]byte, []byte, bool, error) {
-	return cpg.g.HasPrefix(name, prefix)
-}
-
-func (cpg *cachePopulatingGetter) StepsInFiles(entitySet ...kv.Domain) kv.Step {
-	return cpg.g.StepsInFiles(entitySet...)
 }
 
 func (bra *BlockReadAheader) AddHeaderAndBody(ctx context.Context, db kv.RoDB, header *types.Header, body *types.Body) {
@@ -162,6 +96,11 @@ func (bra *BlockReadAheader) AddSenders(senders []byte, blockHash common.Hash) {
 // It reads: To accounts, To account code, To account storage from access lists,
 // and block-level access lists. Each worker creates its own transaction.
 // Only one warmBody can run at a time - concurrent calls are no-ops.
+//
+// It deliberately does not populate the state cache: each worker reads a
+// separate committed snapshot that can lag an in-flight reorg unwind, so
+// seeding the coherence-tracked cache here would serve dead-fork state as
+// canonical and produce a wrong trie root.
 func (bra *BlockReadAheader) warmBody(ctx context.Context, db kv.RoDB, header *types.Header, body *types.Body, workers int) {
 	defer bra.warming.Store(false)
 
@@ -223,11 +162,7 @@ func (bra *BlockReadAheader) warmBody(ctx context.Context, db kv.RoDB, header *t
 				if !ok {
 					return nil
 				}
-				var getter kv.TemporalGetter = ttx
-				if bra.stateCache != nil {
-					getter = &cachePopulatingGetter{g: ttx, sc: bra.stateCache, stepSize: ttx.Debug().StepSize()}
-				}
-				stateReader := state.NewReaderV3(getter)
+				stateReader := state.NewReaderV3(ttx)
 
 				for idx := workerStart; idx < workerEnd; idx++ {
 					select {
@@ -293,13 +228,7 @@ func (bra *BlockReadAheader) warmBody(ctx context.Context, db kv.RoDB, header *t
 			if !ok {
 				return nil
 			}
-			var getter kv.TemporalGetter = ttx
-			var cpg *cachePopulatingGetter
-			if bra.stateCache != nil {
-				cpg = &cachePopulatingGetter{g: ttx, sc: bra.stateCache, stepSize: ttx.Debug().StepSize()}
-				getter = cpg
-			}
-			stateReader := state.NewReaderV3(getter)
+			stateReader := state.NewReaderV3(ttx)
 
 			for txIdx := workerStart; txIdx < workerEnd; txIdx++ {
 				select {

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -293,13 +293,6 @@ func NewExecModule(
 		stopNode:                stopNode,
 	}
 
-	// Wire the process-global state cache into the read-ahead so its
-	// prefetches populate the same hashmap that SharedDomains.GetLatest
-	// probes on the EVM hot path. Reth's "same hashmap" pattern.
-	if readAheader != nil {
-		readAheader.SetStateCache(domainCache)
-	}
-
 	if stateCache != nil {
 		stateCache.execModule = em
 	}


### PR DESCRIPTION
## Problem

The async block read-ahead (`warmBody`) populated the process-global `StateCache` via a cache-populating getter reading a **separate committed RoTx snapshot**. After a reorg, `SharedDomains.Unwind` reverts `sd.mem` and bumps the cache coherence epoch, but it does **not** rewrite the committed on-disk files until the canonical re-flush. So during fork-validation re-execution the read-ahead reads **dead-fork state** from the still-stale committed files and `Put`s it stamped with the **current** epoch.

The `(txNum, epoch)` coherence scheme deliberately exempts current-epoch entries from the `txNum`/floor check — it assumes anything written in the current epoch is canonical, which holds for the synchronous writer (which writes what it computed) but **not** for an async reader of stale committed files. So `IsStale` short-circuits `false`, the dead-fork value is served to commitment as canonical, and the block gets a **wrong trie root → `payload status INVALID`**.

The existing `drainReadAhead()` calls before each cache-invalidating unwind close the "warmBody in-flight *during* the unwind" window, but not the "warmBody seeds *after* the unwind, during re-exec, from still-stale committed files" window.

## Reproduction

`evm enginextest` over the EEST stable engine-x `test_excess_blob_gas_fork_transition` fixtures (fork transitions reorg across the boundary), `ERIGON_EXEC3_PARALLEL=false`:

- `USE_STATE_CACHE=true`, read-ahead on: **reproduces ~1/28** (`[5/5 Execution] Wrong trie root of block N` → `INVALID`).
- `USE_STATE_CACHE=false`: clean 150/150.
- `USE_STATE_CACHE=true`, `READ_AHEAD=false`: clean 105/105.

This is the same failure that intermittently dequeues PRs from the merge queue (e.g. the `eest-spec-enginextests-stable-sequential` job on #22125 and #22133).

## Fix

Stop the async read-ahead from populating the `StateCache`. `warmBody` still warms the OS page cache + RoTx cursors; the **synchronous writer (`SharedDomains` flush) becomes the sole `StateCache` populator**, so every cached entry reflects canonical state and the coherence current-epoch exemption is sound again.

After the fix, the exact 1/28 config (`USE_STATE_CACHE=true`, read-ahead on) runs **200/200 clean** (zero wrong-roots) — corroborated by the `READ_AHEAD=false` A/B arm above (105/105 clean), which is functionally what this change makes permanent for the cache-seeding path.

`make lint`, `make erigon integration`, and the `execution/engineapi` unwind/reorg/state-churn + `execution/exec` package tests all pass.

## Perf note / follow-up

This reverts the read-ahead's "same hashmap" prefetch into the `StateCache` (the EVM now pays an in-process cache miss — not the file-accessor stack, since the value is still warm in the page cache — on first touch of a prefetched address). A perf-preserving version that keeps the read-ahead seeding needs a per-read gate that skips future/dead-fork committed data, which requires **exact per-read txNum** (step granularity is a no-op at `stepSize=390_625` — a small fixture's whole reorg range is one step; exact txNum is only exposed via `AggregatorRoTx.MeteredGetLatestWithTxN`) **plus** a fork-correct pre-state txNum bound. Tracked as a follow-up.

## TDD note

The bug is a timing race, reproduced via the `evm enginextest` loop (~1/28) rather than a deterministic Go test; the fix is verified by that loop going clean and by the existing `execution/engineapi` unwind/reorg/state-churn tests continuing to pass.
