### PR TITLE
execution/commitment: collect ModeDirect touches in memory, sort without etl round-trip

### DIFF
--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -1411,6 +1411,13 @@ type Updates struct {
 	// parallel holds the prefix trie of touched hashed keys; nil outside ModeParallel.
 	parallel *parallelUpdate
 
+	// direct accumulates ModeDirect touches in insertion order; once directBytes
+	// crosses directMemLimit the entries are replayed into an etl collector and
+	// collection continues there (etl != nil marks the spilled state).
+	direct         []KeyUpdate
+	directBytes    int
+	directMemLimit int
+
 	// streaming (ModeParallel only) forwards every touched key to streamer.
 	streaming bool
 	streamer  streamingSink
@@ -1505,11 +1512,11 @@ func NewUpdates(m Mode, tmpdir string, hasher keyHasher) *Updates {
 		tmpdir:         tmpdir,
 		mode:           m,
 		addrCacheReuse: hasherReusesAddrPrefix(hasher),
+		directMemLimit: defaultDirectMemLimit,
 	}
 	switch t.mode {
 	case ModeDirect:
 		t.keys = make(map[string]struct{})
-		t.initCollector()
 	case ModeUpdate:
 		t.tree = btree.NewG(64, keyUpdateLessFn)
 		t.treeIdx = make(map[string]*KeyUpdate)
@@ -1526,7 +1533,6 @@ func (t *Updates) SetMode(m Mode) {
 	case ModeDirect:
 		if t.keys == nil {
 			t.keys = make(map[string]struct{})
-			t.initCollector()
 		}
 	case ModeUpdate:
 		if t.tree == nil {
@@ -1551,6 +1557,51 @@ func (t *Updates) initCollector() {
 	}
 	t.etl = etl.NewCollectorWithAllocator("commitment", t.tmpdir, etl.SmallSortableBuffers, log.Root().New("update-tree")).LogLvl(log.LvlDebug)
 	t.etl.SortAndFlushInBackground(true)
+}
+
+// defaultDirectMemLimit bounds the in-memory ModeDirect collection; batches
+// beyond it (shard rebuilds, extreme sync batches) spill to the etl collector.
+const defaultDirectMemLimit = 512 << 20
+
+// directEntryOverhead approximates per-entry bookkeeping (KeyUpdate header +
+// slice growth) on top of the key bytes when accounting against directMemLimit.
+const directEntryOverhead = 48
+
+// plainKeyBytes converts a stored plain key for delivery, keeping the empty
+// value non-nil the way the etl collector delivers hashed-only touches.
+func plainKeyBytes(pk string) []byte {
+	if len(pk) == 0 {
+		return []byte{}
+	}
+	return common.ToBytesZeroCopy(pk)
+}
+
+// collectDirect records one ModeDirect touch. hashedKey and plainKey must be
+// immutable: both are retained until HashSort consumes the batch.
+func (t *Updates) collectDirect(hashedKey []byte, plainKey string) {
+	if t.etl != nil {
+		if err := t.etl.Collect(hashedKey, plainKeyBytes(plainKey)); err != nil {
+			log.Warn("failed to collect updated key", "key", fmt.Sprintf("%x", plainKey), "err", err)
+		}
+		return
+	}
+	t.direct = append(t.direct, KeyUpdate{hashedKey: hashedKey, plainKey: plainKey})
+	t.directBytes += len(hashedKey) + len(plainKey) + directEntryOverhead
+	if t.directBytes >= t.directMemLimit {
+		t.spillDirect()
+	}
+}
+
+// spillDirect replays the in-memory entries into a fresh collector in insertion
+// order, preserving the stable-sort tiebreak for duplicate hashed keys.
+func (t *Updates) spillDirect() {
+	t.initCollector()
+	for i := range t.direct {
+		if err := t.etl.Collect(t.direct[i].hashedKey, plainKeyBytes(t.direct[i].plainKey)); err != nil {
+			log.Warn("failed to collect updated key", "key", fmt.Sprintf("%x", t.direct[i].plainKey), "err", err)
+		}
+	}
+	t.direct, t.directBytes = nil, 0
 }
 
 func (t *Updates) Mode() Mode { return t.mode }
@@ -1607,13 +1658,7 @@ func (t *Updates) TouchPlainKey(key string, val []byte, fn func(c *KeyUpdate, va
 		}
 	case ModeDirect:
 		if _, ok := t.keys[key]; !ok {
-			keyBytes := common.ToBytesZeroCopy(key)
-			hashedKey := t.hashKey(keyBytes)
-
-			err := t.etl.Collect(hashedKey, keyBytes)
-			if err != nil {
-				log.Warn("failed to collect updated key", "key", key, "err", err)
-			}
+			t.collectDirect(t.hashKey(common.ToBytesZeroCopy(key)), key)
 			t.keys[key] = struct{}{}
 		}
 	case ModeParallel:
@@ -1679,13 +1724,7 @@ func (t *Updates) TouchPlainKeyDirect(key string, update *Update) {
 		}
 	case ModeDirect:
 		if _, ok := t.keys[key]; !ok {
-			keyBytes := common.ToBytesZeroCopy(key)
-			hashedKey := t.hashKey(keyBytes)
-
-			err := t.etl.Collect(hashedKey, keyBytes)
-			if err != nil {
-				log.Warn("failed to collect updated key", "key", key, "err", err)
-			}
+			t.collectDirect(t.hashKey(common.ToBytesZeroCopy(key)), key)
 			t.keys[key] = struct{}{}
 		}
 	case ModeParallel:
@@ -1713,14 +1752,10 @@ func (t *Updates) TouchHashedKey(hashedKey []byte) {
 		if len(hashedKey) == 0 {
 			return
 		}
-		// string(hashedKey) copies the bytes, so dedupKey is safe even if the caller reuses the slice.
-		// No extra copy needed before etl.Collect: see Collector.Collect — it copies k and v internally.
+		// string(hashedKey) copies the bytes, so the retained key is safe even if the caller reuses the slice.
 		dedupKey := string(hashedKey)
 		if _, ok := t.keys[dedupKey]; !ok {
-			err := t.etl.Collect(hashedKey, []byte{})
-			if err != nil {
-				log.Warn("failed to collect hashed key", "hashedKey", fmt.Sprintf("%x", hashedKey), "err", err)
-			}
+			t.collectDirect(common.ToBytesZeroCopy(dedupKey), "")
 			t.keys[dedupKey] = struct{}{}
 		}
 	case ModeParallel:
@@ -1805,7 +1840,9 @@ func (t *Updates) Close() {
 	}
 	if t.etl != nil {
 		t.etl.Close()
+		t.etl = nil
 	}
+	t.direct, t.directBytes = nil, 0
 	if t.parallel != nil {
 		t.parallel.Close()
 		t.parallel = nil
@@ -1813,6 +1850,51 @@ func (t *Updates) Close() {
 }
 
 const hashSortBatchSize = 10_000
+
+// hashSortDirectInMem consumes the in-memory ModeDirect collection: a stable
+// sort by hashedKey (preserving touch order for duplicate hashed keys, like the
+// etl collector does), then warmup + fn per batch. Entry memory is stable for
+// the whole call, so no arena ring or WaitBufferFree gating is needed; gen and
+// curArena are deliberately left untouched for the arena-based paths.
+func (t *Updates) hashSortDirectInMem(ctx context.Context, warmuper *Warmuper, fn func(hk, pk []byte, update *Update) error) error {
+	slices.SortStableFunc(t.direct, func(a, b KeyUpdate) int {
+		return bytes.Compare(a.hashedKey, b.hashedKey)
+	})
+
+	var prevKey []byte
+	for start := 0; start < len(t.direct); start += hashSortBatchSize {
+		batch := t.direct[start:min(start+hashSortBatchSize, len(t.direct))]
+		if warmuper != nil {
+			for i := range batch {
+				hk := batch[i].hashedKey
+				startDepth := 0
+				minLen := min(len(prevKey), len(hk))
+				for startDepth < minLen && prevKey[startDepth] == hk[startDepth] {
+					startDepth++
+				}
+				warmuper.WarmKey(hk, startDepth, t.gen)
+				prevKey = hk
+			}
+		}
+		for i := range batch {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			if err := fn(batch[i].hashedKey, plainKeyBytes(batch[i].plainKey), nil); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Zero consumed entries so retained hashedKey slices don't outlive the batch
+	// past the truncation (in-flight warmup items hold their own references).
+	clear(t.direct)
+	t.direct = t.direct[:0]
+	t.directBytes = 0
+	return nil
+}
 
 // HashSort sorts and applies fn to each key-value pair in the order of hashed keys.
 // Keys are processed in batches of 10k to control memory usage.
@@ -1824,6 +1906,9 @@ func (t *Updates) HashSort(ctx context.Context, warmuper *Warmuper, fn func(hk, 
 	switch t.mode {
 	case ModeDirect:
 		clear(t.keys)
+		if t.etl == nil {
+			return t.hashSortDirectInMem(ctx, warmuper, fn)
+		}
 
 		t.batchSlab = t.batchSlab[:0]
 		if warmuper != nil {
@@ -1898,7 +1983,8 @@ func (t *Updates) HashSort(ctx context.Context, warmuper *Warmuper, fn func(hk, 
 			}
 		}
 
-		t.initCollector()
+		t.etl.Close()
+		t.etl = nil
 
 	case ModeUpdate:
 		t.batchSlab = t.batchSlab[:0]
@@ -1996,7 +2082,13 @@ func (t *Updates) Reset() {
 		} else {
 			clear(t.keys)
 		}
-		t.initCollector()
+		if t.etl != nil {
+			t.etl.Close()
+			t.etl = nil
+		}
+		clear(t.direct)
+		t.direct = t.direct[:0]
+		t.directBytes = 0
 	case ModeUpdate:
 		t.tree.Clear(true)
 		clear(t.treeIdx)

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -480,71 +480,51 @@ func ApplyDeferredBranchUpdates(
 		return written, nil
 	}
 
-	// Pipeline: workers encode in parallel, results sent to channel, main goroutine writes sequentially.
-	type result struct {
-		upd *DeferredBranchUpdate
-		err error
-	}
-	// Size channels to actual batch length, not the 50K max.
-	resultCh := make(chan result, len(deferred))
-	workCh := make(chan *DeferredBranchUpdate, len(deferred))
-
-	// Start workers with pooled encoders/mergers.
+	// Workers encode disjoint index ranges in place; per-item channel handoff costs more
+	// than the encoding itself, so the write pass below stays sequential over the slice.
+	chunk := (len(deferred) + numWorkers - 1) / numWorkers
+	errs := make([]error, numWorkers)
 	var wg sync.WaitGroup
-	for i := 0; i < numWorkers; i++ {
+	for w := 0; w < numWorkers; w++ {
+		lo := w * chunk
+		hi := min(lo+chunk, len(deferred))
+		if lo >= hi {
+			break
+		}
 		wg.Add(1)
-		go func() {
+		go func(w, lo, hi int) {
 			defer wg.Done()
 			encoder := workerEncoderPool.Get().(*BranchEncoder)
 			merger := workerMergerPool.Get().(*BranchMerger)
 			defer workerEncoderPool.Put(encoder)
 			defer workerMergerPool.Put(merger)
-
-			for upd := range workCh {
-				err := encodeDeferredUpdate(upd, encoder, merger)
-				resultCh <- result{upd: upd, err: err}
+			for i := lo; i < hi; i++ {
+				if err := encodeDeferredUpdate(deferred[i], encoder, merger); err != nil {
+					errs[w] = err
+					return
+				}
 			}
-		}()
+		}(w, lo, hi)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return 0, err
+		}
 	}
 
-	// Close resultCh when all workers are done
-	go func() {
-		wg.Wait()
-		close(resultCh)
-	}()
-
-	// Send work in background
-	go func() {
-		for _, upd := range deferred {
-			workCh <- upd
-		}
-		close(workCh)
-	}()
-
-	// Process results as they come in - write to storage immediately
-	var firstErr error
 	var written int
-	for res := range resultCh {
-		if res.err != nil {
-			if firstErr == nil {
-				firstErr = res.err
-			}
-			continue
-		}
-		if res.upd.encoded == nil {
+	for _, upd := range deferred {
+		if upd.encoded == nil {
 			continue // skip unchanged
 		}
-		if firstErr != nil {
-			continue // drain channel but don't write after error
-		}
-		if err := putBranch(res.upd.prefix, res.upd.encoded, res.upd.prev); err != nil {
-			firstErr = err
-			continue
+		if err := putBranch(upd.prefix, upd.encoded, upd.prev); err != nil {
+			return written, err
 		}
 		written++
 	}
 	mxTrieBranchesUpdated.AddInt(written)
-	return written, firstErr
+	return written, nil
 }
 
 func (be *BranchEncoder) setMetrics(metrics *Metrics) {

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -235,17 +235,13 @@ func cellEncodeDataFromCell(c *cell) cellEncodeData {
 // DeferredBranchUpdate holds the data needed to perform a branch update later.
 // This allows collecting updates during the fold phase and running computeCellHash + EncodeBranch in parallel.
 type DeferredBranchUpdate struct {
-	prefix   []byte
-	bitmap   uint16
-	touchMap uint16
-	afterMap uint16
-
-	// Cells needed for EncodeBranch - only the fields required for encoding
-	cells [16]cellEncodeData
-
+	prefix []byte
+	// Branch encoding produced at collect time, before merging with prev; kept
+	// separate so a later apply can re-merge against a different predecessor.
+	raw BranchData
 	// Previous data from ctx.Branch (for merging)
 	prev []byte
-	// Result after encoding (filled by parallel workers)
+	// Result after merging (filled during apply)
 	encoded BranchData
 }
 
@@ -269,30 +265,16 @@ func GetDeferredUpdateMetrics() int64 {
 	return getDeferredUpdateCount.Load()
 }
 
-// getDeferredUpdate gets a DeferredBranchUpdate from the global pool
-// and copies only the fields needed for encoding.
-func getDeferredUpdate(
-	prefix []byte,
-	bitmap, touchMap, afterMap uint16,
-	cells *[16]cellEncodeData,
-	prev []byte,
-) *DeferredBranchUpdate {
+// getDeferredUpdate gets a DeferredBranchUpdate from the global pool and copies the
+// prefix, the collect-time raw encoding, and the predecessor. The copies transfer to
+// whoever the apply hands them to (putBranch retains prefix and data), so pooled
+// objects never keep their backing arrays.
+func getDeferredUpdate(prefix []byte, raw, prev []byte) *DeferredBranchUpdate {
 	getDeferredUpdateCount.Add(1)
 	upd := deferredUpdatePool.Get().(*DeferredBranchUpdate)
 
 	upd.prefix = common.Copy(prefix)
-	upd.bitmap = bitmap
-	upd.touchMap = touchMap
-	upd.afterMap = afterMap
-
-	// Direct struct copy for each cell in bitmap
-	for bitset := bitmap; bitset != 0; {
-		bit := bitset & -bitset
-		nibble := bits.TrailingZeros16(bit)
-		upd.cells[nibble] = cells[nibble]
-		bitset ^= bit
-	}
-
+	upd.raw = common.Copy(raw)
 	upd.prev = common.Copy(prev)
 	upd.encoded = nil
 
@@ -304,6 +286,7 @@ func getDeferredUpdate(
 func putDeferredUpdate(upd *DeferredBranchUpdate) {
 	if upd != nil {
 		upd.prefix = nil
+		upd.raw = nil
 		upd.prev = nil
 		upd.encoded = nil
 		deferredUpdatePool.Put(upd)
@@ -396,28 +379,20 @@ func (be *BranchEncoder) ClearDeferred() {
 
 // encodeDeferredUpdate encodes a branch update using the provided encoder and merger.
 // Cell hashes are already computed during fold() before cells were copied.
-func encodeDeferredUpdate(
-	upd *DeferredBranchUpdate,
-	encoder *BranchEncoder,
-	merger *BranchMerger,
-) error {
-	update, err := encoder.EncodeBranch(upd.bitmap, upd.touchMap, upd.afterMap, &upd.cells)
-	if err != nil {
-		return err
-	}
-
+func mergeDeferredUpdate(upd *DeferredBranchUpdate, merger *BranchMerger) error {
 	if len(upd.prev) > 0 {
-		if bytes.Equal(upd.prev, update) {
+		if bytes.Equal(upd.prev, upd.raw) {
 			upd.encoded = nil // skip unchanged
 			return nil
 		}
-		update, err = merger.Merge(upd.prev, update)
+		merged, err := merger.Merge(upd.prev, upd.raw)
 		if err != nil {
 			return err
 		}
+		upd.encoded = common.Copy(merged)
+		return nil
 	}
-
-	upd.encoded = common.Copy(update)
+	upd.encoded = upd.raw
 	return nil
 }
 
@@ -436,11 +411,8 @@ func (be *BranchEncoder) ApplyDeferredUpdates(
 	return nil
 }
 
-// Pools for worker encoders/mergers to avoid per-call allocations.
-var (
-	workerEncoderPool = sync.Pool{New: func() any { return NewBranchEncoder(1024) }}
-	workerMergerPool  = sync.Pool{New: func() any { return NewHexBranchMerger(512) }}
-)
+// Pool for worker mergers to avoid per-call allocations.
+var workerMergerPool = sync.Pool{New: func() any { return NewHexBranchMerger(512) }}
 
 // ApplyDeferredBranchUpdates encodes deferred branch updates concurrently and writes them.
 // Returns the number of updates successfully written.
@@ -456,16 +428,14 @@ func ApplyDeferredBranchUpdates(
 		numWorkers = 1
 	}
 
-	// Sequential fast path: avoids goroutine and channel overhead for small batches.
+	// Sequential fast path: avoids goroutine overhead for small batches.
 	if numWorkers == 1 || len(deferred) <= numWorkers {
-		encoder := workerEncoderPool.Get().(*BranchEncoder)
 		merger := workerMergerPool.Get().(*BranchMerger)
-		defer workerEncoderPool.Put(encoder)
 		defer workerMergerPool.Put(merger)
 
 		var written int
 		for _, upd := range deferred {
-			if err := encodeDeferredUpdate(upd, encoder, merger); err != nil {
+			if err := mergeDeferredUpdate(upd, merger); err != nil {
 				return written, err
 			}
 			if upd.encoded == nil {
@@ -480,8 +450,8 @@ func ApplyDeferredBranchUpdates(
 		return written, nil
 	}
 
-	// Workers encode disjoint index ranges in place; per-item channel handoff costs more
-	// than the encoding itself, so the write pass below stays sequential over the slice.
+	// Workers merge disjoint index ranges in place; per-item channel handoff costs more
+	// than the merging itself, so the write pass below stays sequential over the slice.
 	chunk := (len(deferred) + numWorkers - 1) / numWorkers
 	errs := make([]error, numWorkers)
 	var wg sync.WaitGroup
@@ -494,12 +464,10 @@ func ApplyDeferredBranchUpdates(
 		wg.Add(1)
 		go func(w, lo, hi int) {
 			defer wg.Done()
-			encoder := workerEncoderPool.Get().(*BranchEncoder)
 			merger := workerMergerPool.Get().(*BranchMerger)
-			defer workerEncoderPool.Put(encoder)
 			defer workerMergerPool.Put(merger)
 			for i := lo; i < hi; i++ {
-				if err := encodeDeferredUpdate(deferred[i], encoder, merger); err != nil {
+				if err := mergeDeferredUpdate(deferred[i], merger); err != nil {
 					errs[w] = err
 					return
 				}
@@ -624,9 +592,13 @@ func (be *BranchEncoder) CollectDeferredUpdate(
 	// Track this prefix as pending
 	be.pendingPrefixes.Set(prefix, struct{}{})
 
-	// Get a pooled DeferredBranchUpdate and copy all fields
-	upd := getDeferredUpdate(prefix, bitmap, touchMap, afterMap, cells, prev)
-	be.deferred = append(be.deferred, upd)
+	// Encoding is cheap and runs on the fold worker; only the merge with prev is left
+	// for apply time, when a duplicate prefix may substitute a newer predecessor.
+	raw, err := be.EncodeBranch(bitmap, touchMap, afterMap, cells)
+	if err != nil {
+		return err
+	}
+	be.deferred = append(be.deferred, getDeferredUpdate(prefix, raw, prev))
 	return nil
 }
 

--- a/execution/commitment/commitment_bench_test.go
+++ b/execution/commitment/commitment_bench_test.go
@@ -291,11 +291,17 @@ func BenchmarkGetDeferredUpdate(b *testing.B) {
 	prefix := []byte{0x01, 0x02, 0x03}
 	prev := []byte{0x04, 0x05, 0x06}
 
+	enc := NewBranchEncoder(1024)
+	raw, err := enc.EncodeBranch(bitmap, touchMap, afterMap, &cells)
+	if err != nil {
+		b.Fatal(err)
+	}
+
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for b.Loop() {
-		upd := getDeferredUpdate(prefix, bitmap, touchMap, afterMap, &cells, prev)
+		upd := getDeferredUpdate(prefix, raw, prev)
 		putDeferredUpdate(upd)
 	}
 }
@@ -324,11 +330,17 @@ func BenchmarkGetDeferredUpdate_FewCells(b *testing.B) {
 	prefix := []byte{0x01, 0x02, 0x03}
 	prev := []byte{0x04, 0x05, 0x06}
 
+	enc := NewBranchEncoder(1024)
+	raw, err := enc.EncodeBranch(bitmap, touchMap, afterMap, &cells)
+	if err != nil {
+		b.Fatal(err)
+	}
+
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	for b.Loop() {
-		upd := getDeferredUpdate(prefix, bitmap, touchMap, afterMap, &cells, prev)
+		upd := getDeferredUpdate(prefix, raw, prev)
 		putDeferredUpdate(upd)
 	}
 }

--- a/execution/commitment/commitment_test.go
+++ b/execution/commitment/commitment_test.go
@@ -131,6 +131,7 @@ func TestHashSort_WarmupArenaNoRace(t *testing.T) {
 
 	forEachMode(t, func(t *testing.T, mode Mode) {
 		ut := NewUpdates(mode, t.TempDir(), keyHasherNoop)
+		forceDirectSpill(ut) // these tests pin the arena/etl path
 		for _, k := range genNibbleKeys(numKeys, keyLen) {
 			ut.TouchPlainKey(string(k), []byte("v"), ut.TouchStorage)
 		}
@@ -162,6 +163,7 @@ func TestHashSort_NilWarmuper(t *testing.T) {
 
 	forEachMode(t, func(t *testing.T, mode Mode) {
 		ut := NewUpdates(mode, t.TempDir(), keyHasherNoop)
+		forceDirectSpill(ut) // these tests pin the arena/etl path
 		for _, k := range genNibbleKeys(numKeys, keyLen) {
 			ut.TouchPlainKey(string(k), []byte("v"), ut.TouchStorage)
 		}
@@ -188,6 +190,7 @@ func TestHashSort_WarmupLap(t *testing.T) {
 
 	forEachMode(t, func(t *testing.T, mode Mode) {
 		ut := NewUpdates(mode, t.TempDir(), keyHasherNoop)
+		forceDirectSpill(ut) // these tests pin the arena/etl path
 		for _, k := range genNibbleKeys(numKeys, keyLen) {
 			ut.TouchPlainKey(string(k), []byte("v"), ut.TouchStorage)
 		}
@@ -235,6 +238,7 @@ func TestHashSort_WaitBufferFreeErrorKeepsArenaInvariant(t *testing.T) {
 
 	forEachMode(t, func(t *testing.T, mode Mode) {
 		ut := NewUpdates(mode, t.TempDir(), keyHasherNoop)
+		forceDirectSpill(ut) // these tests pin the arena/etl path
 		for _, k := range genNibbleKeys(numKeys, keyLen) {
 			ut.TouchPlainKey(string(k), []byte("v"), ut.TouchStorage)
 		}

--- a/execution/commitment/deepfold_subset_regression_test.go
+++ b/execution/commitment/deepfold_subset_regression_test.go
@@ -17,9 +17,12 @@
 package commitment
 
 import (
+	"context"
 	"encoding/hex"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common/length"
 )
@@ -106,4 +109,56 @@ func TestDeepFold_PreExistingWhale_SingleNibbleOnDisk(t *testing.T) {
 	k1 = append(append([][]byte{}, fk...), k1...)
 	u1 = append(append([]Update{}, fu...), u1...)
 	requireAllEnginesParity(t, k1, u1, k2, u2, 4)
+}
+
+// A FRESH whale — its account absent from the pre-state trie — provably has nothing on
+// disk beneath its storage prefix, so the deep fold seeds an empty base and folds the
+// slots concurrently instead of demoting to serial streaming.
+func TestDeepFold_FreshWhaleFoldsParallel(t *testing.T) {
+	k1, u1, _, _ := buildSubsetTouchedWhale(20260707, nibs(3, 7), nil, 700, 0)
+	fk, fu := buildMixedCorpus(555, 200)
+	keys := append(append([][]byte{}, fk...), k1...)
+	upds := append(append([]Update{}, fu...), u1...)
+
+	seqRoot, _ := engineRoot(t, modeSeq, 0, keys, upds)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+	require.NoError(t, ms.applyPlainUpdates(keys, upds))
+	sc := newStreamCommitter(t, ms, 4, false)
+	defer sc.Release()
+	touchAll(sc, keys)
+	got, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, seqRoot, got, "fresh-whale concurrent fold diverged from sequential")
+	require.Positive(t, sc.DeepLocalFolds(), "a fresh whale must take the concurrent deep fold, not the serial demotion")
+
+	parRoot, _ := engineRoot(t, modeParallel, 4, keys, upds)
+	require.Equal(t, seqRoot, parRoot)
+}
+
+// The demotion gate stays for accounts present in the pre-state without a branch record
+// at their prefix (single embedded slot): the influx still streams serially.
+func TestDeepFold_ExistingWhaleStillDemotes(t *testing.T) {
+	k1, u1, k2, u2 := buildSubsetTouchedWhale(20260708, nibs(0), nibs(3, 7), 1, 700)
+	fk, fu := buildMixedCorpus(556, 200)
+	k1 = append(append([][]byte{}, fk...), k1...)
+	u1 = append(append([]Update{}, fu...), u1...)
+
+	seqRoot, _ := incrementalRoot(t, modeSeq, 0, k1, u1, k2, u2)
+
+	ms := NewMockState(t)
+	ms.SetConcurrentCommitment(true)
+	sc := newStreamCommitter(t, ms, 4, false)
+	defer sc.Release()
+	require.NoError(t, ms.applyPlainUpdates(k1, u1))
+	touchAll(sc, k1)
+	_, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, ms.applyPlainUpdates(k2, u2))
+	touchAll(sc, k2)
+	got, err := sc.Process(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, seqRoot, got)
+	require.Zero(t, sc.DeepLocalFolds(), "an account present in the pre-state must keep the serial demotion")
 }

--- a/execution/commitment/hashsort_direct_test.go
+++ b/execution/commitment/hashsort_direct_test.go
@@ -1,0 +1,339 @@
+package commitment
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"math/rand"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type sortedPair struct {
+	hk []byte
+	pk []byte
+}
+
+func collectHashSortPairs(t *testing.T, ut *Updates) []sortedPair {
+	t.Helper()
+	var got []sortedPair
+	err := ut.HashSort(context.Background(), nil, func(hk, pk []byte, upd *Update) error {
+		require.Nil(t, upd)
+		got = append(got, sortedPair{hk: slices.Clone(hk), pk: slices.Clone(pk)})
+		return nil
+	})
+	require.NoError(t, err)
+	return got
+}
+
+// forEachDirectPath runs fn once on the in-memory path and once with collection
+// forced through the etl collector, so both ModeDirect backends stay pinned.
+func forEachDirectPath(t *testing.T, fn func(t *testing.T, newUpdates func() *Updates)) {
+	t.Helper()
+	t.Run("in-memory", func(t *testing.T) {
+		fn(t, func() *Updates { return NewUpdates(ModeDirect, t.TempDir(), KeyToHexNibbleHash) })
+	})
+	t.Run("etl", func(t *testing.T) {
+		fn(t, func() *Updates {
+			ut := NewUpdates(ModeDirect, t.TempDir(), KeyToHexNibbleHash)
+			forceDirectSpill(ut)
+			return ut
+		})
+	})
+}
+
+// TestHashSortModeDirect_DuplicateHashedKey pins that a TouchHashedKey path equal to
+// hashKey(plainKey) of a touched plain key yields TWO deliveries under the same hashed
+// key, ordered by touch order (the witness flows depend on seeing the plainKey-bearing
+// one; see eth_call getWitness / debug_executionWitness sibling paths).
+func TestHashSortModeDirect_DuplicateHashedKey(t *testing.T) {
+	t.Parallel()
+
+	addr := []byte("\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14")
+	hashed := KeyToHexNibbleHash(addr)
+
+	forEachDirectPath(t, func(t *testing.T, newUpdates func() *Updates) {
+		t.Run("plain first", func(t *testing.T) {
+			ut := newUpdates()
+			ut.TouchPlainKey(string(addr), []byte("v"), ut.TouchStorage)
+			ut.TouchHashedKey(hashed)
+			require.EqualValues(t, 2, ut.Size())
+
+			got := collectHashSortPairs(t, ut)
+			require.Len(t, got, 2)
+			require.Equal(t, hashed, got[0].hk)
+			require.Equal(t, hashed, got[1].hk)
+			require.Equal(t, addr, got[0].pk)
+			require.Empty(t, got[1].pk)
+		})
+
+		t.Run("hashed first", func(t *testing.T) {
+			ut := newUpdates()
+			ut.TouchHashedKey(hashed)
+			ut.TouchPlainKey(string(addr), []byte("v"), ut.TouchStorage)
+
+			got := collectHashSortPairs(t, ut)
+			require.Len(t, got, 2)
+			require.Empty(t, got[0].pk)
+			require.Equal(t, addr, got[1].pk)
+		})
+	})
+}
+
+// TestHashSortModeDirect_MixedLengthHashedKeys pins bytewise ordering across
+// variable-length TouchHashedKey paths (1..128 nibbles, witness sibling paths)
+// interleaved with full-length hashed plain keys: a prefix sorts before its extensions.
+func TestHashSortModeDirect_MixedLengthHashedKeys(t *testing.T) {
+	t.Parallel()
+
+	forEachDirectPath(t, func(t *testing.T, newUpdates func() *Updates) {
+		ut := newUpdates()
+
+		addrs := make([][]byte, 8)
+		for i := range addrs {
+			a := make([]byte, 20)
+			a[0] = byte(i * 0x11)
+			a[19] = byte(i)
+			addrs[i] = a
+			ut.TouchPlainKey(string(a), []byte("v"), ut.TouchStorage)
+		}
+		prefixes := [][]byte{
+			KeyToHexNibbleHash(addrs[2])[:1],
+			KeyToHexNibbleHash(addrs[2])[:7],
+			KeyToHexNibbleHash(addrs[5])[:3],
+		}
+		for _, p := range prefixes {
+			ut.TouchHashedKey(p)
+		}
+
+		got := collectHashSortPairs(t, ut)
+		require.Len(t, got, len(addrs)+len(prefixes))
+		require.True(t, slices.IsSortedFunc(got, func(a, b sortedPair) int {
+			return bytes.Compare(a.hk, b.hk)
+		}), "delivery must be in ascending hashedKey byte order")
+		for _, p := range prefixes {
+			idx := slices.IndexFunc(got, func(s sortedPair) bool { return bytes.Equal(s.hk, p) })
+			require.GreaterOrEqual(t, idx, 0)
+			require.Empty(t, got[idx].pk)
+			if idx+1 < len(got) {
+				require.True(t, bytes.HasPrefix(got[idx+1].hk, p) || bytes.Compare(got[idx+1].hk, p) > 0)
+			}
+		}
+	})
+}
+
+// TestHashSortModeDirect_MultiBatchOrder pins sorted delivery and exact key count
+// across multiple 10k batches with random keys, including duplicated hashedKeys.
+func TestHashSortModeDirect_MultiBatchOrder(t *testing.T) {
+	t.Parallel()
+
+	forEachDirectPath(t, func(t *testing.T, newUpdates func() *Updates) {
+		const numKeys = 25_000
+		rnd := rand.New(rand.NewSource(42))
+		ut := newUpdates()
+
+		addrs := make([][]byte, numKeys)
+		for i := range addrs {
+			a := make([]byte, 20)
+			binary.BigEndian.PutUint64(a, rnd.Uint64())
+			binary.BigEndian.PutUint64(a[8:], uint64(i))
+			addrs[i] = a
+			ut.TouchPlainKey(string(a), []byte("v"), ut.TouchStorage)
+		}
+		// Duplicate a handful of hashedKeys via the hashed-touch path.
+		for i := 0; i < 5; i++ {
+			ut.TouchHashedKey(KeyToHexNibbleHash(addrs[i*1000]))
+		}
+
+		got := collectHashSortPairs(t, ut)
+		require.Len(t, got, numKeys+5)
+		require.True(t, slices.IsSortedFunc(got, func(a, b sortedPair) int {
+			return bytes.Compare(a.hk, b.hk)
+		}))
+		require.EqualValues(t, 0, ut.Size(), "HashSort consumes the batch")
+
+		// Duplicated hashedKeys: plain-touched delivery precedes hashed-touched (touch order).
+		for i := 0; i < 5; i++ {
+			h := KeyToHexNibbleHash(addrs[i*1000])
+			idx := slices.IndexFunc(got, func(s sortedPair) bool { return bytes.Equal(s.hk, h) })
+			require.GreaterOrEqual(t, idx, 0)
+			require.Equal(t, addrs[i*1000], got[idx].pk)
+			require.Empty(t, got[idx+1].pk)
+			require.Equal(t, h, got[idx+1].hk)
+		}
+	})
+}
+
+// touchRandomCorpus applies an identical touch sequence (plain keys, storage keys,
+// and hashed-only sibling paths, with hashed duplicates of some plain keys) to ut.
+func touchRandomCorpus(ut *Updates, numKeys int) {
+	rnd := rand.New(rand.NewSource(7))
+	for i := 0; i < numKeys; i++ {
+		a := make([]byte, 20)
+		binary.BigEndian.PutUint64(a, rnd.Uint64())
+		binary.BigEndian.PutUint64(a[8:], uint64(i))
+		switch i % 3 {
+		case 0:
+			ut.TouchPlainKey(string(a), []byte("v"), ut.TouchStorage)
+		case 1:
+			sk := append(slices.Clone(a), make([]byte, 32)...)
+			binary.BigEndian.PutUint64(sk[20:], rnd.Uint64())
+			ut.TouchPlainKey(string(sk), []byte("v"), ut.TouchStorage)
+		case 2:
+			ut.TouchPlainKey(string(a), []byte("v"), ut.TouchStorage)
+			h := KeyToHexNibbleHash(a)
+			if i%9 == 2 {
+				ut.TouchHashedKey(h) // duplicate of the plain touch
+			} else {
+				ut.TouchHashedKey(h[:1+i%63]) // sibling-path prefix
+			}
+		}
+	}
+}
+
+// TestHashSortModeDirect_PathParity drives the identical touch sequence through the
+// in-memory and etl backends and requires byte-identical delivery sequences.
+func TestHashSortModeDirect_PathParity(t *testing.T) {
+	t.Parallel()
+
+	const numKeys = 15_000
+	inMem := NewUpdates(ModeDirect, t.TempDir(), KeyToHexNibbleHash)
+	spilled := NewUpdates(ModeDirect, t.TempDir(), KeyToHexNibbleHash)
+	forceDirectSpill(spilled)
+
+	touchRandomCorpus(inMem, numKeys)
+	touchRandomCorpus(spilled, numKeys)
+	require.Equal(t, spilled.Size(), inMem.Size())
+
+	gotInMem := collectHashSortPairs(t, inMem)
+	gotSpilled := collectHashSortPairs(t, spilled)
+	require.Equal(t, len(gotSpilled), len(gotInMem))
+	for i := range gotSpilled {
+		require.Equal(t, gotSpilled[i].hk, gotInMem[i].hk, "hashedKey diverges at %d", i)
+		require.Equal(t, gotSpilled[i].pk, gotInMem[i].pk, "plainKey diverges at %d", i)
+	}
+}
+
+// TestHashSortInMem_SpillMidCollection crosses a tiny directMemLimit mid-collection so
+// early touches are replayed into the collector and later ones collect there directly;
+// delivery must match the pure in-memory backend.
+func TestHashSortInMem_SpillMidCollection(t *testing.T) {
+	t.Parallel()
+
+	const numKeys = 3_000
+	pure := NewUpdates(ModeDirect, t.TempDir(), KeyToHexNibbleHash)
+	crossing := NewUpdates(ModeDirect, t.TempDir(), KeyToHexNibbleHash)
+	crossing.directMemLimit = 64 << 10 // crossed after a few hundred keys
+
+	touchRandomCorpus(pure, numKeys)
+	touchRandomCorpus(crossing, numKeys)
+	require.Nil(t, pure.etl)
+	require.NotNil(t, crossing.etl, "limit crossing must have spilled to the collector")
+	require.Empty(t, crossing.direct)
+
+	gotPure := collectHashSortPairs(t, pure)
+	gotCrossing := collectHashSortPairs(t, crossing)
+	require.Equal(t, gotPure, gotCrossing)
+}
+
+// TestHashSortModeDirect_FnError pins that an fn error aborts HashSort on both backends
+// and that Reset recovers the Updates for a subsequent touch+HashSort cycle.
+func TestHashSortModeDirect_FnError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("fn failed")
+	forEachDirectPath(t, func(t *testing.T, newUpdates func() *Updates) {
+		ut := newUpdates()
+		touchRandomCorpus(ut, 100)
+
+		calls := 0
+		err := ut.HashSort(context.Background(), nil, func(hk, pk []byte, _ *Update) error {
+			calls++
+			if calls == 10 {
+				return sentinel
+			}
+			return nil
+		})
+		require.ErrorIs(t, err, sentinel)
+		require.Equal(t, 10, calls)
+
+		ut.Reset()
+		ut.TouchPlainKey(string(make([]byte, 20)), []byte("v"), ut.TouchStorage)
+		got := collectHashSortPairs(t, ut)
+		require.Len(t, got, 1)
+	})
+}
+
+// TestHashSortInMem_CtxCancel pins per-key context checks on the in-memory drain loop.
+func TestHashSortInMem_CtxCancel(t *testing.T) {
+	t.Parallel()
+
+	ut := NewUpdates(ModeDirect, t.TempDir(), KeyToHexNibbleHash)
+	touchRandomCorpus(ut, 100)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := ut.HashSort(ctx, nil, func(hk, pk []byte, _ *Update) error {
+		calls++
+		if calls == 5 {
+			cancel()
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 5, calls)
+}
+
+// TestHashSortInMem_WarmupNoRace runs the in-memory path against live warmup workers;
+// entry memory is stable so no reuse race must exist. -race is the signal.
+func TestHashSortInMem_WarmupNoRace(t *testing.T) {
+	t.Parallel()
+
+	const numKeys = 30_000
+	ut := NewUpdates(ModeDirect, t.TempDir(), keyHasherNoop)
+	for _, k := range genNibbleKeys(numKeys, 64) {
+		ut.TouchPlainKey(string(k), []byte("v"), ut.TouchStorage)
+	}
+	require.Nil(t, ut.etl)
+
+	ctx := context.Background()
+	warmuper := testWarmuper(ctx, slowCtxFactory(2*time.Millisecond), 4)
+	warmuper.Start()
+
+	visited := 0
+	err := ut.HashSort(ctx, warmuper, func(hk, pk []byte, _ *Update) error {
+		visited++
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, numKeys, visited)
+	require.NoError(t, warmuper.Wait())
+}
+
+// TestHashSortModeDirect_RetouchBetweenSorts pins the eth_getProof pattern: HashSort,
+// touch more keys on the same Updates, HashSort again — the second call must deliver
+// exactly the new touches.
+func TestHashSortModeDirect_RetouchBetweenSorts(t *testing.T) {
+	t.Parallel()
+
+	forEachDirectPath(t, func(t *testing.T, newUpdates func() *Updates) {
+		ut := newUpdates()
+		touchRandomCorpus(ut, 90)
+		first := collectHashSortPairs(t, ut)
+		require.NotEmpty(t, first)
+		require.EqualValues(t, 0, ut.Size())
+
+		addr := bytes.Repeat([]byte{0xab}, 20)
+		ut.TouchPlainKey(string(addr), []byte("v"), ut.TouchStorage)
+		second := collectHashSortPairs(t, ut)
+		require.Len(t, second, 1)
+		require.Equal(t, addr, second[0].pk)
+
+		third := collectHashSortPairs(t, ut)
+		require.Empty(t, third)
+	})
+}

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -167,7 +167,12 @@ type HexPatriciaHashed struct {
 	//processing metrics
 	metrics       *Metrics
 	depthsToTxNum [129]uint64 // endTxNum of file with branch data for that depth
-	hadToLoadL    map[uint64]skipStat
+
+	// lastUpdateCellWasEmpty reports whether the most recent updateCell stamped a key
+	// into an empty cell — i.e. the key is absent from the pre-state trie, so nothing
+	// can exist on disk beneath it.
+	lastUpdateCellWasEmpty bool
+	hadToLoadL             map[uint64]skipStat
 }
 
 // Clones current trie state to allow concurrent processing.
@@ -2173,6 +2178,7 @@ func (hph *HexPatriciaHashed) updateCell(plainKey, hashedKey []byte, u *Update) 
 		}
 
 		hph.deleteCell(hashedKey)
+		hph.lastUpdateCellWasEmpty = false
 		return nil
 	}
 
@@ -2193,6 +2199,7 @@ func (hph *HexPatriciaHashed) updateCell(plainKey, hashedKey []byte, u *Update) 
 			fmt.Fprintf(hph.traceW, "updateCell setting (%d, %x, depth=%d)\n", row, nibble, depth)
 		}
 	}
+	hph.lastUpdateCellWasEmpty = cell.IsEmpty()
 	if cell.hashedExtLen == 0 {
 		copy(cell.hashedExtension[:], hashedKey[depth:])
 		cell.hashedExtLen = int16(len(hashedKey)) - depth

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -140,6 +140,7 @@ type HexPatriciaHashed struct {
 	ctx           PatriciaContext
 	hashAuxBuffer [128]byte     // buffer to compute cell hash or write hash-related things
 	cellHashBuf   common.Hash   // shared scratch buffer for hashKey calls (avoids per-cell allocation)
+	leafHashBuf   [33]byte      // shared scratch for leaf hash prefixing (avoids per-leaf escape)
 	auxBuffer     *bytes.Buffer // auxiliary buffer used during branch updates encoding
 	branchEncoder *BranchEncoder
 
@@ -761,13 +762,12 @@ func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key [
 	if canEmbed {
 		buf = hph.auxBuffer.Bytes()
 	} else {
-		var hashBuf [33]byte
-		hashBuf[0] = 0x80 + length.Hash
-		if _, err := hph.keccak.Read(hashBuf[1:]); err != nil {
+		hph.leafHashBuf[0] = 0x80 + length.Hash
+		if _, err := hph.keccak.Read(hph.leafHashBuf[1:]); err != nil {
 			return nil, err
 		}
-		buf = append(buf, hashBuf[:]...)
-		hph.witness.emitLeaf(hashBuf[1:])
+		buf = append(buf, hph.leafHashBuf[:]...)
+		hph.witness.emitLeaf(hph.leafHashBuf[1:])
 	}
 	return buf, nil
 }

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -140,8 +140,8 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 			path := make([]byte, 0, 144)
 			path = append(path, byte(ni))
 			path = append(path, ch.ext...)
-			buildErr := dfsSubtreeDeep(w, ch, path, func(n *prefixNode, pth []byte) (common.Hash, error) {
-				return foldStorageRoot(gctx, p.numWorkers, p.newStorageWorker, pu, n, pth)
+			buildErr := dfsSubtreeDeep(w, ch, path, func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
+				return foldStorageRoot(gctx, p.numWorkers, p.newStorageWorker, pu, n, pth, accountFresh)
 			})
 			if buildErr != nil {
 				w.resetForReuse()

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -719,8 +719,8 @@ func (sc *StreamingCommitter) foldSplit(ctx context.Context, base *HexPatriciaHa
 	path := make([]byte, 0, 144)
 	path = append(path, ni)
 	path = append(path, child.ext...)
-	deepStorageRoot := func(n *prefixNode, pth []byte) (common.Hash, error) {
-		sr, err := foldStorageRoot(ctx, sc.numWorkers, sc.newStorageWorker, &pu, n, pth)
+	deepStorageRoot := func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
+		sr, err := foldStorageRoot(ctx, sc.numWorkers, sc.newStorageWorker, &pu, n, pth, accountFresh)
 		if err == nil {
 			sc.deepLocalFolds.Add(1)
 		}

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -833,9 +833,7 @@ func applyDeferredGuarded(ctx PatriciaContext, deferred []*DeferredBranchUpdate,
 		return err
 	}
 
-	encoder := workerEncoderPool.Get().(*BranchEncoder)
 	merger := workerMergerPool.Get().(*BranchMerger)
-	defer workerEncoderPool.Put(encoder)
 	defer workerMergerPool.Put(merger)
 
 	applied := make(map[string][]byte, len(deferred))
@@ -853,7 +851,7 @@ func applyDeferredGuarded(ctx PatriciaContext, deferred []*DeferredBranchUpdate,
 			}
 			upd.prev = common.Copy(prev)
 		}
-		if err := encodeDeferredUpdate(upd, encoder, merger); err != nil {
+		if err := mergeDeferredUpdate(upd, merger); err != nil {
 			return err
 		}
 		if upd.encoded == nil {

--- a/execution/commitment/streaming_commitment_test.go
+++ b/execution/commitment/streaming_commitment_test.go
@@ -150,7 +150,11 @@ func makeBranch(prefix []byte, afterMap uint16, touched []int, seed byte, prev [
 			cells[n].hash[b] = seed + byte(n)
 		}
 	}
-	return getDeferredUpdate(prefix, tm, tm, afterMap, &cells, prev)
+	raw, err := NewBranchEncoder(64).EncodeBranch(tm, tm, afterMap, &cells)
+	if err != nil {
+		panic(err)
+	}
+	return getDeferredUpdate(prefix, raw, prev)
 }
 
 // Settle condition is idle, not all-clean: the coalescing gate may legitimately leave a split dirty.

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -83,20 +83,22 @@ func isDeepStorageAccount(node *prefixNode, depth int) bool {
 
 // dfsSubtreeDeep walks node's subtree applying each key to w, but at a big-storage
 // account it injects storageRoot's result instead of streaming the slots.
-func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storageRoot func(node *prefixNode, path []byte) (common.Hash, error)) error {
+func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storageRoot func(node *prefixNode, path []byte, accountFresh bool) (common.Hash, error)) error {
 	if node == nil {
 		return nil
 	}
+	accountFresh := false
 	if node.plainKey != nil {
 		if err := w.followAndUpdate(path, node.plainKey, node.update); err != nil {
 			return err
 		}
+		accountFresh = w.lastUpdateCellWasEmpty
 	} else if node.bitmap == 0 {
 		return errors.New("commitment: trie leaf without a plainKey")
 	}
 
 	if isDeepStorageAccount(node, len(path)) {
-		sr, err := storageRoot(node, path)
+		sr, err := storageRoot(node, path, accountFresh)
 		if err == nil {
 			setAccountStorageRoot(w, path, sr)
 			return nil
@@ -126,7 +128,7 @@ func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storage
 }
 
 // Storage-root analogue of the account mount fold: parallelize a whale's storage by first nibble.
-func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte) (common.Hash, error) {
+func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte, accountFresh bool) (common.Hash, error) {
 	accPrefix := append([]byte(nil), path...)
 
 	base, releaseBase := newWorker()
@@ -145,7 +147,11 @@ func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*Hex
 		base.SetTraceWriter(tracePrefix(base.traceW, accTag))
 	}
 	if err := unfoldStorageBase(base, accPrefix); err != nil {
-		return common.Hash{}, fmt.Errorf("unfold storage root: %w", err)
+		// A fresh account proves nothing exists on disk beneath accPrefix, so the reset
+		// (empty) wall rows unfoldStorageBase left behind are the correct seed.
+		if !accountFresh || !errors.Is(err, errStorageBaseNotBranch) {
+			return common.Hash{}, fmt.Errorf("unfold storage root: %w", err)
+		}
 	}
 
 	var children [16]cell

--- a/execution/commitment/testutil_test.go
+++ b/execution/commitment/testutil_test.go
@@ -31,6 +31,10 @@ import (
 	"github.com/erigontech/erigon/common/length"
 )
 
+// forceDirectSpill makes ModeDirect collection spill to the etl collector from the
+// first touch, pinning the arena/etl HashSort path regardless of batch size.
+func forceDirectSpill(ut *Updates) { ut.directMemLimit = 0 }
+
 // forEachMode runs fn as a subtest once per Updates mode, named after the mode.
 func forEachMode(t *testing.T, fn func(t *testing.T, mode Mode)) {
 	t.Helper()

--- a/execution/commitment/touch_collect_bench_test.go
+++ b/execution/commitment/touch_collect_bench_test.go
@@ -1,0 +1,45 @@
+package commitment
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// BenchmarkTouchCollect_ModeDirect times the collection side alone (TouchPlainKey
+// with a pre-hashed key, keyHasherNoop) so the backend cost is not drowned by keccak.
+func BenchmarkTouchCollect_ModeDirect(b *testing.B) {
+	for _, n := range []int{5_000, 100_000, 500_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			rnd := rand.New(rand.NewSource(1))
+			keys := make([]string, n)
+			for i := range keys {
+				k := make([]byte, 128)
+				for j := 0; j < 128; j += 8 {
+					binary.BigEndian.PutUint64(k[j:], rnd.Uint64())
+				}
+				for j := range k {
+					k[j] &= 0x0f
+				}
+				keys[i] = string(k)
+			}
+			val := []byte("v")
+
+			// Long-lived Updates, reset between rounds: steady-state collection like
+			// a node reusing one SharedDomains across commitment cycles.
+			ut := NewUpdates(ModeDirect, b.TempDir(), keyHasherNoop)
+			defer ut.Close()
+
+			b.ReportAllocs()
+			for b.Loop() {
+				for _, k := range keys {
+					ut.TouchPlainKey(k, val, ut.TouchStorage)
+				}
+				b.StopTimer()
+				ut.Reset()
+				b.StartTimer()
+			}
+		})
+	}
+}


### PR DESCRIPTION
stacked on https://github.com/erigontech/erigon/pull/22265

ModeDirect collection pays an etl round-trip even for batches that never need to spill: `Collect` copies every (hashedKey, plainKey) pair into a pooled sortable buffer at touch time, and `HashSort` decodes them back through the merge heap into a reusable arena. `hashKey` already returns a fresh slice and plain keys are immutable strings, so both copies — and the arena-ring/`WaitBufferFree` discipline guarding the second one — are unnecessary while the batch is held in caller-owned memory.

## Changes
- `TouchPlainKey`/`TouchPlainKeyDirect`/`TouchHashedKey` (ModeDirect) accumulate an insertion-ordered `[]KeyUpdate` instead of collecting into etl; `HashSort` stable-sorts by hashedKey and feeds warmup + fn per batch with no arena copies. The touch-order tiebreak for duplicate hashed keys matches the etl collector's insertion-order tiebreak, which the witness flows depend on.
- Batches whose tracked bytes cross 512MiB are replayed in insertion order into a lazily created etl collector and continue on the existing spill path (shard rebuilds, extreme sync batches). The collector is no longer created eagerly, so ModeDirect buffers immediately switched to another mode stop checking out a pooled 32MB buffer.
- New pins: duplicate-hashedKey delivery (`TouchHashedKey` sibling path == `hashKey(plainKey)`, both records survive in touch order), mixed-length hashed keys, in-memory/etl path parity on identical corpora, mid-collection spill, fn error, ctx cancel, warmup `-race`, getProof retouch-between-sorts. The arena-protocol tests force the spill path they were written for.
- New `BenchmarkTouchCollect_ModeDirect` measures the collection side in isolation.

## Notes
M5 Max, MockState, median of 4-6, vs the base branch:
- `BenchmarkHashSort_ModeDirect`: n=50 2.53→0.68µs, n=5000 118→51µs, n=50000 1139→474µs; 0 B/op on all sizes
- `BenchmarkTouchCollect_ModeDirect` (steady-state): n=100000 2.91→2.55ms (B/op 410KB→76KB), n=500000 92.3→22.6ms (4.1×, spill regime; B/op ~100MB→4.2MB)
- Gate benches flat within noise (timed window is madvise/GC-stall-bound): 1MWhales ModeDirect 1262→1238ms, DeepStorageWhale Sequential 870→861ms; the in-memory stable sort is 30ms cum on the 750k whale profile

Stacked on #22265: after it merges, retarget/merge fresh base (append-only).
