### PR TITLE
execution/commitment: fold fresh whales concurrently via proven-empty storage seed

### DIFF
--- a/execution/commitment/deepfold_subset_regression_test.go
+++ b/execution/commitment/deepfold_subset_regression_test.go
@@ -17,9 +17,12 @@
 package commitment
 
 import (
+	"context"
 	"encoding/hex"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common/length"
 )
@@ -106,4 +109,56 @@ func TestDeepFold_PreExistingWhale_SingleNibbleOnDisk(t *testing.T) {
 	k1 = append(append([][]byte{}, fk...), k1...)
 	u1 = append(append([]Update{}, fu...), u1...)
 	requireAllEnginesParity(t, k1, u1, k2, u2, 4)
+}
+
+// A FRESH whale — its account absent from the pre-state trie — provably has nothing on
+// disk beneath its storage prefix, so the deep fold seeds an empty base and folds the
+// slots concurrently instead of demoting to serial streaming.
+func TestDeepFold_FreshWhaleFoldsParallel(t *testing.T) {
+	k1, u1, _, _ := buildSubsetTouchedWhale(20260707, nibs(3, 7), nil, 700, 0)
+	fk, fu := buildMixedCorpus(555, 200)
+	keys := append(append([][]byte{}, fk...), k1...)
+	upds := append(append([]Update{}, fu...), u1...)
+
+	seqRoot, _ := engineRoot(t, modeSeq, 0, keys, upds)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+	require.NoError(t, ms.applyPlainUpdates(keys, upds))
+	sc := newStreamCommitter(t, ms, 4, false)
+	defer sc.Release()
+	touchAll(sc, keys)
+	got, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, seqRoot, got, "fresh-whale concurrent fold diverged from sequential")
+	require.Positive(t, sc.DeepLocalFolds(), "a fresh whale must take the concurrent deep fold, not the serial demotion")
+
+	parRoot, _ := engineRoot(t, modeParallel, 4, keys, upds)
+	require.Equal(t, seqRoot, parRoot)
+}
+
+// The demotion gate stays for accounts present in the pre-state without a branch record
+// at their prefix (single embedded slot): the influx still streams serially.
+func TestDeepFold_ExistingWhaleStillDemotes(t *testing.T) {
+	k1, u1, k2, u2 := buildSubsetTouchedWhale(20260708, nibs(0), nibs(3, 7), 1, 700)
+	fk, fu := buildMixedCorpus(556, 200)
+	k1 = append(append([][]byte{}, fk...), k1...)
+	u1 = append(append([]Update{}, fu...), u1...)
+
+	seqRoot, _ := incrementalRoot(t, modeSeq, 0, k1, u1, k2, u2)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+	sc := newStreamCommitter(t, ms, 4, false)
+	defer sc.Release()
+	require.NoError(t, ms.applyPlainUpdates(k1, u1))
+	touchAll(sc, k1)
+	_, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, ms.applyPlainUpdates(k2, u2))
+	touchAll(sc, k2)
+	got, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, seqRoot, got)
+	require.Zero(t, sc.DeepLocalFolds(), "an account present in the pre-state must keep the serial demotion")
 }

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -167,7 +167,12 @@ type HexPatriciaHashed struct {
 	//processing metrics
 	metrics       *Metrics
 	depthsToTxNum [129]uint64 // endTxNum of file with branch data for that depth
-	hadToLoadL    map[uint64]skipStat
+
+	// lastUpdateCellWasEmpty reports whether the most recent updateCell stamped a key
+	// into an empty cell — i.e. the key is absent from the pre-state trie, so nothing
+	// can exist on disk beneath it.
+	lastUpdateCellWasEmpty bool
+	hadToLoadL             map[uint64]skipStat
 }
 
 // Clones current trie state to allow concurrent processing.
@@ -2173,6 +2178,7 @@ func (hph *HexPatriciaHashed) updateCell(plainKey, hashedKey []byte, u *Update) 
 		}
 
 		hph.deleteCell(hashedKey)
+		hph.lastUpdateCellWasEmpty = false
 		return nil
 	}
 
@@ -2193,6 +2199,7 @@ func (hph *HexPatriciaHashed) updateCell(plainKey, hashedKey []byte, u *Update) 
 			fmt.Fprintf(hph.traceW, "updateCell setting (%d, %x, depth=%d)\n", row, nibble, depth)
 		}
 	}
