### PR TITLE
execution/commitment: fix trie state round-trip for propagate-folded roots

### DIFF
--- a/execution/commitment/deepfold_regression_test.go
+++ b/execution/commitment/deepfold_regression_test.go
@@ -127,8 +127,9 @@ func runEngineBatches(t *testing.T, mode runMode, workers int, batches []engineB
 		ms.SetConcurrentCommitment(true)
 	}
 	roots := make([][]byte, len(batches))
+	var blob []byte
 	for i, b := range batches {
-		roots[i] = processModeBatch(t, ms, mode, workers, b.keys, b.upds)
+		roots[i], blob = processModeBatchState(t, ms, mode, workers, b.keys, b.upds, blob)
 	}
 	return roots, ms
 }

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -3038,7 +3038,19 @@ func (hph *HexPatriciaHashed) SetState(buf []byte) error {
 			return err
 		}
 		hph.root.setFromUpdate(update)
-		//hph.root.deriveHashedKeys(0, hph.keccak, hph.accountKeyLen)
+	}
+	// A leaf root's navigation path is derivable but not reliably persisted: without it a
+	// wall probe sees an unfoldable root and the mount paths overwrite the leaf in place.
+	if hph.root.accountAddrLen > 0 || hph.root.storageAddrLen > 0 {
+		hph.root.hashedExtLen = 0
+		if err := hph.root.deriveHashedKeys(0, hph.keccak, hph.accountKeyLen, hph.cellHashBuf[:]); err != nil {
+			return err
+		}
+	}
+	// Blobs written before propagate folds set rootPresent carry false for non-empty
+	// roots; a non-empty root is present by definition.
+	if !hph.root.IsEmpty() {
+		hph.rootPresent = true
 	}
 
 	return nil

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -490,7 +490,10 @@ func (cell *cell) fillFromLowerCell(lowCell *cell, lowDepth int16, preExtension 
 	}
 	if lowCell.hashLen > 0 {
 		if (lowCell.accountAddrLen == 0 && lowDepth < 64) || (lowCell.storageAddrLen == 0 && lowDepth > 64) {
-			// Extension is related to either accounts branch node, or storage branch node, we prepend it by preExtension | nibble
+			// Extension is related to either accounts branch node, or storage branch node, we prepend it by preExtension | nibble.
+			// The same nibbles are the unfold navigation path, so hashedExtension must stay in sync
+			// (like foldBranch does), or the cell demands an on-disk branch record that a propagate
+			// fold never writes.
 			if len(preExtension) > 0 {
 				copy(cell.extension[:], preExtension)
 			}
@@ -499,6 +502,8 @@ func (cell *cell) fillFromLowerCell(lowCell *cell, lowDepth int16, preExtension 
 				copy(cell.extension[1+len(preExtension):], lowCell.extension[:lowCell.extLen])
 			}
 			cell.extLen = lowCell.extLen + 1 + int16(len(preExtension))
+			copy(cell.hashedExtension[:], cell.extension[:cell.extLen])
+			cell.hashedExtLen = cell.extLen
 		} else {
 			// Extension is related to a storage branch node, so we copy it upwards as is
 			cell.extLen = lowCell.extLen
@@ -1265,9 +1270,14 @@ func (hph *HexPatriciaHashed) needUnfolding(hashedKey []byte) int16 {
 		}
 		cell = &hph.root
 	} else {
+		depth = hph.depths[hph.activeRows-1]
+		// Guard before indexing: a probe key shorter than the row's depth (an unfold can
+		// consume several extension nibbles at once) needs no further unfolding.
+		if int16(len(hashedKey)) <= depth {
+			return 0
+		}
 		nibble := int(hashedKey[hph.currentKeyLen])
 		cell = &hph.grid[hph.activeRows-1][nibble]
-		depth = hph.depths[hph.activeRows-1]
 		if hph.traceW != nil {
 			fmt.Fprintf(hph.traceW, "currentKey [%x] needUnfolding cell (%d, %x, depth=%d) cell.hash=[%x]\n", hph.currentKey[:hph.currentKeyLen], hph.activeRows-1, nibble, depth, cell.hash[:cell.hashLen])
 		}
@@ -1892,6 +1902,9 @@ func (hph *HexPatriciaHashed) foldPropagate(row int, nibble, upDepth, depth int1
 		// any modifications
 		if row == 0 {
 			hph.rootTouched = true
+			// A propagate fold leaves exactly one survivor, so the root exists; without this
+			// the next unfold reads touched && !present and deletes the whole subtree.
+			hph.rootPresent = true
 		} else {
 			// Modification is propagated upwards
 			hph.touchMap[row-1] |= uint16(1) << nibble

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -19,6 +19,22 @@ var cmtTiming = os.Getenv("ERIGON_CMT_TIMING") == "1"
 // deepStorageThreshold is the touched-slot count above which an account's storage subtree folds concurrently instead of streaming through its worker.
 const deepStorageThreshold = 1_000
 
+// unfoldRootWall unfolds base at the root until row 0 forms the top-nibble mount wall,
+// consuming at most one nibble per step: a restored root extension sharing the probe's
+// leading nibble would otherwise unfold several levels at once and misplace the wall.
+func unfoldRootWall(ctx context.Context, base *HexPatriciaHashed) error {
+	zero := []byte{0}
+	for u := base.needUnfolding(zero); u > 0; u = base.needUnfolding(zero) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := base.unfold(zero, min(u, 1)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // seedRootBase synthesizes a row-0 wall when the on-disk root has no branch, so foldMounted stops
 // at the mount boundary and returns cells excluding the mount nibble for empty and non-empty bases alike.
 func seedRootBase(base *HexPatriciaHashed) {
@@ -90,14 +106,8 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 		tStart = time.Now()
 	}
 
-	zero := []byte{0}
-	for u := base.needUnfolding(zero); u > 0; u = base.needUnfolding(zero) {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		if err := base.unfold(zero, u); err != nil {
-			return nil, fmt.Errorf("processMounted: unfold root: %w", err)
-		}
+	if err := unfoldRootWall(ctx, base); err != nil {
+		return nil, fmt.Errorf("processMounted: unfold root: %w", err)
 	}
 	seedRootBase(base)
 	if cmtTiming {
@@ -194,8 +204,6 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 			return nil, fmt.Errorf("processMounted: root fold: %w", err)
 		}
 	}
-	// fold() only sets rootPresent on a multi-child root fold, so set it here for the EncodeCurrentState/SetState round-trip.
-	base.rootPresent = !base.root.IsEmpty()
 	if deferred := base.TakeDeferredUpdates(); len(deferred) > 0 {
 		pu.appendDeferred(deferred)
 	}

--- a/execution/commitment/parallel_patricia_hashed.go
+++ b/execution/commitment/parallel_patricia_hashed.go
@@ -259,6 +259,9 @@ func (p *ParallelPatriciaHashed) RootHash() ([]byte, error) {
 
 // processStreaming delegates Process to the attached StreamingCommitter and republishes the root.
 func (p *ParallelPatriciaHashed) processStreaming(ctx context.Context) ([]byte, error) {
+	// The template root is the restore target of SetState, so it seeds the committer's base;
+	// PromoteRootInto below keeps the two in sync after every fold.
+	p.streaming.SeedRootFrom(p.template)
 	rh, err := p.streaming.Process(ctx)
 	if err != nil {
 		return nil, err

--- a/execution/commitment/parallel_testkit_test.go
+++ b/execution/commitment/parallel_testkit_test.go
@@ -160,13 +160,31 @@ func processRoot(t *testing.T, trie Trie, ut *Updates) []byte {
 
 func processModeBatch(t *testing.T, ms *MockState, mode runMode, workers int, keys [][]byte, upds []Update) []byte {
 	t.Helper()
+	root, _ := processModeBatchState(t, ms, mode, workers, keys, upds, nil)
+	return root
+}
+
+// processModeBatchState folds one batch through the engine's production restart lifecycle:
+// the trie is restored from blob (the previous batch's EncodeCurrentState output, nil for
+// the first batch) before Process, and the new state blob is returned alongside the root.
+// State that never reaches a branch record — a propagate-folded root — survives batches
+// only through this blob.
+func processModeBatchState(t *testing.T, ms *MockState, mode runMode, workers int, keys [][]byte, upds []Update, blob []byte) ([]byte, []byte) {
+	t.Helper()
 	ctx := context.Background()
 	require.NoError(t, ms.applyPlainUpdates(keys, upds))
+
+	encoded := func(tr *HexPatriciaHashed) []byte {
+		out, err := tr.EncodeCurrentState(nil)
+		require.NoError(t, err)
+		return out
+	}
 
 	switch mode {
 	case modeParallel:
 		tr := newParTrie(t, ms, workers)
 		defer tr.Release()
+		require.NoError(t, tr.RootTrie().SetState(blob))
 		ut := NewUpdates(ModeParallel, t.TempDir(), KeyToHexNibbleHash)
 		defer ut.Close()
 		for i, k := range keys {
@@ -177,16 +195,25 @@ func processModeBatch(t *testing.T, ms *MockState, mode runMode, workers int, ke
 				c.update = &upds[i]
 			})
 		}
-		return processRoot(t, tr, ut)
+		return processRoot(t, tr, ut), encoded(tr.RootTrie())
 	case modeStreaming, modeStreamingScheduled:
-		sc := newStreamCommitter(t, ms, workers, mode == modeStreamingScheduled)
+		sc := NewStreamingCommitter(mockTrieCtxFactory(ms), length.Addr, DefaultTrieConfig())
 		defer sc.Release()
+		sc.SetNumWorkers(workers)
+		tmpl := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+		defer tmpl.Release()
+		require.NoError(t, tmpl.SetState(blob))
+		sc.SeedRootFrom(tmpl)
+		if mode == modeStreamingScheduled {
+			require.NoError(t, sc.StartScheduler(context.Background()))
+		}
 		for _, k := range keys {
 			sc.TouchKey(KeyToHexNibbleHash(k), k, nil)
 		}
 		r, err := sc.Process(ctx)
 		require.NoError(t, err)
-		return common.Copy(r)
+		sc.PromoteRootInto(tmpl)
+		return common.Copy(r), encoded(tmpl)
 	case modeStreamingPublic:
 		cfg := DefaultTrieConfig()
 		cfg.Variant = VariantStreamingHexPatricia
@@ -197,16 +224,18 @@ func processModeBatch(t *testing.T, ms *MockState, mode runMode, workers int, ke
 		pt.SetNumWorkers(workers)
 		pt.SetTrieContextFactory(mockTrieCtxFactory(ms))
 		pt.ResetContext(ms)
+		require.NoError(t, pt.RootTrie().SetState(blob))
 		for _, key := range keys {
 			ut.TouchPlainKey(string(key), nil, ut.TouchAccount)
 		}
-		return processRoot(t, trie, ut)
+		return processRoot(t, trie, ut), encoded(pt.RootTrie())
 	default:
 		tr := newSeqTrie(t, ms)
 		defer tr.Release()
+		require.NoError(t, tr.SetState(blob))
 		ut := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, keys, upds)
 		defer ut.Close()
-		return processRoot(t, tr, ut)
+		return processRoot(t, tr, ut), encoded(tr)
 	}
 }
 
@@ -219,15 +248,17 @@ func engineRoot(t *testing.T, mode runMode, workers int, keys [][]byte, upds []U
 	return processModeBatch(t, ms, mode, workers, keys, upds), ms
 }
 
-// Folds two batches into one MockState so batch-1 branches become on-disk state for batch-2.
+// Folds two batches into one MockState so batch-1 branches become on-disk state for
+// batch-2, with the trie state blob carried across the batches (encode/restore cycle).
 func incrementalRoot(t *testing.T, mode runMode, workers int, k1 [][]byte, u1 []Update, k2 [][]byte, u2 []Update) ([]byte, *MockState) {
 	t.Helper()
 	ms := NewMockState(t)
 	if mode != modeSeq {
 		ms.SetConcurrentCommitment(true)
 	}
-	processModeBatch(t, ms, mode, workers, k1, u1)
-	return processModeBatch(t, ms, mode, workers, k2, u2), ms
+	_, blob := processModeBatchState(t, ms, mode, workers, k1, u1, nil)
+	root, _ := processModeBatchState(t, ms, mode, workers, k2, u2, blob)
+	return root, ms
 }
 
 func requireRootParity(t *testing.T, keys [][]byte, upds []Update, workers int) []byte {

--- a/execution/commitment/state_roundtrip_regression_test.go
+++ b/execution/commitment/state_roundtrip_regression_test.go
@@ -186,6 +186,62 @@ func TestStateRoundTrip_DeleteCollapseToSingleNibble(t *testing.T) {
 	requireRestartParity(t, []engineBatch{{k1, u1}, {k2, u2}, {k3, u3}}, kc, uc)
 }
 
+// A sole account is a LEAF at the root — no hash, no extension, only the plain key. Its
+// navigation path must be re-derived on restore, or the wall probe sees an unfoldable
+// root and the next block's insert under a different first nibble overwrites the leaf.
+func TestStateRoundTrip_LeafRootNewNibbleInsert(t *testing.T) {
+	t.Parallel()
+	a := addrHex(findAddressForNibble(3, 4242))
+	b := addrHex(findAddressForNibble(7, 777))
+	loc := hex.EncodeToString(slotHashBytes(9))
+
+	ub1 := NewUpdateBuilder().Balance(a, 100)
+	ub1.Storage(a, loc, "abcd")
+	k1, u1 := ub1.Build()
+	k2, u2 := NewUpdateBuilder().Balance(b, 200).Build()
+
+	ubc := NewUpdateBuilder().Balance(a, 100).Balance(b, 200)
+	ubc.Storage(a, loc, "abcd")
+	kc, uc := ubc.Build()
+
+	requireRestartParity(t, []engineBatch{{k1, u1}, {k2, u2}}, kc, uc)
+}
+
+// A state blob written before propagate folds marked the root present carries
+// rootPresent=false for a non-empty root; restoring it must repair the flag instead of
+// letting the next unfold treat the carried subtree as deleted.
+func TestSetState_RepairsLegacyRootPresent(t *testing.T) {
+	t.Parallel()
+	k1, u1, k2, u2, kc, uc := singleNibbleCorpus()
+	oracle, _ := engineRoot(t, modeSeq, 0, kc, uc)
+
+	ms := NewMockState(t)
+	tr := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+	require.NoError(t, ms.applyPlainUpdates(k1, u1))
+	ut1 := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, k1, u1)
+	processRoot(t, tr, ut1)
+	ut1.Close()
+	blob, err := tr.EncodeCurrentState(nil)
+	require.NoError(t, err)
+	tr.Release()
+
+	var s state
+	require.NoError(t, s.Decode(blob))
+	s.RootTouched = true
+	s.RootPresent = false
+	legacy, err := s.Encode(nil)
+	require.NoError(t, err)
+
+	tr2 := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+	defer tr2.Release()
+	require.NoError(t, tr2.SetState(legacy))
+	require.NoError(t, ms.applyPlainUpdates(k2, u2))
+	ut2 := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, k2, u2)
+	defer ut2.Close()
+	got := processRoot(t, tr2, ut2)
+	require.Equal(t, oracle, got, "legacy rootPresent=false blob dropped the carried state")
+}
+
 // Restoring the template AFTER a scheduler already built its base must not fold against
 // the stale base: the changed seed drops it so Process rebuilds from the restored root.
 func TestStateRoundTrip_SeedAfterSchedulerStart(t *testing.T) {
@@ -214,6 +270,65 @@ func TestStateRoundTrip_SeedAfterSchedulerStart(t *testing.T) {
 	got, err := sc.Process(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, oracle, got, "seed arriving after StartScheduler was folded against the stale base")
+}
+
+// A background fold completed against the previous seed's base must not be stitched after
+// the seed changes: SeedRootFrom invalidates folded splits so Process re-folds them.
+func TestStateRoundTrip_SeedChangeInvalidatesFoldedSplits(t *testing.T) {
+	t.Parallel()
+	var addrs []string
+	for i := 0; i < 6; i++ {
+		addrs = append(addrs, addrHex(findAddressForNibble(7, 500+i)))
+	}
+	ub1 := NewUpdateBuilder()
+	for i, a := range addrs {
+		ub1.Balance(a, uint64(100+i))
+	}
+	k1, u1 := ub1.Build()
+
+	ub2 := NewUpdateBuilder().Balance(addrs[0], 9100).Balance(addrs[1], 9200).
+		Balance(addrHex(findAddressForNibble(7, 5100)), 51).Balance(addrHex(findAddressForNibble(7, 5200)), 52)
+	k2, u2 := ub2.Build()
+
+	ubc := NewUpdateBuilder().Balance(addrs[0], 9100).Balance(addrs[1], 9200)
+	for i, a := range addrs[2:] {
+		ubc.Balance(a, uint64(102+i))
+	}
+	ubc.Balance(addrHex(findAddressForNibble(7, 5100)), 51).Balance(addrHex(findAddressForNibble(7, 5200)), 52)
+	kc, uc := ubc.Build()
+	oracle, _ := engineRoot(t, modeSeq, 0, kc, uc)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+	_, blob := processModeBatchState(t, ms, modeStreaming, 4, k1, u1, nil)
+
+	require.NoError(t, ms.applyPlainUpdates(k2, u2))
+	sc := NewStreamingCommitter(mockTrieCtxFactory(ms), length.Addr, DefaultTrieConfig())
+	defer sc.Release()
+	sc.SetNumWorkers(4)
+	require.NoError(t, sc.StartScheduler(context.Background()))
+	for _, k := range k2 {
+		sc.TouchKey(KeyToHexNibbleHash(k), k, nil)
+	}
+	// fold the touched split against the scheduler's unseeded base, synchronously, leaving
+	// it in the reusable folded state a background fold would produce
+	sc.foldSplitBg(7)
+	sc.trieMu.RLock()
+	s := sc.splits[byte(7)]
+	sc.trieMu.RUnlock()
+	require.NotNil(t, s)
+	s.mu.Lock()
+	require.True(t, s.reusable(), "precondition: split folded against the stale base")
+	s.mu.Unlock()
+
+	tmpl := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+	defer tmpl.Release()
+	require.NoError(t, tmpl.SetState(blob))
+	sc.SeedRootFrom(tmpl)
+
+	got, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, oracle, got, "a split folded against the stale base was stitched after the seed changed")
 }
 
 // A fresh trie with NO carried state blob must still bootstrap from the on-disk branch

--- a/execution/commitment/state_roundtrip_regression_test.go
+++ b/execution/commitment/state_roundtrip_regression_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/length"
+)
+
+// requireRestartParity folds the batches through every engine with a node restart between
+// batches (runEngineBatches carries state via EncodeCurrentState/SetState) and requires
+// every batch root to match the sequential arm, whose final root must match the combined
+// single-batch oracle.
+func requireRestartParity(t *testing.T, batches []engineBatch, combinedK [][]byte, combinedU []Update) {
+	t.Helper()
+	oracle, _ := engineRoot(t, modeSeq, 0, combinedK, combinedU)
+	seqRoots, _ := runEngineBatches(t, modeSeq, 0, batches)
+	require.Equal(t, oracle, seqRoots[len(seqRoots)-1], "sequential restart lifecycle diverged from the combined oracle")
+
+	for _, tc := range []struct {
+		name    string
+		mode    runMode
+		workers int
+	}{
+		{"parallel_w1", modeParallel, 1},
+		{"parallel_w4", modeParallel, 4},
+		{"streaming_committer_w4", modeStreaming, 4},
+		{"streaming_scheduled_w4", modeStreamingScheduled, 4},
+		{"streaming_public_w4", modeStreamingPublic, 4},
+	} {
+		roots, _ := runEngineBatches(t, tc.mode, tc.workers, batches)
+		for i := range batches {
+			require.Equalf(t, seqRoots[i], roots[i],
+				"%s: batch %d root diverged from sequential under the restart lifecycle", tc.name, i+1)
+		}
+	}
+}
+
+// singleNibbleCorpus builds a trie whose accounts all hash under first nibble 7, so the
+// root row folds via propagate and no root branch record ever reaches disk.
+func singleNibbleCorpus() (k1 [][]byte, u1 []Update, k2 [][]byte, u2 []Update, kc [][]byte, uc []Update) {
+	var addrs []string
+	for i := 0; i < 6; i++ {
+		addrs = append(addrs, addrHex(findAddressForNibble(7, 100+i)))
+	}
+	newcomer := addrHex(findAddressForNibble(7, 4711))
+
+	ub1 := NewUpdateBuilder()
+	for i, a := range addrs {
+		ub1.Balance(a, uint64(1000+i))
+	}
+	for i := 0; i < 3; i++ {
+		ub1.Storage(addrs[0], hex.EncodeToString(slotHashBytes(i)), "0badc0de")
+	}
+	ub1.Storage(addrs[1], hex.EncodeToString(slotHashBytes(7)), "cafe")
+	k1, u1 = ub1.Build()
+
+	ub2 := NewUpdateBuilder().Balance(addrs[2], 2222).Balance(addrs[3], 3333).Balance(newcomer, 42)
+	k2, u2 = ub2.Build()
+
+	ubc := NewUpdateBuilder()
+	for i, a := range addrs {
+		bal := uint64(1000 + i)
+		switch i {
+		case 2:
+			bal = 2222
+		case 3:
+			bal = 3333
+		}
+		ubc.Balance(a, bal)
+	}
+	ubc.Balance(newcomer, 42)
+	for i := 0; i < 3; i++ {
+		ubc.Storage(addrs[0], hex.EncodeToString(slotHashBytes(i)), "0badc0de")
+	}
+	ubc.Storage(addrs[1], hex.EncodeToString(slotHashBytes(7)), "cafe")
+	kc, uc = ubc.Build()
+	return k1, u1, k2, u2, kc, uc
+}
+
+// A trie whose accounts all hash under ONE first nibble folds its root row via propagate:
+// the root becomes an extension-topped cell and no root branch record exists on disk. The
+// persisted trie state must round-trip so the next block after a restart navigates through
+// the root cell's extension instead of demanding the absent root record.
+func TestStateRoundTrip_PropagateRootSingleNibble(t *testing.T) {
+	t.Parallel()
+	k1, u1, k2, u2, kc, uc := singleNibbleCorpus()
+	requireRestartParity(t, []engineBatch{{k1, u1}, {k2, u2}}, kc, uc)
+}
+
+// The same propagate-root shape with the collapsed extension starting at nibble ZERO and
+// running two nibbles deep: the engines' root probe key must tolerate an unfold that
+// consumes more of the extension than the probe's length instead of panicking on the
+// out-of-range read, and the top-nibble mount wall must stay at depth one.
+func TestStateRoundTrip_PropagateRootZeroNibblePrefix(t *testing.T) {
+	t.Parallel()
+	var addrs []string
+	for i := 0; i < 6; i++ {
+		addrs = append(addrs, addrHex(findAddressForHexPrefix([]byte{0, 0xa}, 800+i)))
+	}
+
+	ub1 := NewUpdateBuilder()
+	for i, a := range addrs {
+		ub1.Balance(a, uint64(3000+i))
+	}
+	ub1.Storage(addrs[0], hex.EncodeToString(slotHashBytes(4)), "dead")
+	k1, u1 := ub1.Build()
+
+	ub2 := NewUpdateBuilder().Balance(addrs[1], 3111).Balance(addrs[4], 3444)
+	k2, u2 := ub2.Build()
+
+	ubc := NewUpdateBuilder()
+	for i, a := range addrs {
+		bal := uint64(3000 + i)
+		switch i {
+		case 1:
+			bal = 3111
+		case 4:
+			bal = 3444
+		}
+		ubc.Balance(a, bal)
+	}
+	ubc.Storage(addrs[0], hex.EncodeToString(slotHashBytes(4)), "dead")
+	kc, uc := ubc.Build()
+
+	requireRestartParity(t, []engineBatch{{k1, u1}, {k2, u2}}, kc, uc)
+}
+
+// A root row that WAS a branch collapses to one surviving first nibble when a block
+// deletes every account under the other nibbles: the propagate fold removes the root
+// branch record and leaves the collapsed shape only in the trie state. The restart
+// round-trip must survive the collapse and keep the survivors' untouched storage.
+func TestStateRoundTrip_DeleteCollapseToSingleNibble(t *testing.T) {
+	t.Parallel()
+	var gone, kept []string
+	for i := 0; i < 4; i++ {
+		gone = append(gone, addrHex(findAddressForNibble(3, 200+i)))
+		kept = append(kept, addrHex(findAddressForNibble(7, 300+i)))
+	}
+
+	ub1 := NewUpdateBuilder()
+	for i, a := range gone {
+		ub1.Balance(a, uint64(100+i))
+	}
+	for i, a := range kept {
+		ub1.Balance(a, uint64(500+i))
+	}
+	ub1.Storage(kept[0], hex.EncodeToString(slotHashBytes(1)), "beef")
+	ub1.Storage(kept[0], hex.EncodeToString(slotHashBytes(2)), "f00d")
+	k1, u1 := ub1.Build()
+
+	ub2 := NewUpdateBuilder().Balance(kept[1], 5511)
+	for _, a := range gone {
+		ub2.Delete(a)
+	}
+	k2, u2 := ub2.Build()
+
+	ub3 := NewUpdateBuilder().Balance(kept[2], 5522)
+	k3, u3 := ub3.Build()
+
+	ubc := NewUpdateBuilder().
+		Balance(kept[0], 500).Balance(kept[1], 5511).Balance(kept[2], 5522).Balance(kept[3], 503)
+	ubc.Storage(kept[0], hex.EncodeToString(slotHashBytes(1)), "beef")
+	ubc.Storage(kept[0], hex.EncodeToString(slotHashBytes(2)), "f00d")
+	kc, uc := ubc.Build()
+
+	requireRestartParity(t, []engineBatch{{k1, u1}, {k2, u2}, {k3, u3}}, kc, uc)
+}
+
+// Restoring the template AFTER a scheduler already built its base must not fold against
+// the stale base: the changed seed drops it so Process rebuilds from the restored root.
+func TestStateRoundTrip_SeedAfterSchedulerStart(t *testing.T) {
+	t.Parallel()
+	k1, u1, k2, u2, kc, uc := singleNibbleCorpus()
+	oracle, _ := engineRoot(t, modeSeq, 0, kc, uc)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+	_, blob := processModeBatchState(t, ms, modeStreaming, 4, k1, u1, nil)
+
+	require.NoError(t, ms.applyPlainUpdates(k2, u2))
+	sc := NewStreamingCommitter(mockTrieCtxFactory(ms), length.Addr, DefaultTrieConfig())
+	defer sc.Release()
+	sc.SetNumWorkers(4)
+	require.NoError(t, sc.StartScheduler(context.Background()))
+
+	tmpl := NewHexPatriciaHashed(length.Addr, ms, DefaultTrieConfig())
+	defer tmpl.Release()
+	require.NoError(t, tmpl.SetState(blob))
+	sc.SeedRootFrom(tmpl)
+
+	for _, k := range k2 {
+		sc.TouchKey(KeyToHexNibbleHash(k), k, nil)
+	}
+	got, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, oracle, got, "seed arriving after StartScheduler was folded against the stale base")
+}
+
+// A fresh trie with NO carried state blob must still bootstrap from the on-disk branch
+// records alone when the root is a real branch — the rebuild/reset shape the blob-carrying
+// helpers no longer exercise.
+func TestFreshTrieBootstrapOverDiskState(t *testing.T) {
+	t.Parallel()
+	k1, u1 := buildMixedCorpus(31337, 120)
+	ub2 := NewUpdateBuilder()
+	n := 0
+	for _, k := range k1 {
+		if len(k) != length.Addr {
+			continue
+		}
+		ub2.Balance(hex.EncodeToString(k), uint64(90_000+n))
+		if n++; n == 5 {
+			break
+		}
+	}
+	k2, u2 := ub2.Build()
+	require.NotEmpty(t, k2)
+
+	bootstrapRoot := func(mode runMode, workers int) []byte {
+		ms := NewMockState(t)
+		if mode != modeSeq {
+			ms.SetConcurrentCommitment(true)
+		}
+		processModeBatchState(t, ms, mode, workers, k1, u1, nil)
+		root, _ := processModeBatchState(t, ms, mode, workers, k2, u2, nil)
+		return root
+	}
+
+	want := bootstrapRoot(modeSeq, 0)
+	for _, tc := range []struct {
+		name    string
+		mode    runMode
+		workers int
+	}{
+		{"parallel_w4", modeParallel, 4},
+		{"streaming_committer_w4", modeStreaming, 4},
+		{"streaming_public_w4", modeStreamingPublic, 4},
+	} {
+		require.Equalf(t, want, bootstrapRoot(tc.mode, tc.workers), "%s: blobless bootstrap diverged", tc.name)
+	}
+}

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -96,11 +96,15 @@ type StreamingCommitter struct {
 
 	// rootValid gates root promotion: cleared each Process and set only on the
 	// folded path, so the no-touch path leaves the template's prior root untouched.
+	// rootSeeded marks the same snapshot as a base seed: a trie whose root row
+	// collapsed to one child has no root branch record on disk, so the carried
+	// root cell is the only way a fresh base can see the existing state.
 	rootCell    cell
 	rootChecked bool
 	rootTouched bool
 	rootPresent bool
 	rootValid   bool
+	rootSeeded  bool
 
 	traceW io.Writer
 }
@@ -287,6 +291,32 @@ func (sc *StreamingCommitter) captureRoot(base *HexPatriciaHashed) {
 	sc.rootTouched = base.rootTouched
 	sc.rootPresent = base.rootPresent
 	sc.rootValid = true
+	sc.rootSeeded = true
+}
+
+// SeedRootFrom snapshots tmpl's root cell and flags as the seed for the next
+// Process's base — the mirror of PromoteRootInto, used after tmpl was restored
+// via SetState. A changed seed invalidates any base built from the previous one
+// (including a running scheduler's), which is dropped so the next Process
+// rebuilds from the new seed instead of folding against stale root state.
+func (sc *StreamingCommitter) SeedRootFrom(tmpl *HexPatriciaHashed) {
+	if tmpl == nil {
+		return
+	}
+	if sc.rootCell == tmpl.root && sc.rootChecked == tmpl.rootChecked &&
+		sc.rootTouched == tmpl.rootTouched && sc.rootPresent == tmpl.rootPresent {
+		sc.rootSeeded = true
+		return
+	}
+	sc.rootCell = tmpl.root
+	sc.rootChecked = tmpl.rootChecked
+	sc.rootTouched = tmpl.rootTouched
+	sc.rootPresent = tmpl.rootPresent
+	sc.rootSeeded = true
+	if sc.base != nil {
+		sc.Stop()
+		sc.releaseBase()
+	}
 }
 
 // PromoteRootInto copies the most recently folded root cell and flags into tmpl,
@@ -321,7 +351,8 @@ func (sc *StreamingCommitter) newProcessBase(ctx context.Context) (*HexPatriciaH
 	return base, cleanup, root, nil
 }
 
-// newBaseTrie constructs a fresh deferring base trie and a cleanup releasing it.
+// newBaseTrie constructs a fresh deferring base trie, seeded with the carried
+// root snapshot when one exists, and a cleanup releasing it.
 func (sc *StreamingCommitter) newBaseTrie() (*HexPatriciaHashed, func()) {
 	base := NewHexPatriciaHashed(sc.accountKeyLen, nil, sc.cfg)
 	bctx, bclean := sc.trieCtxFactory()
@@ -329,6 +360,12 @@ func (sc *StreamingCommitter) newBaseTrie() (*HexPatriciaHashed, func()) {
 	base.SetTraceWriter(sc.traceW)
 	base.branchEncoder.setDeferUpdates(true)
 	base.SetLeaveDeferredForCaller(true)
+	if sc.rootSeeded {
+		base.root = sc.rootCell
+		base.rootChecked = sc.rootChecked
+		base.rootTouched = sc.rootTouched
+		base.rootPresent = sc.rootPresent
+	}
 	return base, func() {
 		base.Release()
 		if bclean != nil {
@@ -355,16 +392,9 @@ func (sc *StreamingCommitter) processBase(ctx context.Context) (*HexPatriciaHash
 func (sc *StreamingCommitter) buildBase(ctx context.Context) (*HexPatriciaHashed, func(), error) {
 	base, cleanup := sc.newBaseTrie()
 
-	zero := []byte{0}
-	for u := base.needUnfolding(zero); u > 0; u = base.needUnfolding(zero) {
-		if err := ctx.Err(); err != nil {
-			cleanup()
-			return nil, nil, err
-		}
-		if err := base.unfold(zero, u); err != nil {
-			cleanup()
-			return nil, nil, fmt.Errorf("StreamingCommitter: unfold root: %w", err)
-		}
+	if err := unfoldRootWall(ctx, base); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("StreamingCommitter: unfold root: %w", err)
 	}
 	seedRootBase(base)
 	return base, cleanup, nil
@@ -897,6 +927,7 @@ func (sc *StreamingCommitter) Reset() {
 		putDeferredUpdate(upd)
 	}
 	sc.deferredForCaller = nil
+	sc.rootValid, sc.rootSeeded = false, false
 	sc.resetPool()
 }
 
@@ -921,5 +952,6 @@ func (sc *StreamingCommitter) Release() {
 		putDeferredUpdate(upd)
 	}
 	sc.deferredForCaller = nil
+	sc.rootValid, sc.rootSeeded = false, false
 	sc.resetPool()
 }

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -317,6 +317,18 @@ func (sc *StreamingCommitter) SeedRootFrom(tmpl *HexPatriciaHashed) {
 		sc.Stop()
 		sc.releaseBase()
 	}
+	// Splits folded against the previous seed's base are stale; drop their cells and
+	// deferred updates so Process re-folds them against the reseeded base.
+	for _, s := range sc.splits {
+		s.mu.Lock()
+		s.folded = false
+		s.dirty = true
+		for _, upd := range s.deferred {
+			putDeferredUpdate(upd)
+		}
+		s.deferred = nil
+		s.mu.Unlock()
+	}
 }
 
 // PromoteRootInto copies the most recently folded root cell and flags into tmpl,


### PR DESCRIPTION
Restarting a node whose commitment trie root row folded to a single child (all remaining accounts under one first hashed nibble, or a delete-driven collapse to one root nibble — small/dev chains) bricked the parallel engine (`empty branch data read during unfold, compact prefix 00` on every Process) and silently dropped the whole trie on the sequential engine's delete-collapse shape. Such roots write no root branch record, so their state travels only in the trie state blob — and three separate defects broke that carry.

## Changes
- `fillFromLowerCell`: sync `hashedExtension` with the prepended extension (mirrors `foldBranch`), so a restored extension-topped root navigates in-cell instead of demanding the absent root record.
- `foldPropagate`: set `rootPresent` on a row-0 fold; the next unfold otherwise treats the whole subtree as deleted (`touched && !present`). Replaces the call-site patch in `processMounted`.
- streaming committer: seed each per-Process base from the carried root (`SeedRootFrom`, the mirror of `PromoteRootInto`; `processStreaming` seeds from the template `SetState` restores into). A changed seed drops a base built from the previous one, covering a restore after `StartScheduler`.
- `needUnfolding`: length-guard the probe key before indexing, and cap the root probe (`unfoldRootWall`) to one nibble per step — a restored root extension starting with nibble 0 panicked the probe loop and misplaced the top-nibble mount wall.
- testkit: `processModeBatchState` threads `EncodeCurrentState`/`SetState` blobs between batches for every engine, so all incremental tests exercise the production restart lifecycle; red-first regression tests in `state_roundtrip_regression_test.go`; blobless rebuild coverage kept via `TestFreshTrieBootstrapOverDiskState`.
- restore hardening (second commit): `SetState` re-derives a leaf root's navigation path from its plain key (a restored sole-account root was otherwise unfoldable and a new-nibble insert overwrote it), repairs `rootPresent=false` in blobs written before the propagate fold set it, and `SeedRootFrom` invalidates splits folded against a dropped stale base. Each pinned by a regression test (`TestStateRoundTrip_LeafRootNewNibbleInsert`, `TestSetState_RepairsLegacyRootPresent`, `TestStateRoundTrip_SeedChangeInvalidatesFoldedSplits`).
