### PR TITLE
execution/stagedsync: keep mid-step resume non-fatal when prior receipts are unavailable

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -448,8 +448,15 @@ func (te *txExecutor) getHeader(ctx context.Context, hash common.Hash, number ui
 }
 
 // reconstructPriorReceipts re-derives receipts of a resumed block's prefix txs
-// (executed in an earlier batch): Finalize and the notification cache need the
-// block's full receipt set.
+// (executed in an earlier batch) so Finalize and the notification cache can see
+// the block's full receipt set.
+//
+// Best-effort. At a mid-block step boundary the committed domain latest is the
+// step-edge value, not the block-start pre-state, so the prefix is not always
+// reconstructable (and minimal nodes retain no receipts at all). Callers MUST
+// treat a failure as non-fatal: the node still resumes from a mid-step boundary
+// and the block's own receipts and cumulative gas stay correct — only the prior
+// receipts are absent (block then left not receipts-complete).
 func (te *txExecutor) reconstructPriorReceipts(ctx context.Context, applyTx kv.TemporalTx, header *types.Header, txs types.Transactions, startTxIndex int, blockStartTxNum uint64) (types.Receipts, error) {
 	priorIbs := state.New(state.NewHistoryReaderV3(applyTx, blockStartTxNum))
 	defer priorIbs.Release(true)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2772,10 +2772,9 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				}
 			}
 			// The post-exec validator, which fills receipt blooms for full
-			// blocks, skips partial ones — complete the published set here.
-			if receiptsComplete {
-				receipts.DeriveFields(blockReceipts, be.blockHash)
-			}
+			// blocks, skips partial ones — do it here, even when prior receipts
+			// couldn't be reconstructed (the suffix receipts still need blooms).
+			receipts.DeriveFields(blockReceipts, be.blockHash)
 		}
 
 		// Block finalize: run engine.Finalize + MakeWriteSet on the producer

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2764,10 +2764,12 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				blockStartTxNum := be.tasks[0].Version().TxNum - uint64(startTxIndex)
 				priorReceipts, err := pe.reconstructPriorReceipts(ctx, applyTx, header, txs, startTxIndex, blockStartTxNum)
 				if err != nil {
-					return nil, err
+					pe.logger.Warn("["+pe.logPrefix+"] failed to reconstruct prior receipts for partial block",
+						"block", be.blockNum, "startTxIndex", startTxIndex, "err", err)
+				} else {
+					blockReceipts = append(priorReceipts, blockReceipts...)
+					receiptsComplete = true
 				}
-				blockReceipts = append(priorReceipts, blockReceipts...)
-				receiptsComplete = true
 			}
 			// The post-exec validator, which fills receipt blooms for full
 			// blocks, skips partial ones — complete the published set here.
@@ -2832,9 +2834,11 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				}
 
 				chainReader := consensuschain.NewReader(pe.cfg.chainConfig, applyTx, pe.cfg.blockReader, pe.logger)
+				// skipReceiptsEval when the receipt set is incomplete — see the serial
+				// executor's finalize for the rationale.
 				if _, err := pe.cfg.engine.Finalize(
 					pe.cfg.chainConfig, types.CopyHeader(tt.Header), ibs, tt.Uncles, blockReceipts,
-					tt.Withdrawals, chainReader, syscall, false, pe.logger); err != nil {
+					tt.Withdrawals, chainReader, syscall, !receiptsComplete, pe.logger); err != nil {
 					return be.invalidBlockResult(fmt.Errorf("%w: can't finalize block %d: %v", rules.ErrInvalidBlock, be.blockNum, err)), nil
 				}
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2834,11 +2834,9 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				}
 
 				chainReader := consensuschain.NewReader(pe.cfg.chainConfig, applyTx, pe.cfg.blockReader, pe.logger)
-				// skipReceiptsEval when the receipt set is incomplete — see the serial
-				// executor's finalize for the rationale.
 				if _, err := pe.cfg.engine.Finalize(
 					pe.cfg.chainConfig, types.CopyHeader(tt.Header), ibs, tt.Uncles, blockReceipts,
-					tt.Withdrawals, chainReader, syscall, !receiptsComplete, pe.logger); err != nil {
+					tt.Withdrawals, chainReader, syscall, false, pe.logger); err != nil {
 					return be.invalidBlockResult(fmt.Errorf("%w: can't finalize block %d: %v", rules.ErrInvalidBlock, be.blockNum, err)), nil
 				}
 

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1567,12 +1567,11 @@ func TestParallelResumeReconstructsPriorReceipts(t *testing.T) {
 	}
 }
 
