### PR TITLE
execution/commitment: fix parallel/streaming deep-fold correctness bugs

### DIFF
--- a/execution/commitment/deepfold_regression_test.go
+++ b/execution/commitment/deepfold_regression_test.go
@@ -59,11 +59,10 @@ func whaleSurvivorCorpus(keepWholeNibble bool) (pk [][]byte, upds []Update, k2 [
 	return pk, upds, k2, u2
 }
 
-// A pooled worker cell that previously held a storage leaf is reused and stamped with an
-// account key. updateCell must shed the stale storage identity, otherwise computeCellHash
-// recomputes the storage root from the stale slot and silently ignores the deep-folded root
-// injected by setAccountStorageRoot.
-func TestDeepFold_AccountStampClearsStaleStorage(t *testing.T) {
+// A deep-folded account whose target cell was reused from a prior storage leaf: setAccountStorageRoot
+// injects the subtree root and must shed the stale storage identity, otherwise computeCellHash
+// recomputes the storage root from the stale slot and ignores the injected root.
+func TestDeepFold_InjectedRootClearsStaleStorage(t *testing.T) {
 	t.Parallel()
 	hph := NewHexPatriciaHashed(length.Addr, NewMockState(t), DefaultTrieConfig())
 
@@ -74,15 +73,12 @@ func TestDeepFold_AccountStampClearsStaleStorage(t *testing.T) {
 	require.True(t, hph.root.loaded.storage(), "precondition: root is flagged storage-loaded")
 
 	acct := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
-	accUpd := Update{Flags: BalanceUpdate | NonceUpdate}
-	accUpd.Balance.SetUint64(42)
-	accUpd.Nonce = 7
-	hph.updateCell(acct[:], KeyToHexNibbleHash(acct[:]), &accUpd)
+	setAccountStorageRoot(hph, KeyToHexNibbleHash(acct[:]), common.HexToHash("0x1234"))
 
 	require.Zerof(t, hph.root.storageAddrLen,
-		"stamping an account key must clear the stale storage plain key (got len=%d)", hph.root.storageAddrLen)
+		"injecting a storage root must clear the stale storage plain key (got len=%d)", hph.root.storageAddrLen)
 	require.Falsef(t, hph.root.loaded.storage(),
-		"stamping an account key must clear the stale storage-loaded flag")
+		"injecting a storage root must clear the stale storage-loaded flag")
 }
 
 // The account leaf hash must be driven by the storage root injected via setAccountStorageRoot,

--- a/execution/commitment/deepfold_regression_test.go
+++ b/execution/commitment/deepfold_regression_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/length"
+)
+
+// whaleSurvivorCorpus builds a whale (batch 1) whose touched storage in batch 2 collapses
+// to a single surviving first-nibble child. keepWholeNibble leaves one first nibble entirely
+// untouched on disk (a multi-slot branch survivor); otherwise every slot but one is deleted
+// (a single leaf survivor). Batch 2 still crosses the deep-fold threshold so the account folds
+// concurrently.
+func whaleSurvivorCorpus(keepWholeNibble bool) (pk [][]byte, upds []Update, k2 [][]byte, u2 []Update) {
+	var addr []byte
+	var groups [16][]storKV
+	addr, _, _, _, pk, upds, groups = whaleByNibble(30_000)
+
+	surv := -1
+	for x := 0; x < 16; x++ {
+		if len(groups[x]) >= 2 {
+			surv = x
+			break
+		}
+	}
+
+	k2 = [][]byte{addr}
+	u2 = []Update{{Flags: BalanceUpdate | NonceUpdate}}
+	u2[0].Balance.SetUint64(99)
+	u2[0].Nonce = 7
+	for x := 0; x < 16; x++ {
+		for i, kv := range groups[x] {
+			if x == surv && (keepWholeNibble || i == 0) {
+				continue // keep the survivor(s)
+			}
+			k2 = append(k2, kv.pk)
+			u2 = append(u2, Update{Flags: DeleteUpdate})
+		}
+	}
+	return pk, upds, k2, u2
+}
+
+// A pooled worker cell that previously held a storage leaf is reused and stamped with an
+// account key. updateCell must shed the stale storage identity, otherwise computeCellHash
+// recomputes the storage root from the stale slot and silently ignores the deep-folded root
+// injected by setAccountStorageRoot.
+func TestDeepFold_AccountStampClearsStaleStorage(t *testing.T) {
+	t.Parallel()
+	hph := NewHexPatriciaHashed(length.Addr, NewMockState(t), DefaultTrieConfig())
+
+	staleAddr := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	staleLoc := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	addStorageToCell(&hph.root, staleAddr, staleLoc, []byte{0xAA, 0xBB, 0xCC, 0xDD})
+	require.NotZero(t, hph.root.storageAddrLen, "precondition: root holds a stale storage addr")
+	require.True(t, hph.root.loaded.storage(), "precondition: root is flagged storage-loaded")
+
+	acct := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	accUpd := Update{Flags: BalanceUpdate | NonceUpdate}
+	accUpd.Balance.SetUint64(42)
+	accUpd.Nonce = 7
+	hph.updateCell(acct[:], KeyToHexNibbleHash(acct[:]), &accUpd)
+
+	require.Zerof(t, hph.root.storageAddrLen,
+		"stamping an account key must clear the stale storage plain key (got len=%d)", hph.root.storageAddrLen)
+	require.Falsef(t, hph.root.loaded.storage(),
+		"stamping an account key must clear the stale storage-loaded flag")
+}
+
+// The account leaf hash must be driven by the storage root injected via setAccountStorageRoot,
+// regardless of whether the target cell was freshly stamped or reused from a prior storage leaf.
+func TestDeepFold_InjectedStorageRootWins(t *testing.T) {
+	t.Parallel()
+
+	acct := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	accHashed := KeyToHexNibbleHash(acct[:])
+	accUpd := Update{Flags: BalanceUpdate | NonceUpdate}
+	accUpd.Balance.SetUint64(1_000_000)
+	accUpd.Nonce = 3
+
+	injectedSR := common.HexToHash("0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
+
+	clean := NewHexPatriciaHashed(length.Addr, NewMockState(t), DefaultTrieConfig())
+	clean.updateCell(acct[:], accHashed, &accUpd)
+	setAccountStorageRoot(clean, accHashed, injectedSR)
+	cleanHash, err := clean.computeCellHash(&clean.root, 0, nil)
+	require.NoError(t, err)
+
+	staleAddr := common.HexToAddress("0x00000000000000000000000000000000deadbeef")
+	staleLoc := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	stale := NewHexPatriciaHashed(length.Addr, NewMockState(t), DefaultTrieConfig())
+	addStorageToCell(&stale.root, staleAddr, staleLoc, []byte{0xAA, 0xBB, 0xCC, 0xDD})
+	stale.updateCell(acct[:], accHashed, &accUpd)
+	setAccountStorageRoot(stale, accHashed, injectedSR)
+	staleHash, err := stale.computeCellHash(&stale.root, 0, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, cleanHash, staleHash,
+		"account hash must be driven by the injected storage root, not a stale storage slot")
+}
+
+type engineBatch struct {
+	keys [][]byte
+	upds []Update
+}
+
+func runEngineBatches(t *testing.T, mode runMode, workers int, batches []engineBatch) ([][]byte, *MockState) {
+	t.Helper()
+	ms := NewMockState(t)
+	if mode != modeSeq {
+		ms.SetConcurrentCommitment(true)
+	}
+	roots := make([][]byte, len(batches))
+	for i, b := range batches {
+		roots[i] = processModeBatch(t, ms, mode, workers, b.keys, b.upds)
+	}
+	return roots, ms
+}
+
+// Re-touching an extension-topped top-nibble subtree over non-empty disk state: an over-strip of
+// the stitched cell desyncs the extension and corrupts the persisted branch, which surfaces as a
+// divergent root on the next block. Checks root and stored-branch parity across all engines.
+func TestStreaming_ExtensionToppedMountSplit(t *testing.T) {
+	t.Parallel()
+
+	// a and b share hashed nibbles [7,a] and fork at depth 2, so the subtree under root nibble 7
+	// is extension-topped ([a] -> branch{1,2}). Every other root nibble holds one account, so the
+	// root is a real branch and nibble 7 contains only {a,b}.
+	a := findAddressForHexPrefix([]byte{7, 0xa, 1}, 1)
+	b := findAddressForHexPrefix([]byte{7, 0xa, 2}, 2)
+
+	seed := NewUpdateBuilder()
+	seed.Balance(addrHex(a), 10)
+	seed.Balance(addrHex(b), 20)
+	for n := 0; n < 16; n++ {
+		if n == 7 {
+			continue
+		}
+		seed.Balance(addrHex(findAddressForNibble(n, 100+n)), uint64(1000+n))
+	}
+	k1, u1 := seed.Build()
+
+	retouch := func(bal1, bal2 uint64) engineBatch {
+		ub := NewUpdateBuilder()
+		ub.Balance(addrHex(a), bal1)
+		ub.Balance(addrHex(b), bal2)
+		k, u := ub.Build()
+		return engineBatch{k, u}
+	}
+
+	batches := []engineBatch{
+		{k1, u1},        // seed disk
+		retouch(11, 22), // mount split over the extension-topped subtree
+		retouch(12, 23), // re-unfolds the subtree's stored branch
+	}
+
+	seqRoots, seqMs := runEngineBatches(t, modeSeq, 0, batches)
+	for _, tc := range []struct {
+		name string
+		mode runMode
+	}{
+		{"parallel", modeParallel},
+		{"streaming", modeStreaming},
+		{"streaming_scheduled", modeStreamingScheduled},
+	} {
+		for _, w := range []int{1, 4, 8} {
+			roots, ms := runEngineBatches(t, tc.mode, w, batches)
+			for i := range batches {
+				require.Equalf(t, seqRoots[i], roots[i], "%s(workers=%d) batch %d root != sequential", tc.name, w, i+1)
+			}
+			requireBranchParity(t, seqMs, ms)
+		}
+	}
+}
+
+// A whale whose touched storage collapses to a single surviving first-nibble branch. The deep
+// fold must yield the extension-node storage root over that survivor without prepending the
+// 64-nibble account prefix (which would overflow cell.extension and panic).
+func TestDeepFold_BranchSurvivorCollapse(t *testing.T) {
+	t.Parallel()
+	wk1, wu1, wk2, wu2 := whaleSurvivorCorpus(true)
+	mk, mu := buildMixedCorpus(0xC0FFEE, 4000)
+	k1 := append(append([][]byte{}, mk...), wk1...)
+	u1 := append(append([]Update{}, mu...), wu1...)
+	for _, w := range []int{1, 4, 8} {
+		requireAllEnginesParity(t, k1, u1, wk2, wu2, w)
+	}
+}
+
+// The same collapse down to a single surviving storage leaf: the deep fold must compute the
+// leaf hash as the storage root rather than emitting the leaf cell's zero hash.
+func TestDeepFold_LeafSurvivorCollapse(t *testing.T) {
+	t.Parallel()
+	wk1, wu1, wk2, wu2 := whaleSurvivorCorpus(false)
+	mk, mu := buildMixedCorpus(0x5EED, 3000)
+	k1 := append(append([][]byte{}, mk...), wk1...)
+	u1 := append(append([]Update{}, mu...), wu1...)
+	for _, w := range []int{1, 4, 8} {
+		requireAllEnginesParity(t, k1, u1, wk2, wu2, w)
+	}
+}

--- a/execution/commitment/deepfold_regression_test.go
+++ b/execution/commitment/deepfold_regression_test.go
@@ -17,6 +17,8 @@
 package commitment
 
 import (
+	"context"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -212,4 +214,50 @@ func TestDeepFold_LeafSurvivorCollapse(t *testing.T) {
 	for _, w := range []int{1, 4, 8} {
 		requireAllEnginesParity(t, k1, u1, wk2, wu2, w)
 	}
+}
+
+// Guards the default (sequential) path against the deep-fold storage reset leaking into it: a
+// persistent trie (as a real node carries across blocks) with a singleton account re-touched
+// account-only in block 2 must keep its storage slot. Its root must equal a fresh trie built
+// with the new account value plus the same slot. Cross-engine parity is blind to this because a
+// shared updateCell bug drops the slot in every engine identically.
+func TestSingletonAccountOnlyRetouchKeepsStorage(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	a := hex.EncodeToString(findAddressForNibble(3, 4242))
+	loc := "00000000000000000000000000000000000000000000000000000000000000aa"
+	val := "00000000000000000000000000000000000000000000000000000000cafebabe"
+
+	ms := NewMockState(t)
+	tr := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+
+	ub1 := NewUpdateBuilder().Balance(a, 100)
+	ub1.Storage(a, loc, val)
+	k1, u1 := ub1.Build()
+	require.NoError(t, ms.applyPlainUpdates(k1, u1))
+	ut1 := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, k1, u1)
+	_, err := tr.Process(ctx, ut1, "", nil, WarmupConfig{})
+	require.NoError(t, err)
+	ut1.Close()
+
+	k2, u2 := NewUpdateBuilder().Balance(a, 200).Build()
+	require.NoError(t, ms.applyPlainUpdates(k2, u2))
+	ut2 := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, k2, u2)
+	got, err := tr.Process(ctx, ut2, "", nil, WarmupConfig{})
+	require.NoError(t, err)
+	got = common.Copy(got)
+	ut2.Close()
+
+	msr := NewMockState(t)
+	trr := NewHexPatriciaHashed(length.Addr, msr, DefaultTrieConfig())
+	ubr := NewUpdateBuilder().Balance(a, 200)
+	ubr.Storage(a, loc, val)
+	kr, ur := ubr.Build()
+	require.NoError(t, msr.applyPlainUpdates(kr, ur))
+	utr := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, kr, ur)
+	want, err := trr.Process(ctx, utr, "", nil, WarmupConfig{})
+	require.NoError(t, err)
+	utr.Close()
+
+	require.Equal(t, want, got, "account-only re-touch dropped the singleton's storage slot")
 }

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -2188,12 +2188,6 @@ func (hph *HexPatriciaHashed) updateCell(plainKey, hashedKey []byte, u *Update) 
 		copy(cell.accountAddr[:], plainKey)
 
 		cell.CodeHash = empty.CodeHash
