### PR TITLE
cl: allow boundary attestations while head state lags

### DIFF
--- a/cl/phase1/network/services/aggregate_and_proof_service.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service.go
@@ -225,7 +225,8 @@ func (a *aggregateAndProofServiceImpl) ProcessMessage(
 		// [IGNORE] the epoch of aggregate.data.slot is either the current or previous epoch
 		// When the head state lags behind (solo validator / genesis start), use the
 		// highest seen slot to widen the accepted epoch window.
-		prevEpoch, currEpoch := validationEpochRange(headState, a.forkchoiceStore.HighestSeen(), a.beaconCfg.SlotsPerEpoch)
+		highestSeen := a.forkchoiceStore.HighestSeen()
+		prevEpoch, currEpoch := validationEpochRange(headState, highestSeen, highestSeen, a.beaconCfg.SlotsPerEpoch)
 		if epoch < prevEpoch || epoch > currEpoch {
 			return fmt.Errorf("%w: epoch is not in previous or current epoch: %d (prev=%d, curr=%d)", ErrIgnore, epoch, prevEpoch, currEpoch)
 		}

--- a/cl/phase1/network/services/aggregate_and_proof_service.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service.go
@@ -228,7 +228,7 @@ func (a *aggregateAndProofServiceImpl) ProcessMessage(
 		highestSeen := a.forkchoiceStore.HighestSeen()
 		prevEpoch, currEpoch := validationEpochRange(headState, highestSeen, highestSeen, a.beaconCfg.SlotsPerEpoch)
 		if epoch < prevEpoch || epoch > currEpoch {
-			return fmt.Errorf("%w: epoch is not in previous or current epoch: %d (prev=%d, curr=%d)", ErrIgnore, epoch, prevEpoch, currEpoch)
+			return fmt.Errorf("%w: epoch outside validation range: %d (prev=%d, curr=%d)", ErrIgnore, epoch, prevEpoch, currEpoch)
 		}
 
 		// [REJECT] The committee index is within the expected range -- i.e. index < get_committee_count_per_slot(state, aggregate.data.target.epoch).

--- a/cl/phase1/network/services/aggregate_and_proof_service.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service.go
@@ -220,21 +220,12 @@ func (a *aggregateAndProofServiceImpl) ProcessMessage(
 	if err := a.syncedDataManager.ViewHeadState(func(headState *state.CachingBeaconState) error {
 		// If our head state is too far from the aggregate's epoch, committee
 		// computations will use a stale RANDAO mix and produce wrong results.
-		// Allow current and previous epoch per spec: compute_epoch_at_slot(slot)
-		// in (get_previous_epoch(state), get_current_epoch(state)).
 		// Note: uses epoch (from slot), not target.Epoch, so malformed messages
 		// with wrong target.Epoch still reach the reject check below.
-		headEpoch := state.Epoch(headState)
-		if epoch != headEpoch && epoch != state.PreviousEpoch(headState) {
-			return fmt.Errorf("head epoch %d too far from aggregate epoch %d: %w",
-				headEpoch, epoch, ErrIgnore)
-		}
 		// [IGNORE] the epoch of aggregate.data.slot is either the current or previous epoch
 		// When the head state lags behind (solo validator / genesis start), use the
 		// highest seen slot to widen the accepted epoch window.
-		highestSeenEpoch := a.forkchoiceStore.HighestSeen() / a.beaconCfg.SlotsPerEpoch
-		prevEpoch := state.PreviousEpoch(headState)
-		currEpoch := max(state.Epoch(headState), highestSeenEpoch)
+		prevEpoch, currEpoch := validationEpochRange(headState, a.forkchoiceStore.HighestSeen(), a.beaconCfg.SlotsPerEpoch)
 		if epoch < prevEpoch || epoch > currEpoch {
 			return fmt.Errorf("%w: epoch is not in previous or current epoch: %d (prev=%d, curr=%d)", ErrIgnore, epoch, prevEpoch, currEpoch)
 		}

--- a/cl/phase1/network/services/aggregate_and_proof_service_test.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service_test.go
@@ -219,6 +219,26 @@ func TestAggregateAndProofRejectsNextEpochBeforeForkchoiceHasSeenIt(t *testing.T
 	require.Contains(t, err.Error(), "epoch is not in previous or current epoch")
 }
 
+func TestAggregateAndProofRejectsBeyondNextEpochDespiteForkchoiceHavingSeenIt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	agg, s := getAggregateAndProofAndState(t)
+	beyondNextEpochSlot := s.Slot() + 2*clparams.MainnetBeaconConfig.SlotsPerEpoch
+	beyondNextEpoch := beyondNextEpochSlot / clparams.MainnetBeaconConfig.SlotsPerEpoch
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.Slot = beyondNextEpochSlot
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.Source.Epoch = beyondNextEpoch - 1
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.Target.Epoch = beyondNextEpoch
+
+	aggService, sd, fcu := setupAggregateAndProofTest(t)
+	sd.OnHeadState(s)
+	fcu.HighestSeenVal = beyondNextEpochSlot
+
+	err := aggService.ProcessMessage(context.Background(), nil, agg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "epoch is not in previous or current epoch")
+}
+
 func TestAggregateAndProofAncestorMissing(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cl/phase1/network/services/aggregate_and_proof_service_test.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service_test.go
@@ -193,10 +193,8 @@ func TestAggregateAndProofAllowsNextEpochWhenForkchoiceHasSeenIt(t *testing.T) {
 	fcu.HighestSeenVal = nextEpochSlot
 
 	err := aggService.ProcessMessage(context.Background(), nil, agg)
-	if err != nil {
-		require.NotContains(t, err.Error(), "too far from aggregate epoch")
-		require.NotContains(t, err.Error(), "epoch is not in previous or current epoch")
-	}
+	require.ErrorIs(t, err, ErrIgnore)
+	require.Contains(t, err.Error(), "block not seen")
 }
 
 func TestAggregateAndProofRejectsNextEpochBeforeForkchoiceHasSeenIt(t *testing.T) {
@@ -216,7 +214,7 @@ func TestAggregateAndProofRejectsNextEpochBeforeForkchoiceHasSeenIt(t *testing.T
 
 	err := aggService.ProcessMessage(context.Background(), nil, agg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "epoch is not in previous or current epoch")
+	require.Contains(t, err.Error(), "epoch outside validation range")
 }
 
 func TestAggregateAndProofRejectsBeyondNextEpochDespiteForkchoiceHavingSeenIt(t *testing.T) {
@@ -236,7 +234,7 @@ func TestAggregateAndProofRejectsBeyondNextEpochDespiteForkchoiceHavingSeenIt(t 
 
 	err := aggService.ProcessMessage(context.Background(), nil, agg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "epoch is not in previous or current epoch")
+	require.Contains(t, err.Error(), "epoch outside validation range")
 }
 
 func TestAggregateAndProofAncestorMissing(t *testing.T) {

--- a/cl/phase1/network/services/aggregate_and_proof_service_test.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service_test.go
@@ -191,10 +191,17 @@ func TestAggregateAndProofAllowsNextEpochWhenForkchoiceHasSeenIt(t *testing.T) {
 	aggService, sd, fcu := setupAggregateAndProofTest(t)
 	sd.OnHeadState(s)
 	fcu.HighestSeenVal = nextEpochSlot
+	fcu.FinalizedCheckpointVal = s.FinalizedCheckpoint()
+	fcu.Ancestors[s.FinalizedCheckpoint().Epoch*clparams.MainnetBeaconConfig.SlotsPerEpoch] = forkchoice.ForkChoiceNode{Root: s.FinalizedCheckpoint().Root}
+	fcu.Ancestors[nextEpochSlot] = forkchoice.ForkChoiceNode{Root: agg.SignedAggregateAndProof.Message.Aggregate.Data.Target.Root}
+	fcu.Headers[agg.SignedAggregateAndProof.Message.Aggregate.Data.BeaconBlockRoot] = &cltypes.BeaconBlockHeader{}
+	committee, err := s.GetBeaconCommitee(nextEpochSlot, agg.SignedAggregateAndProof.Message.Aggregate.Data.CommitteeIndex)
+	require.NoError(t, err)
+	require.NotEmpty(t, committee)
+	agg.SignedAggregateAndProof.Message.AggregatorIndex = committee[0]
 
-	err := aggService.ProcessMessage(context.Background(), nil, agg)
-	require.ErrorIs(t, err, ErrIgnore)
-	require.Contains(t, err.Error(), "block not seen")
+	err = aggService.ProcessMessage(context.Background(), nil, agg)
+	require.NoError(t, err)
 }
 
 func TestAggregateAndProofRejectsNextEpochBeforeForkchoiceHasSeenIt(t *testing.T) {

--- a/cl/phase1/network/services/aggregate_and_proof_service_test.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service_test.go
@@ -177,6 +177,48 @@ func TestAggregateAndProofInvalidCommittee(t *testing.T) {
 	require.Error(t, aggService.ProcessMessage(context.Background(), nil, agg))
 }
 
+func TestAggregateAndProofAllowsNextEpochWhenForkchoiceHasSeenIt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	agg, s := getAggregateAndProofAndState(t)
+	nextEpochSlot := s.Slot() + clparams.MainnetBeaconConfig.SlotsPerEpoch
+	nextEpoch := nextEpochSlot / clparams.MainnetBeaconConfig.SlotsPerEpoch
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.Slot = nextEpochSlot
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.Source.Epoch = nextEpoch - 1
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.Target.Epoch = nextEpoch
+
+	aggService, sd, fcu := setupAggregateAndProofTest(t)
+	sd.OnHeadState(s)
+	fcu.HighestSeenVal = nextEpochSlot
+
+	err := aggService.ProcessMessage(context.Background(), nil, agg)
+	if err != nil {
+		require.NotContains(t, err.Error(), "too far from aggregate epoch")
+		require.NotContains(t, err.Error(), "epoch is not in previous or current epoch")
+	}
+}
+
+func TestAggregateAndProofRejectsNextEpochBeforeForkchoiceHasSeenIt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	agg, s := getAggregateAndProofAndState(t)
+	nextEpochSlot := s.Slot() + clparams.MainnetBeaconConfig.SlotsPerEpoch
+	nextEpoch := nextEpochSlot / clparams.MainnetBeaconConfig.SlotsPerEpoch
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.Slot = nextEpochSlot
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.Source.Epoch = nextEpoch - 1
+	agg.SignedAggregateAndProof.Message.Aggregate.Data.Target.Epoch = nextEpoch
+
+	aggService, sd, fcu := setupAggregateAndProofTest(t)
+	sd.OnHeadState(s)
+	fcu.HighestSeenVal = s.Slot()
+
+	err := aggService.ProcessMessage(context.Background(), nil, agg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "epoch is not in previous or current epoch")
+}
+
 func TestAggregateAndProofAncestorMissing(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -48,7 +48,12 @@ var (
 )
 
 func validationEpochRange(headState *state.CachingBeaconState, highestSeenSlot, slotsPerEpoch uint64) (uint64, uint64) {
-	return state.PreviousEpoch(headState), max(state.Epoch(headState), highestSeenSlot/slotsPerEpoch)
+	headEpoch := state.Epoch(headState)
+	currEpoch := headEpoch
+	if highestSeenSlot/slotsPerEpoch > headEpoch {
+		currEpoch = headEpoch + 1
+	}
+	return state.PreviousEpoch(headState), currEpoch
 }
 
 type attestationService struct {

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -47,6 +47,10 @@ var (
 	computeCommitteeCountPerSlot = subnets.ComputeCommitteeCountPerSlot
 )
 
+func validationEpochRange(headState *state.CachingBeaconState, highestSeenSlot, slotsPerEpoch uint64) (uint64, uint64) {
+	return state.PreviousEpoch(headState), max(state.Epoch(headState), highestSeenSlot/slotsPerEpoch)
+}
+
 type attestationService struct {
 	ctx                    context.Context
 	forkchoiceStore        forkchoice.ForkChoiceStorage
@@ -197,11 +201,10 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	if err := s.syncedDataManager.ViewHeadState(func(headState *state.CachingBeaconState) error {
 		// If our head state is too far from the attestation epoch, committee
 		// computations will use a stale RANDAO mix and produce wrong results.
-		// Allow current and previous epoch (spec permits both).
-		headEpoch := state.Epoch(headState)
-		if attEpoch != headEpoch && attEpoch != state.PreviousEpoch(headState) {
-			return fmt.Errorf("head epoch %d too far from attestation epoch %d: %w",
-				headEpoch, attEpoch, ErrIgnore)
+		prevEpoch, currEpoch := validationEpochRange(headState, s.forkchoiceStore.HighestSeen(), s.beaconCfg.SlotsPerEpoch)
+		if attEpoch < prevEpoch || attEpoch > currEpoch {
+			return fmt.Errorf("head epoch %d too far from attestation epoch %d (prev=%d, curr=%d): %w",
+				state.Epoch(headState), attEpoch, prevEpoch, currEpoch, ErrIgnore)
 		}
 		// [REJECT] The committee index is within the expected range
 		committeeCount := computeCommitteeCountPerSlot(headState, slot, s.beaconCfg.SlotsPerEpoch)

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -315,7 +315,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	blockHeader, ok := s.forkchoiceStore.GetHeader(root)
 	if !ok {
 		//s.scheduleAttestationForLaterProcessing(att)
-		return ErrIgnore
+		return fmt.Errorf("%w: block not seen: %v", ErrIgnore, root)
 	}
 
 	// [New in Gloas] [REJECT] attestation.data.index == 0 if block.slot == attestation.data.slot

--- a/cl/phase1/network/services/attestation_service.go
+++ b/cl/phase1/network/services/attestation_service.go
@@ -47,10 +47,13 @@ var (
 	computeCommitteeCountPerSlot = subnets.ComputeCommitteeCountPerSlot
 )
 
-func validationEpochRange(headState *state.CachingBeaconState, highestSeenSlot, slotsPerEpoch uint64) (uint64, uint64) {
+func validationEpochRange(headState *state.CachingBeaconState, highestSeenSlot, currentSlot, slotsPerEpoch uint64) (uint64, uint64) {
 	headEpoch := state.Epoch(headState)
 	currEpoch := headEpoch
-	if highestSeenSlot/slotsPerEpoch > headEpoch {
+	if currentSlot < highestSeenSlot {
+		currentSlot = highestSeenSlot
+	}
+	if currentSlot/slotsPerEpoch > headEpoch {
 		currEpoch = headEpoch + 1
 	}
 	return state.PreviousEpoch(headState), currEpoch
@@ -206,7 +209,7 @@ func (s *attestationService) ProcessMessage(ctx context.Context, subnet *uint64,
 	if err := s.syncedDataManager.ViewHeadState(func(headState *state.CachingBeaconState) error {
 		// If our head state is too far from the attestation epoch, committee
 		// computations will use a stale RANDAO mix and produce wrong results.
-		prevEpoch, currEpoch := validationEpochRange(headState, s.forkchoiceStore.HighestSeen(), s.beaconCfg.SlotsPerEpoch)
+		prevEpoch, currEpoch := validationEpochRange(headState, s.forkchoiceStore.HighestSeen(), currentSlot, s.beaconCfg.SlotsPerEpoch)
 		if attEpoch < prevEpoch || attEpoch > currEpoch {
 			return fmt.Errorf("head epoch %d too far from attestation epoch %d (prev=%d, curr=%d): %w",
 				state.Epoch(headState), attEpoch, prevEpoch, currEpoch, ErrIgnore)

--- a/cl/phase1/network/services/attestation_service_test.go
+++ b/cl/phase1/network/services/attestation_service_test.go
@@ -384,14 +384,30 @@ func (t *attestationTestSuite) TestAttestationProcessMessageAllowsNextEpochWhenC
 	t.ethClock.EXPECT().GetEpochAtSlot(nextEpochSlot).Return(nextEpoch).Times(1)
 	t.ethClock.EXPECT().GetCurrentSlot().Return(nextEpochSlot).Times(1)
 	t.mockForkChoice.HighestSeenVal = mockSlot
+	computeSigningRoot = func(obj ssz.HashableSSZ, domain []byte) ([32]byte, error) {
+		return [32]byte{}, nil
+	}
+	blsVerifyMultipleSignatures = func(signatures [][]byte, signRoots [][]byte, pks [][]byte) (bool, error) {
+		return true, nil
+	}
+	t.mockForkChoice.Headers = map[common.Hash]*cltypes.BeaconBlockHeader{
+		nextEpochAttData.BeaconBlockRoot: {},
+	}
+	finalizedCheckpoint := solid.Checkpoint{Root: [32]byte{1, 0}, Epoch: 1}
+	t.mockForkChoice.Ancestors = map[uint64]forkchoice.ForkChoiceNode{
+		nextEpoch * mockSlotsPerEpoch:                 {Root: nextEpochAttData.Target.Root},
+		finalizedCheckpoint.Epoch * mockSlotsPerEpoch: {Root: finalizedCheckpoint.Root},
+	}
+	t.mockForkChoice.FinalizedCheckpointVal = finalizedCheckpoint
+	t.committeeSubscibe.EXPECT().AggregateAttestation(&nextEpochAtt).Return(nil).Times(1)
 
 	err := t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
 		Attestation:      &nextEpochAtt,
 		ImmediateProcess: true,
 	})
+	time.Sleep(time.Millisecond * 60)
 
-	t.Require().ErrorIs(err, ErrIgnore)
-	t.Require().Contains(err.Error(), "block not seen")
+	t.Require().NoError(err)
 }
 
 func (t *attestationTestSuite) TestAttestationProcessMessageRejectsBeyondNextEpochDespiteForkchoiceHavingSeenIt() {

--- a/cl/phase1/network/services/attestation_service_test.go
+++ b/cl/phase1/network/services/attestation_service_test.go
@@ -424,6 +424,35 @@ func (t *attestationTestSuite) TestAttestationProcessMessageRejectsNextEpochBefo
 	t.Require().Contains(err.Error(), "too far from attestation epoch")
 }
 
+func (t *attestationTestSuite) TestAttestationProcessMessageRejectsBeyondNextEpochDespiteForkchoiceHavingSeenIt() {
+	beyondNextEpochSlot := mockSlot + 2*mockSlotsPerEpoch
+	beyondNextEpoch := mockEpoch + 2
+	beyondNextEpochAttData := *attData
+	beyondNextEpochAttData.Slot = beyondNextEpochSlot
+	beyondNextEpochAttData.Source.Epoch = beyondNextEpoch - 1
+	beyondNextEpochAttData.Target.Epoch = beyondNextEpoch
+	beyondNextEpochAtt := *att
+	beyondNextEpochAtt.Data = &beyondNextEpochAttData
+
+	computeCommitteeCountPerSlot = func(_ abstract.BeaconStateReader, _, _ uint64) uint64 {
+		return 8
+	}
+	computeSubnetForAttestation = func(_, _, _, _, _ uint64) uint64 {
+		return 1
+	}
+	t.ethClock.EXPECT().GetEpochAtSlot(beyondNextEpochSlot).Return(beyondNextEpoch).Times(1)
+	t.ethClock.EXPECT().GetCurrentSlot().Return(beyondNextEpochSlot).Times(1)
+	t.mockForkChoice.HighestSeenVal = beyondNextEpochSlot
+
+	err := t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
+		Attestation:      &beyondNextEpochAtt,
+		ImmediateProcess: true,
+	})
+
+	t.Require().Error(err)
+	t.Require().Contains(err.Error(), "too far from attestation epoch")
+}
+
 func (t *attestationTestSuite) TestGloasAttestationIndexValidation() {
 	// Override beacon config to enable Gloas version
 	gloasConfig := &clparams.BeaconChainConfig{

--- a/cl/phase1/network/services/attestation_service_test.go
+++ b/cl/phase1/network/services/attestation_service_test.go
@@ -395,7 +395,7 @@ func (t *attestationTestSuite) TestAttestationProcessMessageAllowsNextEpochWhenF
 	}
 }
 
-func (t *attestationTestSuite) TestAttestationProcessMessageRejectsNextEpochBeforeForkchoiceHasSeenIt() {
+func (t *attestationTestSuite) TestAttestationProcessMessageAllowsNextEpochWhenClockHasReachedIt() {
 	nextEpochSlot := mockSlot + mockSlotsPerEpoch
 	nextEpoch := mockEpoch + 1
 	nextEpochAttData := *attData
@@ -420,8 +420,9 @@ func (t *attestationTestSuite) TestAttestationProcessMessageRejectsNextEpochBefo
 		ImmediateProcess: true,
 	})
 
-	t.Require().Error(err)
-	t.Require().Contains(err.Error(), "too far from attestation epoch")
+	if err != nil {
+		t.Require().NotContains(err.Error(), "too far from attestation epoch")
+	}
 }
 
 func (t *attestationTestSuite) TestAttestationProcessMessageRejectsBeyondNextEpochDespiteForkchoiceHavingSeenIt() {

--- a/cl/phase1/network/services/attestation_service_test.go
+++ b/cl/phase1/network/services/attestation_service_test.go
@@ -365,36 +365,6 @@ func (t *attestationTestSuite) TestAttestationProcessMessage() {
 	}
 }
 
-func (t *attestationTestSuite) TestAttestationProcessMessageAllowsNextEpochWhenForkchoiceHasSeenIt() {
-	nextEpochSlot := mockSlot + mockSlotsPerEpoch
-	nextEpoch := mockEpoch + 1
-	nextEpochAttData := *attData
-	nextEpochAttData.Slot = nextEpochSlot
-	nextEpochAttData.Source.Epoch = mockEpoch
-	nextEpochAttData.Target.Epoch = nextEpoch
-	nextEpochAtt := *att
-	nextEpochAtt.Data = &nextEpochAttData
-
-	computeCommitteeCountPerSlot = func(_ abstract.BeaconStateReader, _, _ uint64) uint64 {
-		return 8
-	}
-	computeSubnetForAttestation = func(_, _, _, _, _ uint64) uint64 {
-		return 1
-	}
-	t.ethClock.EXPECT().GetEpochAtSlot(nextEpochSlot).Return(nextEpoch).Times(1)
-	t.ethClock.EXPECT().GetCurrentSlot().Return(nextEpochSlot).Times(1)
-	t.mockForkChoice.HighestSeenVal = nextEpochSlot
-
-	err := t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
-		Attestation:      &nextEpochAtt,
-		ImmediateProcess: true,
-	})
-
-	if err != nil {
-		t.Require().NotContains(err.Error(), "too far from attestation epoch")
-	}
-}
-
 func (t *attestationTestSuite) TestAttestationProcessMessageAllowsNextEpochWhenClockHasReachedIt() {
 	nextEpochSlot := mockSlot + mockSlotsPerEpoch
 	nextEpoch := mockEpoch + 1
@@ -420,9 +390,8 @@ func (t *attestationTestSuite) TestAttestationProcessMessageAllowsNextEpochWhenC
 		ImmediateProcess: true,
 	})
 
-	if err != nil {
-		t.Require().NotContains(err.Error(), "too far from attestation epoch")
-	}
+	t.Require().ErrorIs(err, ErrIgnore)
+	t.Require().Contains(err.Error(), "block not seen")
 }
 
 func (t *attestationTestSuite) TestAttestationProcessMessageRejectsBeyondNextEpochDespiteForkchoiceHavingSeenIt() {

--- a/cl/phase1/network/services/attestation_service_test.go
+++ b/cl/phase1/network/services/attestation_service_test.go
@@ -365,6 +365,65 @@ func (t *attestationTestSuite) TestAttestationProcessMessage() {
 	}
 }
 
+func (t *attestationTestSuite) TestAttestationProcessMessageAllowsNextEpochWhenForkchoiceHasSeenIt() {
+	nextEpochSlot := mockSlot + mockSlotsPerEpoch
+	nextEpoch := mockEpoch + 1
+	nextEpochAttData := *attData
+	nextEpochAttData.Slot = nextEpochSlot
+	nextEpochAttData.Source.Epoch = mockEpoch
+	nextEpochAttData.Target.Epoch = nextEpoch
+	nextEpochAtt := *att
+	nextEpochAtt.Data = &nextEpochAttData
+
+	computeCommitteeCountPerSlot = func(_ abstract.BeaconStateReader, _, _ uint64) uint64 {
+		return 8
+	}
+	computeSubnetForAttestation = func(_, _, _, _, _ uint64) uint64 {
+		return 1
+	}
+	t.ethClock.EXPECT().GetEpochAtSlot(nextEpochSlot).Return(nextEpoch).Times(1)
+	t.ethClock.EXPECT().GetCurrentSlot().Return(nextEpochSlot).Times(1)
+	t.mockForkChoice.HighestSeenVal = nextEpochSlot
+
+	err := t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
+		Attestation:      &nextEpochAtt,
+		ImmediateProcess: true,
+	})
+
+	if err != nil {
+		t.Require().NotContains(err.Error(), "too far from attestation epoch")
+	}
+}
+
+func (t *attestationTestSuite) TestAttestationProcessMessageRejectsNextEpochBeforeForkchoiceHasSeenIt() {
+	nextEpochSlot := mockSlot + mockSlotsPerEpoch
+	nextEpoch := mockEpoch + 1
+	nextEpochAttData := *attData
+	nextEpochAttData.Slot = nextEpochSlot
+	nextEpochAttData.Source.Epoch = mockEpoch
+	nextEpochAttData.Target.Epoch = nextEpoch
+	nextEpochAtt := *att
+	nextEpochAtt.Data = &nextEpochAttData
+
+	computeCommitteeCountPerSlot = func(_ abstract.BeaconStateReader, _, _ uint64) uint64 {
+		return 8
+	}
+	computeSubnetForAttestation = func(_, _, _, _, _ uint64) uint64 {
+		return 1
+	}
+	t.ethClock.EXPECT().GetEpochAtSlot(nextEpochSlot).Return(nextEpoch).Times(1)
+	t.ethClock.EXPECT().GetCurrentSlot().Return(nextEpochSlot).Times(1)
+	t.mockForkChoice.HighestSeenVal = mockSlot
+
+	err := t.attService.ProcessMessage(context.Background(), common.NewUint64(1), &AttestationForGossip{
+		Attestation:      &nextEpochAtt,
+		ImmediateProcess: true,
+	})
+
+	t.Require().Error(err)
+	t.Require().Contains(err.Error(), "too far from attestation epoch")
+}
+
 func (t *attestationTestSuite) TestGloasAttestationIndexValidation() {
 	// Override beacon config to enable Gloas version
 	gloasConfig := &clparams.BeaconChainConfig{


### PR DESCRIPTION
## Summary
- allow attestation validation to accept the next epoch when forkchoice has seen it or the local clock has reached it
- keep aggregate-and-proof validation conservative by only widening to epochs forkchoice has actually seen
- add focused tests for next-epoch boundary acceptance and beyond-next-epoch rejection

## Root cause
At epoch boundaries on Chiado, the validator client could request aggregates for the next epoch while Caplin's head state still pointed at the previous epoch. The first r3.5 fix handled the case where forkchoice had already seen the next epoch, but production logs showed cases where the local slot had crossed the boundary while the next epoch block was not imported yet.

## Validation
- go test ./cl/phase1/network/services -count=1
- focused boundary tests in cl/phase1/network/services
- make lint
- git diff --check

Main-port of the fix deployed and observed on Chiado via release/3.5 PR #22251.