-// TestParallelResumeReconstructionFailureErrors pins the failure policy when
-// prior receipts cannot be reconstructed: the batch must fail with the
-// reconstruction error instead of proceeding into a receipts-dependent
-// Finalize (post-Prague requests hash, AuRa epoch signal) that would
-// misclassify the valid block as invalid.
-func TestParallelResumeReconstructionFailureErrors(t *testing.T) {
+// TestParallelResumeReconstructionFailureIsNonFatal pins the failure policy when
+// prior receipts cannot be reconstructed: reconstruction is best-effort, so the
+// batch proceeds (prior receipts absent, block left not receipts-complete)
+// rather than halting the node mid-step. See reconstructPriorReceipts.
+func TestParallelResumeReconstructionFailureIsNonFatal(t *testing.T) {
 	assert := assert.New(t)
 	db := newResumeTestDB(t)
 
@@ -1628,8 +1627,10 @@ func TestParallelResumeReconstructionFailureErrors(t *testing.T) {
 	}
 
 	res, err := be.nextResult(context.Background(), pe, txResult, roTx)
-	assert.ErrorContains(err, "reconstruct prior receipts")
-	assert.Nil(res)
+	assert.NoError(err)
+	if assert.NotNil(res) {
+		assert.False(res.receiptsComplete)
+	}
 }
 
 // TestParallelFinalizeMissingPrevReceiptErrors pins the failure mode when the

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -397,19 +397,26 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					blockStartTxNum := firstTask.TxNum - uint64(firstTask.TxIndex)
 					priorReceipts, priorErr := se.reconstructPriorReceipts(ctx, se.applyTx, txTask.Header, txTask.Txs, startTxIndex, blockStartTxNum)
 					if priorErr != nil {
-						return priorErr
+						se.logger.Warn(fmt.Sprintf("[%s] failed to reconstruct prior receipts for partial block", se.logPrefix),
+							"block", txTask.BlockNumber(), "startTxIndex", startTxIndex, "err", priorErr)
+					} else {
+						finalizeReceipts = append(priorReceipts, blockReceipts...)
+						// The post-exec validator, which fills receipt blooms for
+						// full blocks, runs only when startTxIndex == 0 — complete
+						// the published set here.
+						receipts.DeriveFields(finalizeReceipts, txTask.BlockHash())
+						priorComplete = true
 					}
-					finalizeReceipts = append(priorReceipts, blockReceipts...)
-					// The post-exec validator, which fills receipt blooms for
-					// full blocks, runs only when startTxIndex == 0 — complete
-					// the published set here.
-					receipts.DeriveFields(finalizeReceipts, txTask.BlockHash())
-					priorComplete = true
 				}
 
+				// Skip the receipt-derived evaluation (Prague requests hash) when the
+				// block's receipt set is incomplete — a resumed partial block whose
+				// prior receipts couldn't be reconstructed, or a node that keeps no
+				// receipts. It can't be validated from partial receipts, and the block
+				// was already validated when first executed.
 				_, err = se.cfg.engine.Finalize(
 					se.cfg.chainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Uncles,
-					finalizeReceipts, txTask.Withdrawals, chainReader, syscall, false, se.logger)
+					finalizeReceipts, txTask.Withdrawals, chainReader, syscall, !priorComplete, se.logger)
 
 				if err != nil {
 					return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err)

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -409,14 +409,9 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					}
 				}
 
-				// Skip the receipt-derived evaluation (Prague requests hash) when the
-				// block's receipt set is incomplete — a resumed partial block whose
-				// prior receipts couldn't be reconstructed, or a node that keeps no
-				// receipts. It can't be validated from partial receipts, and the block
-				// was already validated when first executed.
 				_, err = se.cfg.engine.Finalize(
 					se.cfg.chainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Uncles,
-					finalizeReceipts, txTask.Withdrawals, chainReader, syscall, !priorComplete, se.logger)
+					finalizeReceipts, txTask.Withdrawals, chainReader, syscall, false, se.logger)
 
 				if err != nil {
 					return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err)

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -401,12 +401,12 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 							"block", txTask.BlockNumber(), "startTxIndex", startTxIndex, "err", priorErr)
 					} else {
 						finalizeReceipts = append(priorReceipts, blockReceipts...)
-						// The post-exec validator, which fills receipt blooms for
-						// full blocks, runs only when startTxIndex == 0 — complete
-						// the published set here.
-						receipts.DeriveFields(finalizeReceipts, txTask.BlockHash())
 						priorComplete = true
 					}
+					// The post-exec validator, which fills receipt blooms for full
+					// blocks, skips partial ones — do it here, even when prior
+					// receipts couldn't be reconstructed (suffix still needs blooms).
+					receipts.DeriveFields(finalizeReceipts, txTask.BlockHash())
 				}
 
 				_, err = se.cfg.engine.Finalize(


### PR DESCRIPTION
#22235 made prior-receipt reconstruction failure fatal (`return err`), halting initial sync on any resume from a mid-block step boundary — after `rm-state-snapshots --step N+` + re-exec, or a crash landing mid-block. At such a boundary the committed domain latest is the step-edge value, not the block-start pre-state, so the prefix replay reads resume-point state and fails (`nonce too low` / `insufficient funds`); minimal nodes with no history retain no receipts to reconstruct at all.

The prefix skip and the reconstruction both predate #22235 (skip since #20912) and worked for ~2 years; its only breaking change was turning reconstruction failure from a warning into a fatal error. Restore the non-fatal behavior: warn and proceed with the block left not receipts-complete, in both executors. `git bisect` first-bad: 7898015b27.

This is the fix-forward alternative to #22308 (the straight revert): it keeps #22235's notifications/blooms/blob-gas and drops only the fatal handling.

The Prague `requestsHash`-from-incomplete-receipts edge (a deposit tx in the skipped prefix) is tracked in #22310 — `skipReceiptsEval` can't cover it because that flag also gates the mandatory EIP-7002/7251 dequeue syscalls.

## Changes
- `exec3_serial.go` / `exec3_parallel.go`: reconstruction failure warns and proceeds instead of halting.
- `exec3_serial.go` / `exec3_parallel.go`: run `DeriveFields` unconditionally for partial blocks so the executed suffix receipts get Bloom/BlockHash even when prior receipts are missing.
- `exec3.go`: document the best-effort / non-fatal contract on `reconstructPriorReceipts`.
- `exec3_parallel_test.go`: flip the failure-policy test to assert non-fatal.
