### PR TITLE
cl/p2p: skip nodes that do not provide a tcp port

### DIFF
--- a/cl/p2p/p2p_discovery.go
+++ b/cl/p2p/p2p_discovery.go
@@ -11,18 +11,9 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/p2p/discover"
-	"github.com/erigontech/erigon/p2p/enr"
 )
 
 func (p *p2pManager) connectToBootnodes(ctx context.Context, discoverConfig discover.Config) error {
-	for i := range discoverConfig.Bootnodes {
-		if err := discoverConfig.Bootnodes[i].Record().Load(enr.WithEntry("tcp", new(enr.TCP))); err != nil {
-			if !enr.IsNotFound(err) {
-				log.Error("[Sentinel] Could not retrieve tcp port")
-			}
-			continue
-		}
-	}
 	multiAddresses := ConvertToMultiAddr(discoverConfig.Bootnodes)
 	addrInfos, err := peer.AddrInfosFromP2pAddrs(multiAddresses...)
 	if err != nil {

--- a/cl/p2p/utils.go
+++ b/cl/p2p/utils.go
@@ -45,6 +45,9 @@ func ConvertToAddrInfo(node *enode.Node) (*peer.AddrInfo, multiaddr.Multiaddr, e
 }
 
 func ConvertToSingleMultiAddr(node *enode.Node) (multiaddr.Multiaddr, error) {
+	if node.TCP() == 0 {
+		return nil, fmt.Errorf("node %s does not provide a tcp port", node.ID())
+	}
 	pubkey := node.Pubkey()
 	assertedKey, err := ConvertToInterfacePubkey(pubkey)
 	if err != nil {

--- a/cl/p2p/utils_test.go
+++ b/cl/p2p/utils_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/p2p/enode"
+)
+
+func TestConvertToSingleMultiAddrRejectsNodeWithoutTcpPort(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	noTcp := enode.NewV4(&key.PublicKey, net.ParseIP("192.0.2.2"), 0, 30301)
+
+	_, err = ConvertToSingleMultiAddr(noTcp)
+	require.Error(t, err)
+}
+
+func TestConvertToMultiAddrSkipsNodesWithoutTcpPort(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	withTcp := enode.NewV4(&key.PublicKey, net.ParseIP("192.0.2.1"), 30303, 30301)
+	noTcp := enode.NewV4(&key.PublicKey, net.ParseIP("192.0.2.2"), 0, 30301)
+
+	multiAddrs := ConvertToMultiAddr([]*enode.Node{withTcp, noTcp})
+
+	require.Len(t, multiAddrs, 1)
+	require.Contains(t, multiAddrs[0].String(), "/tcp/30303")
+}


### PR DESCRIPTION
Sentinel builds `/tcp/0` multiaddrs for peers whose ENR has no `tcp` entry
(discovery-only nodes such as bootnodes) and dials them — each attempt wastes
a dial slot and, for static peers, is retried every cycle. The devp2p dialer
skips such nodes (`errNoPort`); sentinel now does the equivalent:
`ConvertToSingleMultiAddr` returns an error for a node without a tcp port,
and the conversion callers already skip on error.

This also removes the bootnode tcp filter loop in `connectToBootnodes`: its
`continue` was the last statement of the loop body, so it filtered nothing,
and the conversion now performs the intended filtering.

Tests were written first and confirmed failing (a tcp-less node produced a
dialable `/ip4/…/tcp/0/p2p/…` address) before the fix.
