### PR TITLE
rpc/mcp, node/eth: shut down MCP SSE server on ctx cancel

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -180,7 +180,7 @@ func serve(ctx context.Context, srv mcpserver.MCPTransport, transport, sseAddr s
 		return srv.ServeContext(ctx)
 	case "sse":
 		logger.Info("[MCP] Starting SSE transport", "addr", sseAddr)
-		return srv.ServeSSE(sseAddr)
+		return srv.ServeSSE(ctx, sseAddr)
 	default:
 		return fmt.Errorf("unknown transport: %s (use 'stdio' or 'sse')", transport)
 	}

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -801,9 +801,9 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	if config.MCPAddress != "" {
 		go func() {
 			logger.Info("serve MCP on", "addr", config.MCPAddress)
-			mcpErr := mcpServer.ServeSSE(config.MCPAddress)
+			mcpErr := mcpServer.ServeSSE(ctx, config.MCPAddress)
 			if mcpErr != nil {
-				logger.Error("mcpServer.ServeSSE", "err", err)
+				logger.Error("mcpServer.ServeSSE", "err", mcpErr)
 				return
 			}
 		}()

--- a/rpc/mcp/mcp.go
+++ b/rpc/mcp/mcp.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -30,7 +31,7 @@ const Version = "0.0.2"
 type MCPTransport interface {
 	Serve() error
 	ServeContext(ctx context.Context) error
-	ServeSSE(addr string) error
+	ServeSSE(ctx context.Context, addr string) error
 }
 
 // ErigonMCPServer wraps Erigon APIs with MCP server capabilities.
@@ -955,8 +956,8 @@ func (e *ErigonMCPServer) ServeContext(ctx context.Context) error {
 	return s.Listen(ctx, os.Stdin, os.Stdout)
 }
 
-// ServeSSE starts MCP server with SSE transport
-func (e *ErigonMCPServer) ServeSSE(addr string) (err error) {
+// ServeSSE starts MCP server with SSE transport, shutting it down when ctx is cancelled.
+func (e *ErigonMCPServer) ServeSSE(ctx context.Context, addr string) error {
 	// Apply NonBlockingAcquire so BeginRo fails fast (ErrServerOverloaded)
 	// instead of blocking the SSE handler goroutine indefinitely when all DB
 	// read slots are held by a concurrent write/ETL transaction. The HTTP RPC
@@ -966,14 +967,30 @@ func (e *ErigonMCPServer) ServeSSE(addr string) (err error) {
 			return kv.WithNonBlockingAcquire(ctx)
 		}),
 	)
+	return serveSSE(ctx, sse, addr)
+}
 
-	defer func() {
-		if r := recover(); r != nil {
-			log.Error("[MCP]: recovered from panic:", "panic", r)
-
-			err = fmt.Errorf("mcp sse server panicked: %v", r)
-		}
+// serveSSE runs the SSE server until ctx is cancelled, then shuts it down.
+// mcp-go's SSEServer.Start takes no ctx and blocks in Accept, so without this
+// the server goroutine leaks on shutdown.
+func serveSSE(ctx context.Context, sse *server.SSEServer, addr string) error {
+	errCh := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("[MCP] recovered from panic", "panic", r)
+				errCh <- fmt.Errorf("mcp sse server panicked: %v", r)
+			}
+		}()
+		errCh <- sse.Start(addr)
 	}()
 
-	return sse.Start(addr)
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return sse.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
 }

--- a/rpc/mcp/mcp.go
+++ b/rpc/mcp/mcp.go
@@ -969,14 +969,13 @@ func (e *ErigonMCPServer) ServeSSE(ctx context.Context, addr string) error {
 	)
 }
 