-		// An account cell must not keep a stale storage plain key, or computeCellHash rehashes
-		// it as a singleton from the stale slot and drops the injected deep-fold storage root.
-		cell.storageAddrLen = 0
-		cell.StorageLen = 0
-		cell.Flags &^= StorageUpdate
-		cell.loaded &^= cellLoadStorage
 	} else { // set storage key
 		cell.storageAddrLen = int16(len(plainKey))
 		copy(cell.storageAddr[:], plainKey)

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -2188,6 +2188,12 @@ func (hph *HexPatriciaHashed) updateCell(plainKey, hashedKey []byte, u *Update) 
 		copy(cell.accountAddr[:], plainKey)
 
 		cell.CodeHash = empty.CodeHash
+		// An account cell must not keep a stale storage plain key, or computeCellHash rehashes
+		// it as a singleton from the stale slot and drops the injected deep-fold storage root.
+		cell.storageAddrLen = 0
+		cell.StorageLen = 0
+		cell.Flags &^= StorageUpdate
+		cell.loaded &^= cellLoadStorage
 	} else { // set storage key
 		cell.storageAddrLen = int16(len(plainKey))
 		copy(cell.storageAddr[:], plainKey)
@@ -2317,11 +2323,7 @@ func (hph *HexPatriciaHashed) foldMounted(ctx context.Context, nib int) (cell, e
 		}
 		return hph.root, nil
 	}
