### PR TITLE
p2p: make Server.Stop transition exactly-once via CompareAndSwap

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -323,14 +323,13 @@ func (srv *Server) Self() (ln *enode.Node) {
 // It blocks until all active connections have been closed.
 func (srv *Server) Stop() {
 	srv.lock.Lock()
-	if !srv.running.Load() {
+	if !srv.running.CompareAndSwap(true, false) {
 		if srv.nodedb != nil {
 			srv.nodedb.Close()
 		}
 		srv.lock.Unlock()
 		return
 	}
-	srv.running.Store(false)
 	srv.quitFunc()
 	if srv.listener != nil {
 		// this unblocks listener Accept


### PR DESCRIPTION
`Server.Stop()` did a `running.Load()` check followed by a separate `running.Store(false)`. That check-then-set is correct today only because the whole body runs under `srv.lock` — but it reads as an atomic guarding its own transition while silently depending on the surrounding mutex, which is fragile.

Fold both into a single `running.CompareAndSwap(true, false)` so the running→stopped transition is atomically exactly-once in its own right, and drop the now-redundant `Store`. Behavior is unchanged (all `running` writes already happen under `srv.lock`); this just removes the reliance on the lock for the transition's exactly-once semantics.