### PR TITLE
cmd/utils/app: return errors from init/import instead of Fatalf

### DIFF
--- a/cmd/utils/app/import_cmd.go
+++ b/cmd/utils/app/import_cmd.go
@@ -77,7 +77,7 @@ processing will proceed even if an individual RLP-file import failure occurs.`,
 
 func importChain(cliCtx *cli.Context) error {
 	if cliCtx.NArg() < 1 {
-		utils.Fatalf("This command requires an argument.")
+		return errors.New("this command requires an argument")
 	}
 
 	// Force-disable subsystems the one-shot import doesn't need, via the normal
@@ -107,7 +107,10 @@ func importChain(cliCtx *cli.Context) error {
 	}
 
 	ethCfg := node.NewEthConfigUrfave(cliCtx, nodeCfg, logger)
-	stack := makeConfigNode(cliCtx.Context, nodeCfg, logger)
+	stack, err := makeConfigNode(cliCtx.Context, nodeCfg, logger)
+	if err != nil {
+		return err
+	}
 	defer stack.Close()
 
 	ethereum, err := eth.New(cliCtx.Context, stack, ethCfg, logger, tracer)

--- a/cmd/utils/app/init_cmd.go
+++ b/cmd/utils/app/init_cmd.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -65,25 +66,25 @@ func initGenesis(cliCtx *cli.Context) error {
 	// Make sure we have a valid genesis JSON
 	genesisPath := cliCtx.Args().First()
 	if len(genesisPath) == 0 {
-		utils.Fatalf("Must supply path to genesis JSON file")
+		return errors.New("must supply path to genesis JSON file")
 	}
 
 	file, err := os.Open(genesisPath)
 	if err != nil {
-		utils.Fatalf("Failed to read genesis file: %v", err)
+		return fmt.Errorf("failed to read genesis file: %w", err)
 	}
 	defer file.Close()
 
 	genesis := new(types.Genesis)
 	if err := json.NewDecoder(file).Decode(genesis); err != nil {
-		utils.Fatalf("invalid genesis file: %v", err)
+		return fmt.Errorf("invalid genesis file: %w", err)
 	}
 
 	if genesis.Config.BorJSON != nil {
 		borConfig := &borcfg.BorConfig{}
 		err = json.Unmarshal(genesis.Config.BorJSON, borConfig)
 		if err != nil {
-			panic(fmt.Sprintf("Could not parse 'bor' config for %s: %v", genesisPath, err))
+			return fmt.Errorf("could not parse 'bor' config for %s: %w", genesisPath, err)
 		}
 
 		genesis.Config.Bor = borConfig
@@ -98,8 +99,9 @@ func initGenesis(cliCtx *cli.Context) error {
 
 	chaindb, err := node.OpenDatabase(cliCtx.Context, stack.Config(), dbcfg.ChainDB, "", false, logger)
 	if err != nil {
-		utils.Fatalf("Failed to open database: %v", err)
+		return fmt.Errorf("failed to open database: %w", err)
 	}
+	defer chaindb.Close()
 
 	if tracer != nil {
 		if tracer.Hooks != nil && tracer.Hooks.OnBlockchainInit != nil {
@@ -108,7 +110,7 @@ func initGenesis(cliCtx *cli.Context) error {
 	}
 	_, block, err := genesiswrite.CommitGenesisBlock(chaindb, genesis, cliCtx.String(utils.ChainFlag.Name), datadir.New(cliCtx.String(utils.DataDirFlag.Name)), logger)
 	if err != nil {
-		utils.Fatalf("Failed to write genesis block: %v", err)
+		return fmt.Errorf("failed to write genesis block: %w", err)
 	}
 	chaindb.Close()
 	logger.Info("Successfully wrote genesis state", "hash", block.Hash(), "root", block.Root())

--- a/cmd/utils/app/init_cmd_test.go
+++ b/cmd/utils/app/init_cmd_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+
+	erigoncli "github.com/erigontech/erigon/node/cli"
+)
+
+// runApp runs the erigon CLI app in-process; the no-op ExitErrHandler makes a
+// failing command return its error instead of calling os.Exit.
+func runApp(args ...string) error {
+	app := MakeApp("erigon", func(*cli.Context) error { return nil }, erigoncli.DefaultFlags)
+	app.ExitErrHandler = func(*cli.Context, error) {}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return app.RunContext(ctx, append([]string{"erigon"}, args...))
+}
+
+// TestInitErrorsReturn pins that init failures surface as returned errors
+// rather than killing the process — required for in-process test drivers of
+// the CLI.
+func TestInitErrorsReturn(t *testing.T) {
+	dataDir := t.TempDir()
+
+	err := runApp("init", "--datadir", dataDir, filepath.Join(dataDir, "missing-genesis.json"))
+	require.ErrorContains(t, err, "genesis")
+
+	err = runApp("init", "--datadir", dataDir)
+	require.ErrorContains(t, err, "genesis")
+}
+
+func TestImportWithoutArgsErrorsReturn(t *testing.T) {
+	err := runApp("import", "--datadir", t.TempDir())
+	require.ErrorContains(t, err, "argument")
+}

--- a/cmd/utils/app/make_app.go
+++ b/cmd/utils/app/make_app.go
@@ -202,14 +202,13 @@ func MakeNodeWithDefaultConfig(cliCtx *cli.Context, logger log.Logger) (*node.No
 	if err != nil {
 		return nil, err
 	}
-	return makeConfigNode(cliCtx.Context, conf, logger), nil
+	return makeConfigNode(cliCtx.Context, conf, logger)
 }
 
-func makeConfigNode(ctx context.Context, config *nodecfg.Config, logger log.Logger) *node.Node {
+func makeConfigNode(ctx context.Context, config *nodecfg.Config, logger log.Logger) (*node.Node, error) {
 	stack, err := node.New(ctx, config, logger)
 	if err != nil {
-		utils.Fatalf("Failed to create Erigon node: %v", err)
+		return nil, fmt.Errorf("failed to create Erigon node: %w", err)
 	}
-
-	return stack
+	return stack, nil
 }


### PR DESCRIPTION
## Summary

`erigon init` and `erigon import` failure paths used `utils.Fatalf` (which calls `os.Exit(1)`) and one `panic`, so any failure — missing/unreadable genesis, invalid JSON, DB-open error, node construction failure — killed the whole process instead of returning an error through urfave/cli. For the real binary that is invisible (`cmd/erigon/main.go` prints a returned error to stderr and exits 1 anyway), but it kills the entire test binary when the CLI is driven in-process, as `TestImportReorgUnwindToGenesis` (#22058) does: no per-test failure attribution, the package's remaining tests are silently skipped, and `t.Cleanup` never runs. Flagged in review on #22058 (https://github.com/erigontech/erigon/pull/22058#discussion_r3512131943).

## Change

- `initGenesis`: five `utils.Fatalf` sites and the bor-config `panic` become returned errors; the chain DB gets a `defer chaindb.Close()` safety net (`MdbxKV.Close` is idempotent) so the new error returns don't leak it.
- `makeConfigNode` returns `(*node.Node, error)` instead of Fatalf-ing; both callers (`MakeNodeWithDefaultConfig`, `importChain`) propagate the error.
- `importChain`: the missing-argument `Fatalf` becomes a returned error.

Real-binary behavior is unchanged: returned errors are printed to stderr and the process exits 1 — only the `Fatal:` prefix is gone.

## Test (TDD)

`TestInitErrorsReturn` and `TestImportWithoutArgsErrorsReturn` drive the CLI in-process and assert failures come back as returned errors. Red before the fix — the test binary died with `Fatal: Failed to read genesis file: ...` and no per-test result — green after.
