### PR TITLE
txnprovider/txpool: skip periodic remote-txn flush lock-free when nothing buffered

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -477,7 +477,6 @@ func (p *TxPool) processRemoteTxns(ctx context.Context) (err error) {
 		}
 	}()
 
-	log.Warn("[dbg.pool] process remote transactions", "len(p.unprocessedRemoteTxns.Txns)", len(p.unprocessedRemoteTxns.Txns))
 	defer processBatchTxnsTimer.ObserveDuration(time.Now())
 	coreDB, cache := p.chainDB()
 	coreTx, err := coreDB.BeginTemporalRo(ctx)

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -542,7 +542,7 @@ func (p *TxPool) processRemoteTxns(ctx context.Context) (err error) {
 	}
 
 	p.unprocessedRemoteTxns.Resize(0)
-	p.hasUnprocessedRemoteTxns.Store(len(p.unprocessedRemoteTxns.Txns) > 0)
+	p.hasUnprocessedRemoteTxns.Store(false)
 	p.unprocessedRemotePeers = p.unprocessedRemotePeers[:0]
 	p.unprocessedRemoteByHash = map[string]int{}
 

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -175,6 +175,8 @@ type TxPool struct {
 	senderLastActivity   map[uint64]uint64 // senderID → block of last on-chain state change
 	avgBlockTimeMs       atomic.Int64      // EWMA of block-to-block wall-clock interval (ms); default 12 000
 	lastBlockTimestampMs atomic.Int64      // unix-ms timestamp of the last processed block
+
+	hasUnprocessedRemoteTxns atomic.Bool // lock-free way to check if pool needs to flush buffered remote txs
 }
 
 type ValidateAA interface {
@@ -463,16 +465,19 @@ func (p *TxPool) OnNewBlock(ctx context.Context, stateChanges *remoteproto.State
 }
 
 func (p *TxPool) processRemoteTxns(ctx context.Context) (err error) {
+	if !p.Started() {
+		return errors.New("txpool not started yet")
+	}
+	if !p.hasUnprocessedRemoteTxns.Load() {
+		return nil
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic: %v\n%s", r, stack.Trace().String())
 		}
 	}()
 
-	if !p.Started() {
-		return errors.New("txpool not started yet")
-	}
-
+	log.Warn("[dbg.pool] process remote transactions", "len(p.unprocessedRemoteTxns.Txns)", len(p.unprocessedRemoteTxns.Txns))
 	defer processBatchTxnsTimer.ObserveDuration(time.Now())
 	coreDB, cache := p.chainDB()
 	coreTx, err := coreDB.BeginTemporalRo(ctx)
@@ -537,6 +542,7 @@ func (p *TxPool) processRemoteTxns(ctx context.Context) (err error) {
 	}
 
 	p.unprocessedRemoteTxns.Resize(0)
+	p.hasUnprocessedRemoteTxns.Store(len(p.unprocessedRemoteTxns.Txns) > 0)
 	p.unprocessedRemotePeers = p.unprocessedRemotePeers[:0]
 	p.unprocessedRemoteByHash = map[string]int{}
 
@@ -946,6 +952,7 @@ func (p *TxPool) AddRemoteTxns(_ context.Context, newTxns TxnSlots, peerID PeerI
 		p.unprocessedRemoteTxns.Append(txn, newTxns.Senders.At(i), false)
 		p.unprocessedRemotePeers = append(p.unprocessedRemotePeers, src)
 	}
+	p.hasUnprocessedRemoteTxns.Store(len(p.unprocessedRemoteTxns.Txns) > 0)
 }
 
 func toBlobs(_blobs [][]byte) []*goethkzg.Blob {

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -494,6 +494,7 @@ func (p *TxPool) processRemoteTxns(ctx context.Context) (err error) {
 
 	l := len(p.unprocessedRemoteTxns.Txns)
 	if l == 0 {
+		p.hasUnprocessedRemoteTxns.Store(false)
 		return nil
 	}
 


### PR DESCRIPTION
The `ProcessRemoteTxnsEvery` ticker (~100ms) calls `processRemoteTxns` on every tick to
flush buffered remote txns. Previously it always opened a temporal RO DB transaction
(`coreDB.BeginTemporalRo`) and took the pool's global lock — even when there was nothing
buffered, which is the common case between bursts. That's pure per-tick overhead.

This adds a lock-free fast path:

- New `hasUnprocessedRemoteTxns atomic.Bool`, set under `p.lock` in `AddRemoteTxns` when
  txns are buffered, and reset after the buffer is drained in `processRemoteTxns`.
- `processRemoteTxns` loads it **lock-free** at the top and returns immediately when false —
  no DB transaction, no global mutex acquisition.

So the periodic tick is now essentially free when idle; the DB tx + lock are taken only
when there is actually something to flush. Worst case, a txn added right after the check
waits one more tick (~100ms) before it's processed — acceptable given the cadence.
