### PR TITLE
txnprovider/txpool/tests: fix p2p benchmark panic on non-erigon node

### DIFF
--- a/txnprovider/txpool/tests/helper/p2p_client.go
+++ b/txnprovider/txpool/tests/helper/p2p_client.go
@@ -3,15 +3,16 @@ package helper
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/holiman/uint256"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/node/direct"
 	"github.com/erigontech/erigon/node/gointerfaces"
@@ -44,6 +45,69 @@ func NewP2P(adminRPC string) *p2pClient {
 	}
 }
 
+type NodeInfo struct {
+	Enode      string
+	NetworkID  uint64
+	Difficulty *uint256.Int
+	Genesis    [32]byte
+}
+
+// FetchNodeInfo queries admin_nodeInfo and returns the node's identity. It errors
+// unless the response is a well-formed, ready erigon node (valid enode and a
+// 32-byte genesis hash), so callers can tell a real node apart from an unrelated
+// service that merely happens to answer on the same port.
+func FetchNodeInfo(adminRPC string) (NodeInfo, error) {
+	r, err := http.Post(adminRPC, "application/json", strings.NewReader(
+		`{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}`,
+	))
+	if err != nil {
+		return NodeInfo{}, err
+	}
+	defer r.Body.Close()
+	return parseNodeInfo(r.Body)
+}
+
+func parseNodeInfo(body io.Reader) (NodeInfo, error) {
+	var resp struct {
+		Result struct {
+			Enode     string `json:"enode"`
+			Protocols struct {
+				Eth struct {
+					Genesis    string `json:"genesis"`
+					Network    int    `json:"network"`
+					Difficulty int    `json:"difficulty"`
+				} `json:"eth"`
+			} `json:"protocols"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(body).Decode(&resp); err != nil {
+		return NodeInfo{}, err
+	}
+
+	eth := resp.Result.Protocols.Eth
+	genesis, err := hexutil.FromHexWithValidation(eth.Genesis)
+	if err != nil {
+		return NodeInfo{}, fmt.Errorf("admin_nodeInfo returned invalid genesis %q: %w", eth.Genesis, err)
+	}
+	if len(genesis) != 32 {
+		return NodeInfo{}, fmt.Errorf("admin_nodeInfo returned genesis of %d bytes, want 32", len(genesis))
+	}
+	if resp.Result.Enode == "" {
+		return NodeInfo{}, fmt.Errorf("admin_nodeInfo returned empty enode")
+	}
+
+	difficulty := eth.Difficulty
+	if difficulty < 0 {
+		difficulty = 0
+	}
+	return NodeInfo{
+		Enode:      resp.Result.Enode,
+		NetworkID:  uint64(eth.Network),
+		Difficulty: uint256.NewInt(uint64(difficulty)),
+		Genesis:    [32]byte(genesis),
+	}, nil
+}
+
 func (p *p2pClient) Connect() (<-chan TxMessage, <-chan error, error) {
 	privateKey, err := crypto.GenerateKey()
 	if err != nil {
@@ -62,32 +126,12 @@ func (p *p2pClient) Connect() (<-chan TxMessage, <-chan error, error) {
 		PrivateKey:      privateKey,
 	}
 
-	r, err := http.Post(p.adminRPC, "application/json", strings.NewReader(
-		`{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}`,
-	))
+	info, err := FetchNodeInfo(p.adminRPC)
 	if err != nil {
 		return nil, nil, err
 	}
-	defer r.Body.Close()
 
-	var resp struct {
-		Result struct {
-			Enode     string `json:"enode"`
-			Protocols struct {
-				Eth struct {
-					Genesis    string `json:"genesis"`
-					Network    int    `json:"network"`
-					Difficulty int    `json:"difficulty"`
-				} `json:"eth"`
-			} `json:"protocols"`
-		} `json:"result"`
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
-		return nil, nil, err
-	}
-
-	if cfg.StaticNodes, err = enode.ParseNodesFromURLs([]string{resp.Result.Enode}); err != nil {
+	if cfg.StaticNodes, err = enode.ParseNodesFromURLs([]string{info.Enode}); err != nil {
 		return nil, nil, err
 	}
 
@@ -103,15 +147,11 @@ func (p *p2pClient) Connect() (<-chan TxMessage, <-chan error, error) {
 	}
 
 	_, err = sentryClient.SetStatus(context.TODO(), &sentryproto.StatusData{
-		NetworkId:       uint64(resp.Result.Protocols.Eth.Network),
-		TotalDifficulty: gointerfaces.ConvertUint256IntToH256(uint256.MustFromDecimal(strconv.Itoa(resp.Result.Protocols.Eth.Difficulty))),
-		BestHash: gointerfaces.ConvertHashToH256(
-			[32]byte(common.FromHex(resp.Result.Protocols.Eth.Genesis)),
-		),
+		NetworkId:       info.NetworkID,
+		TotalDifficulty: gointerfaces.ConvertUint256IntToH256(info.Difficulty),
+		BestHash:        gointerfaces.ConvertHashToH256(info.Genesis),
 		ForkData: &sentryproto.Forks{
-			Genesis: gointerfaces.ConvertHashToH256(
-				[32]byte(common.FromHex(resp.Result.Protocols.Eth.Genesis)),
-			),
+			Genesis: gointerfaces.ConvertHashToH256(info.Genesis),
 		},
 	})
 	if err != nil {

--- a/txnprovider/txpool/tests/helper/p2p_client_test.go
+++ b/txnprovider/txpool/tests/helper/p2p_client_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package helper
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const validEnode = "enode://abc@1.2.3.4:30303"
+
+// A malformed admin_nodeInfo (e.g. from an unrelated service that grabbed the
+// port) must yield an error, never a panic. An empty genesis previously panicked
+// when converted to [32]byte.
+func TestParseNodeInfoRejectsInvalidNode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"empty genesis", `{"result":{"enode":"` + validEnode + `","protocols":{"eth":{"genesis":"","network":1337}}}}`},
+		{"short genesis", `{"result":{"enode":"` + validEnode + `","protocols":{"eth":{"genesis":"0x1234","network":1337}}}}`},
+		{"non-hex genesis", `{"result":{"enode":"` + validEnode + `","protocols":{"eth":{"genesis":"0x` + strings.Repeat("zz", 32) + `","network":1337}}}}`},
+		{"empty enode", `{"result":{"enode":"","protocols":{"eth":{"genesis":"0x` + strings.Repeat("ab", 32) + `","network":1337}}}}`},
+		{"not json", `not json`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := parseNodeInfo(strings.NewReader(tc.body))
+				require.Error(t, err)
+			})
+		})
+	}
+}
+
+func TestParseNodeInfoValid(t *testing.T) {
+	genesis := "0x" + strings.Repeat("ab", 32)
+	info, err := parseNodeInfo(strings.NewReader(
+		`{"result":{"enode":"` + validEnode + `","protocols":{"eth":{"genesis":"` + genesis + `","network":1337,"difficulty":1}}}}`,
+	))
+	require.NoError(t, err)
+	require.Equal(t, validEnode, info.Enode)
+	require.Equal(t, uint64(1337), info.NetworkID)
+	require.Equal(t, uint64(1), info.Difficulty.Uint64())
+
+	var want [32]byte
+	for i := range want {
+		want[i] = 0xab
+	}
+	require.Equal(t, want, info.Genesis)
+}

--- a/txnprovider/txpool/tests/pool_test.go
+++ b/txnprovider/txpool/tests/pool_test.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"fmt"
-	"net"
 	"testing"
 	"time"
 
@@ -52,19 +51,20 @@ var (
 //
 // This test sends transaction to node1 RPC which means they are local for node1
 // P2P helper is binded to node1 port, that's why we measure performance of local txs processing
-func skipIfNodeUnreachable(t *testing.T, addrs ...string) {
+func skipUnlessErigonNodes(t *testing.T, addrs ...string) {
 	t.Helper()
 	for _, addr := range addrs {
-		conn, err := net.DialTimeout("tcp", addr, 300*time.Millisecond)
-		if err != nil {
-			t.Skipf("requires a running node at %s: %v", addr, err)
+		// A bare TCP dial only proves the port is open; during a full `go test ./...`
+		// run an unrelated service can hold it. Probe admin_nodeInfo so the benchmark
+		// runs only against a real, ready erigon node and skips otherwise.
+		if _, err := helper.FetchNodeInfo(fmt.Sprintf("http://%s/", addr)); err != nil {
+			t.Skipf("requires a running erigon node at %s: %v", addr, err)
 		}
-		_ = conn.Close()
 	}
 }
 
 func TestSimpleLocalTxThroughputBenchmark(t *testing.T) {
-	skipIfNodeUnreachable(t, rpcAddressNode1)
+	skipUnlessErigonNodes(t, rpcAddressNode1)
 
 	txToSendCount := 15000
 	measureAtEvery := 1000
@@ -141,7 +141,7 @@ func TestSimpleLocalTxThroughputBenchmark(t *testing.T) {
 // This test sends transaction to node1 RPC which means they are local for node1
 // P2P helper is binded to node1 port, that's why we measure performance of local txs processing
 func TestSimpleLocalTxLatencyBenchmark(t *testing.T) {
-	skipIfNodeUnreachable(t, rpcAddressNode1)
+	skipUnlessErigonNodes(t, rpcAddressNode1)
 
 	txToSendCount := 1000
 
@@ -205,7 +205,7 @@ func TestSimpleLocalTxLatencyBenchmark(t *testing.T) {
 // This test sends transaction to node2 RPC which means they are remote for node1 and local for node2
 // P2P helper is binded to node1 port, that's why we measure performance of remote txs processing
 func TestSimpleRemoteTxThroughputBenchmark(t *testing.T) {
-	skipIfNodeUnreachable(t, rpcAddressNode1, rpcAddressNode2)
+	skipUnlessErigonNodes(t, rpcAddressNode1, rpcAddressNode2)
 
 	nonce := 0
 
@@ -293,7 +293,7 @@ func TestSimpleRemoteTxThroughputBenchmark(t *testing.T) {
 // This test sends transaction to node2 RPC which means they are remote for node1 and local for node2
 // P2P helper is binded to node1 port, that's why we measure performance of remote txs processing
 func TestSimpleRemoteTxLatencyBenchmark(t *testing.T) {
-	skipIfNodeUnreachable(t, rpcAddressNode1, rpcAddressNode2)
+	skipUnlessErigonNodes(t, rpcAddressNode1, rpcAddressNode2)
 
 	txToSendCount := 100
 


### PR DESCRIPTION
## Problem

`go test -race -count=1 --timeout=100m ./...` intermittently panics:

```
panic: runtime error: cannot convert slice with length 0 to array or pointer to array with length 32
  helper.(*p2pClient).Connect  txnprovider/txpool/tests/helper/p2p_client.go:109
  tests.TestSimpleLocalTxThroughputBenchmark  txnprovider/txpool/tests/pool_test.go:74
```

The p2p txpool benchmarks require a manually-started erigon node on `localhost:8545` and guard themselves by *skipping* when it is absent. The guard used a bare TCP dial (`net.DialTimeout`), which only proves the port is open. During a full `go test ./...` run an unrelated service can be listening on 8545, so the guard passed, `Connect()` POSTed `admin_nodeInfo` to it, got a response with no genesis, and `[32]byte(common.FromHex(""))` panicked on the 0-length slice.

This is the same class of flaw already hardened in `graphql_test.go`, which probes its endpoint semantically rather than trusting an open port.

## Fix

- `p2p_client.go`: extract `FetchNodeInfo`/`parseNodeInfo`. They decode `admin_nodeInfo` with a **non-panicking** hex decoder and return an error unless the response is a well-formed, ready erigon node (valid enode + 32-byte genesis). `Connect()` now fetches/validates up front and reuses the parsed genesis instead of doing an unchecked `[32]byte(...)` conversion.
- `pool_test.go`: the skip guard now probes `admin_nodeInfo` (via `FetchNodeInfo`) so the benchmarks skip unless a real, ready erigon node answers — subsuming and strengthening the old TCP-only check.

No test is disabled: the benchmarks still run when a real node is present; the existing conditional skip is made correct so a wrong service on the port yields a clean skip instead of a panic.

## Verification

- New `parseNodeInfo` unit tests (TDD): empty/short/non-hex genesis and empty enode all return an error, never panic (`require.NotPanics`); a valid response parses correctly.
- End-to-end repro: a fake service on `127.0.0.1:8545` returning an empty genesis (the exact panic input) now makes the benchmark **skip** cleanly (`admin_nodeInfo returned genesis of 0 bytes, want 32`) instead of panicking.
- With no node running, all four benchmarks skip as before.
- `make lint` clean; `go test -race` green.