### PR TITLE
sonar: exclude legacy-tests submodule, fix stale test-inclusion path

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,6 +20,7 @@ sonar.exclusions=\
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go,execution/tests/**
+sonar.test.exclusions=execution/tests/legacy-tests/**
 
 sonar.go.coverage.reportPaths=coverage-test-all.out
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectName=erigon
 sonar.sources=.
 sonar.exclusions=\
   .github/**,\
+  execution/tests/legacy-tests/**,\
   docs/**,\
   **/*.pb.go,\
   **/gen_*.go,\
@@ -18,7 +19,7 @@ sonar.exclusions=\
   execution/tracing/tracers/js/internal/tracers/**.js
 
 sonar.tests=.
-sonar.test.inclusions=**/*_test.go,tests/**
+sonar.test.inclusions=**/*_test.go,execution/tests/**
 
 sonar.go.coverage.reportPaths=coverage-test-all.out
 


### PR DESCRIPTION
SonarCloud scans the ethereum/tests submodule as first-party production code: the directory restructure moved it from `tests/` to `execution/tests/legacy-tests`, which dropped it out of `sonar.test.inclusions`' stale `tests/**` pattern, and no exclusion covers the new path (the sonar workflow checks out with `submodules: true`). Whenever SonarCloud activates new rules — four landed today (`docker:S8545`, `docker:S8482`, `jssecurity:S8707`, `jssecurity:S8689`), all hitting legacy-tests fixtures — every PR analyzed before the main baseline absorbs the new issues fails its quality gate on third-party files (see #22194/#22195/#22196 this morning, `new_security_rating` 5).

## Changes
- Exclude `execution/tests/legacy-tests/**` from analysis — third-party fixture content.
- Fix the stale `tests/**` test-inclusion pattern to `execution/tests/**`.
