### PR TITLE
cocoon: reference sovereign-chain wiring on the L2 extension points

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -1148,6 +1148,38 @@ func (e *remoteRulesEngine) GetPostApplyMessageFunc() evmtypes.PostApplyMessageF
 	return e.engine.GetPostApplyMessageFunc()
 }
 
+func (e *remoteRulesEngine) GetStartTxFunc() evmtypes.StartTxFunc {
+	if err := e.validateEngineReady(); err != nil {
+		panic(err)
+	}
+
+	return e.engine.GetStartTxFunc()
+}
+
+func (e *remoteRulesEngine) GetGasChargingFunc() evmtypes.GasChargingFunc {
+	if err := e.validateEngineReady(); err != nil {
+		panic(err)
+	}
+
+	return e.engine.GetGasChargingFunc()
+}
+
+func (e *remoteRulesEngine) GetComputeRefundFunc() evmtypes.ComputeRefundFunc {
+	if err := e.validateEngineReady(); err != nil {
+		panic(err)
+	}
+
+	return e.engine.GetComputeRefundFunc()
+}
+
+func (e *remoteRulesEngine) AmendBlockContext(bc *evmtypes.BlockContext, header *types.Header) {
+	if err := e.validateEngineReady(); err != nil {
+		panic(err)
+	}
+
+	e.engine.AmendBlockContext(bc, header)
+}
+
 func (e *remoteRulesEngine) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
 	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
 	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {

--- a/cocoon/cocoon.go
+++ b/cocoon/cocoon.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package cocoon
+
+import (
+	"context"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/vm"
+	"github.com/erigontech/erigon/node/rulesconfig"
+)
+
+func init() {
+	rulesconfig.RegisterL2Engine("cocoon", func(context.Context, *chain.Config, log.Logger) rules.Engine {
+		return &Engine{}
+	})
+}
+
+// Enable wires cfg for the cocoon sovereign-chain stack: it sets cfg.L2 to a
+// Config keyed on cfg.ChainID and, when precompiles is non-nil, registers it
+// as that chain's precompile provider.
+func Enable(cfg *chain.Config, precompiles vm.PrecompilesFunc) {
+	if cfg.ChainID == nil {
+		panic("cocoon: Enable: chain.Config.ChainID is nil")
+	}
+	chainID := cfg.ChainID.Uint64()
+	cfg.L2 = Config{ChainID: chainID}
+	if precompiles != nil {
+		vm.RegisterPrecompiles(chainID, precompiles)
+	}
+}
+
+// DevChainConfig returns an all-current-forks chain.Config for a cocoon
+// sovereign chain identified by chainID, with L2 pre-set as Enable would
+// (without a precompile provider).
+func DevChainConfig(chainID uint64) *chain.Config {
+	cfg := &chain.Config{
+		ChainName:                     "cocoon-dev",
+		ChainID:                       uint256.NewInt(chainID),
+		Rules:                         chain.CocoonRules,
+		HomesteadBlock:                common.NewUint64(0),
+		TangerineWhistleBlock:         common.NewUint64(0),
+		SpuriousDragonBlock:           common.NewUint64(0),
+		ByzantiumBlock:                common.NewUint64(0),
+		ConstantinopleBlock:           common.NewUint64(0),
+		PetersburgBlock:               common.NewUint64(0),
+		IstanbulBlock:                 common.NewUint64(0),
+		MuirGlacierBlock:              common.NewUint64(0),
+		BerlinBlock:                   common.NewUint64(0),
+		LondonBlock:                   common.NewUint64(0),
+		ArrowGlacierBlock:             common.NewUint64(0),
+		GrayGlacierBlock:              common.NewUint64(0),
+		TerminalTotalDifficulty:       uint256.NewInt(0),
+		TerminalTotalDifficultyPassed: true,
+		ShanghaiTime:                  common.NewUint64(0),
+		CancunTime:                    common.NewUint64(0),
+		PragueTime:                    common.NewUint64(0),
+		OsakaTime:                     common.NewUint64(0),
+		AmsterdamTime:                 common.NewUint64(0),
+	}
+	Enable(cfg, nil)
+	return cfg
+}

--- a/cocoon/cocoon_test.go
+++ b/cocoon/cocoon_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package cocoon_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cocoon"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/mdgas"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
+	"github.com/erigontech/erigon/node/rulesconfig"
+)
+
+type stubStatefulPrecompile struct{}
+
+func (stubStatefulPrecompile) RequiredGas([]byte) uint64        { return 0 }
+func (stubStatefulPrecompile) Run(input []byte) ([]byte, error) { return input, nil }
+func (stubStatefulPrecompile) Name() string                     { return "STUB" }
+
+func (stubStatefulPrecompile) RunStateful(input []byte, gas mdgas.MdGas, _ *vm.PrecompileContext) ([]byte, mdgas.MdGas, error) {
+	return input, gas, nil
+}
+
+func TestCreateRulesEngineBareBonesReturnsCocoonEngine(t *testing.T) {
+	engine := rulesconfig.CreateRulesEngineBareBones(context.Background(), cocoon.DevChainConfig(990101), log.New())
+
+	require.IsType(t, &cocoon.Engine{}, engine)
+}
+
+func TestEnableRegistersPrecompiles(t *testing.T) {
+	const chainID = 990201
+	stubAddr := accounts.InternAddress(common.BytesToAddress([]byte{0xEE}))
+	ecrecoverAddr := accounts.InternAddress(common.BytesToAddress([]byte{0x01}))
+
+	cfg := &chain.Config{ChainID: uint256.NewInt(chainID)}
+	cocoon.Enable(cfg, func(*chain.Rules) vm.PrecompiledContracts {
+		return vm.PrecompiledContracts{stubAddr: stubStatefulPrecompile{}}
+	})
+	t.Cleanup(func() { vm.UnregisterPrecompiles(chainID) })
+
+	contracts := vm.Precompiles(&chain.Rules{ChainID: uint256.NewInt(chainID)})
+
+	require.IsType(t, stubStatefulPrecompile{}, contracts[stubAddr])
+	require.Contains(t, contracts, ecrecoverAddr, "base built-ins must still be present")
+}
+
+func TestEnableNilChainIDPanics(t *testing.T) {
+	require.Panics(t, func() {
+		cocoon.Enable(&chain.Config{}, nil)
+	})
+}

--- a/cocoon/config.go
+++ b/cocoon/config.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+// Package cocoon is the reference wiring for a sovereign single-chain
+// embedder on Erigon's L2 extension points: a chain whose blocks are
+// produced and trusted by the embedder rather than by an L2 stack's own
+// consensus, and which otherwise follows the L1 fork schedule unmodified.
+package cocoon
+
+import "github.com/erigontech/erigon/execution/chain"
+
+// Config is the chain.L2Config for a sovereign chain: it follows the L1 fork
+// schedule as-is, so it has no version ladder of its own to resolve.
+type Config struct {
+	ChainID uint64
+}
+
+var _ chain.L2Config = Config{}
+
+func (Config) Name() string { return "cocoon" }
+
+func (Config) ResolveRules(l2Version, blockNum, blockTime uint64, rules *chain.Rules) {}