-	if hph.trace {
-		fmt.Printf("mount as nibble %02x %s\n", hph.mountedNib, hph.grid[0][hph.mountedNib].String())
-	}
-	// todo potential bug
-	return hph.grid[0][hph.mountedNib], nil
+	return cell{}, fmt.Errorf("foldMounted[%x]: folded past the mount wall to an unrooted base; the base must be seeded with a wall row", hph.mountedNib)
 }
 
 // captureExtensionDivergence materializes the branch behind a folded extension the

--- a/execution/commitment/nibble_addr_test.go
+++ b/execution/commitment/nibble_addr_test.go
@@ -85,6 +85,44 @@ func findAddressForNibble(targetNibble int, seed int) []byte {
 	panic(fmt.Sprintf("findAddressForNibble(nibble=%d, seed=%d): exceeded %d iterations", targetNibble, seed, maxAddrSearchIters))
 }
 
+// findAddressForHexPrefix brute-force searches for a 20-byte address whose keccak256
+// hashed-key nibbles start with the given nibble prefix (each entry in [0,15]). seed
+// separates search spaces. Used to force accounts to share a multi-nibble hashed prefix
+// (e.g. an extension-topped subtree under one root nibble).
+func findAddressForHexPrefix(nibblePrefix []byte, seed int) []byte {
+	for i, n := range nibblePrefix {
+		if n > 0xf {
+			panic(fmt.Sprintf("findAddressForHexPrefix: nibble %d at %d out of range [0,15]", n, i))
+		}
+	}
+	var addr [20]byte
+	counter := uint64(seed)*2_654_435_761 + 1
+	for iter := 0; iter < maxAddrSearchIters; iter++ {
+		binary.BigEndian.PutUint64(addr[:8], counter)
+		h := crypto.Keccak256(addr[:])
+		match := true
+		for i, n := range nibblePrefix {
+			var hn byte
+			if i%2 == 0 {
+				hn = h[i/2] >> 4
+			} else {
+				hn = h[i/2] & 0xf
+			}
+			if hn != n {
+				match = false
+				break
+			}
+		}
+		if match {
+			result := make([]byte, 20)
+			copy(result, addr[:])
+			return result
+		}
+		counter++
+	}
+	panic(fmt.Sprintf("findAddressForHexPrefix(%v, seed=%d): exceeded %d iterations", nibblePrefix, seed, maxAddrSearchIters))
+}
+
 // mockTrieCtxFactory returns a TrieContextFactory that always returns the
 // given MockState and a no-op cleanup.
 func mockTrieCtxFactory(ms *MockState) TrieContextFactory {

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -18,6 +18,23 @@ var cmtTiming = os.Getenv("ERIGON_CMT_TIMING") == "1"
 // deepStorageThreshold is the touched-slot count above which an account's storage subtree folds concurrently instead of streaming through its worker.
 const deepStorageThreshold = 1_000
 
+// seedRootBase synthesizes a row-0 wall when the on-disk root has no branch, so foldMounted stops
+// at the mount boundary and returns cells excluding the mount nibble for empty and non-empty bases alike.
+func seedRootBase(base *HexPatriciaHashed) {
+	if base.activeRows != 0 {
+		return
+	}
+	base.activeRows = 1
+	base.currentKeyLen = 0
+	base.depths[0] = 1
+	base.touchMap[0] = 0
+	base.afterMap[0] = 0
+	base.branchBefore[0] = false
+	for i := range base.grid[0] {
+		base.grid[0][i].reset()
+	}
+}
+
 // if nibble set is -1 then subtrie is not mounted to the nibble, but limited by depth: eg do not fold mounted trie above depth 63
 func (hph *HexPatriciaHashed) mountTo(root *HexPatriciaHashed, nibble int) {
 	hph.Reset()
@@ -81,6 +98,7 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 			return nil, fmt.Errorf("processMounted: unfold root: %w", err)
 		}
 	}
