### PR TITLE
db/state, db/integrity: honor ctx cancellation while opening snapshot files

### DIFF
--- a/cmd/integration/commands/state_history.go
+++ b/cmd/integration/commands/state_history.go
@@ -74,7 +74,7 @@ var historyCmd = &cobra.Command{
 	Use: "history",
 }
 
-func openHistory(dirs datadir.Dirs, domainName string, scanToStep uint64, logger log.Logger) (*state.History, *state.ErigonDBSettings, error) {
+func openHistory(ctx context.Context, dirs datadir.Dirs, domainName string, scanToStep uint64, logger log.Logger) (*state.History, *state.ErigonDBSettings, error) {
 	settings, err := state.ResolveErigonDBSettings(dirs, logger, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve erigondb settings: %w", err)
@@ -93,7 +93,7 @@ func openHistory(dirs datadir.Dirs, domainName string, scanToStep uint64, logger
 	if err != nil {
 		return nil, nil, fmt.Errorf("init history: %w", err)
 	}
-	history.Scan(scanToStep * settings.StepSize)
+	history.Scan(ctx, scanToStep*settings.StepSize)
 	return history, settings, nil
 }
 
@@ -109,7 +109,7 @@ var printCmd = &cobra.Command{
 		}
 		defer l.Unlock()
 
-		history, settings, err := openHistory(dirs, historyDomain, toStep, logger)
+		history, settings, err := openHistory(cmd.Context(), dirs, historyDomain, toStep, logger)
 		if err != nil {
 			logger.Error("Failed to open history", "error", err)
 			return
@@ -153,7 +153,7 @@ var distributionCmd = &cobra.Command{
 		}
 		defer l.Unlock()
 
-		history, settings, err := openHistory(dirs, historyDomain, toStep, logger)
+		history, settings, err := openHistory(cmd.Context(), dirs, historyDomain, toStep, logger)
 		if err != nil {
 			logger.Error("Failed to open history", "error", err)
 			return
@@ -241,7 +241,7 @@ var rebuildCmd = &cobra.Command{
 		}
 		defer l.Unlock()
 
-		history, settings, err := openHistory(dirs, historyDomain, toStep, logger)
+		history, settings, err := openHistory(cmd.Context(), dirs, historyDomain, toStep, logger)
 		if err != nil {
 			logger.Error("Failed to open history", "error", err)
 			return

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -244,7 +244,6 @@ func subscribeToStateChangesLoop(ctx context.Context, client StateChangesClient,
 		for {
 			select {
 			case <-ctx.Done():
-				log.Warn("[rpcdaemon subscribeToStateChanges] ctx done", "err", ctx.Err())
 				return
 			default:
 			}
@@ -256,6 +255,9 @@ func subscribeToStateChangesLoop(ctx context.Context, client StateChangesClient,
 					if err == nil {
 						continue
 					}
+				}
+				if errors.Is(err, context.Canceled) {
+					return
 				}
 				log.Warn("[rpcdaemon subscribeToStateChanges]", "err", err)
 			}

--- a/db/integrity/e3_ef_files.go
+++ b/db/integrity/e3_ef_files.go
@@ -31,7 +31,7 @@ func E3EfFiles(ctx context.Context, db kv.TemporalRwDB, failFast bool, fromStep 
 	defer log.Info("[integrity] InvertedIndex done")
 	logEvery := time.NewTicker(20 * time.Second)
 	defer logEvery.Stop()
-	g := &errgroup.Group{}
+	g, ctx := errgroup.WithContext(ctx)
 	for _, idx := range []kv.InvertedIdx{kv.AccountsHistoryIdx, kv.StorageHistoryIdx, kv.CodeHistoryIdx, kv.CommitmentHistoryIdx, kv.ReceiptHistoryIdx, kv.LogTopicIdx, kv.LogAddrIdx, kv.TracesFromIdx, kv.TracesToIdx} {
 		g.Go(func() error {
 			tx, err := db.BeginTemporalRo(ctx)

--- a/db/integrity/e3_history_no_system_txs.go
+++ b/db/integrity/e3_history_no_system_txs.go
@@ -40,7 +40,7 @@ func HistoryCheckNoSystemTxs(ctx context.Context, db kv.TemporalRwDB, blockReade
 	count := atomic.Uint64{}
 	logEvery := time.NewTicker(20 * time.Second)
 	defer logEvery.Stop()
-	g := &errgroup.Group{}
+	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(estimate.AlmostAllCPUs())
 
 	skipForPerf := 11

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -439,7 +439,9 @@ func (br *BlockRetire) RetireBlocksInBackground(
 		if br.snBuildAllowed != nil {
 			//we are inside own goroutine - it's fine to block here
 			if err := br.snBuildAllowed.Acquire(ctx, 1); err != nil {
-				br.logger.Warn("[snapshots] retire blocks", "err", err)
+				if !errors.Is(err, context.Canceled) && !errors.Is(err, common.ErrStopped) {
+					br.logger.Warn("[snapshots] retire blocks", "err", err)
+				}
 				return
 			}
 			defer br.snBuildAllowed.Release(1)
@@ -456,6 +458,10 @@ func (br *BlockRetire) RetireBlocksInBackground(
 			return
 		}
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, common.ErrStopped) {
+				br.logger.Debug("[snapshots] retire blocks canceled", "err", err)
+				return
+			}
 			br.logger.Error("[snapshots] retire blocks", "err", err)
 			return
 		}

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -2159,7 +2159,9 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 		if a.snapshotBuildSema != nil {
 			//we are inside own goroutine - it's fine to block here
 			if err := a.snapshotBuildSema.Acquire(a.ctx, 1); err != nil { //TODO: not sure if this ctx is correct
-				a.logger.Warn("[snapshots] buildFilesInBackground", "err", err)
+				if !errors.Is(err, context.Canceled) && !errors.Is(err, common.ErrStopped) {
+					a.logger.Warn("[snapshots] buildFilesInBackground", "err", err)
+				}
 				close(fin)
 				return //nolint
 			}

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -560,7 +560,7 @@ func (a *Aggregator) openFolder() error {
 		return err
 	}
 
-	eg := &errgroup.Group{}
+	eg, ctx := errgroup.WithContext(a.ctx)
 	for _, d := range a.d {
 		if d.Disable {
 			continue
@@ -568,12 +568,7 @@ func (a *Aggregator) openFolder() error {
 
 		d := d
 		eg.Go(func() error {
-			select {
-			case <-a.ctx.Done():
-				return a.ctx.Err()
-			default:
-			}
-			return d.openFolder(scanDirsRes)
+			return d.openFolder(ctx, scanDirsRes)
 		})
 	}
 	for _, ii := range a.standaloneIIs() {
@@ -581,7 +576,7 @@ func (a *Aggregator) openFolder() error {
 			continue
 		}
 		ii := ii
-		eg.Go(func() error { return ii.openFolder(scanDirsRes) })
+		eg.Go(func() error { return ii.openFolder(ctx, scanDirsRes) })
 	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("openFolder: %w", err)

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -372,10 +373,16 @@ func retire(dirtyFiles *DirtyFiles, outs []*FilesItem, filenameBase string, reas
 	}
 }
 
-func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
+func (d *Domain) openDirtyFiles(ctx context.Context, dirEntries []string) (err error) {
 	var invalidFileItems []*FilesItem
 	iter := d.dirtyFiles.Iter()
 	for ok := iter.First(); ok; ok = iter.Next() {
+		select {
+		case <-ctx.Done():
+			iter.Release()
+			return ctx.Err()
+		default:
+		}
 		item := iter.Item()
 		fromStep, toStep := item.StepRange(d.stepSize)
 		if item.decompressor == nil {
@@ -466,10 +473,16 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 	return nil
 }
 
-func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
+func (h *History) openDirtyFiles(ctx context.Context, dataEntries, accessorEntries []string) error {
 	var invalidFileItems []*FilesItem
 	iter := h.dirtyFiles.Iter()
 	for ok := iter.First(); ok; ok = iter.Next() {
+		select {
+		case <-ctx.Done():
+			iter.Release()
+			return ctx.Err()
+		default:
+		}
 		item := iter.Item()
 		fromStep, toStep := item.StepRange(h.stepSize)
 		if item.decompressor == nil {
@@ -539,10 +552,16 @@ func (h *History) openDirtyFiles(dataEntries, accessorEntries []string) error {
 	return nil
 }
 
-func (ii *InvertedIndex) openDirtyFiles(dataEntries, accessorEntries []string) error {
+func (ii *InvertedIndex) openDirtyFiles(ctx context.Context, dataEntries, accessorEntries []string) error {
 	var invalidFileItems []*FilesItem
 	iter := ii.dirtyFiles.Iter()
 	for ok := iter.First(); ok; ok = iter.Next() {
+		select {
+		case <-ctx.Done():
+			iter.Release()
+			return ctx.Err()
+		default:
+		}
 		item := iter.Item()
 		fromStep, toStep := item.StepRange(ii.stepSize)
 		if item.decompressor == nil {

--- a/db/state/dirty_files_test.go
+++ b/db/state/dirty_files_test.go
@@ -136,7 +136,7 @@ func TestOpenDirtyFilesAcceptsMixedVersions(t *testing.T) {
 	}
 
 	d.scanDirtyFiles(fileNames)
-	require.NoError(t, d.openDirtyFiles(fileNames))
+	require.NoError(t, d.openDirtyFiles(t.Context(), fileNames))
 
 	opened := make(map[string]bool)
 	d.dirtyFiles.Scan(func(it *FilesItem) bool {
@@ -168,7 +168,7 @@ func TestOpenDirtyFilesSameRangePrefersNewestVersion(t *testing.T) {
 			}
 
 			d.scanDirtyFiles(order)
-			require.NoError(t, d.openDirtyFiles(order))
+			require.NoError(t, d.openDirtyFiles(t.Context(), order))
 
 			require.Equal(t, 1, d.dirtyFiles.Len(), "same-range duplicate must collapse to one dirty file")
 			var opened *FilesItem

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -314,14 +314,14 @@ func (dt *DomainRoTx) NewWriter() *DomainBufferedWriter { return dt.newWriter(dt
 // It's ok if some files was open earlier.
 // If some file already open: noop.
 // If some file already open but not in provided list: close and remove from `files` field.
-func (d *Domain) OpenList(scanResult ScanDirsResult) error {
-	if err := d.History.openList(scanResult.iiFiles, scanResult.historyFiles, scanResult.accessorFiles); err != nil {
+func (d *Domain) OpenList(ctx context.Context, scanResult ScanDirsResult) error {
+	if err := d.History.openList(ctx, scanResult.iiFiles, scanResult.historyFiles, scanResult.accessorFiles); err != nil {
 		return err
 	}
 
 	d.closeWhatNotInList(scanResult.domainFiles)
 	d.scanDirtyFiles(scanResult.domainFiles)
-	if err := d.openDirtyFiles(scanResult.domainFiles); err != nil {
+	if err := d.openDirtyFiles(ctx, scanResult.domainFiles); err != nil {
 		return fmt.Errorf("Domain(%s).openList: %w", d.FilenameBase, err)
 	}
 	d.protectFromHistoryFilesAheadOfDomainFiles()
@@ -335,11 +335,11 @@ func (d *Domain) protectFromHistoryFilesAheadOfDomainFiles() {
 	d.closeFilesAfterStep(kv.Step(d.dirtyFilesEndTxNumMinimax() / d.stepSize))
 }
 
-func (d *Domain) openFolder(r *ScanDirsResult) error {
+func (d *Domain) openFolder(ctx context.Context, r *ScanDirsResult) error {
 	if d.Disable {
 		return nil
 	}
-	return d.OpenList(*r)
+	return d.OpenList(ctx, *r)
 }
 
 func (d *Domain) closeFilesAfterStep(lowerBound kv.Step) {

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -146,7 +146,7 @@ func TestDomain_OpenFolder(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(d.dirs)
 	require.NoError(t, err)
-	err = d.openFolder(scanDirsRes)
+	err = d.openFolder(t.Context(), scanDirsRes)
 	require.NoError(t, err)
 	d.Close()
 }
@@ -853,7 +853,7 @@ func TestDomain_ScanFiles(t *testing.T) {
 	d.closeWhatNotInList([]string{})
 	scanDirsRes, err := scanDirs(d.dirs)
 	require.NoError(t, err)
-	require.NoError(t, d.openFolder(scanDirsRes))
+	require.NoError(t, d.openFolder(t.Context(), scanDirsRes))
 
 	// Check the history
 	checkHistory(t, db, d, txs)
@@ -1439,7 +1439,7 @@ func TestDomain_OpenFilesWithDeletions(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(dom.dirs)
 	require.NoError(t, err)
-	err = dom.openFolder(scanDirsRes)
+	err = dom.openFolder(t.Context(), scanDirsRes)
 
 	require.NoError(t, err)
 

--- a/db/state/forkable_agg.go
+++ b/db/state/forkable_agg.go
@@ -528,12 +528,12 @@ func (r *ForkableAgg) BuildMissedAccessors(ctx context.Context, workers int) err
 ////
 
 func (r *ForkableAgg) openFolder() error {
-	eg := &errgroup.Group{}
+	eg, ctx := errgroup.WithContext(r.ctx)
 	r.loop(func(p *ProtoForkable) error {
 		eg.Go(func() error {
 			select {
-			case <-r.ctx.Done():
-				return r.ctx.Err()
+			case <-ctx.Done():
+				return ctx.Err()
 			default:
 			}
 			return p.snaps.OpenFolder()

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -125,21 +125,21 @@ func (h *History) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
 // It's ok if some files was open earlier.
 // If some file already open: noop.
 // If some file already open but not in provided list: close and remove from `files` field.
-func (h *History) openList(idxFiles, histNames, accessorFiles []string) error {
-	if err := h.InvertedIndex.openList(idxFiles, accessorFiles); err != nil {
+func (h *History) openList(ctx context.Context, idxFiles, histNames, accessorFiles []string) error {
+	if err := h.InvertedIndex.openList(ctx, idxFiles, accessorFiles); err != nil {
 		return err
 	}
 
 	h.closeWhatNotInList(histNames)
 	h.scanDirtyFiles(histNames)
-	if err := h.openDirtyFiles(histNames, accessorFiles); err != nil {
+	if err := h.openDirtyFiles(ctx, histNames, accessorFiles); err != nil {
 		return fmt.Errorf("History(%s).openList: %w", h.FilenameBase, err)
 	}
 	return nil
 }
 
-func (h *History) openFolder(scanDirsRes *ScanDirsResult) error {
-	return h.openList(scanDirsRes.iiFiles, scanDirsRes.historyFiles, scanDirsRes.accessorFiles)
+func (h *History) openFolder(ctx context.Context, scanDirsRes *ScanDirsResult) error {
+	return h.openList(ctx, scanDirsRes.iiFiles, scanDirsRes.historyFiles, scanDirsRes.accessorFiles)
 }
 
 func (h *History) scanDirtyFiles(fileNames []string) {
@@ -352,13 +352,13 @@ func (h *History) BuildMissedAccessors(ctx context.Context, g *errgroup.Group, p
 	}
 }
 
-func (h *History) Scan(toTxNum uint64) error {
+func (h *History) Scan(ctx context.Context, toTxNum uint64) error {
 	scanResult, err := scanDirs(h.dirs)
 	if err != nil {
 		return err
 	}
 
-	if err := h.openFolder(scanResult); err != nil {
+	if err := h.openFolder(ctx, scanResult); err != nil {
 		return err
 	}
 

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -1329,7 +1329,7 @@ func TestHistoryScanFiles(t *testing.T) {
 		// Recreate domain and re-scan the files
 		scanDirsRes, err := scanDirs(h.dirs)
 		require.NoError(err)
-		require.NoError(h.openFolder(scanDirsRes))
+		require.NoError(h.openFolder(t.Context(), scanDirsRes))
 		// Check the history
 		checkHistoryHistory(t, h, txs)
 	}
@@ -1908,7 +1908,7 @@ func TestHistory_OpenFolder(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(h.dirs)
 	require.NoError(t, err)
-	err = h.openFolder(scanDirsRes)
+	err = h.openFolder(t.Context(), scanDirsRes)
 	require.NoError(t, err)
 	h.Close()
 }

--- a/db/state/integrity.go
+++ b/db/state/integrity.go
@@ -158,7 +158,7 @@ func (dt *DomainRoTx) IntegrityKey(k []byte) error {
 
 func (iit *InvertedIndexRoTx) IntegrityInvertedIndexAllValuesAreInRange(ctx context.Context, failFast bool, fromStep uint64) error {
 	fromTxNum := fromStep * iit.ii.stepSize
-	g := &errgroup.Group{}
+	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(estimate.AlmostAllCPUs())
 
 	logEvery := time.NewTicker(30 * time.Second)

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -186,20 +186,20 @@ func filesFromDir(dir string) ([]string, error) {
 	return filtered, nil
 }
 
-func (ii *InvertedIndex) openList(fNames, accessorFiles []string) error {
+func (ii *InvertedIndex) openList(ctx context.Context, fNames, accessorFiles []string) error {
 	ii.closeWhatNotInList(fNames)
 	ii.scanDirtyFiles(fNames)
-	if err := ii.openDirtyFiles(fNames, accessorFiles); err != nil {
+	if err := ii.openDirtyFiles(ctx, fNames, accessorFiles); err != nil {
 		return fmt.Errorf("InvertedIndex(%s).openDirtyFiles: %w", ii.FilenameBase, err)
 	}
 	return nil
 }
 
-func (ii *InvertedIndex) openFolder(r *ScanDirsResult) error {
+func (ii *InvertedIndex) openFolder(ctx context.Context, r *ScanDirsResult) error {
 	if ii.Disable {
 		return nil
 	}
-	return ii.openList(r.iiFiles, r.accessorFiles)
+	return ii.openList(ctx, r.iiFiles, r.accessorFiles)
 }
 
 func (ii *InvertedIndex) scanDirtyFiles(fileNames []string) {

--- a/db/state/inverted_index_test.go
+++ b/db/state/inverted_index_test.go
@@ -934,7 +934,7 @@ func TestInvIndexScanFiles(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(ii.dirs)
 	require.NoError(err)
-	err = ii.openFolder(scanDirsRes)
+	err = ii.openFolder(t.Context(), scanDirsRes)
 	require.NoError(err)
 
 	mergeInverted(t, db, ii, txs)
@@ -1059,7 +1059,7 @@ func TestInvIndex_OpenFolder(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(ii.dirs)
 	require.NoError(t, err)
-	err = ii.openFolder(scanDirsRes)
+	err = ii.openFolder(t.Context(), scanDirsRes)
 	require.NoError(t, err)
 	ii.Close()
 }


### PR DESCRIPTION
Threads the aggregator context down through `openFolder -> openList -> openDirtyFiles` for Domain/History/InvertedIndex, and checks it inside the `openDirtyFiles` loop — the slow file-mmap work. A Ctrl-C during startup now aborts opening dirty files promptly instead of opening every remaining file first; the intermediate `openFolder`/`openList` methods just forward `ctx`.

Also switches the bare `errgroup.Group{}` sites in `db/state` and `db/integrity` to `errgroup.WithContext`, so a failing goroutine cancels its siblings instead of letting them run to completion.

---

**Follow-up commit:** quiet ctx-canceled shutdown logs. On Ctrl-C, `subscribeToStateChanges`, `buildFilesInBackground` (sema acquire), and `retire blocks` were emitting the cancellation as WARN/ERROR noise; those now skip logging when the error is `context.Canceled` / `common.ErrStopped` (expected shutdown), with the retire path keeping a Debug line for traceability.