--- a/cocoon/engine.go
+++ b/cocoon/engine.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package cocoon
+
+import (
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/misc"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/tracing"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm/evmtypes"
+	"github.com/erigontech/erigon/rpc"
+)
+
+// Engine is the rules.Engine for a sovereign chain whose blocks are produced
+// and trusted by the embedder: it neither seals nor validates consensus, and
+// finalization applies nothing beyond what transaction execution already did.
+type Engine struct{}
+
+var _ rules.Engine = (*Engine)(nil)
+
+func (*Engine) Author(header *types.Header) (accounts.Address, error) {
+	return accounts.InternAddress(header.Coinbase), nil
+}
+
+func (*Engine) TxDependencies(*types.Header) [][]int { return nil }
+
+func (*Engine) IsServiceTransaction(accounts.Address, rules.SystemCall) bool { return false }
+
+func (*Engine) Type() chain.RulesName { return chain.CocoonRules }
+
+func (*Engine) CalculateRewards(*chain.Config, *types.Header, []*types.Header, rules.SystemCall,
+) ([]rules.Reward, error) {
+	return nil, nil
+}
+
+func (*Engine) GetTransferFunc() evmtypes.TransferFunc { return misc.Transfer }
+
+func (*Engine) GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc {
+	return misc.LogSelfDestructedAccounts // EIP-7708, same as an L1 post-merge chain
+}
+
+func (*Engine) GetStartTxFunc() evmtypes.StartTxFunc { return nil }
+
+func (*Engine) GetGasChargingFunc() evmtypes.GasChargingFunc { return nil }
+
+func (*Engine) GetComputeRefundFunc() evmtypes.ComputeRefundFunc { return nil }
+
+func (*Engine) AmendBlockContext(*evmtypes.BlockContext, *types.Header) {}
+
+func (*Engine) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
+	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
+	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {
+	return rules.DefaultBlockPostValidation(chainConfig, header, gasUsed, blobGasUsed, checkReceipts, checkBloom, receipts, txns, logger)
+}
+
+func (*Engine) Close() error { return nil }
+
+func (*Engine) VerifyHeader(rules.ChainHeaderReader, *types.Header, bool) error { return nil }
+
+func (*Engine) VerifyUncles(rules.ChainReader, *types.Header, []*types.Header) error { return nil }
+
+func (*Engine) Prepare(rules.ChainHeaderReader, *types.Header, *state.IntraBlockState) error {
+	return nil
+}
+
+func (*Engine) Initialize(*chain.Config, rules.ChainHeaderReader, *types.Header,
+	*state.IntraBlockState, rules.SysCallCustom, log.Logger, *tracing.Hooks) error {
+	return nil
+}
+
+func (*Engine) Finalize(*chain.Config, *types.Header, *state.IntraBlockState,
+	[]*types.Header, types.Receipts, []*types.Withdrawal, rules.ChainReader, rules.SystemCall, bool, log.Logger,
+) (types.FlatRequests, error) {
+	return nil, nil
+}
+
+func (*Engine) FinalizeAndAssemble(_ *chain.Config, header *types.Header, _ *state.IntraBlockState,
+	txs types.Transactions, uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal,
+	_ rules.ChainReader, _ rules.SystemCall, _ rules.Call, _ log.Logger,
+) (*types.Block, types.FlatRequests, error) {
+	return types.NewBlockForAsembling(header, txs, uncles, receipts, withdrawals), nil, nil
+}
+
+// Seal treats the block as already produced by the embedder, mirroring how
+// the Merge engine handles externally-produced (post-merge) blocks: it does
+// not seal anything, it only forwards the block to results.
+func (*Engine) Seal(_ rules.ChainHeaderReader, blockWithReceipts *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, _ <-chan struct{}) error {
+	block := blockWithReceipts.Block
+	header := block.Header()
+	header.Nonce = types.BlockNonce{}
+
+	select {
+	case results <- &types.BlockWithReceipts{
+		Block:           block.WithSeal(header),
+		Receipts:        blockWithReceipts.Receipts,
+		Requests:        blockWithReceipts.Requests,
+		BlockAccessList: blockWithReceipts.BlockAccessList,
+	}:
+	default:
+		log.Warn("Sealing result is not read", "sealhash", block.Hash())
+	}
+	return nil
+}
+
+func (*Engine) SealHash(header *types.Header) common.Hash { return header.Hash() }
+
+func (*Engine) CalcDifficulty(rules.ChainHeaderReader, uint64, uint64, uint256.Int, uint64,
+	common.Hash, common.Hash, uint64) uint256.Int {
+	return uint256.Int{}
+}
+
+func (*Engine) APIs(rules.ChainHeaderReader) []rpc.API { return nil }

--- a/execution/chain/rules.go
+++ b/execution/chain/rules.go
@@ -24,6 +24,7 @@ const (
 	AuRaRules   RulesName = "aura"
 	EtHashRules RulesName = "ethash"
 	BorRules    RulesName = "bor"
+	CocoonRules RulesName = "cocoon"
 )
 
 // ValidRulesNames is the set of recognised consensus engine names.
@@ -31,13 +32,14 @@ var ValidRulesNames = map[RulesName]struct{}{
 	AuRaRules:   {},
 	EtHashRules: {},
 	BorRules:    {},
+	CocoonRules: {},
 	"":          {}, // empty is valid (defaults to ethash)
 }
 
 // Validate returns an error if the RulesName is not a recognised consensus engine.
 func (r RulesName) Validate() error {
 	if _, ok := ValidRulesNames[r]; !ok {
-		return fmt.Errorf("unsupported consensus engine %q (supported: aura, bor, ethash)", r)
+		return fmt.Errorf("unsupported consensus engine %q (supported: aura, bor, ethash, cocoon)", r)
 	}
 	return nil
 }

--- a/execution/protocol/evm.go
+++ b/execution/protocol/evm.go
@@ -79,9 +79,15 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 
 	var transferFunc evmtypes.TransferFunc
 	var postApplyMessageFunc evmtypes.PostApplyMessageFunc
+	var startTxFunc evmtypes.StartTxFunc
+	var gasChargingFunc evmtypes.GasChargingFunc
+	var computeRefundFunc evmtypes.ComputeRefundFunc
 	if engine != nil {
 		transferFunc = engine.GetTransferFunc()
 		postApplyMessageFunc = engine.GetPostApplyMessageFunc()
+		startTxFunc = engine.GetStartTxFunc()
+		gasChargingFunc = engine.GetGasChargingFunc()
+		computeRefundFunc = engine.GetComputeRefundFunc()
 	} else {
 		transferFunc = misc.Transfer
 		postApplyMessageFunc = misc.LogSelfDestructedAccounts
@@ -97,6 +103,9 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 		Transfer:         transferFunc,
 		GetHash:          blockHashFunc,
 		PostApplyMessage: postApplyMessageFunc,
+		StartTx:          startTxFunc,
+		GasCharging:      gasChargingFunc,
+		ComputeRefund:    computeRefundFunc,
 		Coinbase:         beneficiary,
 		BlockNumber:      header.Number.Uint64(),
 		Time:             header.Time,
@@ -106,6 +115,9 @@ func NewEVMBlockContext(header *types.Header, blockHashFunc func(n uint64) (comm
 		PrevRanDao:       prevRandDao,
 		BlobBaseFee:      blobBaseFee,
 		SlotNumber:       slotNumber,
+	}
+	if engine != nil {
+		engine.AmendBlockContext(&blockContext, header)
 	}
 	return blockContext
 }

--- a/execution/protocol/evm_test.go
+++ b/execution/protocol/evm_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/misc"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm/evmtypes"
+)
+
+// fakeAmendEngine implements only the rules.EngineReader methods
+// NewEVMBlockContext calls when an explicit author is supplied, standing in
+// for an L2 rules engine that populates BlockContext.L2Version.
+type fakeAmendEngine struct {
+	rules.EngineReader
+	l2Version uint64
+}
+
+func (f fakeAmendEngine) GetTransferFunc() evmtypes.TransferFunc                 { return misc.Transfer }
+func (f fakeAmendEngine) GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc { return nil }
+func (f fakeAmendEngine) GetStartTxFunc() evmtypes.StartTxFunc                   { return nil }
+func (f fakeAmendEngine) GetGasChargingFunc() evmtypes.GasChargingFunc           { return nil }
+func (f fakeAmendEngine) GetComputeRefundFunc() evmtypes.ComputeRefundFunc       { return nil }
+
+func (f fakeAmendEngine) AmendBlockContext(bc *evmtypes.BlockContext, _ *types.Header) {
+	bc.L2Version = f.l2Version
+}
+
+// fakeL2Config resolves Rules.L2Version straight from BlockContext.L2Version,
+// mirroring the fork-oracle commit's evmtypes rules_test fake.
+type fakeL2Config struct{}
+
+func (fakeL2Config) Name() string { return "fakel2" }
+
+func (fakeL2Config) ResolveRules(l2Version, _, _ uint64, r *chain.Rules) {
+	r.L2Version = l2Version
+}
+
+// TestNewEVMBlockContext_AmendBlockContextReachesRules verifies that
+// NewEVMBlockContext calls the engine's AmendBlockContext after building the
+// context, and that the L2Version it sets flows through to Rules resolution.
+func TestNewEVMBlockContext_AmendBlockContextReachesRules(t *testing.T) {
+	t.Parallel()
+
+	header := &types.Header{}
+	author := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	engine := fakeAmendEngine{l2Version: 7}
+	cfg := &chain.Config{L2: fakeL2Config{}}
+
+	bc := NewEVMBlockContext(header, nil, engine, author, cfg)
+	require.Equal(t, uint64(7), bc.L2Version)
+
+	r := bc.Rules(cfg)
+	require.Equal(t, uint64(7), r.L2Version)
+}
+
+// TestNewEVMBlockContext_NilEngineSkipsAmend verifies the nil-engine call
+// sites (the majority of NewEVMBlockContext callers do not pass an L2
+// engine) are unaffected: AmendBlockContext is simply not invoked.
+func TestNewEVMBlockContext_NilEngineSkipsAmend(t *testing.T) {
+	t.Parallel()
+
+	header := &types.Header{}
+	author := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	cfg := &chain.Config{}
+
+	bc := NewEVMBlockContext(header, nil, nil, author, cfg)
+	require.Zero(t, bc.L2Version)
+}

