### PR TITLE
node/eth, txnprovider/txpool: close txpool DB in Ethereum.Stop

### DIFF
--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1524,6 +1524,12 @@ func (s *Ethereum) Stop() error {
 		s.logger.Error("background component error", "err", err)
 	}
 
+	// The pool's Run closes the txpool DB only if the pool was started;
+	// cover never-started backends (the close is idempotent).
+	if s.txPool != nil {
+		s.txPool.Close()
+	}
+
 	// Wait for any in-flight updateForkChoice goroutine to finish. These are
 	// fire-and-forget goroutines that hold DB read transactions; without this
 	// wait, chainDB.Close() can hang in waitTxsAllDoneOnClose.

--- a/node/eth/backend_stop_test.go
+++ b/node/eth/backend_stop_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/mdbx"
+	"github.com/erigontech/erigon/execution/chain/networkname"
+	chainspec "github.com/erigontech/erigon/execution/chain/spec"
+	"github.com/erigontech/erigon/execution/state/genesiswrite"
+	"github.com/erigontech/erigon/node"
+	"github.com/erigontech/erigon/node/ethconfig"
+	"github.com/erigontech/erigon/node/nodecfg"
+	"github.com/erigontech/erigon/txnprovider/txpool/txpoolcfg"
+)
+
+// TestStopClosesTxPoolDBWithoutStart pins that Stop releases the txpool DB
+// even when the pool's Run loop — which normally owns closing it — never ran
+// because the backend was never started.
+func TestStopClosesTxPoolDBWithoutStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+
+	stack, err := node.New(ctx, &nodecfg.Config{
+		Dirs:            dirs,
+		DisableSentry:   true,
+		MdbxDBSizeLimit: 1 * datasize.GB,
+	}, logger)
+	require.NoError(t, err)
+	defer stack.Close()
+
+	chainDB, err := node.OpenDatabase(ctx, stack.Config(), dbcfg.ChainDB, "", false, logger)
+	require.NoError(t, err)
+	// Copy the spec genesis: it lacks Difficulty, which the stored-genesis
+	// JSON round-trip in New requires.
+	genesis := *chainspec.Test.Genesis
+	genesis.Difficulty = uint256.NewInt(0)
+	_, _, err = genesiswrite.CommitGenesisBlock(chainDB, &genesis, networkname.Test, dirs, logger)
+	require.NoError(t, err)
+	chainDB.Close()
+
+	txPoolConfig := txpoolcfg.DefaultConfig
+	txPoolConfig.DBDir = dirs.TxPool
+	syncCfg := ethconfig.Defaults.Sync
+	syncCfg.ParallelStateFlushing = false
+
+	backend, err := New(ctx, stack, &ethconfig.Config{
+		Sync:                  syncCfg,
+		Dirs:                  dirs,
+		Snapshot:              ethconfig.BlocksFreezing{NoDownloader: true},
+		TxPool:                txPoolConfig,
+		BatchSize:             512 * datasize.MB,
+		KeepStoredChainConfig: true,
+		StateCacheBudget:      1 * datasize.MB,
+	}, logger, nil)
+	require.NoError(t, err)
+	require.NoError(t, backend.Stop())
+
+	poolDB, err := mdbx.New(dbcfg.TxPoolDB, logger).Path(dirs.TxPool).Accede(true).Readonly(true).Open(ctx)
+	require.NoError(t, err, "txpool DB still open after Stop")
+	poolDB.Close()
+}

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -2265,6 +2265,14 @@ func (p *TxPool) promote(pendingBaseFee uint64, pendingBlobFee uint64, announcem
 	}
 }
 
+// Close releases poolDB when Run never ran to close it; idempotent alongside
+// Run's own deferred close.
+func (p *TxPool) Close() {
+	if p.poolDB != nil {
+		p.poolDB.Close()
+	}
+}
+
 // Run - does:
 // send pending byHash to p2p:
 //   - new byHash


### PR DESCRIPTION
## Summary

`Ethereum.Stop` never closed the txpool DB: `poolDB` is opened inside `eth.New` (via `txpool.Assemble`), but its only close is `TxPool.Run`'s deferred one, and `Run` is launched only from `Ethereum.Start`. A backend that is constructed but never started — or whose `Start` fails before the pool goroutine spawns — therefore leaked the open txpool MDBX env for the rest of the process even after a clean `Stop`.

Surfaced by the #22058 review: that PR force-disables the txpool for `erigon import` (the only production never-`Start()`ed backend), which sidesteps the leak for import but leaves the underlying gap in `Stop`. With this fix the import-side disable is a startup optimization rather than a shutdown-correctness requirement.

## Fix

`TxPool.Close` releases `poolDB`, and `Ethereum.Stop` calls it right after `bgComponentsEg.Wait()` — by that point a started pool's `Run` (which lives inside that errgroup) has exited and already closed the DB itself, and `MdbxKV.Close` is CAS-guarded, so the second close on the started path is a no-op with no race window. The shutter pool has no DB of its own, so no equivalent is needed there.

## Test

`TestStopClosesTxPoolDBWithoutStart` (`node/eth`) builds a real backend via `eth.New` with the txpool enabled (mirroring the engineapitester config recipe), calls `Stop` without ever starting the node, and asserts the txpool DB can be reopened in-process — red before the fix (`mdbx_env_open: resource temporarily unavailable, label: txpool`), green after. Skipped in `-short` mode.
