### PR TITLE
rpc: make checkPruneField overlay-aware for the FCU pre-commit window

### DIFF
--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -434,7 +434,7 @@ func (api *BaseAPI) checkPruneField(tx kv.Tx, block uint64, field func(*prune.Mo
 	if !amount.Enabled() {
 		return nil
 	}
-	latest, err := rpchelper.GetLatestBlockNumber(tx)
+	latest, err := rpchelper.GetLatestBlockNumber(api.filters.WithOverlay(tx))
 	if err != nil {
 		return err
 	}

--- a/rpc/jsonrpc/overlay_race_test.go
+++ b/rpc/jsonrpc/overlay_race_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/db/kv/kvcache"
+	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain"
@@ -100,6 +101,7 @@ func newOverlayAheadTestAPI(t *testing.T) (base *BaseAPI, m *execmoduletester.Ex
 	require.NoError(t, rawdb.WriteHeadHeaderHash(overlay, hash))
 	require.NoError(t, rawdb.WriteCanonicalHash(overlay, hash, overlayNumber))
 	require.NoError(t, rawdb.WriteBody(overlay, hash, overlayNumber, &types.Body{}))
+	rawdb.WriteForkchoiceHead(overlay, hash)
 
 	events := shards.NewEvents()
 	events.PublishOverlay(doms)
@@ -225,4 +227,34 @@ func TestTxPoolContentFrom_UsesOverlayHead(t *testing.T) {
 	require.NotNil(t, got)
 	require.Equal(t, overlayHeader.BaseFee.ToBig(), got.GasPrice.ToInt(),
 		"pending tx gas price must be derived from the overlay head's base fee, not the stale MDBX head")
+}
+
+// TestCheckPruneHistory_SeesOverlayHead pins that pruning-availability checks
+// resolve "latest" through the block overlay: once the in-flight head pushes
+// the prune boundary forward by one block, a request for the block that just
+// became prunable must be rejected, not silently allowed through on a stale
+// MDBX-only view of the head.
+func TestCheckPruneHistory_SeesOverlayHead(t *testing.T) {
+	t.Parallel()
+	const pruneDistance = 3
+	base, m, _ := newOverlayAheadTestAPI(t)
+
+	pruneMode := prune.Mode{Initialised: true, History: prune.Distance(pruneDistance), Blocks: prune.KeepPostMergeBlocksPruneMode}
+	rwTx, err := m.DB.BeginTemporalRw(m.Ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	_, err = prune.EnsureNotChanged(rwTx, pruneMode)
+	require.NoError(t, err)
+	require.NoError(t, rwTx.Commit())
+
+	requestTx, err := m.DB.BeginTemporalRo(m.Ctx)
+	require.NoError(t, err)
+	defer requestTx.Rollback()
+
+	// PruneTo(overlayRaceChainSize) == overlayRaceChainSize-pruneDistance == 2. Taking the
+	// overlay head (overlayRaceChainSize+1) into account instead, PruneTo == 3, so block 2
+	// must be rejected as pruned; against the stale MDBX head it would wrongly pass.
+	prunedBlock := uint64(overlayRaceChainSize - pruneDistance)
+	err = base.checkPruneHistory(m.Ctx, requestTx, prunedBlock)
+	require.Error(t, err, "block %d must be reported as pruned once the overlay head is taken into account", prunedBlock)
 }


### PR DESCRIPTION

Between forkchoice publishing the block overlay and the MDBX commit landing, checkPruneField resolved "latest" against the stale MDBX head, letting the prune boundary lag one block behind and wrongly accept a block that just became prunable.

This extends the overlay-aware pattern #21293 established for `headerByHash`,
  the bor methods, `eth_getBlockTransactionCountBy*`, `debug_setHead`,
  `debug_getRawHeader`, etc. to the pruning-availability check in `eth_api.go`.
  