--- a/execution/protocol/rules/aura/aura.go
+++ b/execution/protocol/rules/aura/aura.go
@@ -1212,6 +1212,20 @@ func (c *AuRa) GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc {
 	return nil
 }
 
+func (c *AuRa) GetStartTxFunc() evmtypes.StartTxFunc {
+	return nil
+}
+
+func (c *AuRa) GetGasChargingFunc() evmtypes.GasChargingFunc {
+	return nil
+}
+
+func (c *AuRa) GetComputeRefundFunc() evmtypes.ComputeRefundFunc {
+	return nil
+}
+
+func (c *AuRa) AmendBlockContext(bc *evmtypes.BlockContext, header *types.Header) {}
+
 func (c *AuRa) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
 	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
 	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {

--- a/execution/protocol/rules/ethash/ethash.go
+++ b/execution/protocol/rules/ethash/ethash.go
@@ -609,6 +609,20 @@ func (ethash *Ethash) GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc {
 	return nil
 }
 
+func (ethash *Ethash) GetStartTxFunc() evmtypes.StartTxFunc {
+	return nil
+}
+
+func (ethash *Ethash) GetGasChargingFunc() evmtypes.GasChargingFunc {
+	return nil
+}
+
+func (ethash *Ethash) GetComputeRefundFunc() evmtypes.ComputeRefundFunc {
+	return nil
+}
+
+func (ethash *Ethash) AmendBlockContext(bc *evmtypes.BlockContext, header *types.Header) {}
+
 func (c *Ethash) TxDependencies(h *types.Header) [][]int {
 	return nil
 }

--- a/execution/protocol/rules/merge/merge.go
+++ b/execution/protocol/rules/merge/merge.go
@@ -467,6 +467,22 @@ func (s *Merge) GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc {
 	return misc.LogSelfDestructedAccounts // EIP-7708
 }
 
+func (s *Merge) GetStartTxFunc() evmtypes.StartTxFunc {
+	return s.eth1Engine.GetStartTxFunc()
+}
+
+func (s *Merge) GetGasChargingFunc() evmtypes.GasChargingFunc {
+	return s.eth1Engine.GetGasChargingFunc()
+}
+
+func (s *Merge) GetComputeRefundFunc() evmtypes.ComputeRefundFunc {
+	return s.eth1Engine.GetComputeRefundFunc()
+}
+
+func (s *Merge) AmendBlockContext(bc *evmtypes.BlockContext, header *types.Header) {
+	s.eth1Engine.AmendBlockContext(bc, header)
+}
+
 func (s *Merge) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
 	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
 	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -137,6 +137,24 @@ type EngineReader interface {
 
 	GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc
 
+	// GetStartTxFunc returns the hook consulted at the very top of
+	// TxnExecutor.Execute, before intrinsic gas or preCheck. A non-nil
+	// result short-circuits the whole transition (system/deposit txs).
+	GetStartTxFunc() evmtypes.StartTxFunc
+
+	// GetGasChargingFunc returns the hook consulted once gas has been
+	// purchased and split for execution, letting a chain charge extra cost
+	// out of the tx's own gas budget and redirect the tip recipient.
+	GetGasChargingFunc() evmtypes.GasChargingFunc
+
+	// GetComputeRefundFunc returns the hook that, when non-nil, replaces
+	// TxnExecutor's built-in refund ladder for this tx.
+	GetComputeRefundFunc() evmtypes.ComputeRefundFunc
+
+	// AmendBlockContext lets a rules engine populate BlockContext fields it
+	// owns (e.g. L2Version) after NewEVMBlockContext has built the context.
+	AmendBlockContext(bc *evmtypes.BlockContext, header *types.Header)
+
 	ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
 		gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
 		receipts types.Receipts, txns types.Transactions, logger log.Logger) error

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -138,8 +138,8 @@ type EngineReader interface {
 	GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc
 
 	// GetStartTxFunc returns the hook consulted at the very top of
-	// TxnExecutor.Execute, before intrinsic gas or preCheck. A non-nil
-	// result short-circuits the whole transition (system/deposit txs).
+	// TxnExecutor.Execute, before intrinsic gas or preCheck. Returning
+	// done=true short-circuits the whole transition (system/deposit txs).
 	GetStartTxFunc() evmtypes.StartTxFunc
 
 	// GetGasChargingFunc returns the hook consulted once gas has been

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -480,6 +480,12 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 		}()
 	}
 
+	if hook := st.evm.Context.StartTx; hook != nil {
+		if done, result, hookErr := hook(st.state, st.msg); done {
+			return result, hookErr
+		}
+	}
+
 	coinbase := st.evm.Context.Coinbase
 	senderInitBalance, err := st.state.GetBalance(st.msg.From())
 	if err != nil {
@@ -561,6 +567,17 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 		st.gasRemaining.State += stateIgasRefund
 	}
 
+	if hook := st.evm.Context.GasCharging; hook != nil {
+		adjustedGasRemaining, tipRecipient, hookErr := hook(st.state, st.msg, st.gasRemaining, intrinsicGasResult)
+		if hookErr != nil {
+			return nil, hookErr
+		}
+		st.gasRemaining = adjustedGasRemaining
+		if !tipRecipient.IsNil() {
+			coinbase = tipRecipient
+		}
+	}
+
 	if t := st.evm.Config().Tracer; t != nil && t.OnGasChange != nil {
 		t.OnGasChange(st.msg.Gas(), st.gasRemaining.Total(), tracing.GasChangeTxIntrinsicGas)
 	}
