### PR TITLE
db/kv/kvcache: rename SimpleCache to LatestBatchCache

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -338,7 +338,7 @@ func EmbeddedServices(ctx context.Context,
 		// Remote RPCDaemon: use coherent cache fed by StateChanges stream.
 		stateCache = kvcache.New(stateCacheCfg)
 	} else {
-		stateCache = kvcache.NewSimple()
+		stateCache = kvcache.NewLatestBatchCache()
 	}
 
 	subscribeToStateChangesLoop(ctx, stateDiffClient, stateCache)
@@ -530,7 +530,7 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, err
 		}
-		stateCache = kvcache.NewSimple()
+		stateCache = kvcache.NewLatestBatchCache()
 	}
 	// If DB can't be configured - used PrivateApiAddr as remote DB
 	if db == nil {
@@ -541,7 +541,7 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 		if cfg.StateCache.CacheSize > 0 {
 			stateCache = kvcache.New(cfg.StateCache)
 		} else {
-			stateCache = kvcache.NewSimple()
+			stateCache = kvcache.NewLatestBatchCache()
 		}
 		logger.Info("if you run RPCDaemon on same machine with Erigon add --datadir option")
 	}

--- a/db/kv/kvcache/latest_batch.go
+++ b/db/kv/kvcache/latest_batch.go
@@ -26,25 +26,28 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/remoteproto"
 )
 
