### PR TITLE
cmd/erigon: abort startup on interrupt instead of serving

### DIFF
--- a/cmd/erigon/main.go
+++ b/cmd/erigon/main.go
@@ -88,6 +88,15 @@ func runErigon(cliCtx *cli.Context) (err error) {
 		return err
 	}
 
+	// node.New can take tens of seconds; an interrupt during it cancels the CLI
+	// context but doesn't unwind the in-progress build. Abort here instead of
+	// proceeding to serve a node the user already asked to shut down.
+	if cliCtx.Context.Err() != nil {
+		logger.Info("Interrupted during startup, shutting down")
+		ethNode.Close()
+		return nil
+	}
+
 	//diagnostics.Setup(cliCtx, ethNode, metricsMux, pprofMux)
 
 	err = ethNode.Serve()


### PR DESCRIPTION
## Problem

Ctrl-C during node startup is effectively ignored. The interrupt is caught and logged as `Got interrupt, shutting down...`, but the node continues building and then runs to a fully-started state:

```
^CINFO[..] Got interrupt, shutting down...
INFO[..] KZG crypto context ready  took=10.6s
INFO[..] [Downloader] Torrent config ...
INFO[..] Started P2P networking ...
INFO[..] Initialising Ethereum protocol network=1
INFO[..] rpc filters: subscribing to Erigon events
```

## Root cause

For the `erigon` binary the only signal handler active during startup is the one registered in `MakeApp`'s `app.Before` (`cmd/utils/app/make_app.go`), which cancels the CLI context. That cancelled context is threaded as `ctx` into `node.New` → `eth.New`, but `eth.New` (~880 lines: DB open, snapshot open/index, downloader, sentry, P2P) has no `ctx.Err()` check between its steps — the only `ctx.Done()` uses are inside background goroutines. So cancellation has no effect: the node builds fully, `Serve()` starts it, and it blocks in `stack.Wait()`.

(The `handle=nil` `ListenSignals` at `node/debug/flags.go:169` is in `SetupCobra`, used only by the cobra-based integration tools — not on the `erigon` binary path, which uses `Setup`.)

## Fix

Check the CLI context once after `node.New` returns. If it was cancelled during the build, shut the (built-but-not-started) node down via the canonical `Close()` path and return instead of serving. `node.Node.Close()` already handles the `initializingState` (never-started) case cleanly.

A clean startup interrupt now exits like a Ctrl-C on a running node (exit 0, no `context canceled` on stderr).

## Scope / known limitation

This is the surgical fix: an interrupt still lets the current heavy phase (e.g. snapshot open) finish before the guard aborts — it does not unwind mid-`node.New`. Threading cancellation into the long ops inside `eth.New` for near-instant abort is a larger, separate change.

## Testing

No automated test: exercising SIGINT-during-node-startup requires a full node build plus signal timing, which isn't practical to unit test. The guard reuses the existing shutdown path (`ethNode.Close()`, identical to `Serve()`'s `defer eri.Close()`), verified against `node.Node.Close`'s `initializingState` branch. `make lint` and `go build ./cmd/erigon/` pass.