### PR TITLE
db/version: relax minor version check in Supports

### DIFF
--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -887,12 +887,16 @@ func TestCommitmentKvVersionAcceptance(t *testing.T) {
 	require.True(t, vers.Supports(version.V2_0))
 	require.True(t, vers.Supports(version.V2_1))
 	require.True(t, vers.Supports(version.V2_2))
-	require.False(t, vers.Supports(version.Version{Major: 2, Minor: 3}))
+	// A newer minor within the same major is a content-only, backward-readable change.
+	require.True(t, vers.Supports(version.Version{Major: 2, Minor: 3}))
+	// A newer major changes read logic and is rejected.
+	require.False(t, vers.Supports(version.Version{Major: 3, Minor: 0}))
 
 	require.NotPanics(t, func() { vers.MustSupport(version.V2_0, "v2.0-commitment.0-1.kv") })
 	require.NotPanics(t, func() { vers.MustSupport(version.V2_1, "v2.1-commitment.0-1.kv") })
 	require.NotPanics(t, func() { vers.MustSupport(version.V2_2, "v2.2-commitment.0-1.kv") })
-	require.Panics(t, func() { vers.MustSupport(version.Version{Major: 2, Minor: 3}, "v2.3-commitment.0-1.kv") })
+	require.NotPanics(t, func() { vers.MustSupport(version.Version{Major: 2, Minor: 3}, "v2.3-commitment.0-1.kv") })
+	require.Panics(t, func() { vers.MustSupport(version.Version{Major: 3, Minor: 0}, "v3.0-commitment.0-1.kv") })
 }
 
 func TestDomainRoTx_CursorParentCheck(t *testing.T) {

--- a/db/state/snap_schema.go
+++ b/db/state/snap_schema.go
@@ -620,7 +620,7 @@ func findFilesWithVersionsByPattern(searchVer version.Version, pattern string, s
 		if !ok {
 			panic(fmt.Sprintf("match %s can't be parsed, shouldn't happen, fail fast", filename))
 		}
-		if info.Version.GreaterOrEqual(supported.MinSupported) && info.Version.LessOrEqual(supported.Current) && maxVersion.Less(info.Version) {
+		if supported.Supports(info.Version) && maxVersion.Less(info.Version) {
 			maxVersion = info.Version
 			maxMatch = match
 			continue

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -186,12 +186,22 @@ func (v Versions) String() string {
 }
 
 func (v Versions) Supports(ver Version) bool {
-	return ver.GreaterOrEqual(v.MinSupported) && ver.LessOrEqual(v.Current)
+	if ver.Less(v.MinSupported) {
+		return false
+	}
+	// A minor bump only changes a file's content, not how it is read, so a newer
+	// minor within a supported major stays readable; only a newer major changes
+	// read logic and must be rejected.
+	if ver.Major == v.Current.Major {
+		return true
+	}
+	return ver.LessOrEqual(v.Current)
 }
 
 var mustSupportLogOnce sync.Once
 
-// MustSupport panics if ver is outside [MinSupported, Current].
+// MustSupport panics if ver is unsupported: older than MinSupported, or a newer
+// major than Current (a newer minor within a supported major is allowed).
 func (v Versions) MustSupport(ver Version, filename string) {
 	if v.Supports(ver) {
 		return
@@ -204,8 +214,8 @@ func (v Versions) MustSupport(ver Version, filename string) {
 		)
 	} else {
 		msg = fmt.Sprintf(
-			"Snapshot file is newer than this Erigon build supports: file=%s, highest_supported=<%s. To fix, either upgrade Erigon to a newer release, or align snapshots by command: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
-			filename, v.Current,
+			"Snapshot file is newer than this Erigon build supports: file=%s, highest_supported=v%d.x. To fix, either upgrade Erigon to a newer release, or align snapshots by command: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+			filename, v.Current.Major,
 		)
 	}
 	mustSupportLogOnce.Do(func() { log.Error(msg) })

--- a/db/version/file_version_test.go
+++ b/db/version/file_version_test.go
@@ -470,6 +470,17 @@ func TestMustSupport(t *testing.T) {
 		}()
 		supported.MustSupport(V2_0, "test.kv")
 	})
+
+	t.Run("higher minor within same major does not panic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("unexpected panic for higher minor within same major: %v", r)
+			}
+		}()
+		// v1.5 > Current v1.2 but shares the major: a minor bump is a
+		// content-only, backward-readable change and must be supported.
+		supported.MustSupport(Version{Major: 1, Minor: 5}, "test.kv")
+	})
 }
 
 func BenchmarkMatchVersionedFile(b *testing.B) {


### PR DESCRIPTION
- "Supports?" functions for snapshot version is too strict -- It checks if version is between `MinSupported` and `Current`.
- But we decided that Minor version bumps means "data fix" and snapshot can still be read by some older binary which has the ability to read the major versioned file.
- this breaks sync-from-scratch from older binary with the strict check (they can't read the new, bumped and published snapshots anymore)
- Faced this problem when regenerating rcache with Sahil's fix. I bumped rcache version, and realized that I cannot checkout old erigon binary anymore (because it had current=3.0; and the regen+bump produced snapshots of version=3.1). 
- For above particular case, I'll de-bump the minor version for regenerated snapshots, so that older erigon binaries (latest 3.4.x release, 3.5.0 release etc.) -- effectively, no version bump for the data fix for this regeneration.

## Related PRs
Backports: #22205 (release/3.5), #22206 (release/3.4)
Related reverts (de-bump rcache on the rigid release lines): #22207 (reverts #22047, release/3.5), #22208 (reverts #21974, release/3.4)