-// SimpleCache is a minimal cache for in-process use. It does not track versions
-// — it simply remembers account data from the most recent OnNewBlock batch so
-// that callers (e.g. the txpool) see the correct nonce/balance even when their
-// read-only DB transaction was opened before the data was committed to the
-// database. The map is replaced on every OnNewBlock call, so memory stays
-// proportional to one batch (~400 addresses per 60 M-gas block).
-type SimpleCache struct {
+// LatestBatchCache serves the most recent announced state-change batch on top
+// of the caller's tx — freshness over snapshot-consistency, with staleness
+// bounded to one batch by FCU serialization (contrast Coherent, which keys
+// entries by state version so readers stay consistent with their own
+// snapshot). It does not track versions: the map remembers account data from
+// the latest OnNewBlock batch so that callers (e.g. the txpool) see the
+// announced nonce/balance even when their read-only DB transaction was opened
+// before that data was committed. The map is replaced on every batch, so
+// memory stays proportional to one batch (~400 addresses per 60 M-gas block).
+type LatestBatchCache struct {
 	mu       sync.RWMutex
 	accounts map[common.Address][]byte // address → latest serialised account
 }
 
-var _ Cache = (*SimpleCache)(nil)    // compile-time interface check
-var _ CacheView = (*SimpleView)(nil) // compile-time interface check
+var _ Cache = (*LatestBatchCache)(nil)    // compile-time interface check
+var _ CacheView = (*LatestBatchView)(nil) // compile-time interface check
 
-func NewSimple() *SimpleCache { return &SimpleCache{} }
-func (c *SimpleCache) View(_ context.Context, tx kv.TemporalTx) (CacheView, error) {
-	return &SimpleView{cache: c, tx: tx}, nil
+func NewLatestBatchCache() *LatestBatchCache { return &LatestBatchCache{} }
+func (c *LatestBatchCache) View(_ context.Context, tx kv.TemporalTx) (CacheView, error) {
+	return &LatestBatchView{cache: c, tx: tx}, nil
 }
-func (c *SimpleCache) OnNewBlock(sc *remoteproto.StateChangeBatch) {
+func (c *LatestBatchCache) OnNewBlock(sc *remoteproto.StateChangeBatch) {
 	if sc == nil {
 		return
 	}
@@ -70,13 +73,13 @@ func (c *SimpleCache) OnNewBlock(sc *remoteproto.StateChangeBatch) {
 		}
 	}
 }
-func (c *SimpleCache) Evict() int { return 0 }
-func (c *SimpleCache) Len() int {
+func (c *LatestBatchCache) Evict() int { return 0 }
+func (c *LatestBatchCache) Len() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return len(c.accounts)
 }
-func (c *SimpleCache) Get(k []byte, tx kv.TemporalTx, id uint64) ([]byte, error) {
+func (c *LatestBatchCache) Get(k []byte, tx kv.TemporalTx, id uint64) ([]byte, error) {
 	// Check the in-memory account cache first (populated by OnNewBlock).
 	if len(k) == 20 {
 		c.mu.RLock()
@@ -91,25 +94,27 @@ func (c *SimpleCache) Get(k []byte, tx kv.TemporalTx, id uint64) ([]byte, error)
 	v, _, err := tx.GetLatest(kv.StorageDomain, k)
 	return v, err
 }
-func (c *SimpleCache) GetCode(k []byte, tx kv.TemporalTx, id uint64) ([]byte, error) {
+func (c *LatestBatchCache) GetCode(k []byte, tx kv.TemporalTx, id uint64) ([]byte, error) {
 	v, _, err := tx.GetLatest(kv.CodeDomain, k)
 	return v, err
 }
-func (c *SimpleCache) ValidateCurrentRoot(_ context.Context, _ kv.TemporalTx) (*CacheValidationResult, error) {
+func (c *LatestBatchCache) ValidateCurrentRoot(_ context.Context, _ kv.TemporalTx) (*CacheValidationResult, error) {
 	return &CacheValidationResult{Enabled: false}, nil
 }
 
-type SimpleView struct {
-	cache *SimpleCache
+type LatestBatchView struct {
+	cache *LatestBatchCache
 	tx    kv.TemporalTx
 }
 
-func (c *SimpleView) Get(k []byte) ([]byte, error) { return c.cache.Get(k, c.tx, 0) }
-func (c *SimpleView) GetAsOf(key []byte, ts uint64) (v []byte, ok bool, err error) {
+func (c *LatestBatchView) Get(k []byte) ([]byte, error) { return c.cache.Get(k, c.tx, 0) }
+
+// The cache holds latest-state only, so historical reads always fall through.
+func (c *LatestBatchView) GetAsOf(key []byte, ts uint64) (v []byte, ok bool, err error) {
 	return nil, false, nil
 }
-func (c *SimpleView) GetCode(k []byte) ([]byte, error) { return c.cache.GetCode(k, c.tx, 0) }
-func (c *SimpleView) HasStorage(address common.Address) (bool, error) {
+func (c *LatestBatchView) GetCode(k []byte) ([]byte, error) { return c.cache.GetCode(k, c.tx, 0) }
+func (c *LatestBatchView) HasStorage(address common.Address) (bool, error) {
 	_, _, hasStorage, err := c.tx.HasPrefix(kv.StorageDomain, address[:])
 	return hasStorage, err
 }

--- a/db/kv/kvcache/latest_batch.go
+++ b/db/kv/kvcache/latest_batch.go
@@ -73,7 +73,6 @@ func (c *LatestBatchCache) OnNewBlock(sc *remoteproto.StateChangeBatch) {
 		}
 	}
 }
-func (c *LatestBatchCache) Evict() int { return 0 }
 func (c *LatestBatchCache) Len() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -592,7 +592,7 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 			ctx,
 			poolCfg,
 			mock.DB,
-			kvcache.NewSimple(),
+			kvcache.NewLatestBatchCache(),
 			sentries,
 			stateChangesClient,
 			func() {}, /* builderNotifyNewTxns */

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -723,7 +723,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 			ctx,
 			config.TxPool,
 			backend.chainDB,
-			kvcache.NewSimple(),
+			kvcache.NewLatestBatchCache(),
 			sentries,
 			backend.stateDiffClient,
 			blockBuilderNotifyNewTxns,

--- a/rpc/gasprice/bench_test.go
+++ b/rpc/gasprice/bench_test.go
@@ -93,7 +93,7 @@ func BenchmarkSuggestTipCap(b *testing.B) {
 	m := newTestBackendN(b, numBlocks)
 	defer m.Close()
 
-	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
+	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewLatestBatchCache(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
 
 	cases := []struct {
 		name        string
@@ -156,7 +156,7 @@ func BenchmarkFeeHistory(b *testing.B) {
 	m := newTestBackendN(b, numBlocks)
 	defer m.Close()
 
-	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
+	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewLatestBatchCache(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
 
 	gasCache := jsonrpc.NewGasPriceCache()
 

--- a/rpc/gasprice/feehistory_test.go
+++ b/rpc/gasprice/feehistory_test.go
@@ -79,7 +79,7 @@ func TestFeeHistory(t *testing.T) {
 			m := newTestBackend(t) //, big.NewInt(16), c.pending)
 			defer m.Close()
 
-			baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
+			baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewLatestBatchCache(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
 			tx, err := m.DB.BeginTemporalRo(m.Ctx)
 			require.NoError(t, err)
 			defer tx.Rollback()

--- a/rpc/gasprice/gasprice_test.go
+++ b/rpc/gasprice/gasprice_test.go
@@ -87,7 +87,7 @@ func TestSuggestPrice(t *testing.T) {
 	}
 
 	m := newTestBackend(t) //, big.NewInt(16), c.pending)
-	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
+	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewLatestBatchCache(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
 
 	tx, err := m.DB.BeginTemporalRo(m.Ctx)
 	require.NoError(t, err)
@@ -392,7 +392,7 @@ func TestSuggestTipCap_SparseBlocks(t *testing.T) {
 		Percentile: 60,
 		Default:    uint256.NewInt(common.GWei),
 	}
-	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
+	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewLatestBatchCache(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
 
 	dbTx, txErr := m.DB.BeginTemporalRo(m.Ctx)
 	require.NoError(t, txErr)
@@ -429,7 +429,7 @@ func TestSuggestTipCap_AllEmptyBlocks(t *testing.T) {
 		Percentile: 60,
 		Default:    uint256.NewInt(common.GWei),
 	}
-	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
+	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewLatestBatchCache(), m.BlockReader, m.Engine, nil, &jsonrpc.BaseApiConfig{Dirs: m.Dirs})
 
 	dbTx, txErr := m.DB.BeginTemporalRo(m.Ctx)
 	require.NoError(t, txErr)

--- a/txnprovider/txpool/pool_test.go
+++ b/txnprovider/txpool/pool_test.go
@@ -899,7 +899,7 @@ func TestShanghaiValidateTxn(t *testing.T) {
 			sd, err := execctx.NewSharedDomains(ctx, tx, logger)
 			asrt.NoError(err)
 			defer sd.Close()
-			cache := kvcache.NewSimple()
+			cache := kvcache.NewLatestBatchCache()
 			pool, err := New(ctx, ch, nil, coreDB, cfg, cache, chainConfig, nil, nil, func() {}, nil, nil, logger, WithFeeCalculator(nil))
 			asrt.NoError(err)
 
@@ -1016,7 +1016,7 @@ func TestSetCodeTxnValidationWithLargeAuthorizationValues(t *testing.T) {
 	var chainConfig chain.Config
 	require.NoError(t, copier.CopyWithOption(&chainConfig, testforks.Forks["Prague"], copier.Option{DeepCopy: true}))
 	chainConfig.ChainID = maxUint256
-	cache := kvcache.NewSimple()
+	cache := kvcache.NewLatestBatchCache()
 	logger := log.New()
 	pool, err := New(ctx, ch, nil, coreDB, cfg, cache, &chainConfig, nil, nil, func() {}, nil, nil, logger, WithFeeCalculator(nil))
 	require.NoError(t, err)
@@ -2134,8 +2134,8 @@ func TestStalePendingEvictionViaMineNonce(t *testing.T) {
 	coreDB := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
 	cfg := txpoolcfg.DefaultConfig
 
-	// SimpleCache — avoids coherence-version coupling.
-	pool, err := New(ctx, ch, nil, coreDB, cfg, kvcache.NewSimple(), chain.AllProtocolChanges, nil, nil, func() {}, nil, nil, logger, WithFeeCalculator(nil))
+	// LatestBatchCache — avoids coherence-version coupling.
+	pool, err := New(ctx, ch, nil, coreDB, cfg, kvcache.NewLatestBatchCache(), chain.AllProtocolChanges, nil, nil, func() {}, nil, nil, logger, WithFeeCalculator(nil))
 	req.NoError(err)
 	req.NotNil(pool)
 
@@ -2239,7 +2239,7 @@ func TestStalePendingEvictionViaMineNonce(t *testing.T) {
 // client see a receipt — and submit the next-nonce tx — before the txpool has
 // processed the dispatched StateChangeBatch. PR #20515 narrowed but did not
 // close the resulting race: AddLocalTxns can still capture a cacheView whose
-// SimpleCache lookups return the pre-block sender nonce. With NoNonceGaps
+// LatestBatchCache lookups return the pre-block sender nonce. With NoNonceGaps
 // unset, the new tx lands in queued. The only mechanism that re-evaluates a
 // queued sender's bits is `addTxnsOnNewBlock`'s sendersWithChangedState loop,
 // which depends on the sender appearing in stateChanges. If the sender's only
@@ -2247,10 +2247,10 @@ func TestStalePendingEvictionViaMineNonce(t *testing.T) {
 // again and the tx is stuck (until the dormancy sweep evicts it).
 //
 // Scenario:
-//  1. addr1 starts at on-chain nonce=0; OnNewBlock seeds the SimpleCache.
+//  1. addr1 starts at on-chain nonce=0; OnNewBlock seeds the LatestBatchCache.
 //  2. The chain advances addr1 to nonce=1 but the pool has not yet received
 //     the corresponding StateChangeBatch. Modeled directly: write the new
-//     on-chain state to the DB while the SimpleCache still holds nonce=0
+//     on-chain state to the DB while the LatestBatchCache still holds nonce=0
 //     from the seed batch — same observable conditions as the production
 //     race when AddLocalTxns reads the cache before cache.OnNewBlock fires.
 //  3. AddLocalTxns adds a nonce=1 tx. The cache hit returns nonce=0,
@@ -2273,9 +2273,9 @@ func TestQueuedTxnPromotedAfterStaleAddLocal(t *testing.T) {
 	coreDB := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
 	cfg := txpoolcfg.DefaultConfig
 
-	// SimpleCache matches the in-process embedded RPC daemon configuration in
+	// LatestBatchCache matches the in-process embedded RPC daemon configuration in
 	// node/eth/backend.go and the cache the production failure was observed on.
-	pool, err := New(ctx, ch, nil, coreDB, cfg, kvcache.NewSimple(), chain.AllProtocolChanges, nil, nil, func() {}, nil, nil, logger, WithFeeCalculator(nil))
+	pool, err := New(ctx, ch, nil, coreDB, cfg, kvcache.NewLatestBatchCache(), chain.AllProtocolChanges, nil, nil, func() {}, nil, nil, logger, WithFeeCalculator(nil))
 	req.NoError(err)
 	req.NotNil(pool)
 
@@ -2291,7 +2291,7 @@ func TestQueuedTxnPromotedAfterStaleAddLocal(t *testing.T) {
 		return accounts3.SerialiseV3(&a)
 	}
 
-	// 1) Bootstrap addr1 at nonce=0 in both DB and SimpleCache.
+	// 1) Bootstrap addr1 at nonce=0 in both DB and LatestBatchCache.
 	writeTestSenderState(t, ctx, coreDB, logger, addr1, serialiseAcc(0), 0)
 	initChange := &remoteproto.StateChangeBatch{
 		StateVersionId: 0, PendingBlockBaseFee: 200_000, BlockGasLimit: 1_000_000,
@@ -2306,10 +2306,10 @@ func TestQueuedTxnPromotedAfterStaleAddLocal(t *testing.T) {
 
 	// 2) Chain advances addr1 to nonce=1 (a tx from addr1 mined) but the pool
 	// has not yet processed the StateChangeBatch for that block. The DB now
-	// reflects the new on-chain state; the SimpleCache still holds nonce=0.
+	// reflects the new on-chain state; the LatestBatchCache still holds nonce=0.
 	writeTestSenderState(t, ctx, coreDB, logger, addr1, serialiseAcc(1), 1)
 
-	// 3) AddLocalTxns runs in this race window. The SimpleCache hit returns
+	// 3) AddLocalTxns runs in this race window. The LatestBatchCache hit returns
 	// the stale nonce=0, so the nonce=1 tx is misclassified into queued.
 	txn := newTestTxnSlot(1, 0, 300_000, 300_000, 100_000)
 	txn.IDHash[0] = 1


### PR DESCRIPTION
Renames `SimpleCache` → `LatestBatchCache` (with `NewSimple` → `NewLatestBatchCache`, `SimpleView` → `LatestBatchView`, `simple.go` → `latest_batch.go`).

"Simple" described the implementation rather than the contract, and suggested Simple and Coherent sit on a complexity spectrum. They actually sit on opposite sides of a semantic fork:

- **`Coherent`** — snapshot-consistency first: entries are keyed by `PlainStateVersion`, so a reader stays consistent with its own committed view and never sees fresher data.
- **`LatestBatchCache`** — freshness first: version-blind, it serves the most recent announced state-change batch on top of the caller's tx, deliberately showing announced-but-not-yet-committed account data; staleness is bounded to one batch by FCU serialization.

That fork is what decides which cache is safe where (in-process txpool vs RPC reads — see #22532 / #22269), and the new name carries it: content (the latest batch), lifetime (replaced wholesale per batch), and the trade-off (by contrast with `Coherent`). Also updates the type doc comment to lead with the contract.

One cleanup rider in the same spirit: the dead `Evict() int { return 0 }` stub is removed (no callers, not part of the `Cache` interface — a `DummyCache`-era leftover).

Mechanical rename + dead-code removal, no behavior change (TDD not applicable).
