### PR TITLE
db/state, execution/stagedsync: consolidate accumulator swap/restore behind SwapChangesetAccumulatorLocked

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -370,24 +370,20 @@ func (sd *SharedDomains) flushPendingUpdates(ctx context.Context, tx kv.Temporal
 		blockHash, cs = switcher.GetChangesetByBlockNum(upd.BlockNum)
 	}
 	if cs != nil {
-		// Save current accumulator, switch to the pending update's block
-		// changeset, apply deferred branch writes, save it back, then
-		// restore the original accumulator. All accesses under
-		// changesetMu — see concurrency contract on the wrappers above.
-		prev := switcher.GetChangesetAccumulator()
-		switcher.SetChangesetAccumulator(cs)
+		// Apply deferred branch writes under the pending update's block
+		// changeset, then save it back. All accesses under changesetMu —
+		// see concurrency contract on the wrappers above.
+		defer sd.SwapAccumulatorLocked(cs)()
 
 		if _, err := commitment.ApplyDeferredBranchUpdates(upd.Deferred, runtime.NumCPU(), putBranch); err != nil {
-			switcher.SetChangesetAccumulator(prev)
 			return err
 		}
 
 		switcher.SavePastChangesetAccumulator(blockHash, upd.BlockNum, cs)
-		switcher.SetChangesetAccumulator(prev)
 		return nil
 	}
 
-	// No past changeset found — write into whatever is current
+	// No past changeset found — write into whatever is current.
 	_, err := commitment.ApplyDeferredBranchUpdates(upd.Deferred, runtime.NumCPU(), putBranch)
 	return err
 }
@@ -597,6 +593,20 @@ func (sd *SharedDomains) GetChangesetAccumulatorLocked() *changeset.StateChangeS
 		return h.GetChangesetAccumulator()
 	}
 	return nil
