### PR TITLE
db/snapshotsync: say why snapshot segments are unavailable

### DIFF
--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -1305,7 +1305,8 @@ func (s *RoSnapshots) BuildMissedIndices(ctx context.Context, logPrefix string, 
 		return nil
 	}
 	if !s.SegmentsReady() {
-		return errors.New("not all snapshot segments are available")
+		return fmt.Errorf("not all snapshot segments are available: snapshots are not opened yet (dir=%s, segments max=%d, indices max=%d, download ready=%t)",
+			s.dir, s.SegmentsMax(), s.IndicesMax(), s.DownloadReady())
 	}
 
 	// wait for Downloader service to download all expected snapshots

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -1305,8 +1305,8 @@ func (s *RoSnapshots) BuildMissedIndices(ctx context.Context, logPrefix string, 
 		return nil
 	}
 	if !s.SegmentsReady() {
-		return fmt.Errorf("not all snapshot segments are available: snapshots are not opened yet (dir=%s, segments max=%d, indices max=%d, download ready=%t)",
-			s.dir, s.SegmentsMax(), s.IndicesMax(), s.DownloadReady())
+		return fmt.Errorf("not all snapshot segments are available: segments max=%d, indices max=%d, download ready=%t",
+			s.SegmentsMax(), s.IndicesMax(), s.DownloadReady())
 	}
 
 	// wait for Downloader service to download all expected snapshots


### PR DESCRIPTION
`BuildMissedIndices` fails retire attempts with a bare "not all snapshot segments are available", which says nothing about whether snapshots are still downloading, not yet opened, or genuinely incomplete — the message shows up in test and node logs with no way to tell the cases apart.

## Changes
- Include the snapshot dir, segments/indices progress, and downloader readiness in the error.
