### PR TITLE
cl: bound caplin archive blob-column backfill so it can't wedge on Fulu

### DIFF
--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -39,7 +39,6 @@ const (
 	blobLogInterval             = 30 * time.Second
 	blobBackfillWarningInterval = 4 * time.Minute
 	blocksBatchSize             = uint64(8)
-	maxIterations               = uint64(32)
 	minPeersForBlobDownload     = 16
 	// bounds a fulu block's column recovery; columns past the custody window are
 	// unfetchable and would otherwise block forever.
@@ -304,9 +303,6 @@ func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot 
 
 	batch = make([]*cltypes.SignedBeaconBlock, 0, blocksBatchSize)
 	for ; visited < blocksBatchSize; visited++ {
-		if visited >= maxIterations {
-			break
-		}
 		if currentSlot < visited || currentSlot-visited < targetSlot {
 			break
 		}
@@ -356,15 +352,15 @@ func (b *BlobHistoryDownloader) processBatch(batch []*cltypes.SignedBeaconBlock)
 		}
 	}
 	if len(denebBlocks) > 0 {
-		b.recoverDenebBlobs(batch)
+		b.recoverDenebBlobs(denebBlocks)
 	}
 	if len(fuluBlocks) > 0 {
 		b.recoverFuluColumns(fuluBlocks)
 	}
 }
 