+	hph.lastUpdateCellWasEmpty = cell.IsEmpty()
 	if cell.hashedExtLen == 0 {
 		copy(cell.hashedExtension[:], hashedKey[depth:])
 		cell.hashedExtLen = int16(len(hashedKey)) - depth

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -140,8 +140,8 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 			path := make([]byte, 0, 144)
 			path = append(path, byte(ni))
 			path = append(path, ch.ext...)
-			buildErr := dfsSubtreeDeep(w, ch, path, func(n *prefixNode, pth []byte) (common.Hash, error) {
-				return foldStorageRoot(gctx, p.numWorkers, p.newStorageWorker, pu, n, pth)
+			buildErr := dfsSubtreeDeep(w, ch, path, func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
+				return foldStorageRoot(gctx, p.numWorkers, p.newStorageWorker, pu, n, pth, accountFresh)
 			})
 			if buildErr != nil {
 				w.resetForReuse()

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -719,8 +719,8 @@ func (sc *StreamingCommitter) foldSplit(ctx context.Context, base *HexPatriciaHa
 	path := make([]byte, 0, 144)
 	path = append(path, ni)
 	path = append(path, child.ext...)
-	deepStorageRoot := func(n *prefixNode, pth []byte) (common.Hash, error) {
-		sr, err := foldStorageRoot(ctx, sc.numWorkers, sc.newStorageWorker, &pu, n, pth)
+	deepStorageRoot := func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
+		sr, err := foldStorageRoot(ctx, sc.numWorkers, sc.newStorageWorker, &pu, n, pth, accountFresh)
 		if err == nil {
 			sc.deepLocalFolds.Add(1)
 		}

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -83,20 +83,22 @@ func isDeepStorageAccount(node *prefixNode, depth int) bool {
 
 // dfsSubtreeDeep walks node's subtree applying each key to w, but at a big-storage
 // account it injects storageRoot's result instead of streaming the slots.
-func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storageRoot func(node *prefixNode, path []byte) (common.Hash, error)) error {
+func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storageRoot func(node *prefixNode, path []byte, accountFresh bool) (common.Hash, error)) error {
 	if node == nil {
 		return nil
 	}
+	accountFresh := false
 	if node.plainKey != nil {
 		if err := w.followAndUpdate(path, node.plainKey, node.update); err != nil {
 			return err
 		}
+		accountFresh = w.lastUpdateCellWasEmpty
 	} else if node.bitmap == 0 {
 		return errors.New("commitment: trie leaf without a plainKey")
 	}
 
 	if isDeepStorageAccount(node, len(path)) {
-		sr, err := storageRoot(node, path)
+		sr, err := storageRoot(node, path, accountFresh)
 		if err == nil {
 			setAccountStorageRoot(w, path, sr)
 			return nil
@@ -126,7 +128,7 @@ func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storage
 }
 
 // Storage-root analogue of the account mount fold: parallelize a whale's storage by first nibble.
-func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte) (common.Hash, error) {
+func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte, accountFresh bool) (common.Hash, error) {
 	accPrefix := append([]byte(nil), path...)
 
 	base, releaseBase := newWorker()
@@ -145,7 +147,11 @@ func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*Hex
 		base.SetTraceWriter(tracePrefix(base.traceW, accTag))
 	}
 	if err := unfoldStorageBase(base, accPrefix); err != nil {
-		return common.Hash{}, fmt.Errorf("unfold storage root: %w", err)
+		// A fresh account proves nothing exists on disk beneath accPrefix, so the reset
+		// (empty) wall rows unfoldStorageBase left behind are the correct seed.
+		if !accountFresh || !errors.Is(err, errStorageBaseNotBranch) {
+			return common.Hash{}, fmt.Errorf("unfold storage root: %w", err)
+		}
 	}
 
 	var children [16]cell


### PR DESCRIPTION
The deep storage fold demotes to serial streaming whenever no branch record exists at the account prefix (#22113): an empty seed there would drop unseen on-disk siblings. That is the only safe answer for accounts present in the pre-state — but it also covered accounts that do not exist at all, so a new contract crossing the deep-storage threshold in its first block folds its entire storage in one goroutine. On the 1M-whale benchmark this made `ModeParallel-w18` ~2.9x slower (368ms → 1054ms; a two-commit bisect pins the whole jump on the #22113 merge).

## Changes
- `updateCell` records whether the stamped cell was empty after the full unfold — an empty target cell means the key is absent from the pre-state trie, which proves nothing exists on disk beneath it.
- `dfsSubtreeDeep` threads that `accountFresh` evidence to `foldStorageRoot`, which accepts the empty wall rows left by `unfoldStorageBase` as the seed for a fresh account instead of demoting. Accounts present in the pre-state keep the serial fallback unchanged.
- regression pins: `TestDeepFold_FreshWhaleFoldsParallel` (fresh whale takes the concurrent fold — `DeepLocalFolds` asserted — with root parity vs sequential) and `TestDeepFold_ExistingWhaleStillDemotes` (the demotion gate stays for pre-existing accounts).

Benchmark (M5 Max 18c, MockState, count≥5): `Benchmark_Commitment_1MWhales/ModeParallel-w18` 1054ms → ~364ms, matching the pre-demotion arm; `Clustered/8acct-500K` w8 185ms → 151ms; sequential paths unchanged.
