### PR TITLE
.github: add @sudeepdino008 as CODEOWNER for /cl/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 *                      @AskAlexSharov @yperbasis
 /.github/workflows     @mriccobene @lystopad
-/cl/                   @domiwei @Giulio2002
+/cl/                   @domiwei @Giulio2002 @sudeepdino008
 /db/                   @AskAlexSharov @sudeepdino008
 /docs/                 @bloxster @AskAlexSharov @yperbasis
 /execution/            @yperbasis @mh0lt


### PR DESCRIPTION
Adds @sudeepdino008 to the `/cl/` CODEOWNERS entry so cl PRs request a review from him.

```
-/cl/                   @domiwei @Giulio2002
+/cl/                   @domiwei @Giulio2002 @sudeepdino008
```