### PR TITLE
cmd/integration: use cobra cmd.Context() instead of re-deriving RootContext per subcommand

### DIFF
--- a/cmd/integration/commands/commitment.go
+++ b/cmd/integration/commands/commitment.go
@@ -187,7 +187,7 @@ Examples:
   integration commitment branch --datadir /path/to/datadir  # reads root (empty prefix)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := debug.SetupCobra(cmd, "integration")
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 
 		prefix, err := commitment.PrefixStringToNibbles(branchPrefixFlag)
 		if err != nil {
@@ -599,7 +599,7 @@ Examples:
   integration commitment bench-lookup --datadir /path/to/datadir --seed 12345`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := debug.SetupCobra(cmd, "integration")
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 
 		if err := benchLookup(ctx, logger); err != nil {
 			if !errors.Is(err, context.Canceled) {
@@ -623,7 +623,7 @@ Examples:
   integration commitment bench-history-lookup --datadir /path/to/datadir --prefix aa --seed 12345`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := debug.SetupCobra(cmd, "integration")
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 
 		if err := benchHistoryLookup(ctx, logger); err != nil {
 			if !errors.Is(err, context.Canceled) {

--- a/cmd/integration/commands/refetence_db.go
+++ b/cmd/integration/commands/refetence_db.go
@@ -48,7 +48,7 @@ var stateBuckets = []string{
 var cmdMdbxTopDup = &cobra.Command{
 	Use: "mdbx_top_dup",
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		logger := debug.SetupCobra(cmd, "integration")
 		err := mdbxTopDup(ctx, chaindata, bucket, logger)
 		if err != nil {
@@ -63,7 +63,7 @@ var cmdCompareBucket = &cobra.Command{
 	Use:   "compare_bucket",
 	Short: "compare bucket to the same bucket in '--chaindata.reference'",
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		logger := debug.SetupCobra(cmd, "integration")
 		if referenceChaindata == "" {
 			referenceChaindata = chaindata + "-copy"
@@ -82,7 +82,7 @@ var cmdCompareStates = &cobra.Command{
 	Use:   "compare_states",
 	Short: "compare state buckets to buckets in '--chaindata.reference'",
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		logger := debug.SetupCobra(cmd, "integration")
 		if referenceChaindata == "" {
 			referenceChaindata = chaindata + "-copy"
@@ -101,7 +101,7 @@ var cmdMdbxToMdbx = &cobra.Command{
 	Use:   "mdbx_to_mdbx",
 	Short: "copy data from '--chaindata' to '--chaindata.to'",
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		logger := debug.SetupCobra(cmd, "integration")
 		from, to := backup.OpenPair(chaindata, toChaindata, dbcfg.ChainDB, 0, logger)
 		err := backup.Kv2kv(ctx, from, to, nil, backup.ReadAheadThreads, logger)
@@ -118,7 +118,7 @@ var cmdFToMdbx = &cobra.Command{
 	Use:   "f_to_mdbx",
 	Short: "copy data from '--chaindata' to '--chaindata.to'",
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		logger := debug.SetupCobra(cmd, "integration")
 		err := fToMdbx(ctx, logger, toChaindata)
 		if err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/integration/commands/reset_state.go
+++ b/cmd/integration/commands/reset_state.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/backup"
@@ -53,7 +52,7 @@ var cmdResetState = &cobra.Command{
 			logger.Error("Opening DB", "error", err)
 			return
 		}
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		defer db.Close()
 
 		sn, borSn, _, _, _, _, err := allSnapshots(ctx, db, logger)
@@ -97,7 +96,7 @@ var cmdClearBadBlocks = &cobra.Command{
 	Short: "Clear table with bad block hashes to allow to process this blocks one more time",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger := debug.SetupCobra(cmd, "integration")
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		db, err := openDB(dbCfg(dbcfg.ChainDB, chaindata), true, chain, logger)
 		if err != nil {
 			logger.Error("Opening DB", "error", err)

--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -71,7 +71,7 @@ var readDomains = &cobra.Command{
 	Args:      cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := debug.SetupCobra(cmd, "integration")
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		cfg := &nodecfg.DefaultConfig
 		utils.SetNodeConfigCobra(cmd, cfg)
 		ethConfig := &ethconfig.Defaults

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/erigontech/erigon/cmd/utils"
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/fromdb"
@@ -64,7 +63,7 @@ Examples:
 	Example: "go run ./cmd/integration state_stages --datadir=... --verbosity=3 --unwind=100 --unwind.every=100000 --block=2000000",
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := debug.SetupCobra(cmd, "integration")
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		cfg := &nodecfg.DefaultConfig
 		utils.SetNodeConfigCobra(cmd, cfg)
 		ethConfig := &ethconfig.Defaults
@@ -105,7 +104,7 @@ var loopExecCmd = &cobra.Command{
 	Use: "loop_exec",
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := debug.SetupCobra(cmd, "integration")
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		db, err := openDB(dbCfg(dbcfg.ChainDB, chaindata), true, chain, logger)
 		if err != nil {
 			logger.Error("Opening DB", "error", err)

--- a/cmd/integration/commands/trigger_fcu.go
+++ b/cmd/integration/commands/trigger_fcu.go
@@ -39,7 +39,7 @@ This is specially useful on devnets where there are network constraints (e.g. fe
 	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := debug.SetupCobra(cmd, "integration")
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 		dirs := datadir.New(datadirCli)
 		jwt := filepath.Join(dirs.DataDir, "jwt.hex")
 

--- a/cmd/integration/commands/write_amplification.go
+++ b/cmd/integration/commands/write_amplification.go
@@ -68,7 +68,7 @@ go run ./cmd/integration write_amplification --datadir=/path/to/db --chain=mainn
 go run ./cmd/integration write_amplification --datadir=/path/to/db --chain=mainnet --domains=accounts`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := debug.SetupCobra(cmd, "integration")
-		ctx, _ := common.RootContext()
+		ctx := cmd.Context()
 
 		dirs := datadir.New(datadirCli)
 		chainDb, err := openDB(dbCfg(dbcfg.ChainDB, dirs.Chaindata), true, chain, logger)


### PR DESCRIPTION
Integration subcommands each called `common.RootContext()` inside their handlers. That re-subscribes to `SIGINT`/`SIGTERM` and derives a fresh context from `context.Background()` — even though `main` already creates one signal-aware root context and threads it through cobra. This replaces those 15 per-subcommand calls with `ctx := cmd.Context()`, so every subcommand shares the single root context instead of spinning up its own redundant signal handler (and discarding the extra `cancel`).

Signal handling is preserved — it lives in `main`, not in the subcommands:

- `cmd/integration/main.go`: `ctx, _ := common.RootContext()` (unchanged) subscribes to signals.
- `rootCmd.ExecuteContext(ctx)` → `c.ctx = ctx` (cobra `command.go:1063`).
- cobra propagates it to the executed subcommand: `if cmd.ctx == nil { cmd.ctx = c.ctx }` (`command.go:1144-1145`).
- inside the subcommand, `cmd.Context()` returns `c.ctx` (`command.go:269-270`) — the same signal-aware context.

So Ctrl-C still cancels the context the subcommand runs under. Go delivers a signal to every registered channel, so the old code merely had N redundant subscriptions; the outcome is unchanged, and cancellation now flows from a single source.

Also drops the now-unused `common` import from `reset_state.go` and `state_stages.go`.
