### PR TITLE
p2p/enode: close sources added after FairMix shutdown

### DIFF
--- a/p2p/enode/iter.go
+++ b/p2p/enode/iter.go
@@ -177,6 +177,7 @@ func (m *FairMix) AddSource(it Iterator) {
 	defer m.mu.Unlock()
 
 	if m.closed == nil {
+		it.Close()
 		return
 	}
 	m.wg.Add(1)

--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -234,6 +234,21 @@ func testMixerClose(t *testing.T) {
 	mix.Close() // shouldn't crash
 }
 
+// This test checks that AddSource closes the rejected iterator when the
+// mixer is already closed, so callers racing with Close do not leak resources.
+func TestFairMixAddSourceAfterClose(t *testing.T) {
+	mix := NewFairMix(-1)
+	mix.Close()
+
+	// Mixer is now closed. AddSource must close the rejected iterator
+	// so the caller does not leak it.
+	rejected := &genIter{index: 1}
+	mix.AddSource(rejected)
+	if rejected.Next() {
+		t.Fatal("rejected iterator was not closed by AddSource")
+	}
+}
+
 func idPrefixDistribution(nodes []*Node) map[uint32]int {
 	d := make(map[uint32]int)
 	for _, node := range nodes {


### PR DESCRIPTION
When `FairMix.AddSource` is called after the mixer has already been shut down, the incoming iterator was silently discarded without being closed. This means any caller that hands off an iterator to `AddSource` while another goroutine is concurrently calling `Close` could end up leaking the iterator's underlying resources.

This change ensures that `AddSource` properly closes the iterator it receives when the mixer is no longer accepting new sources, preserving the ownership contract that `AddSource` is responsible for the iterator's lifecycle once it's handed over.
