### PR TITLE
cmd/utils: enable discv5 by default in standalone sentry

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1376,6 +1376,7 @@ func NewP2PConfig(
 		MaxPendingPeers:   maxPendPeers,
 		NAT:               nat.Any(),
 		NoDiscovery:       nodiscover,
+		DiscoveryV5:       !nodiscover,
 		PrivateKey:        serverKey,
 		Name:              nodeName,
 		NodeDatabase:      enodeDBPath,

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -30,6 +30,9 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/node/direct"
+	"github.com/erigontech/erigon/p2p"
 )
 
 func Test_SplitTagsFlag(t *testing.T) {
@@ -279,6 +282,26 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		dbg.SetNoBackgroundMaintenance(false)
 		run("--exec.no-background-maintenance=true")
 		require.True(t, dbg.NoBackgroundMaintenance())
+	})
+}
+
+func TestNewP2PConfig_DiscoveryDefaults(t *testing.T) {
+	newCfg := func(nodiscover bool) *p2p.Config {
+		cfg, err := NewP2PConfig(nodiscover, datadir.New(t.TempDir()), "", "none", 100, 1000, "test", nil, nil, 30303, direct.ETH68, false, false)
+		require.NoError(t, err)
+		return cfg
+	}
+
+	t.Run("discovery enabled by default", func(t *testing.T) {
+		cfg := newCfg(false)
+		require.False(t, cfg.NoDiscovery)
+		require.True(t, cfg.DiscoveryV5)
+	})
+
+	t.Run("nodiscover disables discovery", func(t *testing.T) {
+		cfg := newCfg(true)
+		require.True(t, cfg.NoDiscovery)
+		require.False(t, cfg.DiscoveryV5)
 	})
 }
 


### PR DESCRIPTION
Since #18578 discovery only starts when `DiscoveryV4`/`DiscoveryV5` is
explicitly enabled, but `NewP2PConfig` (used only by the standalone
`cmd/sentry`) never sets either — so standalone sentry silently lost DHT
discovery and relied on DNS discovery and static peers only, even without
`--nodiscover`. Before #18578 it ran discv4 whenever `--nodiscover` was unset.

Enable `DiscoveryV5` in `NewP2PConfig` unless `--nodiscover` is set, matching
the embedded node default (`nodecfg.DefaultConfig.P2P` after #18640).

TDD: `TestNewP2PConfig_DiscoveryDefaults` written first, red on the
default-discovery case, green after the fix.
