### PR TITLE
db/state: revert #20445 collation/unwind changes

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -949,6 +949,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 	g.SetLimit(a.workers.getCollateAndBuild())
 
 	ac := a.BeginFilesRo()
+	defer ac.Close()
 	for id, d := range a.d {
 		if d.Disable {
 			continue

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -55,7 +55,6 @@ import (
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/commitment"
-	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
 
 type Aggregator struct {
@@ -934,6 +933,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 
 		static          = &AggV3StaticFiles{}
 		closeCollations = true
+		collListMu      = sync.Mutex{}
 		collations      = make([]Collation, 0)
 	)
 	defer func() {
@@ -945,87 +945,40 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 		}
 	}()
 
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(a.workers.getCollateAndBuild())
+
 	ac := a.BeginFilesRo()
-	defer ac.Close()
-
-	// Phase 1: collate all domains and indices using a SINGLE read-transaction.
-	// This guarantees all collations see the exact same MDBX snapshot, eliminating
-	// the collation/pruning race where execution overwrites step S values with
-	// step S+1 data between collation reads. See #20169.
-	collationTx, err := a.db.BeginRo(ctx)
-	if err != nil {
-		return fmt.Errorf("open collation tx: %w", err)
-	}
-	defer collationTx.Rollback()
-
-	type domainCollResult struct {
-		d         *Domain
-		collation Collation
-	}
-	type iiCollResult struct {
-		ii        *InvertedIndex
-		iikey     int
-		collation InvertedIndexCollation
-	}
-	var domainColls []domainCollResult
-	var iiColls []iiCollResult
-	defer func() {
-		if !closeCollations {
-			return
-		}
-		for _, ic := range iiColls {
-			ic.collation.Close()
-		}
-	}()
-
 	for id, d := range a.d {
 		if d.Disable {
 			continue
 		}
+
 		firstStepNotInFiles := ac.d[id].FirstStepNotInFiles()
 		if step < firstStepNotInFiles {
 			continue
 		}
-		collation, err := d.collate(ctx, step, txFrom, txTo, collationTx)
-		if err != nil {
-			return fmt.Errorf("domain collation %q has failed: %w", d.FilenameBase, err)
-		}
-		collations = append(collations, collation)
-		domainColls = append(domainColls, domainCollResult{d: d, collation: collation})
-	}
-	for iikey, ii := range a.standaloneIIs() {
-		if ii.Disable {
-			continue
-		}
-		firstStepNotInFiles := ac.iis[iikey].FirstStepNotInFiles()
-		if step < firstStepNotInFiles {
-			continue
-		}
-		collation, err := ii.collate(ctx, step, collationTx)
-		if err != nil {
-			return fmt.Errorf("index collation %q has failed: %w", ii.FilenameBase, err)
-		}
-		iiColls = append(iiColls, iiCollResult{ii: ii, iikey: iikey, collation: collation})
-	}
-	collationTx.Rollback() // release the read-tx before Phase 2 (no DB access needed)
-	closeCollations = false
-	buildAt := time.Now()
 
-	// Phase 2: build files from collations in parallel (no DB access needed).
-	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(a.workers.getCollateAndBuild())
-
-	for _, dc := range domainColls {
-		dc := dc
 		g.Go(func() error {
-			sf, err := dc.d.buildFiles(ctx, step, dc.collation, a.ps)
-			dc.collation.Close()
+			var collation Collation
+			if err := a.db.View(ctx, func(tx kv.Tx) (err error) {
+				collation, err = d.collate(ctx, step, txFrom, txTo, tx)
+				return err
+			}); err != nil {
+				return fmt.Errorf("domain collation %q has failed: %w", d.FilenameBase, err)
+			}
+			collListMu.Lock()
+			collations = append(collations, collation)
+			collListMu.Unlock()
+
+			sf, err := d.buildFiles(ctx, step, collation, a.ps)
+			collation.Close()
 			if err != nil {
 				sf.CleanupOnError()
 				return err
 			}
 
-			dd, err := kv.String2Domain(dc.d.FilenameBase)
+			dd, err := kv.String2Domain(d.FilenameBase)
 			if err != nil {
 				return err
 			}
@@ -1033,16 +986,35 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 			return nil
 		})
 	}
-	for _, ic := range iiColls {
-		ic := ic
+	closeCollations = false
+
+	// indices are built concurrently
+	for iikey, ii := range a.standaloneIIs() {
+		if ii.Disable {
+			continue
+		}
+
+		firstStepNotInFiles := ac.iis[iikey].FirstStepNotInFiles()
+		if step < firstStepNotInFiles {
+			continue
+		}
+
 		g.Go(func() error {
-			sf, err := ic.ii.buildFiles(ctx, step, ic.collation, a.ps)
+			var collation InvertedIndexCollation
+			err := a.db.View(ctx, func(tx kv.Tx) (err error) {
+				collation, err = ii.collate(ctx, step, tx)
+				return err
+			})
+			if err != nil {
+				return fmt.Errorf("index collation %q has failed: %w", ii.FilenameBase, err)
+			}
+			sf, err := ii.buildFiles(ctx, step, collation, a.ps)
 			if err != nil {
 				sf.CleanupOnError()
 				return err
 			}
 
-			static.ivfs[ic.iikey] = sf
+			static.ivfs[iikey] = sf
 			return nil
 		})
 	}
@@ -1051,7 +1023,7 @@ func (a *Aggregator) buildFiles(ctx context.Context, step kv.Step) error {
 		static.CleanupOnError()
 		return fmt.Errorf("domain collate-build: %w", err)
 	}
-	a.logger.Debug("[agg] collate-build", "step", step, "collate_workers", a.workers.getCollateAndBuild(), "compress_workers", a.d[kv.AccountsDomain].CompressCfg.Workers, "collate_in", buildAt.Sub(stepStartedAt), "build_in", time.Since(buildAt))
+	a.logger.Debug("[agg] collate-build", "step", step, "collate_workers", a.workers.getCollateAndBuild(), "compress_workers", a.d[kv.AccountsDomain].CompressCfg.Workers, "took", time.Since(stepStartedAt))
 	mxStepTook.ObserveDuration(stepStartedAt)
 	a.IntegrateDirtyFiles(static, txFrom, txTo)
 	a.logger.Info("[snapshots] aggregated", "step", step, "took", time.Since(stepStartedAt), "workers", a.workers.getCollateAndBuild())
@@ -1729,18 +1701,6 @@ func lastTxNumOfStep(step kv.Step, stepSize uint64) uint64 {
 	return firstTxNumOfStep(step+1, stepSize) - 1
 }
 
-// stepFullyCommitted reports whether all txNums in `step` have been committed
-// to the DB, based on the committedTxNum stored by ComputeCommitment.
-// When committedTxNum == 0 (no ComputeCommitment yet, e.g. in tests), the
-// guard is bypassed and the caller should fall through to the lastInDB check.
-func stepFullyCommitted(committedTxNum uint64, step kv.Step, stepSize uint64) bool {
-	if committedTxNum == 0 {
-		return true // guard bypassed — no commitment state yet
-	}
-	stepEndTxNum := firstTxNumOfStep(step+1, stepSize)
-	return committedTxNum+1 >= stepEndTxNum
-}
-
 // firstTxNumOfStep returns txStepBeginning of given step.
 // Step 0 is a range [0, stepSize).
 // To prune step needed to fully Prune range [txStepBeginning, txNextStepBeginning)
@@ -2263,33 +2223,6 @@ func (a *Aggregator) buildFilesInBackground(txNum uint64, doMerge bool) chan str
 		// - to remove old data from db as early as possible
 		// - during files build, may happen commit of new data. on each loop step getting latest id in db
 		for ; step < lastInDB; step++ { //`step` must be fully-written - means `step+1` records must be visible
-			// Guard against collation/pruning race: only collate step S when the
-			// execution layer has committed ALL data through the end of step S.
-			// Read the latest committed txNum from the commitment domain state
-			// (written by SharedDomains.ComputeCommitment after each flush+commit).
-			// Without this check, the collation's read-transaction may snapshot
-			// the DB before a CommitCycle flushes step S's writes, producing a
-			// file that misses entries. Pruning then removes those entries from
-			// the DB, and the values are lost. See #20169.
-			var committedTxNum uint64
-			if temporalDB, ok := a.db.(kv.TemporalRoDB); ok {
-				if err := temporalDB.ViewTemporal(a.ctx, func(tx kv.TemporalTx) error {
-					v, _, err := tx.GetLatest(kv.CommitmentDomain, commitmentdb.KeyCommitmentState)
-					if err != nil {
-						return err
-					}
-					if len(v) >= 16 {
-						committedTxNum, _ = commitmentdb.DecodeTxBlockNums(v)
-					}
-					return nil
-				}); err != nil {
-					a.logger.Warn("[snapshots] buildFilesInBackground: read commitment", "err", err)
-					break
-				}
-			}
-			if !stepFullyCommitted(committedTxNum, step, a.StepSize()) {
-				break // step not fully committed yet — wait for execution to catch up
-			}
 			if err := a.buildFiles(a.ctx, step); err != nil {
 				if errors.Is(err, errStepNotReady) {
 					break
@@ -2605,13 +2538,8 @@ func (at *AggregatorRoTx) Unwind(ctx context.Context, tx kv.RwTx, txNumUnwindTo 
 	defer logEvery.Stop()
 
 	step := txNumUnwindTo / at.StepSize()
-	// Use the CURRENT (atomically published) file boundary, not the stale
-	// tx-scoped snapshot. BuildFilesInBackground may have filed new steps
-	// since this AggregatorRoTx was opened, and getLatestFromDb will use
-	// the current view — so the unwind must tag entries beyond it.
-	currentFilesEndStep := at.a.EndTxNumMinimax() / at.StepSize()
 	for idx, d := range at.d {
-		if err := d.unwind(ctx, tx, step, txNumUnwindTo, currentFilesEndStep, changeset[idx]); err != nil {
+		if err := d.unwind(ctx, tx, step, txNumUnwindTo, changeset[idx]); err != nil {
 			return err
 		}
 	}

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -547,34 +547,6 @@ func generateCommitmentHistoryAndIndexFiles(t *testing.T, dirs datadir.Dirs, ran
 	populateFiles2(t, dirs, idxRepo, ranges)
 }
 
-// TestAggregator_CommittedTxNumGuard verifies the stepFullyCommitted predicate
-// used by buildFilesInBackground: a step S should only be collated when
-// committedTxNum+1 >= firstTxNum(S+1), meaning all txNums in step S have been
-// committed to the DB. ComputeCommitment writes the last txNum of the block
-// (e.g. firstTxNum(S+1)-1 when the step boundary aligns with a block), so
-// the +1 avoids an off-by-one that would delay collation unnecessarily.
-func TestAggregator_CommittedTxNumGuard(t *testing.T) {
-	t.Parallel()
-	stepSize := uint64(100)
-
-	// Step 5 covers txNums [500, 600). firstTxNum(6) = 600.
-	assert.False(t, stepFullyCommitted(550, 5, stepSize),
-		"guard should block: committed txNum is mid-step")
-	assert.True(t, stepFullyCommitted(0, 5, stepSize),
-		"guard should be bypassed when committedTxNum is 0 (no commitment)")
-	assert.False(t, stepFullyCommitted(598, 5, stepSize),
-		"guard should block: committed txNum is 1 before last txNum of step")
-
-	// committedTxNum = 599 = lastTxNumOfStep(5) = firstTxNum(6)-1
-	// This is the value ComputeCommitment writes at the step boundary.
-	assert.True(t, stepFullyCommitted(599, 5, stepSize),
-		"guard should allow: committed txNum is last txNum of the step")
-	assert.True(t, stepFullyCommitted(600, 5, stepSize),
-		"guard should allow: committed txNum is past the step")
-	assert.True(t, stepFullyCommitted(1000, 5, stepSize),
-		"guard should allow: committed txNum is well past the step")
-}
-
 // TestAggregator_BuildFiles_GapRefuses verifies that buildFilesInBackground
 // refuses to aggregate when MDBX's earliest history entry lies strictly above
 // the next step to build AND snapshot files already cover the earlier range.

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1309,7 +1309,7 @@ func (d *Domain) integrateDirtyFiles(sf StaticFiles, txNumFrom, txNumTo uint64) 
 
 // unwind is similar to prune but the difference is that it restores domain values from the history as of txFrom
 // context Flush should be managed by caller.
-func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwindTo, currentFilesEndStep uint64, domainDiffs []kv.DomainEntryDiff) error {
+func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwindTo uint64, domainDiffs []kv.DomainEntryDiff) error {
 	// fmt.Printf("[domain][%s] unwinding domain to txNum=%d, step %d\n", d.filenameBase, txNumUnwindTo, step)
 	d := dt.d
 
@@ -1335,17 +1335,8 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 	//                       empty tombstone to prevent getLatestFromDb falling through to files
 	//                       (which have no concept of deletions) and returning stale data
 	//   - non-empty      → restore the actual previous value
-	//
-	// The step tag for restored entries must be BEYOND the filed range, otherwise
-	// getLatestFromDb will discard them (step covered by files → fall through to
-	// files which have the pre-unwind value). Use the larger of the natural step
-	// and the first unfiled step. See #20169.
-	unwindStep := step
-	if currentFilesEndStep > unwindStep {
-		unwindStep = currentFilesEndStep
-	}
 	unwindStepBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(unwindStepBytes, ^uint64(unwindStep))
+	binary.BigEndian.PutUint64(unwindStepBytes, ^uint64(step))
 
 	for i := range domainDiffs {
 		keyStr, value := domainDiffs[i].Key, domainDiffs[i].Value
@@ -1383,8 +1374,8 @@ func (dt *DomainRoTx) unwind(ctx context.Context, rwTx kv.RwTx, step, txNumUnwin
 		// A key changed at several steps in the range has one diff per step, sorted
 		// by key then descending step; only the lowest step's value is the value at
 		// txNumUnwindTo. Restore once, on the last (lowest-step) diff — else the
-		// DupSort table keeps several dups at unwindStep and getLatestFromDb returns
-		// the smallest. nil = different step, skip; []byte{} = absent, write tombstone.
+		// DupSort table keeps several dups at the unwind step and getLatestFromDb
+		// returns the smallest. nil = different step, skip; []byte{} = absent, write tombstone.
 		lastForKey := i+1 == len(domainDiffs) || domainDiffs[i+1].Key[:len(domainDiffs[i+1].Key)-8] != keyStr[:len(keyStr)-8]
 		if value != nil && lastForKey {
 			if err := valsCursor.Put(fullKey, append(unwindStepBytes, value...)); err != nil {

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -953,156 +953,6 @@ func TestDomainRoTx_CursorParentCheck(t *testing.T) {
 	require.NoError(err)
 }
 
-// TestDomain_CollationIsolatedFromLaterSteps verifies that collation for step S
-// produces correct results even when step S+1 data is present in the DB.
-// This is a correctness test for the collation/pruning race fix (#20169).
-//
-// The collation/pruning race occurs when BuildFilesInBackground's collation
-// read-transaction sees step S+1 values that overwrite step S entries. The
-// fix uses a single read-tx for all collations in buildFiles, ensuring they
-// all see the same MDBX snapshot. While the exact race is timing-dependent
-// and hard to reproduce in a unit test, this test verifies the invariant:
-// step S collation must produce a file with step S values regardless of
-// later step data in the DB.
-func TestDomain_CollationIsolatedFromLaterSteps(t *testing.T) {
-	logger := log.New()
-	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
-	ctx := t.Context()
-
-	k1 := []byte("key1")
-	k2 := []byte("key2")
-	v1s0 := []byte("value1_step0")
-	v2s0 := []byte("value2_step0")
-	v1s1 := []byte("value1_step1") // k1 modified again in step 1
-	// k2 is NOT modified in step 1
-
-	// Write both keys in step 0, then k1 again in step 1, all in one transaction.
-	tx, err := db.BeginRw(ctx)
-	require.NoError(t, err)
-	defer tx.Rollback() //nolint:gocritic
-	dt := d.beginForTests()
-	w := dt.NewWriter()
-
-	// Step 0 writes (txNums 0-15)
-	require.NoError(t, w.PutWithPrev(k1, v1s0, 5, nil))
-	require.NoError(t, w.PutWithPrev(k2, v2s0, 7, nil))
-
-	// Step 1 write (txNums 16-31) — overwrites k1 only
-	require.NoError(t, w.PutWithPrev(k1, v1s1, 20, v1s0))
-
-	require.NoError(t, w.Flush(ctx, tx))
-	require.NoError(t, tx.Commit())
-	w.Close()
-	dt.Close()
-
-	// Collate step 0 — should get k1=v1s0 and k2=v2s0, NOT k1=v1s1.
-	roTx, err := db.BeginRo(ctx)
-	require.NoError(t, err)
-	defer roTx.Rollback()
-
-	coll, err := d.collate(ctx, 0, 0, 16, roTx)
-	require.NoError(t, err)
-	defer coll.Close()
-	sf, err := d.buildFiles(ctx, 0, coll, background.NewProgressSet())
-	require.NoError(t, err)
-	defer sf.CleanupOnError()
-
-	g := d.dataReader(sf.valuesDecomp)
-	g.Reset(0)
-	var words []string
-	for g.HasNext() {
-		w, _ := g.Next(nil)
-		words = append(words, string(w))
-	}
-	require.Equal(t, []string{"key1", "value1_step0", "key2", "value2_step0"}, words,
-		"step 0 collation must contain step 0 values, not step 1 overwrites")
-
-	// Collate step 1 — should get k1=v1s1 only (k2 was not modified in step 1).
-	coll1, err := d.collate(ctx, 1, 16, 32, roTx)
-	require.NoError(t, err)
-	defer coll1.Close()
-	sf1, err := d.buildFiles(ctx, 1, coll1, background.NewProgressSet())
-	require.NoError(t, err)
-	defer sf1.CleanupOnError()
-
-	g = d.dataReader(sf1.valuesDecomp)
-	g.Reset(0)
-	var words1 []string
-	for g.HasNext() {
-		w, _ := g.Next(nil)
-		words1 = append(words1, string(w))
-	}
-	require.Equal(t, []string{"key1", "value1_step1"}, words1,
-		"step 1 collation must contain only step 1 values")
-}
-
-// TestDomain_UnwindRestoredEntryVisibility verifies that after an unwind, restored
-// domain entries are visible to GetLatest even when the entry's natural step has
-// been filed by BuildFilesInBackground. See #20169.
-//
-// The bug: unwind tags restored entries with the step of the unwind-target txNum.
-// If that step is covered by domain files, getLatestFromDb discards the entry and
-// falls through to getLatestFromFiles, returning the stale end-of-step value from
-// the file instead of the changeset-restored value.
-func TestDomain_UnwindRestoredEntryVisibility(t *testing.T) {
-	logger := log.New()
-	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
-	ctx := t.Context()
-	logEvery := time.NewTicker(30 * time.Second)
-	defer logEvery.Stop()
-
-	k1 := []byte("key1")
-
-	// Step 0: write k1 twice — first V1 at txNum 2, then V2 at txNum 10.
-	// The file for step 0 will have k1=V2 (latest value in the step).
-	tx, err := db.BeginRw(ctx)
-	require.NoError(t, err)
-	defer tx.Rollback() //nolint:gocritic
-
-	dt := d.beginForTests()
-	w := dt.NewWriter()
-	require.NoError(t, w.PutWithPrev(k1, []byte("V1"), 2, nil))
-	require.NoError(t, w.PutWithPrev(k1, []byte("V2"), 10, []byte("V1")))
-	require.NoError(t, w.Flush(ctx, tx))
-	w.Close()
-	dt.Close()
-
-	// Build files for step 0 → file has k1=V2.
-	require.NoError(t, d.collateBuildIntegrate(ctx, 0, tx, background.NewProgressSet()))
-
-	// Prune step 0 from DB — entries now only in files.
-	dt = d.beginForTests()
-	_, err = dt.Prune(ctx, tx, 0, 0, 16, math.MaxUint64, logEvery)
-	dt.Close()
-	require.NoError(t, err)
-
-	// Now simulate an unwind that restores k1=V1 (reverting the V1→V2 write at txNum 10).
-	// The changeset entry has: key="key1" + step0_bytes, value=V1.
-	step0Bytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(step0Bytes, ^uint64(0))
-	diffs := []kv.DomainEntryDiff{
-		{
-			Key:   string(k1) + string(step0Bytes),
-			Value: []byte("V1"),
-		},
-	}
-
-	// Unwind to txNum 5 (between the V1 write at 2 and V2 write at 10, still in step 0).
-	dt = d.beginForTests()
-	err = dt.unwind(ctx, tx, 0, 5, uint64(dt.FirstStepNotInFiles()), diffs)
-	dt.Close()
-	require.NoError(t, err)
-
-	// GetLatest must return V1 (the changeset-restored value), NOT V2 (the file value).
-	dt = d.beginForTests()
-	defer dt.Close()
-	v, _, found, err := dt.GetLatest(k1, tx)
-	require.NoError(t, err)
-	require.True(t, found, "key should be found after unwind")
-	require.Equal(t, "V1", string(v),
-		"GetLatest must return the unwind-restored value V1, not the file value V2")
-}
-
 func TestDomain_Delete(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -2621,7 +2471,7 @@ func TestDomain_Unwind(t *testing.T) {
 			}
 		}
 
-		err = domainRoTx.unwind(ctx, tx, unwindTo/d.stepSize, unwindTo, uint64(domainRoTx.FirstStepNotInFiles()), totalDiff)
+		err = domainRoTx.unwind(ctx, tx, unwindTo/d.stepSize, unwindTo, totalDiff)
 		currTx = unwindTo
 		require.NoError(t, err)
 		domainRoTx.Close()
@@ -3745,7 +3595,9 @@ func TestDomain_UnwindRestoresDeletionMarker(t *testing.T) {
 			ctx := t.Context()
 			require := require.New(t)
 
-			// Phase 1: Write key1 through three states within step 0 and record diffs.
+			// Phase 1: Write key1=value1 in step 0, then delete and re-write it in
+			// step 1, recording diffs. Step 0 gets filed; the unwind target stays
+			// above the file boundary, as production unwinds always do.
 			tx, err := db.BeginRw(ctx)
 			require.NoError(err)
 			defer tx.Rollback()
@@ -3759,39 +3611,38 @@ func TestDomain_UnwindRestoresDeletionMarker(t *testing.T) {
 			value1 := []byte("value1")
 			value2 := []byte("value2")
 
-			// txNum 0: write key1=value1 (new key, prev=nil)
+			// txNum 0 (step 0): write key1=value1 (new key, prev=nil)
 			writer.diff = &kv.DomainDiff{}
 			err = writer.PutWithPrev(key, value1, 0, nil)
 			require.NoError(err)
 
-			// txNum 1: delete key1 (prev=value1)
+			// txNum 17 (step 1): delete key1 (prev=value1)
 			writer.diff = &kv.DomainDiff{}
-			err = writer.DeleteWithPrev(key, 1, value1)
+			err = writer.DeleteWithPrev(key, 17, value1)
 			require.NoError(err)
 
-			// txNum 2: re-write key1=value2 (prev=nil, key was deleted)
+			// txNum 18 (step 1): re-write key1=value2 (prev=nil, key was deleted)
 			// Only this diff is needed for the unwind — it captures the previous
 			// state (deleted → Value=[]byte{}) that unwind must restore.
 			writer.diff = &kv.DomainDiff{}
-			err = writer.PutWithPrev(key, value2, 2, nil)
+			err = writer.PutWithPrev(key, value2, 18, nil)
 			require.NoError(err)
-			txNum2Diff := writer.diff.GetDiffSet()
+			txNum18Diff := writer.diff.GetDiffSet()
 
 			// Verify the nil-vs-empty distinction survives serialization round-trip.
 			// Production diffs go through SerializeDiffSet/DeserializeDiffSet when
 			// stored in ChangeSets3; this ensures the []byte{} tombstone is preserved.
-			txNum2Diff = changeset.DeserializeDiffSet(changeset.SerializeDiffSet(txNum2Diff, nil))
+			txNum18Diff = changeset.DeserializeDiffSet(changeset.SerializeDiffSet(txNum18Diff, nil))
 
 			err = writer.Flush(ctx, tx)
 			require.NoError(err)
 			domainRoTx.Close()
 
-			// Phase 2: Build files for step 0. The file will contain key1=value2
-			// (the latest value within step 0).
+			// Phase 2: Build files for step 0. The file will contain key1=value1.
 			require.NoError(d.collateBuildIntegrate(ctx, 0, tx, background.NewProgressSet()))
 			require.NoError(tx.Commit())
 
-			// Phase 3: Unwind to revert txNum 2 (keep txNums 0 and 1).
+			// Phase 3: Unwind to revert txNum 18 (keep txNums 0..17).
 			tx, err = db.BeginRw(ctx)
 			require.NoError(err)
 			defer tx.Rollback()
@@ -3799,8 +3650,8 @@ func TestDomain_UnwindRestoresDeletionMarker(t *testing.T) {
 			domainRoTx = d.beginForTests()
 			defer domainRoTx.Close()
 
-			// diff for txNum 2: prev was empty (key was deleted) → Value=[]byte{}
-			err = domainRoTx.unwind(ctx, tx, 0, 2, 1, txNum2Diff)
+			// diff for txNum 18: prev was empty (key was deleted) → Value=[]byte{}
+			err = domainRoTx.unwind(ctx, tx, 1, 18, txNum18Diff)
 			require.NoError(err)
 			domainRoTx.Close()
 			require.NoError(tx.Commit())
@@ -3815,11 +3666,11 @@ func TestDomain_UnwindRestoresDeletionMarker(t *testing.T) {
 
 			v, _, found, err := domainRoTx.GetLatest(key, roTx)
 			require.NoError(err)
-			// After unwinding txNum 2, the state should reflect txNums 0-1.
-			// At txNum 1, key1 was deleted. The unwind must restore the deletion
+			// After unwinding txNum 18, the state should reflect txNums 0..17.
+			// At txNum 17, key1 was deleted. The unwind must restore the deletion
 			// marker (empty tombstone) in DB. Without the fix, `if len(value) > 0`
 			// skips restoring the empty tombstone, and getLatestFromFiles returns
-			// stale "value2" from the step 0 file.
+			// stale "value1" from the step 0 file.
 			require.True(found, "deletion marker should be found after unwind")
 			require.Empty(v, "deleted key should have empty value after unwind, got %q", v)
 		})

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -953,6 +953,82 @@ func TestDomainRoTx_CursorParentCheck(t *testing.T) {
 	require.NoError(err)
 }
 
+// TestDomain_CollationSelectsExactStep pins that collate picks only entries
+// tagged with the requested step. This is what makes the per-domain collation
+// read-tx snapshots in buildFiles interchangeable: later-step data visible in
+// a newer snapshot cannot leak into an earlier step's file.
+func TestDomain_CollationSelectsExactStep(t *testing.T) {
+	logger := log.New()
+	db, d := testDbAndDomainOfStep(t, statecfg.Schema.StorageDomain, 16, logger)
+	ctx := t.Context()
+
+	k1 := []byte("key1")
+	k2 := []byte("key2")
+	v1s0 := []byte("value1_step0")
+	v2s0 := []byte("value2_step0")
+	v1s1 := []byte("value1_step1") // k1 modified again in step 1
+	// k2 is NOT modified in step 1
+
+	// Write both keys in step 0, then k1 again in step 1, all in one transaction.
+	tx, err := db.BeginRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback() //nolint:gocritic
+	dt := d.beginForTests()
+	w := dt.NewWriter()
+
+	// Step 0 writes (txNums 0-15)
+	require.NoError(t, w.PutWithPrev(k1, v1s0, 5, nil))
+	require.NoError(t, w.PutWithPrev(k2, v2s0, 7, nil))
+
+	// Step 1 write (txNums 16-31) — overwrites k1 only
+	require.NoError(t, w.PutWithPrev(k1, v1s1, 20, v1s0))
+
+	require.NoError(t, w.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+	w.Close()
+	dt.Close()
+
+	// Collate step 0 — should get k1=v1s0 and k2=v2s0, NOT k1=v1s1.
+	roTx, err := db.BeginRo(ctx)
+	require.NoError(t, err)
+	defer roTx.Rollback()
+
+	coll, err := d.collate(ctx, 0, 0, 16, roTx)
+	require.NoError(t, err)
+	defer coll.Close()
+	sf, err := d.buildFiles(ctx, 0, coll, background.NewProgressSet())
+	require.NoError(t, err)
+	defer sf.CleanupOnError()
+
+	g := d.dataReader(sf.valuesDecomp)
+	g.Reset(0)
+	var words []string
+	for g.HasNext() {
+		w, _ := g.Next(nil)
+		words = append(words, string(w))
+	}
+	require.Equal(t, []string{"key1", "value1_step0", "key2", "value2_step0"}, words,
+		"step 0 collation must contain step 0 values only")
+
+	// Collate step 1 — should get k1=v1s1 only (k2 was not modified in step 1).
+	coll1, err := d.collate(ctx, 1, 16, 32, roTx)
+	require.NoError(t, err)
+	defer coll1.Close()
+	sf1, err := d.buildFiles(ctx, 1, coll1, background.NewProgressSet())
+	require.NoError(t, err)
+	defer sf1.CleanupOnError()
+
+	g = d.dataReader(sf1.valuesDecomp)
+	g.Reset(0)
+	var words1 []string
+	for g.HasNext() {
+		w, _ := g.Next(nil)
+		words1 = append(words1, string(w))
+	}
+	require.Equal(t, []string{"key1", "value1_step1"}, words1,
+		"step 1 collation must contain only step 1 values")
+}
+
 func TestDomain_Delete(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/db/state/domain_unwind_multistep_test.go
+++ b/db/state/domain_unwind_multistep_test.go
@@ -130,7 +130,7 @@ func TestDomain_MultiStepUnwindMatchesGroundTruth(t *testing.T) {
 			merged = changeset.MergeDiffSets(merged, blockDiffs[b])
 		}
 	}
-	require.NoError(t, udt.unwind(ctx, tx, target/stepSize, target, uint64(udt.FirstStepNotInFiles()), merged))
+	require.NoError(t, udt.unwind(ctx, tx, target/stepSize, target, merged))
 	udt.Close()
 
 	rdt := d.beginForTests()


### PR DESCRIPTION
## Summary

Reverts the functional changes of #20445 ("fix collation/pruning race and unwind visibility in BuildFilesInBackground"). Based on how the domain state layer works, neither bug that PR describes exists, its new guard is dead code, and its unwind change introduces a stale-read hazard of its own. Issue #20169, which it claimed to fix, reproduced again two days after the merge and was closed only after unrelated fixes landed.

## Reasons

**1. The "collation/pruning race" (its bug 1) cannot occur.**
Domain entries are keyed by `(key, inverted step)` — a step S+1 write never overwrites a step S value — and `Domain.collate` selects entries by exact step tag (`bytes.Equal(stepBytes, stepInDB)`), so later-step data is invisible to a step-S collation regardless of when its read-tx opens. Execution flushes in txNum-prefix batches with atomic commits, and `buildFilesInBackground` only collates `step < lastInDB` (step S+1 records visible ⇒ step S complete), so each per-domain `a.db.View` already saw all of step S. Empirically: the PR's own regression test `TestDomain_CollationIsolatedFromLaterSteps` passes verbatim against the pre-PR code (`16ac9850^`) — it never reproduced a bug. The two-phase restructure only serialized previously parallel collation.

**2. The committed-txNum guard has never executed.**
`Aggregator.db` is the raw MDBX `kv.RoDB` — `temporal.New(rawDB, agg)` wraps it *after* the aggregator is constructed — so `a.db.(kv.TemporalRoDB)` always fails, `committedTxNum` stays 0, and `stepFullyCommitted(0, …)` returns true unconditionally. Dead code in every production and test configuration (and its 0-sentinel conflates "genesis committed at txNum 0" with "no commitment yet", so it couldn't work as specified even if wired — see the failing tests in #20596 / 522bca8dc5).

**3. The unwind step bump is a no-op when legal and corrupting when engaged.**
For every legal unwind, `step(txNumUnwindTo) >= EndTxNumMinimax/stepSize`: unwind targets are bounded by changeset retention (`MaxReorgDepth` = 96 blocks) while `readyForCollation` — already present before #20445 — holds collation `reorgBlockDepth` (= the same `dbg.MaxReorgDepth`) blocks behind the tip, so files never cover an unwindable txNum and `max()` changes nothing. In the raced scenario the PR postulates (files published past the unwind target mid-unwind), the bump tags restored entries with a *future* step; post-reorg re-execution then writes at natural (lower) steps, and `getLatestFromDb` keeps returning the stale restored value (inverted-step dups sort higher steps first). Reproduced on current main by adapting AskAlexSharov's `TestDomain_UnwindOverBumpedStepMasksNewWrites` (522bca8dc5): `GetLatest` returns the pre-reorg value instead of the re-executed one. And in that raced state the history/inverted-index files would already contain unwound txNums — no DB re-tagging can repair that; the invariant is enforced at the source by `readyForCollation`.

## Corroborating timeline

- #20169's own investigation pointed at EIP-7702 EVM gas forwarding, not the domain layer.
- 2026-04-18, two days after the merge (and the r3.4 backport #20594): "1 my server and 1 validator got: gas missmatch" — the issue reproduced with the fix in tree, and was closed "Seems fixed" on 04-23 after other fixes merged in that window (e.g. #20609, #20681).
- Maintainer follow-up #20596 added failing tests exposing three bugs in the PR; it was closed unmerged, leaving the defects on main until now.

## Scope

- **Reverted:** single-tx two-phase `buildFiles`; committed-txNum guard + `stepFullyCommitted` + its test; `currentFilesEndStep` unwind parameter and bump; the PR's two domain tests (one pins pre-existing behavior under a false race narrative, the other pins the corrupting bump behavior in an out-of-contract state).
- **Kept:** #21981's `lastForKey` multi-step unwind fix (test adapted to the 4-arg signature); #20627's tombstone-restore fix — its regression test reworked to put the delete/re-write above the file boundary, i.e. a legal unwind, with identical coverage; the reorg-depth collation gating; #20445's cosmetic commitmentdb changes (typo fix, value-length guard, exported decoder).
- The masking reproduction cannot be carried as a test post-revert: the parameter it exercises no longer exists.

If accepted, this should also be cherry-picked to `release/3.4`, which carries #20445 via #20594.

## Test plan

- [x] Full `db/state` suite green (`go test ./db/state/... -count=1`)
- [x] `TestDomain_UnwindRestoresDeletionMarker` (reworked), `TestDomain_MultiStepUnwindMatchesGroundTruth`, `TestDomain_Unwind`, `TestDomain_DeletedKeyNotResurrectedByFiles`, `TestAggregator_BuildFiles_GapRefuses`
- [x] `make lint`
- [x] `make erigon integration`
