### PR TITLE
execution/commitment: cut deferred branch update staging and handoff overhead

### DIFF
--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -480,71 +480,51 @@ func ApplyDeferredBranchUpdates(
 		return written, nil
 	}
 
-	// Pipeline: workers encode in parallel, results sent to channel, main goroutine writes sequentially.
-	type result struct {
-		upd *DeferredBranchUpdate
-		err error
-	}
-	// Size channels to actual batch length, not the 50K max.
-	resultCh := make(chan result, len(deferred))
-	workCh := make(chan *DeferredBranchUpdate, len(deferred))
-
-	// Start workers with pooled encoders/mergers.
+	// Workers encode disjoint index ranges in place; per-item channel handoff costs more
+	// than the encoding itself, so the write pass below stays sequential over the slice.
+	chunk := (len(deferred) + numWorkers - 1) / numWorkers
+	errs := make([]error, numWorkers)
 	var wg sync.WaitGroup
-	for i := 0; i < numWorkers; i++ {
+	for w := 0; w < numWorkers; w++ {
+		lo := w * chunk
+		hi := min(lo+chunk, len(deferred))
+		if lo >= hi {
+			break
+		}
 		wg.Add(1)
-		go func() {
+		go func(w, lo, hi int) {
 			defer wg.Done()
 			encoder := workerEncoderPool.Get().(*BranchEncoder)
 			merger := workerMergerPool.Get().(*BranchMerger)
 			defer workerEncoderPool.Put(encoder)
 			defer workerMergerPool.Put(merger)
-
-			for upd := range workCh {
-				err := encodeDeferredUpdate(upd, encoder, merger)
-				resultCh <- result{upd: upd, err: err}
+			for i := lo; i < hi; i++ {
+				if err := encodeDeferredUpdate(deferred[i], encoder, merger); err != nil {
+					errs[w] = err
+					return
+				}
 			}
-		}()
+		}(w, lo, hi)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return 0, err
+		}
 	}
 
-	// Close resultCh when all workers are done
-	go func() {
-		wg.Wait()
-		close(resultCh)
-	}()
-
-	// Send work in background
-	go func() {
-		for _, upd := range deferred {
-			workCh <- upd
-		}
-		close(workCh)
-	}()
-
-	// Process results as they come in - write to storage immediately
-	var firstErr error
 	var written int
-	for res := range resultCh {
-		if res.err != nil {
-			if firstErr == nil {
-				firstErr = res.err
-			}
-			continue
-		}
-		if res.upd.encoded == nil {
+	for _, upd := range deferred {
+		if upd.encoded == nil {
 			continue // skip unchanged
 		}
-		if firstErr != nil {
-			continue // drain channel but don't write after error
-		}
-		if err := putBranch(res.upd.prefix, res.upd.encoded, res.upd.prev); err != nil {
-			firstErr = err
-			continue
+		if err := putBranch(upd.prefix, upd.encoded, upd.prev); err != nil {
+			return written, err
 		}
 		written++
 	}
 	mxTrieBranchesUpdated.AddInt(written)
-	return written, firstErr
+	return written, nil
 }
 
 func (be *BranchEncoder) setMetrics(metrics *Metrics) {

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -235,17 +235,13 @@ func cellEncodeDataFromCell(c *cell) cellEncodeData {
 // DeferredBranchUpdate holds the data needed to perform a branch update later.
 // This allows collecting updates during the fold phase and running computeCellHash + EncodeBranch in parallel.
 type DeferredBranchUpdate struct {
-	prefix   []byte
-	bitmap   uint16
-	touchMap uint16
-	afterMap uint16
-
-	// Cells needed for EncodeBranch - only the fields required for encoding
-	cells [16]cellEncodeData
-
+	prefix []byte
+	// Branch encoding produced at collect time, before merging with prev; kept
+	// separate so a later apply can re-merge against a different predecessor.
+	raw BranchData
 	// Previous data from ctx.Branch (for merging)
 	prev []byte
-	// Result after encoding (filled by parallel workers)
+	// Result after merging (filled during apply)
 	encoded BranchData
 }
 
@@ -269,30 +265,16 @@ func GetDeferredUpdateMetrics() int64 {
 	return getDeferredUpdateCount.Load()
 }
 
-// getDeferredUpdate gets a DeferredBranchUpdate from the global pool
-// and copies only the fields needed for encoding.
-func getDeferredUpdate(
-	prefix []byte,
-	bitmap, touchMap, afterMap uint16,
-	cells *[16]cellEncodeData,
-	prev []byte,
-) *DeferredBranchUpdate {
+// getDeferredUpdate gets a DeferredBranchUpdate from the global pool and copies the
+// prefix, the collect-time raw encoding, and the predecessor. The copies transfer to
+// whoever the apply hands them to (putBranch retains prefix and data), so pooled
+// objects never keep their backing arrays.
+func getDeferredUpdate(prefix []byte, raw, prev []byte) *DeferredBranchUpdate {
 	getDeferredUpdateCount.Add(1)
 	upd := deferredUpdatePool.Get().(*DeferredBranchUpdate)
 
 	upd.prefix = common.Copy(prefix)
-	upd.bitmap = bitmap
-	upd.touchMap = touchMap
-	upd.afterMap = afterMap
-
-	// Direct struct copy for each cell in bitmap
-	for bitset := bitmap; bitset != 0; {
-		bit := bitset & -bitset
-		nibble := bits.TrailingZeros16(bit)
-		upd.cells[nibble] = cells[nibble]
-		bitset ^= bit
-	}
-
+	upd.raw = common.Copy(raw)
 	upd.prev = common.Copy(prev)
 	upd.encoded = nil
 
@@ -304,6 +286,7 @@ func getDeferredUpdate(
 func putDeferredUpdate(upd *DeferredBranchUpdate) {
 	if upd != nil {
 		upd.prefix = nil
+		upd.raw = nil
 		upd.prev = nil
 		upd.encoded = nil
 		deferredUpdatePool.Put(upd)
@@ -396,28 +379,20 @@ func (be *BranchEncoder) ClearDeferred() {
 
 // encodeDeferredUpdate encodes a branch update using the provided encoder and merger.
 // Cell hashes are already computed during fold() before cells were copied.
-func encodeDeferredUpdate(
-	upd *DeferredBranchUpdate,
-	encoder *BranchEncoder,
-	merger *BranchMerger,
-) error {
-	update, err := encoder.EncodeBranch(upd.bitmap, upd.touchMap, upd.afterMap, &upd.cells)
-	if err != nil {
-		return err
-	}
-
+func mergeDeferredUpdate(upd *DeferredBranchUpdate, merger *BranchMerger) error {
 	if len(upd.prev) > 0 {
-		if bytes.Equal(upd.prev, update) {
+		if bytes.Equal(upd.prev, upd.raw) {
 			upd.encoded = nil // skip unchanged
 			return nil
 		}
-		update, err = merger.Merge(upd.prev, update)
+		merged, err := merger.Merge(upd.prev, upd.raw)
 		if err != nil {
 			return err
 		}
+		upd.encoded = common.Copy(merged)
+		return nil
 	}
-
-	upd.encoded = common.Copy(update)
+	upd.encoded = upd.raw
 	return nil
 }
 
@@ -436,11 +411,8 @@ func (be *BranchEncoder) ApplyDeferredUpdates(
 	return nil
 }
 
-// Pools for worker encoders/mergers to avoid per-call allocations.
-var (
-	workerEncoderPool = sync.Pool{New: func() any { return NewBranchEncoder(1024) }}
-	workerMergerPool  = sync.Pool{New: func() any { return NewHexBranchMerger(512) }}
-)
+// Pool for worker mergers to avoid per-call allocations.
+var workerMergerPool = sync.Pool{New: func() any { return NewHexBranchMerger(512) }}
 
 // ApplyDeferredBranchUpdates encodes deferred branch updates concurrently and writes them.
 // Returns the number of updates successfully written.
@@ -456,16 +428,14 @@ func ApplyDeferredBranchUpdates(
 		numWorkers = 1
 	}
 
-	// Sequential fast path: avoids goroutine and channel overhead for small batches.
+	// Sequential fast path: avoids goroutine overhead for small batches.
 	if numWorkers == 1 || len(deferred) <= numWorkers {
-		encoder := workerEncoderPool.Get().(*BranchEncoder)
 		merger := workerMergerPool.Get().(*BranchMerger)
-		defer workerEncoderPool.Put(encoder)
 		defer workerMergerPool.Put(merger)
 
 		var written int
 		for _, upd := range deferred {
-			if err := encodeDeferredUpdate(upd, encoder, merger); err != nil {
+			if err := mergeDeferredUpdate(upd, merger); err != nil {
 				return written, err
 			}
 			if upd.encoded == nil {
@@ -480,8 +450,8 @@ func ApplyDeferredBranchUpdates(
 		return written, nil
 	}
 
-	// Workers encode disjoint index ranges in place; per-item channel handoff costs more
-	// than the encoding itself, so the write pass below stays sequential over the slice.
+	// Workers merge disjoint index ranges in place; per-item channel handoff costs more
+	// than the merging itself, so the write pass below stays sequential over the slice.
 	chunk := (len(deferred) + numWorkers - 1) / numWorkers
 	errs := make([]error, numWorkers)
 	var wg sync.WaitGroup
@@ -494,12 +464,10 @@ func ApplyDeferredBranchUpdates(
 		wg.Add(1)
 		go func(w, lo, hi int) {
 			defer wg.Done()
-			encoder := workerEncoderPool.Get().(*BranchEncoder)
 			merger := workerMergerPool.Get().(*BranchMerger)
-			defer workerEncoderPool.Put(encoder)
 			defer workerMergerPool.Put(merger)
 			for i := lo; i < hi; i++ {
-				if err := encodeDeferredUpdate(deferred[i], encoder, merger); err != nil {
+				if err := mergeDeferredUpdate(deferred[i], merger); err != nil {
 					errs[w] = err
 					return
 				}
@@ -624,9 +592,13 @@ func (be *BranchEncoder) CollectDeferredUpdate(
 	// Track this prefix as pending
 	be.pendingPrefixes.Set(prefix, struct{}{})
 
-	// Get a pooled DeferredBranchUpdate and copy all fields
-	upd := getDeferredUpdate(prefix, bitmap, touchMap, afterMap, cells, prev)
-	be.deferred = append(be.deferred, upd)
+	// Encoding is cheap and runs on the fold worker; only the merge with prev is left
+	// for apply time, when a duplicate prefix may substitute a newer predecessor.
+	raw, err := be.EncodeBranch(bitmap, touchMap, afterMap, cells)
+	if err != nil {
+		return err
+	}
+	be.deferred = append(be.deferred, getDeferredUpdate(prefix, raw, prev))
 	return nil
 }
 

--- a/execution/commitment/commitment_bench_test.go
+++ b/execution/commitment/commitment_bench_test.go
@@ -291,11 +291,17 @@ func BenchmarkGetDeferredUpdate(b *testing.B) {
 	prefix := []byte{0x01, 0x02, 0x03}
 	prev := []byte{0x04, 0x05, 0x06}
 
+	enc := NewBranchEncoder(1024)
+	raw, err := enc.EncodeBranch(bitmap, touchMap, afterMap, &cells)
+	if err != nil {
+		b.Fatal(err)
+	}
+
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for b.Loop() {
-		upd := getDeferredUpdate(prefix, bitmap, touchMap, afterMap, &cells, prev)
+		upd := getDeferredUpdate(prefix, raw, prev)
 		putDeferredUpdate(upd)
 	}
 }
@@ -324,11 +330,17 @@ func BenchmarkGetDeferredUpdate_FewCells(b *testing.B) {
 	prefix := []byte{0x01, 0x02, 0x03}
 	prev := []byte{0x04, 0x05, 0x06}
 
+	enc := NewBranchEncoder(1024)
+	raw, err := enc.EncodeBranch(bitmap, touchMap, afterMap, &cells)
+	if err != nil {
+		b.Fatal(err)
+	}
+
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for b.Loop() {
-		upd := getDeferredUpdate(prefix, bitmap, touchMap, afterMap, &cells, prev)
+		upd := getDeferredUpdate(prefix, raw, prev)
 		putDeferredUpdate(upd)
 	}
 }

--- a/execution/commitment/deepfold_subset_regression_test.go
+++ b/execution/commitment/deepfold_subset_regression_test.go
@@ -17,9 +17,12 @@
 package commitment
 
 import (
+	"context"
 	"encoding/hex"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common/length"
 )
@@ -106,4 +109,56 @@ func TestDeepFold_PreExistingWhale_SingleNibbleOnDisk(t *testing.T) {
 	k1 = append(append([][]byte{}, fk...), k1...)
 	u1 = append(append([]Update{}, fu...), u1...)
 	requireAllEnginesParity(t, k1, u1, k2, u2, 4)
+}
+
+// A FRESH whale — its account absent from the pre-state trie — provably has nothing on
+// disk beneath its storage prefix, so the deep fold seeds an empty base and folds the
+// slots concurrently instead of demoting to serial streaming.
+func TestDeepFold_FreshWhaleFoldsParallel(t *testing.T) {
+	k1, u1, _, _ := buildSubsetTouchedWhale(20260707, nibs(3, 7), nil, 700, 0)
+	fk, fu := buildMixedCorpus(555, 200)
+	keys := append(append([][]byte{}, fk...), k1...)
+	upds := append(append([]Update{}, fu...), u1...)
+
+	seqRoot, _ := engineRoot(t, modeSeq, 0, keys, upds)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+	require.NoError(t, ms.applyPlainUpdates(keys, upds))
+	sc := newStreamCommitter(t, ms, 4, false)
+	defer sc.Release()
+	touchAll(sc, keys)
+	got, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, seqRoot, got, "fresh-whale concurrent fold diverged from sequential")
+	require.Positive(t, sc.DeepLocalFolds(), "a fresh whale must take the concurrent deep fold, not the serial demotion")
+
+	parRoot, _ := engineRoot(t, modeParallel, 4, keys, upds)
+	require.Equal(t, seqRoot, parRoot)
+}
+
+// The demotion gate stays for accounts present in the pre-state without a branch record
+// at their prefix (single embedded slot): the influx still streams serially.
+func TestDeepFold_ExistingWhaleStillDemotes(t *testing.T) {
+	k1, u1, k2, u2 := buildSubsetTouchedWhale(20260708, nibs(0), nibs(3, 7), 1, 700)
+	fk, fu := buildMixedCorpus(556, 200)
+	k1 = append(append([][]byte{}, fk...), k1...)
+	u1 = append(append([]Update{}, fu...), u1...)
+
+	seqRoot, _ := incrementalRoot(t, modeSeq, 0, k1, u1, k2, u2)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+	sc := newStreamCommitter(t, ms, 4, false)
+	defer sc.Release()
+	require.NoError(t, ms.applyPlainUpdates(k1, u1))
+	touchAll(sc, k1)
+	_, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, ms.applyPlainUpdates(k2, u2))
+	touchAll(sc, k2)
+	got, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, seqRoot, got)
+	require.Zero(t, sc.DeepLocalFolds(), "an account present in the pre-state must keep the serial demotion")
 }

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -167,7 +167,12 @@ type HexPatriciaHashed struct {
 	//processing metrics
 	metrics       *Metrics
 	depthsToTxNum [129]uint64 // endTxNum of file with branch data for that depth
-	hadToLoadL    map[uint64]skipStat
+
+	// lastUpdateCellWasEmpty reports whether the most recent updateCell stamped a key
+	// into an empty cell — i.e. the key is absent from the pre-state trie, so nothing
+	// can exist on disk beneath it.
+	lastUpdateCellWasEmpty bool
+	hadToLoadL             map[uint64]skipStat
 }
 
 // Clones current trie state to allow concurrent processing.
@@ -2173,6 +2178,7 @@ func (hph *HexPatriciaHashed) updateCell(plainKey, hashedKey []byte, u *Update) 
 		}
 
 		hph.deleteCell(hashedKey)
+		hph.lastUpdateCellWasEmpty = false
 		return nil
 	}
 
@@ -2193,6 +2199,7 @@ func (hph *HexPatriciaHashed) updateCell(plainKey, hashedKey []byte, u *Update) 
 			fmt.Fprintf(hph.traceW, "updateCell setting (%d, %x, depth=%d)\n", row, nibble, depth)
 		}
 	}
+	hph.lastUpdateCellWasEmpty = cell.IsEmpty()
 	if cell.hashedExtLen == 0 {
 		copy(cell.hashedExtension[:], hashedKey[depth:])
 		cell.hashedExtLen = int16(len(hashedKey)) - depth

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -140,6 +140,7 @@ type HexPatriciaHashed struct {
 	ctx           PatriciaContext
 	hashAuxBuffer [128]byte     // buffer to compute cell hash or write hash-related things
 	cellHashBuf   common.Hash   // shared scratch buffer for hashKey calls (avoids per-cell allocation)
+	leafHashBuf   [33]byte      // shared scratch for leaf hash prefixing (avoids per-leaf escape)
 	auxBuffer     *bytes.Buffer // auxiliary buffer used during branch updates encoding
 	branchEncoder *BranchEncoder
 
@@ -761,13 +762,12 @@ func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key [
 	if canEmbed {
 		buf = hph.auxBuffer.Bytes()
 	} else {
-		var hashBuf [33]byte
-		hashBuf[0] = 0x80 + length.Hash
-		if _, err := hph.keccak.Read(hashBuf[1:]); err != nil {
+		hph.leafHashBuf[0] = 0x80 + length.Hash
+		if _, err := hph.keccak.Read(hph.leafHashBuf[1:]); err != nil {
 			return nil, err
 		}
-		buf = append(buf, hashBuf[:]...)
-		hph.witness.emitLeaf(hashBuf[1:])
+		buf = append(buf, hph.leafHashBuf[:]...)
+		hph.witness.emitLeaf(hph.leafHashBuf[1:])
 	}
 	return buf, nil
 }

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -140,8 +140,8 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 			path := make([]byte, 0, 144)
 			path = append(path, byte(ni))
 			path = append(path, ch.ext...)
-			buildErr := dfsSubtreeDeep(w, ch, path, func(n *prefixNode, pth []byte) (common.Hash, error) {
-				return foldStorageRoot(gctx, p.numWorkers, p.newStorageWorker, pu, n, pth)
+			buildErr := dfsSubtreeDeep(w, ch, path, func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
+				return foldStorageRoot(gctx, p.numWorkers, p.newStorageWorker, pu, n, pth, accountFresh)
 			})
 			if buildErr != nil {
 				w.resetForReuse()

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -719,8 +719,8 @@ func (sc *StreamingCommitter) foldSplit(ctx context.Context, base *HexPatriciaHa
 	path := make([]byte, 0, 144)
 	path = append(path, ni)
 	path = append(path, child.ext...)
-	deepStorageRoot := func(n *prefixNode, pth []byte) (common.Hash, error) {
-		sr, err := foldStorageRoot(ctx, sc.numWorkers, sc.newStorageWorker, &pu, n, pth)
+	deepStorageRoot := func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
+		sr, err := foldStorageRoot(ctx, sc.numWorkers, sc.newStorageWorker, &pu, n, pth, accountFresh)
 		if err == nil {
 			sc.deepLocalFolds.Add(1)
 		}

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -833,9 +833,7 @@ func applyDeferredGuarded(ctx PatriciaContext, deferred []*DeferredBranchUpdate,
 		return err
 	}
 
-	encoder := workerEncoderPool.Get().(*BranchEncoder)
 	merger := workerMergerPool.Get().(*BranchMerger)
-	defer workerEncoderPool.Put(encoder)
 	defer workerMergerPool.Put(merger)
 
 	applied := make(map[string][]byte, len(deferred))
@@ -853,7 +851,7 @@ func applyDeferredGuarded(ctx PatriciaContext, deferred []*DeferredBranchUpdate,
 			}
 			upd.prev = common.Copy(prev)
 		}
-		if err := encodeDeferredUpdate(upd, encoder, merger); err != nil {
+		if err := mergeDeferredUpdate(upd, merger); err != nil {
 			return err
 		}
 		if upd.encoded == nil {

--- a/execution/commitment/streaming_commitment_test.go
+++ b/execution/commitment/streaming_commitment_test.go
@@ -150,7 +150,11 @@ func makeBranch(prefix []byte, afterMap uint16, touched []int, seed byte, prev [
 			cells[n].hash[b] = seed + byte(n)
 		}
 	}
-	return getDeferredUpdate(prefix, tm, tm, afterMap, &cells, prev)
+	raw, err := NewBranchEncoder(64).EncodeBranch(tm, tm, afterMap, &cells)
+	if err != nil {
+		panic(err)
+	}
+	return getDeferredUpdate(prefix, raw, prev)
 }
 
 // Settle condition is idle, not all-clean: the coalescing gate may legitimately leave a split dirty.

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -83,20 +83,22 @@ func isDeepStorageAccount(node *prefixNode, depth int) bool {
 
 // dfsSubtreeDeep walks node's subtree applying each key to w, but at a big-storage
 // account it injects storageRoot's result instead of streaming the slots.
-func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storageRoot func(node *prefixNode, path []byte) (common.Hash, error)) error {
+func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storageRoot func(node *prefixNode, path []byte, accountFresh bool) (common.Hash, error)) error {
 	if node == nil {
 		return nil
 	}
+	accountFresh := false
 	if node.plainKey != nil {
 		if err := w.followAndUpdate(path, node.plainKey, node.update); err != nil {
 			return err
 		}
+		accountFresh = w.lastUpdateCellWasEmpty
 	} else if node.bitmap == 0 {
 		return errors.New("commitment: trie leaf without a plainKey")
 	}
 
 	if isDeepStorageAccount(node, len(path)) {
-		sr, err := storageRoot(node, path)
+		sr, err := storageRoot(node, path, accountFresh)
 		if err == nil {
 			setAccountStorageRoot(w, path, sr)
 			return nil
@@ -126,7 +128,7 @@ func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storage
 }
 
 // Storage-root analogue of the account mount fold: parallelize a whale's storage by first nibble.
-func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte) (common.Hash, error) {
+func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte, accountFresh bool) (common.Hash, error) {
 	accPrefix := append([]byte(nil), path...)
 
 	base, releaseBase := newWorker()
@@ -145,7 +147,11 @@ func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*Hex
 		base.SetTraceWriter(tracePrefix(base.traceW, accTag))
 	}
 	if err := unfoldStorageBase(base, accPrefix); err != nil {
-		return common.Hash{}, fmt.Errorf("unfold storage root: %w", err)
+		// A fresh account proves nothing exists on disk beneath accPrefix, so the reset
+		// (empty) wall rows unfoldStorageBase left behind are the correct seed.
+		if !accountFresh || !errors.Is(err, errStorageBaseNotBranch) {
+			return common.Hash{}, fmt.Errorf("unfold storage root: %w", err)
+		}
 	}
 
 	var children [16]cell


### PR DESCRIPTION
Stacks on #22263 (the first commit is that PR; review the last three commits here).

The deferred-branch-update pipeline cost far more than the work it parallelized: profiles on the whale benchmarks put ~92% of `ApplyDeferredBranchUpdates`' CPU in per-item channel handoff, and `CollectDeferredUpdate` staged ~3.4KB of fold inputs per update (`[16]cellEncodeData` duffcopies on the fold hot path, feeding a `sync.Pool` that always misses because every object stays live until apply) — roughly half the parallel engine's allocation volume, which in turn drove the dominant GC/madvise share of the profile.

## Changes
- `ApplyDeferredBranchUpdates`: workers encode disjoint index ranges in place; one sequential pass writes the results in slice order (write order was completion order before, so no ordering contract changes; encode errors now abort before any write).
- `CollectDeferredUpdate` runs `EncodeBranch` inline on the fold worker and stages only `{prefix, prev, raw}`; the merge with `prev` stays at apply time because `applyDeferredGuarded` may substitute a newer predecessor for duplicate prefixes and re-merges from the raw encoding. The apply phase loses its encode step; `DeferredBranchUpdate` sheds the cells payload.
- `completeLeafHash`: the escaping per-leaf 33-byte hash buffer becomes a scratch field on the per-goroutine trie (the witness tracer copies before retaining).

Benchmarks (M5 Max 18c, MockState, count=6, measured per commit; cumulative below vs this branch's base):
- `1MWhales/ModeParallel-w18` 363ms → 203ms (−44%); vs current main 1054ms → 203ms
- `Clustered/8acct-500K` w8 163ms → 85ms (−48%)
- `1MWhales/ModeDirect` (sequential) −11%, `DeepStorageWhale` sequential −14%
- allocated bytes per op −47% (1.3GiB → 681MiB on 1MWhales-w18)