+}
+
+// SwapAccumulatorLocked installs the given changeset accumulator and returns
+// a func that restores the previous one. Callers must hold changesetMu.
+func (sd *SharedDomains) SwapAccumulatorLocked(acc *changeset.StateChangeSet) (restore func()) {
+	prev := sd.GetChangesetAccumulatorLocked()
+	sd.SetChangesetAccumulatorLocked(acc)
+	return func() { sd.SetChangesetAccumulatorLocked(prev) }
+}
+
+// DetachAccumulatorLocked installs a nil changeset accumulator and returns a
+// func that restores the previous one. Callers must hold changesetMu.
+func (sd *SharedDomains) DetachAccumulatorLocked() (restore func()) {
+	return sd.SwapAccumulatorLocked(nil)
 }
 
 // GetChangesetByBlockNum returns the saved changeset for a given block

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -373,7 +373,7 @@ func (sd *SharedDomains) flushPendingUpdates(ctx context.Context, tx kv.Temporal
 		// Apply deferred branch writes under the pending update's block
 		// changeset, then save it back. All accesses under changesetMu —
 		// see concurrency contract on the wrappers above.
-		defer sd.SwapAccumulatorLocked(cs)()
+		defer sd.SwapChangesetAccumulatorLocked(cs)()
 
 		if _, err := commitment.ApplyDeferredBranchUpdates(upd.Deferred, runtime.NumCPU(), putBranch); err != nil {
 			return err
@@ -551,8 +551,8 @@ func (sd *SharedDomains) flushRequestMetrics() {
 // derivation lands and this lock + the swap dance can both be deleted.
 //
 // Inside the locked window callers must use the *Locked variants
-// (SwapAccumulatorLocked / DetachAccumulatorLocked) — the public Set/Get
-// acquire the same Mutex and would self-deadlock.
+// (SwapChangesetAccumulatorLocked / DetachChangesetAccumulatorLocked) —
+// the public Set/Get acquire the same Mutex and would self-deadlock.
 func (sd *SharedDomains) LockChangesetAccumulator()   { sd.changesetMu.Lock() }
 func (sd *SharedDomains) UnlockChangesetAccumulator() { sd.changesetMu.Unlock() }
 
@@ -562,7 +562,7 @@ func (sd *SharedDomains) UnlockChangesetAccumulator() { sd.changesetMu.Unlock() 
 // paths cannot torn-write or torn-read this pointer.
 func (sd *SharedDomains) SetChangesetAccumulator(acc *changeset.StateChangeSet) {
 	sd.changesetMu.Lock()
-	sd.mem.(accHolder).SetChangesetAccumulator(acc)
+	sd.setChangesetAccumulatorLocked(acc)
 	sd.changesetMu.Unlock()
 }
 
@@ -575,7 +575,8 @@ func (sd *SharedDomains) setChangesetAccumulatorLocked(acc *changeset.StateChang
 // GetChangesetAccumulator returns the currently-installed live changeset
 // accumulator (the one DomainPut writes diff entries into). Returns nil if
 // none is installed. Locks changesetMu internally — must NOT be called
-// while already holding the lock (use getChangesetAccumulatorLocked).
+// while already holding the lock (locked-window callers use
+// SwapChangesetAccumulatorLocked / DetachChangesetAccumulatorLocked).
 func (sd *SharedDomains) GetChangesetAccumulator() *changeset.StateChangeSet {
 	sd.changesetMu.Lock()
 	defer sd.changesetMu.Unlock()
@@ -591,18 +592,20 @@ func (sd *SharedDomains) getChangesetAccumulatorLocked() *changeset.StateChangeS
 	return nil
 }
 
-// SwapAccumulatorLocked installs the given changeset accumulator and returns
-// a func that restores the previous one. Callers must hold changesetMu.
-func (sd *SharedDomains) SwapAccumulatorLocked(acc *changeset.StateChangeSet) (restore func()) {
+// SwapChangesetAccumulatorLocked installs the given changeset accumulator
+// and returns a func that restores the previous one. Callers must hold
+// changesetMu.
+func (sd *SharedDomains) SwapChangesetAccumulatorLocked(acc *changeset.StateChangeSet) (restore func()) {
 	prev := sd.getChangesetAccumulatorLocked()
 	sd.setChangesetAccumulatorLocked(acc)
 	return func() { sd.setChangesetAccumulatorLocked(prev) }
 }
 
-// DetachAccumulatorLocked installs a nil changeset accumulator and returns a
-// func that restores the previous one. Callers must hold changesetMu.
-func (sd *SharedDomains) DetachAccumulatorLocked() (restore func()) {
-	return sd.SwapAccumulatorLocked(nil)
+// DetachChangesetAccumulatorLocked installs a nil changeset accumulator and
+// returns a func that restores the previous one. Callers must hold
+// changesetMu.
+func (sd *SharedDomains) DetachChangesetAccumulatorLocked() (restore func()) {
+	return sd.SwapChangesetAccumulatorLocked(nil)
 }
 
 // GetChangesetByBlockNum returns the saved changeset for a given block

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -551,8 +551,8 @@ func (sd *SharedDomains) flushRequestMetrics() {
 // derivation lands and this lock + the swap dance can both be deleted.
 //
 // Inside the locked window callers must use the *Locked variants
-// (Set/GetChangesetAccumulatorLocked) — the public Set/Get acquire the
-// same Mutex and would self-deadlock.
+// (SwapAccumulatorLocked / DetachAccumulatorLocked) — the public Set/Get
+// acquire the same Mutex and would self-deadlock.
 func (sd *SharedDomains) LockChangesetAccumulator()   { sd.changesetMu.Lock() }
 func (sd *SharedDomains) UnlockChangesetAccumulator() { sd.changesetMu.Unlock() }
 
@@ -566,29 +566,25 @@ func (sd *SharedDomains) SetChangesetAccumulator(acc *changeset.StateChangeSet) 
 	sd.changesetMu.Unlock()
 }
 
-// SetChangesetAccumulatorLocked is the unlocked variant for callers that
-// already hold changesetMu via LockChangesetAccumulator (the calculator's
-// per-block compute window).
-func (sd *SharedDomains) SetChangesetAccumulatorLocked(acc *changeset.StateChangeSet) {
+// setChangesetAccumulatorLocked is the unlocked variant of
+// SetChangesetAccumulator for use under changesetMu.
+func (sd *SharedDomains) setChangesetAccumulatorLocked(acc *changeset.StateChangeSet) {
 	sd.mem.(accHolder).SetChangesetAccumulator(acc)
 }
 
 // GetChangesetAccumulator returns the currently-installed live changeset
 // accumulator (the one DomainPut writes diff entries into). Returns nil if
 // none is installed. Locks changesetMu internally — must NOT be called
-// while already holding the lock (use GetChangesetAccumulatorLocked).
+// while already holding the lock (use getChangesetAccumulatorLocked).
 func (sd *SharedDomains) GetChangesetAccumulator() *changeset.StateChangeSet {
 	sd.changesetMu.Lock()
 	defer sd.changesetMu.Unlock()
-	if h, ok := sd.mem.(changesetSwitcher); ok {
-		return h.GetChangesetAccumulator()
-	}
-	return nil
+	return sd.getChangesetAccumulatorLocked()
 }
 
-// GetChangesetAccumulatorLocked is the unlocked variant for callers that
-// already hold changesetMu.
-func (sd *SharedDomains) GetChangesetAccumulatorLocked() *changeset.StateChangeSet {
+// getChangesetAccumulatorLocked is the unlocked variant of
+// GetChangesetAccumulator for use under changesetMu.
+func (sd *SharedDomains) getChangesetAccumulatorLocked() *changeset.StateChangeSet {
 	if h, ok := sd.mem.(changesetSwitcher); ok {
 		return h.GetChangesetAccumulator()
 	}
@@ -598,9 +594,9 @@ func (sd *SharedDomains) GetChangesetAccumulatorLocked() *changeset.StateChangeS
 // SwapAccumulatorLocked installs the given changeset accumulator and returns
 // a func that restores the previous one. Callers must hold changesetMu.
 func (sd *SharedDomains) SwapAccumulatorLocked(acc *changeset.StateChangeSet) (restore func()) {
-	prev := sd.GetChangesetAccumulatorLocked()
-	sd.SetChangesetAccumulatorLocked(acc)
-	return func() { sd.SetChangesetAccumulatorLocked(prev) }
+	prev := sd.getChangesetAccumulatorLocked()
+	sd.setChangesetAccumulatorLocked(acc)
+	return func() { sd.setChangesetAccumulatorLocked(prev) }
 }
 
 // DetachAccumulatorLocked installs a nil changeset accumulator and returns a

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -423,7 +423,7 @@ func (cc *commitmentCalculator) compute(ctx context.Context, t commitTarget, m c
 func (cc *commitmentCalculator) computeIsolated(ctx context.Context, t commitTarget) ([]byte, error) {
 	cc.doms.LockChangesetAccumulator()
 	defer cc.doms.UnlockChangesetAccumulator()
-	defer cc.doms.DetachAccumulatorLocked()()
+	defer cc.doms.DetachChangesetAccumulatorLocked()()
 
 	rh, err := cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 	if err != nil {
@@ -464,7 +464,7 @@ func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockRe
 // not pend into the first window block's changeset-routed compute.
 func (cc *commitmentCalculator) flushPendingUpdatesWithoutChangeset(ctx context.Context, br *blockResult) {
 	cc.doms.LockChangesetAccumulator()
-	restore := cc.doms.DetachAccumulatorLocked()
+	restore := cc.doms.DetachChangesetAccumulatorLocked()
 	err := cc.doms.FlushPendingUpdatesLocked(ctx, cc.roTx)
 	restore()
 	cc.doms.UnlockChangesetAccumulator()
@@ -556,7 +556,7 @@ func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context,
 	//
 	// Inside the lock we must use the *Locked variants — the public
 	// counterparts re-acquire the same Mutex and would self-deadlock.
-	defer cc.doms.SwapAccumulatorLocked(cs)()
+	defer cc.doms.SwapChangesetAccumulatorLocked(cs)()
 	return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 }
 

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -423,9 +423,7 @@ func (cc *commitmentCalculator) compute(ctx context.Context, t commitTarget, m c
 func (cc *commitmentCalculator) computeIsolated(ctx context.Context, t commitTarget) ([]byte, error) {
 	cc.doms.LockChangesetAccumulator()
 	defer cc.doms.UnlockChangesetAccumulator()
-	prev := cc.doms.GetChangesetAccumulatorLocked()
-	cc.doms.SetChangesetAccumulatorLocked(nil)
-	defer cc.doms.SetChangesetAccumulatorLocked(prev)
+	defer cc.doms.DetachAccumulatorLocked()()
 
 	rh, err := cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 	if err != nil {
@@ -466,10 +464,9 @@ func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockRe
 // not pend into the first window block's changeset-routed compute.
 func (cc *commitmentCalculator) flushPendingUpdatesWithoutChangeset(ctx context.Context, br *blockResult) {
 	cc.doms.LockChangesetAccumulator()
-	prev := cc.doms.GetChangesetAccumulatorLocked()
-	cc.doms.SetChangesetAccumulatorLocked(nil)
+	restore := cc.doms.DetachAccumulatorLocked()
 	err := cc.doms.FlushPendingUpdatesLocked(ctx, cc.roTx)
-	cc.doms.SetChangesetAccumulatorLocked(prev)
+	restore()
 	cc.doms.UnlockChangesetAccumulator()
 	if err != nil {
 		cc.publish(ctx, commitmentResult{
@@ -550,19 +547,16 @@ func (cc *commitmentCalculator) computeWithBlockAccumulator(ctx context.Context,
 		return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 	}
 	// LOAD-BEARING swap under the outer lock (already taken above). The
-	// Set/restore dance below mutates the global current-accumulator
-	// pointer; the deferred branch writes from block N-1 (flushed inside
+	// swap below mutates the global current-accumulator pointer; the
+	// deferred branch writes from block N-1 (flushed inside
 	// ComputeCommitmentLocked → FlushPendingUpdatesLocked) AND the [state]
 	// marker write at end of compute also touch that same global pointer
 	// and the per-domain diff fields. Holding changesetMu through all of
 	// it serializes against the apply goroutine's DomainPut/DomainDel.
 	//
-	// Inside the lock we must use the *Locked variants of Get/Set/Compute
-	// — the public counterparts re-acquire the same Mutex and would
-	// self-deadlock.
-	prev := cc.doms.GetChangesetAccumulatorLocked()
-	cc.doms.SetChangesetAccumulatorLocked(cs)
-	defer cc.doms.SetChangesetAccumulatorLocked(prev)
+	// Inside the lock we must use the *Locked variants — the public
+	// counterparts re-acquire the same Mutex and would self-deadlock.
+	defer cc.doms.SwapAccumulatorLocked(cs)()
 	return cc.doms.ComputeCommitmentLocked(ctx, cc.roTx, true, t.blockNum, t.lastTxNum, cc.logPrefix, nil)
 }
 

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -463,11 +463,14 @@ func (cc *commitmentCalculator) computeAndCheck(ctx context.Context, br *blockRe
 // update under a nil accumulator — a pre-window block's branch deltas must
 // not pend into the first window block's changeset-routed compute.
 func (cc *commitmentCalculator) flushPendingUpdatesWithoutChangeset(ctx context.Context, br *blockResult) {
-	cc.doms.LockChangesetAccumulator()
-	restore := cc.doms.DetachChangesetAccumulatorLocked()
-	err := cc.doms.FlushPendingUpdatesLocked(ctx, cc.roTx)
-	restore()
-	cc.doms.UnlockChangesetAccumulator()
+	// The closure bounds the locked window: publish must stay outside it —
+	// the send can block on the apply loop, which contends on changesetMu.
+	err := func() error {
+		cc.doms.LockChangesetAccumulator()
+		defer cc.doms.UnlockChangesetAccumulator()
+		defer cc.doms.DetachChangesetAccumulatorLocked()()
+		return cc.doms.FlushPendingUpdatesLocked(ctx, cc.roTx)
+	}()
 	if err != nil {
 		cc.publish(ctx, commitmentResult{
 			blockNum: br.BlockNum,


### PR DESCRIPTION
Split out of #22058 so the reorg-to-genesis regression test and this refactor can land independently.

## Accumulator-swap cleanup

The swap/restore pattern around commitment writes is consolidated behind `SharedDomains.SwapChangesetAccumulatorLocked(acc)` (returns a restore func), with `DetachChangesetAccumulatorLocked` as its nil case. The previously hand-rolled swap/restore sequences in `flushPendingUpdates`, `flushPendingUpdatesWithoutChangeset`, `computeWithBlockAccumulator`, and `computeIsolated` now use the helpers, collapsing the duplicated restores on error/success paths. `flushPendingUpdatesWithoutChangeset` scopes its locked window in a closure so restore and unlock are defer-based, while the error publish stays outside the lock (the send can block on the apply loop, which contends on `changesetMu`).

The consolidation leaves `Get`/`SetChangesetAccumulatorLocked` with no callers outside `SwapChangesetAccumulatorLocked` itself, so they are unexported (with the public `Set`/`GetChangesetAccumulator` delegating to them), and the `LockChangesetAccumulator` / `GetChangesetAccumulator` docs point locked-window callers at the swap helpers instead.
