### PR TITLE
db/state: fix Close vs external MergeLoop/BuildFiles* WaitGroup races

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -2304,6 +2304,7 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 			a.onFilesChange(nil)
 		}
 		if !doMerge {
+			close(fin)
 			return
 		}
 		a.wg.AddFromRegistered()

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -622,6 +622,7 @@ func (a *Aggregator) Close() {
 	if !a.wg.BeginClose() { // invariant: it's safe to call Close multiple times, even concurrently
 		return
 	}
+	defer a.wg.MarkClosed()
 	a.ctxCancel()
 	if a.metricsCollector != nil {
 		a.metricsCollector.Stop() // drain buffered samples before wg.Wait joins the goroutine
@@ -1022,7 +1023,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 
 	for _, dc := range domainColls {
 		dc := dc
-		a.wg.Add(1)
+		a.wg.AddFromRegistered()
 		g.Go(func() error {
 			defer a.wg.Done()
 
@@ -1043,7 +1044,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 	}
 	for _, ic := range iiColls {
 		ic := ic
-		a.wg.Add(1)
+		a.wg.AddFromRegistered()
 		g.Go(func() error {
 			defer a.wg.Done()
 
@@ -1180,7 +1181,7 @@ func (a *Aggregator) BuildFiles2(ctx context.Context, fromStep, toStep kv.Step, 
 		}
 
 		if doMerge {
-			a.wg.Add(1)
+			a.wg.AddFromRegistered()
 			go func() {
 				defer a.wg.Done()
 				if err := a.mergeLoop(ctx); err != nil {
@@ -2306,7 +2307,7 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 		if !doMerge {
 			return
 		}
-		a.wg.Add(1)
+		a.wg.AddFromRegistered()
 		go func() {
 			defer a.wg.Done()
 			defer close(fin)

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -619,25 +619,24 @@ func (a *Aggregator) WaitForFiles() {
 
 func (a *Aggregator) Close() {
 	a.WaitForFiles()
-	if !a.wg.BeginClose() { // invariant: it's safe to call Close multiple times, even concurrently
-		return
-	}
-	defer a.wg.MarkClosed()
-	a.ctxCancel()
-	if a.metricsCollector != nil {
-		a.metricsCollector.Stop() // drain buffered samples before wg.Wait joins the goroutine
-	}
-	a.wg.Wait()
+	// RunClose makes this safe to call multiple times, even concurrently.
+	a.wg.RunClose(func() {
+		a.ctxCancel()
+		if a.metricsCollector != nil {
+			a.metricsCollector.Stop() // drain buffered samples before wg.Wait joins the goroutine
+		}
+		a.wg.Wait()
 
-	// A closed Aggregator may linger referenced; release the cached branch data eagerly.
-	if cd := a.d[kv.CommitmentDomain]; cd != nil && cd.branchCache != nil {
-		cd.branchCache.Clear()
-	}
+		// A closed Aggregator may linger referenced; release the cached branch data eagerly.
+		if cd := a.d[kv.CommitmentDomain]; cd != nil && cd.branchCache != nil {
+			cd.branchCache.Clear()
+		}
 
-	a.dirtyFilesLock.Lock()
-	defer a.dirtyFilesLock.Unlock()
-	a.closeDirtyFiles()
-	a.recalcVisibleFiles(nil)
+		a.dirtyFilesLock.Lock()
+		defer a.dirtyFilesLock.Unlock()
+		a.closeDirtyFiles()
+		a.recalcVisibleFiles(nil)
+	})
 }
 
 func (a *Aggregator) closeDirtyFiles() {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -107,12 +107,7 @@ type Aggregator struct {
 	// openTxs=1). Exposed via CommitGate() for use by any component.
 	commitGate sync.RWMutex
 
-	wg sync.WaitGroup // goroutines spawned by Aggregator, to ensure all of them are finish at agg.Close
-
-	// closing, guarded by closingMu, is set before Close waits on wg; MergeLoop
-	// refuses to register once set, so a late Add can't race that Wait.
-	closing   bool
-	closingMu sync.Mutex
+	wg closingWaitGroup // goroutines spawned by Aggregator, to ensure all of them are finish at agg.Close
 
 	// metricsCollector is the process-level KV-read metrics aggregate. Every read
 	// path (exec, commitment, warmup, RPC, engine) hands its finished per-worker
@@ -624,14 +619,10 @@ func (a *Aggregator) WaitForFiles() {
 
 func (a *Aggregator) Close() {
 	a.WaitForFiles()
-	if a.ctxCancel == nil { // invariant: it's safe to call Close multiple times
+	if !a.wg.BeginClose() { // invariant: it's safe to call Close multiple times, even concurrently
 		return
 	}
-	a.closingMu.Lock()
-	a.closing = true
-	a.closingMu.Unlock()
 	a.ctxCancel()
-	a.ctxCancel = nil
 	if a.metricsCollector != nil {
 		a.metricsCollector.Stop() // drain buffered samples before wg.Wait joins the goroutine
 	}
@@ -1164,7 +1155,10 @@ func (a *Aggregator) BuildFiles2(ctx context.Context, fromStep, toStep kv.Step, 
 	if ok := a.buildingFiles.CompareAndSwap(false, true); !ok {
 		return nil
 	}
-	a.wg.Add(1)
+	if !a.wg.TryAdd() {
+		a.buildingFiles.Store(false)
+		return nil
+	}
 	go func() {
 		defer a.wg.Done()
 		defer a.buildingFiles.Store(false)
@@ -1233,13 +1227,9 @@ func (a *Aggregator) RemoveOverlapsAfterMerge(ctx context.Context) (err error) {
 }
 
 func (a *Aggregator) MergeLoop(ctx context.Context) error {
-	a.closingMu.Lock()
-	if a.closing {
-		a.closingMu.Unlock()
+	if !a.wg.TryAdd() {
 		return nil
 	}
-	a.wg.Add(1)
-	a.closingMu.Unlock()
 	defer a.wg.Done()
 	return a.mergeLoop(ctx)
 }
@@ -2166,9 +2156,14 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 		return fin
 	}
 
+	if !a.wg.TryAdd() {
+		a.buildingFiles.Store(false)
+		close(fin)
+		return fin
+	}
+
 	step := kv.Step(a.EndTxNumMinimax() / a.StepSize())
 
-	a.wg.Add(1)
 	go func() {
 		defer a.wg.Done()
 		defer a.buildingFiles.Store(false)

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -107,7 +107,7 @@ type Aggregator struct {
 	// openTxs=1). Exposed via CommitGate() for use by any component.
 	commitGate sync.RWMutex
 
-	wg closingWaitGroup // goroutines spawned by Aggregator, to ensure all of them are finish at agg.Close
+	wg closingWaitGroup // goroutines spawned by Aggregator, to ensure all of them are finished at agg.Close
 
 	// metricsCollector is the process-level KV-read metrics aggregate. Every read
 	// path (exec, commitment, warmup, RPC, engine) hands its finished per-worker

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -109,6 +109,11 @@ type Aggregator struct {
 
 	wg sync.WaitGroup // goroutines spawned by Aggregator, to ensure all of them are finish at agg.Close
 
+	// closing, guarded by closingMu, is set before Close waits on wg; MergeLoop
+	// refuses to register once set, so a late Add can't race that Wait.
+	closing   bool
+	closingMu sync.Mutex
+
 	// metricsCollector is the process-level KV-read metrics aggregate. Every read
 	// path (exec, commitment, warmup, RPC, engine) hands its finished per-worker
 	// metrics here; one goroutine folds them grouped by source and self-publishes
@@ -622,6 +627,9 @@ func (a *Aggregator) Close() {
 	if a.ctxCancel == nil { // invariant: it's safe to call Close multiple times
 		return
 	}
+	a.closingMu.Lock()
+	a.closing = true
+	a.closingMu.Unlock()
 	a.ctxCancel()
 	a.ctxCancel = nil
 	if a.metricsCollector != nil {
@@ -1225,7 +1233,13 @@ func (a *Aggregator) RemoveOverlapsAfterMerge(ctx context.Context) (err error) {
 }
 
 func (a *Aggregator) MergeLoop(ctx context.Context) error {
+	a.closingMu.Lock()
+	if a.closing {
+		a.closingMu.Unlock()
+		return nil
+	}
 	a.wg.Add(1)
+	a.closingMu.Unlock()
 	defer a.wg.Done()
 	return a.mergeLoop(ctx)
 }

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -619,24 +619,24 @@ func (a *Aggregator) WaitForFiles() {
 
 func (a *Aggregator) Close() {
 	a.WaitForFiles()
-	// RunClose makes this safe to call multiple times, even concurrently.
-	a.wg.RunClose(func() {
-		a.ctxCancel()
-		if a.metricsCollector != nil {
-			a.metricsCollector.Stop() // drain buffered samples before wg.Wait joins the goroutine
-		}
-		a.wg.Wait()
+	if !a.wg.BeginClose() { // idempotent: safe to call Close multiple times
+		return
+	}
+	a.ctxCancel()
+	if a.metricsCollector != nil {
+		a.metricsCollector.Stop() // drain buffered samples before wg.Wait joins the goroutine
+	}
+	a.wg.Wait()
 
-		// A closed Aggregator may linger referenced; release the cached branch data eagerly.
-		if cd := a.d[kv.CommitmentDomain]; cd != nil && cd.branchCache != nil {
-			cd.branchCache.Clear()
-		}
+	// A closed Aggregator may linger referenced; release the cached branch data eagerly.
+	if cd := a.d[kv.CommitmentDomain]; cd != nil && cd.branchCache != nil {
+		cd.branchCache.Clear()
+	}
 
-		a.dirtyFilesLock.Lock()
-		defer a.dirtyFilesLock.Unlock()
-		a.closeDirtyFiles()
-		a.recalcVisibleFiles(nil)
-	})
+	a.dirtyFilesLock.Lock()
+	defer a.dirtyFilesLock.Unlock()
+	a.closeDirtyFiles()
+	a.recalcVisibleFiles(nil)
 }
 
 func (a *Aggregator) closeDirtyFiles() {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1022,10 +1022,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 
 	for _, dc := range domainColls {
 		dc := dc
-		a.wg.AddFromRegistered()
 		g.Go(func() error {
-			defer a.wg.Done()
-
 			sf, err := dc.d.buildFiles(ctx, step, dc.collation, a.ps)
 			dc.collation.Close()
 			if err != nil {
@@ -1043,10 +1040,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 	}
 	for _, ic := range iiColls {
 		ic := ic
-		a.wg.AddFromRegistered()
 		g.Go(func() error {
-			defer a.wg.Done()
-
 			sf, err := ic.ii.buildFiles(ctx, step, ic.collation, a.ps)
 			if err != nil {
 				sf.CleanupOnError()
@@ -1179,8 +1173,7 @@ func (a *Aggregator) BuildFiles2(ctx context.Context, fromStep, toStep kv.Step, 
 			a.onFilesChange(nil)
 		}
 
-		if doMerge {
-			a.wg.AddFromRegistered()
+		if doMerge && a.wg.TryAdd() {
 			go func() {
 				defer a.wg.Done()
 				if err := a.mergeLoop(ctx); err != nil {
@@ -2303,11 +2296,10 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 			}
 			a.onFilesChange(nil)
 		}
-		if !doMerge {
+		if !doMerge || !a.wg.TryAdd() {
 			close(fin)
 			return
 		}
-		a.wg.AddFromRegistered()
 		go func() {
 			defer a.wg.Done()
 			defer close(fin)

--- a/db/state/aggregator_close_test.go
+++ b/db/state/aggregator_close_test.go
@@ -125,13 +125,12 @@ func TestAggregatorCloseVsConcurrentBuildFiles2(t *testing.T) {
 			loops.Go(func() {
 				<-start
 				time.Sleep(time.Duration(i) * 250 * time.Microsecond)
-				_ = agg.BuildFiles2(context.Background(), 0, 0, false)
+				_ = agg.BuildFiles2(context.Background(), 0, 0, true)
 			})
 		}
 		close(start)
 		agg.Close()
 		loops.Wait()
-		agg.wg.Wait()
 		db.Close()
 	}
 }

--- a/db/state/aggregator_close_test.go
+++ b/db/state/aggregator_close_test.go
@@ -54,8 +54,9 @@ func TestAggregatorCloseWaitsForBackgroundMerge(t *testing.T) {
 // node's background-maintenance goroutine), so its wg registration must be ordered
 // against Close's Wait — an unordered Add from zero is WaitGroup reuse, flagged by -race.
 func TestAggregatorCloseVsConcurrentMergeLoop(t *testing.T) {
+	t.Parallel()
 	logger := log.New()
-	for range 16 {
+	for range 4 {
 		dirs := datadir.New(t.TempDir())
 		db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
 		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
@@ -73,6 +74,88 @@ func TestAggregatorCloseVsConcurrentMergeLoop(t *testing.T) {
 		close(start)
 		agg.Close()
 		loops.Wait()
+		db.Close()
+	}
+}
+
+// BuildFilesInBackground twin of TestAggregatorCloseVsConcurrentMergeLoop.
+func TestAggregatorCloseVsConcurrentBuildFilesInBackground(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+	for range 4 {
+		dirs := datadir.New(t.TempDir())
+		db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
+		require.NoError(t, agg.OpenFolder())
+
+		start := make(chan struct{})
+		fins := make(chan chan struct{}, 8)
+		var loops sync.WaitGroup
+		for i := range 8 {
+			loops.Go(func() {
+				<-start
+				time.Sleep(time.Duration(i) * 250 * time.Microsecond)
+				fins <- agg.BuildFilesInBackground(1_000_000)
+			})
+		}
+		close(start)
+		agg.Close()
+		loops.Wait()
+		close(fins)
+		for fin := range fins {
+			<-fin
+		}
+		db.Close()
+	}
+}
+
+// BuildFiles2 twin of TestAggregatorCloseVsConcurrentMergeLoop.
+func TestAggregatorCloseVsConcurrentBuildFiles2(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+	for range 4 {
+		dirs := datadir.New(t.TempDir())
+		db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
+		require.NoError(t, agg.OpenFolder())
+
+		start := make(chan struct{})
+		var loops sync.WaitGroup
+		for i := range 8 {
+			loops.Go(func() {
+				<-start
+				time.Sleep(time.Duration(i) * 250 * time.Microsecond)
+				_ = agg.BuildFiles2(context.Background(), 0, 0, false)
+			})
+		}
+		close(start)
+		agg.Close()
+		loops.Wait()
+		agg.wg.Wait()
+		db.Close()
+	}
+}
+
+// Close must be safe to call concurrently with itself.
+func TestAggregatorConcurrentClose(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+	for range 4 {
+		dirs := datadir.New(t.TempDir())
+		db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
+		require.NoError(t, agg.OpenFolder())
+
+		start := make(chan struct{})
+		var closes sync.WaitGroup
+		for range 4 {
+			closes.Go(func() {
+				<-start
+				agg.Close()
+			})
+		}
+		close(start)
+		closes.Wait()
 		db.Close()
 	}
 }

--- a/db/state/aggregator_close_test.go
+++ b/db/state/aggregator_close_test.go
@@ -17,7 +17,10 @@
 package state
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
@@ -43,6 +46,33 @@ func TestAggregatorCloseWaitsForBackgroundMerge(t *testing.T) {
 		require.NoError(t, agg.BuildFiles2(t.Context(), 0, 0, true))
 		agg.wg.Wait()
 		agg.Close()
+		db.Close()
+	}
+}
+
+// MergeLoop is also called from goroutines the aggregator did not spawn (e.g. the
+// node's background-maintenance goroutine), so its wg registration must be ordered
+// against Close's Wait — an unordered Add from zero is WaitGroup reuse, flagged by -race.
+func TestAggregatorCloseVsConcurrentMergeLoop(t *testing.T) {
+	logger := log.New()
+	for range 16 {
+		dirs := datadir.New(t.TempDir())
+		db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+		agg := NewTest(dirs).StepSize(16).Logger(logger).MustOpen(t.Context(), db)
+		require.NoError(t, agg.OpenFolder())
+
+		start := make(chan struct{})
+		var loops sync.WaitGroup
+		for i := range 8 {
+			loops.Go(func() {
+				<-start
+				time.Sleep(time.Duration(i) * 250 * time.Microsecond)
+				_ = agg.MergeLoop(context.Background())
+			})
+		}
+		close(start)
+		agg.Close()
+		loops.Wait()
 		db.Close()
 	}
 }

--- a/db/state/closing_waitgroup.go
+++ b/db/state/closing_waitgroup.go
@@ -19,17 +19,17 @@ package state
 import "sync"
 
 // closingWaitGroup is a sync.WaitGroup with a close latch. A goroutine the owner
-// did not spawn must register via TryAdd, which refuses once BeginClose latches;
+// did not spawn must register via TryAdd, which refuses once RunClose has latched;
 // this keeps its Add from racing Wait on a zero counter (WaitGroup reuse). The
 // WaitGroup is a named field, not embedded, so no bare Add can bypass the latch.
 type closingWaitGroup struct {
-	wg      sync.WaitGroup
-	mu      sync.Mutex
-	closing bool
-	closed  chan struct{}
+	wg        sync.WaitGroup
+	mu        sync.Mutex
+	closing   bool
+	closeOnce sync.Once
 }
 
-// TryAdd registers the caller on the group unless BeginClose has latched.
+// TryAdd registers the caller on the group unless RunClose has latched.
 func (g *closingWaitGroup) TryAdd() bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -49,23 +49,14 @@ func (g *closingWaitGroup) Done() { g.wg.Done() }
 
 func (g *closingWaitGroup) Wait() { g.wg.Wait() }
 
-// BeginClose latches the group closed and reports whether this call is the one
-// that must run teardown. Callers that lose the latch block until the winner
-// calls MarkClosed, so Close blocks until teardown is complete for every caller.
-func (g *closingWaitGroup) BeginClose() bool {
-	g.mu.Lock()
-	if g.closing {
-		closed := g.closed
+// RunClose latches the group closed and runs teardown exactly once; concurrent
+// and later callers block until that first teardown returns. Latching before
+// teardown makes every TryAdd either ordered before teardown's Wait or refused.
+func (g *closingWaitGroup) RunClose(teardown func()) {
+	g.closeOnce.Do(func() {
+		g.mu.Lock()
+		g.closing = true
 		g.mu.Unlock()
-		<-closed
-		return false
-	}
-	g.closing = true
-	g.closed = make(chan struct{})
-	g.mu.Unlock()
-	return true
+		teardown()
+	})
 }
-
-// MarkClosed releases callers blocked in BeginClose; the caller that won the
-// latch must call it exactly once, once teardown is complete.
-func (g *closingWaitGroup) MarkClosed() { close(g.closed) }

--- a/db/state/closing_waitgroup.go
+++ b/db/state/closing_waitgroup.go
@@ -18,10 +18,10 @@ package state
 
 import "sync"
 
-// closingWaitGroup is a sync.WaitGroup with a close latch. A goroutine the owner
-// did not spawn must register via TryAdd, which refuses once BeginClose has latched;
-// this keeps its Add from racing Wait on a zero counter (WaitGroup reuse). The
-// WaitGroup is a named field, not embedded, so no bare Add can bypass the latch.
+// closingWaitGroup is a sync.WaitGroup with a close latch. Every goroutine
+// registers via TryAdd, which refuses once BeginClose has latched, so an Add
+// can't race Wait on a zero counter (WaitGroup reuse). The WaitGroup is a named
+// field, not embedded, so no bare Add can bypass the latch.
 type closingWaitGroup struct {
 	wg      sync.WaitGroup
 	mu      sync.Mutex
@@ -38,11 +38,6 @@ func (g *closingWaitGroup) TryAdd() bool {
 	g.wg.Add(1)
 	return true
 }
-
-// AddFromRegistered registers a goroutine spawned from one already registered on
-// the group. The parent's outstanding count keeps Wait from returning, so this
-// Add can't race it and needs no latch check — unlike TryAdd.
-func (g *closingWaitGroup) AddFromRegistered() { g.wg.Add(1) }
 
 func (g *closingWaitGroup) Done() { g.wg.Done() }
 

--- a/db/state/closing_waitgroup.go
+++ b/db/state/closing_waitgroup.go
@@ -18,34 +18,54 @@ package state
 
 import "sync"
 
-// closingWaitGroup is a sync.WaitGroup with a close latch: TryAdd refuses to
-// register once BeginClose has run, so an Add from a goroutine the owner did not
-// spawn can't race Wait (WaitGroup reuse). Plain Add remains for goroutines
-// spawned from an already-registered one, whose Add can't observe a zero counter.
+// closingWaitGroup is a sync.WaitGroup with a close latch. A goroutine the owner
+// did not spawn must register via TryAdd, which refuses once BeginClose latches;
+// this keeps its Add from racing Wait on a zero counter (WaitGroup reuse). The
+// WaitGroup is a named field, not embedded, so no bare Add can bypass the latch.
 type closingWaitGroup struct {
-	sync.WaitGroup
+	wg      sync.WaitGroup
 	mu      sync.Mutex
 	closing bool
+	closed  chan struct{}
 }
 
-// TryAdd registers the caller on the WaitGroup unless BeginClose has run.
+// TryAdd registers the caller on the group unless BeginClose has latched.
 func (g *closingWaitGroup) TryAdd() bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.closing {
 		return false
 	}
-	g.WaitGroup.Add(1)
+	g.wg.Add(1)
 	return true
 }
 
-// BeginClose latches the group closed; reports whether this call did the latching.
+// AddFromRegistered registers a goroutine spawned from one already registered on
+// the group. The parent's outstanding count keeps Wait from returning, so this
+// Add can't race it and needs no latch check — unlike TryAdd.
+func (g *closingWaitGroup) AddFromRegistered() { g.wg.Add(1) }
+
+func (g *closingWaitGroup) Done() { g.wg.Done() }
+
+func (g *closingWaitGroup) Wait() { g.wg.Wait() }
+
+// BeginClose latches the group closed and reports whether this call is the one
+// that must run teardown. Callers that lose the latch block until the winner
+// calls MarkClosed, so Close blocks until teardown is complete for every caller.
 func (g *closingWaitGroup) BeginClose() bool {
 	g.mu.Lock()
-	defer g.mu.Unlock()
 	if g.closing {
+		closed := g.closed
+		g.mu.Unlock()
+		<-closed
 		return false
 	}
 	g.closing = true
+	g.closed = make(chan struct{})
+	g.mu.Unlock()
 	return true
 }
+
+// MarkClosed releases callers blocked in BeginClose; the caller that won the
+// latch must call it exactly once, once teardown is complete.
+func (g *closingWaitGroup) MarkClosed() { close(g.closed) }

--- a/db/state/closing_waitgroup.go
+++ b/db/state/closing_waitgroup.go
@@ -19,17 +19,16 @@ package state
 import "sync"
 
 // closingWaitGroup is a sync.WaitGroup with a close latch. A goroutine the owner
-// did not spawn must register via TryAdd, which refuses once RunClose has latched;
+// did not spawn must register via TryAdd, which refuses once BeginClose has latched;
 // this keeps its Add from racing Wait on a zero counter (WaitGroup reuse). The
 // WaitGroup is a named field, not embedded, so no bare Add can bypass the latch.
 type closingWaitGroup struct {
-	wg        sync.WaitGroup
-	mu        sync.Mutex
-	closing   bool
-	closeOnce sync.Once
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	closing bool
 }
 
-// TryAdd registers the caller on the group unless RunClose has latched.
+// TryAdd registers the caller on the group unless BeginClose has latched.
 func (g *closingWaitGroup) TryAdd() bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -49,14 +48,15 @@ func (g *closingWaitGroup) Done() { g.wg.Done() }
 
 func (g *closingWaitGroup) Wait() { g.wg.Wait() }
 
-// RunClose latches the group closed and runs teardown exactly once; concurrent
-// and later callers block until that first teardown returns. Latching before
-// teardown makes every TryAdd either ordered before teardown's Wait or refused.
-func (g *closingWaitGroup) RunClose(teardown func()) {
-	g.closeOnce.Do(func() {
-		g.mu.Lock()
-		g.closing = true
-		g.mu.Unlock()
-		teardown()
-	})
+// BeginClose latches the group closed, returning false if it was already latched
+// so Close is idempotent. Latching before Close's Wait makes every TryAdd either
+// register before Wait or get refused.
+func (g *closingWaitGroup) BeginClose() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.closing {
+		return false
+	}
+	g.closing = true
+	return true
 }

--- a/db/state/closing_waitgroup.go
+++ b/db/state/closing_waitgroup.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import "sync"
+
+// closingWaitGroup is a sync.WaitGroup with a close latch: TryAdd refuses to
+// register once BeginClose has run, so an Add from a goroutine the owner did not
+// spawn can't race Wait (WaitGroup reuse). Plain Add remains for goroutines
+// spawned from an already-registered one, whose Add can't observe a zero counter.
+type closingWaitGroup struct {
+	sync.WaitGroup
+	mu      sync.Mutex
+	closing bool
+}
+
+// TryAdd registers the caller on the WaitGroup unless BeginClose has run.
+func (g *closingWaitGroup) TryAdd() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.closing {
+		return false
+	}
+	g.WaitGroup.Add(1)
+	return true
+}
+
+// BeginClose latches the group closed; reports whether this call did the latching.
+func (g *closingWaitGroup) BeginClose() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.closing {
+		return false
+	}
+	g.closing = true
+	return true
+}

--- a/db/state/forkable_agg.go
+++ b/db/state/forkable_agg.go
@@ -451,17 +451,16 @@ func (r *ForkableAgg) Close() {
 	if r == nil {
 		return
 	}
-	if !r.wg.BeginClose() { // invariant: it's safe to call Close multiple times, even concurrently
-		return
-	}
-	defer r.wg.MarkClosed()
-	r.ctxCancel()
-	r.wg.Wait()
+	// RunClose makes this safe to call multiple times, even concurrently.
+	r.wg.RunClose(func() {
+		r.ctxCancel()
+		r.wg.Wait()
 
-	r.dirtyFilesLock.Lock()
-	defer r.dirtyFilesLock.Unlock()
-	r.closeDirtyFiles()
-	r.recalcVisibleFiles()
+		r.dirtyFilesLock.Lock()
+		defer r.dirtyFilesLock.Unlock()
+		r.closeDirtyFiles()
+		r.recalcVisibleFiles()
+	})
 }
 
 func (r *ForkableAgg) closeDirtyFiles() {

--- a/db/state/forkable_agg.go
+++ b/db/state/forkable_agg.go
@@ -45,6 +45,10 @@ type ForkableAgg struct {
 
 	wg sync.WaitGroup
 
+	// see Aggregator.closing
+	closing   bool
+	closingMu sync.Mutex
+
 	ps *background.ProgressSet
 
 	leakDetector *dbg.LeakDetector
@@ -218,7 +222,13 @@ func (a *ForkableAgg) WaitForBuildAndMerge(ctx context.Context) chan struct{} {
 }
 
 func (r *ForkableAgg) MergeLoop(ctx context.Context) error {
+	r.closingMu.Lock()
+	if r.closing {
+		r.closingMu.Unlock()
+		return nil
+	}
 	r.wg.Add(1)
+	r.closingMu.Unlock()
 	defer r.wg.Done()
 	return r.mergeLoop(ctx)
 }
@@ -444,6 +454,9 @@ func (r *ForkableAgg) Close() {
 	if r == nil || r.ctxCancel == nil { // invariant: it's safe to call Close multiple times
 		return
 	}
+	r.closingMu.Lock()
+	r.closing = true
+	r.closingMu.Unlock()
 	r.ctxCancel()
 	r.ctxCancel = nil
 	r.wg.Wait()

--- a/db/state/forkable_agg.go
+++ b/db/state/forkable_agg.go
@@ -43,11 +43,7 @@ type ForkableAgg struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 
-	wg sync.WaitGroup
-
-	// see Aggregator.closing
-	closing   bool
-	closingMu sync.Mutex
+	wg closingWaitGroup
 
 	ps *background.ProgressSet
 
@@ -163,10 +159,15 @@ func (r *ForkableAgg) BuildFilesInBackground(num RootNum) chan struct{} {
 		return fin
 	}
 
+	if !r.wg.TryAdd() {
+		r.buildingFiles.Store(false)
+		close(fin)
+		return fin
+	}
+
 	built := true
 	var err error
 
-	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
 		defer r.buildingFiles.Store(false)
@@ -222,13 +223,9 @@ func (a *ForkableAgg) WaitForBuildAndMerge(ctx context.Context) chan struct{} {
 }
 
 func (r *ForkableAgg) MergeLoop(ctx context.Context) error {
-	r.closingMu.Lock()
-	if r.closing {
-		r.closingMu.Unlock()
+	if !r.wg.TryAdd() {
 		return nil
 	}
-	r.wg.Add(1)
-	r.closingMu.Unlock()
 	defer r.wg.Done()
 	return r.mergeLoop(ctx)
 }
@@ -451,14 +448,13 @@ func (r *ForkableAgg) buildFile(ctx context.Context, to RootNum) (built bool, er
 }
 
 func (r *ForkableAgg) Close() {
-	if r == nil || r.ctxCancel == nil { // invariant: it's safe to call Close multiple times
+	if r == nil {
 		return
 	}
-	r.closingMu.Lock()
-	r.closing = true
-	r.closingMu.Unlock()
+	if !r.wg.BeginClose() { // invariant: it's safe to call Close multiple times, even concurrently
+		return
+	}
 	r.ctxCancel()
-	r.ctxCancel = nil
 	r.wg.Wait()
 
 	r.dirtyFilesLock.Lock()

--- a/db/state/forkable_agg.go
+++ b/db/state/forkable_agg.go
@@ -451,16 +451,16 @@ func (r *ForkableAgg) Close() {
 	if r == nil {
 		return
 	}
-	// RunClose makes this safe to call multiple times, even concurrently.
-	r.wg.RunClose(func() {
-		r.ctxCancel()
-		r.wg.Wait()
+	if !r.wg.BeginClose() { // idempotent: safe to call Close multiple times
+		return
+	}
+	r.ctxCancel()
+	r.wg.Wait()
 
-		r.dirtyFilesLock.Lock()
-		defer r.dirtyFilesLock.Unlock()
-		r.closeDirtyFiles()
-		r.recalcVisibleFiles()
-	})
+	r.dirtyFilesLock.Lock()
+	defer r.dirtyFilesLock.Unlock()
+	r.closeDirtyFiles()
+	r.recalcVisibleFiles()
 }
 
 func (r *ForkableAgg) closeDirtyFiles() {

--- a/db/state/forkable_agg.go
+++ b/db/state/forkable_agg.go
@@ -182,7 +182,7 @@ func (r *ForkableAgg) BuildFilesInBackground(num RootNum) chan struct{} {
 			}
 		}
 
-		r.wg.Add(1)
+		r.wg.AddFromRegistered()
 		go func() {
 			defer r.wg.Done()
 			defer func() {
@@ -380,7 +380,7 @@ func (r *ForkableAgg) buildFile(ctx context.Context, to RootNum) (built bool, er
 
 	firstRootNumNotInFiles := tx.AlignedMaxRootNum()
 	r.loop(func(p *ProtoForkable) error {
-		r.wg.Add(1)
+		r.wg.AddFromRegistered()
 		g.Go(func() error {
 			defer r.wg.Done()
 
@@ -454,6 +454,7 @@ func (r *ForkableAgg) Close() {
 	if !r.wg.BeginClose() { // invariant: it's safe to call Close multiple times, even concurrently
 		return
 	}
+	defer r.wg.MarkClosed()
 	r.ctxCancel()
 	r.wg.Wait()
 

--- a/db/state/forkable_agg.go
+++ b/db/state/forkable_agg.go
@@ -182,12 +182,13 @@ func (r *ForkableAgg) BuildFilesInBackground(num RootNum) chan struct{} {
 			}
 		}
 
-		r.wg.AddFromRegistered()
+		if !r.wg.TryAdd() {
+			close(fin)
+			return
+		}
 		go func() {
 			defer r.wg.Done()
-			defer func() {
-				close(fin)
-			}()
+			defer close(fin)
 			if err := r.mergeLoop(r.ctx); err != nil {
 				if errors.Is(err, context.Canceled) || errors.Is(err, common.ErrStopped) {
 					r.logger.Debug("[fork_agg] MergeLoop cancelled/stopped", "err", err)
@@ -380,10 +381,7 @@ func (r *ForkableAgg) buildFile(ctx context.Context, to RootNum) (built bool, er
 
 	firstRootNumNotInFiles := tx.AlignedMaxRootNum()
 	r.loop(func(p *ProtoForkable) error {
-		r.wg.AddFromRegistered()
 		g.Go(func() error {
-			defer r.wg.Done()
-
 			fromRootNum := firstRootNumNotInFiles
 			if p.unaligned {
 				fromRootNum = tx.MaxRootNum(p.id)

--- a/db/state/forkable_agg_test.go
+++ b/db/state/forkable_agg_test.go
@@ -679,7 +679,9 @@ func TestForkableAggCloseWaitsForBackgroundMerge(t *testing.T) {
 	}
 }
 
-// ForkableAgg twin of TestAggregatorCloseVsConcurrentMergeLoop.
+// ForkableAgg twin of TestAggregatorCloseVsConcurrentMergeLoop. Unlike the
+// Aggregator twins it can't run t.Parallel: setup registers into the global
+// forkable Registry, whose reads aren't lock-guarded, so parallel setups race.
 func TestForkableAggCloseVsConcurrentMergeLoop(t *testing.T) {
 	for range 16 {
 		dirs, db, logger := setupDb(t)
@@ -689,18 +691,23 @@ func TestForkableAggCloseVsConcurrentMergeLoop(t *testing.T) {
 		agg.RegisterMarkedForkable(header)
 		require.NoError(t, agg.OpenFolder())
 
+		start := make(chan struct{})
 		var loops sync.WaitGroup
-		for range 4 {
+		for i := range 8 {
 			loops.Go(func() {
+				<-start
+				time.Sleep(time.Duration(i) * 250 * time.Microsecond)
 				_ = agg.MergeLoop(context.Background())
 			})
 		}
+		close(start)
 		agg.Close()
 		loops.Wait()
 	}
 }
 
 // ForkableAgg twin of TestAggregatorCloseVsConcurrentBuildFilesInBackground.
+// Not t.Parallel: see TestForkableAggCloseVsConcurrentMergeLoop.
 func TestForkableAggCloseVsConcurrentBuildFilesInBackground(t *testing.T) {
 	for range 4 {
 		dirs, db, logger := setupDb(t)
@@ -710,13 +717,17 @@ func TestForkableAggCloseVsConcurrentBuildFilesInBackground(t *testing.T) {
 		agg.RegisterMarkedForkable(header)
 		require.NoError(t, agg.OpenFolder())
 
-		fins := make(chan chan struct{}, 4)
+		start := make(chan struct{})
+		fins := make(chan chan struct{}, 8)
 		var loops sync.WaitGroup
-		for range 4 {
+		for i := range 8 {
 			loops.Go(func() {
+				<-start
+				time.Sleep(time.Duration(i) * 250 * time.Microsecond)
 				fins <- agg.BuildFilesInBackground(RootNum(10))
 			})
 		}
+		close(start)
 		agg.Close()
 		loops.Wait()
 		close(fins)
@@ -727,6 +738,7 @@ func TestForkableAggCloseVsConcurrentBuildFilesInBackground(t *testing.T) {
 }
 
 // ForkableAgg twin of TestAggregatorConcurrentClose.
+// Not t.Parallel: see TestForkableAggCloseVsConcurrentMergeLoop.
 func TestForkableAggConcurrentClose(t *testing.T) {
 	for range 4 {
 		dirs, db, logger := setupDb(t)

--- a/db/state/forkable_agg_test.go
+++ b/db/state/forkable_agg_test.go
@@ -679,9 +679,7 @@ func TestForkableAggCloseWaitsForBackgroundMerge(t *testing.T) {
 	}
 }
 
-// MergeLoop is also called from goroutines the aggregator did not spawn, so its wg
-// registration must be ordered against Close's Wait — an unordered Add from zero is
-// WaitGroup reuse, flagged by -race.
+// ForkableAgg twin of TestAggregatorCloseVsConcurrentMergeLoop.
 func TestForkableAggCloseVsConcurrentMergeLoop(t *testing.T) {
 	for range 16 {
 		dirs, db, logger := setupDb(t)
@@ -699,5 +697,54 @@ func TestForkableAggCloseVsConcurrentMergeLoop(t *testing.T) {
 		}
 		agg.Close()
 		loops.Wait()
+	}
+}
+
+// ForkableAgg twin of TestAggregatorCloseVsConcurrentBuildFilesInBackground.
+func TestForkableAggCloseVsConcurrentBuildFilesInBackground(t *testing.T) {
+	for range 4 {
+		dirs, db, logger := setupDb(t)
+		_, header := setupHeader(t, db, logger, dirs)
+
+		agg := NewForkableAgg(t.Context(), dirs, db, logger)
+		agg.RegisterMarkedForkable(header)
+		require.NoError(t, agg.OpenFolder())
+
+		fins := make(chan chan struct{}, 4)
+		var loops sync.WaitGroup
+		for range 4 {
+			loops.Go(func() {
+				fins <- agg.BuildFilesInBackground(RootNum(10))
+			})
+		}
+		agg.Close()
+		loops.Wait()
+		close(fins)
+		for fin := range fins {
+			<-fin
+		}
+	}
+}
+
+// ForkableAgg twin of TestAggregatorConcurrentClose.
+func TestForkableAggConcurrentClose(t *testing.T) {
+	for range 4 {
+		dirs, db, logger := setupDb(t)
+		_, header := setupHeader(t, db, logger, dirs)
+
+		agg := NewForkableAgg(t.Context(), dirs, db, logger)
+		agg.RegisterMarkedForkable(header)
+		require.NoError(t, agg.OpenFolder())
+
+		start := make(chan struct{})
+		var closes sync.WaitGroup
+		for range 4 {
+			closes.Go(func() {
+				<-start
+				agg.Close()
+			})
+		}
+		close(start)
+		closes.Wait()
 	}
 }

--- a/db/state/forkable_agg_test.go
+++ b/db/state/forkable_agg_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -675,5 +676,28 @@ func TestForkableAggCloseWaitsForBackgroundMerge(t *testing.T) {
 	for range 64 {
 		agg.BuildFilesInBackground(RootNum(10))
 		agg.wg.Wait()
+	}
+}
+
+// MergeLoop is also called from goroutines the aggregator did not spawn, so its wg
+// registration must be ordered against Close's Wait — an unordered Add from zero is
+// WaitGroup reuse, flagged by -race.
+func TestForkableAggCloseVsConcurrentMergeLoop(t *testing.T) {
+	for range 16 {
+		dirs, db, logger := setupDb(t)
+		_, header := setupHeader(t, db, logger, dirs)
+
+		agg := NewForkableAgg(t.Context(), dirs, db, logger)
+		agg.RegisterMarkedForkable(header)
+		require.NoError(t, agg.OpenFolder())
+
+		var loops sync.WaitGroup
+		for range 4 {
+			loops.Go(func() {
+				_ = agg.MergeLoop(context.Background())
+			})
+		}
+		agg.Close()
+		loops.Wait()
 	}
 }


### PR DESCRIPTION
Fixes the data race that failed the `race-tests / tests-linux (other, serial)` job on #22163's CI run ([failing job](https://github.com/erigontech/erigon/actions/runs/28648204895/job/84959805713)): `TestImportClosesChaindataOnInitError` flagged `Aggregator.Close`'s `wg.Wait` racing `MergeLoop`'s `wg.Add`.

## Root cause

`MergeLoop`, `BuildFilesInBackground` (on both `Aggregator` and `ForkableAgg`) and `BuildFiles2` register on the aggregator's lifecycle WaitGroup from whatever goroutine calls them. For external callers nothing orders that `Add` against `Close`'s `Wait`. An `Add` from a zero counter concurrent with `Wait` is `sync.WaitGroup` reuse (undefined behavior, flagged by `-race`), and semantically the unregistered goroutine can keep running while `Close` tears down the dirty files.

The CI failure hit the `MergeLoop` door (the background-maintenance goroutine `eth.New` spawns), but the same race is reachable through the sibling doors, so this PR guards all of them:

- `Aggregator.BuildFilesInBackground` — live on a stock node: the fire-and-forget FCU background-prune goroutine (`FcuBackgroundPrune` defaults to true) ends in `CollateAndPrune → BuildFilesInBackground`, and its adaptive budget can reach 2/3 slot ≈ 8s on mainnet while `Ethereum.Stop` waits on the exec semaphore for at most 5s (`WaitIdle`) before proceeding to `chainDB.Close → Aggregator.Close → wg.Wait`. Same shape for `ProcessFrozenBlocks`' commit cycle, which calls `BuildFilesInBackground` right after a ctx-oblivious MDBX commit.
- `Aggregator.BuildFiles2` and `ForkableAgg.BuildFilesInBackground` — same unguarded caller-side `Add`; currently only reachable from tooling/tests, guarded all the same.

#21528 fixed this class for the *nested* spawn sites by making the already-registered parent goroutine `Add` before spawning; that pattern can't cover the entry points themselves — the registration has to be lifecycle-aware. The window became CI-visible when #22058 added a test that starts the import node, fails init, and immediately stops it.

## Fix

A small `closingWaitGroup` (a `sync.WaitGroup` with a mutex-guarded close latch), shared by `Aggregator` and `ForkableAgg`:

- `TryAdd` registers unless the latch is set. Every external entry point (`MergeLoop`, `BuildFilesInBackground`, `BuildFiles2`) refuses once closing and returns its usual "nothing to do" result, like the existing `dbg.NoMerge()` / `buildingFiles`-CAS early-outs (the CAS is unwound and `fin` closed on refusal).
- `Close` latches via `BeginClose` before cancelling the context and waiting. The mutex gives the happens-before edge: every `Add` is either strictly ordered before `Close`'s `Wait`, or refused.
- `BeginClose` doubles as the Close-idempotency latch, replacing the previously unsynchronized `ctxCancel == nil` check / `ctxCancel = nil` write — two concurrent `Close` calls used to race on `ctxCancel` and could invoke a nil func; `Close` is now safe to call concurrently with itself.
- Registration goes through a single path — `TryAdd`. The fire-and-forget merge spawns use it too (refused once closing: the merge is skipped and `fin` closed, rather than an unconditional `Add`), and the `buildFiles` errgroup children no longer touch the lifecycle `wg` at all (see *Why dropping the `wg.Add` in `buildFiles` is safe* below).

## TDD

Red first, one test per door plus concurrent-Close, each reproducing the exact race signature under `-race` before the fix:

- `TestAggregatorCloseVsConcurrentBuildFilesInBackground` — `wg.Wait` (`aggregator.go:638`) vs `wg.Add` (`aggregator.go:2171`)
- `TestAggregatorCloseVsConcurrentBuildFiles2` — `wg.Wait` vs `wg.Add` (`aggregator.go:1167`)
- `TestAggregatorConcurrentClose` — data races on `ctxCancel` (reads at `aggregator.go:627`/`633` vs the nil-write at `634`)
- `TestForkableAggCloseVsConcurrentBuildFilesInBackground` — `forkable_agg.go:462` vs the `BuildFilesInBackground` `Add`, plus the secondary merge-internals vs `closeDirtyFiles` race
- `TestForkableAggConcurrentClose` — `ctxCancel` races escalating to an actual nil-func-call panic

Green after the fix. Verified additionally:

- all Close-related tests (the five above plus `TestAggregatorCloseVsConcurrentMergeLoop`, `TestForkableAggCloseVsConcurrentMergeLoop`, both #21528 regression tests, and `TestAggregatorCloseReleasesBranchCache`) pass under `-race` with `-count=2`, zero race reports
- `TestAggregatorCloseVsConcurrentMergeLoop` also got cheaper: it burned ~42s under `-race` (~97% idle in `WaitForFiles`' 3-second poll ticker whenever a merge attempt overlapped `Close`); with 4 iterations and `t.Parallel` it runs in 6–9s and the whole Close suite finishes in ~19s under `-race -count=2`
- `go test -short ./db/state/... ./db/kv/temporal/...` passes
- `make lint` clean (two consecutive runs), `make erigon integration` builds
- `TestImportClosesChaindataOnInitError` (the original CI failure) passes locally without `-race`; it cannot run under `-race` on darwin/arm64 at all (`fatal error: too many address space collisions for -race mode` at startup — a Go runtime limitation with this test's MDBX mappings, unrelated to this change), so the Linux `race-tests` job on this PR is the definitive check for it


## Why dropping the `wg.Add` in `buildFiles` is safe

`buildFiles` (and forkable `buildFile`) build their per-domain / per-II files on an `errgroup.Group` and block on `g.Wait()` before returning. Two facts make a *separate* lifecycle-`wg` registration of those children redundant:

1. `buildFiles` is only ever called **synchronously** from the background goroutine that already registered on the lifecycle `wg` via `TryAdd` (the `buildFilesInBackground` / `BuildFiles2` goroutine).
2. That goroutine cannot reach its own `defer wg.Done()` until `buildFiles` returns — i.e. until `g.Wait()` has joined every child.

So `Close`'s `wg.Wait()` already blocks on those children **transitively**, through the still-held count of the entry goroutine. Registering them on the lifecycle `wg` as well was pure double-counting — it changed the counter value but not the set of goroutines `Close` waits for. Removing it keeps `Close`'s guarantee intact while getting rid of an `Add` whose safety depended on the caller's context (which Go code can't observe — a function doesn't know whether it runs inline or in a goroutine).