@@ -607,27 +624,35 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 	}
 
 	if refunds && !gasBailout {
-		refundQuotient := params.RefundQuotient
-		if rules.IsLondon {
-			refundQuotient = params.RefundQuotientEIP3529
-		}
-		if rules.IsAmsterdam {
-			combined := gasUsed.PlusIntrinsic(imdGas)
-			st.blockStateGasUsed = combined.StateClamped()
-			st.blockRegularGasUsed = max(combined.Regular, intrinsicGasResult.FloorGasCost)
-			st.txnGasUsedB4Refunds = combined.Total()
-			refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund())
-			st.txnGasUsed = max(intrinsicGasResult.FloorGasCost, st.txnGasUsedB4Refunds-refund)
-		} else if rules.IsPrague {
-			st.txnGasUsedB4Refunds = imdGas.Regular + gasUsed.Regular
-			refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund())
-			st.txnGasUsed = max(intrinsicGasResult.FloorGasCost, st.txnGasUsedB4Refunds-refund)
-			st.blockRegularGasUsed = st.txnGasUsed
+		if hook := st.evm.Context.ComputeRefund; hook != nil {
+			rr := hook(gasUsed, imdGas, intrinsicGasResult, st.state.GetRefund(), rules)
+			st.blockRegularGasUsed = rr.BlockRegularGasUsed
+			st.blockStateGasUsed = rr.BlockStateGasUsed
+			st.txnGasUsedB4Refunds = rr.TxnGasUsedB4Refunds
+			st.txnGasUsed = rr.TxnGasUsed
 		} else {
-			st.txnGasUsedB4Refunds = imdGas.Regular + gasUsed.Regular
-			refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund())
-			st.txnGasUsed = st.txnGasUsedB4Refunds - refund
-			st.blockRegularGasUsed = st.txnGasUsed
+			refundQuotient := params.RefundQuotient
+			if rules.IsLondon {
+				refundQuotient = params.RefundQuotientEIP3529
+			}
+			if rules.IsAmsterdam {
+				combined := gasUsed.PlusIntrinsic(imdGas)
+				st.blockStateGasUsed = combined.StateClamped()
+				st.blockRegularGasUsed = max(combined.Regular, intrinsicGasResult.FloorGasCost)
+				st.txnGasUsedB4Refunds = combined.Total()
+				refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund())
+				st.txnGasUsed = max(intrinsicGasResult.FloorGasCost, st.txnGasUsedB4Refunds-refund)
+			} else if rules.IsPrague {
+				st.txnGasUsedB4Refunds = imdGas.Regular + gasUsed.Regular
+				refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund())
+				st.txnGasUsed = max(intrinsicGasResult.FloorGasCost, st.txnGasUsedB4Refunds-refund)
+				st.blockRegularGasUsed = st.txnGasUsed
+			} else {
+				st.txnGasUsedB4Refunds = imdGas.Regular + gasUsed.Regular
+				refund := min(st.txnGasUsedB4Refunds/refundQuotient, st.state.GetRefund())
+				st.txnGasUsed = st.txnGasUsedB4Refunds - refund
+				st.blockRegularGasUsed = st.txnGasUsed
+			}
 		}
 		st.refundGas()
 	} else if rules.IsAmsterdam {

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -482,6 +482,9 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 
 	if hook := st.evm.Context.StartTx; hook != nil {
 		if done, result, hookErr := hook(st.state, st.msg); done {
+			if result == nil && hookErr == nil {
+				return nil, fmt.Errorf("%w: StartTx hook short-circuited with neither result nor error", ErrTxnExecutionFailed)
+			}
 			return result, hookErr
 		}
 	}
@@ -626,6 +629,9 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 	if refunds && !gasBailout {
 		if hook := st.evm.Context.ComputeRefund; hook != nil {
 			rr := hook(gasUsed, imdGas, intrinsicGasResult, st.state.GetRefund(), rules)
+			if rr.TxnGasUsed > st.msg.Gas() {
+				return nil, fmt.Errorf("%w: ComputeRefund hook claims %d gas used, above the tx limit %d", ErrTxnExecutionFailed, rr.TxnGasUsed, st.msg.Gas())
+			}
 			st.blockRegularGasUsed = rr.BlockRegularGasUsed
 			st.blockStateGasUsed = rr.BlockStateGasUsed
 			st.txnGasUsedB4Refunds = rr.TxnGasUsedB4Refunds

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -17,6 +17,7 @@
 package protocol
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/mdgas"
 	"github.com/erigontech/erigon/execution/protocol/misc"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/state"
@@ -295,4 +297,127 @@ func TestPreCheckErrorOrdering_GasBeforeFeeCap(t *testing.T) {
 		gp := NewGasPool(100_000, 0)
 		require.NoError(t, CheckBlockGasInclusion(gp, 50_000, 80_000))
 	})
+}
+
+// TestStartTxHook_ShortCircuits verifies that a non-nil StartTx result skips
+// the whole transition — preCheck never runs, so the block gas pool is
+// untouched and Execute returns the hook's result and error verbatim.
+func TestStartTxHook_ShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 30_000_000
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	wantResult := &evmtypes.ExecutionResult{ReceiptGasUsed: 42}
+	ibs := state.New(state.NewNoopReader())
+	blockCtx := evmtypes.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    misc.Transfer,
+		GasLimit:    blockGasLimit,
+		StartTx: func(_ evmtypes.IntraBlockState, _ evmtypes.Message) (bool, *evmtypes.ExecutionResult, error) {
+			return true, wantResult, nil
+		},
+	}
+	evm := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs, chain.TestChainOsakaConfig, vm.Config{NoBaseFee: true})
+	msg := newSimpleTransferMsg(sender, recipient, 100_000, true)
+	gp := new(GasPool).AddGas(blockGasLimit)
+
+	st := NewTxnExecutor(evm, msg, gp)
+	result, err := st.Execute(true, false)
+
+	require.NoError(t, err)
+	require.Same(t, wantResult, result)
+	require.Equal(t, uint64(blockGasLimit), gp.Gas(), "short-circuited tx must not touch the gas pool")
+}
+
+// TestGasChargingHook_ErrorAbortsTx verifies that a GasCharging error aborts
+// the transition before EVM execution starts.
+func TestGasChargingHook_ErrorAbortsTx(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 30_000_000
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+	wantErr := errors.New("l2: insufficient balance for L1 data fee")
+
+	ibs := state.New(state.NewNoopReader())
+	blockCtx := evmtypes.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    misc.Transfer,
+		GasLimit:    blockGasLimit,
+		GasCharging: func(_ evmtypes.IntraBlockState, _ evmtypes.Message, gasRemaining mdgas.MdGas, _ mdgas.IntrinsicGasCalcResult) (mdgas.MdGas, accounts.Address, error) {
+			return gasRemaining, accounts.NilAddress, wantErr
+		},
+	}
+	evm := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs, chain.TestChainOsakaConfig, vm.Config{NoBaseFee: true})
+	msg := newSimpleTransferMsg(sender, recipient, 100_000, true)
+	gp := new(GasPool).AddGas(blockGasLimit)
+
+	st := NewTxnExecutor(evm, msg, gp)
+	result, err := st.Execute(true, false)
+
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, result)
+}
+
+// TestComputeRefundHook_ReplacesLadder verifies that a non-nil ComputeRefund
+// result replaces TxnExecutor's built-in refund ladder for the tx.
+func TestComputeRefundHook_ReplacesLadder(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 30_000_000
+	const overriddenGasUsed = 12_345
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	ibs := state.New(state.NewNoopReader())
+	blockCtx := evmtypes.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    misc.Transfer,
+		GasLimit:    blockGasLimit,
+		ComputeRefund: func(_ mdgas.MdGasUsage, _ mdgas.MdGas, _ mdgas.IntrinsicGasCalcResult, _ uint64, _ *chain.Rules) evmtypes.RefundResult {
+			return evmtypes.RefundResult{
+				BlockRegularGasUsed: overriddenGasUsed,
+				TxnGasUsedB4Refunds: overriddenGasUsed,
+				TxnGasUsed:          overriddenGasUsed,
+			}
+		},
+	}
+	evm := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs, chain.TestChainOsakaConfig, vm.Config{NoBaseFee: true})
+	msg := newSimpleTransferMsg(sender, recipient, 100_000, true)
+	gp := new(GasPool).AddGas(blockGasLimit)
+
+	st := NewTxnExecutor(evm, msg, gp)
+	result, err := st.Execute(true, false)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(overriddenGasUsed), result.ReceiptGasUsed)
+	require.Equal(t, uint64(overriddenGasUsed), result.BlockRegularGasUsed)
+	require.Equal(t, uint64(blockGasLimit-overriddenGasUsed), gp.Gas(),
+		"pool must be debited by the hook's BlockRegularGasUsed, not the ladder's")
+}
+
+// TestNilHooks_GoldenPathUnchanged pins the existing EIP-7825 golden-path
+// expectation (a valid tx debits the gas pool normally) with all three
+// lifecycle hooks left nil, proving their absence leaves Execute untouched.
+func TestNilHooks_GoldenPathUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 30_000_000
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	ibs := state.New(state.NewNoopReader())
+	evm := newTestEVM(ibs, chain.TestChainOsakaConfig, blockGasLimit)
+	msg := newSimpleTransferMsg(sender, recipient, params.MaxTxnGasLimit, true)
+	gp := new(GasPool).AddGas(blockGasLimit)
+
+	st := NewTxnExecutor(evm, msg, gp)
+	result, err := st.Execute(true, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Less(t, gp.Gas(), uint64(blockGasLimit),
+		"gas pool must be debited for a valid transaction")
 }

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -299,7 +299,7 @@ func TestPreCheckErrorOrdering_GasBeforeFeeCap(t *testing.T) {
 	})
 }
 
