### PR TITLE
execution: update to latest stable eest spec test fixtures v20.0.0

### DIFF
--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -123,3 +123,34 @@ jobs:
         run: |
           echo "::error title=Merge-queue root-cause failure::This job failed and is fast-cancelling the CI Gate run; THIS job is the real failure (the others show as cancelled). See its logs."
           gh run cancel ${{ github.run_id }} || true
+
+  # Fast guard (no fixture execution): catches coverage regressions a normal test
+  # run does NOT surface — the stable race / hive-consume-engine fork partitions
+  # (a fork silently unmatched by any shard) and glamsterdam-devnet EIP-filter
+  # liveness+completeness. Reads live config + corpus .meta/index.json. Part of
+  # this reusable workflow, so ci-gate's eest-spec-tests dependency fails when
+  # coverage regresses.
+  eest-shard-coverage:
+    if: ${{ !inputs.cache-warming-only }}
+    name: eest-shard-coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Restore EEST tarballs
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            test-fixtures-cache/eest_stable.tar.gz
+            test-fixtures-cache/eest_devnet.tar.gz
+            test-fixtures-cache/eest_benchmark.tar.gz
+            test-fixtures-cache/eest_zkevm.tar.gz
+          key: test-fixtures-eest-${{ runner.os }}-${{ hashFiles('test-fixtures.json') }}
+          restore-keys: |
+            test-fixtures-eest-${{ runner.os }}-
+
+      - name: Check EEST shard coverage
+        run: make check-eest-shards

--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -154,3 +154,14 @@ jobs:
 
       - name: Check EEST shard coverage
         run: make check-eest-shards
+
+      # In the merge queue, cancel the run on first failure so the gate
+      # doesn't stall waiting for still-running siblings. PR runs keep
+      # going so authors see the full failure picture.
+      - name: Cancel workflow run on failure
+        if: failure() && github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "::error title=Merge-queue root-cause failure::This job failed and is fast-cancelling the CI Gate run; THIS job is the real failure (the others show as cancelled). See its logs."
+          gh run cancel ${{ github.run_id }} || true

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -28,8 +28,9 @@ jobs:
         # entries spawn separate `hive` group runners and run concurrently —
         # wall-clock unchanged, runner-minutes doubled.
         include:
-          # consume-engine: split by fork for parallelism (61k+ tests total).
-          # Engine API tests only exist from Paris (The Merge) onwards.
+          # consume-engine: split by fork for parallelism (~50k tests total).
+          # Engine API tests only exist from Paris (The Merge) onwards; the
+          # osaka shard also carries the BPO fork-transition fixtures.
           # Pattern format: "<suite-regex>/<test-regex>" — the leading ".*/""
           # matches the suite name (eest/consume-engine) while the remainder
           # filters individual pytest test IDs by fork parameter.
@@ -84,14 +85,14 @@ jobs:
             max-failures: 0
             exec_mode: parallel
           - sim: consume-engine
-            sim-limit: ".*/.*fork_Osaka"
+            sim-limit: ".*/.*fork_(Osaka|BPO)"
             shard: osaka
             pool-size: 4
             fixtures-tarball: eest_stable
             max-failures: 0
             exec_mode: serial
           - sim: consume-engine
-            sim-limit: ".*/.*fork_Osaka"
+            sim-limit: ".*/.*fork_(Osaka|BPO)"
             shard: osaka
             pool-size: 4
             fixtures-tarball: eest_stable

--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,15 @@ $(addprefix eest-spec-,$(EEST_SPEC_RACE_SHARDS)): eest-spec-%: evm.race
 	@EVM_BIN=$(GOBIN)/evm.race bash tools/run-eest-spec-test.sh "$*"
 endif
 
+## check-eest-shards:                  verify EEST shard coverage (stable fork partition + devnet EIP-filter liveness/completeness)
+.PHONY: check-eest-shards
+check-eest-shards:
+	@bash tools/test-fixtures.sh --download-only test-fixtures.json test-fixtures-cache eest_stable eest_devnet
+	@mkdir -p test-fixtures-cache/eest_stable/fixtures/.meta test-fixtures-cache/eest_devnet/fixtures/.meta
+	@tar -xzf test-fixtures-cache/eest_stable.tar.gz -C test-fixtures-cache/eest_stable fixtures/.meta/index.json
+	@tar -xzf test-fixtures-cache/eest_devnet.tar.gz -C test-fixtures-cache/eest_devnet fixtures/.meta/index.json
+	@bash tools/check-eest-shard-coverage.sh
+
 ## test-bench:                         check the benchmarks compile and run
 test-bench: override GO_FLAGS += -run=^$$ -bench=. -benchtime=1x -short -timeout=5m
 test-bench:

