### PR TITLE
[r3.5] Revert "db/state/statecfg: bump rcache domain kv/.v to v3.1 (#22047)"

### DIFF
--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -33,9 +33,9 @@ func InitSchemasGen() {
 	Schema.LogAddrIdx.FileVersion.AccessorEFI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.LogTopicIdx.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.LogTopicIdx.FileVersion.AccessorEFI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
-	Schema.RCacheDomain.FileVersion.DataKV = version.Versions{version.Version{3, 1}, version.Version{1, 0}}
+	Schema.RCacheDomain.FileVersion.DataKV = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.RCacheDomain.FileVersion.AccessorKVI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.RCacheDomain.Hist.FileVersion.DataV = version.Versions{version.Version{3, 1}, version.Version{1, 0}}
+	Schema.RCacheDomain.Hist.FileVersion.DataV = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.RCacheDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.RCacheDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.RCacheDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -105,14 +105,14 @@ logtopics:
 rcache:
     domain:
         kv:
-            current: v3.1
+            current: v3.0
             min: v1.0
         kvi:
             current: v2.0
             min: v1.0
     hist:
         v:
-            current: v3.1
+            current: v3.0
             min: v1.0
         vi:
             current: v1.1


### PR DESCRIPTION
Reverts #22047 (rcache `.kv`/`.v` bump v3.0→v3.1) on release/3.5.

Published rcache snapshots are consumed by already-released 3.4.x and 3.5.x binaries, which have the strict version check baked in (`Current = v3.0`) and can't read `v3.1-rcache.*` files — a minor bump breaks sync-from-scratch on those releases. Since released binaries are rigid and can't be changed retroactively, we avoid minor version bumps on these release lines as long as possible: de-bump rcache back to v3.0 so the regenerated (data-fix) snapshots carry no version change and existing 3.4.x/3.5.x binaries keep reading them.

Related: #22202 / #22205 relax the strict check so future minor bumps aren't breaking — but that only helps binaries built with it, not already-released 3.4.x/3.5.x.
