### PR TITLE
db/state: say "serializable" isolation level instead of "snapshot isolation"

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -2395,7 +2395,7 @@ func (at *AggregatorRoTx) FileStream(name kv.Domain, fromTxNum, toTxNum uint64) 
 	return NewSegStreamReader(r, -1), nil
 }
 
-// AggregatorRoTx guarantee consistent View of files ("snapshots isolation" level https://en.wikipedia.org/wiki/Snapshot_isolation):
+// AggregatorRoTx guarantee consistent View of files ("serializable" isolation level https://en.wikipedia.org/wiki/Serializability):
 //   - long-living consistent view of all files (no limitations)
 //   - hiding garbage and files overlaps
 //   - protecting useful files from removal


### PR DESCRIPTION
Erigon uses a single-writer (serializable) transaction model, not snapshot isolation. `AggregatorRoTx` gives readers a long-living consistent view of files, which is the *serializable* isolation level — snapshot isolation is a strictly weaker guarantee (allows write skew).

Update the wording and the Wikipedia link accordingly.