--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -619,13 +619,13 @@ type forkBlockNumber struct {
 	name        string
 	blockNumber *uint64
 	optional    bool // if true, the fork may be nil and next fork is still allowed
+	outOfOrder  bool // if true, the fork is exempt from the ordering check (one-off fork, e.g. DAO)
 }
 
 func (c *Config) forkBlockNumbers() []forkBlockNumber {
 	return []forkBlockNumber{
 		{name: "homesteadBlock", blockNumber: c.HomesteadBlock},
-		// daoForkBlock is intentionally excluded from the ordering: it is a one-off
-		// state-change fork that test chains may schedule out of order relative to eip150.
+		{name: "daoForkBlock", blockNumber: c.DAOForkBlock, optional: true, outOfOrder: true},
 		{name: "eip150Block", blockNumber: c.TangerineWhistleBlock},
 		{name: "eip155Block", blockNumber: c.SpuriousDragonBlock},
 		{name: "byzantiumBlock", blockNumber: c.ByzantiumBlock},
@@ -650,7 +650,7 @@ func (c *Config) CheckConfigForkOrder() error {
 	var lastFork forkBlockNumber
 
 	for _, fork := range c.forkBlockNumbers() {
-		if lastFork.name != "" {
+		if lastFork.name != "" && !fork.outOfOrder {
 			// Next one must be higher number
 			if lastFork.blockNumber == nil && fork.blockNumber != nil {
 				return fmt.Errorf("unsupported fork ordering: %v not enabled, but %v enabled at %v",
@@ -664,7 +664,7 @@ func (c *Config) CheckConfigForkOrder() error {
 			}
 			// If it was optional and not set, then ignore it
 		}
-		if !fork.optional || fork.blockNumber != nil {
+		if (!fork.optional || fork.blockNumber != nil) && !fork.outOfOrder {
 			lastFork = fork
 		}
 	}

--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -624,7 +624,8 @@ type forkBlockNumber struct {
 func (c *Config) forkBlockNumbers() []forkBlockNumber {
 	return []forkBlockNumber{
 		{name: "homesteadBlock", blockNumber: c.HomesteadBlock},
-		{name: "daoForkBlock", blockNumber: c.DAOForkBlock, optional: true},
+		// daoForkBlock is intentionally excluded from the ordering: it is a one-off
+		// state-change fork that test chains may schedule out of order relative to eip150.
 		{name: "eip150Block", blockNumber: c.TangerineWhistleBlock},
 		{name: "eip155Block", blockNumber: c.SpuriousDragonBlock},
 		{name: "byzantiumBlock", blockNumber: c.ByzantiumBlock},

--- a/execution/chain/chain_config_test.go
+++ b/execution/chain/chain_config_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/erigontech/erigon/common"
@@ -275,4 +276,45 @@ func TestBlobParameterDencunAndPectraAtGenesis(t *testing.T) {
 	assert.Equal(t, uint64(6), c.GetTargetBlobsPerBlock(0))
 	assert.Equal(t, uint64(9), c.GetMaxBlobsPerBlock(0))
 	assert.Equal(t, uint64(5007716), c.GetBlobGasPriceUpdateFraction(0))
+}
+
+func TestCheckConfigForkOrder(t *testing.T) {
+	t.Parallel()
+	u64 := func(n uint64) *uint64 { return &n }
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{
+			// EEST TangerineWhistle/SpuriousDragon test genesis: EIP-150 active at
+			// block 0 with the DAO fork scheduled past the test's blocks. The DAO
+			// fork block sits after eip150 but must not be rejected.
+			name:    "dao after eip150",
+			cfg:     Config{ChainID: uint256.NewInt(1), HomesteadBlock: u64(0), DAOForkBlock: u64(2000), TangerineWhistleBlock: u64(0), SpuriousDragonBlock: u64(0)},
+			wantErr: false,
+		},
+		{
+			name:    "dao disabled",
+			cfg:     Config{ChainID: uint256.NewInt(1), HomesteadBlock: u64(0), TangerineWhistleBlock: u64(0), SpuriousDragonBlock: u64(0)},
+			wantErr: false,
+		},
+		{
+			name:    "eip150 after eip155 still rejected",
+			cfg:     Config{ChainID: uint256.NewInt(1), HomesteadBlock: u64(0), TangerineWhistleBlock: u64(10), SpuriousDragonBlock: u64(5)},
+			wantErr: true,
+		},
+	}
+	for i := range cases {
+		tc := &cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.cfg.CheckConfigForkOrder()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/execution/tests/testforks/forks.go
+++ b/execution/tests/testforks/forks.go
@@ -83,10 +83,12 @@ func init() {
 	c = configCopy(c)
 	c.TangerineWhistleBlock = common.NewUint64(0)
 	Forks["EIP150"] = c
+	Forks["TangerineWhistle"] = c
 
 	c = configCopy(c)
 	c.SpuriousDragonBlock = common.NewUint64(0)
 	Forks["EIP158"] = c
+	Forks["SpuriousDragon"] = c
 
 	c = configCopy(c)
 	c.ByzantiumBlock = common.NewUint64(5)

--- a/execution/types/ethutils/receipt.go
+++ b/execution/types/ethutils/receipt.go
@@ -45,7 +45,7 @@ func MarshalReceipt(
 	switch t := txn.(type) {
 	case *types.LegacyTx:
 		if t.Protected() {
-			chainId = types.DeriveChainId(&t.V)
+			chainId, _ = types.DeriveChainId(&t.V)
 		}
 	default:
 		chainId = txn.GetChainID()

--- a/execution/types/legacy_tx.go
+++ b/execution/types/legacy_tx.go
@@ -404,7 +404,11 @@ func (tx *LegacyTx) RawSignatureValues() (*uint256.Int, *uint256.Int, *uint256.I
 }
 
 func (tx *LegacyTx) GetChainID() *uint256.Int {
-	return DeriveChainId(&tx.V)
+	chainID, err := DeriveChainId(&tx.V)
+	if err != nil {
+		return new(uint256.Int)
+	}
+	return chainID
 }
 
 func (tx *LegacyTx) cachedSender() (sender accounts.Address, ok bool) {

--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -320,8 +320,11 @@ func sanityCheckSignature(v *uint256.Int, r *uint256.Int, s *uint256.Int, maybeP
 
 	var plainV byte
 	if isProtectedV(v) {
-		chainID := DeriveChainId(v).Uint64()
-		plainV = byte(v.Uint64() - 35 - 2*chainID)
+		chainID, err := DeriveChainId(v)
+		if err != nil {
+			return err
+		}
+		plainV = byte(v.Uint64() - 35 - 2*chainID.Uint64())
 	} else if maybeProtected {
 		// Only EIP-155 signatures can be optionally protected. Since
 		// we determined this v value is not protected, it must be a

--- a/execution/types/transaction_signing.go
+++ b/execution/types/transaction_signing.go
@@ -236,7 +236,11 @@ func (sg Signer) SenderWithContext(context *secp256k1.Context, txn Transaction) 
 			if !sg.protected {
 				return accounts.NilAddress, fmt.Errorf("protected txn is not supported by signer %s", sg)
 			}
-			if !DeriveChainId(&t.V).Eq(&sg.chainID) {
+			chainID, err := DeriveChainId(&t.V)
+			if err != nil {
+				return accounts.NilAddress, err
+			}
+			if !chainID.Eq(&sg.chainID) {
 				return accounts.NilAddress, ErrInvalidChainId
 			}
 			V.Sub(&t.V, &sg.chainIDMul)
@@ -384,15 +388,20 @@ func recoverPlain(context *secp256k1.Context, sighash common.Hash, R, S, Vb *uin
 	return accounts.InternAddress(addr), nil
 }
 
-// deriveChainID derives the chain id from the given v parameter
-func DeriveChainId(v *uint256.Int) *uint256.Int {
+// DeriveChainId derives the chain id from a legacy transaction's v value.
+// Valid v is 27/28 (pre-EIP-155, chain id 0) or >= 35 (EIP-155); a smaller
+// value would underflow, so it is rejected as an invalid signature value.
+func DeriveChainId(v *uint256.Int) (*uint256.Int, error) {
 	if v.IsUint64() {
 		v := v.Uint64()
 		if v == 27 || v == 28 {
-			return new(uint256.Int)
+			return new(uint256.Int), nil
 		}
-		return new(uint256.Int).SetUint64((v - 35) / 2)
+		if v < 35 {
+			return nil, ErrInvalidSig
+		}
+		return new(uint256.Int).SetUint64((v - 35) / 2), nil
 	}
 	r := new(uint256.Int).Sub(v, &u256.Num35)
-	return r.Rsh(r, 1) // ÷2
+	return r.Rsh(r, 1), nil // ÷2
 }

--- a/execution/types/transaction_signing_test.go
+++ b/execution/types/transaction_signing_test.go
@@ -165,6 +165,60 @@ func TestChainId(t *testing.T) {
 	}
 }
 
+func TestLegacyOutOfRangeVIsInvalidSig(t *testing.T) {
+	t.Parallel()
+	// v=34 is not a valid legacy v: it is neither the pre-EIP-155 values 27/28 nor
+	// a valid EIP-155 encoding (v >= 35), so it must be rejected as a bad signature
+	// value rather than mis-reported as an invalid chain id.
+	signer := LatestSignerForChainID(uint256.NewInt(1))
+	txn := &LegacyTx{
+		CommonTx: CommonTx{
+			Nonce:    0,
+			GasLimit: 21000,
+			Value:    *uint256.NewInt(0),
+			V:        *uint256.NewInt(34),
+			R:        *uint256.NewInt(1),
+			S:        *uint256.NewInt(1),
+		},
+		GasPrice: *uint256.NewInt(1),
+	}
+	_, err := txn.Sender(*signer)
+	if !errors.Is(err, ErrInvalidSig) {
+		t.Errorf("expected %v for out-of-range legacy v, got %v", ErrInvalidSig, err)
+	}
+}
+
+func TestDeriveChainId(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		v       uint64
+		want    uint64
+		wantErr bool
+	}{
+		{27, 0, false},
+		{28, 0, false},
+		{35, 0, false},
+		{37, 1, false}, // mainnet EIP-155
+		{38, 1, false},
+		{0, 0, true},
+		{29, 0, true},
+		{34, 0, true},
+	} {
+		got, err := DeriveChainId(uint256.NewInt(tc.v))
+		if tc.wantErr {
+			if !errors.Is(err, ErrInvalidSig) {
+				t.Errorf("v=%d: expected ErrInvalidSig, got %v", tc.v, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("v=%d: unexpected error %v", tc.v, err)
+		} else if got.Uint64() != tc.want {
+			t.Errorf("v=%d: chainId=%d, want %d", tc.v, got.Uint64(), tc.want)
+		}
+	}
+}
+
 func TestSignatureValuesError(t *testing.T) {
 	// 1. Setup a valid transaction
 	tx := NewTransaction(0, common.Address{}, new(uint256.Int), 0, new(uint256.Int), nil)

--- a/rpc/ethapi/api.go
+++ b/rpc/ethapi/api.go
@@ -606,7 +606,7 @@ func NewRPCTransaction(txn types.Transaction, blockHash common.Hash, blockTime u
 			chainId, err = types.DeriveChainId(v)
 			// if a legacy transaction has an EIP-155 chain id, include it explicitly, otherwise chain id is not included
 			if err != nil {
-				log.Warn("chain id derivation", "err", err)
+				log.Warn("[rpc] chain id derivation", "err", err)
 			} else if !chainId.IsZero() {
 				result.ChainID = (*hexutil.Big)(chainId.ToBig())
 			}

--- a/rpc/ethapi/api.go
+++ b/rpc/ethapi/api.go
@@ -602,9 +602,12 @@ func NewRPCTransaction(txn types.Transaction, blockHash common.Hash, blockTime u
 
 	if txn.Type() == types.LegacyTxType {
 		if !v.IsZero() { // skip chain id derivation in case of call simulation (where v,r,s are zero)
-			chainId = types.DeriveChainId(v)
+			var err error
+			chainId, err = types.DeriveChainId(v)
 			// if a legacy transaction has an EIP-155 chain id, include it explicitly, otherwise chain id is not included
-			if !chainId.IsZero() {
+			if err != nil {
+				log.Warn("chain id derivation", "err", err)
+			} else if !chainId.IsZero() {
 				result.ChainID = (*hexutil.Big)(chainId.ToBig())
 			}
 		}

--- a/rpc/ethapi/api_test.go
+++ b/rpc/ethapi/api_test.go
@@ -3,12 +3,14 @@ package ethapi
 import (
 	"bytes"
 	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -45,6 +47,21 @@ func TestNewRPCTransaction_SignedLegacy(t *testing.T) {
 	require.NotNil(t, result.V)
 	require.NotNil(t, result.R)
 	require.NotNil(t, result.S)
+}
+
+func TestNewRPCTransaction_SignedLegacyEIP155(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	to := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	chainID := uint256.NewInt(1)
+	tx, err := types.SignTx(types.NewTransaction(1, to, uint256.NewInt(0), 21000, uint256.NewInt(1), nil), *types.LatestSignerForChainID(chainID), key)
+	require.NoError(t, err)
+	result := NewRPCTransaction(tx, common.Hash{}, 0, 0, 0, nil)
+	// from is recovered with the chain id derived from the EIP-155 v value.
+	require.Equal(t, from, result.From)
+	require.NotNil(t, result.ChainID)
+	require.Equal(t, chainID.ToBig(), (*big.Int)(result.ChainID))
 }
 
 func TestNewRPCTransaction_EIP1559_YParityZero(t *testing.T) {

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -11,9 +11,9 @@
     "branch": "devnets/bal/7"
   },
   "eest_stable": {
-    "url": "https://github.com/ethereum/execution-spec-tests/releases/download/v5.4.0/fixtures_develop.tar.gz",
-    "sha256": "3e2b02d49fe903eda4fd8caca5cbf0d139c470e97e1de9a85299b1b034f97099",
-    "size": 422845437
+    "url": "https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.0/fixtures.tar.gz",
+    "sha256": "b183702a5b447b465873865357ced9eb342315922e52e31b714e2de115dd0bb4",
+    "size": 399656884
   },
   "eest_zkevm": {
     "url": "https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.4.1/fixtures_zkevm.tar.gz",

--- a/tools/check-eest-shard-coverage.sh
+++ b/tools/check-eest-shard-coverage.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Fails when the EEST shards stop covering their corpus, so a fixtures bump
+# can't silently drop tests. It targets the failures a normal test run does NOT
+# surface — a fork or EIP quietly dropped while the shard still runs enough tests
+# to look green. Two invariants, read from the live config and the corpus
+# manifests (.meta/index.json); nothing is hard-coded:
+#
+#   1. partition (stable): the fork-split families each run every fork exactly
+#      once — spec race shards (run-eest-spec-test.sh, blocktest --run) over
+#      blockchain_test, and hive consume-engine (test-hive-eest.yml sim-limit)
+#      over blockchain_test_engine. A gap silently never runs a fork; an overlap
+#      runs it twice.
+#   2. EIP-filter liveness + completeness (devnet): the hive glamsterdam-devnet
+#      sim-limit hand-picks the target fork's EIPs. Liveness — every token still
+#      matches a fixture (a renamed/dropped EIP can't silently shrink the shard
+#      while it still runs enough tests to look healthy). Completeness — every EIP
+#      module under the source-fork dir(s) the filter targets is in the filter, so
+#      a NEW EIP added to that fork on a devnet bump can't be silently left out.
+#      The target dir(s) are derived from where the filter's own EIPs live (no
+#      hard-coded fork name).
+#
+# The devnet check is skipped (not failed) when the devnet corpus isn't staged,
+# so a stable-only local run still works; `make check-eest-shards` stages both.
+#
+# Usage: tools/check-eest-shard-coverage.sh [STABLE_INDEX_JSON [DEVNET_INDEX_JSON]]
+set -euo pipefail
+
+here=$(cd "$(dirname "$0")/.." && pwd)
+stable_index="${1:-$here/test-fixtures-cache/eest_stable/fixtures/.meta/index.json}"
+devnet_index="${2:-$here/test-fixtures-cache/eest_devnet/fixtures/.meta/index.json}"
+runner="$here/tools/run-eest-spec-test.sh"
+hive="$here/.github/workflows/test-hive-eest.yml"
+
+for tool in jq yq awk; do
+	command -v "$tool" >/dev/null 2>&1 || { echo "check-eest-shard-coverage: $tool not found in PATH" >&2; exit 1; }
+done
+[[ -f "$stable_index" ]] || { echo "check-eest-shard-coverage: stable index not found: $stable_index" >&2; exit 1; }
+
+# Live regexes, one "shard=regex" per line, parsed from the shard definitions.
+race_regexes() {
+	awk '
+		/blocktests-stable-race-[a-z-]+\)/ { n=$0; sub(/.*blocktests-stable-race-/,"",n); sub(/\).*/,"",n) }
+		n!="" && /--run/ { r=$0; sub(/.*--run '\''/,"",r); sub(/'\''.*/,"",r); print n"="r; n="" }
+	' "$runner"
+}
+hive_consume_engine_regexes() {
+	yq -o=json '.jobs.test-hive-eest.strategy.matrix.include' "$hive" \
+		| jq -r '.[] | select(.sim=="consume-engine" and .["fixtures-tarball"]=="eest_stable") | "\(.shard)=\(.["sim-limit"])"' \
+		| sort -u
+}
+
+# --- 1. partition ---
+check_partition() {
+	local title="$1" index="$2" format="$3" idprefix="$4" regexes="$5"
+	echo "==== partition: $title (format=$format) ===="
+	printf '%s\n' "$regexes" | sed 's/^/  regex  /'
+	jq -r --arg f "$format" '.test_cases | map(select(.format==$f)) | group_by(.fork)[] | "\(.[0].fork)\t\(length)"' "$index" \
+	| awk -v idprefix="$idprefix" '
+		FNR==NR { i=index($0,"="); name[++k]=substr($0,1,i-1); rx[k]=substr($0,i+1); n=k; next }
+		{
+			fork=$1; cnt=$2; id=idprefix "[fork_" fork "-x]"; m=0
+			for (i=1;i<=n;i++) if (id ~ rx[i]) { m++; tot[name[i]]+=cnt }
+			total+=cnt
+			if (m==0)      { printf "  GAP      %-28s %7d  (matched by no shard)\n", fork, cnt; gaps++ }
+			else if (m>=2) { printf "  OVERLAP  %-28s %7d  (matched by %d shards)\n", fork, cnt, m; overlaps++ }
+		}
+		END {
+			print "  --- per-shard totals ---"
+			for (s in tot) printf "  %-18s %7d\n", s, tot[s]
+			printf "  total=%d  gaps=%d  overlaps=%d\n", total, gaps+0, overlaps+0
+			if (gaps || overlaps) exit 1
+		}
+	' <(printf '%s\n' "$regexes") -
+}
+
+# --- 2. EIP-filter liveness + completeness ---
+check_hive_eip_filter() {
+	local index="$1"
+	echo "==== EIP filter: hive glamsterdam-devnet (liveness + target-fork completeness) ===="
+	local simlimit
+	simlimit=$(yq -o=json '.jobs.test-hive-eest.strategy.matrix.include' "$hive" \
+		| jq -r '.[] | select(.shard=="glamsterdam-devnet") | .["sim-limit"]' | head -1)
+	[[ -n "$simlimit" ]] || { echo "  glamsterdam-devnet shard not found" >&2; return 1; }
+	local rc=0 e hits ids targets filter
+	filter=$(printf '%s' "$simlimit" | grep -oE '[0-9]{4,}' | sort -u)
+	ids=$(mktemp); targets=$(mktemp)
+	jq -r '.test_cases[] | select(.format=="blockchain_test_engine") | .id' "$index" > "$ids"
+	# liveness: each filter token must match a fixture; collect its source-fork dir
+	for e in $filter; do
+		hits=$(grep -cE "eip$e" "$ids" || true)
+		if [[ "$hits" -eq 0 ]]; then echo "  DEAD TOKEN  eip$e  matches 0 devnet engine tests"; rc=1; continue; fi
+		printf '  live  eip%-6s %6d engine tests\n' "$e" "$hits"
+		grep -oE "tests/[a-z0-9]+/eip$e" "$ids" | grep -oE 'tests/[a-z0-9]+/' >> "$targets"
+	done
+	# completeness: every EIP module under those target dir(s) must be in the filter
+	local tdirs corpus missing d n
+	tdirs=$(sort -u "$targets")
+	echo "  target source-fork dir(s): $(printf '%s ' $tdirs)"
+	corpus=$(for d in $tdirs; do grep -oE "^${d}eip[0-9]+" "$ids"; done | grep -oE '[0-9]+' | sort -u)
+	missing=$(comm -23 <(printf '%s\n' $corpus) <(printf '%s\n' $filter))
+	if [[ -n "$missing" ]]; then
+		for e in $missing; do
+			n=$(grep -cE "eip$e" "$ids" || true)
+			echo "  MISSING FROM FILTER  eip$e  ($n engine tests under the target fork, not matched by sim-limit)"
+		done
+		echo "  => add the new EIP(s) to the glamsterdam-devnet sim-limit in .github/workflows/test-hive-eest.yml" >&2
+		rc=1
+	fi
+	rm -f "$ids" "$targets"
+	[[ "$rc" -eq 0 ]] && echo "  OK: all filter tokens live and cover every EIP module under the target fork dir(s)"
+	return $rc
+}
+
+rc=0
+check_partition "spec race shards (blocktest --run)"  "$stable_index" blockchain_test        ""                     "$(race_regexes)" || rc=1
+echo
+check_partition "hive consume-engine (sim-limit)"     "$stable_index" blockchain_test_engine "eels/consume-engine/" "$(hive_consume_engine_regexes)" || rc=1
+echo
+if [[ -f "$devnet_index" ]]; then
+	check_hive_eip_filter "$devnet_index" || rc=1
+	echo
+else
+	echo "==== devnet check SKIPPED (index not found: $devnet_index) ===="
+	echo
+fi
+if (( rc == 0 )); then
+	echo "EEST shard coverage OK."
+else
+	echo "EEST shard coverage FAILED: fix the regexes in tools/run-eest-spec-test.sh and/or .github/workflows/test-hive-eest.yml." >&2
+fi
+exit $rc

--- a/tools/check-eest-shard-coverage.sh
+++ b/tools/check-eest-shard-coverage.sh
@@ -39,7 +39,7 @@ done
 # Live regexes, one "shard=regex" per line, parsed from the shard definitions.
 race_regexes() {
 	awk '
-		/blocktests-stable-race-[a-z-]+\)/ { n=$0; sub(/.*blocktests-stable-race-/,"",n); sub(/\).*/,"",n) }
+		/blocktests-stable-race-[a-z0-9-]+\)/ { n=$0; sub(/.*blocktests-stable-race-/,"",n); sub(/\).*/,"",n) }
 		n!="" && /--run/ { r=$0; sub(/.*--run '\''/,"",r); sub(/'\''.*/,"",r); print n"="r; n="" }
 	' "$runner"
 }
@@ -53,6 +53,10 @@ hive_consume_engine_regexes() {
 check_partition() {
 	local title="$1" index="$2" format="$3" idprefix="$4" regexes="$5"
 	echo "==== partition: $title (format=$format) ===="
+	if [[ -z "${regexes//[[:space:]]/}" ]]; then
+		echo "  ERROR: no shard regexes parsed for $title — the scrape returned empty (shard rename / label or quoting change?)" >&2
+		return 1
+	fi
 	printf '%s\n' "$regexes" | sed 's/^/  regex  /'
 	jq -r --arg f "$format" '.test_cases | map(select(.format==$f)) | group_by(.fork)[] | "\(.[0].fork)\t\(length)"' "$index" \
 	| awk -v idprefix="$idprefix" '
@@ -68,6 +72,7 @@ check_partition() {
 			print "  --- per-shard totals ---"
 			for (s in tot) printf "  %-18s %7d\n", s, tot[s]
 			printf "  total=%d  gaps=%d  overlaps=%d\n", total, gaps+0, overlaps+0
+			if (total == 0) { print "  ERROR: no forks found for this format — index format labels changed?" > "/dev/stderr"; exit 1 }
 			if (gaps || overlaps) exit 1
 		}
 	' <(printf '%s\n' "$regexes") -
@@ -95,8 +100,16 @@ check_hive_eip_filter() {
 	# completeness: every EIP module under those target dir(s) must be in the filter
 	local tdirs corpus missing d n
 	tdirs=$(sort -u "$targets")
+	if [[ -z "${tdirs//[[:space:]]/}" ]]; then
+		echo "  ERROR: no target fork dir derived from filter EIPs (fixture id path format changed?)" >&2
+		rm -f "$ids" "$targets"; return 1
+	fi
 	echo "  target source-fork dir(s): $(printf '%s ' $tdirs)"
 	corpus=$(for d in $tdirs; do grep -oE "^${d}eip[0-9]+" "$ids"; done | grep -oE '[0-9]+' | sort -u)
+	if [[ -z "${corpus//[[:space:]]/}" ]]; then
+		echo "  ERROR: no EIP modules found under target dir(s)" >&2
+		rm -f "$ids" "$targets"; return 1
+	fi
 	missing=$(comm -23 <(printf '%s\n' $corpus) <(printf '%s\n' $filter))
 	if [[ -n "$missing" ]]; then
 		for e in $missing; do

--- a/tools/run-eest-spec-test.sh
+++ b/tools/run-eest-spec-test.sh
@@ -111,13 +111,13 @@ case "$shard_route" in
 		cmd=blocktest;   path="$base/blockchain_tests" ;;
 	blocktests-stable-race-pre-cancun)
 		cmd=blocktest;   path="$base/blockchain_tests"
-		extra=(--run 'fork_(Frontier|Homestead|Byzantium|ConstantinopleFix|Istanbul|Berlin|London|Paris|Shanghai)') ;;
+		extra=(--run 'fork_(Frontier|Homestead|TangerineWhistle|SpuriousDragon|Byzantium|ConstantinopleFix|Istanbul|Berlin|London|Paris|Shanghai)') ;;
 	blocktests-stable-race-cancun)
 		cmd=blocktest;   path="$base/blockchain_tests"; extra=(--run 'fork_Cancun') ;;
 	blocktests-stable-race-prague)
 		cmd=blocktest;   path="$base/blockchain_tests"; extra=(--run 'fork_Prague') ;;
 	blocktests-stable-race-osaka)
-		cmd=blocktest;   path="$base/blockchain_tests"; extra=(--run 'fork_Osaka') ;;
+		cmd=blocktest;   path="$base/blockchain_tests"; extra=(--run 'fork_(Osaka|BPO)') ;;
 	blocktests-devnet-race-amsterdam)
 		cmd=blocktest;   path="$base/blockchain_tests"; extra=(--run 'fork_Amsterdam') ;;
 	enginextests-stable)


### PR DESCRIPTION
Transitions the `eest_stable` corpus to the first mainnet fixture release from
`ethereum/execution-specs` (`tests@v20.0.0`, Osaka+BPO1+BPO2 — 216,525 cases),
fixes the fork-mapping and shard-coverage breakage the new release exposes, and
adds a CI guard so future fixture bumps can't silently drop coverage.

## Why
- EEST moved: `ethereum/execution-spec-tests` is archived; mainnet fixtures now
  ship from `ethereum/execution-specs` as a single `fixtures.tar.gz` (replacing
  the `fixtures_develop`/`fixtures_stable` split).
- The new corpus is reorganized by top-level `for_<fork>/` dirs, renames two
  forks (`EIP150`→`TangerineWhistle`, `EIP158`→`SpuriousDragon`), and adds BPO
  transition forks — which broke fork lookup and left our fork-split shards with
  coverage gaps.

## What changed
- **`test-fixtures.json`**: `eest_stable` → `execution-specs` `tests@v20.0.0`
  `fixtures.tar.gz` (sha256 verified against the release digest).
- **`execution/tests/testforks/forks.go`**: register `TangerineWhistle` /
  `SpuriousDragon` as aliases of the existing `EIP150` / `EIP158` configs (legacy
  names kept).
- **`tools/run-eest-spec-test.sh`**: race-shard fork regexes — pre-cancun
  `+= TangerineWhistle|SpuriousDragon`; osaka `fork_Osaka → fork_(Osaka|BPO)`.
- **`.github/workflows/test-hive-eest.yml`**: hive consume-engine osaka
  `sim-limit → fork_(Osaka|BPO)`.
- **`tools/check-eest-shard-coverage.sh`** (new) + `make check-eest-shards` +
  `eest-shard-coverage` CI job: fast guard against silent coverage regressions.

## Correctness (before → after, on the v20 corpus)
| Check | Before | After |
|-------|--------|-------|
| statetest+blocktest for TangerineWhistle/SpuriousDragon | 2,627 fail (`unsupported fork`) | 0 fail |
| race shards cover `blockchain_test` (63,109) | 61,476 (1,633 missed: TW/SD/BPO) | 63,109 — 0 gaps, 0 overlaps |
| hive consume-engine covers `blockchain_test_engine` (50,564) | 50,493 (71 BPO ran nowhere) | 50,564 — 0 gaps, 0 overlaps |

## Coverage guard
Reads the live shard regexes (runner + workflow) and the corpus
`.meta/index.json`; fails on regressions a normal test run would not surface:
- **partition** (stable race + hive consume-engine): every fork matched by
  exactly one shard — no gap (miss), no overlap (duplicate).
- **devnet hive EIP filter**: liveness (every filter EIP still matches a fixture)
  + completeness (every EIP under the target fork is in the filter).

## Testing
- Full v20 stable suites pass: statetest 52,169/0, blocktest 63,109/0,
  enginextest 50,564/0; parallel-exec smoke (Osaka+BPO) 16,644/0.
- Devnet corpus verified: whole-dir shards fully cover state/blockchain tests;
  hive EIP filter live + complete.
- Guard soundness harness: 18/18 (regressions caught, valid changes stay green).
- `make lint`, shellcheck, actionlint clean.

## Out of scope
- `eest_devnet` / `eest_benchmark` / `eest_zkevm` are separate feature releases —
  unchanged.
- EEST `transaction_test` (110) + `blockchain_test_sync` (9) have no runner
  (pre-existing).
