### PR TITLE
[r3.5] db/version: relax minor version check in Supports

### DIFF
--- a/db/state/snap_schema.go
+++ b/db/state/snap_schema.go
@@ -620,7 +620,7 @@ func findFilesWithVersionsByPattern(searchVer version.Version, pattern string, s
 		if !ok {
 			panic(fmt.Sprintf("match %s can't be parsed, shouldn't happen, fail fast", filename))
 		}
-		if info.Version.GreaterOrEqual(supported.MinSupported) && info.Version.LessOrEqual(supported.Current) && maxVersion.Less(info.Version) {
+		if supported.Supports(info.Version) && maxVersion.Less(info.Version) {
 			maxVersion = info.Version
 			maxMatch = match
 			continue

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -185,12 +185,22 @@ func (v Versions) String() string {
 }
 
 func (v Versions) Supports(ver Version) bool {
-	return ver.GreaterOrEqual(v.MinSupported) && ver.LessOrEqual(v.Current)
+	if ver.Less(v.MinSupported) {
+		return false
+	}
+	// A minor bump only changes a file's content, not how it is read, so a newer
+	// minor within a supported major stays readable; only a newer major changes
+	// read logic and must be rejected.
+	if ver.Major == v.Current.Major {
+		return true
+	}
+	return ver.LessOrEqual(v.Current)
 }
 
 var mustSupportLogOnce sync.Once
 
-// MustSupport panics if ver is outside [MinSupported, Current].
+// MustSupport panics if ver is unsupported: older than MinSupported, or a newer
+// major than Current (a newer minor within a supported major is allowed).
 func (v Versions) MustSupport(ver Version, filename string) {
 	if v.Supports(ver) {
 		return
@@ -203,8 +213,8 @@ func (v Versions) MustSupport(ver Version, filename string) {
 		)
 	} else {
 		msg = fmt.Sprintf(
-			"Snapshot file is newer than this Erigon build supports: file=%s, highest_supported=<%s. To fix, either upgrade Erigon to a newer release, or align snapshots by command: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
-			filename, v.Current,
+			"Snapshot file is newer than this Erigon build supports: file=%s, highest_supported=v%d.x. To fix, either upgrade Erigon to a newer release, or align snapshots by command: `erigon snapshots reset --datadir $DATADIR --chain $CHAIN`",
+			filename, v.Current.Major,
 		)
 	}
 	mustSupportLogOnce.Do(func() { log.Error(msg) })

--- a/db/version/file_version_test.go
+++ b/db/version/file_version_test.go
@@ -470,6 +470,17 @@ func TestMustSupport(t *testing.T) {
 		}()
 		supported.MustSupport(V2_0, "test.kv")
 	})
+
+	t.Run("higher minor within same major does not panic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("unexpected panic for higher minor within same major: %v", r)
+			}
+		}()
+		// v1.5 > Current v1.2 but shares the major: a minor bump is a
+		// content-only, backward-readable change and must be supported.
+		supported.MustSupport(Version{Major: 1, Minor: 5}, "test.kv")
+	})
 }
 
 func BenchmarkMatchVersionedFile(b *testing.B) {


### PR DESCRIPTION
Cherry-pick of #22202 to release/3.5.

Relaxes `Versions.Supports` so a newer **minor** within a supported **major** is accepted (per the #20722 versioning contract: minor = content-only, backward-readable). Also updates the `MustSupport` panic wording and routes the inline gate in `snap_schema.go` through `Supports`.

## r3.5-specific adaptations
- Dropped the `db/state/domain_test.go` hunk — `TestCommitmentKvVersionAcceptance` does not exist on release/3.5.
