### PR TITLE
execution/commitment: cache nibblized keccak(addr) for storage keys

### DIFF
--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -1453,10 +1454,11 @@ type Updates struct {
 	curArena int
 	gen      uint64
 
-	// addrNibblesCache caches nibblized keccak(addr) for storage keys, avoiding
-	// redundant hashing when one address has many dirty storage slots (whale storage).
-	// Keyed by 20-byte address, value is the 64 nibbles of the address hash.
-	addrNibblesCache map[[20]byte][64]byte
+	// addrCache reuses the nibblized keccak(addr) prefix across a run of storage
+	// keys sharing one address (whale storage). Enabled only when hasher is the
+	// nibblizing hasher whose key layout the reuse assumes (addrCacheReuse).
+	addrCache      addrHashCache
+	addrCacheReuse bool
 }
 
 // arenaRingSize is how many byte arenas HashSort cycles; raising it only adds memory headroom, never affects correctness.
@@ -1504,6 +1506,22 @@ type keyHasher func(key []byte) []byte
 
 func keyHasherNoop(key []byte) []byte { return key }
 
+// hasherReusesAddrPrefix reports whether h is the nibblizing hasher whose key
+// layout keyToHexNibbleHashCached assumes; only then may the address-prefix
+// cache be used in place of h.
+func hasherReusesAddrPrefix(h keyHasher) bool {
+	return reflect.ValueOf(h).Pointer() == reflect.ValueOf(KeyToHexNibbleHash).Pointer()
+}
+
+// hashKey nibblizes key, reusing the cached address prefix for a run of storage
+// keys sharing one address when the configured hasher permits it.
+func (t *Updates) hashKey(key []byte) []byte {
+	if t.addrCacheReuse {
+		return keyToHexNibbleHashCached(key, &t.addrCache)
+	}
+	return t.hasher(key)
+}
+
 // NewEmpty creates a fresh Updates matching the receiver. The streaming sink must
 // carry over, or a buffer rotated mid-stream silently computes a stale root.
 func (t *Updates) NewEmpty() *Updates {
@@ -1515,9 +1533,10 @@ func (t *Updates) NewEmpty() *Updates {
 
 func NewUpdates(m Mode, tmpdir string, hasher keyHasher) *Updates {
 	t := &Updates{
-		hasher: hasher,
-		tmpdir: tmpdir,
-		mode:   m,
+		hasher:         hasher,
+		tmpdir:         tmpdir,
+		mode:           m,
+		addrCacheReuse: hasherReusesAddrPrefix(hasher),
 	}
 	switch t.mode {
 	case ModeDirect:
@@ -1529,7 +1548,6 @@ func NewUpdates(m Mode, tmpdir string, hasher keyHasher) *Updates {
 	case ModeParallel:
 		t.keys = make(map[string]struct{})
 		t.parallel = newParallelUpdate()
-		t.addrNibblesCache = make(map[[20]byte][64]byte)
 	}
 	return t
 }
@@ -1612,7 +1630,7 @@ func (t *Updates) TouchPlainKey(key string, val []byte, fn func(c *KeyUpdate, va
 		} else {
 			pivot := &KeyUpdate{
 				plainKey:  key,
-				hashedKey: t.hasher(common.ToBytesZeroCopy(key)),
+				hashedKey: t.hashKey(common.ToBytesZeroCopy(key)),
 				update:    new(Update),
 			}
 			fn(pivot, val)
@@ -1622,7 +1640,7 @@ func (t *Updates) TouchPlainKey(key string, val []byte, fn func(c *KeyUpdate, va
 	case ModeDirect:
 		if _, ok := t.keys[key]; !ok {
 			keyBytes := common.ToBytesZeroCopy(key)
-			hashedKey := t.hasher(keyBytes)
+			hashedKey := t.hashKey(keyBytes)
 
 			err := t.etl.Collect(hashedKey, keyBytes)
 			if err != nil {
@@ -1633,7 +1651,7 @@ func (t *Updates) TouchPlainKey(key string, val []byte, fn func(c *KeyUpdate, va
 	case ModeParallel:
 		if _, ok := t.keys[key]; !ok {
 			keyBytes := common.ToBytesZeroCopy(key)
-			hashedKey := t.hasher(keyBytes)
+			hashedKey := t.hashKey(keyBytes)
 			ik := t.parallel.internKey(keyBytes)
 			t.parallel.Insert(hashedKey, ik, nil)
 			if t.streaming && t.streamer != nil {
@@ -1684,7 +1702,7 @@ func (t *Updates) TouchPlainKeyDirect(key string, update *Update) {
 		} else {
 			pivot := &KeyUpdate{
 				plainKey:  key,
-				hashedKey: t.hasher(common.ToBytesZeroCopy(key)),
+				hashedKey: t.hashKey(common.ToBytesZeroCopy(key)),
 				update:    new(Update),
 			}
 			*pivot.update = *update
@@ -1694,7 +1712,7 @@ func (t *Updates) TouchPlainKeyDirect(key string, update *Update) {
 	case ModeDirect:
 		if _, ok := t.keys[key]; !ok {
 			keyBytes := common.ToBytesZeroCopy(key)
-			hashedKey := t.hasher(keyBytes)
+			hashedKey := t.hashKey(keyBytes)
 
 			err := t.etl.Collect(hashedKey, keyBytes)
 			if err != nil {
@@ -1704,12 +1722,7 @@ func (t *Updates) TouchPlainKeyDirect(key string, update *Update) {
 		}
 	case ModeParallel:
 		keyBytes := common.ToBytesZeroCopy(key)
-		var hashedKey []byte
-		if t.addrNibblesCache != nil {
-			hashedKey = KeyToHexNibbleHashWithCache(keyBytes, t.addrNibblesCache)
-		} else {
-			hashedKey = t.hasher(keyBytes)
-		}
+		hashedKey := t.hashKey(keyBytes)
 		// Carry the value so the fold uses it directly instead of re-reading ctx, which lags cc.state.
 		u := new(Update)
 		*u = *update
@@ -2036,6 +2049,7 @@ func (t *Updates) Reset() {
 	}
 	t.curArena = 0
 	t.gen = 0
+	t.addrCache.reset()
 }
 
 type KeyUpdate struct {

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -1452,6 +1452,11 @@ type Updates struct {
 	arenas   [arenaRingSize][]byte
 	curArena int
 	gen      uint64
+
+	// addrNibblesCache caches nibblized keccak(addr) for storage keys, avoiding
+	// redundant hashing when one address has many dirty storage slots (whale storage).
+	// Keyed by 20-byte address, value is the 64 nibbles of the address hash.
+	addrNibblesCache map[[20]byte][64]byte
 }
 
 // arenaRingSize is how many byte arenas HashSort cycles; raising it only adds memory headroom, never affects correctness.
@@ -1524,6 +1529,7 @@ func NewUpdates(m Mode, tmpdir string, hasher keyHasher) *Updates {
 	case ModeParallel:
 		t.keys = make(map[string]struct{})
 		t.parallel = newParallelUpdate()
+		t.addrNibblesCache = make(map[[20]byte][64]byte)
 	}
 	return t
 }
@@ -1698,7 +1704,12 @@ func (t *Updates) TouchPlainKeyDirect(key string, update *Update) {
 		}
 	case ModeParallel:
 		keyBytes := common.ToBytesZeroCopy(key)
-		hashedKey := t.hasher(keyBytes)
+		var hashedKey []byte
+		if t.addrNibblesCache != nil {
+			hashedKey = KeyToHexNibbleHashWithCache(keyBytes, t.addrNibblesCache)
+		} else {
+			hashedKey = t.hasher(keyBytes)
+		}
 		// Carry the value so the fold uses it directly instead of re-reading ctx, which lags cc.state.
 		u := new(Update)
 		*u = *update

--- a/execution/commitment/keys_nibbles.go
+++ b/execution/commitment/keys_nibbles.go
@@ -39,51 +39,47 @@ func KeyToHexNibbleHash(key []byte) []byte {
 	return nibblized
 }
 
-// KeyToHexNibbleHashWithCache is like KeyToHexNibbleHash but caches nibblized address hashes.
-// For storage keys (len > 20), the first 64 nibbles (nibblized keccak(addr)) are cached keyed by [20]byte address.
-// Subsequent calls with the same address reuse the cached nibbles, avoiding redundant keccak + expand.
-// For account keys (len <= 20), no caching is performed.
-// Returns a newly allocated 128-byte (storage) or 64-byte (account) nibblized slice.
-func KeyToHexNibbleHashWithCache(key []byte, cache map[[20]byte][64]byte) []byte {
-	if len(key) > length.Addr { // storage
-		nibblized := make([]byte, 128)
-		var addrKey [20]byte
-		copy(addrKey[:], key[:length.Addr])
-
-		// Address portion: check cache or compute + cache
-		if addrNibs, ok := cache[addrKey]; ok {
-			copy(nibblized[:64], addrNibs[:])
-		} else {
-			h := keccak.Sum256(key[:length.Addr])
-			copy(nibblized[32:64], h[:])
-			for i, b := range nibblized[32:64] {
-				nibblized[i*2] = (b >> 4) & 0xf
-				nibblized[i*2+1] = b & 0xf
-			}
-			var arr [64]byte
-			copy(arr[:], nibblized[:64])
-			cache[addrKey] = arr
-		}
-
-		// Slot portion: always compute (unique per storage key)
-		h := keccak.Sum256(key[length.Addr:])
-		copy(nibblized[96:], h[:])
-		for i := 0; i < 32; i++ {
-			b := nibblized[96+i]
-			nibblized[64+i*2] = (b >> 4) & 0xf
-			nibblized[64+i*2+1] = b & 0xf
-		}
-		return nibblized
+// expandNibbles writes each byte of src as two nibbles (src[i] -> dst[2i], dst[2i+1]).
+// src and dst must not overlap.
+func expandNibbles(src, dst []byte) {
+	_ = dst[len(src)*2-1] // bounds-check elimination
+	for i, b := range src {
+		dst[i*2] = (b >> 4) & 0xf
+		dst[i*2+1] = b & 0xf
 	}
+}
 
-	// Account key: no caching
-	nibblized := make([]byte, 64)
-	h := keccak.Sum256(key)
-	copy(nibblized[32:], h[:])
-	for i, b := range nibblized[32:] {
-		nibblized[i*2] = (b >> 4) & 0xf
-		nibblized[i*2+1] = b & 0xf
+// addrHashCache memoizes the nibblized keccak(addr) prefix of the most recent
+// storage key's address, so a run of slots under one address (whale storage)
+// reuses the 64-nibble prefix instead of re-hashing the address. keccak(addr)
+// is immutable, so a hit is always correct and a miss simply recomputes.
+type addrHashCache struct {
+	addr  [20]byte
+	nibs  [64]byte
+	valid bool
+}
+
+func (c *addrHashCache) reset() { c.valid = false }
+
+// keyToHexNibbleHashCached returns the same bytes as KeyToHexNibbleHash, reusing
+// c's cached address prefix across consecutive storage keys that share an address.
+func keyToHexNibbleHashCached(key []byte, c *addrHashCache) []byte {
+	if len(key) <= length.Addr { // account key: no reusable prefix
+		return KeyToHexNibbleHash(key)
 	}
+	nibblized := make([]byte, 128)
+	addr := [20]byte(key[:length.Addr])
+	if c.valid && c.addr == addr {
+		copy(nibblized[:64], c.nibs[:])
+	} else {
+		h := keccak.Sum256(key[:length.Addr])
+		expandNibbles(h[:], nibblized[:64])
+		c.addr = addr
+		copy(c.nibs[:], nibblized[:64])
+		c.valid = true
+	}
+	h := keccak.Sum256(key[length.Addr:])
+	expandNibbles(h[:], nibblized[64:])
 	return nibblized
 }
 

--- a/execution/commitment/keys_nibbles.go
+++ b/execution/commitment/keys_nibbles.go
@@ -39,6 +39,54 @@ func KeyToHexNibbleHash(key []byte) []byte {
 	return nibblized
 }
 
+// KeyToHexNibbleHashWithCache is like KeyToHexNibbleHash but caches nibblized address hashes.
+// For storage keys (len > 20), the first 64 nibbles (nibblized keccak(addr)) are cached keyed by [20]byte address.
+// Subsequent calls with the same address reuse the cached nibbles, avoiding redundant keccak + expand.
+// For account keys (len <= 20), no caching is performed.
+// Returns a newly allocated 128-byte (storage) or 64-byte (account) nibblized slice.
+func KeyToHexNibbleHashWithCache(key []byte, cache map[[20]byte][64]byte) []byte {
+	if len(key) > length.Addr { // storage
+		nibblized := make([]byte, 128)
+		var addrKey [20]byte
+		copy(addrKey[:], key[:length.Addr])
+
+		// Address portion: check cache or compute + cache
+		if addrNibs, ok := cache[addrKey]; ok {
+			copy(nibblized[:64], addrNibs[:])
+		} else {
+			h := keccak.Sum256(key[:length.Addr])
+			copy(nibblized[32:64], h[:])
+			for i, b := range nibblized[32:64] {
+				nibblized[i*2] = (b >> 4) & 0xf
+				nibblized[i*2+1] = b & 0xf
+			}
+			var arr [64]byte
+			copy(arr[:], nibblized[:64])
+			cache[addrKey] = arr
+		}
+
+		// Slot portion: always compute (unique per storage key)
+		h := keccak.Sum256(key[length.Addr:])
+		copy(nibblized[96:], h[:])
+		for i := 0; i < 32; i++ {
+			b := nibblized[96+i]
+			nibblized[64+i*2] = (b >> 4) & 0xf
+			nibblized[64+i*2+1] = b & 0xf
+		}
+		return nibblized
+	}
+
+	// Account key: no caching
+	nibblized := make([]byte, 64)
+	h := keccak.Sum256(key)
+	copy(nibblized[32:], h[:])
+	for i, b := range nibblized[32:] {
+		nibblized[i*2] = (b >> 4) & 0xf
+		nibblized[i*2+1] = b & 0xf
+	}
+	return nibblized
+}
+
 func KeyToNibblizedHash(key []byte) []byte {
 	nibblized := make([]byte, 64) // nibblized hash
 	hashed := nibblized[32:]

--- a/execution/commitment/keys_nibbles_cache_test.go
+++ b/execution/commitment/keys_nibbles_cache_test.go
@@ -1,0 +1,201 @@
+package commitment
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/common/length"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKeyToHexNibbleHashWithCache_Correctness verifies that the cached variant
+// produces byte-identical output to the uncached KeyToHexNibbleHash for
+// account keys, storage keys, and whale storage patterns.
+func TestKeyToHexNibbleHashWithCache_Correctness(t *testing.T) {
+	t.Parallel()
+
+	cache := make(map[[20]byte][64]byte)
+
+	// Account keys (len <= 20)
+	t.Run("account_keys", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			addr := make([]byte, length.Addr)
+			addr[0] = byte(i)
+			addr[19] = byte(i * 7)
+			got := KeyToHexNibbleHashWithCache(addr, cache)
+			want := KeyToHexNibbleHash(addr)
+			assert.Equal(t, want, got, "account key %d mismatch", i)
+		}
+	})
+
+	// Storage keys (len > 20) — various addresses and slots
+	t.Run("storage_keys", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			key := make([]byte, 52) // 20 addr + 32 slot
+			key[0] = byte(i % 30)   // some address reuse
+			key[19] = byte(i)
+			key[20] = byte(i) // slot
+			key[51] = byte(i * 3)
+			got := KeyToHexNibbleHashWithCache(key, cache)
+			want := KeyToHexNibbleHash(key)
+			assert.Equal(t, want, got, "storage key %d mismatch", i)
+		}
+	})
+
+	// Whale storage: one address, many slots — primary target of the optimization
+	t.Run("whale_storage", func(t *testing.T) {
+		whaleCache := make(map[[20]byte][64]byte)
+		addr := make([]byte, length.Addr)
+		addr[0] = 0xDE
+		addr[1] = 0xAD
+		addr[19] = 0xBE
+
+		for slot := 0; slot < 1000; slot++ {
+			key := make([]byte, 52)
+			copy(key[:20], addr)
+			key[20] = byte(slot >> 8)
+			key[51] = byte(slot)
+
+			got := KeyToHexNibbleHashWithCache(key, whaleCache)
+			want := KeyToHexNibbleHash(key)
+			assert.Equal(t, want, got, "whale storage slot %d mismatch", slot)
+
+			// First slot populates cache; subsequent should hit
+			if slot == 0 {
+				require.Len(t, whaleCache, 1, "cache should have exactly 1 entry after first slot")
+			}
+		}
+		// Only 1 addr cached despite 1000 calls
+		assert.Equal(t, 1, len(whaleCache), "whale cache should have exactly 1 entry")
+	})
+
+	// Mixed: 50 addresses × 50 slots each
+	t.Run("mixed_keys", func(t *testing.T) {
+		cache2 := make(map[[20]byte][64]byte)
+		for a := 0; a < 50; a++ {
+			for s := 0; s < 50; s++ {
+				key := make([]byte, 52)
+				key[0] = byte(a)
+				key[19] = byte(a * 3)
+				key[20] = byte(s >> 8)
+				key[51] = byte(s)
+
+				got := KeyToHexNibbleHashWithCache(key, cache2)
+				want := KeyToHexNibbleHash(key)
+				assert.Equal(t, want, got, "mixed addr=%d slot=%d mismatch", a, s)
+			}
+		}
+		assert.Equal(t, 50, len(cache2), "should cache exactly 50 unique addresses")
+	})
+}
+
+func Benchmark_KeyNibbleHash_NoCache(b *testing.B) {
+	// Whale storage: 1 addr × 1000 slots
+	keys := make([][]byte, 1000)
+	addr := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}
+	for i := range keys {
+		keys[i] = make([]byte, 52)
+		copy(keys[i][:20], addr)
+		keys[i][20] = byte(i >> 8)
+		keys[i][51] = byte(i)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			_ = KeyToHexNibbleHash(key)
+		}
+	}
+}
+
+func Benchmark_KeyNibbleHash_WithCache_Whale(b *testing.B) {
+	// Whale storage: 1 addr × 1000 slots
+	keys := make([][]byte, 1000)
+	addr := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}
+	for i := range keys {
+		keys[i] = make([]byte, 52)
+		copy(keys[i][:20], addr)
+		keys[i][20] = byte(i >> 8)
+		keys[i][51] = byte(i)
+	}
+	cache := make(map[[20]byte][64]byte)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			_ = KeyToHexNibbleHashWithCache(key, cache)
+		}
+	}
+}
+
+func Benchmark_KeyNibbleHash_WithCache_Spread5(b *testing.B) {
+	// 5 addresses × 200 slots each
+	keys := make([][]byte, 1000)
+	for i := range keys {
+		keys[i] = make([]byte, 52)
+		addrIdx := byte(i / 200)
+		slotIdx := i % 200
+		keys[i][0] = addrIdx
+		keys[i][19] = addrIdx * 7
+		keys[i][20] = byte(slotIdx >> 8)
+		keys[i][51] = byte(slotIdx)
+	}
+	cache := make(map[[20]byte][64]byte)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			_ = KeyToHexNibbleHashWithCache(key, cache)
+		}
+	}
+}
+
+func Benchmark_KeyNibbleHash_WithCache_Spread100(b *testing.B) {
+	// 100 addresses × 10 slots each
+	keys := make([][]byte, 1000)
+	for i := range keys {
+		keys[i] = make([]byte, 52)
+		addrIdx := byte(i / 10)
+		slotIdx := i % 10
+		keys[i][0] = addrIdx
+		keys[i][19] = addrIdx * 3
+		keys[i][20] = byte(slotIdx >> 8)
+		keys[i][51] = byte(slotIdx)
+	}
+	cache := make(map[[20]byte][64]byte)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			_ = KeyToHexNibbleHashWithCache(key, cache)
+		}
+	}
+}
+
+func Benchmark_KeyNibbleHash_NoCache_Spread100(b *testing.B) {
+	// 100 addresses × 10 slots each — baseline
+	keys := make([][]byte, 1000)
+	for i := range keys {
+		keys[i] = make([]byte, 52)
+		addrIdx := byte(i / 10)
+		slotIdx := i % 10
+		keys[i][0] = addrIdx
+		keys[i][19] = addrIdx * 3
+		keys[i][20] = byte(slotIdx >> 8)
+		keys[i][51] = byte(slotIdx)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			_ = KeyToHexNibbleHash(key)
+		}
+	}
+}

--- a/execution/commitment/keys_nibbles_cache_test.go
+++ b/execution/commitment/keys_nibbles_cache_test.go
@@ -8,194 +8,181 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestKeyToHexNibbleHashWithCache_Correctness verifies that the cached variant
-// produces byte-identical output to the uncached KeyToHexNibbleHash for
-// account keys, storage keys, and whale storage patterns.
-func TestKeyToHexNibbleHashWithCache_Correctness(t *testing.T) {
+// TestKeyToHexNibbleHashCached_MatchesUncached verifies the cached variant is
+// byte-identical to KeyToHexNibbleHash regardless of key type or ordering — a
+// cache hit and a cache miss must both reproduce the uncached result.
+func TestKeyToHexNibbleHashCached_MatchesUncached(t *testing.T) {
 	t.Parallel()
 
-	cache := make(map[[20]byte][64]byte)
-
-	// Account keys (len <= 20)
 	t.Run("account_keys", func(t *testing.T) {
+		var c addrHashCache
 		for i := 0; i < 100; i++ {
 			addr := make([]byte, length.Addr)
 			addr[0] = byte(i)
 			addr[19] = byte(i * 7)
-			got := KeyToHexNibbleHashWithCache(addr, cache)
-			want := KeyToHexNibbleHash(addr)
-			assert.Equal(t, want, got, "account key %d mismatch", i)
+			assert.Equal(t, KeyToHexNibbleHash(addr), keyToHexNibbleHashCached(addr, &c), "account key %d", i)
 		}
 	})
 
-	// Storage keys (len > 20) — various addresses and slots
 	t.Run("storage_keys", func(t *testing.T) {
+		var c addrHashCache
 		for i := 0; i < 100; i++ {
-			key := make([]byte, 52) // 20 addr + 32 slot
-			key[0] = byte(i % 30)   // some address reuse
+			key := make([]byte, 52)
+			key[0] = byte(i % 30)
 			key[19] = byte(i)
-			key[20] = byte(i) // slot
+			key[20] = byte(i)
 			key[51] = byte(i * 3)
-			got := KeyToHexNibbleHashWithCache(key, cache)
-			want := KeyToHexNibbleHash(key)
-			assert.Equal(t, want, got, "storage key %d mismatch", i)
+			assert.Equal(t, KeyToHexNibbleHash(key), keyToHexNibbleHashCached(key, &c), "storage key %d", i)
 		}
 	})
 
-	// Whale storage: one address, many slots — primary target of the optimization
+	// Whale: one address, many slots — the reuse target.
 	t.Run("whale_storage", func(t *testing.T) {
-		whaleCache := make(map[[20]byte][64]byte)
+		var c addrHashCache
 		addr := make([]byte, length.Addr)
-		addr[0] = 0xDE
-		addr[1] = 0xAD
-		addr[19] = 0xBE
-
+		addr[0], addr[1], addr[19] = 0xDE, 0xAD, 0xBE
 		for slot := 0; slot < 1000; slot++ {
 			key := make([]byte, 52)
 			copy(key[:20], addr)
 			key[20] = byte(slot >> 8)
 			key[51] = byte(slot)
-
-			got := KeyToHexNibbleHashWithCache(key, whaleCache)
-			want := KeyToHexNibbleHash(key)
-			assert.Equal(t, want, got, "whale storage slot %d mismatch", slot)
-
-			// First slot populates cache; subsequent should hit
-			if slot == 0 {
-				require.Len(t, whaleCache, 1, "cache should have exactly 1 entry after first slot")
-			}
+			assert.Equal(t, KeyToHexNibbleHash(key), keyToHexNibbleHashCached(key, &c), "whale slot %d", slot)
 		}
-		// Only 1 addr cached despite 1000 calls
-		assert.Equal(t, 1, len(whaleCache), "whale cache should have exactly 1 entry")
 	})
 
-	// Mixed: 50 addresses × 50 slots each
-	t.Run("mixed_keys", func(t *testing.T) {
-		cache2 := make(map[[20]byte][64]byte)
-		for a := 0; a < 50; a++ {
-			for s := 0; s < 50; s++ {
-				key := make([]byte, 52)
-				key[0] = byte(a)
-				key[19] = byte(a * 3)
-				key[20] = byte(s >> 8)
-				key[51] = byte(s)
+	// Account/storage interleaving forces cache misses and address changes;
+	// the cache must never leak a stale prefix across an address change.
+	t.Run("interleaved", func(t *testing.T) {
+		var c addrHashCache
+		for i := 0; i < 200; i++ {
+			addr := make([]byte, length.Addr)
+			addr[0] = byte(i % 4) // only 4 distinct addresses, non-consecutive
+			addr[19] = byte(i % 4)
+			assert.Equal(t, KeyToHexNibbleHash(addr), keyToHexNibbleHashCached(addr, &c), "acct %d", i)
 
-				got := KeyToHexNibbleHashWithCache(key, cache2)
-				want := KeyToHexNibbleHash(key)
-				assert.Equal(t, want, got, "mixed addr=%d slot=%d mismatch", a, s)
-			}
+			key := make([]byte, 52)
+			copy(key[:20], addr)
+			key[20] = byte(i)
+			key[51] = byte(i)
+			assert.Equal(t, KeyToHexNibbleHash(key), keyToHexNibbleHashCached(key, &c), "storage %d", i)
 		}
-		assert.Equal(t, 50, len(cache2), "should cache exactly 50 unique addresses")
 	})
+}
+
+// TestAddrHashCache_ReuseAndInvalidation pins the cache state transitions the
+// reuse depends on: populated on first storage slot, retained across same-addr
+// slots, replaced on an address change, cleared by reset.
+func TestAddrHashCache_ReuseAndInvalidation(t *testing.T) {
+	t.Parallel()
+	var c addrHashCache
+	require.False(t, c.valid)
+
+	mkKey := func(addrByte, slot byte) []byte {
+		key := make([]byte, 52)
+		key[0] = addrByte
+		key[51] = slot
+		return key
+	}
+
+	keyToHexNibbleHashCached(mkKey(0xAA, 0), &c)
+	require.True(t, c.valid)
+	require.Equal(t, byte(0xAA), c.addr[0])
+	firstNibs := c.nibs
+
+	// Same address, different slot: prefix retained unchanged.
+	keyToHexNibbleHashCached(mkKey(0xAA, 1), &c)
+	require.Equal(t, firstNibs, c.nibs)
+
+	// Different address: prefix replaced.
+	keyToHexNibbleHashCached(mkKey(0xBB, 0), &c)
+	require.Equal(t, byte(0xBB), c.addr[0])
+	require.NotEqual(t, firstNibs, c.nibs)
+
+	// Account key does not touch the cache.
+	acctBefore := c.addr
+	keyToHexNibbleHashCached(make([]byte, length.Addr), &c)
+	require.Equal(t, acctBefore, c.addr)
+
+	c.reset()
+	require.False(t, c.valid)
+}
+
+// TestUpdatesHashKey_MatchesHasher verifies hashKey reproduces the configured
+// hasher across every mode that hashes plain keys.
+func TestUpdatesHashKey_MatchesHasher(t *testing.T) {
+	t.Parallel()
+	keys := [][]byte{
+		{0x01, 0x02},
+		make([]byte, length.Addr),
+		func() []byte { k := make([]byte, 52); k[0], k[51] = 0x11, 0x22; return k }(),
+	}
+	for _, mode := range []Mode{ModeDirect, ModeUpdate, ModeParallel} {
+		u := NewUpdates(mode, t.TempDir(), KeyToHexNibbleHash)
+		require.True(t, u.addrCacheReuse, "cache must be enabled for the nibblizing hasher")
+		for _, k := range keys {
+			assert.Equal(t, KeyToHexNibbleHash(k), u.hashKey(k), "mode=%d key=%x", mode, k)
+		}
+	}
+}
+
+func TestHasherReusesAddrPrefix(t *testing.T) {
+	t.Parallel()
+	assert.True(t, hasherReusesAddrPrefix(KeyToHexNibbleHash))
+	assert.False(t, hasherReusesAddrPrefix(keyHasherNoop))
+}
+
+func benchKeys(numAddr, slotsPer int) [][]byte {
+	keys := make([][]byte, 0, numAddr*slotsPer)
+	for a := 0; a < numAddr; a++ {
+		for s := 0; s < slotsPer; s++ {
+			k := make([]byte, 52)
+			k[0] = byte(a)
+			k[1] = byte(a >> 8)
+			k[19] = byte(a * 7)
+			k[20] = byte(s >> 8)
+			k[51] = byte(s)
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+var benchWorkloads = []struct {
+	name    string
+	numAddr int
+	slots   int
+}{
+	{"whale_1x1000", 1, 1000},
+	{"spread5_5x200", 5, 200},
+	{"spread100_100x10", 100, 10},
+	{"scatter1000_1000x1", 1000, 1},
 }
 
 func Benchmark_KeyNibbleHash_NoCache(b *testing.B) {
-	// Whale storage: 1 addr × 1000 slots
-	keys := make([][]byte, 1000)
-	addr := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
-		0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}
-	for i := range keys {
-		keys[i] = make([]byte, 52)
-		copy(keys[i][:20], addr)
-		keys[i][20] = byte(i >> 8)
-		keys[i][51] = byte(i)
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, key := range keys {
-			_ = KeyToHexNibbleHash(key)
-		}
+	for _, w := range benchWorkloads {
+		keys := benchKeys(w.numAddr, w.slots)
+		b.Run(w.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				for _, k := range keys {
+					_ = KeyToHexNibbleHash(k)
+				}
+			}
+		})
 	}
 }
 
-func Benchmark_KeyNibbleHash_WithCache_Whale(b *testing.B) {
-	// Whale storage: 1 addr × 1000 slots
-	keys := make([][]byte, 1000)
-	addr := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
-		0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}
-	for i := range keys {
-		keys[i] = make([]byte, 52)
-		copy(keys[i][:20], addr)
-		keys[i][20] = byte(i >> 8)
-		keys[i][51] = byte(i)
-	}
-	cache := make(map[[20]byte][64]byte)
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, key := range keys {
-			_ = KeyToHexNibbleHashWithCache(key, cache)
-		}
-	}
-}
-
-func Benchmark_KeyNibbleHash_WithCache_Spread5(b *testing.B) {
-	// 5 addresses × 200 slots each
-	keys := make([][]byte, 1000)
-	for i := range keys {
-		keys[i] = make([]byte, 52)
-		addrIdx := byte(i / 200)
-		slotIdx := i % 200
-		keys[i][0] = addrIdx
-		keys[i][19] = addrIdx * 7
-		keys[i][20] = byte(slotIdx >> 8)
-		keys[i][51] = byte(slotIdx)
-	}
-	cache := make(map[[20]byte][64]byte)
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, key := range keys {
-			_ = KeyToHexNibbleHashWithCache(key, cache)
-		}
-	}
-}
-
-func Benchmark_KeyNibbleHash_WithCache_Spread100(b *testing.B) {
-	// 100 addresses × 10 slots each
-	keys := make([][]byte, 1000)
-	for i := range keys {
-		keys[i] = make([]byte, 52)
-		addrIdx := byte(i / 10)
-		slotIdx := i % 10
-		keys[i][0] = addrIdx
-		keys[i][19] = addrIdx * 3
-		keys[i][20] = byte(slotIdx >> 8)
-		keys[i][51] = byte(slotIdx)
-	}
-	cache := make(map[[20]byte][64]byte)
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, key := range keys {
-			_ = KeyToHexNibbleHashWithCache(key, cache)
-		}
-	}
-}
-
-func Benchmark_KeyNibbleHash_NoCache_Spread100(b *testing.B) {
-	// 100 addresses × 10 slots each — baseline
-	keys := make([][]byte, 1000)
-	for i := range keys {
-		keys[i] = make([]byte, 52)
-		addrIdx := byte(i / 10)
-		slotIdx := i % 10
-		keys[i][0] = addrIdx
-		keys[i][19] = addrIdx * 3
-		keys[i][20] = byte(slotIdx >> 8)
-		keys[i][51] = byte(slotIdx)
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		for _, key := range keys {
-			_ = KeyToHexNibbleHash(key)
-		}
+func Benchmark_KeyNibbleHash_Cached(b *testing.B) {
+	for _, w := range benchWorkloads {
+		keys := benchKeys(w.numAddr, w.slots)
+		b.Run(w.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var c addrHashCache
+				for _, k := range keys {
+					_ = keyToHexNibbleHashCached(k, &c)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Commitment re-nibblizes keccak(addr) for every storage slot, so a whale contract (one address, thousands of dirty slots) pays the same address hash thousands of times per commitment.

Reuse the nibblized keccak(addr) prefix across a run of storage keys that share an address, via a single-entry last-address cache routed through `Updates.hashKey`. Applies to serial (ModeDirect/ModeUpdate) and parallel commitment, gated to the nibblizing hasher whose key layout the reuse assumes. keccak(addr) is immutable, so a hit is always correct and a miss simply recomputes.

## Changes
- `addrHashCache` + `keyToHexNibbleHashCached`: one fixed-size cache entry; a hit copies the 64-nibble prefix, a miss recomputes and repopulates.
- `Updates.hashKey` wraps every plain-key hash site in both `TouchPlainKey` and `TouchPlainKeyDirect`, so all three modes benefit; enabled only when the hasher is `KeyToHexNibbleHash`.
- `Reset()` clears the cache.

Nibblization microbench (1000 keys/op): whale 1x1000 -46%, spread 5x200 -45%, spread 100x10 -40%, scatter 1000x1 +6%. Zero added allocations.

End-to-end commitment over a 200K-slot single-address whale (touch + fold, benchstat n=6): ModeDirect -7.5%, ModeParallel -15.3% (p=0.002); allocations unchanged. The gain scales with how whale-heavy the storage writes are — a normal mixed block sees less.