-// TestStartTxHook_ShortCircuits verifies that a non-nil StartTx result skips
+// TestStartTxHook_ShortCircuits verifies that done=true from StartTx skips
 // the whole transition — preCheck never runs, so the block gas pool is
 // untouched and Execute returns the hook's result and error verbatim.
 func TestStartTxHook_ShortCircuits(t *testing.T) {
@@ -420,4 +420,59 @@ func TestNilHooks_GoldenPathUnchanged(t *testing.T) {
 	require.NotNil(t, result)
 	require.Less(t, gp.Gas(), uint64(blockGasLimit),
 		"gas pool must be debited for a valid transaction")
+}
+
+// TestStartTxHook_NilResultIsError pins the hook contract: done=true must
+// come with a result or an error, never neither.
+func TestStartTxHook_NilResultIsError(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 30_000_000
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	ibs := state.New(state.NewNoopReader())
+	blockCtx := evmtypes.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    misc.Transfer,
+		GasLimit:    blockGasLimit,
+		StartTx: func(_ evmtypes.IntraBlockState, _ evmtypes.Message) (bool, *evmtypes.ExecutionResult, error) {
+			return true, nil, nil
+		},
+	}
+	evm := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs, chain.TestChainOsakaConfig, vm.Config{NoBaseFee: true})
+	msg := newSimpleTransferMsg(sender, recipient, 100_000, true)
+
+	_, err := NewTxnExecutor(evm, msg, new(GasPool).AddGas(blockGasLimit)).Execute(true, false)
+	require.Error(t, err)
+}
+
+// TestComputeRefundHook_GasUsedAboveLimitIsError pins that a refund override
+// claiming more gas used than the tx's limit is rejected instead of
+// underflowing the sender refund in refundGas.
+func TestComputeRefundHook_GasUsedAboveLimitIsError(t *testing.T) {
+	t.Parallel()
+
+	const blockGasLimit = 30_000_000
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	ibs := state.New(state.NewNoopReader())
+	blockCtx := evmtypes.BlockContext{
+		CanTransfer: CanTransfer,
+		Transfer:    misc.Transfer,
+		GasLimit:    blockGasLimit,
+		ComputeRefund: func(_ mdgas.MdGasUsage, _ mdgas.MdGas, _ mdgas.IntrinsicGasCalcResult, _ uint64, _ *chain.Rules) evmtypes.RefundResult {
+			return evmtypes.RefundResult{
+				BlockRegularGasUsed: 200_000,
+				TxnGasUsedB4Refunds: 200_000,
+				TxnGasUsed:          200_000, // above the 100k tx gas limit
+			}
+		},
+	}
+	evm := vm.NewEVM(blockCtx, evmtypes.TxContext{}, ibs, chain.TestChainOsakaConfig, vm.Config{NoBaseFee: true})
+	msg := newSimpleTransferMsg(sender, recipient, 100_000, true)
+
+	_, err := NewTxnExecutor(evm, msg, new(GasPool).AddGas(blockGasLimit)).Execute(true, false)
+	require.Error(t, err)
 }

