### PR TITLE
commitment: deep storage fold dropped untouched on-disk slots (#22113)

### DIFF
--- a/execution/commitment/deepfold_subset_regression_test.go
+++ b/execution/commitment/deepfold_subset_regression_test.go
@@ -90,3 +90,20 @@ func TestDeepFold_PreExistingWhale_SubsetTouched(t *testing.T) {
 	u1 = append(append([]Update{}, fu...), u1...)
 	requireAllEnginesParity(t, k1, u1, k2, u2, 4)
 }
+
+// A pre-existing on-disk whale whose storage all sits under a SINGLE first-storage-nibble
+// has no branch record exactly at the account prefix — its storage top is a deeper
+// extension. The next block touches other first-nibbles, crossing deepStorageThreshold and
+// driving the deep storage fold. unfoldStorageBase finds no branch at the account prefix;
+// it must still recover the untouched single-nibble subtree rather than seeding an empty
+// base and dropping it, so the parallel/streaming root matches sequential. Regression for
+// the empty-seed sibling drop (#22113).
+func TestDeepFold_PreExistingWhale_SingleNibbleOnDisk(t *testing.T) {
+	onDisk := nibs(0)   // all existing slots under one first-nibble -> no branch at the account prefix
+	touch := nibs(3, 7) // next block touches disjoint first-nibbles, crossing the deep-fold threshold
+	k1, u1, k2, u2 := buildSubsetTouchedWhale(20260702, onDisk, touch, 120, 700)
+	fk, fu := buildMixedCorpus(4242, 200)
+	k1 = append(append([][]byte{}, fk...), k1...)
+	u1 = append(append([]Update{}, fu...), u1...)
+	requireAllEnginesParity(t, k1, u1, k2, u2, 4)
+}

--- a/execution/commitment/streaming_commitment_test.go
+++ b/execution/commitment/streaming_commitment_test.go
@@ -936,8 +936,7 @@ func TestStreaming_MultiDepthSplitParity(t *testing.T) {
 		require.Equalf(t, seqRoot, root, "multi-depth streaming(workers=%d) root != ModeDirect", w)
 		require.Equalf(t, parRoot, root, "multi-depth streaming(workers=%d) root != ModeParallel", w)
 		requireBranchParity(t, seqMs, ms)
-		// First-commit whale: no persisted branch at the account prefix, so it takes the
-		// streaming-recursion fallback, not the deep fold; root/branch parity above is the check.
+		// First-commit whale takes the streaming-recursion fallback, not the deep fold.
 		sc.Release()
 	}
 }
@@ -1002,8 +1001,7 @@ func TestStreaming_StorageInteriorSplits(t *testing.T) {
 
 		require.Equalf(t, seqRoot, root, "whale storage-interior split(workers=%d) root != sequential", w)
 		requireBranchParity(t, seqMs, ms)
-		// First-commit whale: no persisted branch at the account prefix, so it takes the
-		// streaming-recursion fallback, not the deep fold; root/branch parity above is the check.
+		// First-commit whale takes the streaming-recursion fallback, not the deep fold.
 		sc.Release()
 	}
 }

--- a/execution/commitment/streaming_commitment_test.go
+++ b/execution/commitment/streaming_commitment_test.go
@@ -936,7 +936,8 @@ func TestStreaming_MultiDepthSplitParity(t *testing.T) {
 		require.Equalf(t, seqRoot, root, "multi-depth streaming(workers=%d) root != ModeDirect", w)
 		require.Equalf(t, parRoot, root, "multi-depth streaming(workers=%d) root != ModeParallel", w)
 		requireBranchParity(t, seqMs, ms)
-		require.NotZerof(t, sc.DeepLocalFolds(), "account@64 must fold through foldStorageRoot (workers=%d)", w)
+		// First-commit whale: no persisted branch at the account prefix, so it takes the
+		// streaming-recursion fallback, not the deep fold; root/branch parity above is the check.
 		sc.Release()
 	}
 }
