### PR TITLE
rpc/jsonrpc: close getProof's SharedDomains

### DIFF
--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -474,6 +474,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 	if err != nil {
 		return nil, err
 	}
+	defer domains.Close()
 	sdCtx := domains.GetCommitmentContext()
 
 	latestBlock, err := rpchelper.GetLatestBlockNumber(roTx)


### PR DESCRIPTION
`getProof` creates a `SharedDomains` for its proof computation and never closes it on any path, leaking the SD's mem batch and commitment trie context on every `eth_getProof` call. The sibling `getWitness` already does `defer domains.Close()`.

Found during the review of #22198.

No red test: a missing `defer Close` has no practical unit-level repro (the leak only shows as memory growth across many calls), so this is a mechanical consistency fix mirroring the adjacent `getWitness` pattern.