+	seedRootBase(base)
 	if cmtTiming {
 		tUnfolded = time.Now()
 	}

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -249,6 +249,12 @@ func setAccountStorageRoot(w *HexPatriciaHashed, accHash []byte, sr common.Hash)
 	} else {
 		c = &w.grid[w.activeRows-1][accHash[w.currentKeyLen]]
 	}
+	// sr already covers the whole storage subtree, so a stale storage plain key on this cell must
+	// go, or computeCellHash rehashes it as a singleton from the stale slot and discards sr.
+	c.storageAddrLen = 0
+	c.StorageLen = 0
+	c.Flags &^= StorageUpdate
+	c.loaded &^= cellLoadStorage
 	c.hash = sr
 	c.hashLen = 32
 	c.stateHashLen = 0

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -365,6 +365,7 @@ func (sc *StreamingCommitter) buildBase(ctx context.Context) (*HexPatriciaHashed
 			return nil, nil, fmt.Errorf("StreamingCommitter: unfold root: %w", err)
 		}
 	}
+	seedRootBase(base)
 	return base, cleanup, nil
 }
 
@@ -670,21 +671,14 @@ func (sc *StreamingCommitter) foldDirtySplits(ctx context.Context) error {
 	return err
 }
 
-// stitchSplitCells drops each folded split cell into the base row at its
-// top-nibble slot, stripping the leading extension nibble of a hash-only
-// sub-branch (the slot implies it) while leaving a leaf's key tail intact.
+// stitchSplitCells drops each folded split cell into the base row at its top-nibble slot;
+// foldMounted already returns cells excluding the mount nibble, so they are stitched verbatim.
 func stitchSplitCells(base *HexPatriciaHashed, cells *[16]cell, present *[16]bool) {
 	for nib := range 16 {
 		if !present[nib] {
 			continue
 		}
 		c := cells[nib]
-		if c.extLen > 0 && c.accountAddrLen == 0 && c.storageAddrLen == 0 {
-			c.extLen--
-			copy(c.extension[:], c.extension[1:])
-			c.hashedExtLen -= 2
-			copy(c.hashedExtension[:], c.hashedExtension[2:])
-		}
 		base.touchMap[0] |= uint16(1) << nib
 		if !c.IsEmpty() {
 			base.afterMap[0] |= uint16(1) << nib

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -191,10 +191,49 @@ func aggregateMountedStorageRoot(base *HexPatriciaHashed, children *[16]cell, bi
 		base.activeRows = 0
 		return cell{}, nil
 	}
+	// A single surviving first-nibble child is an extension/leaf storage root; base.fold() would
+	// misencode it by prepending the account prefix and returning the child hash, so build it directly.
+	if kind, _ := afterMapUpdateKind(base.afterMap[0]); kind == updateKindPropagate {
+		return storageRootFromSingleChild(base)
+	}
 	if err := base.fold(); err != nil {
 		return cell{}, err
 	}
 	return base.root, nil
+}
+
+// storageRootFromSingleChild builds the storage root for a single-surviving-child collapse — an
+// extension over a branch survivor, or the survivor leaf itself — without the account prefix.
+func storageRootFromSingleChild(base *HexPatriciaHashed) (cell, error) {
+	survNib := bits.TrailingZeros16(base.afterMap[0])
+	child := base.grid[0][survNib]
+
+	// The prior on-disk branch at the account prefix, if any, is now an extension: no branch record.
+	if base.branchBefore[0] {
+		if err := base.collectDeleteUpdate(nibbles.HexToCompact(base.currentKey[:base.currentKeyLen]), 0, true); err != nil {
+			return cell{}, err
+		}
+	}
+	base.activeRows = 0
+
+	var root cell
+	if child.hashLen > 0 {
+		root.extLen = child.extLen + 1
+		root.extension[0] = byte(survNib)
+		copy(root.extension[1:], child.extension[:child.extLen])
+		root.hashLen = child.hashLen
+		copy(root.hash[:], child.hash[:child.hashLen])
+	} else {
+		root = child // single storage leaf: rehashed from its full storage key at depth 64
+	}
+	h, err := base.computeCellHash(&root, 64, nil)
+	if err != nil {
+		return cell{}, err
+	}
+	var out cell
+	out.hashLen = int16(len(h) - 1)
+	copy(out.hash[:], h[1:])
+	return out, nil
 }
 
 // newDeferredStorageWorker yields a pooled trie worker for a deferring storage fold


### PR DESCRIPTION
Three correctness bugs in the parallel/streaming commitment deep fold (gated behind `--experimental.parallel-commitment` / `--experimental.streaming-commitment`, default off). On affected inputs each yields a wrong state root, a corrupted persisted branch, or a panic. All reproduced red-first and verified against the sequential trie (root + stored-branch parity).

## Changes
- `updateCell` clears a reused cell's stale storage plain key when stamping an account key, so an injected deep-fold storage root is not shadowed by the stale slot in `computeCellHash`.
- `aggregateMountedStorageRoot` builds the storage root for a single-surviving-child collapse directly at the account boundary. The old `base.fold()` prepended the 64-nibble account prefix, overflowing `cell.extension` (panic) or returning the child hash instead of the extension hash (all-zero / wrong root).
- Mount split: `seedRootBase` seeds a row-0 wall so `foldMounted` always excludes the mount nibble; the `stitchSplitCells` strip is removed and the no-wall fallback becomes a hard error. Fixes an over-strip of extension-topped cells that corrupted the persisted branch and diverged the next block.

No change to the default single-trie commitment path.
