### PR TITLE
txnprovider/txpool: don't panic on short genesis in p2p test client

### DIFF
--- a/txnprovider/txpool/tests/helper/p2p_client.go
+++ b/txnprovider/txpool/tests/helper/p2p_client.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -102,16 +103,16 @@ func (p *p2pClient) Connect() (<-chan TxMessage, <-chan error, error) {
 		return nil, nil, err
 	}
 
+	genesis := common.FromHex(resp.Result.Protocols.Eth.Genesis)
+	if len(genesis) != 32 {
+		return nil, nil, fmt.Errorf("admin_nodeInfo returned genesis of length %d, want 32 (%q)", len(genesis), resp.Result.Protocols.Eth.Genesis)
+	}
 	_, err = sentryClient.SetStatus(context.TODO(), &sentryproto.StatusData{
 		NetworkId:       uint64(resp.Result.Protocols.Eth.Network),
 		TotalDifficulty: gointerfaces.ConvertUint256IntToH256(uint256.MustFromDecimal(strconv.Itoa(resp.Result.Protocols.Eth.Difficulty))),
-		BestHash: gointerfaces.ConvertHashToH256(
-			[32]byte(common.FromHex(resp.Result.Protocols.Eth.Genesis)),
-		),
+		BestHash:        gointerfaces.ConvertHashToH256([32]byte(genesis)),
 		ForkData: &sentryproto.Forks{
-			Genesis: gointerfaces.ConvertHashToH256(
-				[32]byte(common.FromHex(resp.Result.Protocols.Eth.Genesis)),
-			),
+			Genesis: gointerfaces.ConvertHashToH256([32]byte(genesis)),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
`go test -race ./...` **panics** (crashing the whole test binary, not just failing one test) in `TestSimpleLocalTxThroughputBenchmark`:

```
--- FAIL: TestSimpleLocalTxThroughputBenchmark (0.01s)
panic: runtime error: cannot convert slice with length 0 to array or pointer to array with length 32 [recovered, repanicked]
  ...
  txnprovider/txpool/tests/helper.(*p2pClient).Connect
        txnprovider/txpool/tests/helper/p2p_client.go:109
  txnprovider/txpool/tests.TestSimpleLocalTxThroughputBenchmark
        txnprovider/txpool/tests/pool_test.go:74
```

`Connect` reads the node's `admin_nodeInfo` genesis hash and converts it to `[32]byte` without checking the length. When the node returns an empty `genesis`, `common.FromHex("")` is a length-0 slice and `[32]byte(...)` panics — taking down the whole package's test run.

This parses the genesis once and validates its length before the array conversion, so `Connect` returns a descriptive error instead of panicking:

```go
genesis := common.FromHex(resp.Result.Protocols.Eth.Genesis)
if len(genesis) != 32 {
    return nil, nil, fmt.Errorf("admin_nodeInfo returned genesis of length %d, want 32 (%q)", len(genesis), resp.Result.Protocols.Eth.Genesis)
}
```

Note: the root cause — the node reporting an empty genesis — is separate; this change only makes the helper fail loudly and safely instead of crashing the process. Found via `go test -race ./...` run locally (no CI job).