### PR TITLE
db/downloader: lock torrentsByName write in AddNewSeedableFile

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -761,11 +761,7 @@ func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error 
 		return fmt.Errorf("building metainfo for new seedable file: %w", err)
 	}
 	// The above BuildTorrentIfNeed should put the metainfo in the right place for name.
-	// Hold d.lock across the torrentsByName mutation like the download add paths do, so
-	// it cannot race allActiveSnapshots' iteration (which holds only RLock).
-	d.lock.Lock()
 	_, _, err = d.addCompleteTorrent(name)
-	d.lock.Unlock()
 	if err != nil {
 		return fmt.Errorf("adding torrent: %w", err)
 	}
@@ -1310,6 +1306,11 @@ func (d *Downloader) addCompleteTorrent(
 		err = fmt.Errorf("loading metainfo from disk: %w", err)
 		return
 	}
+	// Hold d.lock only for the torrentsByName mutation, like the download add paths do,
+	// so it cannot race allActiveSnapshots' iteration (which holds only RLock). This is
+	// the sole caller path that reaches addTorrent without the caller already holding it.
+	d.lock.Lock()
+	defer d.lock.Unlock()
 	return d.addCompleteTorrentFromMetainfo(name, mi)
 }
 

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -761,7 +761,11 @@ func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error 
 		return fmt.Errorf("building metainfo for new seedable file: %w", err)
 	}
 	// The above BuildTorrentIfNeed should put the metainfo in the right place for name.
+	// Hold d.lock across the torrentsByName mutation like the download add paths do, so
+	// it cannot race allActiveSnapshots' iteration (which holds only RLock).
+	d.lock.Lock()
 	_, _, err = d.addCompleteTorrent(name)
+	d.lock.Unlock()
 	if err != nil {
 		return fmt.Errorf("adding torrent: %w", err)
 	}

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -96,12 +96,11 @@ func TestAllActiveSnapshotsConcurrentWithWrites(t *testing.T) {
 	}
 }
 
-// TestAllActiveSnapshotsRaceWithAddNewSeedableFile pins that AddNewSeedableFile mutates
-// torrentsByName without holding d.lock, so it data-races allActiveSnapshots' iteration
-// under -race even though the read side takes d.lock.RLock — an RLock cannot exclude a
-// writer that holds no lock. The locked download paths make this invisible; the seed path
-// does not.
-func TestAllActiveSnapshotsRaceWithAddNewSeedableFile(t *testing.T) {
+// TestAddNewSeedableFileConcurrentWithAllActiveSnapshots pins that AddNewSeedableFile's
+// torrentsByName mutation holds d.lock, so it does not race allActiveSnapshots' iteration.
+// Without the lock the map write and the RLock'd read report a data race under -race — an
+// RLock cannot exclude a writer that holds no lock.
+func TestAddNewSeedableFileConcurrentWithAllActiveSnapshots(t *testing.T) {
 	test := newDownloaderTest(t)
 	d := test.downloader
 	ctx := t.Context()

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -96,6 +96,43 @@ func TestAllActiveSnapshotsConcurrentWithWrites(t *testing.T) {
 	}
 }
 
+// TestAllActiveSnapshotsRaceWithAddNewSeedableFile pins that AddNewSeedableFile mutates
+// torrentsByName without holding d.lock, so it data-races allActiveSnapshots' iteration
+// under -race even though the read side takes d.lock.RLock — an RLock cannot exclude a
+// writer that holds no lock. The locked download paths make this invisible; the seed path
+// does not.
+func TestAllActiveSnapshotsRaceWithAddNewSeedableFile(t *testing.T) {
+	test := newDownloaderTest(t)
+	d := test.downloader
+	ctx := t.Context()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				d.allActiveSnapshots()
+			}
+		}
+	}()
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
+
+	for i := range 64 {
+		name := fmt.Sprintf("v1-%06d-%06d-headers.seg", i, i+1)
+		require.NoError(t, os.WriteFile(filepath.Join(test.dirs.Snap, name), nil, 0o644))
+		require.NoError(t, d.AddNewSeedableFile(ctx, name))
+	}
+}
+
 func TestChangeInfoHashOfSameFile(t *testing.T) {
 	ctx := t.Context()
 	require := require.New(t)


### PR DESCRIPTION
`allActiveSnapshots` iterates the downloader's `torrentsByName` map under `d.lock.RLock`, but the `AddNewSeedableFile → addCompleteTorrent → addTorrent` path mutates that map without holding `d.lock`. When a node builds and seeds newly created snapshot files during execution (via the gRPC `Seed` handler), that lock-free write races the background logger's iteration and aborts the process with `fatal error: concurrent map iteration and map write`. The `RLock` from #21696 doesn't cover it — an RWMutex read-lock cannot exclude a writer that holds no lock.

The race under `go test -race` (write = the seed path, read = the logger's iteration):

```
WARNING: DATA RACE
Write at 0x... by goroutine 32:
  db/downloader.(*Downloader).addTorrent()                     downloader.go:1708
  db/downloader.(*Downloader).addTorrentFromMetainfo()         downloader.go:1166
  db/downloader.(*Downloader).addCompleteTorrentFromMetainfo() downloader.go:1316
  db/downloader.(*Downloader).addCompleteTorrent()             downloader.go:1309
  db/downloader.(*Downloader).AddNewSeedableFile()             downloader.go:764

Previous read at 0x... by goroutine 73:
  db/downloader.(*Downloader).allActiveSnapshots()             downloader.go:889
```

## Changes
- Take `d.lock` around the `torrentsByName` mutation in `addCompleteTorrent` (after the on-disk metainfo read, with `defer Unlock`), so the seed path locks like the download add paths that already hold it via their callers.
- Add `TestAddNewSeedableFileConcurrentWithAllActiveSnapshots`, which reports the write-vs-iterate data race under `-race` without the lock.
