### PR TITLE
.github: bump actionlint 1.7.7→1.7.12, zizmor 1.24.1→1.26.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Install actionlint
         run: |
           curl -sSfL \
-            "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz" \
             | tar -xz -C /usr/local/bin actionlint
 
       - name: Install zizmor
-        run: pip install --break-system-packages zizmor==1.24.1
+        run: pip install --break-system-packages zizmor==1.26.1
 
       # -shellcheck '' disables actionlint's built-in inline-script checking;
       # the repo's QA workflow run: blocks have many pre-existing shellcheck
@@ -51,7 +51,7 @@ jobs:
       # without noise from pure style hints.
       - name: shellcheck
         run: |
-          find . -name '*.sh' -not -path './.git/*' -print0 \
+          find . -name '*.sh' -not -path './.git/*' -not -path '*/node_modules/*' -print0 \
             | xargs -0 shellcheck --severity=warning
 
       - uses: ./.github/actions/setup-erigon

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -47,6 +47,14 @@ rules:
       - test-kurtosis-assertoor.yml
       - test-kurtosis-gloas.yml
 
+  # create-github-app-token steps scope `repositories:` but not per-permission
+  # scopes, so the app token inherits blanket installation permissions.
+  # Scoping these down is a release-pipeline change; tracked in #21132.
+  github-app:
+    ignore:
+      - release.yml
+      - update-disk-sizes.yml
+
   # Workflows missing explicit permissions: blocks — needs a cleanup pass
   # to add least-privilege permissions to each workflow; tracked in #21132.
   excessive-permissions:


### PR DESCRIPTION
Updates the two workflow linters pinned in `.github/workflows/lint.yml`.

## Changes
- **actionlint** `v1.7.7` → `v1.7.12` (both occurrences in the download URL: release-tag path and tarball filename).
- **zizmor** `1.24.1` → `1.26.1`.
- **shellcheck** `find` now also excludes `*/node_modules/*`.

## Validation
Both new tool versions were installed locally and run with the exact CI commands against the real `.github/workflows/`:

- **actionlint 1.7.12** — exit 0, no new findings.
- **shellcheck** — all git-tracked `.sh` files pass `--severity=warning`. The only warning locally was `SC2166` inside `docs/site/node_modules/**`, which is gitignored third-party code CI never sees (the lint job runs no `npm install` before shellcheck). Excluding `node_modules` from the `find` makes a local run match CI instead of tripping over vendored scripts.
- **zizmor 1.26.1** — 1.26.1 ships a new `github-app` audit that flags the pre-existing `actions/create-github-app-token` steps in `release.yml` (×2) and `update-disk-sizes.yml` (×1) at **error** severity. That raises zizmor's exit code 12 → 14, which trips the workflow's `< 14` pass threshold and would fail CI. These steps already scope `repositories:` but not per-permission scopes; scoping them down is a release-pipeline change, so they're deferred via a `zizmor.yml` ignore following the existing `#21132` convention (the same pattern already used for `template-injection`, `cache-poisoning`, `excessive-permissions`, etc.). With the ignore, 1.26.1 exits 12 again — same baseline as 1.24.1.

## Note
zizmor `1.26.1` (everything from `1.17.0` on) requires Python ≥3.10. CI's `ubuntu-latest` ships 3.12+, so the `pip install` is unaffected.