### PR TITLE
backend.go: nil-ptr on Ctrl-C at startup

### DIFF
--- a/node/components/downloader/provider.go
+++ b/node/components/downloader/provider.go
@@ -140,6 +140,18 @@ func (p *Provider) initDownloader(ctx context.Context) (downloaderproto.Download
 	return dl.DirectGrpcServerClient(bittorrentServer), nil
 }
 
+// AddTorrentsFromDisk adds completed on-disk torrents via the local downloader.
+// It is a no-op returning (0, nil) when no local downloader is present — a remote
+// or disabled downloader, or one already closed during shutdown. Guards against
+// the shutdown race where this fires after Close() has nil'd p.Downloader.
+func (p *Provider) AddTorrentsFromDisk(ctx context.Context) (incompleteTorrents int, err error) {
+	d := p.Downloader
+	if d == nil {
+		return 0, nil
+	}
+	return d.AddTorrentsFromDisk(ctx)
+}
+
 // Close shuts down the downloader. Safe to call multiple times.
 func (p *Provider) Close() {
 	if p.Downloader != nil {

--- a/node/components/downloader/provider_test.go
+++ b/node/components/downloader/provider_test.go
@@ -68,3 +68,23 @@ func TestProviderCloseIdempotent(t *testing.T) {
 	p.Close()
 	p.Close()
 }
+
+// Reproduces the shutdown race where the afterSnapshotDownload callback fires
+// after Close() has nil'd p.Downloader: the call must be a no-op, not a nil
+// pointer dereference.
+func TestProviderAddTorrentsFromDiskAfterClose(t *testing.T) {
+	p := &Provider{}
+	p.Configure(
+		nil,
+		ethconfig.BlocksFreezing{NoDownloader: true},
+		datadir.New(t.TempDir()),
+		log.Root(),
+		nil,
+	)
+	require.NoError(t, p.Initialize(t.Context()))
+	p.Close()
+
+	incomplete, err := p.AddTorrentsFromDisk(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, incomplete)
+}

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -931,9 +931,9 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	// snapshots not in that set could cause issues. That's an unsolved issue and probably requires
 	// always resetting before resuming/starting a sync.
 	var afterSnapshotDownload func(ctx context.Context) error
-	if backend.components.Downloader != nil && backend.components.Downloader.Downloader != nil {
+	if dp := backend.components.Downloader; dp != nil && dp.Downloader != nil {
 		afterSnapshotDownload = func(ctx context.Context) (err error) {
-			incomplete, err := backend.components.Downloader.Downloader.AddTorrentsFromDisk(ctx)
+			incomplete, err := dp.AddTorrentsFromDisk(ctx)
 			if err != nil {
 				err = fmt.Errorf("adding torrents from disk: %w", err)
 				return


### PR DESCRIPTION
## Problem

Ctrl-C during the snapshots stage can crash the node with a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/erigontech/erigon/db/downloader.(*Downloader).log(...)
        db/downloader/downloader.go:1794
github.com/erigontech/erigon/db/downloader.(*Downloader).AddTorrentsFromDisk(0x0, ...)   ← nil receiver
        db/downloader/downloader.go:340
github.com/erigontech/erigon/node/eth.New.func13(...)
        node/eth/backend.go:936
```

The log ordering around the crash shows it is a shutdown race:

```
13:08:32.412  [Downloader] Stopped                        ← Provider.Close() nil'd p.Downloader
13:08:32.827  [1/6 OtterSync] Skipping SyncSnapshots ...   ← snapshots stage still running
              panic: nil pointer  AddTorrentsFromDisk(0x0, ...)
```

## Root cause

The `afterSnapshotDownload` callback re-reads `backend.components.Downloader.Downloader`
at *invocation* time, but the `if ... != nil` guard only validated it at closure-*creation*
time. On shutdown, `Provider.Close()` nils that field. If the snapshots-stage goroutine
reaches the callback after `Close()` has run, it calls `AddTorrentsFromDisk` on a nil
`*Downloader` and dereferences `d.logger`, giving the SIGSEGV.

## Fix

- Add a nil-safe `Provider.AddTorrentsFromDisk(ctx)` that no-ops (returns `0, nil`) when
  no local downloader is present — remote, disabled, or already closed during shutdown.
  This is the component's single access point, matching its Configure → Initialize →
  Close lifecycle design.
- Route the `afterSnapshotDownload` callback through that method instead of dereferencing
  the field directly.

The `Provider` itself (`backend.components.Downloader`) is allocated once in
`nodebuilder.New()` and never nil'd — only its inner `.Downloader` field is cleared by
`Close()` — so capturing it and calling through the method is safe against shutdown
ordering.

## Test

`TestProviderAddTorrentsFromDiskAfterClose` reproduces the race (Configure → Initialize →
Close → call) and asserts the call is a no-op rather than a panic. Written failing first
(method missing), then made to pass.

## Note / follow-up

This closes the crash. A benign data race remains on the `p.Downloader` field itself
(concurrent read in the callback vs. write in `Close()`); it predates this change and no
longer crashes. Making it fully `-race`-clean would mean guarding the field with an
atomic/mutex and updating the other direct readers (`backend.go:489-490`) — left out of
this targeted fix.