-// serveSSE runs the SSE server until ctx is cancelled, then shuts it down.
-// mcp-go's SSEServer.Start takes no ctx and blocks in Accept. The http.Server is
-// pre-created (WithHTTPServer) so a Shutdown that races ahead of Start still
-// targets it — otherwise Start's lazily-created server makes an early Shutdown a
-// no-op and the goroutine leaks in Accept.
+// serveSSE runs the SSE server until ctx is cancelled. The http.Server is
+// pre-created so a Shutdown racing ahead of Start targets it instead of leaking
+// Start in Accept; it must carry Handler: sse because Start wires the handler
+// only on a server it creates itself.
 func serveSSE(ctx context.Context, mcpServer *server.MCPServer, addr string, opts ...server.SSEOption) error {
-	opts = append(opts, server.WithHTTPServer(&http.Server{Addr: addr}))
 	sse := server.NewSSEServer(mcpServer, opts...)
+	server.WithHTTPServer(&http.Server{Addr: addr, Handler: sse})(sse)
 	errCh := make(chan error, 1)
 	go func() {
 		defer func() {

--- a/rpc/mcp/mcp.go
+++ b/rpc/mcp/mcp.go
@@ -962,18 +962,21 @@ func (e *ErigonMCPServer) ServeSSE(ctx context.Context, addr string) error {
 	// instead of blocking the SSE handler goroutine indefinitely when all DB
 	// read slots are held by a concurrent write/ETL transaction. The HTTP RPC
 	// layer sets the same flag in node/rpcstack.go.
-	sse := server.NewSSEServer(e.mcpServer,
+	return serveSSE(ctx, e.mcpServer, addr,
 		server.WithSSEContextFunc(func(ctx context.Context, _ *http.Request) context.Context {
 			return kv.WithNonBlockingAcquire(ctx)
 		}),
 	)
-	return serveSSE(ctx, sse, addr)
 }
 
 // serveSSE runs the SSE server until ctx is cancelled, then shuts it down.
-// mcp-go's SSEServer.Start takes no ctx and blocks in Accept, so without this
-// the server goroutine leaks on shutdown.
-func serveSSE(ctx context.Context, sse *server.SSEServer, addr string) error {
+// mcp-go's SSEServer.Start takes no ctx and blocks in Accept. The http.Server is
+// pre-created (WithHTTPServer) so a Shutdown that races ahead of Start still
+// targets it — otherwise Start's lazily-created server makes an early Shutdown a
+// no-op and the goroutine leaks in Accept.
+func serveSSE(ctx context.Context, mcpServer *server.MCPServer, addr string, opts ...server.SSEOption) error {
+	opts = append(opts, server.WithHTTPServer(&http.Server{Addr: addr}))
+	sse := server.NewSSEServer(mcpServer, opts...)
 	errCh := make(chan error, 1)
 	go func() {
 		defer func() {

--- a/rpc/mcp/mcp_test.go
+++ b/rpc/mcp/mcp_test.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"maps"
+	"net"
+	"net/http"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -181,6 +184,45 @@ func TestEmbeddedAndStandaloneCatalogsMatch(t *testing.T) {
 	embeddedTemplates := resourceTemplateURIs(t, embedded.mcpServer)
 	require.ElementsMatch(t, embeddedTemplates, resourceTemplateURIs(t, standalone.mcpServer))
 	require.NotEmpty(t, embeddedTemplates)
+}
+
+// Start wires the SSE handler only on a server it creates itself, so serveSSE's
+// pre-created server must carry Handler: sse or every MCP request 404s.
+func TestServeSSEHandlerWired(t *testing.T) {
+	addr := freeAddr(t)
+	srv := NewStandaloneMCPServer(nil, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- serveSSE(ctx, srv.mcpServer, addr) }()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	var resp *http.Response
+	var err error
+	for i := 0; i < 100; i++ {
+		resp, err = client.Get("http://" + addr + "/sse")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.NotEqual(t, http.StatusNotFound, resp.StatusCode, "SSE endpoint not served — handler not wired")
+	require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+	return addr
 }
 
 func TestMCPServerCreation(t *testing.T) {

--- a/rpc/mcp/standalone.go
+++ b/rpc/mcp/standalone.go
@@ -27,7 +27,6 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
-	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/rpc"
 )
 
@@ -1113,16 +1112,8 @@ func (s *StandaloneMCPServer) ServeContext(ctx context.Context) error {
 	return stdio.Listen(ctx, os.Stdin, os.Stdout)
 }
 
-// ServeSSE starts the MCP server with SSE transport on the given address.
-func (s *StandaloneMCPServer) ServeSSE(addr string) (err error) {
-	sse := server.NewSSEServer(s.mcpServer)
-
-	defer func() {
-		if r := recover(); r != nil {
-			log.Error("[MCP] recovered from panic", "panic", r)
-			err = fmt.Errorf("mcp sse server panicked: %v", r)
-		}
-	}()
-
-	return sse.Start(addr)
+// ServeSSE starts the MCP server with SSE transport on the given address,
+// shutting it down when ctx is cancelled.
+func (s *StandaloneMCPServer) ServeSSE(ctx context.Context, addr string) error {
+	return serveSSE(ctx, server.NewSSEServer(s.mcpServer), addr)
 }

--- a/rpc/mcp/standalone.go
+++ b/rpc/mcp/standalone.go
@@ -1115,5 +1115,5 @@ func (s *StandaloneMCPServer) ServeContext(ctx context.Context) error {
 // ServeSSE starts the MCP server with SSE transport on the given address,
 // shutting it down when ctx is cancelled.
 func (s *StandaloneMCPServer) ServeSSE(ctx context.Context, addr string) error {
-	return serveSSE(ctx, server.NewSSEServer(s.mcpServer), addr)
+	return serveSSE(ctx, s.mcpServer, addr)
 }


### PR DESCRIPTION
`ServeSSE` called `sse.Start` — a blocking `ListenAndServe()` with no ctx and no shutdown hook. On shutdown nothing called `Shutdown`, so the goroutine stayed parked in `Accept` until the process was force-killed (leaked `sse.go` frame in Ctrl-C dumps).

`ServeSSE` now takes a ctx, runs `sse.Start` in a goroutine, and calls `sse.Shutdown` on cancel — mcp-go's intended pattern (there is no ctx-aware `Start`). The backend passes `sentryCtx`, cancelled by `Ethereum.Stop()`, so MCP stops with graceful shutdown. Embedded and standalone transports share one helper.

The `http.Server` is pre-created so a `Shutdown` racing ahead of `Start` targets it instead of no-op'ing (Start creates its server lazily). That server carries `Handler: sse`: `Start` wires the handler only on a server it creates itself, so a nil-Handler server would 404 every MCP request while looking healthy.

Also fixes the caller logging the enclosing `New` `err` (always nil) instead of the actual `ServeSSE` error.