-func (b *BlobHistoryDownloader) recoverDenebBlobs(batch []*cltypes.SignedBeaconBlock) {
-	req, err := BlobsIdentifiersFromBlocks(batch, b.beaconCfg)
+func (b *BlobHistoryDownloader) recoverDenebBlobs(blocks []*cltypes.SignedBeaconBlock) {
+	req, err := BlobsIdentifiersFromBlocks(blocks, b.beaconCfg)
 	if err != nil {
 		b.logger.Debug("[BlobHistoryDownloader] Error generating blob identifiers", "err", err)
 		return
@@ -376,7 +372,7 @@ func (b *BlobHistoryDownloader) recoverDenebBlobs(batch []*cltypes.SignedBeaconB
 	}
 	_, _, err = blob_storage.VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(b.ctx, b.blobStorage, req, blobs.Responses, func(header *cltypes.SignedBeaconBlockHeader) error {
 		// The block is preverified so just check that the signature is correct against the block
-		for _, block := range batch {
+		for _, block := range blocks {
 			if block.Block.Slot != header.Header.Slot {
 				continue
 			}

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -267,10 +267,11 @@ func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
 			b.highestBackfilledSlot.Store(currentSlot)
 		}
 
-		// Always advance so an uncompletable batch can't rebuild at the same slot forever;
-		// step>=1 guarantees progress and the floor check avoids uint64 underflow.
+		// Always advance so an uncompletable batch can't rebuild at the same slot forever.
+		// step>=1 guarantees progress; stop once the distance left to the floor is below one
+		// step. The loop guard keeps currentSlot>=targetSlot, so neither subtraction underflows.
 		step := max(visited, 1)
-		if currentSlot < targetSlot+step {
+		if currentSlot-targetSlot < step {
 			break
 		}
 		currentSlot -= step
@@ -397,9 +398,10 @@ func (b *BlobHistoryDownloader) recoverFuluColumns(blocks []*cltypes.SignedBeaco
 	for _, block := range blocks {
 		// [Modified in Gloas:EIP7732] Use ColumnSyncableSignedBlock interface
 		ctx, cancel := context.WithTimeout(b.ctx, b.columnBackfillTimeout)
-		if err := peerDas.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}); err != nil {
+		err := peerDas.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block})
+		cancel()
+		if err != nil {
 			b.logger.Warn("[BlobHistoryDownloader] Error recovering blobs from block", "err", err, "slot", block.GetSlot())
 		}
-		cancel()
 	}
 }

--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -41,6 +41,9 @@ const (
 	blocksBatchSize             = uint64(8)
 	maxIterations               = uint64(32)
 	minPeersForBlobDownload     = 16
+	// bounds a fulu block's column recovery; columns past the custody window are
+	// unfetchable and would otherwise block forever.
+	blobColumnBackfillTimeout = 30 * time.Second
 )
 
 // SyncedChecker is an interface to check if the forkchoice is synced
@@ -77,6 +80,8 @@ type BlobHistoryDownloader struct {
 	archiveBlobs bool
 	// immediateBlobsBackfilling indicates whether to backfill blobs immediately
 	immediateBlobsBackfilling bool
+	// columnBackfillTimeout bounds each fulu block's PeerDAS column recovery
+	columnBackfillTimeout time.Duration
 
 	running           atomic.Bool
 	backfillCompleted atomic.Bool
@@ -117,6 +122,7 @@ func NewBlobHistoryDownloader(
 		targetSlot:                targetSlot,
 		archiveBlobs:              archiveBlobs,
 		immediateBlobsBackfilling: immediateBlobsBackfilling,
+		columnBackfillTimeout:     blobColumnBackfillTimeout,
 		logger:                    logger,
 	}
 }
@@ -210,12 +216,6 @@ func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
 		return nil
 	}
 
-	tx, err := b.indiciesDB.BeginRo(b.ctx)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
 	logInterval := time.NewTicker(blobLogInterval)
 	defer logInterval.Stop()
 
@@ -246,120 +246,35 @@ func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
 			continue
 		}
 
-		batch := make([]*cltypes.SignedBeaconBlock, 0, blocksBatchSize)
-		visited := uint64(0)
-		for ; visited < blocksBatchSize; visited++ {
-			if visited >= maxIterations {
-				break
-			}
-			if currentSlot-visited < targetSlot {
-				break
-			}
-			block, err := b.blockReader.ReadBeaconBlockBodyBySlot(b.ctx, tx, currentSlot-visited)
-			if err != nil {
-				return err
-			}
-			if block == nil {
-				continue
-			}
-			if block.Version() < clparams.DenebVersion {
-				break
-			}
-			blockRoot, err := block.Block.HashSSZ()
-			if err != nil {
-				return err
-			}
-			blobsCount, err := b.blobStorage.KzgCommitmentsCount(b.ctx, blockRoot)
-			if err != nil {
-				return err
-			}
-			commitments := block.Block.Body.GetBlobKzgCommitments()
-			if commitments == nil {
-				// For GLOAS, nil means SignedExecutionPayloadBid is absent — unexpected for a valid block.
-				// For pre-GLOAS this should not happen on Deneb+.
-				b.logger.Warn("[BlobHistoryDownloader] skipping block with nil kzg commitments", "slot", block.Block.Slot, "version", block.Version())
-				continue
-			}
-			if commitments.Len() == int(blobsCount) {
-				continue
-			}
-			batch = append(batch, block)
-		}
-		if len(batch) == 0 {
-			currentSlot -= visited
-			continue
+		batch, visited, err := b.collectIncompleteBlocks(currentSlot, targetSlot)
+		if err != nil {
+			return err
 		}
 
-		select {
-		case <-b.ctx.Done():
-			return b.ctx.Err()
-		case <-logInterval.C:
-			if !shouldLog {
-				continue
-			}
-			blkSec := float64(prevLogSlot-currentSlot) / time.Since(prevTime).Seconds()
-			blkSecStr := fmt.Sprintf("%.1f", blkSec)
-			prevLogSlot = currentSlot
-			prevTime = time.Now()
-
-			b.logger.Info("[BlobHistoryDownloader] Downloading blobs backwards", "slot", currentSlot, "blks/sec", blkSecStr)
-		default:
-		}
-
-		// Generate the request
-		fuluBlocks := []*cltypes.SignedBeaconBlock{}
-		denebBlocks := []*cltypes.SignedBeaconBlock{}
-		for _, block := range batch {
-			if block.Version() >= clparams.FuluVersion {
-				fuluBlocks = append(fuluBlocks, block)
-			} else {
-				denebBlocks = append(denebBlocks, block)
-			}
-		}
-
-		if len(denebBlocks) > 0 {
-			req, err := BlobsIdentifiersFromBlocks(batch, b.beaconCfg)
-			if err != nil {
-				b.logger.Debug("[BlobHistoryDownloader] Error generating blob identifiers", "err", err)
-				continue
-			}
-			// Request the blobs
-			blobs, err := RequestBlobsFrantically(b.ctx, b.rpc, req)
-			if err != nil {
-				b.logger.Debug("[BlobHistoryDownloader] Error requesting blobs", "err", err)
-				continue
-			}
-			_, _, err = blob_storage.VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(b.ctx, b.blobStorage, req, blobs.Responses, func(header *cltypes.SignedBeaconBlockHeader) error {
-				// The block is preverified so just check that the signature is correct against the block
-				for _, block := range batch {
-					if block.Block.Slot != header.Header.Slot {
-						continue
-					}
-					if block.Signature != header.Signature {
-						return errors.New("signature mismatch between blob and stored block")
-					}
-					return nil
+		if len(batch) > 0 {
+			select {
+			case <-b.ctx.Done():
+				return b.ctx.Err()
+			case <-logInterval.C:
+				if shouldLog {
+					blkSec := float64(prevLogSlot-currentSlot) / time.Since(prevTime).Seconds()
+					prevLogSlot = currentSlot
+					prevTime = time.Now()
+					b.logger.Info("[BlobHistoryDownloader] Downloading blobs backwards", "slot", currentSlot, "blks/sec", fmt.Sprintf("%.1f", blkSec))
 				}
-				return errors.New("block not in batch")
-			})
-			if err != nil {
-				b.rpc.BanPeer(blobs.Peer)
-				b.logger.Warn("[BlobHistoryDownloader] Error verifying blobs", "err", err)
-				continue
+			default:
 			}
-		}
-		if len(fuluBlocks) > 0 {
-			peerDas := b.peerDasGetter.GetPeerDas()
-			for _, block := range fuluBlocks {
-				// [Modified in Gloas:EIP7732] Use ColumnSyncableSignedBlock interface
-				if err := peerDas.DownloadColumnsAndRecoverBlobs(b.ctx, []cltypes.ColumnSyncableSignedBlock{block}); err != nil {
-					b.logger.Warn("[BlobHistoryDownloader] Error recovering blobs from block", "err", err, "slot", block.GetSlot())
-				}
-			}
+			b.processBatch(batch)
+			b.highestBackfilledSlot.Store(currentSlot)
 		}
 
-		// Update highest backfilled slot
-		b.highestBackfilledSlot.Store(currentSlot)
+		// Always advance so an uncompletable batch can't rebuild at the same slot forever;
+		// step>=1 guarantees progress and the floor check avoids uint64 underflow.
+		step := max(visited, 1)
+		if currentSlot < targetSlot+step {
+			break
+		}
+		currentSlot -= step
 	}
 
 	if shouldLog {
@@ -376,4 +291,119 @@ func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
 	}
 
 	return nil
+}
+
+// collectIncompleteBlocks scans backwards from currentSlot for Deneb+ blocks still
+// missing blobs. Its read tx is released before the caller's network download.
+func (b *BlobHistoryDownloader) collectIncompleteBlocks(currentSlot, targetSlot uint64) (batch []*cltypes.SignedBeaconBlock, visited uint64, err error) {
+	tx, err := b.indiciesDB.BeginRo(b.ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer tx.Rollback()
+
+	batch = make([]*cltypes.SignedBeaconBlock, 0, blocksBatchSize)
+	for ; visited < blocksBatchSize; visited++ {
+		if visited >= maxIterations {
+			break
+		}
+		if currentSlot < visited || currentSlot-visited < targetSlot {
+			break
+		}
+		block, err := b.blockReader.ReadBeaconBlockBodyBySlot(b.ctx, tx, currentSlot-visited)
+		if err != nil {
+			return nil, 0, err
+		}
+		if block == nil {
+			continue
+		}
+		if block.Version() < clparams.DenebVersion {
+			break
+		}
+		blockRoot, err := block.Block.HashSSZ()
+		if err != nil {
+			return nil, 0, err
+		}
+		blobsCount, err := b.blobStorage.KzgCommitmentsCount(b.ctx, blockRoot)
+		if err != nil {
+			return nil, 0, err
+		}
+		commitments := block.Block.Body.GetBlobKzgCommitments()
+		if commitments == nil {
+			// For GLOAS, nil means SignedExecutionPayloadBid is absent — unexpected for a valid block.
+			// For pre-GLOAS this should not happen on Deneb+.
+			b.logger.Warn("[BlobHistoryDownloader] skipping block with nil kzg commitments", "slot", block.Block.Slot, "version", block.Version())
+			continue
+		}
+		if commitments.Len() == int(blobsCount) {
+			continue
+		}
+		batch = append(batch, block)
+	}
+	return batch, visited, nil
+}
+
+// processBatch best-effort recovers each block's blobs: Deneb by-root, Fulu from
+// PeerDAS columns.
+func (b *BlobHistoryDownloader) processBatch(batch []*cltypes.SignedBeaconBlock) {
+	fuluBlocks := make([]*cltypes.SignedBeaconBlock, 0, len(batch))
+	denebBlocks := make([]*cltypes.SignedBeaconBlock, 0, len(batch))
+	for _, block := range batch {
+		if block.Version() >= clparams.FuluVersion {
+			fuluBlocks = append(fuluBlocks, block)
+		} else {
+			denebBlocks = append(denebBlocks, block)
+		}
+	}
+	if len(denebBlocks) > 0 {
+		b.recoverDenebBlobs(batch)
+	}
+	if len(fuluBlocks) > 0 {
+		b.recoverFuluColumns(fuluBlocks)
+	}
+}
+
+func (b *BlobHistoryDownloader) recoverDenebBlobs(batch []*cltypes.SignedBeaconBlock) {
+	req, err := BlobsIdentifiersFromBlocks(batch, b.beaconCfg)
+	if err != nil {
+		b.logger.Debug("[BlobHistoryDownloader] Error generating blob identifiers", "err", err)
+		return
+	}
+	blobs, err := RequestBlobsFrantically(b.ctx, b.rpc, req)
+	if err != nil {
+		b.logger.Debug("[BlobHistoryDownloader] Error requesting blobs", "err", err)
+		return
+	}
+	_, _, err = blob_storage.VerifyAgainstIdentifiersAndInsertIntoTheBlobStore(b.ctx, b.blobStorage, req, blobs.Responses, func(header *cltypes.SignedBeaconBlockHeader) error {
+		// The block is preverified so just check that the signature is correct against the block
+		for _, block := range batch {
+			if block.Block.Slot != header.Header.Slot {
+				continue
+			}
+			if block.Signature != header.Signature {
+				return errors.New("signature mismatch between blob and stored block")
+			}
+			return nil
+		}
+		return errors.New("block not in batch")
+	})
+	if err != nil {
+		// Best-effort backfill: log and move on rather than banning a peer from the
+		// shared live-sync pool for a historical-blob verification miss.
+		b.logger.Warn("[BlobHistoryDownloader] Error verifying blobs", "err", err)
+	}
+}
+
+// recoverFuluColumns recovers blobs from PeerDAS columns, bounding each attempt so
+// columns no peer still serves can't block the backfill indefinitely.
+func (b *BlobHistoryDownloader) recoverFuluColumns(blocks []*cltypes.SignedBeaconBlock) {
+	peerDas := b.peerDasGetter.GetPeerDas()
+	for _, block := range blocks {
+		// [Modified in Gloas:EIP7732] Use ColumnSyncableSignedBlock interface
+		ctx, cancel := context.WithTimeout(b.ctx, b.columnBackfillTimeout)
+		if err := peerDas.DownloadColumnsAndRecoverBlobs(ctx, []cltypes.ColumnSyncableSignedBlock{block}); err != nil {
+			b.logger.Warn("[BlobHistoryDownloader] Error recovering blobs from block", "err", err, "slot", block.GetSlot())
+		}
+		cancel()
+	}
 }

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/das"
+	"github.com/erigontech/erigon/cl/das/mock_services"
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+type staticPeerDasGetter struct{ pd das.PeerDas }
+
+func (s staticPeerDasGetter) GetPeerDas() das.PeerDas { return s.pd }
+
+// A historical fulu block whose PeerDAS data columns are served by no peer (older
+// than the network custody window) makes DownloadColumnsAndRecoverBlobs block until
+// its context is cancelled. Column recovery must be bounded per block so the archive
+// blob backfill cannot hang forever holding the index read tx.
+func TestBlobHistoryDownloaderFuluColumnRecoveryIsBounded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	peerDas := mock_services.NewMockPeerDas(ctrl)
+	peerDas.EXPECT().
+		DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ []cltypes.ColumnSyncableSignedBlock) error {
+			<-ctx.Done() // never recovers — unblocks only when the per-attempt ctx expires
+			return ctx.Err()
+		}).
+		AnyTimes()
+
+	b := &BlobHistoryDownloader{
+		ctx:                   context.Background(),
+		peerDasGetter:         staticPeerDasGetter{pd: peerDas},
+		columnBackfillTimeout: 50 * time.Millisecond,
+		logger:                log.New(),
+	}
+
+	fulu := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	fulu.Block.Slot = 100
+
+	done := make(chan struct{})
+	go func() {
+		b.recoverFuluColumns([]*cltypes.SignedBeaconBlock{fulu})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recoverFuluColumns hung — unbounded PeerDAS column recovery")
+	}
+}

--- a/cl/phase1/network/blob_downloader_test.go
+++ b/cl/phase1/network/blob_downloader_test.go
@@ -40,6 +40,7 @@ func (s staticPeerDasGetter) GetPeerDas() das.PeerDas { return s.pd }
 // blob backfill cannot hang forever holding the index read tx.
 func TestBlobHistoryDownloaderFuluColumnRecoveryIsBounded(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	peerDas := mock_services.NewMockPeerDas(ctrl)
 	peerDas.EXPECT().
 		DownloadColumnsAndRecoverBlobs(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
The caplin archive blob backfill (`BlobHistoryDownloader`) can wedge for the node's lifetime on a PeerDAS (Fulu) chain. It walks backwards from head recovering historical blobs; for Fulu blocks it recovers blobs from PeerDAS data columns, but no peer serves columns older than the custody-retention window, so `DownloadColumnsAndRecoverBlobs` (no deadline) blocked forever, and the loop advanced `currentSlot` only on an empty batch. `downloadOnce` therefore parked for the node lifetime holding a single `indiciesDB` read tx — observed on a live Gnosis archive node as a multi-hour "long living resources" MDBX reader that blocked free-page reclamation and bloated the caplin DB.

## Changes
- `collectIncompleteBlocks` opens and releases the index read tx per batch, before any network I/O, so a stalled download can no longer pin an MDBX read snapshot.
- Each Fulu column recovery is bounded with `context.WithTimeout`.
- The loop always advances `currentSlot` (guarded against uint64 underflow at the target floor), so an uncompletable batch is retried on a later pass instead of rebuilding at the same slot forever.
- The best-effort historical backfill no longer bans peers on a verification miss — it should not evict peers from the shared live-sync pool for a historical hiccup.

In non-archive mode `targetSlot` tracks the head, so a retention-boundary blob that transiently fails on its last in-window pass may be skipped; archive mode retries from a fixed target and is unaffected. Affects any caplin archive-blobs node once its chain is past Fulu.