--- a/execution/vm/evmtypes/evmtypes.go
+++ b/execution/vm/evmtypes/evmtypes.go
@@ -38,6 +38,9 @@ type BlockContext struct {
 	// GetHash returns the hash corresponding to n
 	GetHash          GetHashFunc
 	PostApplyMessage PostApplyMessageFunc
+	StartTx          StartTxFunc
+	GasCharging      GasChargingFunc
+	ComputeRefund    ComputeRefundFunc
 
 	// Block information
 	Coinbase    accounts.Address // Provides information for COINBASE
@@ -88,6 +91,10 @@ type ExecutionResult struct {
 	// execution but received ETH after the SELFDESTRUCT opcode ran (EIP-7708).
 	// Captured before SoftFinalise clears the journal.
 	SelfDestructedWithBalance []AddressAndBalance
+
+	// L2 is an opaque value the lifecycle hooks may populate (e.g. an L1-fee
+	// split or retryable ticket info); nil unless a hook sets it.
+	L2 any
 }
 
 // Unwrap returns the internal evm error which allows us for further
@@ -131,7 +138,60 @@ type (
 	// PostApplyMessageFunc is an extension point to execute custom logic at the end of core.ApplyMessage.
 	// It's used in Bor for AddFeeTransferLog or in ethereum to clear out the authority code at end of tx.
 	PostApplyMessageFunc func(ibs IntraBlockState, sender accounts.Address, coinbase accounts.Address, result *ExecutionResult, chainRules *chain.Rules)
+
+	// StartTxFunc runs at the very top of TxnExecutor.Execute, before
+	// intrinsic gas or preCheck. When done is true it short-circuits the
+	// whole transition, returning result and err as-is (system/deposit txs).
+	StartTxFunc func(ibs IntraBlockState, msg Message) (done bool, result *ExecutionResult, err error)
+
+	// GasChargingFunc runs once gas has been purchased and split for
+	// execution, letting a chain charge extra cost out of the tx's own gas
+	// budget (via ibs) and redirect the tip recipient. A non-nil error
+	// aborts the transaction before execution starts.
+	GasChargingFunc func(ibs IntraBlockState, msg Message, gasRemaining mdgas.MdGas, intrinsicGas mdgas.IntrinsicGasCalcResult) (adjustedGasRemaining mdgas.MdGas, tipRecipient accounts.Address, err error)
+
+	// ComputeRefundFunc, when non-nil, replaces TxnExecutor's built-in
+	// refund ladder for this tx.
+	ComputeRefundFunc func(gasUsed mdgas.MdGasUsage, imdGas mdgas.MdGas, intrinsicGas mdgas.IntrinsicGasCalcResult, stateRefund uint64, rules *chain.Rules) RefundResult
 )
+
+// RefundResult is what ComputeRefundFunc produces in place of the refund
+// ladder: the final per-tx gas-used values TxnExecutor.Execute needs to
+// charge the block gas pool and pay tips/burn the base fee.
+type RefundResult struct {
+	BlockRegularGasUsed uint64
+	BlockStateGasUsed   uint64
+	TxnGasUsedB4Refunds uint64
+	TxnGasUsed          uint64
+}
+
+// Message is the subset of protocol.Message the lifecycle hooks read; its
+// method set must stay a subset of protocol.Message so that type satisfies
+// this interface structurally without evmtypes importing protocol.
+type Message interface {
+	From() accounts.Address
+	To() accounts.Address
+
+	GasPrice() *uint256.Int
+	FeeCap() *uint256.Int
+	TipCap() *uint256.Int
+	Gas() uint64
+	CheckGas() bool
+	BlobGas() uint64
+	MaxFeePerBlobGas() *uint256.Int
+	Value() *uint256.Int
+
+	Nonce() uint64
+	CheckNonce() bool
+	CheckTransaction() bool
+	Data() []byte
+	AccessList() types.AccessList
+	BlobHashes() []common.Hash
+	Authorizations() []types.Authorization
+
+	IsFree() bool
+	SetIsFree(bool)
+}
 
 type AddressAndBalance struct {
 	Address common.Address

--- a/node/rulesconfig/config.go
+++ b/node/rulesconfig/config.go
@@ -93,55 +93,57 @@ func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainCon
 		if !ok {
 			panic("no L2 rules engine registered for: " + chainConfig.L2.Name())
 		}
-		eng = newEngine(ctx, chainConfig, logger)
-	} else {
-		switch consensusCfg := config.(type) {
-		case *ethashcfg.Config:
-			switch consensusCfg.PowMode {
-			case ethashcfg.ModeFake:
-				logger.Warn("Ethash used in fake mode")
-				eng = ethash.NewFaker()
-			case ethashcfg.ModeTest:
-				logger.Warn("Ethash used in test mode")
-				eng = ethash.NewTester(noVerify)
-			case ethashcfg.ModeShared:
-				logger.Warn("Ethash used in shared mode")
-				eng = ethash.NewShared()
-			default:
-				eng = ethash.New(ethashcfg.Config{
-					CachesInMem:      consensusCfg.CachesInMem,
-					CachesLockMmap:   consensusCfg.CachesLockMmap,
-					DatasetDir:       consensusCfg.DatasetDir,
-					DatasetsInMem:    consensusCfg.DatasetsInMem,
-					DatasetsOnDisk:   consensusCfg.DatasetsOnDisk,
-					DatasetsLockMmap: consensusCfg.DatasetsLockMmap,
-				}, noVerify)
-			}
-		case *chain.AuRaConfig:
-			if chainConfig.Aura != nil {
-				var err error
-				var db kv.RwDB
+		// An L2 engine owns its complete behavior; the merge (PoS) wrap below
+		// is for L1-family engines even when the L2 chain config carries a
+		// terminal total difficulty.
+		return newEngine(ctx, chainConfig, logger)
+	}
+	switch consensusCfg := config.(type) {
+	case *ethashcfg.Config:
+		switch consensusCfg.PowMode {
+		case ethashcfg.ModeFake:
+			logger.Warn("Ethash used in fake mode")
+			eng = ethash.NewFaker()
+		case ethashcfg.ModeTest:
+			logger.Warn("Ethash used in test mode")
+			eng = ethash.NewTester(noVerify)
+		case ethashcfg.ModeShared:
+			logger.Warn("Ethash used in shared mode")
+			eng = ethash.NewShared()
+		default:
+			eng = ethash.New(ethashcfg.Config{
+				CachesInMem:      consensusCfg.CachesInMem,
+				CachesLockMmap:   consensusCfg.CachesLockMmap,
+				DatasetDir:       consensusCfg.DatasetDir,
+				DatasetsInMem:    consensusCfg.DatasetsInMem,
+				DatasetsOnDisk:   consensusCfg.DatasetsOnDisk,
+				DatasetsLockMmap: consensusCfg.DatasetsLockMmap,
+			}, noVerify)
+		}
+	case *chain.AuRaConfig:
+		if chainConfig.Aura != nil {
+			var err error
+			var db kv.RwDB
 
-				db, err = node.OpenDatabase(ctx, nodeConfig, dbcfg.ConsensusDB, "aura", readonly, logger)
+			db, err = node.OpenDatabase(ctx, nodeConfig, dbcfg.ConsensusDB, "aura", readonly, logger)
 
-				if err != nil {
-					panic(err)
-				}
+			if err != nil {
+				panic(err)
+			}
 
-				eng, err = aura.NewAuRa(chainConfig.Aura, db)
-				if err != nil {
-					panic(err)
-				}
+			eng, err = aura.NewAuRa(chainConfig.Aura, db)
+			if err != nil {
+				panic(err)
 			}
-		case *borcfg.BorConfig:
-			// If Matic bor consensus is requested, set it up
-			// In order to pass the ethereum transaction tests, we need to set the burn contract which is in the bor config
-			// Then, bor != nil will also be enabled for ethash. Only enable Bor for real if there is a validator contract present.
-			if chainConfig.Bor != nil && consensusCfg.ValidatorContract != "" {
-				stateReceiver := bor.NewStateReceiver(consensusCfg.StateReceiverContractAddress())
-				spanner := bor.NewChainSpanner(borabi.ValidatorSetContractABI(), chainConfig, withoutHeimdall, logger)
-				eng = bor.New(chainConfig, blockReader, spanner, stateReceiver, logger, polygonBridge, heimdallService)
-			}
+		}
+	case *borcfg.BorConfig:
+		// If Matic bor consensus is requested, set it up
+		// In order to pass the ethereum transaction tests, we need to set the burn contract which is in the bor config
+		// Then, bor != nil will also be enabled for ethash. Only enable Bor for real if there is a validator contract present.
+		if chainConfig.Bor != nil && consensusCfg.ValidatorContract != "" {
+			stateReceiver := bor.NewStateReceiver(consensusCfg.StateReceiverContractAddress())
+			spanner := bor.NewChainSpanner(borabi.ValidatorSetContractABI(), chainConfig, withoutHeimdall, logger)
+			eng = bor.New(chainConfig, blockReader, spanner, stateReceiver, logger, polygonBridge, heimdallService)
 		}
 	}
 

--- a/node/rulesconfig/config.go
+++ b/node/rulesconfig/config.go
@@ -40,58 +40,80 @@ import (
 	"github.com/erigontech/erigon/polygon/heimdall"
 )
 
+// L2EngineFactory builds an L2 stack's rules engine for a chain configured
+// with that stack's L2Config. Registered by the L2 package at init time and
+// consulted by CreateRulesEngine before the built-in type switch.
+type L2EngineFactory func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine
+
+var l2EngineFactories = map[string]L2EngineFactory{}
+
+// RegisterL2Engine registers an L2 stack's rules-engine factory under its
+// L2Config.Name(). Panics if name is already registered.
+func RegisterL2Engine(name string, factory L2EngineFactory) {
+	if _, exists := l2EngineFactories[name]; exists {
+		panic("L2 rules engine already registered: " + name)
+	}
+	l2EngineFactories[name] = factory
+}
+
 func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainConfig *chain.Config, config any, noVerify bool,
 	withoutHeimdall bool, blockReader services.FullBlockReader, readonly bool,
 	logger log.Logger, polygonBridge *bridge.Service, heimdallService *heimdall.Service,
 ) rules.Engine {
 	var eng rules.Engine
 
-	switch consensusCfg := config.(type) {
-	case *ethashcfg.Config:
-		switch consensusCfg.PowMode {
-		case ethashcfg.ModeFake:
-			logger.Warn("Ethash used in fake mode")
-			eng = ethash.NewFaker()
-		case ethashcfg.ModeTest:
-			logger.Warn("Ethash used in test mode")
-			eng = ethash.NewTester(noVerify)
-		case ethashcfg.ModeShared:
-			logger.Warn("Ethash used in shared mode")
-			eng = ethash.NewShared()
-		default:
-			eng = ethash.New(ethashcfg.Config{
-				CachesInMem:      consensusCfg.CachesInMem,
-				CachesLockMmap:   consensusCfg.CachesLockMmap,
-				DatasetDir:       consensusCfg.DatasetDir,
-				DatasetsInMem:    consensusCfg.DatasetsInMem,
-				DatasetsOnDisk:   consensusCfg.DatasetsOnDisk,
-				DatasetsLockMmap: consensusCfg.DatasetsLockMmap,
-			}, noVerify)
+	if chainConfig.L2 != nil {
+		if factory, ok := l2EngineFactories[chainConfig.L2.Name()]; ok {
+			eng = factory(ctx, chainConfig, logger)
 		}
-	case *chain.AuRaConfig:
-		if chainConfig.Aura != nil {
-			var err error
-			var db kv.RwDB
-
-			db, err = node.OpenDatabase(ctx, nodeConfig, dbcfg.ConsensusDB, "aura", readonly, logger)
-
-			if err != nil {
-				panic(err)
+	} else {
+		switch consensusCfg := config.(type) {
+		case *ethashcfg.Config:
+			switch consensusCfg.PowMode {
+			case ethashcfg.ModeFake:
+				logger.Warn("Ethash used in fake mode")
+				eng = ethash.NewFaker()
+			case ethashcfg.ModeTest:
+				logger.Warn("Ethash used in test mode")
+				eng = ethash.NewTester(noVerify)
+			case ethashcfg.ModeShared:
+				logger.Warn("Ethash used in shared mode")
+				eng = ethash.NewShared()
+			default:
+				eng = ethash.New(ethashcfg.Config{
+					CachesInMem:      consensusCfg.CachesInMem,
+					CachesLockMmap:   consensusCfg.CachesLockMmap,
+					DatasetDir:       consensusCfg.DatasetDir,
+					DatasetsInMem:    consensusCfg.DatasetsInMem,
+					DatasetsOnDisk:   consensusCfg.DatasetsOnDisk,
+					DatasetsLockMmap: consensusCfg.DatasetsLockMmap,
+				}, noVerify)
 			}
+		case *chain.AuRaConfig:
+			if chainConfig.Aura != nil {
+				var err error
+				var db kv.RwDB
 
-			eng, err = aura.NewAuRa(chainConfig.Aura, db)
-			if err != nil {
-				panic(err)
+				db, err = node.OpenDatabase(ctx, nodeConfig, dbcfg.ConsensusDB, "aura", readonly, logger)
+
+				if err != nil {
+					panic(err)
+				}
+
+				eng, err = aura.NewAuRa(chainConfig.Aura, db)
+				if err != nil {
+					panic(err)
+				}
 			}
-		}
-	case *borcfg.BorConfig:
-		// If Matic bor consensus is requested, set it up
-		// In order to pass the ethereum transaction tests, we need to set the burn contract which is in the bor config
-		// Then, bor != nil will also be enabled for ethash. Only enable Bor for real if there is a validator contract present.
-		if chainConfig.Bor != nil && consensusCfg.ValidatorContract != "" {
-			stateReceiver := bor.NewStateReceiver(consensusCfg.StateReceiverContractAddress())
-			spanner := bor.NewChainSpanner(borabi.ValidatorSetContractABI(), chainConfig, withoutHeimdall, logger)
-			eng = bor.New(chainConfig, blockReader, spanner, stateReceiver, logger, polygonBridge, heimdallService)
+		case *borcfg.BorConfig:
+			// If Matic bor consensus is requested, set it up
+			// In order to pass the ethereum transaction tests, we need to set the burn contract which is in the bor config
+			// Then, bor != nil will also be enabled for ethash. Only enable Bor for real if there is a validator contract present.
+			if chainConfig.Bor != nil && consensusCfg.ValidatorContract != "" {
+				stateReceiver := bor.NewStateReceiver(consensusCfg.StateReceiverContractAddress())
+				spanner := bor.NewChainSpanner(borabi.ValidatorSetContractABI(), chainConfig, withoutHeimdall, logger)
+				eng = bor.New(chainConfig, blockReader, spanner, stateReceiver, logger, polygonBridge, heimdallService)
+			}
 		}
 	}
 
@@ -113,6 +135,8 @@ func CreateRulesEngineBareBones(ctx context.Context, chainConfig *chain.Config, 
 		consensusConfig = chainConfig.Aura
 	} else if chainConfig.Bor != nil {
 		consensusConfig = chainConfig.Bor
+	} else if chainConfig.L2 != nil {
+		consensusConfig = chainConfig.L2
 	} else {
 		var ethashCfg ethashcfg.Config
 		ethashCfg.PowMode = ethashcfg.ModeFake

--- a/node/rulesconfig/config.go
+++ b/node/rulesconfig/config.go
@@ -40,20 +40,20 @@ import (
 	"github.com/erigontech/erigon/polygon/heimdall"
 )
 
-// L2EngineFactory builds an L2 stack's rules engine for a chain configured
+// L2EngineFunc builds an L2 stack's rules engine for a chain configured
 // with that stack's L2Config. Registered by the L2 package at init time and
 // consulted by CreateRulesEngine before the built-in type switch.
-type L2EngineFactory func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine
+type L2EngineFunc func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine
 
-var l2EngineFactories = map[string]L2EngineFactory{}
+var l2Engines = map[string]L2EngineFunc{}
 
-// RegisterL2Engine registers an L2 stack's rules-engine factory under its
+// RegisterL2Engine registers an L2 stack's rules-engine constructor under its
 // L2Config.Name(). Panics if name is already registered.
-func RegisterL2Engine(name string, factory L2EngineFactory) {
-	if _, exists := l2EngineFactories[name]; exists {
+func RegisterL2Engine(name string, newEngine L2EngineFunc) {
+	if _, exists := l2Engines[name]; exists {
 		panic("L2 rules engine already registered: " + name)
 	}
-	l2EngineFactories[name] = factory
+	l2Engines[name] = newEngine
 }
 
 func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainConfig *chain.Config, config any, noVerify bool,
@@ -63,8 +63,8 @@ func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainCon
 	var eng rules.Engine
 
 	if chainConfig.L2 != nil {
-		if factory, ok := l2EngineFactories[chainConfig.L2.Name()]; ok {
-			eng = factory(ctx, chainConfig, logger)
+		if newEngine, ok := l2Engines[chainConfig.L2.Name()]; ok {
+			eng = newEngine(ctx, chainConfig, logger)
 		}
 	} else {
 		switch consensusCfg := config.(type) {

--- a/node/rulesconfig/config.go
+++ b/node/rulesconfig/config.go
@@ -18,6 +18,7 @@ package rulesconfig
 
 import (
 	"context"
+	"sync"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -45,15 +46,40 @@ import (
 // consulted by CreateRulesEngine before the built-in type switch.
 type L2EngineFunc func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine
 
-var l2Engines = map[string]L2EngineFunc{}
+var (
+	l2EnginesMu sync.RWMutex
+	l2Engines   = map[string]L2EngineFunc{}
+)
 
 // RegisterL2Engine registers an L2 stack's rules-engine constructor under its
-// L2Config.Name(). Panics if name is already registered.
+// L2Config.Name(). Panics on an empty name, a nil constructor, or a name that
+// is already registered — all programming errors caught at init time.
 func RegisterL2Engine(name string, newEngine L2EngineFunc) {
+	if name == "" {
+		panic("rulesconfig: RegisterL2Engine: empty name")
+	}
+	if newEngine == nil {
+		panic("rulesconfig: RegisterL2Engine: nil constructor for " + name)
+	}
+	l2EnginesMu.Lock()
+	defer l2EnginesMu.Unlock()
 	if _, exists := l2Engines[name]; exists {
 		panic("L2 rules engine already registered: " + name)
 	}
 	l2Engines[name] = newEngine
+}
+
+func unregisterL2Engine(name string) {
+	l2EnginesMu.Lock()
+	defer l2EnginesMu.Unlock()
+	delete(l2Engines, name)
+}
+
+func l2Engine(name string) (L2EngineFunc, bool) {
+	l2EnginesMu.RLock()
+	defer l2EnginesMu.RUnlock()
+	newEngine, ok := l2Engines[name]
+	return newEngine, ok
 }
 
 func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainConfig *chain.Config, config any, noVerify bool,
@@ -63,9 +89,11 @@ func CreateRulesEngine(ctx context.Context, nodeConfig *nodecfg.Config, chainCon
 	var eng rules.Engine
 
 	if chainConfig.L2 != nil {
-		if newEngine, ok := l2Engines[chainConfig.L2.Name()]; ok {
-			eng = newEngine(ctx, chainConfig, logger)
+		newEngine, ok := l2Engine(chainConfig.L2.Name())
+		if !ok {
+			panic("no L2 rules engine registered for: " + chainConfig.L2.Name())
 		}
+		eng = newEngine(ctx, chainConfig, logger)
 	} else {
 		switch consensusCfg := config.(type) {
 		case *ethashcfg.Config:

--- a/node/rulesconfig/config_test.go
+++ b/node/rulesconfig/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Erigon Authors
+// Copyright 2026 The Erigon Authors
 // This file is part of Erigon.
 //
 // Erigon is free software: you can redistribute it and/or modify

--- a/node/rulesconfig/config_test.go
+++ b/node/rulesconfig/config_test.go
@@ -1,0 +1,70 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package rulesconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/protocol/rules/ethash"
+)
+
+type fakeL2Config struct {
+	name string
+}
+
+func (f fakeL2Config) Name() string { return f.name }
+
+func (f fakeL2Config) ResolveRules(l2Version, blockNum, blockTime uint64, r *chain.Rules) {}
+
+func TestRegisterL2EngineAndCreateRulesEngineBareBones(t *testing.T) {
+	want := ethash.NewFaker()
+	RegisterL2Engine("testl2", func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine {
+		return want
+	})
+
+	chainConfig := &chain.Config{L2: fakeL2Config{name: "testl2"}}
+	got := CreateRulesEngineBareBones(context.Background(), chainConfig, log.New())
+
+	assert.Same(t, want, got)
+}
+
+func TestRegisterL2EngineDuplicatePanics(t *testing.T) {
+	RegisterL2Engine("duptest", func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine {
+		return ethash.NewFaker()
+	})
+
+	assert.Panics(t, func() {
+		RegisterL2Engine("duptest", func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine {
+			return ethash.NewFaker()
+		})
+	})
+}
+
+func TestCreateRulesEngineUnknownL2Panics(t *testing.T) {
+	chainConfig := &chain.Config{L2: fakeL2Config{name: "unregisteredl2"}}
+
+	require.Panics(t, func() {
+		CreateRulesEngineBareBones(context.Background(), chainConfig, log.New())
+	})
+}

--- a/node/rulesconfig/config_test.go
+++ b/node/rulesconfig/config_test.go
@@ -42,6 +42,7 @@ func TestRegisterL2EngineAndCreateRulesEngineBareBones(t *testing.T) {
 	RegisterL2Engine("testl2", func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine {
 		return want
 	})
+	t.Cleanup(func() { unregisterL2Engine("testl2") })
 
 	chainConfig := &chain.Config{L2: fakeL2Config{name: "testl2"}}
 	got := CreateRulesEngineBareBones(context.Background(), chainConfig, log.New())
@@ -53,6 +54,7 @@ func TestRegisterL2EngineDuplicatePanics(t *testing.T) {
 	RegisterL2Engine("duptest", func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine {
 		return ethash.NewFaker()
 	})
+	t.Cleanup(func() { unregisterL2Engine("duptest") })
 
 	assert.Panics(t, func() {
 		RegisterL2Engine("duptest", func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine {
@@ -65,6 +67,25 @@ func TestCreateRulesEngineUnknownL2Panics(t *testing.T) {
 	chainConfig := &chain.Config{L2: fakeL2Config{name: "unregisteredl2"}}
 
 	require.Panics(t, func() {
+		CreateRulesEngineBareBones(context.Background(), chainConfig, log.New())
+	})
+}
+
+func TestRegisterL2EngineRejectsBadInput(t *testing.T) {
+	assert.Panics(t, func() {
+		RegisterL2Engine("", func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine {
+			return ethash.NewFaker()
+		})
+	})
+	assert.Panics(t, func() {
+		RegisterL2Engine("nilfunc", nil)
+	})
+}
+
+func TestCreateRulesEngineUnknownL2PanicNamesTheStack(t *testing.T) {
+	chainConfig := &chain.Config{L2: fakeL2Config{name: "unregisteredl2"}}
+
+	require.PanicsWithValue(t, "no L2 rules engine registered for: unregisteredl2", func() {
 		CreateRulesEngineBareBones(context.Background(), chainConfig, log.New())
 	})
 }

--- a/node/rulesconfig/config_test.go
+++ b/node/rulesconfig/config_test.go
@@ -23,10 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/holiman/uint256"
+
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/protocol/rules"
 	"github.com/erigontech/erigon/execution/protocol/rules/ethash"
+	"github.com/erigontech/erigon/execution/protocol/rules/ethash/ethashcfg"
+	"github.com/erigontech/erigon/node/nodecfg"
 )
 
 type fakeL2Config struct {
@@ -88,4 +92,18 @@ func TestCreateRulesEngineUnknownL2PanicNamesTheStack(t *testing.T) {
 	require.PanicsWithValue(t, "no L2 rules engine registered for: unregisteredl2", func() {
 		CreateRulesEngineBareBones(context.Background(), chainConfig, log.New())
 	})
+}
+
+func TestCreateRulesEngineL2NotMergeWrapped(t *testing.T) {
+	want := ethash.NewFaker()
+	RegisterL2Engine("ttdl2", func(ctx context.Context, chainConfig *chain.Config, logger log.Logger) rules.Engine {
+		return want
+	})
+	t.Cleanup(func() { unregisterL2Engine("ttdl2") })
+
+	chainConfig := &chain.Config{L2: fakeL2Config{name: "ttdl2"}, TerminalTotalDifficulty: uint256.NewInt(0)}
+	got := CreateRulesEngine(context.Background(), &nodecfg.Config{}, chainConfig, &ethashcfg.Config{PowMode: ethashcfg.ModeFake},
+		true, true, nil, false, log.New(), nil, nil)
+
+	assert.Same(t, want, got)
 }

--- a/polygon/bor/bor.go
+++ b/polygon/bor/bor.go
@@ -1328,6 +1328,20 @@ func (c *Bor) GetPostApplyMessageFunc() evmtypes.PostApplyMessageFunc {
 	return AddFeeTransferLog
 }
 
+func (c *Bor) GetStartTxFunc() evmtypes.StartTxFunc {
+	return nil
+}
+
+func (c *Bor) GetGasChargingFunc() evmtypes.GasChargingFunc {
+	return nil
+}
+
+func (c *Bor) GetComputeRefundFunc() evmtypes.ComputeRefundFunc {
+	return nil
+}
+
+func (c *Bor) AmendBlockContext(bc *evmtypes.BlockContext, header *types.Header) {}
+
 func (c *Bor) ValidateBlockPostExecution(chainConfig *chain.Config, header *types.Header,
 	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
 	receipts types.Receipts, txns types.Transactions, logger log.Logger) error {


### PR DESCRIPTION
cocoon-node embeds erigon as a sovereign single-chain rollup and needs chain identity, an engine, and custom precompiles without forking — the needs #21976 addresses with standalone pieces. This wires the same use case through the L2-SDK extension points (#22193) as their first non-Arbitrum consumer, and doubles as the reference every future embedder can copy. cocoon-pocs itself is design-phase (no erigon integration code exists there yet), so this is reference wiring in-tree, the `polygon/chain` counterpart for sovereign chains.

## Changes
- `cocoon.Config` — `chain.L2Config` implementation; no version ladder, a sovereign chain follows the L1 fork schedule, so `ResolveRules` is a no-op.
- `cocoon.Engine` — the canonical no-op `rules.Engine` for embedder-produced blocks: header verification accepts, finalization applies nothing, `Seal` mirrors the merge engine's externally-produced-block semantics, lifecycle hooks nil, EIP-7708 self-destruct logging wired like any post-merge chain.
- `cocoon.Enable(cfg, precompiles)` — sets `cfg.L2` and registers the chain's precompile provider (`vm.RegisterPrecompiles`, so sets can be stateful and version-gated); `cocoon.DevChainConfig(chainID)` for dev-mode embedding.
- `chain.CocoonRules` name registered alongside ethash/aura/bor.

## Notes
Draft: stacks across #22196, #22200 and #22217; rebases to a single base once those land. Complements #21976 — `InProcServer`, `ExtraGenesisAlloc` and `datadir.ForChain` remain valuable there; the precompile-registration half is expressible here as a provider.

Part of #22193.
