### PR TITLE
execution/execmodule: instrument FCU tail-hold and semaphore wait

### DIFF
--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -451,6 +451,7 @@ func (e *ExecModule) ValidateChain(ctx context.Context, blockHash common.Hash, b
 	defer validateChainDuration.ObserveDuration(time.Now())
 	if !e.semaphore.TryAcquire(1) {
 		e.logger.Trace("ethereumExecutionModule.ValidateChain: ExecutionStatus_Busy")
+		semaphoreBusyValidateChain.Inc()
 		return ValidationResult{
 			ValidationStatus: ExecutionStatusBusy,
 		}, nil

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -157,6 +157,7 @@ func writeForkChoiceHashes(tx kv.RwTx, blockHash, safeHash, finalizedHash common
 func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, safeHash, finalizedHash common.Hash, outcomeCh chan forkchoiceOutcome) (err error) {
 	if !e.semaphore.TryAcquire(1) {
 		e.logger.Trace("ethereumExecutionModule.updateForkChoice: ExecutionStatus_Busy")
+		semaphoreBusyUpdateForkChoice.Inc()
 		sendForkchoiceResultWithoutWaiting(outcomeCh, ForkChoiceResult{
 			LatestValidHash: common.Hash{},
 			Status:          ExecutionStatusBusy,
@@ -164,8 +165,12 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		return fmt.Errorf("semaphore timeout")
 	}
 	shouldReleaseSema := true
+	// Set once the FCU result is returned early to the CL; measures how long the
+	// semaphore stays held for the durability tail after the CL is unblocked.
+	var tailHoldStart time.Time
 	defer func() {
 		if shouldReleaseSema {
+			observeForkChoiceTailHold(tailHoldStart)
 			e.semaphore.Release(1)
 		}
 	}()
@@ -514,6 +519,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 				Status:          ExecutionStatusSuccess,
 				ValidationError: validationError,
 			}, false)
+			tailHoldStart = time.Now()
 			e.logHeadUpdated(blockHash, fcuHeader, 0, "head validated", false)
 		}
 		if err := e.forkValidator.MergeExtendingFork(ctx, tx, currentContext, e.accum); err != nil {
@@ -681,7 +687,10 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 			shouldReleaseSema = false
 			cleanupBeforeSemaRelease()
 			go func() {
-				defer e.semaphore.Release(1)
+				defer func() {
+					observeForkChoiceTailHold(tailHoldStart)
+					e.semaphore.Release(1)
+				}()
 				if err := work(); err != nil && !errors.Is(err, context.Canceled) {
 					e.logger.Error("Error running background post forkchoice", "err", err)
 				}

--- a/execution/execmodule/inserters.go
+++ b/execution/execmodule/inserters.go
@@ -61,6 +61,7 @@ func (e *ExecModule) InsertBlocks(ctx context.Context, blocks []*types.RawBlock)
 	if err := e.semaphore.Acquire(ctx, 1); err != nil {
 		return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: semaphore acquire: %w", err)
 	}
+	insertBlocksSemaphoreWait.ObserveDuration(start)
 	defer e.semaphore.Release(1)
 	e.logger.Debug("ethereumExecutionModule.InsertBlocks: semaphore acquired", "wait", time.Since(start))
 	e.forkValidator.ClearWithUnwind()

--- a/execution/execmodule/metrics.go
+++ b/execution/execmodule/metrics.go
@@ -29,7 +29,30 @@ var (
 	updateForkChoicePruneDuration = metrics.NewSummary(`update_fork_choice{type="prune_duration"}`)
 	validateChainDuration         = metrics.NewSummary(`validate_chain{type="execution_duration"}`)
 	insertBlocksDuration          = metrics.NewSummary(`insert_blocks{type="execution_duration"}`)
+
+	// Semaphore wait inside InsertBlocks, isolated from the insert body: how
+	// long the next block waited for the previous FCU's durability tail to
+	// release the module semaphore.
+	insertBlocksSemaphoreWait = metrics.NewSummary(`insert_blocks{type="semaphore_wait"}`)
+	// Time the module semaphore stays held after the FCU result was returned
+	// early to the consensus client (flush+commit+prune tail). The quantity the
+	// tail-decoupling work is meant to shrink.
+	updateForkChoiceTailHold = metrics.NewSummary(`update_fork_choice{type="tail_hold"}`)
+
+	// Count of ops that bailed with Busy because the semaphore was held (a
+	// ValidateChain bail surfaces to the CL as SYNCING).
+	semaphoreBusyValidateChain    = metrics.NewCounter(`execmodule_semaphore_busy{op="validate_chain"}`)
+	semaphoreBusyUpdateForkChoice = metrics.NewCounter(`execmodule_semaphore_busy{op="update_fork_choice"}`)
 )
+
+// observeForkChoiceTailHold records how long the semaphore was held past the
+// early FCU return. No-op when start is zero (paths that never returned early).
+func observeForkChoiceTailHold(start time.Time) {
+	if start.IsZero() {
+		return
+	}
+	updateForkChoiceTailHold.ObserveDuration(start)
+}
 
 func UpdateForkChoiceArrivalDelay(blockTime uint64) {
 	t := time.Unix(int64(blockTime), 0)


### PR DESCRIPTION
## What

Measurement-only metrics (no behavior change) to quantify how one block's durability tail gates the next block via the execution module's single weight-1 semaphore (`exec_module.go` `semaphore.NewWeighted(1)`). This lands **ahead of** the structural tail-decoupling work so we can capture a clean baseline and then attribute the improvement precisely.

## New metrics

| Metric | Type | Meaning |
|---|---|---|
| `insert_blocks{type="semaphore_wait"}` | summary | Semaphore-acquire wait inside `InsertBlocks`, isolated from the insert body — i.e. how long the next block waited for the previous FCU's tail to release the semaphore. The headline number. |
| `update_fork_choice{type="tail_hold"}` | summary | Time the semaphore stays held **after** the FCU result was returned early to the CL (the `flush + commit + prune` tail). The quantity the decoupling work is meant to shrink. Observed at the single actual release site (foreground deferred release or the background handoff goroutine). |
| `execmodule_semaphore_busy{op="validate_chain"}` | counter | `ValidateChain` `TryAcquire` bails (surface to the CL as `SYNCING`). |
| `execmodule_semaphore_busy{op="update_fork_choice"}` | counter | `UpdateForkChoice` `TryAcquire` bails (Busy). |

The existing `validate_chain{type="execution_duration"}` acts as a control — it measures real validation work and should stay flat across the upcoming change.

## Why

`engine_newPayload` median is dominated by execution + state-root, which the structural change does not touch. What it moves is the **tail latency** the previous block imposes on the next one (semaphore wait) and the **SYNCING/Busy bail rate** under load. Today `insert_blocks{type="execution_duration"}` conflates the semaphore wait with the insert body, and nothing isolates the tail-hold — these instruments make both directly observable so the before/after is unambiguous.

## Suggested Grafana panels

```promql
insert_blocks{type="semaphore_wait", quantile="0.99"}
update_fork_choice{type="tail_hold", quantile="0.99"}
update_fork_choice{type="prune_duration", quantile="0.99"}
rate(execmodule_semaphore_busy{op="validate_chain"}[5m])
validate_chain{type="execution_duration", quantile="0.5"}   # control, should not move
```

## Testing

- `make erigon` — clean build.
- `make lint` — `0 issues`.
- No behavior change; metrics-only.