@@ -1001,7 +1002,8 @@ func TestStreaming_StorageInteriorSplits(t *testing.T) {
 
 		require.Equalf(t, seqRoot, root, "whale storage-interior split(workers=%d) root != sequential", w)
 		requireBranchParity(t, seqMs, ms)
-		require.NotZerof(t, sc.DeepLocalFolds(), "account must fold through foldStorageRoot (workers=%d)", w)
+		// First-commit whale: no persisted branch at the account prefix, so it takes the
+		// streaming-recursion fallback, not the deep fold; root/branch parity above is the check.
 		sc.Release()
 	}
 }

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -51,8 +51,12 @@ func unfoldStorageBase(base *HexPatriciaHashed, accPrefix []byte) error {
 	if err != nil {
 		return err
 	}
-	if len(branch) < 4 {
+	if len(branch) == 0 {
 		return errStorageBaseNotBranch
+	}
+	// A stored branch is always >= 4 bytes (touchMap+afterMap); a shorter non-empty read is corrupt, not missing.
+	if len(branch) < 4 {
+		return fmt.Errorf("unfoldStorageBase: corrupt branch record at %x: %d bytes", accPrefix, len(branch))
 	}
 	base.branchBefore[0] = true
 	return base.decodeBranchIntoRow(0, d+1, branch[2:], false)

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -31,6 +31,13 @@ import (
 )
 
 // Seed the base from the real on-disk branch, not a hand-seed, so untouched first-nibble subtrees survive instead of dropping and diverging the root from the sequential trie.
+// errStorageBaseNotBranch signals that the on-disk storage trie has no branch
+// exactly at the account prefix (its top is a deeper extension because the
+// existing slots share a first nibble). The deep parallel storage fold seeds
+// row 0 from that branch, so its absence would drop untouched on-disk siblings
+// from the storage root. Callers fall back to normal streaming recursion.
+var errStorageBaseNotBranch = errors.New("streaming: storage base has no branch at account prefix")
+
 func unfoldStorageBase(base *HexPatriciaHashed, accPrefix []byte) error {
 	d := int16(len(accPrefix))
 	copy(base.currentKey[:], accPrefix)
@@ -47,7 +54,7 @@ func unfoldStorageBase(base *HexPatriciaHashed, accPrefix []byte) error {
 		return err
 	}
 	if len(branch) < 4 {
-		return nil
+		return errStorageBaseNotBranch
 	}
 	base.branchBefore[0] = true
 	return base.decodeBranchIntoRow(0, d+1, branch[2:], false)
@@ -87,11 +94,17 @@ func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storage
 
 	if isDeepStorageAccount(node, len(path)) {
 		sr, err := storageRoot(node, path)
-		if err != nil {
+		if err == nil {
+			setAccountStorageRoot(w, path, sr)
+			return nil
+		}
+		if !errors.Is(err, errStorageBaseNotBranch) {
 			return fmt.Errorf("storageRoot: %w", err)
 		}
-		setAccountStorageRoot(w, path, sr)
-		return nil
+		// No on-disk branch exactly at the account prefix: seeding row 0 from the
+		// (absent) branch would drop untouched on-disk siblings living under a
+		// deeper branch. Fall through to normal streaming recursion, which
+		// recovers them via per-key unfolds (the sequential path).
 	}
 
 	childIdx := 0

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -30,13 +30,11 @@ import (
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
 
-// Seed the base from the real on-disk branch, not a hand-seed, so untouched first-nibble subtrees survive instead of dropping and diverging the root from the sequential trie.
-// errStorageBaseNotBranch signals that the on-disk storage trie has no branch
-// exactly at the account prefix (its top is a deeper extension because the
-// existing slots share a first nibble). The deep parallel storage fold seeds
-// row 0 from that branch, so its absence would drop untouched on-disk siblings
-// from the storage root. Callers fall back to normal streaming recursion.
+// errStorageBaseNotBranch: no on-disk branch exactly at the account prefix (its
+// storage top is a deeper extension); callers fall back to streaming recursion.
 var errStorageBaseNotBranch = errors.New("streaming: storage base has no branch at account prefix")
+
+// Seed the base from the real on-disk branch, not a hand-seed, so untouched first-nibble subtrees survive instead of dropping and diverging the root from the sequential trie.
 
 func unfoldStorageBase(base *HexPatriciaHashed, accPrefix []byte) error {
 	d := int16(len(accPrefix))
@@ -101,10 +99,8 @@ func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storage
 		if !errors.Is(err, errStorageBaseNotBranch) {
 			return fmt.Errorf("storageRoot: %w", err)
 		}
-		// No on-disk branch exactly at the account prefix: seeding row 0 from the
-		// (absent) branch would drop untouched on-disk siblings living under a
-		// deeper branch. Fall through to normal streaming recursion, which
-		// recovers them via per-key unfolds (the sequential path).
+		// fall through to normal streaming recursion, which recovers the untouched
+		// on-disk siblings via per-key unfolds
 	}
 
 	childIdx := 0


### PR DESCRIPTION
Fixes #22113.

## Summary

Re-executing mainnet from genesis produced a wrong state root at ~block 1.33M under `--experimental.streaming-commitment` / `--experimental.parallel-commitment` (sequential commitment is unaffected).

A large-storage account whose existing on-disk slots share a first storage nibble has no commitment branch exactly at the account prefix — its storage top is a deeper extension. `unfoldStorageBase` seeded the deep-fold base empty in that case, so `foldStorageRoot` folded only the touched first-nibbles and dropped the untouched on-disk subtree, giving a wrong storage root and hence a wrong state root.

## Changes

- `unfoldStorageBase` returns a sentinel when there is no branch at the account prefix; `dfsSubtreeDeep` falls back to normal streaming recursion, which recovers the on-disk siblings via per-key unfolds.
- Regression test for a pre-existing single-nibble on-disk whale (RED before the fix, GREEN after).
- Two single-commit whale tests now assert root/branch parity: a first-commit whale (nothing to recover) also takes the fallback.
