### PR TITLE
db/snapshotsync: remove overlapping caplin state snapshots on retire

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3423,7 +3423,7 @@ func doRetireCommand(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs
 	cfg := ethconfig.NewSnapCfg(false, true, true, chainConfig.ChainName)
 
 	res, clean, err := openSnaps(ctx, cfg, dirs, db, logger)
-	caplinSnaps, br, agg := res.CaplinSnaps, res.BlockRetire, res.Aggregator
+	caplinSnaps, caplinStateSnaps, br, agg := res.CaplinSnaps, res.CaplinStateSnaps, res.BlockRetire, res.Aggregator
 	if err != nil {
 		return err
 	}
@@ -3471,6 +3471,10 @@ func doRetireCommand(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs
 	}
 
 	if err := br.RemoveOverlaps(nil); err != nil {
+		return err
+	}
+
+	if err := caplinStateSnaps.RemoveOverlaps(); err != nil {
 		return err
 	}
 

--- a/db/snapshotsync/caplin_state_overlap_test.go
+++ b/db/snapshotsync/caplin_state_overlap_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshotsync
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dir2 "github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/recsplit"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/chain/networkname"
+	"github.com/erigontech/erigon/node/ethconfig"
+)
+
+func writeCaplinStateFixture(t *testing.T, dir, table string, from, to uint64, logger log.Logger) (segPath, idxPath string) {
+	t.Helper()
+	segName := strings.ReplaceAll(snaptype.BeaconBlocks.FileName(version.ZeroVersion, from, to), "beaconblocks", table)
+	segPath = filepath.Join(dir, segName)
+
+	compressCfg := seg.DefaultCfg
+	compressCfg.MinPatternScore = 100
+	c, err := seg.NewCompressor(t.Context(), "test", segPath, dir, compressCfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	defer c.Close()
+	c.DisableFsync()
+	require.NoError(t, c.AddWord([]byte{1}))
+	require.NoError(t, c.Compress())
+
+	idxPath = strings.ReplaceAll(segPath, ".seg", ".idx")
+	idx, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
+		KeyCount:   1,
+		BucketSize: 10,
+		TmpDir:     dir,
+		IndexFile:  idxPath,
+		LeafSize:   8,
+		BaseDataID: from,
+	}, logger)
+	require.NoError(t, err)
+	defer idx.Close()
+	idx.DisableFsync()
+	require.NoError(t, idx.AddKey([]byte{1}, 0))
+	require.NoError(t, idx.Build(t.Context()))
+	return segPath, idxPath
+}
+
+// hasDiskOverlap mirrors the publishable integrity check (cmd/utils/app/publishable_check.go):
+// it walks the real directory, sorts by (from,to), and reports whether any file's range
+// starts before the previous file's end.
+func hasDiskOverlap(t *testing.T, dir, table string) bool {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	type rng struct{ from, to uint64 }
+	var rs []rng
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) != ".seg" {
+			continue
+		}
+		fi, _, ok := snaptype.ParseFileName(dir, e.Name())
+		if !ok || fi.CaplinTypeString != table {
+			continue
+		}
+		rs = append(rs, rng{fi.From, fi.To})
+	}
+	sort.Slice(rs, func(i, j int) bool {
+		return rs[i].from < rs[j].from || (rs[i].from == rs[j].from && rs[i].to < rs[j].to)
+	})
+	for i := 1; i < len(rs); i++ {
+		if rs[i].from < rs[i-1].to {
+			return true
+		}
+	}
+	return false
+}
+
+func openTestCaplinStateSnapshots(t *testing.T, dirs datadir.Dirs, table string, logger log.Logger) *CaplinStateSnapshots {
+	t.Helper()
+	types := SnapshotTypes{
+		KeyValueGetters: map[string]KeyValueGetter{table: nil},
+		Compression:     map[string]bool{},
+	}
+	s := NewCaplinStateSnapshots(ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}, nil, dirs, types, logger)
+	t.Cleanup(s.Close)
+	require.NoError(t, s.OpenFolder())
+	return s
+}
+
+// A genesis-rooted superset that fully covers an interior/trailing subset must not
+// appear as two separate covered ranges: DirtySegmentLess sorts the superset first,
+// so the interior subset is the case the visible-list subset check must still hide.
+func TestCaplinStateRecalcHidesInteriorSubset(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 150_000, logger)
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 150_000, logger)
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+
+	ranges := s.coveredRangesForType(table)
+	require.Len(t, ranges, 1, "interior subset must be hidden by the covering superset")
+	require.Equal(t, Range{from: 0, to: 150_000}, ranges[0])
+}
+
+// RemoveOverlaps must physically delete a subset .seg/.idx that is fully covered by a
+// larger indexed segment of the same type, so the on-disk publishable check stops
+// reporting an overlap. Reproduces the Gnosis PendingDepositsDump failure.
+func TestCaplinStateRemoveOverlaps(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	// Published shape: genesis-rooted superset, an interior orphan subset that must
+	// go, and an abutting forward chunk that must stay (it is not a subset).
+	supSeg, supIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 150_000, logger)
+	subSeg, subIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 150_000, logger)
+	tailSeg, tailIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 150_000, 200_000, logger)
+
+	require.True(t, hasDiskOverlap(t, dirs.SnapCaplin, table), "fixture must reproduce the on-disk overlap")
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.NoError(t, s.RemoveOverlaps())
+
+	require.NoFileExists(t, subSeg)
+	require.NoFileExists(t, subIdx)
+	require.FileExists(t, supSeg)
+	require.FileExists(t, supIdx)
+	require.FileExists(t, tailSeg, "abutting non-subset chunk must be kept")
+	require.FileExists(t, tailIdx)
+	require.False(t, hasDiskOverlap(t, dirs.SnapCaplin, table), "overlap must be gone after RemoveOverlaps")
+
+	ranges := s.coveredRangesForType(table)
+	require.Equal(t, []Range{{from: 0, to: 150_000}, {from: 150_000, to: 200_000}}, ranges)
+}
+
+// A covered subset whose .idx is missing (e.g. a process killed between the .seg and
+// .idx writes) must still be removed, without panicking on the nil index entry.
+func TestCaplinStateRemoveOverlapsSubsetMissingIndex(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	supSeg, _ := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 150_000, logger)
+	subSeg, subIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 150_000, logger)
+	require.NoError(t, dir2.RemoveFile(subIdx)) // subset .seg present, .idx missing
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.NoError(t, s.RemoveOverlaps())
+
+	require.NoFileExists(t, subSeg, "covered subset must be removed even without its index")
+	require.FileExists(t, supSeg)
+	require.False(t, hasDiskOverlap(t, dirs.SnapCaplin, table))
+}
+
+// A subset must be kept when no fully-present indexed superset covers it: deleting it
+// would drop data. Here the "superset" lacks its .idx, so it is not usable yet.
+func TestCaplinStateRemoveOverlapsKeepsSubsetWithoutIndexedSuperset(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	supSeg, supIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 150_000, logger)
+	subSeg, _ := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 150_000, logger)
+	require.NoError(t, dir2.RemoveFile(supIdx)) // superset not indexed → not a valid cover
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.NoError(t, s.RemoveOverlaps())
+
+	require.FileExists(t, subSeg, "subset must survive when its superset is not indexed")
+	require.FileExists(t, supSeg)
+}

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -461,6 +461,9 @@ func (s *CaplinStateSnapshots) recalcVisibleFiles() {
 				if !isIndexed(sn) {
 					continue
 				}
+				if n := len(newVisibleSegments); n > 0 && sn.isSubSetOf(newVisibleSegments[n-1].src) {
+					continue
+				}
 				for len(newVisibleSegments) > 0 && newVisibleSegments[len(newVisibleSegments)-1].src.isSubSetOf(sn) {
 					newVisibleSegments[len(newVisibleSegments)-1].src = nil
 					newVisibleSegments = newVisibleSegments[:len(newVisibleSegments)-1]
@@ -483,6 +486,58 @@ func (s *CaplinStateSnapshots) recalcVisibleFiles() {
 		s.visible.Store(k, getNewVisibleSegments(s.dirty[k.(string)]))
 		return true
 	})
+}
+
+// RemoveOverlaps deletes state segment files that are fully covered by a larger
+// indexed segment of the same type, so the on-disk publishable check stops flagging
+// them as overlapping. Offline maintenance only: it munmaps and unlinks files, so no
+// CaplinStateView may be open concurrently.
+func (s *CaplinStateSnapshots) RemoveOverlaps() error {
+	if s == nil {
+		return nil
+	}
+	s.dirtySegmentsLock.Lock()
+
+	var toRemove []*DirtySegment
+	for _, dirtySegments := range s.dirty {
+		var indexed []*DirtySegment
+		dirtySegments.Walk(func(segments []*DirtySegment) bool {
+			for _, sn := range segments {
+				if isIndexed(sn) {
+					indexed = append(indexed, sn)
+				}
+			}
+			return true
+		})
+
+		var rm []*DirtySegment
+		dirtySegments.Walk(func(segments []*DirtySegment) bool {
+			for _, sn := range segments {
+				for _, sup := range indexed {
+					if sn != sup && sn.isSubSetOf(sup) {
+						rm = append(rm, sn)
+						break
+					}
+				}
+			}
+			return true
+		})
+
+		for _, sn := range rm {
+			dirtySegments.Delete(sn)
+		}
+		toRemove = append(toRemove, rm...)
+	}
+
+	s.dirtySegmentsLock.Unlock()
+
+	s.recalcVisibleFiles()
+
+	for _, sn := range toRemove {
+		s.logger.Info("[caplin-state] removing overlapped segment", "file", sn.FileName())
+		sn.closeAndRemoveFiles()
+	}
+	return nil
 }
 
 func (s *CaplinStateSnapshots) idxAvailability() uint64 {

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -377,6 +377,9 @@ func (s *DirtySegment) closeAndRemoveFiles() {
 		toRemove := make([]string, 0, 1+len(s.indexes))
 		toRemove = append(toRemove, s.FilePath())
 		for _, index := range s.indexes {
+			if index == nil {
+				continue
+			}
 			toRemove = append(toRemove, index.FilePath())
 		}
 		s.closeIdx()

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -359,6 +359,9 @@ func (s *DirtySegment) closeSeg() {
 
 func (s *DirtySegment) closeIdx() {
 	for _, index := range s.indexes {
+		if index == nil {
+			continue
+		}
 		index.Close()
 	}
 


### PR DESCRIPTION
Caplin state snapshots have no on-disk overlap cleanup. When a genesis-rooted superset (e.g. `PendingDepositsDump` `000000-020350`) coexists with an interior 50k chunk it covers (`020250-020300`), both stay on disk and `snapshots retire` leaves a directory the publishable integrity check rejects as overlapping. Unlike block snapshots, caplin state has no merger to mark constituents for deletion, its segments are opened `frozen` so the refcount-based deletion path is skipped, and the `recalcVisibleFiles` subset check only hid a subset that sorted before its superset.

## Changes
- Add `CaplinStateSnapshots.RemoveOverlaps`: deletes state `.seg`/`.idx` files fully covered by a larger indexed segment of the same type.
- Call it from `doRetireCommand`, after the block `RemoveOverlaps`.
- Make the `recalcVisibleFiles` subset check symmetric so interior/trailing subsets are hidden from the visible list.
- Make `DirtySegment.closeAndRemoveFiles` nil-safe for segments opened without an index.