### PR TITLE
execution/chain: add opaque L2 config slot (L2JSON/L2Config)

### DIFF
--- a/db/rawdb/accessors_metadata.go
+++ b/db/rawdb/accessors_metadata.go
@@ -75,6 +75,17 @@ func WriteChainConfig(db kv.Putter, hash common.Hash, cfg *chain.Config) error {
 		cfg.BorJSON = borJSON
 	}
 
+	// L2 resolution from L2JSON is owned by the registering L2 package, so
+	// only the raw payload round-trips here; a present L2JSON is the source
+	// of truth and is not clobbered by re-marshalling the resolved value.
+	if cfg.L2 != nil && len(cfg.L2JSON) == 0 {
+		l2JSON, err := jsoniter.ConfigFastest.Marshal(cfg.L2)
+		if err != nil {
+			return fmt.Errorf("failed to JSON encode chain config 'l2': %w", err)
+		}
+		cfg.L2JSON = l2JSON
+	}
+
 	data, err := jsoniter.ConfigFastest.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to JSON encode chain config: %w", err)

--- a/db/rawdb/accessors_metadata.go
+++ b/db/rawdb/accessors_metadata.go
@@ -78,7 +78,9 @@ func WriteChainConfig(db kv.Putter, hash common.Hash, cfg *chain.Config) error {
 	// L2 resolution from L2JSON is owned by the registering L2 package, so
 	// only the raw payload round-trips here; a present L2JSON is the source
 	// of truth and is not clobbered by re-marshalling the resolved value.
-	if cfg.L2 != nil && len(cfg.L2JSON) == 0 {
+	// A `"l2": null` payload counts as absent, so the resolved value still
+	// backfills it rather than persisting the literal `null`.
+	if cfg.L2 != nil && (len(cfg.L2JSON) == 0 || bytes.Equal(cfg.L2JSON, []byte("null"))) {
 		l2JSON, err := jsoniter.ConfigFastest.Marshal(cfg.L2)
 		if err != nil {
 			return fmt.Errorf("failed to JSON encode chain config 'l2': %w", err)

--- a/db/rawdb/accessors_metadata_test.go
+++ b/db/rawdb/accessors_metadata_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/execution/chain"
+)
+
+type testL2Config struct {
+	Stack string `json:"stack"`
+}
+
+func (c *testL2Config) Name() string { return c.Stack }
+
+func (c *testL2Config) ResolveRules(l2Version, blockNum, blockTime uint64, r *chain.Rules) {}
+
+func TestChainConfigL2JSONRoundTrip(t *testing.T) {
+	_, tx := memdb.NewTestTx(t)
+	hash := common.Hash{1}
+
+	cfg := &chain.Config{L2: &testL2Config{Stack: "testl2"}}
+	require.NoError(t, WriteChainConfig(tx, hash, cfg))
+
+	got, err := ReadChainConfig(tx, hash)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"stack":"testl2"}`, string(got.L2JSON))
+	require.True(t, got.IsL2())
+}

--- a/db/rawdb/accessors_metadata_test.go
+++ b/db/rawdb/accessors_metadata_test.go
@@ -46,3 +46,16 @@ func TestChainConfigL2JSONRoundTrip(t *testing.T) {
 	require.JSONEq(t, `{"stack":"testl2"}`, string(got.L2JSON))
 	require.True(t, got.IsL2())
 }
+
+func TestChainConfigL2JSONNullBackfill(t *testing.T) {
+	_, tx := memdb.NewTestTx(t)
+	hash := common.Hash{2}
+
+	cfg := &chain.Config{L2JSON: []byte("null"), L2: &testL2Config{Stack: "testl2"}}
+	require.NoError(t, WriteChainConfig(tx, hash, cfg))
+
+	got, err := ReadChainConfig(tx, hash)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"stack":"testl2"}`, string(got.L2JSON))
+	require.True(t, got.IsL2())
+}

--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -123,6 +123,12 @@ type Config struct {
 	Bor     BorConfig       `json:"-"`
 	BorJSON json.RawMessage `json:"bor,omitempty"`
 
+	// L2 carries opaque L2-chain-specific config. L2JSON is decoded from the
+	// chainspec JSON verbatim; the registering L2 package unmarshals it into
+	// L2 at spec-registration time, same contract as BorJSON/Bor.
+	L2     L2Config        `json:"-"`
+	L2JSON json.RawMessage `json:"l2,omitempty"`
+
 	// DisabledEIPs lists EIPs that are disabled for this chain, even when
 	// their parent fork is active. Used for devnets where the reference
 	// client doesn't yet implement certain EIPs (e.g. [7708, 7778, 7928]).
@@ -135,6 +141,12 @@ type Config struct {
 // IsEIPDisabled returns true if the given EIP number is in the DisabledEIPs list.
 func (c *Config) IsEIPDisabled(eip int) bool {
 	return slices.Contains(c.DisabledEIPs, eip)
+}
+
+// IsL2 returns whether this chain config carries L2-chain-specific config,
+// either already resolved (L2) or still opaque (L2JSON).
+func (c *Config) IsL2() bool {
+	return c.L2 != nil || len(c.L2JSON) > 0
 }
 
 var (
@@ -240,6 +252,14 @@ type BorConfig interface {
 	CalculateSprintNumber(number uint64) uint64
 	CalculateSprintLength(number uint64) uint64
 	CalculateCoinbase(number uint64) accounts.Address
+}
+
+// L2Config is the resolved implementation of an L2 stack's chain-specific
+// config, registered by the L2 package at spec-registration time.
+type L2Config interface {
+	// Name returns the short identifier of the L2 stack (e.g. used to select
+	// a registered rules engine).
+	Name() string
 }
 
 func timestampToTime(unixSec uint64) *time.Time {

--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -147,7 +147,7 @@ func (c *Config) IsEIPDisabled(eip int) bool {
 // IsL2 returns whether this chain config carries L2-chain-specific config,
 // either already resolved (L2) or still opaque (L2JSON).
 func (c *Config) IsL2() bool {
-	return c.L2 != nil || (len(c.L2JSON) > 0 && !bytes.Equal(c.L2JSON, jsonNull))
+	return c != nil && (c.L2 != nil || (len(c.L2JSON) > 0 && !bytes.Equal(c.L2JSON, jsonNull)))
 }
 
 var jsonNull = []byte("null")

--- a/execution/chain/chain_config.go
+++ b/execution/chain/chain_config.go
@@ -17,6 +17,7 @@
 package chain
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -146,8 +147,10 @@ func (c *Config) IsEIPDisabled(eip int) bool {
 // IsL2 returns whether this chain config carries L2-chain-specific config,
 // either already resolved (L2) or still opaque (L2JSON).
 func (c *Config) IsL2() bool {
-	return c.L2 != nil || len(c.L2JSON) > 0
+	return c.L2 != nil || (len(c.L2JSON) > 0 && !bytes.Equal(c.L2JSON, jsonNull))
 }
+
+var jsonNull = []byte("null")
 
 var (
 	TestChainAuraConfig = &Config{

--- a/execution/chain/chain_config_test.go
+++ b/execution/chain/chain_config_test.go
@@ -243,6 +243,9 @@ func TestConfigL2JSONRoundTrip(t *testing.T) {
 
 	resolved := Config{L2: fakeL2{}}
 	a.True(resolved.IsL2())
+
+	var nilCfg *Config
+	a.False(nilCfg.IsL2())
 }
 
 type fakeL2 struct{}

--- a/execution/chain/chain_config_test.go
+++ b/execution/chain/chain_config_test.go
@@ -228,15 +228,27 @@ func TestBlobParameterInactiveHardfork(t *testing.T) {
 
 func TestConfigL2JSONRoundTrip(t *testing.T) {
 	var c Config
-	require := assert.New(t)
-	require.NoError(json.Unmarshal([]byte(`{"chainId":1,"l2":{"name":"testl2","foo":1}}`), &c))
-	require.JSONEq(`{"name":"testl2","foo":1}`, string(c.L2JSON))
-	require.True(c.IsL2())
+	a := assert.New(t)
+	a.NoError(json.Unmarshal([]byte(`{"chainId":1,"l2":{"name":"testl2","foo":1}}`), &c))
+	a.JSONEq(`{"name":"testl2","foo":1}`, string(c.L2JSON))
+	a.True(c.IsL2())
 
 	var noL2 Config
-	require.NoError(json.Unmarshal([]byte(`{"chainId":1}`), &noL2))
-	require.False(noL2.IsL2())
+	a.NoError(json.Unmarshal([]byte(`{"chainId":1}`), &noL2))
+	a.False(noL2.IsL2())
+
+	var nullL2 Config
+	a.NoError(json.Unmarshal([]byte(`{"chainId":1,"l2":null}`), &nullL2))
+	a.False(nullL2.IsL2())
+
+	resolved := Config{L2: fakeL2{}}
+	a.True(resolved.IsL2())
 }
+
+type fakeL2 struct{}
+
+func (fakeL2) Name() string                                                 { return "fake" }
+func (fakeL2) ResolveRules(l2Version, blockNum, blockTime uint64, r *Rules) {}
 
 func TestBlobParameterDencunAndPectraAtGenesis(t *testing.T) {
 	var c Config

--- a/execution/chain/chain_config_test.go
+++ b/execution/chain/chain_config_test.go
@@ -17,6 +17,7 @@
 package chain
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -223,6 +224,18 @@ func TestBlobParameterInactiveHardfork(t *testing.T) {
 	assert.Equal(t, uint64(6), c.GetTargetBlobsPerBlock(time))
 	assert.Equal(t, uint64(9), c.GetMaxBlobsPerBlock(time))
 	assert.Equal(t, uint64(5007716), c.GetBlobGasPriceUpdateFraction(time))
+}
+
+func TestConfigL2JSONRoundTrip(t *testing.T) {
+	var c Config
+	require := assert.New(t)
+	require.NoError(json.Unmarshal([]byte(`{"chainId":1,"l2":{"name":"testl2","foo":1}}`), &c))
+	require.JSONEq(`{"name":"testl2","foo":1}`, string(c.L2JSON))
+	require.True(c.IsL2())
+
+	var noL2 Config
+	require.NoError(json.Unmarshal([]byte(`{"chainId":1}`), &noL2))
+	require.False(noL2.IsL2())
 }
 
 func TestBlobParameterDencunAndPectraAtGenesis(t *testing.T) {


### PR DESCRIPTION
L2 stacks embedding erigon need chain-specific parameters on `chain.Config`; today the only option is forking the struct (the nitro-erigon pilot hardcodes `ArbitrumChainParams` on it). Bor already solved this shape for itself with `BorJSON`/`BorConfig`.

## Changes
- `Config.L2JSON json.RawMessage` (`"l2"` key in chainspec JSON) and `Config.L2 L2Config`, mirroring the `BorJSON`/`Bor` contract: opaque payload decoded and assigned by the registering L2 package at spec-registration time.
- `L2Config` interface, minimal for now (`Name() string`); grows with the follow-up PRs.
- `Config.IsL2()` accessor; `"l2": null` counts as absent.
- `WriteChainConfig`/`ReadChainConfig` round-trip `L2JSON` (like `BorJSON`); a resolved `L2` backfills `L2JSON`.

Part of #22193.
