### PR TITLE
db/integrity: add CaplinStateRoots check for blank root snapshots

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1646,6 +1646,8 @@ func doIntegrity(ctx context.Context, cliCtx *cli.Command) error {
 			return integrity.CheckStateProgress(ctx, db, blockReader, failFast)
 		case integrity.Publishable:
 			return doPublishable(dirs, chainDB)
+		case integrity.CaplinStateRoots:
+			return integrity.CheckCaplinStateRoots(ctx, dirs, failFast, logger)
 		case integrity.BorEvents:
 			if !CheckBorChain(chainConfig.ChainName) {
 				logger.Info("BorEvents skipped because not bor chain")

--- a/db/integrity/caplin_state_integrity.go
+++ b/db/integrity/caplin_state_integrity.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package integrity
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/snaptype"
+)
+
+// caplinDenseRootTables are the caplin state snapshot types that carry one 32-byte
+// root per slot: process_slot writes block_roots/state_roots every slot, so an empty
+// word is always a reconstruction gap, never valid state. A blank segment shadows the
+// DB (snapshots take read precedence) and breaks historical-state reads for its range.
+var caplinDenseRootTables = []string{"BlockRoot", "StateRoot"}
+
+// CheckCaplinStateRoots verifies frozen caplin block_roots/state_roots snapshots hold a
+// 32-byte root for every slot, catching ranges frozen before they were reconstructed.
+func CheckCaplinStateRoots(ctx context.Context, dirs datadir.Dirs, failFast bool, logger log.Logger) error {
+	var firstErr error
+	for _, table := range caplinDenseRootTables {
+		files, err := filepath.Glob(filepath.Join(dirs.SnapCaplin, "*-"+table+".seg"))
+		if err != nil {
+			return err
+		}
+		sort.Strings(files)
+		for _, path := range files {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			blank, total, firstBlankSlot, err := scanBlankRoots(path)
+			if err != nil {
+				return err
+			}
+			if blank == 0 {
+				continue
+			}
+			err = fmt.Errorf("caplin %s snapshot %s: %d/%d slots have no root (first at slot %d)", table, filepath.Base(path), blank, total, firstBlankSlot)
+			logger.Error("[integrity] CaplinStateRoots", "err", err)
+			if failFast {
+				return err
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+func scanBlankRoots(path string) (blank, total, firstBlankSlot uint64, err error) {
+	var from uint64
+	if info, _, ok := snaptype.ParseFileName(filepath.Dir(path), filepath.Base(path)); ok {
+		from = info.From
+	}
+	d, err := seg.NewDecompressor(path)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	defer d.Close()
+	g := d.MakeGetter()
+	for g.HasNext() {
+		w, _ := g.Next(nil)
+		if len(w) != length.Hash {
+			if blank == 0 {
+				firstBlankSlot = from + total
+			}
+			blank++
+		}
+		total++
+	}
+	return blank, total, firstBlankSlot, nil
+}

--- a/db/integrity/caplin_state_integrity.go
+++ b/db/integrity/caplin_state_integrity.go
@@ -49,14 +49,14 @@ func CheckCaplinStateRoots(ctx context.Context, dirs datadir.Dirs, failFast bool
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			blank, total, firstBlankSlot, err := scanBlankRoots(path)
+			blank, total, firstBlankSlot, err := scanBlankRoots(ctx, path)
 			if err != nil {
 				return err
 			}
 			if blank == 0 {
 				continue
 			}
-			err = fmt.Errorf("caplin %s snapshot %s: %d/%d slots have no root (first at slot %d)", table, filepath.Base(path), blank, total, firstBlankSlot)
+			err = fmt.Errorf("caplin %s snapshot %s: %d/%d slots have a missing or invalid root (first at slot %d)", table, filepath.Base(path), blank, total, firstBlankSlot)
 			logger.Error("[integrity] CaplinStateRoots", "err", err)
 			if failFast {
 				return err
@@ -69,7 +69,7 @@ func CheckCaplinStateRoots(ctx context.Context, dirs datadir.Dirs, failFast bool
 	return firstErr
 }
 
-func scanBlankRoots(path string) (blank, total, firstBlankSlot uint64, err error) {
+func scanBlankRoots(ctx context.Context, path string) (blank, total, firstBlankSlot uint64, err error) {
 	var from uint64
 	if info, _, ok := snaptype.ParseFileName(filepath.Dir(path), filepath.Base(path)); ok {
 		from = info.From
@@ -81,6 +81,9 @@ func scanBlankRoots(path string) (blank, total, firstBlankSlot uint64, err error
 	defer d.Close()
 	g := d.MakeGetter()
 	for g.HasNext() {
+		if total%8192 == 0 && ctx.Err() != nil {
+			return 0, 0, 0, ctx.Err()
+		}
 		w, _ := g.Next(nil)
 		if len(w) != length.Hash {
 			if blank == 0 {

--- a/db/integrity/caplin_state_integrity_test.go
+++ b/db/integrity/caplin_state_integrity_test.go
@@ -33,10 +33,10 @@ import (
 	"github.com/erigontech/erigon/db/version"
 )
 
-func writeBlockRootSeg(t *testing.T, dirs datadir.Dirs, from, to uint64, words [][]byte) {
+func writeRootSeg(t *testing.T, dirs datadir.Dirs, table string, from, to uint64, words [][]byte) {
 	t.Helper()
 	name := snaptype.BeaconBlocks.FileName(version.ZeroVersion, from, to)
-	name = strings.ReplaceAll(name, "beaconblocks", "BlockRoot")
+	name = strings.ReplaceAll(name, "beaconblocks", table)
 	c, err := seg.NewCompressor(context.Background(), "test", filepath.Join(dirs.SnapCaplin, name), dirs.Tmp, seg.DefaultCfg, log.LvlCrit, log.New())
 	require.NoError(t, err)
 	defer c.Close()
@@ -47,24 +47,52 @@ func writeBlockRootSeg(t *testing.T, dirs datadir.Dirs, from, to uint64, words [
 }
 
 func TestCheckCaplinStateRoots(t *testing.T) {
-	dirs := datadir.New(t.TempDir())
-	require.NoError(t, os.MkdirAll(dirs.SnapCaplin, 0o755))
-	require.NoError(t, os.MkdirAll(dirs.Tmp, 0o755))
 	ctx, logger := context.Background(), log.New()
 
-	root := make([]byte, length.Hash)
-	full := make([][]byte, 0, 20)
-	for range 20 {
-		full = append(full, root)
+	fullRoots := func() [][]byte {
+		root := make([]byte, length.Hash)
+		w := make([][]byte, 0, 20)
+		for range 20 {
+			w = append(w, root)
+		}
+		return w
+	}
+	holed := func() [][]byte {
+		w := fullRoots()
+		w[7] = nil
+		return w
+	}
+	setup := func(t *testing.T) datadir.Dirs {
+		t.Helper()
+		dirs := datadir.New(t.TempDir())
+		require.NoError(t, os.MkdirAll(dirs.SnapCaplin, 0o755))
+		require.NoError(t, os.MkdirAll(dirs.Tmp, 0o755))
+		return dirs
 	}
 
-	writeBlockRootSeg(t, dirs, 0, 50000, full)
-	require.NoError(t, CheckCaplinStateRoots(ctx, dirs, true, logger))
+	t.Run("all roots present", func(t *testing.T) {
+		dirs := setup(t)
+		writeRootSeg(t, dirs, "BlockRoot", 0, 50000, fullRoots())
+		writeRootSeg(t, dirs, "StateRoot", 0, 50000, fullRoots())
+		require.NoError(t, CheckCaplinStateRoots(ctx, dirs, true, logger))
+	})
 
-	holed := append([][]byte{}, full...)
-	holed[7] = nil
-	writeBlockRootSeg(t, dirs, 50000, 100000, holed)
-	err := CheckCaplinStateRoots(ctx, dirs, true, logger)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no root")
+	t.Run("hole in BlockRoot", func(t *testing.T) {
+		dirs := setup(t)
+		writeRootSeg(t, dirs, "BlockRoot", 50000, 100000, holed())
+		err := CheckCaplinStateRoots(ctx, dirs, true, logger)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "BlockRoot")
+		require.Contains(t, err.Error(), "invalid root")
+	})
+
+	t.Run("hole in StateRoot", func(t *testing.T) {
+		dirs := setup(t)
+		writeRootSeg(t, dirs, "BlockRoot", 0, 50000, fullRoots())
+		writeRootSeg(t, dirs, "StateRoot", 50000, 100000, holed())
+		err := CheckCaplinStateRoots(ctx, dirs, true, logger)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "StateRoot")
+		require.Contains(t, err.Error(), "invalid root")
+	})
 }

--- a/db/integrity/caplin_state_integrity_test.go
+++ b/db/integrity/caplin_state_integrity_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package integrity
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/version"
+)
+
+func writeBlockRootSeg(t *testing.T, dirs datadir.Dirs, from, to uint64, words [][]byte) {
+	t.Helper()
+	name := snaptype.BeaconBlocks.FileName(version.ZeroVersion, from, to)
+	name = strings.ReplaceAll(name, "beaconblocks", "BlockRoot")
+	c, err := seg.NewCompressor(context.Background(), "test", filepath.Join(dirs.SnapCaplin, name), dirs.Tmp, seg.DefaultCfg, log.LvlCrit, log.New())
+	require.NoError(t, err)
+	defer c.Close()
+	for _, w := range words {
+		require.NoError(t, c.AddWord(w))
+	}
+	require.NoError(t, c.Compress())
+}
+
+func TestCheckCaplinStateRoots(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+	require.NoError(t, os.MkdirAll(dirs.SnapCaplin, 0o755))
+	require.NoError(t, os.MkdirAll(dirs.Tmp, 0o755))
+	ctx, logger := context.Background(), log.New()
+
+	root := make([]byte, length.Hash)
+	full := make([][]byte, 0, 20)
+	for range 20 {
+		full = append(full, root)
+	}
+
+	writeBlockRootSeg(t, dirs, 0, 50000, full)
+	require.NoError(t, CheckCaplinStateRoots(ctx, dirs, true, logger))
+
+	holed := append([][]byte{}, full...)
+	holed[7] = nil
+	writeBlockRootSeg(t, dirs, 50000, 100000, holed)
+	err := CheckCaplinStateRoots(ctx, dirs, true, logger)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no root")
+}

--- a/db/integrity/integrity_action_type.go
+++ b/db/integrity/integrity_action_type.go
@@ -125,12 +125,18 @@ const (
 	// DeriveSha, and compares it with block.header.ReceiptHash. Similar to StateRootVerifyByHistory
 	// but for receipt roots instead of state roots.
 	ReceiptRootIntegrity Check = "ReceiptRootIntegrity"
+
+	// CaplinStateRoots verifies frozen caplin block_roots/state_roots snapshots hold a
+	// 32-byte root for every slot. process_slot writes these every slot, so an empty word is
+	// a range frozen before it was reconstructed; such a blank segment shadows the DB and
+	// breaks historical-state reads. Cheap: iterates the .seg words, no DB or re-derivation.
+	CaplinStateRoots Check = "CaplinStateRoots"
 )
 
 // FastChecks is ordered cheapest → heaviest so time-budgeted runs give unused
 // budget to the heavier checks at the tail.
 var FastChecks = []Check{
-	Publishable, HeaderNoGaps, BlocksTxnID, Blocks,
+	Publishable, HeaderNoGaps, BlocksTxnID, Blocks, CaplinStateRoots,
 	ReceiptsNoDups, RCacheNoDups, ReceiptRootIntegrity, InvertedIndex, CommitmentRoot, CommitmentKvi,
 	HistoryNoSystemTxs, CommitmentHistVal, StateRootVerifyByHistory,
 }


### PR DESCRIPTION
Caplin `block_roots`/`state_roots` state snapshots can be frozen full of empty words when a range is dumped before it was reconstructed. Those blanks shadow the DB (snapshots take read precedence) and silently break historical-state reads for the range, and no integrity check catches it.

## Changes
- Add a `CaplinStateRoots` check that iterates the frozen `BlockRoot`/`StateRoot` `.seg` words and fails on any that isn't a 32-byte root (`process_slot` writes these every slot, so empty is always a gap), reporting the file and first blank slot.
- Cheap (no DB or re-derivation), so it joins `FastChecks` and Publishable-tier validation.
