### PR TITLE
compatible branch for jochemnet36-noref-base.tar.zst

### DIFF
--- a/.claude/skills/erigondb-sync-integration-test-plan/SKILL.md
+++ b/.claude/skills/erigondb-sync-integration-test-plan/SKILL.md
@@ -51,7 +51,7 @@ All scenarios use `--prune.mode=archive`.
    ```bash
    cat <clone-path>/snapshots/erigondb.toml
    ```
-   Expected: `step_size = 1562500`
+   Expected: `step_size = 1562500` and `references_in_commitment_branches = true`
 6. Kill the process and clean up the ephemeral datadir.
 
 ## Scenario B: Fresh sync with downloader
@@ -102,16 +102,34 @@ All scenarios use `--prune.mode=archive`.
    ```bash
    cat <empty-path>/snapshots/erigondb.toml
    ```
-   Expected: `step_size = 1562500` (code defaults, since no downloader to provide network settings)
+   Expected: `step_size = 1562500` and `references_in_commitment_branches = true` (code defaults, since no downloader to provide network settings)
 5. Kill the process and clean up the ephemeral datadir.
 
 ## Success Criteria
 
-| Scenario | Condition | Expected step_size | File timing |
-|----------|-----------|-------------------|-------------|
-| A (legacy) | `Creating erigondb.toml with LEGACY settings` log | 1,562,500 | Written immediately on startup |
-| B (fresh+downloader) | `erigondb.toml not found, using defaults` then `erigondb stepSize changed, propagating` | Code default 1,562,500 then network value (chain-dependent) | After downloader delivers it |
-| C (fresh+no-downloader) | `Initializing erigondb.toml with DEFAULT settings (nodownloader)` log | 1,562,500 | Written immediately on startup |
+| Scenario | Condition | Expected step_size | Expected references_in_commitment_branches | File timing |
+|----------|-----------|-------------------|--------------------------------------------|-------------|
+| A (legacy) | `Creating erigondb.toml with LEGACY settings` log | 1,562,500 | `true` (written explicitly) | Written immediately on startup |
+| B (fresh+downloader) | `erigondb.toml not found, using defaults` then `erigondb stepSize changed, propagating` | Code default 1,562,500 then network value (chain-dependent) | Resolves to `true` in memory until the downloader delivers the file; whatever the network publishes thereafter (a producer-published plain snapshot set ships `false`) | After downloader delivers it |
+| C (fresh+no-downloader) | `Initializing erigondb.toml with DEFAULT settings (nodownloader)` log | 1,562,500 | `true` (written explicitly) | Written immediately on startup |
+
+### references_in_commitment_branches per scenario
+
+The `references_in_commitment_branches` field governs whether new commitment merges write referenced (short-key) `.kv` files. It resolves identically to `step_size` across the three scenarios — absent field normalizes to `true` in memory, and a downloaded `erigondb.toml` is never rewritten (it is synced snapshot metadata, so a producer's published `false` survives). The resolution logic is unit-tested in `db/state/erigondb_settings_test.go` (`TestResolveErigonDBSettings*`); these runtime scenarios confirm the same behavior end-to-end.
+
+- **A (legacy):** the generated file contains `references_in_commitment_branches = true`.
+- **B (fresh+downloader):** no file until the downloader delivers it; the in-memory resolved value is `true`. After delivery the field reflects the network's published value (a plain-snapshot producer ships `false`).
+- **C (fresh+no-downloader):** the immediately-written file contains `references_in_commitment_branches = true`.
+
+## Producer workflow: publishing plain (unreferenced) snapshots
+
+`references_in_commitment_branches` governs only *new* commitment merges; reads are version-aware and stay correct regardless of the flag (a `v2.0` commitment `.kv` whose range ≥ threshold is referenced/short-key; a `v2.1` file is plain). To publish a snapshot set whose commitment files carry no plain-key references:
+
+1. In the producer datadir's `snapshots/erigondb.toml`, set `references_in_commitment_branches = false` **before** running merges.
+2. Run the node / merge so commitment merges produce plain `v2.2` `.kv` files. Existing `v2.1` referenced files convert to plain lazily as they are merged — no upfront migration.
+3. Ship the datadir's `erigondb.toml` with the snapshot set. Consumers read the file and inherit `false`; a downloaded `erigondb.toml` is never rewritten, so the producer's `false` survives.
+
+This supersedes the build-time const flip (`awskii/36exp`): no binary divergence and no CLI flag. Default nodes (field absent → `true`) keep writing byte-compatible `v2.1` referenced files with no behavior change.
 
 ## Cleanup
 

--- a/cmd/commitment-regime/README.md
+++ b/cmd/commitment-regime/README.md
@@ -1,0 +1,33 @@
+# commitment-regime
+
+Reports whether a commitment domain `.kv` file stores **plain** full keys or
+**referenced** (shortened file-offset) keys in its branch values.
+
+It reads every key/value pair in order and stops at the first branch that
+carries a shortened key:
+
+- `referenced` — at least one shortened key found (prints the pair index where).
+- `plain` — every pair scanned, all keys are full account (20B) / storage (52B) keys.
+
+A malformed branch or corrupt word stream is reported conservatively as
+`referenced`. Files are opened read-only, so a running node need not be stopped.
+
+## Run
+
+```sh
+go run ./cmd/commitment-regime <path/to/vX.Y-commitment.A-B.kv> [more.kv ...]
+```
+
+or build once and point it at a datadir:
+
+```sh
+go build -o /tmp/commitment-regime ./cmd/commitment-regime
+/tmp/commitment-regime <datadir>/snapshots/domain/*commitment*.kv
+```
+
+Example output:
+
+```
+v1.1-commitment.0-512.kv      referenced (first shortened key at pair 4 of 4)
+v2.1-commitment.576-640.kv    plain (scanned all 57763381 pairs)
+```

--- a/cmd/commitment-regime/main.go
+++ b/cmd/commitment-regime/main.go
@@ -1,0 +1,71 @@
+// Command commitment-regime classifies a commitment .kv file as plain or referenced
+// (shortened keys). Temporary diagnostic tooling as-is — remove once the regime work
+// settles, or promote into cmd/integration.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+)
+
+// scan reads every key/value pair greedily and stops at the first branch that
+// carries a shortened key. referenced=true means at least one shortened key was
+// found; firstAt is the 1-based pair index where it was found.
+func scan(path string) (referenced bool, firstAt, pairs uint64, err error) {
+	d, derr := seg.NewDecompressor(path)
+	if derr != nil {
+		return false, 0, 0, derr
+	}
+	defer d.Close()
+
+	defer func() {
+		if rec := recover(); rec != nil {
+			referenced, err = true, fmt.Errorf("corrupt word stream: %v", rec)
+		}
+	}()
+
+	r := seg.NewReader(d.MakeGetter(), seg.CompressKeys)
+	var keyBuf, valBuf []byte
+	for r.HasNext() {
+		keyBuf, _ = r.Next(keyBuf[:0])
+		if !r.HasNext() {
+			break
+		}
+		valBuf, _ = r.Next(valBuf[:0])
+		pairs++
+		if bytes.Equal(keyBuf, commitmentdb.KeyCommitmentState) {
+			continue
+		}
+		if commitment.BranchData(valBuf).HasShortenedKeys() {
+			return true, pairs, pairs, nil
+		}
+	}
+	return false, 0, pairs, nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: commitment-regime <commitment.kv> [more.kv ...]")
+		os.Exit(2)
+	}
+	for _, path := range os.Args[1:] {
+		referenced, firstAt, pairs, err := scan(path)
+		name := filepath.Base(path)
+		switch {
+		case err != nil && referenced:
+			fmt.Printf("%-40s referenced (%v, scanned %d)\n", name, err, pairs)
+		case err != nil:
+			fmt.Printf("%-40s ERROR %v\n", name, err)
+		case referenced:
+			fmt.Printf("%-40s referenced (first shortened key at pair %d of %d)\n", name, firstAt, pairs)
+		default:
+			fmt.Printf("%-40s plain (scanned all %d pairs)\n", name, pairs)
+		}
+	}
+}

--- a/cmd/integration/commands/commitment.go
+++ b/cmd/integration/commands/commitment.go
@@ -394,7 +394,7 @@ func commitmentRebuild(db kv.TemporalRwDB, ctx context.Context, logger log.Logge
 	}
 
 	blockSnapBuildSema := semaphore.NewWeighted(int64(runtime.NumCPU()))
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 	agg.SetSnapshotBuildSema(blockSnapBuildSema)
 	agg.SetErigondbDomainStepsInFrozenFile(config3.UnboundedDomainMerge)
 	agg.PresetOfflineMerge()
@@ -557,14 +557,6 @@ func commitmentConvert(db kv.TemporalRwDB, ctx context.Context, logger log.Logge
 	agg.SetSnapshotBuildSema(semaphore.NewWeighted(int64(runtime.NumCPU())))
 	agg.DisableAllDependencies()
 	defer agg.MadvNormal().DisableReadAhead()
-	// commitmentValTransformDomain (the squeeze path's value transformer)
-	// short-circuits to pass-through when the live runtime flag is false.
-	// Force-enable it for the duration of the converter run so --squeeze=true
-	// works regardless of the operator's current schema config. Matches the
-	// pattern in RebuildCommitmentFiles / RebuildCommitmentFilesWithHistory.
-	if opts.TargetSqueeze {
-		agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
-	}
 
 	acRo := agg.BeginFilesRo()
 	defer acRo.Close()

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2857,7 +2857,7 @@ func doDecompressSpeed(cliCtx *cli.Context) error {
 		//defer decompressor.MadvSequential().DisableReadAhead()
 
 		t := time.Now()
-		view, err := decompressor.OpenSequentialView()
+		view, err := decompressor.OpenSequentialView(true)
 		if err != nil {
 			panic(err)
 		}
@@ -2873,7 +2873,7 @@ func doDecompressSpeed(cliCtx *cli.Context) error {
 		//defer decompressor.MadvSequential().DisableReadAhead()
 
 		t := time.Now()
-		view, err := decompressor.OpenSequentialView()
+		view, err := decompressor.OpenSequentialView(true)
 		if err != nil {
 			panic(err)
 		}
@@ -3455,8 +3455,8 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	}
 	defer clean()
 
-	defer br.MadvNormal().DisableReadAhead()
-	defer agg.MadvNormal().DisableReadAhead()
+	//defer br.MadvNormal().DisableReadAhead()
+	//defer agg.MadvNormal().DisableReadAhead()
 
 	if cliCtx.IsSet(utils.ErigondbDomainStepsInFrozenFileFlag.Name) {
 		s := cliCtx.String(utils.ErigondbDomainStepsInFrozenFileFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1160,6 +1160,11 @@ var (
 		Name:  "erigondb.domain.steps-in-frozen-file",
 		Usage: `Override erigondb.toml "steps_in_frozen_file" for the domain merge cap only (history/inverted-index merges are unaffected). Pass a positive integer to set an explicit cap, or "Inf" to leave the domain merge unbounded. Default: unset, meaning the domain uses the same cap as determined by erigondb.toml.`,
 	}
+	CommitmentPlainValuesFlag = cli.BoolFlag{
+		Name:  "commitment.plainValues",
+		Usage: "On first start of a fresh datadir, write commitment values as plain (no shortened key references). Ignored if erigondb.toml already exists.",
+		Value: false,
+	}
 	ExecBatchedIOFlag = cli.BoolFlag{
 		Name:  "exec.batched-io",
 		Usage: "Enable BAL-driven I/O and write-dependency optimisations: (1) read-ahead pre-warms the DB page cache with account/code/storage reads before block execution (READ_AHEAD=true), and (2) the parallel executor pre-populates the version map from BAL hints (IGNORE_BAL=false). Disable for cold-read or non-BAL scheduling performance measurements.",
@@ -2141,6 +2146,17 @@ func SetEthConfig(ctx *cli.Context, nodeConfig *nodecfg.Config, cfg *ethconfig.C
 		}
 		cfg.ErigondbDomainStepsInFrozenFile = &v
 	}
+	cfg.CommitmentPlainValues = CommitmentPlainValuesFromCtx(ctx)
+}
+
+// CommitmentPlainValuesFromCtx returns the parsed --commitment.plainValues override:
+// nil when the flag was not set, otherwise a pointer to its boolean value.
+func CommitmentPlainValuesFromCtx(ctx *cli.Context) *bool {
+	if !ctx.IsSet(CommitmentPlainValuesFlag.Name) {
+		return nil
+	}
+	v := ctx.Bool(CommitmentPlainValuesFlag.Name)
+	return &v
 }
 
 // setDevnetEthConfig configures PoS dev mode (--chain dev): embedded Caplin with

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -256,3 +256,27 @@ func TestExecPerfFlags_OverrideDbg(t *testing.T) {
 		require.True(t, dbg.NoBackgroundMaintenance())
 	})
 }
+
+func TestCommitmentPlainValuesFromCtx(t *testing.T) {
+	parse := func(args ...string) *bool {
+		var got *bool
+		app := cli.NewApp()
+		app.Flags = []cli.Flag{&CommitmentPlainValuesFlag}
+		app.Action = func(ctx *cli.Context) error {
+			got = CommitmentPlainValuesFromCtx(ctx)
+			return nil
+		}
+		require.NoError(t, app.Run(append([]string{"test"}, args...)))
+		return got
+	}
+
+	require.Nil(t, parse(), "unset => nil")
+
+	gotTrue := parse("--commitment.plainValues")
+	require.NotNil(t, gotTrue)
+	require.True(t, *gotTrue)
+
+	gotFalse := parse("--commitment.plainValues=false")
+	require.NotNil(t, gotFalse)
+	require.False(t, *gotFalse)
+}

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -83,7 +83,9 @@ var (
 	BuildSnapshotAllowance = EnvInt("SNAPSHOT_BUILD_SEMA_SIZE", 1) // allows 1 kind of snapshots to be built simultaneously
 
 	SnapshotMadvRnd = EnvBool("SNAPSHOT_MADV_RND", true)
-	OnlyCreateDB    = EnvBool("ONLY_CREATE_DB", false)
+	// kill-switch: set SNAPSHOT_MADV_SEQUENTIAL=false to skip MADV_SEQUENTIAL in seg.OpenSequentialView
+	SnapshotMadvSequential = EnvBool("SNAPSHOT_MADV_SEQUENTIAL", true)
+	OnlyCreateDB           = EnvBool("ONLY_CREATE_DB", false)
 
 	CaplinSyncedDataMangerDeadlockDetection = EnvBool("CAPLIN_SYNCED_DATA_MANAGER_DEADLOCK_DETECTION", false)
 

--- a/db/agents.md
+++ b/db/agents.md
@@ -66,3 +66,15 @@ Sorts data before database insertion to reduce write amplification:
 - Downloaded via BitTorrent with WebSeed fallback
 - Piece size: 2MB default
 - Verification on download
+
+## Runtime settings (`snapshots/erigondb.toml`)
+
+Per-datadir settings that travel with a snapshot set rather than the binary, resolved by `state.ResolveErigonDBSettings` (`state/erigondb_settings.go`). A downloaded `erigondb.toml` is synced snapshot metadata and is never rewritten, so a producer's published values survive on consumers.
+
+| Field | Meaning |
+|-------|---------|
+| `step_size` | txs per step |
+| `steps_in_frozen_file` | steps merged into a frozen (immutable) file |
+| `references_in_commitment_branches` | whether new commitment merges write referenced (short-key, `v2.1`) `.kv` files; absent → default `true` |
+
+`references_in_commitment_branches` governs *writes* only. Reads are version-aware (a commitment `.kv` is referenced iff its version `< v2.2` and its range ≥ the referencing threshold), so flipping the flag on a populated datadir stays correct in both directions and old referenced files convert to plain lazily through merges. To publish plain (`v2.2`) snapshots, a producer sets it `false` before running merges (see the `erigondb-sync-integration-test-plan` skill).

--- a/db/config3/config3.go
+++ b/db/config3/config3.go
@@ -38,6 +38,9 @@ const DefaultStepsInFrozenFile = LegacyStepsInFrozenFile * 4 // 256
 // this value can be used to restore it.
 const UnboundedDomainMerge uint64 = math.MaxUint64
 
+// DefaultReferencesInCommitmentBranches is the default when erigondb.toml omits it.
+const DefaultReferencesInCommitmentBranches = true
+
 const EnableHistoryV4InTest = true
 
 // DefaultPruneDistance is the retention window used by full and blocks prune

--- a/db/config3/config3.go
+++ b/db/config3/config3.go
@@ -39,7 +39,7 @@ const DefaultStepsInFrozenFile = LegacyStepsInFrozenFile * 4 // 256
 const UnboundedDomainMerge uint64 = math.MaxUint64
 
 // DefaultReferencesInCommitmentBranches is the default when erigondb.toml omits it.
-const DefaultReferencesInCommitmentBranches = true
+const DefaultReferencesInCommitmentBranches = false
 
 const EnableHistoryV4InTest = true
 

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -506,14 +506,57 @@ func checkDerefBranch(
 	return dc, newBranchData, integrityErr
 }
 
+// commitmentReferencingMemo caches commitmentFileReferencing per file path. Integrity checks run
+// over an immutable file set within a process and several phases query the same file, so the full
+// content scan is done once per file.
+var commitmentReferencingMemo sync.Map // string -> bool
+
+// commitmentFileReferencing reports whether a commitment file carries shortened key references.
+// The integrity tool full-scans the content (not the file's version stamp) to catch a mis-stamped
+// file; any read error returns true rather than under-report as plain. Memoized per path.
+func commitmentFileReferencing(file state.VisibleFile) bool {
+	if v, ok := commitmentReferencingMemo.Load(file.Fullpath()); ok {
+		return v.(bool)
+	}
+	r := computeCommitmentFileReferencing(file)
+	commitmentReferencingMemo.Store(file.Fullpath(), r)
+	return r
+}
+
+func computeCommitmentFileReferencing(file state.VisibleFile) bool {
+	decomp, err := seg.NewDecompressor(file.Fullpath())
+	if err != nil {
+		log.Root().Warn("[integrity] commitmentFileReferencing: open failed, treating as referenced", "file", file.Fullpath(), "err", err)
+		return true
+	}
+	defer decomp.Close()
+
+	g := seg.NewReader(decomp.MakeGetter(), statecfg.Schema.GetDomainCfg(kv.CommitmentDomain).Compression)
+	var k, v []byte
+	for g.HasNext() {
+		k, _ = g.Next(k[:0])
+		if !g.HasNext() {
+			break
+		}
+		v, _ = g.Next(v[:0])
+		if bytes.Equal(k, commitmentdb.KeyCommitmentState) {
+			continue
+		}
+		if commitment.BranchData(v).HasShortenedKeys() {
+			return true
+		}
+	}
+	return false
+}
+
 func checkCommitmentKvDeref(ctx context.Context, file state.VisibleFile, stepSize uint64, failFast bool, logger log.Logger) (derefCounts, error) {
 	start := time.Now()
 	fileName := filepath.Base(file.Fullpath())
 	startTxNum := file.StartRootNum()
 	endTxNum := file.EndRootNum()
-	if !state.ValuesPlainKeyReferencingThresholdReached(stepSize, startTxNum, endTxNum) {
+	if !commitmentFileReferencing(file) {
 		logger.Info(
-			"[integrity] CommitmentKvDeref skipped, file not above min steps",
+			"[integrity] CommitmentKvDeref skipped, no shortened keys found (full scan)",
 			"file", fileName,
 			"startTxNum", startTxNum,
 			"endTxNum", endTxNum,
@@ -1269,7 +1312,7 @@ func checkStateCorrespondenceBase(ctx context.Context, file state.VisibleFile, s
 	expectedAccounts := uint64(accDecomp.Count()) / 2
 	expectedStorages := uint64(stoDecomp.Count()) / 2
 
-	isReferencing := state.ValuesPlainKeyReferencingThresholdReached(stepSize, startTxNum, endTxNum)
+	isReferencing := commitmentFileReferencing(file)
 
 	// Track unique keys found in commitment branches via ETL collectors (disk-spilling dedup).
 	accCollector := etl.NewCollector("[integrity] StateVerify acc", "", etl.NewOldestEntryBuffer(etl.BufferOptimalSize), logger)
@@ -1866,8 +1909,8 @@ func extractCommitmentRefsToCollectors(ctx context.Context, file state.VisibleFi
 	commCompression := statecfg.Schema.GetDomainCfg(kv.CommitmentDomain).Compression
 	commReader := seg.NewReader(commDecomp.MakeGetter(), commCompression)
 
-	// Always open domain readers for dereferencing (commitment files may contain
-	// reference keys regardless of ValuesPlainKeyReferencingThresholdReached result)
+	// Always open domain readers: this walk handles both referenced (offset) and plain
+	// keys, so it works regardless of the file's version regime.
 	_, nextAccReader, nextAccClose, err := deriveDecompAndReaderForOtherDomain(file.Fullpath(), kv.CommitmentDomain, kv.AccountsDomain)
 	if err != nil {
 		return err
@@ -1961,10 +2004,8 @@ var valMapPool = sync.Pool{New: func() any { return make(map[string][]byte, 8) }
 func checkHashVerification(ctx context.Context, file state.VisibleFile, stepSize uint64, failFast bool, numWorkers int, logger log.Logger) error {
 	start := time.Now()
 	fileName := filepath.Base(file.Fullpath())
-	startTxNum := file.StartRootNum()
-	endTxNum := file.EndRootNum()
 
-	isReferencing := state.ValuesPlainKeyReferencingThresholdReached(stepSize, startTxNum, endTxNum)
+	isReferencing := commitmentFileReferencing(file)
 
 	logger.Info("[integrity] StateVerify hash verification starting",
 		"kv", fileName, "workers", numWorkers, "referencing", isReferencing)

--- a/db/integrity/commitment_plainvalues_firststart_integration_test.go
+++ b/db/integrity/commitment_plainvalues_firststart_integration_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package integrity_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/integrity"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/kv/temporal"
+	"github.com/erigontech/erigon/db/state"
+)
+
+// TestFirstStartPlainValuesRegime bootstraps a fresh datadir, resolves erigondb.toml through the
+// --commitment.plainValues first-start override, and asserts the merged commitment .kv lands in the
+// matching version regime (plain => v2.2, referenced => v2.1) and passes the regime-aware integrity
+// checks — i.e. the flag's chosen regime flows resolver -> settings -> schema -> merge.
+func TestFirstStartPlainValuesRegime(t *testing.T) {
+	t.Run("plain", func(t *testing.T) {
+		t.Parallel()
+		runFirstStartRegimeCheck(t, true)
+	})
+	t.Run("referenced", func(t *testing.T) {
+		t.Parallel()
+		runFirstStartRegimeCheck(t, false)
+	})
+}
+
+func runFirstStartRegimeCheck(t *testing.T, plainValues bool) {
+	t.Helper()
+	logger := log.New()
+	ctx := t.Context()
+	const stepSize = uint64(10)
+	const txs = 80 // 8 steps -> merge produces a >= threshold commitment file
+
+	dirs := datadir.New(t.TempDir())
+
+	refs := !plainValues
+	settings, err := state.ResolveErigonDBSettingsWithRefsDefault(dirs, logger, true /* noDownloader */, &refs)
+	require.NoError(t, err)
+	require.Equal(t, refs, settings.RefsInCommitmentBranches(), "resolved regime must match the first-start override")
+
+	// Shrink the step size so a few steps trigger a >= threshold merge; the regime under test is
+	// carried by settings.ReferencesInCommitmentBranches, independent of the step size.
+	settings.StepSize = stepSize
+
+	db := newTestDBWithSettings(t, ctx, dirs, settings)
+	agg := db.(state.HasAgg).Agg().(*state.Aggregator)
+
+	writeAndBuild(t, ctx, db, agg, txs)
+	require.NoError(t, agg.MergeLoop(ctx))
+
+	db = reopenAgg(t, db, agg, dirs, stepSize, logger)
+
+	gotReferenced, gotSpan := largestCommitmentFile(t, ctx, db, stepSize)
+	require.GreaterOrEqual(t, gotSpan, 2*stepSize, "expected a merged commitment file spanning >= 2 steps")
+	require.Equal(t, refs, gotReferenced, "merged commitment file's version regime must match the first-start override")
+
+	require.NoError(t, integrity.CheckStateVerify(ctx, db, true /* failFast */, 0 /* fromStep */, logger))
+
+	// For the plain regime the v2.1 file must be recognised as plain and skipped by the deref
+	// validator (the version-aware skip); the referenced regime needs real chain data, so it is
+	// covered by CheckStateVerify only, mirroring TestCheckStateVerify_VersionRegimes.
+	if plainValues {
+		require.NoError(t, integrity.CheckCommitmentKvDeref(ctx, db, nil /* cache */, true /* failFast */, logger))
+	}
+}
+
+func newTestDBWithSettings(t *testing.T, ctx context.Context, dirs datadir.Dirs, settings *state.ErigonDBSettings) kv.TemporalRwDB {
+	t.Helper()
+	rawDB := memdb.NewTestDB(t, dbcfg.ChainDB)
+	agg := state.NewTest(dirs).WithErigonDBSettings(settings).MustOpen(ctx, rawDB)
+	require.NoError(t, agg.OpenFolder())
+	t.Cleanup(agg.Close)
+	db, err := temporal.New(rawDB, agg)
+	require.NoError(t, err)
+	t.Cleanup(db.Close)
+	return db
+}

--- a/db/integrity/commitment_version_integration_test.go
+++ b/db/integrity/commitment_version_integration_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package integrity_test
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/integrity"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/temporal"
+	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// TestCheckStateVerify_VersionRegimes builds two single-regime datadirs — one referenced and one
+// plain, each with a merged commitment file whose range exceeds the referencing threshold — and
+// asserts the regime-aware integrity checks pass on both. The regime is decided by the flag on
+// WRITE and recovered from file content on read: with the flag on, the merged file must carry
+// shortened keys (referenced); with it off it must be plain (read/verified directly, not as a
+// referenced file with stale offsets).
+func TestCheckStateVerify_VersionRegimes(t *testing.T) {
+	t.Run("referenced", func(t *testing.T) {
+		t.Parallel()
+		runVersionRegimeCheck(t, true)
+	})
+	t.Run("plain", func(t *testing.T) {
+		t.Parallel()
+		runVersionRegimeCheck(t, false)
+	})
+}
+
+func runVersionRegimeCheck(t *testing.T, referencesInCommitmentBranches bool) {
+	t.Helper()
+	logger := log.New()
+	ctx := t.Context()
+	const stepSize = uint64(10)
+	const txs = 80 // 8 steps -> merge produces a >= threshold commitment file
+
+	dirs := datadir.New(t.TempDir())
+	db := temporaltest.NewTestDBWithStepSize(t, dirs, stepSize)
+	agg := db.(state.HasAgg).Agg().(*state.Aggregator)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, referencesInCommitmentBranches)
+
+	writeAndBuild(t, ctx, db, agg, txs)
+	require.NoError(t, agg.MergeLoop(ctx))
+
+	// Reopen so the commitment file's referenced regime is re-derived from the on-disk version,
+	// exercising the version-based path independently of the in-memory flag used during merge.
+	db = reopenAgg(t, db, agg, dirs, stepSize, logger)
+
+	gotReferenced, gotSpan := largestCommitmentFile(t, ctx, db, stepSize)
+	require.GreaterOrEqual(t, gotSpan, 2*stepSize, "expected a merged commitment file spanning >= 2 steps")
+	require.Equal(t, referencesInCommitmentBranches, gotReferenced, "merged commitment file's version regime must match the write flag")
+
+	require.NoError(t, integrity.CheckStateVerify(ctx, db, true /* failFast */, 0 /* fromStep */, logger))
+
+	// CheckCommitmentKvDeref dereferences short keys and structurally validates each branch;
+	// that validator needs real chain data, so it is asserted only for the plain regime, where
+	// it must recognise the v2.1 file as plain and skip it (the version-aware skip under test).
+	if !referencesInCommitmentBranches {
+		require.NoError(t, integrity.CheckCommitmentKvDeref(ctx, db, nil /* cache */, true /* failFast */, logger))
+	}
+}
+
+func writeAndBuild(t *testing.T, ctx context.Context, db kv.TemporalRwDB, agg *state.Aggregator, txs uint64) {
+	t.Helper()
+	tx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	domains, err := execctx.NewSharedDomains(ctx, tx, log.New())
+	require.NoError(t, err)
+	defer domains.Close()
+
+	rnd := rand.New(rand.NewSource(7))
+	for txNum := uint64(1); txNum <= txs; txNum++ {
+		addr := make([]byte, length.Addr)
+		loc := make([]byte, length.Hash)
+		rnd.Read(addr)
+		rnd.Read(loc)
+
+		acc := accounts.Account{Nonce: txNum, Balance: *uint256.NewInt(txNum * 1000), CodeHash: accounts.EmptyCodeHash}
+		require.NoError(t, domains.DomainPut(kv.AccountsDomain, tx, addr, accounts.SerialiseV3(&acc), txNum, nil))
+
+		storageKey := append(common.Copy(addr), loc...)
+		require.NoError(t, domains.DomainPut(kv.StorageDomain, tx, storageKey, []byte{addr[0], loc[0]}, txNum, nil))
+
+		_, err = domains.ComputeCommitment(ctx, tx, true, txNum, txNum, "test", nil)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, domains.Flush(ctx, tx))
+	require.NoError(t, tx.Commit())
+	require.NoError(t, agg.BuildFiles(txs))
+}
+
+func reopenAgg(t *testing.T, db kv.TemporalRwDB, agg *state.Aggregator, dirs datadir.Dirs, stepSize uint64, logger log.Logger) kv.TemporalRwDB {
+	t.Helper()
+	agg.Close()
+	newAgg := state.NewTest(dirs).StepSize(stepSize).Logger(logger).MustOpen(t.Context(), db)
+	t.Cleanup(newAgg.Close)
+	require.NoError(t, newAgg.OpenFolder())
+	require.NoError(t, newAgg.BuildMissedAccessors(t.Context(), 1))
+	newDB, err := temporal.New(db, newAgg)
+	require.NoError(t, err)
+	return newDB
+}
+
+// largestCommitmentFile returns the version-derived referenced regime and txNum span of the
+// widest-range commitment .kv file visible after reopen (the merged one).
+func largestCommitmentFile(t *testing.T, ctx context.Context, db kv.TemporalRoDB, stepSize uint64) (bool, uint64) {
+	t.Helper()
+	tx, err := db.BeginTemporalRo(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	aggTx := state.AggTx(tx)
+	defer aggTx.Close()
+
+	var referenced bool
+	var bestSpan uint64
+	found := false
+	for _, f := range aggTx.Files(kv.CommitmentDomain) {
+		if !strings.HasSuffix(f.Fullpath(), ".kv") {
+			continue
+		}
+		if span := f.EndRootNum() - f.StartRootNum(); span >= bestSpan {
+			referenced, bestSpan, found = state.CommitmentBranchReferenced(f.Version(), stepSize, f.StartRootNum(), f.EndRootNum()), span, true
+		}
+	}
+	require.True(t, found, "expected at least one commitment .kv file")
+	return referenced, bestSpan
+}

--- a/db/integrity/commitment_version_test.go
+++ b/db/integrity/commitment_version_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package integrity
+
+import (
+	"encoding/binary"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+)
+
+type fakeVisibleFile struct {
+	path                 string
+	startTxNum, endTxNum uint64
+	version              version.Version
+}
+
+func (f fakeVisibleFile) Fullpath() string         { return f.path }
+func (f fakeVisibleFile) StartRootNum() uint64     { return f.startTxNum }
+func (f fakeVisibleFile) EndRootNum() uint64       { return f.endTxNum }
+func (f fakeVisibleFile) Version() version.Version { return f.version }
+
+// accountBranch builds a single-cell BranchData carrying one account-addr key: touchMap=afterMap=1,
+// fieldBits=fieldAccountAddr(2), then uvarint(len)+addr. A 20-byte addr is plain; a shorter one is a
+// shortened (offset) reference.
+func accountBranch(addr []byte) []byte {
+	b := []byte{0, 1, 0, 1, 0x02}
+	var n [binary.MaxVarintLen64]byte
+	c := binary.PutUvarint(n[:], uint64(len(addr)))
+	b = append(b, n[:c]...)
+	return append(b, addr...)
+}
+
+// writeCommitmentKV writes a tiny commitment .kv (state record + one account branch) with the
+// commitment domain's compression. referencedContent => the branch carries a shortened key.
+func writeCommitmentKV(t *testing.T, referencedContent bool) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "v2.1-commitment.0-2.kv")
+	comp, err := seg.NewCompressor(t.Context(), "test", path, t.TempDir(), seg.DefaultCfg, log.LvlDebug, log.New())
+	require.NoError(t, err)
+	w := seg.NewWriter(comp, statecfg.Schema.GetDomainCfg(kv.CommitmentDomain).Compression)
+
+	_, err = w.Write(commitmentdb.KeyCommitmentState)
+	require.NoError(t, err)
+	_, err = w.Write([]byte("state-blob"))
+	require.NoError(t, err)
+
+	addr := make([]byte, length.Addr) // plain 20-byte account key
+	if referencedContent {
+		addr = []byte{0x81, 0x02} // shortened (varint offset) key
+	}
+	_, err = w.Write([]byte("\x01"))
+	require.NoError(t, err)
+	_, err = w.Write(accountBranch(addr))
+	require.NoError(t, err)
+
+	require.NoError(t, comp.Compress())
+	comp.Close()
+	return path
+}
+
+// TestCommitmentFileReferencing pins that the integrity referencing decision is taken from a FULL
+// content scan of the file, independent of the file's version stamp — so it catches a file whose
+// version says plain (v2.1 below) yet whose content carries shortened keys.
+func TestCommitmentFileReferencing(t *testing.T) {
+	t.Run("referenced content is referencing even when version says plain", func(t *testing.T) {
+		f := fakeVisibleFile{path: writeCommitmentKV(t, true), endTxNum: 20, version: version.V2_1}
+		require.True(t, commitmentFileReferencing(f))
+	})
+	t.Run("plain content is not referencing even when version says referenced", func(t *testing.T) {
+		f := fakeVisibleFile{path: writeCommitmentKV(t, false), endTxNum: 20, version: version.V2_0}
+		require.False(t, commitmentFileReferencing(f))
+	})
+}

--- a/db/kv/visible_file.go
+++ b/db/kv/visible_file.go
@@ -3,12 +3,15 @@ package kv
 import (
 	"path/filepath"
 	"strings"
+
+	"github.com/erigontech/erigon/db/version"
 )
 
 type VisibleFile interface {
 	Fullpath() string
 	StartRootNum() uint64
 	EndRootNum() uint64
+	Version() version.Version
 }
 
 type VisibleFiles []VisibleFile

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -595,13 +595,17 @@ func (d *Decompressor) GetMetadata() []byte {
 	return d.metadata
 }
 
-// WithReadAhead - Expect read in sequential order. (Hence, pages in the given range can be aggressively read ahead, and may be freed soon after they are accessed.)
-func (d *Decompressor) WithReadAhead(f func() error) error {
+// WithReadAhead reads in sequential order via a separate MADV_SEQUENTIAL mmap, so the shared mmap used by concurrent random readers is unaffected.
+func (d *Decompressor) WithReadAhead(f func(*Getter) error) error {
 	if d == nil || d.mmapHandle1 == nil {
 		return nil
 	}
-	defer d.MadvSequential().DisableReadAhead()
-	return f()
+	v, err := d.OpenSequentialView(true)
+	if err != nil {
+		return err
+	}
+	defer v.Close()
+	return f(v.MakeGetter())
 }
 
 // DisableReadAhead - usage: `defer d.EnableReadAhead().DisableReadAhead()`. Please don't use this funcs without `defer` to avoid leak.
@@ -708,17 +712,27 @@ type SequentialView struct {
 	data        []byte // words data region from the sequential mmap
 }
 
-// OpenSequentialView creates a separate mmap of the same file with MADV_SEQUENTIAL.
-// The caller must call Close when done.
-func (d *Decompressor) OpenSequentialView() (*SequentialView, error) {
+// OpenSequentialView returns a view for a sequential scan of the file. With separateReadahead
+// it creates a second mmap of the same file with MADV_SEQUENTIAL, isolating aggressive readahead
+// (and its deactivate-behind eviction) from the shared mmap used by concurrent random readers;
+// the caller must call Close. Without it the view shares the decompressor's mmap with MADV_NORMAL —
+// used when concurrent random readers of the same file (e.g. commitment dereference) must keep their
+// pages resident; Close is then a no-op.
+func (d *Decompressor) OpenSequentialView(separateReadahead bool) (*SequentialView, error) {
 	if d == nil || d.f == nil {
 		return nil, nil
+	}
+	if !separateReadahead {
+		_ = mmap.MadviseNormal(d.mmapHandle1)
+		return &SequentialView{d: d, data: d.data[d.wordsStart:]}, nil
 	}
 	h1, h2, err := mmap.Mmap(d.f, int(d.size))
 	if err != nil {
 		return nil, err
 	}
-	_ = mmap.MadviseSequential(h1)
+	if dbg.SnapshotMadvSequential {
+		_ = mmap.MadviseSequential(h1)
+	}
 	// d.data is a sub-slice of d.mmapHandle1 starting after file headers
 	// (version, feature flags, metadata). wordsStart is relative to d.data,
 	// so the file offset is: headerSize + wordsStart.

--- a/db/seg/decompress_test.go
+++ b/db/seg/decompress_test.go
@@ -90,6 +90,36 @@ func TestDecompressSkip(t *testing.T) {
 	require.Equal(t, 16, int(offset))
 }
 
+func TestOpenSequentialView(t *testing.T) {
+	d := prepareLoremDict(t)
+	defer d.Close()
+
+	var want [][]byte
+	g := d.MakeGetter()
+	for g.HasNext() {
+		w, _ := g.Next(nil)
+		want = append(want, w)
+	}
+
+	readAll := func(separateReadahead bool) [][]byte {
+		v, err := d.OpenSequentialView(separateReadahead)
+		require.NoError(t, err)
+		defer v.Close()
+		var got [][]byte
+		vg := v.MakeGetter()
+		for vg.HasNext() {
+			w, _ := vg.Next(nil)
+			got = append(got, w)
+		}
+		return got
+	}
+
+	require.Equal(t, want, readAll(true), "separate MADV_SEQUENTIAL mmap view")
+	require.Equal(t, want, readAll(false), "shared mmap view (MADV_NORMAL)")
+	// the shared view's Close must be a no-op on the decompressor's mmap: a subsequent read still works
+	require.Equal(t, want, readAll(true))
+}
+
 func TestDecompressMatchOK(t *testing.T) {
 	loremStrings := append(strings.Split(rmNewLine(lorem), " "), "") // including emtpy string - to trigger corner cases
 	d := prepareLoremDict(t)

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -458,12 +458,12 @@ func KnownCfgOrDevnet(networkName string) *Cfg {
 // from erigon-snapshot/webseed, which used to ship one one-key TOML file per
 // chain; the only consumers want the URL list, so the TOML wrapper was dropped.
 var EmbeddedWebseeds = map[string][]string{
-	networkname.Mainnet:  {"v1:https://erigon34-v1-snapshots-mainnet.erigon.network"},
-	networkname.Sepolia:  {"v1:https://erigon34-v1-snapshots-sepolia.erigon.network"},
-	networkname.Gnosis:   {"v1:https://erigon34-v1-snapshots-gnosis.erigon.network"},
-	networkname.Chiado:   {"v1:https://erigon34-v1-snapshots-chiado.erigon.network"},
-	networkname.Hoodi:    {"v1:https://erigon34-v1-snapshots-hoodi.erigon.network"},
-	networkname.Bloatnet: {"v1:https://erigon34-v1-snapshots-bloatnet.erigon.network"},
+	networkname.Mainnet:  {"v1:https://erigon36-v1-snapshots-mainnet.erigon.network"},
+	networkname.Sepolia:  {"v1:https://erigon36-v1-snapshots-sepolia.erigon.network"},
+	networkname.Gnosis:   {"v1:https://erigon36-v1-snapshots-gnosis.erigon.network"},
+	networkname.Chiado:   {"v1:https://erigon36-v1-snapshots-chiado.erigon.network"},
+	networkname.Hoodi:    {"v1:https://erigon36-v1-snapshots-hoodi.erigon.network"},
+	networkname.Bloatnet: {"v1:https://erigon36-v1-snapshots-bloatnet.erigon.network"},
 }
 
 // GetEmbeddedWebseeds returns the webseed URLs for a single chain.

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -1103,8 +1103,7 @@ func ForEachHeader(ctx context.Context, s *RoSnapshots, walker func(header *type
 	var header types.Header
 
 	for _, sn := range view.Headers() {
-		if err := sn.Src().WithReadAhead(func() error {
-			g := sn.Src().MakeGetter()
+		if err := sn.Src().WithReadAhead(func(g *seg.Getter) error {
 			for i := 0; g.HasNext(); i++ {
 				word, _ = g.Next(word[:0])
 				if err := types.DecodeHeader(word[1:], &header); err != nil {

--- a/db/snapshotsync/merger.go
+++ b/db/snapshotsync/merger.go
@@ -342,17 +342,17 @@ func (m *Merger) merge(ctx context.Context, v *View, toMerge []*DirtySegment, ta
 	m.logger.Debug("[snapshots] merge", "file", targetFile.Name())
 
 	for _, d := range cList {
-		if err := d.WithReadAhead(func() error {
-			g := d.MakeGetter()
-			for g.HasNext() {
-				word, _ = g.Next(word[:0])
-				if err := f.AddWord(word); err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		view, err := d.OpenSequentialView(true)
+		if err != nil {
 			return nil, err
+		}
+		defer view.Close()
+		g := view.MakeGetter()
+		for g.HasNext() {
+			word, _ = g.Next(word[:0])
+			if err := f.AddWord(word); err != nil {
+				return nil, err
+			}
 		}
 	}
 	if f.Count() != expectedTotal {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -78,6 +79,9 @@ type Aggregator struct {
 	reorgBlockDepth uint64
 
 	dirtyFilesLock sync.Mutex
+	// commitmentRefsMu guards the runtime-mutable commitment ReferencesInCommitmentBranches
+	// flag: ReloadErigonDBSettings writes it while background merges read it.
+	commitmentRefsMu sync.RWMutex
 	// visible is CoW field updated only by `recalcVisibleFiles`.
 	visible atomic.Pointer[aggregatorVisible]
 	// oldestVisible head of linked-list of visibleFiles objects (oldest still-have-reader object). Mutated only under dirtyFilesLock.
@@ -119,9 +123,10 @@ type Aggregator struct {
 	checker *DependencyIntegrityChecker
 
 	// Domain configuration state: ConfigureDomains() is a no-op once configured is true.
-	configured   bool
-	savedSalt    *uint32
-	disableFsync bool
+	configured             bool
+	savedSalt              *uint32
+	disableFsync           bool
+	commitmentRefsOverride *bool
 }
 
 func newAggregator(ctx context.Context, dirs datadir.Dirs, reorgBlockDepth uint64, db kv.RoDB, logger log.Logger) (*Aggregator, error) {
@@ -262,9 +267,49 @@ func (a *Aggregator) SetErigondbDomainStepsInFrozenFile(steps uint64) {
 	a.erigondbDomainStepsInFrozenFile = steps
 }
 
-func (a *Aggregator) ForTestReplaceKeysInValues(domain kv.Domain, v bool) {
-	a.d[domain].ReplaceKeysInValues = v
+func (a *Aggregator) ForTestReferencesInCommitmentBranches(domain kv.Domain, v bool) {
+	a.commitmentRefsMu.Lock()
+	defer a.commitmentRefsMu.Unlock()
+	a.d[domain].ReferencesInCommitmentBranches = v
 }
+
+// referencesInCommitmentBranches reads the live commitment flag under the lock; merge and
+// squeeze paths must use it instead of touching the field directly.
+func (a *Aggregator) referencesInCommitmentBranches() bool {
+	a.commitmentRefsMu.RLock()
+	defer a.commitmentRefsMu.RUnlock()
+	return a.d[kv.CommitmentDomain].ReferencesInCommitmentBranches
+}
+
+// applyReferencesInCommitmentBranches stores the resolved flag pre-configure (ConfigureDomains
+// consumes it via a local Schema copy) and updates the live commitment domain post-configure.
+func (a *Aggregator) applyReferencesInCommitmentBranches(refs bool) {
+	if !a.configured {
+		a.commitmentRefsOverride = &refs
+		return
+	}
+	a.commitmentRefsMu.Lock()
+	defer a.commitmentRefsMu.Unlock()
+	if a.d[kv.CommitmentDomain] != nil {
+		a.d[kv.CommitmentDomain].ReferencesInCommitmentBranches = refs
+	}
+}
+
+// SetDomainStepsInFrozenFile sets the domain merge cap from a flag spec: empty or
+// "Inf" means unbounded, otherwise a positive integer step count.
+func (a *Aggregator) SetDomainStepsInFrozenFile(spec string) error {
+	v := config3.UnboundedDomainMerge
+	if spec != "" && !strings.EqualFold(spec, "inf") {
+		parsed, err := strconv.ParseUint(spec, 10, 64)
+		if err != nil || parsed == 0 {
+			return fmt.Errorf("invalid domain steps-in-frozen-file %q: must be a positive integer or \"Inf\"", spec)
+		}
+		v = parsed
+	}
+	a.SetErigondbDomainStepsInFrozenFile(v)
+	return nil
+}
+
 func (a *Aggregator) Cfg(domain kv.Domain) statecfg.DomainCfg { return a.d[domain].DomainCfg }
 
 func (a *Aggregator) reloadSalt() error {
@@ -305,6 +350,7 @@ func (a *Aggregator) ReloadErigonDBSettings(noDownloader bool) error {
 	}
 	a.stepSize.Store(settings.StepSize)
 	a.stepsInFrozenFile.Store(settings.StepsInFrozenFile)
+	a.applyReferencesInCommitmentBranches(settings.RefsInCommitmentBranches())
 
 	if a.configured && (settings.StepSize != oldStepSize || settings.StepsInFrozenFile != oldStepsInFrozenFile) {
 		a.logger.Info("erigondb stepSize changed, propagating to domains/IIs",
@@ -339,7 +385,13 @@ func (a *Aggregator) ConfigureDomains() error {
 	if err := statecfg.AdjustReceiptCurrentVersionIfNeeded(a.dirs, a.logger); err != nil {
 		return err
 	}
-	if err := statecfg.Configure(statecfg.Schema, a, a.dirs, a.savedSalt, a.logger); err != nil {
+	// Local Schema copy with the per-datadir override: avoids racing global mutation
+	// with concurrent opens that resolve a different erigondb.toml value.
+	schema := statecfg.Schema
+	if a.commitmentRefsOverride != nil {
+		schema.CommitmentDomain.ReferencesInCommitmentBranches = *a.commitmentRefsOverride
+	}
+	if err := statecfg.Configure(schema, a, a.dirs, a.savedSalt, a.logger); err != nil {
 		return err
 	}
 	a.configured = true
@@ -1784,8 +1836,9 @@ func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFil
 	}
 
 	r := &Ranges{}
-	commitmentUseReferencedBranches := at.a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues
-	if commitmentUseReferencedBranches {
+	// Account/storage must stay range-aligned with commitment whenever referencing is active.
+	commitmentMergeReferencing := at.a.referencesInCommitmentBranches() || at.commitmentVisibleFilesReferenced()
+	if commitmentMergeReferencing {
 		lmrAcc := at.d[kv.AccountsDomain].files.LatestMergedRange(stepSize)
 		lmrSto := at.d[kv.StorageDomain].files.LatestMergedRange(stepSize)
 		lmrCom := at.d[kv.CommitmentDomain].files.LatestMergedRange(stepSize)
@@ -1804,7 +1857,7 @@ func (at *AggregatorRoTx) findMergeRange(maxEndTxNum, stepSize, stepsInFrozenFil
 		r.domain[id] = d.findMergeRange(maxEndTxNum, domainMaxSpan, maxSpan)
 	}
 
-	if commitmentUseReferencedBranches && r.domain[kv.CommitmentDomain].values.needMerge {
+	if commitmentMergeReferencing && r.domain[kv.CommitmentDomain].values.needMerge {
 		cr := r.domain[kv.CommitmentDomain]
 
 		restorePrevRange := false
@@ -1874,7 +1927,16 @@ func (at *AggregatorRoTx) mergeFiles(ctx context.Context, files *FilesForMerge, 
 	t := time.Now()
 
 	at.a.logger.Debug("[snapshots] merge state " + r.String())
-	commitmentUseReferencedBranches := at.a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues
+	// Block account/storage before commitment only when the commitment merge needs the merged files:
+	// to expand referenced inputs, or to re-shorten the output. Plain inputs merged without
+	// re-shortening (flag off, or flag on below threshold) need neither and run in parallel.
+	comVals := r.domain[kv.CommitmentDomain].values
+	commitmentRefsEnabled := at.a.referencesInCommitmentBranches()
+	// With referenced commitment files present, concurrent dereference does random reads; keep the shared
+	// mmap at MADV_NORMAL during merge instead of a separate sequential view that would evict those pages.
+	seqReadahead := !at.commitmentVisibleFilesReferenced()
+	needCommitmentTransform := comVals.needMerge &&
+		commitmentMergeNeedsTransform(files.d[kv.CommitmentDomain], commitmentRefsEnabled, at.StepSize(), comVals.from, comVals.to)
 
 	accStorageMerged := new(sync.WaitGroup)
 
@@ -1888,26 +1950,26 @@ func (at *AggregatorRoTx) mergeFiles(ctx context.Context, files *FilesForMerge, 
 
 		id := id
 		kid := kv.Domain(id)
-		if commitmentUseReferencedBranches && (kid == kv.AccountsDomain || kid == kv.StorageDomain) {
+		if needCommitmentTransform && (kid == kv.AccountsDomain || kid == kv.StorageDomain) {
 			accStorageMerged.Add(1)
 		}
 
 		g.Go(func() (err error) {
 			var vt valueTransformer
-			if commitmentUseReferencedBranches && kid == kv.CommitmentDomain && r.domain[kid].values.needMerge {
+			if needCommitmentTransform && kid == kv.CommitmentDomain {
 				accStorageMerged.Wait()
 
 				// prepare transformer callback to correctly dereference previously merged accounts/storage plain keys
 				vt, err = at.d[kv.CommitmentDomain].commitmentValTransformDomain(r.domain[kid].values, at.d[kv.AccountsDomain], at.d[kv.StorageDomain],
-					mf.d[kv.AccountsDomain], mf.d[kv.StorageDomain])
+					mf.d[kv.AccountsDomain], mf.d[kv.StorageDomain], commitmentRefsEnabled)
 
 				if err != nil {
 					return fmt.Errorf("failed to create commitment value transformer: %w", err)
 				}
 			}
 
-			mf.d[id], mf.dIdx[id], mf.dHist[id], err = at.d[id].mergeFiles(ctx, files.d[id], files.dIdx[id], files.dHist[id], r.domain[id], vt, at.a.ps)
-			if commitmentUseReferencedBranches {
+			mf.d[id], mf.dIdx[id], mf.dHist[id], err = at.d[id].mergeFiles(ctx, files.d[id], files.dIdx[id], files.dHist[id], r.domain[id], vt, seqReadahead, at.a.ps)
+			if needCommitmentTransform {
 				if kid == kv.AccountsDomain || kid == kv.StorageDomain {
 					accStorageMerged.Done()
 				}

--- a/db/state/aggregator2.go
+++ b/db/state/aggregator2.go
@@ -28,6 +28,8 @@ type AggOpts struct { //nolint:gocritic
 	erigondbDomainStepsInFrozenFile uint64
 	reorgBlockDepth                 uint64
 
+	referencesInCommitmentBranches *bool // nil = leave global schema default untouched
+
 	genSaltIfNeed   bool
 	sanityOldNaming bool // prevent start directory with old file names
 	disableFsync    bool // for tests speed
@@ -76,6 +78,10 @@ func (opts AggOpts) Open(ctx context.Context, db kv.RoDB) (*Aggregator, error) {
 
 	a.savedSalt = salt
 
+	if opts.referencesInCommitmentBranches != nil {
+		a.applyReferencesInCommitmentBranches(*opts.referencesInCommitmentBranches)
+	}
+
 	if err := a.ConfigureDomains(); err != nil {
 		return nil, err
 	}
@@ -120,10 +126,12 @@ func (opts AggOpts) SanityOldNaming() AggOpts { //nolint:gocritic
 	return opts
 }
 
-// WithErigonDBSettings assigns pre-resolved DB settings (stepSize, stepsInFrozenFile).
+// WithErigonDBSettings assigns pre-resolved DB settings.
 func (opts AggOpts) WithErigonDBSettings(s *ErigonDBSettings) AggOpts { //nolint:gocritic
 	opts.stepSize = s.StepSize
 	opts.stepsInFrozenFile = s.StepsInFrozenFile
+	refs := s.RefsInCommitmentBranches()
+	opts.referencesInCommitmentBranches = &refs
 	return opts
 }
 

--- a/db/state/aggregator_files.go
+++ b/db/state/aggregator_files.go
@@ -104,7 +104,7 @@ func (mf MergeResult) FilePaths(relative string) (fPaths []string) {
 		if mf.dHist[id] != nil {
 			fPaths = append(fPaths, mf.dHist[id].FilePaths(relative)...)
 		}
-		if mf.dIdx[id] != nil && mf.dIdx[id].frozen {
+		if mf.dIdx[id] != nil {
 			fPaths = append(fPaths, mf.dIdx[id].FilePaths(relative)...)
 		}
 	}

--- a/db/state/aggregator_fuzz_test.go
+++ b/db/state/aggregator_fuzz_test.go
@@ -155,7 +155,7 @@ func Fuzz_AggregatorV3_Merge(f *testing.F) {
 
 func Fuzz_AggregatorV3_MergeValTransform(f *testing.F) {
 	db, agg := testFuzzDbAndAggregatorv3(f, 10)
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 
 	rwTx, err := db.BeginTemporalRw(f.Context())
 	require.NoError(f, err)

--- a/db/state/aggregator_refs_test.go
+++ b/db/state/aggregator_refs_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/config3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/mdbx"
+	"github.com/erigontech/erigon/db/version"
+)
+
+func writeRefsToml(t *testing.T, dirs datadir.Dirs, refs bool) {
+	t.Helper()
+	content := fmt.Appendf(nil, "step_size = %d\nsteps_in_frozen_file = %d\nreferences_in_commitment_branches = %v\n",
+		config3.DefaultStepSize, config3.DefaultStepsInFrozenFile, refs)
+	require.NoError(t, os.WriteFile(filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE), content, 0644))
+}
+
+func openTestAggForRefs(t *testing.T, dirs datadir.Dirs, settings *ErigonDBSettings) *Aggregator {
+	t.Helper()
+	logger := log.New()
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := NewTest(dirs).Logger(logger).WithErigonDBSettings(settings).MustOpen(t.Context(), db)
+	t.Cleanup(agg.Close)
+	return agg
+}
+
+// ReloadErigonDBSettings is the primary runtime path; a toml that says false must
+// land on the live commitment domain.
+func TestReloadErigonDBSettingsAppliesCommitmentRefsFlag(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+	writeRefsToml(t, dirs, false)
+
+	logger := log.New()
+	db := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).GrowthStep(32 * datasize.MB).MapSize(2 * datasize.GB).MustOpen()
+	t.Cleanup(db.Close)
+	agg := NewTest(dirs).Logger(logger).MustOpen(t.Context(), db)
+	t.Cleanup(agg.Close)
+
+	require.NoError(t, agg.ReloadErigonDBSettings(true))
+
+	require.False(t, agg.Cfg(kv.CommitmentDomain).ReferencesInCommitmentBranches, "live commitment domain reflects toml false")
+}
+
+// The builder path (WithErigonDBSettings → Open) is used by every standalone entry point;
+// the resolved flag must reach the live commitment domain.
+func TestOpenAppliesCommitmentRefsFlagFalse(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+	writeRefsToml(t, dirs, false)
+	settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
+	require.NoError(t, err)
+	require.False(t, settings.RefsInCommitmentBranches())
+
+	agg := openTestAggForRefs(t, dirs, settings)
+
+	require.False(t, agg.Cfg(kv.CommitmentDomain).ReferencesInCommitmentBranches, "live commitment domain reflects resolved false")
+}
+
+func TestOpenAppliesCommitmentRefsFlagTrue(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+	writeRefsToml(t, dirs, true)
+	settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
+	require.NoError(t, err)
+	require.True(t, settings.RefsInCommitmentBranches())
+
+	agg := openTestAggForRefs(t, dirs, settings)
+
+	require.True(t, agg.Cfg(kv.CommitmentDomain).ReferencesInCommitmentBranches, "live commitment domain reflects resolved true")
+}
+
+// The resolved erigondb.toml regime must bind to the produced commitment file version:
+// an in-place upgrade (toml without the field -> default true) keeps writing v2.1
+// referenced files; a downloaded plain set (references=false) writes v2.2 plain files.
+func TestResolvedRefsFlagBindsCommitmentWriteVersion(t *testing.T) {
+	t.Run("in-place upgrade without field writes v2.1 referenced", func(t *testing.T) {
+		dirs := datadir.New(t.TempDir())
+		content := fmt.Appendf(nil, "step_size = %d\nsteps_in_frozen_file = %d\n",
+			config3.DefaultStepSize, config3.DefaultStepsInFrozenFile)
+		require.NoError(t, os.WriteFile(filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE), content, 0644))
+
+		settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
+		require.NoError(t, err)
+		require.True(t, settings.RefsInCommitmentBranches())
+
+		agg := openTestAggForRefs(t, dirs, settings)
+		commit := agg.d[kv.CommitmentDomain]
+		require.True(t, agg.Cfg(kv.CommitmentDomain).ReferencesInCommitmentBranches)
+		require.Equal(t, version.V2_1, commit.kvWriteVersion())
+		require.Contains(t, commit.kvNewFilePath(0, 1), "v2.1-commitment.0-1.kv")
+	})
+
+	t.Run("downloaded plain set writes v2.2 plain", func(t *testing.T) {
+		dirs := datadir.New(t.TempDir())
+		writeRefsToml(t, dirs, false)
+
+		settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
+		require.NoError(t, err)
+		require.False(t, settings.RefsInCommitmentBranches())
+
+		agg := openTestAggForRefs(t, dirs, settings)
+		commit := agg.d[kv.CommitmentDomain]
+		require.False(t, agg.Cfg(kv.CommitmentDomain).ReferencesInCommitmentBranches)
+		require.Equal(t, version.V2_2, commit.kvWriteVersion())
+		require.Contains(t, commit.kvNewFilePath(0, 1), "v2.2-commitment.0-1.kv")
+	})
+}

--- a/db/state/aggregator_refs_test.go
+++ b/db/state/aggregator_refs_test.go
@@ -95,10 +95,10 @@ func TestOpenAppliesCommitmentRefsFlagTrue(t *testing.T) {
 }
 
 // The resolved erigondb.toml regime must bind to the produced commitment file version:
-// an in-place upgrade (toml without the field -> default true) keeps writing v2.1
-// referenced files; a downloaded plain set (references=false) writes v2.2 plain files.
+// a toml without the field inherits the compiled default; a downloaded plain set
+// (references=false) writes v2.2 plain files.
 func TestResolvedRefsFlagBindsCommitmentWriteVersion(t *testing.T) {
-	t.Run("in-place upgrade without field writes v2.1 referenced", func(t *testing.T) {
+	t.Run("absent field inherits the compiled default", func(t *testing.T) {
 		dirs := datadir.New(t.TempDir())
 		content := fmt.Appendf(nil, "step_size = %d\nsteps_in_frozen_file = %d\n",
 			config3.DefaultStepSize, config3.DefaultStepsInFrozenFile)
@@ -106,13 +106,18 @@ func TestResolvedRefsFlagBindsCommitmentWriteVersion(t *testing.T) {
 
 		settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
 		require.NoError(t, err)
-		require.True(t, settings.RefsInCommitmentBranches())
+		require.Equal(t, config3.DefaultReferencesInCommitmentBranches, settings.RefsInCommitmentBranches())
 
 		agg := openTestAggForRefs(t, dirs, settings)
 		commit := agg.d[kv.CommitmentDomain]
-		require.True(t, agg.Cfg(kv.CommitmentDomain).ReferencesInCommitmentBranches)
-		require.Equal(t, version.V2_1, commit.kvWriteVersion())
-		require.Contains(t, commit.kvNewFilePath(0, 1), "v2.1-commitment.0-1.kv")
+		require.Equal(t, config3.DefaultReferencesInCommitmentBranches, agg.Cfg(kv.CommitmentDomain).ReferencesInCommitmentBranches)
+
+		wantVersion, wantName := version.V2_2, "v2.2-commitment.0-1.kv"
+		if config3.DefaultReferencesInCommitmentBranches {
+			wantVersion, wantName = version.V2_1, "v2.1-commitment.0-1.kv"
+		}
+		require.Equal(t, wantVersion, commit.kvWriteVersion())
+		require.Contains(t, commit.kvNewFilePath(0, 1), wantName)
 	})
 
 	t.Run("downloaded plain set writes v2.2 plain", func(t *testing.T) {

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -148,6 +149,30 @@ func testDbAndAggregatorv3(tb testing.TB, stepSize uint64) (kv.RwDB, *Aggregator
 	err := agg.OpenFolder()
 	require.NoError(tb, err)
 	return db, agg
+}
+
+// TestReferencesInCommitmentBranchesConcurrent exercises the lock guarding the runtime-mutable
+// commitment flag against the reload-writes-while-merge-reads race; meaningful under -race.
+func TestReferencesInCommitmentBranchesConcurrent(t *testing.T) {
+	t.Parallel()
+	_, agg := testDbAndAggregatorv3(t, 1)
+
+	const iters = 2000
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			agg.applyReferencesInCommitmentBranches(i%2 == 0)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_ = agg.referencesInCommitmentBranches()
+		}
+	}()
+	wg.Wait()
 }
 
 // generate test data for table tests, containing n; n < 20 keys of length 20 bytes and values of length <= 16 bytes
@@ -600,7 +625,7 @@ func TestAggregator_CommitmentHistoryOnlyMerge(t *testing.T) {
 	// v2.0-storage.0-0.kv was not found".
 	stepSize := uint64(10)
 	_, agg := testDbAndAggregatorv3(t, stepSize)
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 	dirs := agg.Dirs()
 
 	// Accounts/storage/code: all files merged {0,2}, no further merge needed.
@@ -631,6 +656,113 @@ func TestAggregator_CommitmentHistoryOnlyMerge(t *testing.T) {
 		assert.NotContains(t, err.Error(), "failed to create commitment value transformer",
 			"transformer must not be called when values.needMerge=false")
 	}
+}
+
+// TestCommitmentMergeInputsReferenced covers the resolved-inputs predicate that gates merge
+// transformer creation. With the write flag off, this predicate alone decides whether the merge
+// expands referenced inputs (creating the transformer) or takes the plain fast path (no transformer).
+func TestCommitmentMergeInputsReferenced(t *testing.T) {
+	t.Parallel()
+	const stepSize = uint64(10)
+	fi := func(fromStep, toStep uint64, v version.Version) *FilesItem {
+		return &FilesItem{startTxNum: fromStep * stepSize, endTxNum: toStep * stepSize, version: v}
+	}
+	cases := []struct {
+		name   string
+		inputs []*FilesItem
+		want   bool
+	}{
+		{"v2.0 at threshold is referenced", []*FilesItem{fi(0, 2, version.V2_0)}, true},
+		{"v1.0 at threshold is referenced", []*FilesItem{fi(0, 2, version.V1_0)}, true},
+		{"v2.1 at threshold is referenced", []*FilesItem{fi(0, 2, version.V2_1)}, true},
+		{"v2.0 below threshold is plain", []*FilesItem{fi(0, 1, version.V2_0)}, false},
+		{"v2.2 is plain", []*FilesItem{fi(0, 2, version.V2_2)}, false},
+		{"empty inputs", nil, false},
+		{"nil entries skipped", []*FilesItem{nil}, false},
+		{"any referenced input wins", []*FilesItem{fi(0, 2, version.V2_1), fi(2, 4, version.V2_0)}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, commitmentMergeInputsReferenced(tc.inputs, stepSize))
+		})
+	}
+}
+
+// TestCommitmentMergeNeedsTransform covers the barrier gate: the commitment merge blocks on the
+// account/storage merges only when it needs the merged files — to expand referenced inputs or to
+// re-shorten the output. Plain inputs merged without re-shortening (flag off, or flag on below
+// threshold) need neither and must not block.
+func TestCommitmentMergeNeedsTransform(t *testing.T) {
+	t.Parallel()
+	const stepSize = uint64(10)
+	in := func(v version.Version) []*FilesItem {
+		return []*FilesItem{{startTxNum: 0, endTxNum: 2 * stepSize, version: v}}
+	}
+	const fromAbove, toAbove = uint64(0), uint64(20) // 2 steps -> threshold reached
+	const fromBelow, toBelow = uint64(0), uint64(10) // 1 step  -> below threshold
+	cases := []struct {
+		name        string
+		inputs      []*FilesItem
+		refsEnabled bool
+		from, to    uint64
+		want        bool
+	}{
+		{"plain inputs, flag off -> no transform, no block", in(version.V2_2), false, fromAbove, toAbove, false},
+		{"plain inputs, flag on, below threshold -> no transform, no block", in(version.V2_2), true, fromBelow, toBelow, false},
+		{"plain inputs, flag on, at threshold -> reshorten, block", in(version.V2_2), true, fromAbove, toAbove, true},
+		{"referenced input, flag off -> expand, block", in(version.V2_0), false, fromAbove, toAbove, true},
+		{"referenced input, flag on -> block", in(version.V2_0), true, fromAbove, toAbove, true},
+		{"no inputs -> no transform", nil, true, fromBelow, toBelow, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, commitmentMergeNeedsTransform(tc.inputs, tc.refsEnabled, stepSize, tc.from, tc.to))
+		})
+	}
+}
+
+// TestCommitmentVisibleFilesReferenced covers the planning-time over-approximation that gates the
+// range-alignment hold. It reads each file's version through the visible-files layer and must
+// report referencing independently of the live write flag (set off here on purpose).
+func TestCommitmentVisibleFilesReferenced(t *testing.T) {
+	check := func(t *testing.T, ver version.Version, want bool) {
+		t.Helper()
+		stepSize := uint64(10)
+		_, agg := testDbAndAggregatorv3(t, stepSize)
+		agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
+		dirs := agg.Dirs()
+		ranges := []testFileRange{{0, 2}}
+		generateAccountsFile(t, dirs, ranges)
+		generateStorageFile(t, dirs, ranges)
+		generateCodeFile(t, dirs, ranges)
+		generateCommitmentFile(t, dirs, ranges)
+		require.NoError(t, agg.OpenFolder())
+
+		// Drive the verdict by version+range: set the version directly on the dirty FilesItem
+		// (visibleFile.Version reads it live through src), independent of the generated file name.
+		var found int
+		agg.d[kv.CommitmentDomain].dirtyFiles.Scan(func(it *FilesItem) bool {
+			it.version = ver
+			found++
+			return true
+		})
+		require.Positive(t, found, "setup must produce a dirty commitment file")
+
+		aggTx := agg.BeginFilesRo()
+		got := aggTx.commitmentVisibleFilesReferenced()
+		aggTx.Close()
+		require.Equal(t, want, got)
+	}
+
+	t.Run("v2.0 at-threshold file reports referencing with flag off", func(t *testing.T) {
+		check(t, version.V2_0, true)
+	})
+	t.Run("v2.1 at-threshold file reports referencing with flag off", func(t *testing.T) {
+		check(t, version.V2_1, true)
+	})
+	t.Run("v2.2 file does not report referencing", func(t *testing.T) {
+		check(t, version.V2_2, false)
+	})
 }
 
 func setupAggSnapRepo(t *testing.T, dirs datadir.Dirs, genRepo func(stepSize uint64, dirs datadir.Dirs) (name string, schema SnapNameSchema)) *SnapshotRepo {

--- a/db/state/commitment_convert.go
+++ b/db/state/commitment_convert.go
@@ -19,7 +19,6 @@ package state
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -39,7 +38,6 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
-	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
@@ -116,50 +114,9 @@ func detectKeyEncoding(samples []sampledPair) (bool, error) {
 	return true, nil
 }
 
-// detectSqueezeState votes squeezed vs unsqueezed by looking for any embedded
-// plain-key field shorter than binary.MaxVarintLen64 (10 bytes) in the sampled
-// BranchData values. Real plain keys are exactly 20 bytes (account address) or
-// 52 bytes (address + storage slot); a single field with length < 10 proves
-// the value was squeezed (varint file offset). Asymmetric on purpose — one
-// short field is decisive, "unsqueezed" requires every sampled plain-key
-// field to be ≥ 10 bytes.
-//
-// Parse failures on a single BranchData are not decisive; the caller may
-// have sampled a malformed or empty branch (unlikely in practice). The
-// detector skips such samples and votes on what remains; zero usable
-// non-state samples returns errNoNonStateSamples.
-func detectSqueezeState(samples []sampledPair) (bool, error) {
-	sawAny := false
-	for _, p := range samples {
-		if bytes.Equal(p.k, commitmentdb.KeyCommitmentState) {
-			continue
-		}
-		if len(p.v) == 0 {
-			continue
-		}
-		short := false
-		_, err := commitment.BranchData(p.v).ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
-			if len(key) < binary.MaxVarintLen64 {
-				short = true
-			}
-			return nil, nil
-		})
-		if err != nil {
-			continue
-		}
-		sawAny = true
-		if short {
-			return true, nil
-		}
-	}
-	if !sawAny {
-		return false, errNoNonStateSamples
-	}
-	return false, nil
-}
-
 // detectFileState reads `samples` distributed (k, v) pairs from the commitment
-// file and runs both detectors. Uses BT ordinal lookup when available (constant
+// file to vote the key encoding (V1/V2), and derives the squeeze (referenced)
+// state from the file version. Uses BT ordinal lookup when available (constant
 // per-sample cost regardless of file size); falls back to stride-skip on a
 // sequential seg.Reader if the file has no BT index.
 //
@@ -189,10 +146,9 @@ func detectFileState(at *AggregatorRoTx, file VisibleFile, samples int) (fileSta
 	if err != nil {
 		return fileState{}, fmt.Errorf("detectFileState: %q: key-encoding vote: %w", file.Fullpath(), err)
 	}
-	squeezed, err := detectSqueezeState(pairs)
-	if err != nil {
-		return fileState{}, fmt.Errorf("detectFileState: %q: squeeze-state vote: %w", file.Fullpath(), err)
-	}
+	// Squeeze (referenced) state follows the version gate, like the live read path: referenced iff
+	// the file version is below the plain ceiling and its range reaches the threshold. No sampling.
+	squeezed := CommitmentBranchReferenced(file.Version(), at.StepSize(), file.StartRootNum(), file.EndRootNum())
 	return fileState{keysV2: keysV2, squeezed: squeezed}, nil
 }
 
@@ -328,7 +284,7 @@ func buildValueTransformer(
 			srcPath, errRangeMatch, stepFrom, stepTo, err)
 	}
 	if !detectedSqueezed && targetSqueezed {
-		vt, err := commitmentRo.commitmentValTransformDomain(rng, accounts, storage, af, sf)
+		vt, err := commitmentRo.commitmentValTransformDomain(rng, accounts, storage, af, sf, true)
 		if err != nil {
 			return nil, fmt.Errorf("buildValueTransformer unsqueezed→squeezed: %w", err)
 		}
@@ -659,6 +615,12 @@ func ConvertCommitmentFiles(ctx context.Context, at *AggregatorRoTx, opts Conver
 		logger.Info("[commitment_convert] no commitment files to convert")
 		return nil
 	}
+
+	// Output .kv version encodes the squeeze target for the version-gated reader (v2.1 squeezed,
+	// v2.2 plain); set once for the run so phase 1 writes and phase 2 discovery agree, then restore.
+	prevRefs := at.a.referencesInCommitmentBranches()
+	at.a.applyReferencesInCommitmentBranches(opts.TargetSqueeze)
+	defer at.a.applyReferencesInCommitmentBranches(prevRefs)
 
 	dirs := at.Dirs()
 	rebuildDir := filepath.Join(dirs.Snap, "rebuild", "domain")

--- a/db/state/commitment_convert_blackbox_test.go
+++ b/db/state/commitment_convert_blackbox_test.go
@@ -205,12 +205,12 @@ func TestConvertCommitmentFile_V1ToV1_Squeeze(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	// Build fixtures with ReplaceKeysInValues=false so the on-disk files start
+	// Build fixtures with ReferencesInCommitmentBranches=false so the on-disk files start
 	// unsqueezed. Then flip the config flag to true before running the converter
 	// so commitmentValTransformDomain's inner guard lets the squeeze fire.
 	cfg := &testAggConfig{stepSize: 10, disableCommitmentBranchTransform: true}
 	db, agg := testDbAggregatorWithFiles(t, cfg)
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 
 	rwTx, err := db.BeginTemporalRw(context.Background())
 	require.NoError(t, err)
@@ -228,9 +228,8 @@ func TestConvertCommitmentFile_V1ToV1_Squeeze(t *testing.T) {
 	require.NotEmpty(t, newKVPath)
 
 	// Squeezed values contain at least one embedded plain-key field shorter than
-	// binary.MaxVarintLen64 (10 bytes) — the marker the read-side detector
-	// (detectSqueezeState) keys off. Walk every non-state branch in the new
-	// file and assert at least one such short field exists.
+	// 10 bytes (a varint file offset, vs a 20- or 52-byte plain key). Walk every
+	// non-state branch in the new file and assert at least one such short field exists.
 	newKeys, newVals := readKVFile(t, agg, newKVPath)
 	require.NotEmpty(t, newVals)
 	foundShort := false
@@ -363,7 +362,7 @@ func TestConvertCommitmentFiles_FullFlow(t *testing.T) {
 	// runtime flag is false. Flip it on so TargetSqueeze:true actually fires —
 	// otherwise the orchestrator silently no-ops on the squeeze axis and the
 	// "root unchanged" assertion below holds trivially.
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 
 	// Compute the commitment root via the pre-conversion files.
 	rootBefore := computeCommitmentRoot(t, db)
@@ -390,7 +389,7 @@ func TestConvertCommitmentFiles_FullFlow(t *testing.T) {
 	// Verify the squeeze actually fired: at least one promoted file must
 	// contain a sub-10B embedded plain-key field. Without this check the
 	// "root unchanged" assertion below would also pass when the value codec
-	// silently no-oped (e.g. ReplaceKeysInValues=false in the fixture).
+	// silently no-oped (e.g. ReferencesInCommitmentBranches=false in the fixture).
 	newKVsForSqueezeCheck, gErr := filepath.Glob(filepath.Join(snapDir, "*-commitment.*.kv"))
 	require.NoError(t, gErr)
 	require.NotEmpty(t, newKVsForSqueezeCheck)
@@ -516,10 +515,10 @@ func TestConvertCommitmentFiles_RoundTripComposed(t *testing.T) {
 	}
 	cfg := &testAggConfig{stepSize: 10, disableCommitmentBranchTransform: true}
 	db, agg := testDbAggregatorWithFiles(t, cfg)
-	// Enable ReplaceKeysInValues so the squeeze axis actually fires in both
+	// Enable ReferencesInCommitmentBranches so the squeeze axis actually fires in both
 	// directions; without it the squeeze→unsqueezed leg of the round-trip is
 	// a silent no-op and byte equality holds for the wrong reason.
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 
 	snapDir := agg.Dirs().SnapDomain
 	origFiles := snapshotCommitmentFiles(t, snapDir)

--- a/db/state/commitment_convert_test.go
+++ b/db/state/commitment_convert_test.go
@@ -18,7 +18,6 @@ package state
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
@@ -41,47 +41,6 @@ func hexCompact(nibs ...byte) []byte {
 // v2Key emits a V2 canonical key for the supplied nibbles.
 func v2Key(nibs ...byte) []byte {
 	return nibbles.EncodeKeyV2(nibs)
-}
-
-// branchWithAccountKey returns a minimal valid BranchData containing exactly one
-// fieldAccountAddr cell at nibble 0 with the supplied bytes as the plain-key
-// payload. The varint length prefix uses a single byte (so keys must be < 128B).
-//
-// Layout: [touchMap=0x0001 BE][afterMap=0x0001 BE][fields=0x02][varint(len)][keyBytes]
-// fieldAccountAddr = 2 (see execution/commitment/commitment.go:180).
-func branchWithAccountKey(keyBytes []byte) []byte {
-	require := func(cond bool, msg string) {
-		if !cond {
-			panic(msg)
-		}
-	}
-	require(len(keyBytes) < 128, "branchWithAccountKey: keyBytes must fit single-byte varint")
-	var buf bytes.Buffer
-	var hdr [4]byte
-	binary.BigEndian.PutUint16(hdr[0:], 0x0001) // touchMap: nibble 0
-	binary.BigEndian.PutUint16(hdr[2:], 0x0001) // afterMap: nibble 0
-	buf.Write(hdr[:])
-	buf.WriteByte(0x02)                // fields = fieldAccountAddr
-	buf.WriteByte(byte(len(keyBytes))) // varint length (single-byte form for len < 128)
-	buf.Write(keyBytes)
-	return buf.Bytes()
-}
-
-// branchWithStorageKey is the storage-side variant of branchWithAccountKey.
-// fieldStorageAddr = 4 (commitment.go:181).
-func branchWithStorageKey(keyBytes []byte) []byte {
-	if len(keyBytes) >= 128 {
-		panic("branchWithStorageKey: keyBytes must fit single-byte varint")
-	}
-	var buf bytes.Buffer
-	var hdr [4]byte
-	binary.BigEndian.PutUint16(hdr[0:], 0x0001)
-	binary.BigEndian.PutUint16(hdr[2:], 0x0001)
-	buf.Write(hdr[:])
-	buf.WriteByte(0x04)
-	buf.WriteByte(byte(len(keyBytes)))
-	buf.Write(keyBytes)
-	return buf.Bytes()
 }
 
 func TestDetectKeyEncoding_AllV1(t *testing.T) {
@@ -159,65 +118,6 @@ func TestDetectKeyEncoding_KnownAmbiguous(t *testing.T) {
 	require.True(t, v2,
 		"detector classifies ambiguous V1 file as V2 — known limitation, "+
 			"documented in detectKeyEncoding godoc")
-}
-
-func TestDetectSqueezeState_AllSqueezed(t *testing.T) {
-	// All embedded plain-key fields are short (4-byte file offsets).
-	samples := []sampledPair{
-		{k: []byte("key1"), v: branchWithAccountKey([]byte{0x01, 0x02, 0x03, 0x04})},
-		{k: []byte("key2"), v: branchWithAccountKey([]byte{0x05, 0x06, 0x07})},
-		{k: []byte("key3"), v: branchWithStorageKey([]byte{0x08, 0x09})},
-	}
-	squeezed, err := detectSqueezeState(samples)
-	require.NoError(t, err)
-	require.True(t, squeezed)
-}
-
-func TestDetectSqueezeState_AllUnsqueezed(t *testing.T) {
-	addr20 := bytes.Repeat([]byte{0xaa}, 20)
-	addr52 := bytes.Repeat([]byte{0xbb}, 52)
-	samples := []sampledPair{
-		{k: []byte("key1"), v: branchWithAccountKey(addr20)},
-		{k: []byte("key2"), v: branchWithAccountKey(addr20)},
-		{k: []byte("key3"), v: branchWithStorageKey(addr52)},
-	}
-	squeezed, err := detectSqueezeState(samples)
-	require.NoError(t, err)
-	require.False(t, squeezed)
-}
-
-func TestDetectSqueezeState_PartialSqueezed(t *testing.T) {
-	// One short key among full-length keys — decisive squeezed signal.
-	addr20 := bytes.Repeat([]byte{0xcc}, 20)
-	samples := []sampledPair{
-		{k: []byte("key1"), v: branchWithAccountKey(addr20)},
-		{k: []byte("key2"), v: branchWithAccountKey(addr20)},
-		{k: []byte("key3"), v: branchWithAccountKey([]byte{0x01, 0x02, 0x03})}, // short
-		{k: []byte("key4"), v: branchWithAccountKey(addr20)},
-	}
-	squeezed, err := detectSqueezeState(samples)
-	require.NoError(t, err)
-	require.True(t, squeezed)
-}
-
-func TestDetectSqueezeState_StateKeysOnly(t *testing.T) {
-	samples := []sampledPair{
-		{k: commitmentdb.KeyCommitmentState, v: []byte{0x01, 0x02, 0x03}},
-		{k: commitmentdb.KeyCommitmentState, v: nil},
-	}
-	_, err := detectSqueezeState(samples)
-	require.ErrorIs(t, err, errNoNonStateSamples)
-}
-
-func TestDetectSqueezeState_EmptyValuesSkipped(t *testing.T) {
-	addr20 := bytes.Repeat([]byte{0xdd}, 20)
-	samples := []sampledPair{
-		{k: []byte("key1"), v: nil}, // skipped (empty value)
-		{k: []byte("key2"), v: branchWithAccountKey(addr20)},
-	}
-	squeezed, err := detectSqueezeState(samples)
-	require.NoError(t, err)
-	require.False(t, squeezed)
 }
 
 // nibblePaths covers the keyXform fixtures: a handful of distinct nibble paths
@@ -333,9 +233,10 @@ type fakeVisibleFile struct {
 	end   uint64
 }
 
-func (f fakeVisibleFile) Fullpath() string     { return f.path }
-func (f fakeVisibleFile) StartRootNum() uint64 { return f.start }
-func (f fakeVisibleFile) EndRootNum() uint64   { return f.end }
+func (f fakeVisibleFile) Fullpath() string         { return f.path }
+func (f fakeVisibleFile) StartRootNum() uint64     { return f.start }
+func (f fakeVisibleFile) EndRootNum() uint64       { return f.end }
+func (f fakeVisibleFile) Version() version.Version { return version.V1_0 }
 
 // preflightTestStepSize matches the unit step used in these tests: each input
 // "file" spans one step, so StartRootNum=N maps to step range [N, N+1).

--- a/db/state/commitment_merge_version_test.go
+++ b/db/state/commitment_merge_version_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"bytes"
+	"math"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/rawdbv3"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/version"
+)
+
+// TestCommitmentMergeFlagOffExpandsReferencedInputs exercises the corruption vector: v2.1 referenced
+// commitment files merged with the write flag off. The transformer must expand the referenced inputs
+// to plain keys (never copy short offsets into the plain output). setA is written only in early steps
+// with a disjoint nibble prefix, so its referenced branches survive as merge winners and reach the
+// flag-off merge.
+func TestCommitmentMergeFlagOffExpandsReferencedInputs(t *testing.T) {
+	t.Parallel()
+	const stepSize = uint64(10)
+	setA := mkAddrs(0x10, 12)
+	setB := mkAddrs(0xf0, 12)
+
+	db, agg := testDbAndAggregatorv3(t, stepSize)
+	dirs := agg.Dirs()
+
+	// phase 1: flag on -> referenced (v2.1) files
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
+	writeStepsKeys(t, db, agg, setA, 0, 6)
+	writeStepsKeys(t, db, agg, setB, 6, 32)
+	require.NoError(t, agg.BuildFiles(32*stepSize))
+
+	in016 := filepath.Join(dirs.SnapDomain, "v2.1-commitment.0-16.kv")
+	_, shortIn := branchKeyKinds(t, in016)
+	require.Positive(t, shortIn, "flag on must produce a referenced v2.1 input with short keys")
+
+	// phase 2: flag off -> the merge consuming the v2.1 inputs must produce plain (v2.2) output
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
+	writeStepsKeys(t, db, agg, setB, 32, 64)
+	require.NoError(t, agg.BuildFiles(64*stepSize))
+	require.NoError(t, agg.MergeLoop(t.Context()))
+
+	merged := filepath.Join(dirs.SnapDomain, "v2.2-commitment.0-32.kv")
+	plainOut, shortOut := branchKeyKinds(t, merged)
+	require.Positive(t, plainOut, "merged plain file must carry expanded plain keys")
+	require.Zero(t, shortOut, "merged v2.2 plain file must not carry stale short offsets")
+
+	// reopen from disk (file versions parsed from names) and confirm the state still reads back
+	db, agg = reopenAggregator(t, db, agg, stepSize)
+	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.BuildMissedAccessors(t.Context(), 1))
+	assertCommitmentVersionConsistency(t, dirs.SnapDomain)
+	require.NotEmpty(t, recomputeRootFromState(t, db))
+}
+
+// TestCommitmentRebuildSqueezeReadableAfterReload runs the full rebuild → squeeze cycle, which toggles
+// the write flag off (rebuild loop, writing plain v2.2) then on (squeeze, re-referencing). The squeezed
+// files must be stamped v2.1 so they read back correctly after a disk reload.
+func TestCommitmentRebuildSqueezeReadableAfterReload(t *testing.T) {
+	const stepSize = uint64(10)
+	db, agg := testDbAggregatorWithFiles(t, &testAggConfig{stepSize: stepSize, disableCommitmentBranchTransform: false})
+	dirs := agg.Dirs()
+
+	refRoot := recomputeRootFromState(t, db)
+	require.NotEmpty(t, refRoot)
+
+	db, agg = wipeCommitment(t, db, agg, dirs)
+
+	_, err := state.RebuildCommitmentFiles(t.Context(), db, &rawdbv3.TxNums, log.New(), true)
+	require.NoError(t, err)
+
+	// reopen fresh so commitment file versions come from the on-disk names
+	db, agg = reopenAggregator(t, db, agg, stepSize)
+	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.BuildMissedAccessors(t.Context(), 1))
+
+	referenced := assertCommitmentVersionConsistency(t, dirs.SnapDomain)
+	require.Positive(t, referenced, "squeeze must produce referenced (v2.1) commitment files")
+	require.Equal(t, refRoot, recomputeRootFromState(t, db), "rebuilt+squeezed state must read back to the same root")
+}
+
+// TestMergedCommitmentFileVersionStampedInMemory guards that a freshly-merged commitment file carries
+// its write version in memory (matching the on-disk name) without waiting for a folder reopen. A zero
+// in-memory version makes the merge-scheduling predicates treat a plain v2.2 file as referenced.
+func TestMergedCommitmentFileVersionStampedInMemory(t *testing.T) {
+	const stepSize = uint64(10)
+	keys := mkAddrs(0x20, 16)
+
+	db, agg := testDbAndAggregatorv3(t, stepSize)
+
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
+	writeStepsKeys(t, db, agg, keys, 0, 8)
+	require.NoError(t, agg.BuildFiles(8*stepSize))
+	require.NoError(t, agg.MergeLoop(t.Context()))
+
+	tx, err := db.BeginTemporalRw(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+	ac := state.AggTx(tx)
+
+	var checked int
+	for _, f := range ac.Files(kv.CommitmentDomain) {
+		if (f.EndRootNum()-f.StartRootNum())/stepSize < 2 {
+			continue
+		}
+		require.Equalf(t, version.V2_2, f.Version(),
+			"merged plain commitment file %s must be stamped v2.2 in memory, not the zero version", f.Fullpath())
+		checked++
+	}
+	require.Positive(t, checked, "setup must produce a merged commitment file at >= threshold range")
+}
+
+// TestMixedVersionDatadirReadsVersionDriven builds a datadir holding both v2.1-referenced and
+// v2.2-plain commitment files and pins the branch's central safety claim: reads are driven by each
+// file's own version, not the live write flag.
+func TestMixedVersionDatadirReadsVersionDriven(t *testing.T) {
+	const stepSize = uint64(10)
+	const frozenSteps = uint64(4) // freeze below the referencing threshold so v2.1 and v2.2 files coexist
+	db, agg, dirs, _, _ := buildMixedRegimeDatadir(t, stepSize, frozenSteps)
+
+	referenced, plain := commitmentVersionCounts(t, dirs.SnapDomain)
+	require.Positive(t, referenced, "datadir must contain v2.1 referenced commitment files")
+	require.Positive(t, plain, "datadir must contain v2.2 plain commitment files")
+	assertCommitmentVersionConsistency(t, dirs.SnapDomain)
+
+	// A referenced (v2.1) file must have its short keys expanded on read even with the flag off — the
+	// deref is driven by the file's own version, not the flag.
+	t.Run("referenced branches deref with flag off", func(t *testing.T) {
+		var refPrefixes [][]byte
+		for _, f := range commitmentKVFiles(t, dirs.SnapDomain) {
+			if f.version.Less(version.V2_2) {
+				refPrefixes = append(refPrefixes, referencedBranchPrefixes(t, f.path)...)
+			}
+		}
+		require.NotEmpty(t, refPrefixes, "setup must produce v2.1 branches carrying short keys")
+
+		readBranch := func(prefix []byte) (v []byte, fileStart, fileEnd uint64) {
+			tx, err := db.BeginTemporalRw(t.Context())
+			require.NoError(t, err)
+			defer tx.Rollback()
+			ac := state.AggTx(tx)
+			val, ok, fs, fe, err := ac.DebugGetLatestFromFiles(kv.CommitmentDomain, prefix, math.MaxUint64)
+			require.NoError(t, err)
+			require.True(t, ok)
+			return bytes.Clone(val), fs, fe
+		}
+
+		var expandedFromReferenced int
+		for _, prefix := range refPrefixes {
+			agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
+			vOn, _, _ := readBranch(prefix)
+			agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
+			vOff, fs, fe := readBranch(prefix)
+
+			require.Equalf(t, vOn, vOff, "deref must be driven by file version, not the live flag (prefix %x)", prefix)
+			plainKeys, shortKeys := branchKeyKindsVal(t, vOff)
+			require.Zerof(t, shortKeys, "reading a referenced branch with the flag off must expand all short refs (prefix %x)", prefix)
+			if commitmentRangeReferenced(t, dirs.SnapDomain, fs, fe, stepSize) {
+				require.Positivef(t, plainKeys, "expanded referenced branch must carry plain keys (prefix %x)", prefix)
+				expandedFromReferenced++
+			}
+		}
+		require.Positive(t, expandedFromReferenced, "at least one read must source a referenced v2.1 file and exercise deref")
+	})
+
+	// Flipping the flag on a populated datadir performs no migration: the recomputed root is identical
+	// across flips and the file set/regimes are unchanged.
+	t.Run("root stable across flag flips, no migration", func(t *testing.T) {
+		referencedBefore, plainBefore := commitmentVersionCounts(t, dirs.SnapDomain)
+
+		agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
+		rootOn := recomputeRootFromState(t, db)
+		require.NotEmpty(t, rootOn)
+
+		agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
+		require.Equal(t, rootOn, recomputeRootFromState(t, db), "flipping the flag off must not change reads on a populated datadir")
+
+		agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
+		require.Equal(t, rootOn, recomputeRootFromState(t, db), "flipping the flag back on must stay correct")
+
+		assertCommitmentVersionConsistency(t, dirs.SnapDomain)
+		referencedAfter, plainAfter := commitmentVersionCounts(t, dirs.SnapDomain)
+		require.Equal(t, referencedBefore, referencedAfter)
+		require.Equal(t, plainBefore, plainAfter)
+	})
+}

--- a/db/state/commitment_version_testutil_test.go
+++ b/db/state/commitment_version_testutil_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/temporal"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+func mkAddrs(firstByte byte, n int) [][]byte {
+	out := make([][]byte, n)
+	for i := range n {
+		a := make([]byte, length.Addr)
+		a[0] = firstByte
+		a[1] = byte(i)
+		a[length.Addr-1] = byte(i)
+		out[i] = a
+	}
+	return out
+}
+
+func writeStepsKeys(t *testing.T, db kv.TemporalRwDB, agg *state.Aggregator, keys [][]byte, fromStep, toStep uint64) {
+	t.Helper()
+	stepSize := agg.StepSize()
+	rwTx, err := db.BeginTemporalRw(t.Context())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
+	require.NoError(t, err)
+	defer domains.Close()
+	var blockNum uint64
+	for i := fromStep * stepSize; i < toStep*stepSize; i++ {
+		for j := range keys {
+			acc := accounts.Account{Nonce: i + 1, Balance: *uint256.NewInt(i*100_000 + uint64(j)), CodeHash: accounts.EmptyCodeHash}
+			buf := accounts.SerialiseV3(&acc)
+			prev, _, err := domains.GetLatest(kv.AccountsDomain, rwTx, keys[j])
+			require.NoError(t, err)
+			require.NoError(t, domains.DomainPut(kv.AccountsDomain, rwTx, keys[j], buf, i, prev))
+		}
+		if (i+1)%stepSize == 0 {
+			_, err := domains.ComputeCommitment(t.Context(), rwTx, true, blockNum, i, "", nil)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, domains.Flush(t.Context(), rwTx))
+	require.NoError(t, rwTx.Commit())
+}
+
+func recomputeRootFromState(t *testing.T, db kv.TemporalRwDB) []byte {
+	t.Helper()
+	rwTx, err := db.BeginTemporalRw(t.Context())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
+	require.NoError(t, err)
+	defer domains.Close()
+	acit, err := rwTx.Debug().RangeLatest(kv.AccountsDomain, nil, nil, -1)
+	require.NoError(t, err)
+	defer acit.Close()
+	trieCtx := domains.GetCommitmentContext()
+	for acit.HasNext() {
+		k, _, err := acit.Next()
+		require.NoError(t, err)
+		trieCtx.TouchKey(kv.AccountsDomain, string(k), nil)
+	}
+	root, err := domains.ComputeCommitment(t.Context(), rwTx, false, 0, 0, "", nil)
+	require.NoError(t, err)
+	return root
+}
+
+// forEachCommitmentBranch iterates the branch (prefix,value) pairs of a commitment .kv file,
+// skipping the commitment-state record.
+func forEachCommitmentBranch(t *testing.T, path string, fn func(prefix, val []byte)) {
+	t.Helper()
+	d, err := seg.NewDecompressor(path)
+	require.NoError(t, err)
+	defer d.Close()
+	g := d.MakeGetter()
+	g.Reset(0)
+	var k, v []byte
+	for g.HasNext() {
+		k, _ = g.Next(k[:0])
+		v, _ = g.Next(v[:0])
+		if bytes.Equal(k, commitmentdb.KeyCommitmentState) {
+			continue
+		}
+		fn(k, v)
+	}
+}
+
+// branchKeyKindsVal counts plain vs short (referenced) keys in a single branch value.
+func branchKeyKindsVal(t *testing.T, v []byte) (plain, short int) {
+	t.Helper()
+	_, err := commitment.BranchData(v).ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+		full := length.Addr
+		if isStorage {
+			full = length.Addr + length.Hash
+		}
+		if len(key) == full {
+			plain++
+		} else {
+			short++
+		}
+		return nil, nil
+	})
+	require.NoError(t, err)
+	return plain, short
+}
+
+// branchKeyKinds counts plain vs short (referenced) keys across all branches of a commitment .kv file.
+func branchKeyKinds(t *testing.T, path string) (plain, short int) {
+	t.Helper()
+	forEachCommitmentBranch(t, path, func(_, v []byte) {
+		p, s := branchKeyKindsVal(t, v)
+		plain += p
+		short += s
+	})
+	return plain, short
+}
+
+// referencedBranchPrefixes returns the branch prefixes whose value carries short (referenced) keys.
+func referencedBranchPrefixes(t *testing.T, path string) [][]byte {
+	t.Helper()
+	var out [][]byte
+	forEachCommitmentBranch(t, path, func(k, v []byte) {
+		if _, short := branchKeyKindsVal(t, v); short > 0 {
+			out = append(out, bytes.Clone(k))
+		}
+	})
+	return out
+}
+
+type commitmentKVFile struct {
+	name    string
+	path    string
+	version version.Version
+}
+
+// commitmentKVFiles lists the commitment .kv files in dir with their parsed on-disk version.
+func commitmentKVFiles(t *testing.T, dir string) []commitmentKVFile {
+	t.Helper()
+	ents, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var out []commitmentKVFile
+	for _, e := range ents {
+		n := e.Name()
+		if !strings.Contains(n, "commitment") || !strings.HasSuffix(n, ".kv") {
+			continue
+		}
+		ver, _, ok := strings.Cut(n, "-")
+		require.True(t, ok)
+		fv, err := version.ParseVersion(ver)
+		require.NoError(t, err)
+		out = append(out, commitmentKVFile{name: n, path: filepath.Join(dir, n), version: fv})
+	}
+	return out
+}
+
+// assertCommitmentVersionConsistency enforces the regime invariant: a v2.2 (plain-regime) commitment
+// file must hold no short reference keys (a v2.2 file with short keys is the stale-offset corruption).
+func assertCommitmentVersionConsistency(t *testing.T, dir string) (referencedFiles int) {
+	t.Helper()
+	for _, f := range commitmentKVFiles(t, dir) {
+		_, short := branchKeyKinds(t, f.path)
+		if !f.version.Less(version.V2_2) {
+			require.Zerof(t, short, "v2.2+ file %s must hold only plain keys, found %d short refs (stale offsets)", f.name, short)
+		} else if short > 0 {
+			referencedFiles++
+		}
+	}
+	return referencedFiles
+}
+
+// commitmentVersionCounts returns how many commitment .kv files are referenced (version < v2.2 and
+// carry short keys) vs plain (version >= v2.2).
+func commitmentVersionCounts(t *testing.T, dir string) (referenced, plain int) {
+	t.Helper()
+	for _, f := range commitmentKVFiles(t, dir) {
+		if f.version.Less(version.V2_2) {
+			if _, short := branchKeyKinds(t, f.path); short > 0 {
+				referenced++
+			}
+		} else {
+			plain++
+		}
+	}
+	return referenced, plain
+}
+
+// commitmentRangeReferenced reports whether the on-disk commitment file covering the tx range is in
+// the referenced regime (version < v2.2 and range >= the referencing threshold).
+func commitmentRangeReferenced(t *testing.T, dir string, fileStart, fileEnd, stepSize uint64) bool {
+	t.Helper()
+	fromStep, toStep := fileStart/stepSize, fileEnd/stepSize
+	if toStep-fromStep < 2 {
+		return false
+	}
+	suffix := fmt.Sprintf("commitment.%d-%d.kv", fromStep, toStep)
+	for _, f := range commitmentKVFiles(t, dir) {
+		if strings.HasSuffix(f.name, suffix) {
+			return f.version.Less(version.V2_2)
+		}
+	}
+	return false
+}
+
+// buildMixedRegimeDatadir builds a datadir holding both v2.1-referenced and v2.2-plain commitment
+// files: setA is frozen early under the flag-on (referenced) regime and never rewritten, so its
+// referenced branches stay read winners; setB advances the tx range into later flag-off (plain) files.
+func buildMixedRegimeDatadir(t *testing.T, stepSize, frozenSteps uint64) (kv.TemporalRwDB, *state.Aggregator, datadir.Dirs, [][]byte, [][]byte) {
+	t.Helper()
+	setA := mkAddrs(0x10, 12)
+	setB := mkAddrs(0xf0, 12)
+
+	db, agg := testDbAndAggregatorv3(t, stepSize)
+	dirs := agg.Dirs()
+	agg.SetErigondbDomainStepsInFrozenFile(frozenSteps)
+
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
+	writeStepsKeys(t, db, agg, setA, 0, frozenSteps)
+	writeStepsKeys(t, db, agg, setB, frozenSteps, 2*frozenSteps)
+	require.NoError(t, agg.BuildFiles(2*frozenSteps*stepSize))
+	require.NoError(t, agg.MergeLoop(t.Context()))
+
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
+	writeStepsKeys(t, db, agg, setB, 2*frozenSteps, 3*frozenSteps)
+	require.NoError(t, agg.BuildFiles(3*frozenSteps*stepSize))
+	require.NoError(t, agg.MergeLoop(t.Context()))
+
+	db, agg = reopenAggregator(t, db, agg, stepSize)
+	require.NoError(t, agg.OpenFolder())
+	require.NoError(t, agg.BuildMissedAccessors(t.Context(), 1))
+	return db, agg, dirs, setA, setB
+}
+
+// collectCommitmentFiles returns a map of filename→size for all commitment .kv files in the domain
+// snapshot directory.
+func collectCommitmentFiles(t *testing.T, dirs datadir.Dirs) map[string]int64 {
+	t.Helper()
+	result := make(map[string]int64)
+	paths, err := dir.ListFiles(dirs.SnapDomain, ".kv")
+	require.NoError(t, err)
+	commitStr := kv.CommitmentDomain.String()
+	for _, p := range paths {
+		name := filepath.Base(p)
+		if !strings.Contains(name, commitStr) {
+			continue
+		}
+		info, err := os.Stat(p)
+		require.NoError(t, err)
+		result[name] = info.Size()
+	}
+	return result
+}
+
+// wipeCommitment removes all commitment state from both database tables and snapshot files,
+// then returns a freshly reopened db and aggregator over the wiped folder.
+func wipeCommitment(t *testing.T, db kv.TemporalRwDB, agg *state.Aggregator, dirs datadir.Dirs) (kv.TemporalRwDB, *state.Aggregator) {
+	t.Helper()
+	stepSize := agg.StepSize()
+
+	rwTx, err := db.BeginRw(t.Context())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+
+	buckets, err := rwTx.ListTables()
+	require.NoError(t, err)
+
+	commitStr := kv.CommitmentDomain.String()
+	for _, b := range buckets {
+		if strings.Contains(strings.ToLower(b), commitStr) {
+			err = rwTx.ClearTable(b)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, rwTx.Commit())
+
+	// Release the aggregator's file handles before deleting the .kv files: Windows refuses to
+	// remove a still-mapped file, while Unix allows unlink-while-open.
+	agg.Close()
+
+	paths, err := dir.ListFiles(dirs.SnapDomain, ".kv")
+	require.NoError(t, err, "listing snapshot domain files")
+	for _, p := range paths {
+		if !strings.Contains(filepath.Base(p), commitStr) {
+			continue
+		}
+		err = dir.RemoveFile(p)
+		require.NoError(t, err, "removing commitment file: %s", p)
+		base := strings.TrimSuffix(p, ".kv")
+		for _, ext := range []string{".kvi", ".kvei", ".bt"} {
+			_ = dir.RemoveFile(base + ext) // best-effort, may not exist
+		}
+	}
+
+	newAgg := testAgg(t, db, dirs, stepSize, log.New())
+	newDB, err := temporal.New(db, newAgg)
+	require.NoError(t, err)
+	require.NoError(t, newAgg.OpenFolder())
+
+	remaining := collectCommitmentFiles(t, dirs)
+	require.Empty(t, remaining, "commitment files must be fully removed after wipe")
+	return newDB, newAgg
+}
+
+// reopenAggregator closes the current aggregator and reopens it with a fresh temporal DB wrapper.
+func reopenAggregator(t *testing.T, db kv.TemporalRwDB, agg *state.Aggregator, stepSize uint64) (kv.TemporalRwDB, *state.Aggregator) {
+	t.Helper()
+	dirs := agg.Dirs()
+	agg.Close()
+
+	newAgg := testAgg(t, db, dirs, stepSize, log.New())
+	newDB, err := temporal.New(db, newAgg)
+	require.NoError(t, err)
+
+	return newDB, newAgg
+}

--- a/db/state/deduplicate.go
+++ b/db/state/deduplicate.go
@@ -387,7 +387,7 @@ func (iit *InvertedIndexRoTx) deduplicateFiles(ctx context.Context, files []*Fil
 	}
 	ps.Delete(p)
 
-	if err := iit.ii.buildMapAccessor(ctx, fromStep, toStep, iit.dataReader(outItem.decompressor), ps); err != nil {
+	if err := iit.ii.buildMapAccessor(ctx, fromStep, toStep, outItem.decompressor, ps); err != nil {
 		return nil, fmt.Errorf("merge %s buildHashMapAccessor [%d-%d]: %w", iit.ii.FilenameBase, startTxNum, endTxNum, err)
 	}
 	if outItem.index, err = iit.ii.openHashMapAccessor(iit.ii.efAccessorNewFilePath(fromStep, toStep)); err != nil {

--- a/db/state/deduplicate.go
+++ b/db/state/deduplicate.go
@@ -381,7 +381,7 @@ func (iit *InvertedIndexRoTx) deduplicateFiles(ctx context.Context, files []*Fil
 	comp.Close()
 	comp = nil
 
-	outItem = newFilesItem(startTxNum, endTxNum, iit.stepSize, iit.stepsInFrozenFile)
+	outItem = newFilesItem(startTxNum, endTxNum)
 	if outItem.decompressor, err = seg.NewDecompressor(datPath); err != nil {
 		return nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", iit.ii.FilenameBase, startTxNum, endTxNum, err)
 	}

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -120,26 +120,15 @@ type FilesItem struct {
 	existence            *existence.Filter
 	startTxNum, endTxNum uint64 //[startTxNum, endTxNum)
 
-	// Frozen: file containing Aggregator.stepsInFrozenFile steps. Completely immutable.
-	// Cold: file containing < Aggregator.stepsInFrozenFile steps. Immutable, but can be closed/removed after merge to bigger file.
-	// Hot: Stored in DB. Providing Snapshot-Isolation by CopyOnWrite.
-	frozen   bool         // immutable, don't need atomic
-	refcount atomic.Int32 // only for `frozen=false`
+	refcount atomic.Int32
 
-	// file can be deleted in 2 cases: 1. when `refcount == 0 && canDelete == true` 2. on app startup when `file.isSubsetOfFrozenFile()`
-	// other processes (which also reading files, may have same logic)
+	// Deprecated: only the not-yet-migrated forkable subsystem still uses this (with
+	// refcount); the aggregator reclaims via aggregatorVisible generations (retired + refcnt).
 	canDelete atomic.Bool
 }
 
-func newFilesItemWithSnapConfig(startTxNum, endTxNum uint64, snapConfig *SnapshotConfig) *FilesItem {
-	return newFilesItem(startTxNum, endTxNum, snapConfig.RootNumPerStep, snapConfig.StepsInFrozenFile())
-}
-
-func newFilesItem(startTxNum, endTxNum, stepSize uint64, stepsInFrozenFile uint64) *FilesItem {
-	startStep := startTxNum / stepSize
-	endStep := endTxNum / stepSize
-	frozen := endStep-startStep >= stepsInFrozenFile
-	return &FilesItem{startTxNum: startTxNum, endTxNum: endTxNum, frozen: frozen}
+func newFilesItem(startTxNum, endTxNum uint64) *FilesItem {
+	return &FilesItem{startTxNum: startTxNum, endTxNum: endTxNum}
 }
 
 func (i *FilesItem) Segment() *seg.Decompressor { return i.decompressor }
@@ -258,14 +247,11 @@ func (i *FilesItem) closeFilesAndRemove() {
 	// permanently orphaned.
 	if i.index != nil {
 		i.index.Close()
-		// paranoic-mode on: don't delete frozen files
-		if !i.frozen {
-			if err := dir.RemoveFile(i.index.FilePath()); err != nil {
-				log.Trace("remove after close", "err", err, "file", i.index.FileName())
-			}
-			if err := dir.RemoveFile(i.index.FilePath() + ".torrent"); err != nil {
-				log.Trace("remove after close", "err", err, "file", i.index.FileName())
-			}
+		if err := dir.RemoveFile(i.index.FilePath()); err != nil {
+			log.Trace("remove after close", "err", err, "file", i.index.FileName())
+		}
+		if err := dir.RemoveFile(i.index.FilePath() + ".torrent"); err != nil {
+			log.Trace("remove after close", "err", err, "file", i.index.FileName())
 		}
 		i.index = nil
 	}
@@ -291,14 +277,11 @@ func (i *FilesItem) closeFilesAndRemove() {
 	}
 	if i.decompressor != nil {
 		i.decompressor.Close()
-		// paranoic-mode on: don't delete frozen files
-		if !i.frozen {
-			if err := dir.RemoveFile(i.decompressor.FilePath()); err != nil {
-				log.Trace("remove after close", "err", err, "file", i.decompressor.FileName())
-			}
-			if err := dir.RemoveFile(i.decompressor.FilePath() + ".torrent"); err != nil {
-				log.Trace("remove after close", "err", err, "file", i.decompressor.FileName()+".torrent")
-			}
+		if err := dir.RemoveFile(i.decompressor.FilePath()); err != nil {
+			log.Trace("remove after close", "err", err, "file", i.decompressor.FileName())
+		}
+		if err := dir.RemoveFile(i.decompressor.FilePath() + ".torrent"); err != nil {
+			log.Trace("remove after close", "err", err, "file", i.decompressor.FileName()+".torrent")
 		}
 		i.decompressor = nil
 	}
@@ -306,7 +289,7 @@ func (i *FilesItem) closeFilesAndRemove() {
 
 var filterDirtyFilesReCache sync.Map // pattern string → *regexp.Regexp
 
-func filterDirtyFiles(fileNames []string, stepSize, stepsInFrozenFile uint64, filenameBase, ext string, logger log.Logger) (res []*FilesItem) {
+func filterDirtyFiles(fileNames []string, stepSize uint64, filenameBase, ext string, logger log.Logger) (res []*FilesItem) {
 	pattern := `^v(\d+(?:\.\d+)?)-` + filenameBase + `\.(\d+)-(\d+)\.` + ext + `$`
 	reVal, ok := filterDirtyFilesReCache.Load(pattern)
 	if !ok {
@@ -346,7 +329,7 @@ func filterDirtyFiles(fileNames []string, stepSize, stepsInFrozenFile uint64, fi
 		//   1-2.kv: [8, 16)
 		startTxNum, endTxNum := startStep*stepSize, endStep*stepSize
 
-		var newFile = newFilesItem(startTxNum, endTxNum, stepSize, stepsInFrozenFile)
+		var newFile = newFilesItem(startTxNum, endTxNum)
 		res = append(res, newFile)
 	}
 	return res

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -120,6 +120,8 @@ type FilesItem struct {
 	existence            *existence.Filter
 	startTxNum, endTxNum uint64 //[startTxNum, endTxNum)
 
+	// version is the file's parsed on-disk version, used as a per-file regime marker.
+	version  version.Version
 	refcount atomic.Int32
 
 	// Deprecated: only the not-yet-migrated forkable subsystem still uses this (with
@@ -376,6 +378,7 @@ func (d *Domain) openDirtyFiles(dirEntries []string) (err error) {
 
 			fName := filepath.Base(fPath)
 			d.FileVersion.DataKV.MustSupport(fileVer, fName)
+			item.version = fileVer
 
 			if item.decompressor, err = seg.NewDecompressor(fPath); err != nil {
 				if errors.Is(err, &seg.ErrCompressedFileCorrupted{}) {
@@ -595,6 +598,10 @@ type visibleFile struct {
 
 func (i visibleFile) Fullpath() string {
 	return i.src.decompressor.FilePath()
+}
+
+func (i visibleFile) Version() version.Version {
+	return i.src.version
 }
 
 func (i visibleFile) StartRootNum() uint64 {

--- a/db/state/dirty_files_test.go
+++ b/db/state/dirty_files_test.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/db/version"
 )
 
 func TestStepRange(t *testing.T) {
@@ -97,4 +102,92 @@ func TestFileItemWithMissedAccessor(t *testing.T) {
 	fileItems := fileItemsWithMissedAccessors(df.Items(), aggStep, accessorFor)
 	require.Len(t, fileItems, 1)
 	require.Equal(t, f3, fileItems[0])
+}
+
+func TestVisibleFileVersion(t *testing.T) {
+	t.Parallel()
+	vf := visibleFile{src: &FilesItem{version: version.V2_1}}
+	require.Equal(t, version.V2_1, vf.Version())
+}
+
+// openDirtyFiles must accept a mixed-version file set (v1.0/v2.0/v2.1) without tripping the
+// MustSupport version-acceptance check, opening one dirty item per range from disk.
+func TestOpenDirtyFilesAcceptsMixedVersions(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+	_, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, 16, logger)
+	// Bump this (accounts) domain's read ceiling to v2.1 so the mixed-version fixtures open without
+	// tripping MustSupport; unrelated to commitment-domain versioning.
+	d.FileVersion.DataKV = version.Versions{Current: version.V2_1, MinSupported: version.V1_0}
+
+	tmp := t.TempDir()
+	cases := []struct {
+		name string
+		rng  string
+	}{
+		{"v1.0-accounts.0-1.kv", "0-1"},
+		{"v2.0-accounts.1-2.kv", "1-2"},
+		{"v2.1-accounts.2-3.kv", "2-3"},
+	}
+	fileNames := make([]string, 0, len(cases))
+	for _, c := range cases {
+		writeTestKVFile(t, filepath.Join(d.dirs.SnapDomain, c.name), tmp, logger)
+		fileNames = append(fileNames, c.name)
+	}
+
+	d.scanDirtyFiles(fileNames)
+	require.NoError(t, d.openDirtyFiles(fileNames))
+
+	opened := make(map[string]bool)
+	d.dirtyFiles.Scan(func(it *FilesItem) bool {
+		from, to := it.StepRange(d.stepSize)
+		require.NotNil(t, it.decompressor, "dirty file %d-%d must be opened", from, to)
+		opened[fmt.Sprintf("%d-%d", from, to)] = true
+		return true
+	})
+
+	for _, c := range cases {
+		require.True(t, opened[c.rng], "range %s must open from %s", c.rng, c.name)
+	}
+}
+
+// Two same-range commitment files of different versions collapse to one dirty item
+// resolved to the highest version (v2.1); the lower v2.0 twin is left on disk, never opened.
+func TestOpenDirtyFilesSameRangePrefersNewestVersion(t *testing.T) {
+	t.Parallel()
+	for _, order := range [][]string{
+		{"v2.0-commitment.0-2.kv", "v2.1-commitment.0-2.kv"},
+		{"v2.1-commitment.0-2.kv", "v2.0-commitment.0-2.kv"},
+	} {
+		t.Run(strings.Join(order, ","), func(t *testing.T) {
+			logger := log.New()
+			_, d := testDbAndDomainOfStep(t, statecfg.Schema.CommitmentDomain, 16, logger)
+			tmp := t.TempDir()
+			for _, name := range order {
+				writeTestKVFile(t, filepath.Join(d.dirs.SnapDomain, name), tmp, logger)
+			}
+
+			d.scanDirtyFiles(order)
+			require.NoError(t, d.openDirtyFiles(order))
+
+			require.Equal(t, 1, d.dirtyFiles.Len(), "same-range duplicate must collapse to one dirty file")
+			var opened *FilesItem
+			d.dirtyFiles.Scan(func(it *FilesItem) bool { opened = it; return true })
+			require.NotNil(t, opened)
+			require.Equal(t, "v2.1-commitment.0-2.kv", filepath.Base(opened.decompressor.FilePath()), "newest version wins")
+
+			_, err := os.Stat(filepath.Join(d.dirs.SnapDomain, "v2.0-commitment.0-2.kv"))
+			require.NoError(t, err, "lower-version twin stays on disk, just unopened")
+		})
+	}
+}
+
+func writeTestKVFile(t *testing.T, path, tmp string, logger log.Logger) {
+	t.Helper()
+	comp, err := seg.NewCompressor(t.Context(), "test", path, tmp, seg.DefaultCfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	defer comp.Close()
+	require.NoError(t, comp.AddWord([]byte("k")))
+	require.NoError(t, comp.AddWord([]byte("v")))
+	require.NoError(t, comp.Compress())
 }

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -353,10 +353,8 @@ func (d *Domain) scanDirtyFiles(fileNames []string) (garbageFiles []*FilesItem) 
 	if d.FilenameBase == "" {
 		panic("assert: empty `filenameBase`")
 	}
-	l := filterDirtyFiles(fileNames, d.stepSize, d.stepsInFrozenFile, d.FilenameBase, "kv", d.logger)
+	l := filterDirtyFiles(fileNames, d.stepSize, d.FilenameBase, "kv", d.logger)
 	for _, dirtyFile := range l {
-		dirtyFile.frozen = false
-
 		if _, has := d.dirtyFiles.Get(dirtyFile); !has {
 			d.dirtyFiles.Set(dirtyFile)
 		}
@@ -1287,8 +1285,7 @@ func (d *Domain) integrateDirtyFiles(sf StaticFiles, txNumFrom, txNumTo uint64) 
 
 	d.History.integrateDirtyFiles(sf.HistoryFiles, txNumFrom, txNumTo)
 
-	fi := newFilesItem(txNumFrom, txNumTo, d.stepSize, d.stepsInFrozenFile)
-	fi.frozen = false
+	fi := newFilesItem(txNumFrom, txNumTo)
 	fi.decompressor = sf.valuesDecomp
 	fi.index = sf.valuesIdx
 	fi.bindex = sf.valuesBt

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -147,6 +147,14 @@ func (d *Domain) BranchCache() *commitment.BranchCache {
 	return d.branchCache
 }
 
+// kvWriteVersion is the version stamped on a new .kv file: the domain's KVWriteVersion hook if set, else DataKV.Current.
+func (d *Domain) kvWriteVersion() version.Version {
+	if d.KVWriteVersion != nil {
+		return d.KVWriteVersion(&d.DomainCfg)
+	}
+	return d.FileVersion.DataKV.Current
+}
+
 func (d *Domain) kvNewFilePath(fromStep, toStep kv.Step) string {
 	return d.kvNewFilePathIn("", fromStep, toStep)
 }
@@ -165,7 +173,7 @@ func (d *Domain) kvNewFilePathIn(baseDir string, fromStep, toStep kv.Step) strin
 	if baseDir == "" {
 		baseDir = d.dirs.SnapDomain
 	}
-	return filepath.Join(baseDir, fmt.Sprintf("%s-%s.%d-%d.kv", d.FileVersion.DataKV.String(), d.FilenameBase, fromStep, toStep))
+	return filepath.Join(baseDir, fmt.Sprintf("%s-%s.%d-%d.kv", d.kvWriteVersion().String(), d.FilenameBase, fromStep, toStep))
 }
 func (d *Domain) kviAccessorNewFilePathIn(baseDir string, fromStep, toStep kv.Step) string {
 	if baseDir == "" {
@@ -958,7 +966,7 @@ func (d *Domain) buildFileRange(ctx context.Context, stepFrom, stepTo kv.Step, c
 
 	if d.Accessors.Has(statecfg.AccessorHashMap) {
 		idxPath := d.kviAccessorNewFilePathIn(dstDir, stepFrom, stepTo)
-		if err = d.buildHashMapAccessorAt(ctx, idxPath, d.dataReader(valuesDecomp), ps); err != nil {
+		if err = d.buildHashMapAccessorAt(ctx, idxPath, valuesDecomp, ps); err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s values idx: %w", d.FilenameBase, err)
 		}
 		valuesIdx, err = d.openHashMapAccessor(idxPath)
@@ -1061,7 +1069,7 @@ func (d *Domain) buildFiles(ctx context.Context, step kv.Step, collation Collati
 	}
 
 	if d.Accessors.Has(statecfg.AccessorHashMap) {
-		if err = d.buildHashMapAccessor(ctx, step, step+1, d.dataReader(valuesDecomp), ps); err != nil {
+		if err = d.buildHashMapAccessor(ctx, step, step+1, valuesDecomp, ps); err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s values idx: %w", d.FilenameBase, err)
 		}
 		valuesIdx, err = d.openHashMapAccessor(d.kviAccessorNewFilePath(step, step+1))
@@ -1101,11 +1109,11 @@ func (d *Domain) buildFiles(ctx context.Context, step kv.Step, collation Collati
 	}, nil
 }
 
-func (d *Domain) buildHashMapAccessor(ctx context.Context, fromStep, toStep kv.Step, data *seg.Reader, ps *background.ProgressSet) error {
+func (d *Domain) buildHashMapAccessor(ctx context.Context, fromStep, toStep kv.Step, data *seg.Decompressor, ps *background.ProgressSet) error {
 	return d.buildHashMapAccessorAt(ctx, d.kviAccessorNewFilePath(fromStep, toStep), data, ps)
 }
 
-func (d *Domain) buildHashMapAccessorAt(ctx context.Context, idxPath string, data *seg.Reader, ps *background.ProgressSet) error {
+func (d *Domain) buildHashMapAccessorAt(ctx context.Context, idxPath string, data *seg.Decompressor, ps *background.ProgressSet) error {
 	versionOfRs := version.DataStructureVersion(0)
 	if !d.FileVersion.AccessorKVI.Current.Eq(version.V1_0) { // v1.0 files predate FuseFilter; dataStructureVersion>=1 is incompatible with them
 		versionOfRs = recsplit.ExistenceFilterVersion
@@ -1123,7 +1131,7 @@ func (d *Domain) buildHashMapAccessorAt(ctx context.Context, idxPath string, dat
 		NoFsync:    d.noFsync,
 		Workers:    d.BuildAccessorsWorkers,
 	}
-	return buildHashMapAccessor(ctx, data, idxPath, false, cfg, ps, d.logger, d._testBuildAccessorHook)
+	return buildHashMapAccessor(ctx, data, d.Compression, idxPath, false, cfg, ps, d.logger, d._testBuildAccessorHook)
 }
 
 func (d *Domain) missedBtreeAccessors(source []*FilesItem, dl dirListing) (l []*FilesItem) {
@@ -1195,7 +1203,7 @@ func (d *Domain) BuildMissedAccessors(ctx context.Context, g *errgroup.Group, ps
 		item := item
 		g.Go(func() error {
 			fromStep, toStep := item.StepRange(d.stepSize)
-			err := d.buildHashMapAccessor(ctx, fromStep, toStep, d.dataReader(item.decompressor), ps)
+			err := d.buildHashMapAccessor(ctx, fromStep, toStep, item.decompressor, ps)
 			if err != nil {
 				return fmt.Errorf("build %s values recsplit index: %w", d.FilenameBase, err)
 			}
@@ -1204,7 +1212,14 @@ func (d *Domain) BuildMissedAccessors(ctx context.Context, g *errgroup.Group, ps
 	}
 }
 
-func buildHashMapAccessor(ctx context.Context, g *seg.Reader, idxPath string, values bool, cfg recsplit.RecSplitArgs, ps *background.ProgressSet, logger log.Logger, testHook func(*recsplit.RecSplit)) (err error) {
+func buildHashMapAccessor(ctx context.Context, decomp *seg.Decompressor, compression seg.FileCompression, idxPath string, values bool, cfg recsplit.RecSplitArgs, ps *background.ProgressSet, logger log.Logger, testHook func(*recsplit.RecSplit)) (err error) {
+	seqView, err := decomp.OpenSequentialView(true)
+	if err != nil {
+		return err
+	}
+	defer seqView.Close()
+	g := seg.NewReader(seqView.MakeGetter(), compression)
+
 	_, fileName := filepath.Split(idxPath)
 	count := g.Count()
 	if !values {
@@ -1212,8 +1227,6 @@ func buildHashMapAccessor(ctx context.Context, g *seg.Reader, idxPath string, va
 	}
 	p := ps.AddNew(fileName, uint64(count))
 	defer ps.Delete(p)
-
-	defer g.MadvNormal().DisableReadAhead()
 
 	var rs *recsplit.RecSplit
 	cfg.KeyCount = count
@@ -1286,6 +1299,7 @@ func (d *Domain) integrateDirtyFiles(sf StaticFiles, txNumFrom, txNumTo uint64) 
 	d.History.integrateDirtyFiles(sf.HistoryFiles, txNumFrom, txNumTo)
 
 	fi := newFilesItem(txNumFrom, txNumTo)
+	fi.version, _ = version.ParseVersion(filepath.Base(sf.valuesDecomp.FilePath()))
 	fi.decompressor = sf.valuesDecomp
 	fi.index = sf.valuesIdx
 	fi.bindex = sf.valuesBt

--- a/db/state/domain_committed.go
+++ b/db/state/domain_committed.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
@@ -41,21 +42,80 @@ func ValuesPlainKeyReferencingThresholdReached(stepSize, from, to uint64) bool {
 	return (to-from)/stepSize >= commitment.DefaultKeyReferencingMinSteps
 }
 
+// CommitmentBranchReferenced reports whether a commitment file at fileVersion over from..to carries
+// shortened key references — a property of the file (version+range), independent of the live write flag.
+func CommitmentBranchReferenced(fileVersion version.Version, stepSize, from, to uint64) bool {
+	return fileVersion.Less(version.V2_2) && ValuesPlainKeyReferencingThresholdReached(stepSize, from, to)
+}
+
+// commitmentVisibleFilesReferenced reports whether any visible commitment file is referenced.
+func (at *AggregatorRoTx) commitmentVisibleFilesReferenced() bool {
+	stepSize := at.StepSize()
+	for _, f := range at.d[kv.CommitmentDomain].files {
+		if CommitmentBranchReferenced(f.Version(), stepSize, f.startTxNum, f.endTxNum) {
+			return true
+		}
+	}
+	return false
+}
+
+// commitmentMergeInputsReferenced reports whether any commitment merge input is referenced.
+func commitmentMergeInputsReferenced(inputs []*FilesItem, stepSize uint64) bool {
+	for _, f := range inputs {
+		if f == nil {
+			continue
+		}
+		if CommitmentBranchReferenced(f.version, stepSize, f.startTxNum, f.endTxNum) {
+			return true
+		}
+	}
+	return false
+}
+
+// commitmentMergeNeedsTransform reports whether a commitment merge needs a value transformer — and
+// thus must wait for the account/storage merges. True when an input must be expanded (any input
+// referenced) or the output must be re-shortened (refsEnabled and output range >= threshold). Plain
+// inputs merged without re-shortening need neither, so they run in parallel with account/storage.
+func commitmentMergeNeedsTransform(inputs []*FilesItem, refsEnabled bool, stepSize, from, to uint64) bool {
+	reshorten := refsEnabled && ValuesPlainKeyReferencingThresholdReached(stepSize, from, to)
+	return reshorten || commitmentMergeInputsReferenced(inputs, stepSize)
+}
+
+// commitmentFileVersionByRange returns the version of the commitment file covering from..to
+// (zero if missing, treated as referenced) and its metric bucket index.
+func (at *AggregatorRoTx) commitmentFileVersionByRange(from, to uint64) (version.Version, int) {
+	for i, f := range at.d[kv.CommitmentDomain].files {
+		if f.startTxNum == from && f.endTxNum == to {
+			if i > 5 {
+				return f.Version(), 5
+			}
+			return f.Version(), i
+		}
+	}
+	return version.Version{}, 0
+}
+
 // replaceShortenedKeysInBranch expands shortened key references (file offsets) in branch data back to full keys
 // by looking them up in the account and storage domain files. It guards the call to
-// ExpandShortenedKeysInBranch with the read-path preconditions (config flag, empty branch,
-// KeyCommitmentState carve-out, files-not-empty, threshold-reached range).
+// ExpandShortenedKeysInBranch with the read-path preconditions (empty branch, KeyCommitmentState
+// carve-out, files-not-empty) and the per-file version gate (referenced iff version < v2.2 and range >= threshold).
 func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch commitment.BranchData, fStartTxNum uint64, fEndTxNum uint64) (commitment.BranchData, error) {
-	commitmentUseReferencedBranches := at.a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues
-	if !commitmentUseReferencedBranches || len(branch) == 0 || bytes.Equal(prefix, commitmentdb.KeyCommitmentState) ||
-		at.TxNumsInFiles(kv.StateDomains...) == 0 || !ValuesPlainKeyReferencingThresholdReached(at.StepSize(), fStartTxNum, fEndTxNum) {
+	logger := log.Root()
+	aggTx := at
+
+	if len(branch) == 0 || bytes.Equal(prefix, commitmentdb.KeyCommitmentState) ||
+		aggTx.TxNumsInFiles(kv.StateDomains...) == 0 {
 
 		return branch, nil // do not transform, return as is
 	}
 
-	logger := log.Root()
-	sto := at.d[kv.StorageDomain]
-	acc := at.d[kv.AccountsDomain]
+	fileVersion, metricI := aggTx.commitmentFileVersionByRange(fStartTxNum, fEndTxNum)
+	if !CommitmentBranchReferenced(fileVersion, at.StepSize(), fStartTxNum, fEndTxNum) {
+		return branch, nil // input file was written plain (v2.2) or below the referencing threshold
+	}
+
+	sto := aggTx.d[kv.StorageDomain]
+	acc := aggTx.d[kv.AccountsDomain]
 	storageItem, err := sto.lookupVisibleFileByRange(fStartTxNum, fEndTxNum)
 	if err != nil {
 		logger.Crit("dereference key during commitment read", "failed", err.Error())
@@ -67,19 +127,7 @@ func (at *AggregatorRoTx) replaceShortenedKeysInBranch(prefix []byte, branch com
 		return nil, err
 	}
 
-	// branchKeyDerefSpent metricI lookup: clamps to max bucket index when the visible commitment
-	// file list grows past the bucket count.
 	if dbg.KVReadLevelledMetrics {
-		metricI := 0
-		for i, f := range at.d[kv.CommitmentDomain].files {
-			if i > 5 {
-				metricI = 5
-				break
-			}
-			if f.startTxNum == fStartTxNum && f.endTxNum == fEndTxNum {
-				metricI = i
-			}
-		}
 		defer branchKeyDerefSpent[metricI].ObserveDuration(time.Now())
 	}
 
@@ -165,6 +213,16 @@ func (dt *DomainRoTx) findShortenedKey(fullKey []byte, itemGetter *seg.Reader, i
 		return offset, true
 	}
 	return 0, false
+}
+
+// fileVersionByRange returns the version of the visible file covering from..to (zero if missing, treated as referenced).
+func (dt *DomainRoTx) fileVersionByRange(from, to uint64) version.Version {
+	for _, f := range dt.files {
+		if f.startTxNum == from && f.endTxNum == to {
+			return f.Version()
+		}
+	}
+	return version.Version{}
 }
 
 // lookupVisibleFileByRange searches only among visible files (those in the RoTx snapshot).
@@ -259,7 +317,7 @@ func (dt *DomainRoTx) lookupByShortenedKey(shortKey []byte, getter *seg.Reader) 
 // commitmentValTransform parses the value of the commitment record to extract references
 // to accounts and storage items, then looks them up in the new, merged files, and replaces them with
 // the updated references
-func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, storage *DomainRoTx, mergedAccount, mergedStorage *FilesItem) (valueTransformer, error) {
+func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, storage *DomainRoTx, mergedAccount, mergedStorage *FilesItem, refsEnabled bool) (valueTransformer, error) {
 	if !rng.needMerge {
 		panic(fmt.Sprintf("assert: commitmentValTransformDomain called with domain.needMerge=false (from=%d to=%d): caller must guard with values.needMerge", rng.from, rng.to))
 	}
@@ -306,22 +364,35 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 	ma := accounts.dataReader(mergedAccount.decompressor)
 	dt.d.logger.Debug("prepare commitmentValTransformDomain", "merge", rng.String("range", dt.d.stepSize), "Mstorage", hadToLookupStorage, "Maccount", hadToLookupAccount)
 
-	// Per-merge caches for findShortenedKey results. The same merged file is
-	// searched once per plain-key reference per commitment branch — and hot
-	// contracts (USDC, WETH, Uniswap routers, etc.) appear in many branches
-	// in the same merge range, so the same full key recurs many times. CPU
-	// profiling identified findShortenedKey → BtIndex.Get as ~52% of merge
-	// CPU; caching its results avoids the repeat B-tree descents.
-	//
-	// The merged file is read-only for the duration of this transformer, so
-	// (key → offset) is invariant within the closure. Both maps live only
-	// for the merge of one range; no cross-merge state.
+	// reshorten governs whether merged output keys are re-referenced (offsets into the merged
+	// account/storage files). It is keyed off the live write flag and the OUTPUT range only;
+	// input expansion below is keyed off each input file's own version+range instead.
+	reshorten := refsEnabled && ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, rng.from, rng.to)
+
+	// Per-merge caches for findShortenedKey (key → offset): the merged file is read-only here and
+	// hot contracts recur across many branches in the same range, so caching avoids repeat B-tree
+	// descents (findShortenedKey → BtIndex.Get dominated merge CPU). Bounded; live only for this merge.
 	const cacheMaxEntries = 100_000
 	storageKeyCache := make(map[string]uint64)
 	accountKeyCache := make(map[string]uint64)
+	// The referenced verdict recurs across every branch of an input file (same from,to) and each
+	// lookup is a linear scan over visible files, so cache the verdict per range.
+	referencedByRange := make(map[[2]uint64]bool)
 
 	vt := func(valBuf []byte, keyFromTxNum, keyEndTxNum uint64) (transValBuf []byte, err error) {
-		if !dt.d.ReplaceKeysInValues || len(valBuf) == 0 || !ValuesPlainKeyReferencingThresholdReached(dt.d.stepSize, rng.from, rng.to) {
+		if len(valBuf) == 0 {
+			return valBuf, nil
+		}
+		// Expand the input's short keys to plain whenever the input file was written referenced
+		// (its own version+range), independent of the live flag — otherwise a referenced input
+		// merged with the flag off would copy stale offsets into the merged file.
+		rngKey := [2]uint64{keyFromTxNum, keyEndTxNum}
+		inputReferenced, cached := referencedByRange[rngKey]
+		if !cached {
+			inputReferenced = CommitmentBranchReferenced(dt.fileVersionByRange(keyFromTxNum, keyEndTxNum), dt.d.stepSize, keyFromTxNum, keyEndTxNum)
+			referencedByRange[rngKey] = inputReferenced
+		}
+		if !inputReferenced && !reshorten {
 			return valBuf, nil
 		}
 		if _, ok := storageFileMap[keyFromTxNum]; !ok {
@@ -354,7 +425,8 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 			var found bool
 			auxBuf := keyBuf[:0]
 			if isStorage {
-				if len(key) == length.Addr+length.Hash {
+				plainKey := len(key) == length.Addr+length.Hash
+				if plainKey {
 					// Non-optimised key originating from a database record
 					auxBuf = append(auxBuf[:0], key...)
 				} else {
@@ -368,6 +440,12 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 						)
 						return nil, fmt.Errorf("lookup lost storage full key %x", key)
 					}
+				}
+				if !reshorten {
+					if plainKey {
+						return nil, nil // leave the already-plain key in place
+					}
+					return auxBuf, nil // emit the expanded plain key
 				}
 
 				var shortenedKeyOffset uint64
@@ -396,7 +474,8 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 				return shortened, nil
 			}
 
-			if len(key) == length.Addr {
+			plainKey := len(key) == length.Addr
+			if plainKey {
 				// Non-optimised key originating from a database record
 				auxBuf = append(auxBuf[:0], key...)
 			} else {
@@ -409,6 +488,12 @@ func (dt *DomainRoTx) commitmentValTransformDomain(rng MergeRange, accounts, sto
 					)
 					return nil, fmt.Errorf("lookup account full key: %x", key)
 				}
+			}
+			if !reshorten {
+				if plainKey {
+					return nil, nil // leave the already-plain key in place
+				}
+				return auxBuf, nil // emit the expanded plain key
 			}
 
 			var shortenedKeyOffset uint64

--- a/db/state/domain_committed_test.go
+++ b/db/state/domain_committed_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/version"
+)
+
+func TestCommitmentBranchReferenced(t *testing.T) {
+	t.Parallel()
+	const stepSize = uint64(10)
+	// commitment.DefaultKeyReferencingMinSteps == 2, so a range >= 2 steps reaches the threshold.
+	const fromAbove = uint64(0)
+	const toAbove = uint64(20) // 2 steps -> threshold reached
+	const fromBelow = uint64(0)
+	const toBelow = uint64(10) // 1 step -> below threshold
+
+	cases := []struct {
+		name        string
+		fileVersion version.Version
+		from, to    uint64
+		want        bool
+	}{
+		{"v2.0 above threshold is referenced", version.V2_0, fromAbove, toAbove, true},
+		{"v1.0 above threshold is referenced", version.V1_0, fromAbove, toAbove, true},
+		{"v2.1 above threshold is referenced", version.V2_1, fromAbove, toAbove, true},
+		{"v2.0 below threshold is plain", version.V2_0, fromBelow, toBelow, false},
+		{"v2.1 below threshold is plain", version.V2_1, fromBelow, toBelow, false},
+		{"v2.2 above threshold is plain", version.V2_2, fromAbove, toAbove, false},
+		{"v2.2 below threshold is plain", version.V2_2, fromBelow, toBelow, false},
+		{"zero version (missing file) above threshold is referenced", version.Version{}, fromAbove, toAbove, true},
+		{"zero version (missing file) below threshold is plain", version.Version{}, fromBelow, toBelow, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CommitmentBranchReferenced(tc.fileVersion, stepSize, tc.from, tc.to)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -540,7 +540,7 @@ func checkHistory(t *testing.T, db kv.RwDB, d *Domain, txs uint64) {
 
 	// Structural invariants: no duplicates, monotonic txNums, index-history consistency, etc.
 	checkHistoryProperties(t, domainRoTx.ht)
-	// Domain file invariants: key-count, accessor presence, frozen flag, sort order, alignment, bloom.
+	// Domain file invariants: key-count, accessor presence, sort order, alignment, bloom.
 	checkDomainFileProperties(t, domainRoTx)
 }
 
@@ -549,7 +549,6 @@ func checkDomainFileProperties(t *testing.T, dt *DomainRoTx) {
 	t.Helper()
 	checkDomainFileKeyCountConsistency(t, dt)
 	checkDomainFileAccessorsPresent(t, dt)
-	checkDomainFileFrozenFlagConsistency(t, dt)
 	checkDomainFileSortedKeyOrder(t, dt)
 	checkDomainHistoryRangeAlignment(t, dt)
 	checkDomainExistenceFilterNoFalseNegatives(t, dt)
@@ -599,20 +598,6 @@ func checkDomainFileAccessorsPresent(t *testing.T, dt *DomainRoTx) {
 				"file %d [%d-%d): AccessorExistence configured but existence is nil",
 				i, f.startTxNum, f.endTxNum)
 		}
-	}
-}
-
-// checkDomainFileFrozenFlagConsistency verifies (property 7):
-// file.frozen == (endStep - startStep >= stepsInFrozenFile).
-func checkDomainFileFrozenFlagConsistency(t *testing.T, dt *DomainRoTx) {
-	t.Helper()
-	for i, f := range dt.files {
-		startStep := f.startTxNum / dt.stepSize
-		endStep := f.endTxNum / dt.stepSize
-		expectedFrozen := (endStep - startStep) >= dt.stepsInFrozenFile
-		require.Equal(t, expectedFrozen, f.src.frozen,
-			"file %d [%d-%d): frozen=%v but expected frozen=%v (steps=%d, stepsInFrozenFile=%d)",
-			i, f.startTxNum, f.endTxNum, f.src.frozen, expectedFrozen, endStep-startStep, dt.stepsInFrozenFile)
 	}
 }
 

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -730,7 +730,7 @@ func collateAndMerge(t *testing.T, tx kv.RwTx, d *Domain, txs uint64) {
 				return true
 			}
 			valuesOuts, indexOuts, historyOuts := domainRoTx.staticFilesInRange(r)
-			valuesIn, indexIn, historyIn, err := domainRoTx.mergeFiles(ctx, valuesOuts, indexOuts, historyOuts, r, nil, background.NewProgressSet())
+			valuesIn, indexIn, historyIn, err := domainRoTx.mergeFiles(ctx, valuesOuts, indexOuts, historyOuts, r, nil, true, background.NewProgressSet())
 			require.NoError(t, err)
 			//if valuesIn != nil && valuesIn.decompressor != nil {
 			//fmt.Printf("merge: %s\n", valuesIn.decompressor.FileName())
@@ -769,7 +769,7 @@ func collateAndMergeOnceWithScanPrune(t *testing.T, d *Domain, tx kv.RwTx, step 
 				return true
 			}
 			valuesOuts, indexOuts, historyOuts := domainRoTx.staticFilesInRange(r)
-			valuesIn, indexIn, historyIn, err := domainRoTx.mergeFiles(ctx, valuesOuts, indexOuts, historyOuts, r, nil, background.NewProgressSet())
+			valuesIn, indexIn, historyIn, err := domainRoTx.mergeFiles(ctx, valuesOuts, indexOuts, historyOuts, r, nil, true, background.NewProgressSet())
 			require.NoError(t, err)
 
 			d.integrateMergedDirtyFiles(valuesIn, indexIn, historyIn)
@@ -806,7 +806,7 @@ func collateAndMergeOnce(t *testing.T, d *Domain, tx kv.RwTx, step kv.Step, prun
 			break
 		}
 		valuesOuts, indexOuts, historyOuts := domainRoTx.staticFilesInRange(r)
-		valuesIn, indexIn, historyIn, err := domainRoTx.mergeFiles(ctx, valuesOuts, indexOuts, historyOuts, r, nil, background.NewProgressSet())
+		valuesIn, indexIn, historyIn, err := domainRoTx.mergeFiles(ctx, valuesOuts, indexOuts, historyOuts, r, nil, true, background.NewProgressSet())
 		require.NoError(t, err)
 
 		d.integrateMergedDirtyFiles(valuesIn, indexIn, historyIn)
@@ -857,6 +857,42 @@ func TestDomain_ScanFiles(t *testing.T) {
 
 	// Check the history
 	checkHistory(t, db, d, txs)
+}
+
+func TestCommitmentKvWriteVersion(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+	_, d := testDbAndDomainOfStep(t, statecfg.Schema.CommitmentDomain, 16, logger)
+
+	d.ReferencesInCommitmentBranches = true
+	require.Equal(t, version.V2_1, d.kvWriteVersion())
+	require.Contains(t, d.kvNewFilePath(0, 1), "v2.1-commitment.0-1.kv")
+
+	d.ReferencesInCommitmentBranches = false
+	require.Equal(t, version.V2_2, d.kvWriteVersion())
+	require.Contains(t, d.kvNewFilePath(0, 1), "v2.2-commitment.0-1.kv")
+}
+
+func TestNonCommitmentKvWriteVersionUsesCurrent(t *testing.T) {
+	t.Parallel()
+	logger := log.New()
+	_, d := testDbAndDomainOfStep(t, statecfg.Schema.AccountsDomain, 16, logger)
+	require.Equal(t, d.FileVersion.DataKV.Current, d.kvWriteVersion())
+	require.Contains(t, d.kvNewFilePath(0, 1), d.FileVersion.DataKV.Current.String()+"-accounts.0-1.kv")
+}
+
+func TestCommitmentKvVersionAcceptance(t *testing.T) {
+	t.Parallel()
+	vers := statecfg.Schema.CommitmentDomain.FileVersion.DataKV
+	require.True(t, vers.Supports(version.V2_0))
+	require.True(t, vers.Supports(version.V2_1))
+	require.True(t, vers.Supports(version.V2_2))
+	require.False(t, vers.Supports(version.Version{Major: 2, Minor: 3}))
+
+	require.NotPanics(t, func() { vers.MustSupport(version.V2_0, "v2.0-commitment.0-1.kv") })
+	require.NotPanics(t, func() { vers.MustSupport(version.V2_1, "v2.1-commitment.0-1.kv") })
+	require.NotPanics(t, func() { vers.MustSupport(version.V2_2, "v2.2-commitment.0-1.kv") })
+	require.Panics(t, func() { vers.MustSupport(version.Version{Major: 2, Minor: 3}, "v2.3-commitment.0-1.kv") })
 }
 
 func TestDomainRoTx_CursorParentCheck(t *testing.T) {
@@ -1661,7 +1697,7 @@ func TestDomainContext_getFromFiles(t *testing.T) {
 		ranges := domainRoTx.findMergeRange(txFrom, txTo, txTo)
 		vl, il, hl := domainRoTx.staticFilesInRange(ranges)
 
-		dv, di, dh, err := domainRoTx.mergeFiles(ctx, vl, il, hl, ranges, nil, ps)
+		dv, di, dh, err := domainRoTx.mergeFiles(ctx, vl, il, hl, ranges, nil, true, ps)
 		require.NoError(t, err)
 
 		d.integrateMergedDirtyFiles(dv, di, dh)
@@ -3545,7 +3581,7 @@ func collateAndMergeWithCollisionRetry(t *testing.T, tx kv.RwTx, d *Domain, txs 
 	r := domainRoTx.findMergeRange(d.dirtyFilesEndTxNumMinimax(), d.dirtyFilesEndTxNumMinimax(), d.dirtyFilesEndTxNumMinimax())
 	if r.values.needMerge {
 		valuesOuts, indexOuts, historyOuts := domainRoTx.staticFilesInRange(r)
-		valuesIn, indexIn, historyIn, err := domainRoTx.mergeFiles(ctx, valuesOuts, indexOuts, historyOuts, r, nil, background.NewProgressSet())
+		valuesIn, indexIn, historyIn, err := domainRoTx.mergeFiles(ctx, valuesOuts, indexOuts, historyOuts, r, nil, true, background.NewProgressSet())
 		require.NoError(t, err)
 		d.integrateMergedDirtyFiles(valuesIn, indexIn, historyIn)
 	}

--- a/db/state/erigondb_settings.go
+++ b/db/state/erigondb_settings.go
@@ -15,8 +15,18 @@ import (
 const ERIGONDB_SETTINGS_FILE = "erigondb.toml"
 
 type ErigonDBSettings struct {
-	StepSize          uint64 `toml:"step_size"`
-	StepsInFrozenFile uint64 `toml:"steps_in_frozen_file"`
+	StepSize                       uint64 `toml:"step_size"`
+	StepsInFrozenFile              uint64 `toml:"steps_in_frozen_file"`
+	ReferencesInCommitmentBranches *bool  `toml:"references_in_commitment_branches"`
+}
+
+// RefsInCommitmentBranches resolves the commitment "references in branches" regime,
+// treating an absent (nil) field as config3.DefaultReferencesInCommitmentBranches.
+func (s *ErigonDBSettings) RefsInCommitmentBranches() bool {
+	if s.ReferencesInCommitmentBranches == nil {
+		return config3.DefaultReferencesInCommitmentBranches
+	}
+	return *s.ReferencesInCommitmentBranches
 }
 
 func readErigonDBSettings(path string) (*ErigonDBSettings, error) {
@@ -46,6 +56,13 @@ func writeErigonDBSettings(path string, s *ErigonDBSettings) error {
 //  3. Fresh datadir (neither file present): returns default settings without writing,
 //     so the downloader can provide the real erigondb.toml during header-chain phase.
 func ResolveErigonDBSettings(dirs datadir.Dirs, logger log.Logger, noDownloader bool) (*ErigonDBSettings, error) {
+	return ResolveErigonDBSettingsWithRefsDefault(dirs, logger, noDownloader, nil)
+}
+
+// ResolveErigonDBSettingsWithRefsDefault is ResolveErigonDBSettings with an optional first-start
+// override: when refsFirstStart is non-nil and erigondb.toml is being created, it sets the initial
+// references_in_commitment_branches; an existing or downloader-delivered toml wins (override logged, ignored).
+func ResolveErigonDBSettingsWithRefsDefault(dirs datadir.Dirs, logger log.Logger, noDownloader bool, refsFirstStart *bool) (*ErigonDBSettings, error) {
 	settingsPath := filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE)
 
 	settingsExists, err := dir.FileExist(settingsPath)
@@ -60,8 +77,20 @@ func ResolveErigonDBSettings(dirs datadir.Dirs, logger log.Logger, noDownloader 
 		if err != nil {
 			return nil, err
 		}
-		logger.Info("erigondb settings", "step_size", settings.StepSize, "steps_in_frozen_file", settings.StepsInFrozenFile)
+		if refsFirstStart != nil {
+			logger.Info("--commitment.plainValues ignored: erigondb.toml already exists",
+				"references_in_commitment_branches", settings.RefsInCommitmentBranches())
+		}
+		// An absent field is resolved through RefsInCommitmentBranches(); the file is synced
+		// snapshot metadata and must not be rewritten.
+		logger.Info("erigondb settings", "step_size", settings.StepSize, "steps_in_frozen_file", settings.StepsInFrozenFile,
+			"references_in_commitment_branches", settings.RefsInCommitmentBranches())
 		return settings, nil
+	}
+
+	refs := config3.DefaultReferencesInCommitmentBranches
+	if refsFirstStart != nil {
+		refs = *refsFirstStart
 	}
 
 	preverifiedExists, err := dir.FileExist(filepath.Join(dirs.Snap, datadir.PreverifiedFileName))
@@ -72,11 +101,13 @@ func ResolveErigonDBSettings(dirs datadir.Dirs, logger log.Logger, noDownloader 
 	// Legacy datadir (Erigon <= 3.3): write legacy settings so erigondb.toml exists on disk.
 	if preverifiedExists {
 		settings := &ErigonDBSettings{
-			StepSize:          config3.LegacyStepSize,
-			StepsInFrozenFile: config3.LegacyStepsInFrozenFile,
+			StepSize:                       config3.LegacyStepSize,
+			StepsInFrozenFile:              config3.LegacyStepsInFrozenFile,
+			ReferencesInCommitmentBranches: &refs,
 		}
 		logger.Info("Creating erigondb.toml with LEGACY settings",
-			"step_size", settings.StepSize, "steps_in_frozen_file", settings.StepsInFrozenFile)
+			"step_size", settings.StepSize, "steps_in_frozen_file", settings.StepsInFrozenFile,
+			"references_in_commitment_branches", settings.RefsInCommitmentBranches())
 		if err := writeErigonDBSettings(settingsPath, settings); err != nil {
 			return nil, err
 		}
@@ -85,18 +116,24 @@ func ResolveErigonDBSettings(dirs datadir.Dirs, logger log.Logger, noDownloader 
 
 	// Fresh datadir, no preverified.toml: use default settings.
 	settings := &ErigonDBSettings{
-		StepSize:          config3.DefaultStepSize,
-		StepsInFrozenFile: config3.DefaultStepsInFrozenFile,
+		StepSize:                       config3.DefaultStepSize,
+		StepsInFrozenFile:              config3.DefaultStepsInFrozenFile,
+		ReferencesInCommitmentBranches: &refs,
 	}
 	if noDownloader {
 		// No downloader to provide the real file — write defaults to disk now.
 		logger.Info("Initializing erigondb.toml with DEFAULT settings (nodownloader)",
-			"step_size", settings.StepSize, "steps_in_frozen_file", settings.StepsInFrozenFile)
+			"step_size", settings.StepSize, "steps_in_frozen_file", settings.StepsInFrozenFile,
+			"references_in_commitment_branches", settings.RefsInCommitmentBranches())
 		if err := writeErigonDBSettings(settingsPath, settings); err != nil {
 			return nil, err
 		}
 	} else {
 		// Downloader will provide the real erigondb.toml during header-chain phase.
+		if refsFirstStart != nil {
+			logger.Info("--commitment.plainValues set but a downloader will deliver erigondb.toml; the downloaded file wins",
+				"requested_references_in_commitment_branches", refs)
+		}
 		logger.Info("erigondb.toml not found, using defaults (downloader will provide real settings)",
 			"step_size", settings.StepSize, "steps_in_frozen_file", settings.StepsInFrozenFile)
 	}

--- a/db/state/erigondb_settings_test.go
+++ b/db/state/erigondb_settings_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/config3"
+	"github.com/erigontech/erigon/db/datadir"
+)
+
+func TestRefsInCommitmentBranchesAccessor(t *testing.T) {
+	t.Parallel()
+	tr, fa := true, false
+	require.Equal(t, config3.DefaultReferencesInCommitmentBranches, (&ErigonDBSettings{ReferencesInCommitmentBranches: nil}).RefsInCommitmentBranches())
+	require.True(t, (&ErigonDBSettings{ReferencesInCommitmentBranches: &tr}).RefsInCommitmentBranches())
+	require.False(t, (&ErigonDBSettings{ReferencesInCommitmentBranches: &fa}).RefsInCommitmentBranches())
+}
+
+func TestErigonDBSettingsRoundTrip(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "erigondb.toml")
+
+	fa := false
+	require.NoError(t, writeErigonDBSettings(path, &ErigonDBSettings{
+		StepSize: 100, StepsInFrozenFile: 8, ReferencesInCommitmentBranches: &fa,
+	}))
+	got, err := readErigonDBSettings(path)
+	require.NoError(t, err)
+	require.NotNil(t, got.ReferencesInCommitmentBranches)
+	require.False(t, *got.ReferencesInCommitmentBranches)
+
+	tr := true
+	require.NoError(t, writeErigonDBSettings(path, &ErigonDBSettings{
+		StepSize: 100, StepsInFrozenFile: 8, ReferencesInCommitmentBranches: &tr,
+	}))
+	got, err = readErigonDBSettings(path)
+	require.NoError(t, err)
+	require.NotNil(t, got.ReferencesInCommitmentBranches)
+	require.True(t, *got.ReferencesInCommitmentBranches)
+}
+
+func TestErigonDBSettingsAbsentFieldUnmarshalsNil(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "erigondb.toml")
+	require.NoError(t, os.WriteFile(path, []byte("step_size = 100\nsteps_in_frozen_file = 8\n"), 0644))
+
+	got, err := readErigonDBSettings(path)
+	require.NoError(t, err)
+	require.Nil(t, got.ReferencesInCommitmentBranches)
+	require.Equal(t, config3.DefaultReferencesInCommitmentBranches, got.RefsInCommitmentBranches())
+}
+
+func TestResolveErigonDBSettingsExistingFileAbsentFieldResolvesToDefault(t *testing.T) {
+	t.Parallel()
+	dirs := datadir.New(t.TempDir())
+	path := filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE)
+	content := []byte("step_size = 390625\nsteps_in_frozen_file = 256\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
+	require.NoError(t, err)
+	require.Equal(t, config3.DefaultReferencesInCommitmentBranches, settings.RefsInCommitmentBranches())
+
+	// Existing erigondb.toml is synced snapshot metadata and must NOT be rewritten.
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, content, after)
+}
+
+func TestResolveErigonDBSettingsExistingFileExplicitFalseHonored(t *testing.T) {
+	t.Parallel()
+	dirs := datadir.New(t.TempDir())
+	path := filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE)
+	content := []byte("step_size = 390625\nsteps_in_frozen_file = 256\nreferences_in_commitment_branches = false\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
+	require.NoError(t, err)
+	require.NotNil(t, settings.ReferencesInCommitmentBranches)
+	require.False(t, settings.RefsInCommitmentBranches())
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, content, after)
+}
+
+func TestResolveErigonDBSettingsExistingFileExplicitTrueHonored(t *testing.T) {
+	t.Parallel()
+	dirs := datadir.New(t.TempDir())
+	path := filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE)
+	require.NoError(t, os.WriteFile(path, []byte("references_in_commitment_branches = true\n"), 0644))
+
+	settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
+	require.NoError(t, err)
+	require.NotNil(t, settings.ReferencesInCommitmentBranches)
+	require.True(t, settings.RefsInCommitmentBranches())
+}
+
+func TestResolveErigonDBSettingsLegacyWritesDefault(t *testing.T) {
+	t.Parallel()
+	dirs := datadir.New(t.TempDir())
+	require.NoError(t, os.WriteFile(filepath.Join(dirs.Snap, datadir.PreverifiedFileName), []byte(""), 0644))
+
+	settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
+	require.NoError(t, err)
+	require.NotNil(t, settings.ReferencesInCommitmentBranches)
+	require.Equal(t, config3.DefaultReferencesInCommitmentBranches, settings.RefsInCommitmentBranches())
+
+	written, err := readErigonDBSettings(filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE))
+	require.NoError(t, err)
+	require.NotNil(t, written.ReferencesInCommitmentBranches)
+	require.Equal(t, config3.DefaultReferencesInCommitmentBranches, *written.ReferencesInCommitmentBranches)
+}
+
+func TestResolveErigonDBSettingsFreshNoDownloaderWritesDefault(t *testing.T) {
+	t.Parallel()
+	dirs := datadir.New(t.TempDir())
+
+	settings, err := ResolveErigonDBSettings(dirs, log.New(), true)
+	require.NoError(t, err)
+	require.NotNil(t, settings.ReferencesInCommitmentBranches)
+	require.Equal(t, config3.DefaultReferencesInCommitmentBranches, settings.RefsInCommitmentBranches())
+
+	written, err := readErigonDBSettings(filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE))
+	require.NoError(t, err)
+	require.NotNil(t, written.ReferencesInCommitmentBranches)
+	require.Equal(t, config3.DefaultReferencesInCommitmentBranches, *written.ReferencesInCommitmentBranches)
+}
+
+func TestResolveErigonDBSettingsFreshWithDownloaderDoesNotWrite(t *testing.T) {
+	t.Parallel()
+	dirs := datadir.New(t.TempDir())
+
+	settings, err := ResolveErigonDBSettings(dirs, log.New(), false)
+	require.NoError(t, err)
+	require.Equal(t, config3.DefaultReferencesInCommitmentBranches, settings.RefsInCommitmentBranches())
+
+	_, err = os.Stat(filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE))
+	require.True(t, os.IsNotExist(err), "fresh+downloader must leave erigondb.toml for the downloader")
+}
+
+func TestResolveErigonDBSettingsWithRefsDefaultFreshNoDownloader(t *testing.T) {
+	t.Parallel()
+	tr, fa := true, false
+	for _, tc := range []struct {
+		name           string
+		refsFirstStart *bool
+		want           bool
+	}{
+		{"plain_writes_false", &fa, false},
+		{"referenced_writes_true", &tr, true},
+		{"unset_uses_config_default", nil, config3.DefaultReferencesInCommitmentBranches},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dirs := datadir.New(t.TempDir())
+			settings, err := ResolveErigonDBSettingsWithRefsDefault(dirs, log.New(), true, tc.refsFirstStart)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, settings.RefsInCommitmentBranches())
+
+			written, err := readErigonDBSettings(filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE))
+			require.NoError(t, err)
+			require.NotNil(t, written.ReferencesInCommitmentBranches)
+			require.Equal(t, tc.want, *written.ReferencesInCommitmentBranches)
+		})
+	}
+}
+
+func TestResolveErigonDBSettingsWithRefsDefaultLegacyWritesChosen(t *testing.T) {
+	t.Parallel()
+	dirs := datadir.New(t.TempDir())
+	require.NoError(t, os.WriteFile(filepath.Join(dirs.Snap, datadir.PreverifiedFileName), []byte(""), 0644))
+
+	fa := false
+	settings, err := ResolveErigonDBSettingsWithRefsDefault(dirs, log.New(), false, &fa)
+	require.NoError(t, err)
+	require.False(t, settings.RefsInCommitmentBranches())
+
+	written, err := readErigonDBSettings(filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE))
+	require.NoError(t, err)
+	require.NotNil(t, written.ReferencesInCommitmentBranches)
+	require.False(t, *written.ReferencesInCommitmentBranches)
+}
+
+func TestResolveErigonDBSettingsWithRefsDefaultExistingFileIgnoresFlag(t *testing.T) {
+	t.Parallel()
+	dirs := datadir.New(t.TempDir())
+	path := filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE)
+	content := []byte("step_size = 390625\nsteps_in_frozen_file = 256\nreferences_in_commitment_branches = true\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	fa := false
+	settings, err := ResolveErigonDBSettingsWithRefsDefault(dirs, log.New(), false, &fa)
+	require.NoError(t, err)
+	require.True(t, settings.RefsInCommitmentBranches(), "existing file wins over the first-start flag")
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, content, after)
+}
+
+func TestResolveErigonDBSettingsWithRefsDefaultFreshWithDownloaderDoesNotWrite(t *testing.T) {
+	t.Parallel()
+	dirs := datadir.New(t.TempDir())
+
+	fa := false
+	settings, err := ResolveErigonDBSettingsWithRefsDefault(dirs, log.New(), false, &fa)
+	require.NoError(t, err)
+	require.False(t, settings.RefsInCommitmentBranches(), "in-memory value reflects the flag until the downloader delivers the file")
+
+	_, err = os.Stat(filepath.Join(dirs.Snap, ERIGONDB_SETTINGS_FILE))
+	require.True(t, os.IsNotExist(err), "fresh+downloader must leave erigondb.toml for the downloader")
+}

--- a/db/state/forkable_debug.go
+++ b/db/state/forkable_debug.go
@@ -19,11 +19,9 @@ func (f *forkableDirtyFilesRoTx) Close() {
 	}
 	f.p = nil
 	for _, item := range f.files {
-		if !item.frozen {
-			refCnt := item.refcount.Add(-1)
-			if refCnt == 0 && item.canDelete.Load() {
-				item.closeFilesAndRemove()
-			}
+		refCnt := item.refcount.Add(-1)
+		if refCnt == 0 && item.canDelete.Load() {
+			item.closeFilesAndRemove()
 		}
 	}
 	f.files = nil

--- a/db/state/forkable_merge.go
+++ b/db/state/forkable_merge.go
@@ -145,7 +145,7 @@ func (f *ProtoForkable) MergeFiles(ctx context.Context, _filesToMerge []visibleF
 		ps.Delete(p)
 	}
 
-	mergedFile = newFilesItemWithSnapConfig(from.Uint64(), to.Uint64(), f.snapCfg)
+	mergedFile = newFilesItem(from.Uint64(), to.Uint64())
 	if mergedFile.decompressor, err = seg.NewDecompressorWithMetadata(segPath, f.snapCfg.HasMetadata); err != nil {
 		return
 	}

--- a/db/state/forkable_merge.go
+++ b/db/state/forkable_merge.go
@@ -105,29 +105,33 @@ func (f *ProtoForkable) MergeFiles(ctx context.Context, _filesToMerge []visibleF
 			startRootNum, endRootNum := item.src.Range()
 			compression := f.isCompressionUsed(RootNum(startRootNum), RootNum(endRootNum))
 
-			if err = item.src.decompressor.WithReadAhead(func() error {
-				reader := f.PagedDataReader(item.src.decompressor, compression)
-				var k, v []byte
-				var fmeta NumMetadata
-				if err := fmeta.Unmarshal(reader.GetMetadata()); err != nil {
-					return err
-				}
-				if meta.Count == 0 {
-					meta.First = fmeta.First
-				}
-				meta.Last = fmeta.Last
-				meta.Count += fmeta.Count
-
-				for reader.HasNext() {
-					k, v, word, _ = reader.Next2(word[:0])
-					if err = writer.Add(k, v); err != nil {
-						return err
-					}
-					p.Processed.Add(1)
-				}
-				return nil
-			}); err != nil {
+			view, viewErr := item.src.decompressor.OpenSequentialView(true)
+			if viewErr != nil {
+				err = viewErr
 				return
+			}
+			defer view.Close()
+			reader := seg.NewPagedReader(
+				seg.NewReader(view.MakeGetter(), f.cfg.Compression),
+				f.cfg.ValuesOnCompressedPage, compression,
+			)
+			var k, v []byte
+			var fmeta NumMetadata
+			if err = fmeta.Unmarshal(reader.GetMetadata()); err != nil {
+				return
+			}
+			if meta.Count == 0 {
+				meta.First = fmeta.First
+			}
+			meta.Last = fmeta.Last
+			meta.Count += fmeta.Count
+
+			for reader.HasNext() {
+				k, v, word, _ = reader.Next2(word[:0])
+				if err = writer.Add(k, v); err != nil {
+					return
+				}
+				p.Processed.Add(1)
 			}
 
 		}

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -225,10 +225,18 @@ func (h *History) buildVI(ctx context.Context, historyIdxPath string, hist, efHi
 	var histKey []byte
 	var valOffset uint64
 
-	defer hist.MadvSequential().DisableReadAhead()
-	defer efHist.MadvSequential().DisableReadAhead()
+	histView, err := hist.OpenSequentialView(true)
+	if err != nil {
+		return err
+	}
+	defer histView.Close()
+	efHistView, err := efHist.OpenSequentialView(true)
+	if err != nil {
+		return err
+	}
+	defer efHistView.Close()
 
-	iiReader := h.InvertedIndex.dataReader(efHist)
+	iiReader := seg.NewReader(efHistView.MakeGetter(), h.InvertedIndex.Compression)
 
 	var keyBuf, valBuf []byte
 	cnt := uint64(0)
@@ -243,7 +251,7 @@ func (h *History) buildVI(ctx context.Context, historyIdxPath string, hist, efHi
 		}
 	}
 
-	histReader := h.dataReader(hist)
+	histReader := seg.NewReader(histView.MakeGetter(), h.Compression)
 
 	_, fName := filepath.Split(historyIdxPath)
 	p := ps.AddNew(fName, uint64(efHist.Count())/2)
@@ -804,7 +812,7 @@ func (h *History) buildFiles(ctx context.Context, step kv.Step, collation Histor
 		return HistoryFiles{}, fmt.Errorf("open %s .ef history decompressor: %w", h.FilenameBase, err)
 	}
 	{
-		if err := h.InvertedIndex.buildMapAccessor(ctx, step, step+1, h.InvertedIndex.dataReader(efHistoryDecomp), ps); err != nil {
+		if err := h.InvertedIndex.buildMapAccessor(ctx, step, step+1, efHistoryDecomp, ps); err != nil {
 			return HistoryFiles{}, fmt.Errorf("build %s .ef history idx: %w", h.FilenameBase, err)
 		}
 		if efHistoryIdx, err = h.InvertedIndex.openHashMapAccessor(h.InvertedIndex.efAccessorNewFilePath(step, step+1)); err != nil {

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -149,7 +149,7 @@ func (h *History) scanDirtyFiles(fileNames []string) {
 	if h.stepSize == 0 {
 		panic("assert: empty `stepSize`")
 	}
-	for _, dirtyFile := range filterDirtyFiles(fileNames, h.stepSize, h.stepsInFrozenFile, h.FilenameBase, "v", h.logger) {
+	for _, dirtyFile := range filterDirtyFiles(fileNames, h.stepSize, h.FilenameBase, "v", h.logger) {
 		if _, has := h.dirtyFiles.Get(dirtyFile); !has {
 			h.dirtyFiles.Set(dirtyFile)
 		}
@@ -853,7 +853,7 @@ func (h *History) integrateDirtyFiles(sf HistoryFiles, txNumFrom, txNumTo uint64
 		existence: sf.efExistence,
 	}, txNumFrom, txNumTo)
 
-	fi := newFilesItem(txNumFrom, txNumTo, h.stepSize, h.stepsInFrozenFile)
+	fi := newFilesItem(txNumFrom, txNumTo)
 	fi.decompressor = sf.historyDecomp
 	fi.index = sf.historyIdx
 	h.dirtyFiles.Set(fi)

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -211,7 +211,7 @@ func (ii *InvertedIndex) scanDirtyFiles(fileNames []string) {
 	if ii.stepSize == 0 {
 		panic("assert: empty `stepSize`")
 	}
-	for _, dirtyFile := range filterDirtyFiles(fileNames, ii.stepSize, ii.stepsInFrozenFile, ii.FilenameBase, "ef", ii.logger) {
+	for _, dirtyFile := range filterDirtyFiles(fileNames, ii.stepSize, ii.FilenameBase, "ef", ii.logger) {
 		if _, has := ii.dirtyFiles.Get(dirtyFile); !has {
 			ii.dirtyFiles.Set(dirtyFile)
 		}
@@ -1201,7 +1201,7 @@ func (ii *InvertedIndex) integrateDirtyFiles(sf InvertedFiles, txNumFrom, txNumT
 	if sf.decomp == nil {
 		return // build was skipped — don't overwrite existing dirty files
 	}
-	fi := newFilesItem(txNumFrom, txNumTo, ii.stepSize, ii.stepsInFrozenFile)
+	fi := newFilesItem(txNumFrom, txNumTo)
 	fi.decompressor = sf.decomp
 	fi.index = sf.index
 	fi.existence = sf.existence

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -258,7 +258,7 @@ func (ii *InvertedIndex) buildEfAccessor(ctx context.Context, item *FilesItem, p
 	if item.decompressor == nil {
 		return fmt.Errorf("buildEfAccessor: passed item with nil decompressor %s %d-%d", ii.FilenameBase, fromStep, toStep)
 	}
-	return ii.buildMapAccessor(ctx, fromStep, toStep, ii.dataReader(item.decompressor), ps)
+	return ii.buildMapAccessor(ctx, fromStep, toStep, item.decompressor, ps)
 }
 func (ii *InvertedIndex) dataReader(f *seg.Decompressor) *seg.Reader {
 	if !strings.Contains(f.FileName(), ".ef") {
@@ -1128,7 +1128,7 @@ func (ii *InvertedIndex) buildFiles(ctx context.Context, step kv.Step, coll Inve
 		return InvertedFiles{}, fmt.Errorf("open %s decompressor: %w", ii.FilenameBase, err)
 	}
 
-	if err := ii.buildMapAccessor(ctx, step, step+1, ii.dataReader(decomp), ps); err != nil {
+	if err := ii.buildMapAccessor(ctx, step, step+1, decomp, ps); err != nil {
 		return InvertedFiles{}, fmt.Errorf("build %s efi: %w", ii.FilenameBase, err)
 	}
 	if ii.Accessors.Has(statecfg.AccessorHashMap) {
@@ -1141,7 +1141,7 @@ func (ii *InvertedIndex) buildFiles(ctx context.Context, step kv.Step, coll Inve
 	return InvertedFiles{decomp: decomp, index: mapAccessor, existence: existenceFilter}, nil
 }
 
-func (ii *InvertedIndex) buildMapAccessor(ctx context.Context, fromStep, toStep kv.Step, data *seg.Reader, ps *background.ProgressSet) error {
+func (ii *InvertedIndex) buildMapAccessor(ctx context.Context, fromStep, toStep kv.Step, data *seg.Decompressor, ps *background.ProgressSet) error {
 	idxPath := ii.efAccessorNewFilePath(fromStep, toStep)
 	versionOfRs := version.DataStructureVersion(0)
 	if !ii.FileVersion.AccessorEFI.Current.Eq(version.V1_0) { // v1.0 files predate FuseFilter; dataStructureVersion>=1 is incompatible with them
@@ -1188,7 +1188,7 @@ func (ii *InvertedIndex) buildMapAccessor(ctx context.Context, fromStep, toStep 
 	// each such non-existing key read `MPH` transforms to random
 	// key read. `LessFalsePositives=true` feature filtering-out such cases (with `1/256=0.3%` false-positives).
 
-	if err := buildHashMapAccessor(ctx, data, idxPath, false, cfg, ps, ii.logger, nil); err != nil {
+	if err := buildHashMapAccessor(ctx, data, ii.Compression, idxPath, false, cfg, ps, ii.logger, nil); err != nil {
 		return err
 	}
 	return nil

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -534,8 +534,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	kvWriter = nil
 	ps.Delete(p)
 
-	valuesIn = newFilesItem(r.values.from, r.values.to, dt.stepSize, dt.stepsInFrozenFile)
-	valuesIn.frozen = false
+	valuesIn = newFilesItem(r.values.from, r.values.to)
 	if valuesIn.decompressor, err = seg.NewDecompressor(kvFilePath); err != nil {
 		return nil, nil, nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", dt.d.FilenameBase, r.values.from, r.values.to, err)
 	}
@@ -710,7 +709,7 @@ func (iit *InvertedIndexRoTx) mergeFiles(ctx context.Context, files []*FilesItem
 	comp.Close()
 	comp = nil
 
-	outItem = newFilesItem(startTxNum, endTxNum, iit.stepSize, iit.stepsInFrozenFile)
+	outItem = newFilesItem(startTxNum, endTxNum)
 	if outItem.decompressor, err = seg.NewDecompressor(datPath); err != nil {
 		return nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", iit.ii.FilenameBase, startTxNum, endTxNum, err)
 	}
@@ -888,7 +887,7 @@ func (ht *HistoryRoTx) mergeFiles(ctx context.Context, indexFiles, historyFiles 
 		if index, err = ht.h.openHashMapAccessor(idxPath); err != nil {
 			return nil, nil, fmt.Errorf("open %s idx: %w", ht.h.FilenameBase, err)
 		}
-		historyIn = newFilesItem(r.history.from, r.history.to, ht.stepSize, ht.stepsInFrozenFile)
+		historyIn = newFilesItem(r.history.from, r.history.to)
 		historyIn.decompressor = decomp
 		historyIn.index = index
 
@@ -1002,10 +1001,6 @@ func garbage(dirtyFiles *DirtyFiles, visibleFiles []visibleFile, merged *FilesIt
 	defer iter.Release()
 	for ok := iter.First(); ok; ok = iter.Next() {
 		item := iter.Item()
-		if item.frozen {
-			continue
-		}
-
 		if merged == nil {
 			if hasCoverVisibleFile(visibleFiles, item) {
 				outs = append(outs, item)

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -38,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
 )
 
@@ -378,7 +379,7 @@ type valueTransformer func(val []byte, startTxNum, endTxNum uint64) ([]byte, err
 
 const DomainMinStepsToCompress = 16
 
-func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, historyFiles []*FilesItem, r DomainRanges, vt valueTransformer, ps *background.ProgressSet) (valuesIn, indexIn, historyIn *FilesItem, err error) {
+func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, historyFiles []*FilesItem, r DomainRanges, vt valueTransformer, seqReadahead bool, ps *background.ProgressSet) (valuesIn, indexIn, historyIn *FilesItem, err error) {
 	if !r.any() {
 		return
 	}
@@ -442,7 +443,12 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	var cp CursorHeap
 	heap.Init(&cp)
 	for _, item := range domainFiles {
-		g := dt.dataReader(item.decompressor)
+		view, err := item.decompressor.OpenSequentialView(seqReadahead)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		defer view.Close()
+		g := seg.NewReader(view.MakeGetter(), dt.d.Compression)
 		g.Reset(0)
 		if g.HasNext() {
 			key, _ := g.Next(nil)
@@ -535,6 +541,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	ps.Delete(p)
 
 	valuesIn = newFilesItem(r.values.from, r.values.to)
+	valuesIn.version, _ = version.ParseVersion(filepath.Base(kvFilePath))
 	if valuesIn.decompressor, err = seg.NewDecompressor(kvFilePath); err != nil {
 		return nil, nil, nil, fmt.Errorf("merge %s decompressor [%d-%d]: %w", dt.d.FilenameBase, r.values.from, r.values.to, err)
 	}
@@ -552,7 +559,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 		}
 	}
 	if dt.d.Accessors.Has(statecfg.AccessorHashMap) {
-		if err = dt.d.buildHashMapAccessor(ctx, fromStep, toStep, dt.dataReader(valuesIn.decompressor), ps); err != nil {
+		if err = dt.d.buildHashMapAccessor(ctx, fromStep, toStep, valuesIn.decompressor, ps); err != nil {
 			return nil, nil, nil, fmt.Errorf("merge %s buildHashMapAccessor [%d-%d]: %w", dt.d.FilenameBase, r.values.from, r.values.to, err)
 		}
 		if valuesIn.index, err = dt.d.openHashMapAccessor(dt.d.kviAccessorNewFilePath(fromStep, toStep)); err != nil {
@@ -626,8 +633,14 @@ func (iit *InvertedIndexRoTx) mergeFiles(ctx context.Context, files []*FilesItem
 	var cp CursorHeap
 	heap.Init(&cp)
 
+	seqReadahead := true
 	for _, item := range files {
-		g := iit.dataReader(item.decompressor)
+		view, err := item.decompressor.OpenSequentialView(seqReadahead)
+		if err != nil {
+			return nil, err
+		}
+		defer view.Close()
+		g := seg.NewReader(view.MakeGetter(), iit.ii.Compression)
 		g.Reset(0)
 		if g.HasNext() {
 			key, _ := g.Next(nil)
@@ -715,7 +728,7 @@ func (iit *InvertedIndexRoTx) mergeFiles(ctx context.Context, files []*FilesItem
 	}
 	ps.Delete(p)
 
-	if err := iit.ii.buildMapAccessor(ctx, fromStep, toStep, iit.dataReader(outItem.decompressor), ps); err != nil {
+	if err := iit.ii.buildMapAccessor(ctx, fromStep, toStep, outItem.decompressor, ps); err != nil {
 		return nil, fmt.Errorf("merge %s buildHashMapAccessor [%d-%d]: %w", iit.ii.FilenameBase, startTxNum, endTxNum, err)
 	}
 	if outItem.index, err = iit.ii.openHashMapAccessor(iit.ii.efAccessorNewFilePath(fromStep, toStep)); err != nil {
@@ -791,7 +804,12 @@ func (ht *HistoryRoTx) mergeFiles(ctx context.Context, indexFiles, historyFiles 
 		var cp CursorHeap
 		heap.Init(&cp)
 		for _, item := range indexFiles {
-			g := ht.iit.dataReader(item.decompressor)
+			idxView, err := item.decompressor.OpenSequentialView(true)
+			if err != nil {
+				return nil, nil, err
+			}
+			defer idxView.Close()
+			g := seg.NewReader(idxView.MakeGetter(), ht.h.InvertedIndex.Compression)
 			g.Reset(0)
 			if g.HasNext() {
 				var g2 *seg.PagedReader
@@ -803,7 +821,12 @@ func (ht *HistoryRoTx) mergeFiles(ctx context.Context, indexFiles, historyFiles 
 							compressedPageValuesCount = ht.h.HistoryValuesOnCompressedPage
 						}
 
-						g2 = seg.NewPagedReader(ht.dataReader(hi.decompressor), compressedPageValuesCount, true)
+						histView, err := hi.decompressor.OpenSequentialView(true)
+						if err != nil {
+							return nil, nil, err
+						}
+						defer histView.Close()
+						g2 = seg.NewPagedReader(seg.NewReader(histView.MakeGetter(), ht.h.Compression), compressedPageValuesCount, true)
 						break
 					}
 				}

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -1046,7 +1046,7 @@ func TestCommitmentValTransformDomainPanicsWithNeedMergeFalse(t *testing.T) {
 	defer dc.Close()
 
 	require.Panics(t, func() {
-		dc.commitmentValTransformDomain(MergeRange{needMerge: false}, dc, dc, nil, nil)
+		dc.commitmentValTransformDomain(MergeRange{needMerge: false}, dc, dc, nil, nil, false)
 	})
 }
 

--- a/db/state/proto_forkable.go
+++ b/db/state/proto_forkable.go
@@ -147,7 +147,7 @@ func (a *ProtoForkable) BuildFile(ctx context.Context, from, to RootNum, db kv.R
 		return nil, false, err
 	}
 
-	df := newFilesItemWithSnapConfig(uint64(calcFrom), uint64(calcTo), cfg)
+	df := newFilesItem(uint64(calcFrom), uint64(calcTo))
 	df.decompressor = valuesDecomp
 
 	indexes, err := a.BuildIndexes(ctx, df.decompressor, calcFrom, calcTo, ps)
@@ -257,10 +257,7 @@ type ProtoForkableTx struct {
 func (a *ProtoForkable) BeginFilesRo() *ProtoForkableTx {
 	visibleFiles := a.snaps.visibleFiles()
 	for i := range visibleFiles {
-		src := visibleFiles[i].src
-		if !src.frozen {
-			src.refcount.Add(1)
-		}
+		visibleFiles[i].src.refcount.Add(1)
 	}
 
 	return &ProtoForkableTx{
@@ -280,9 +277,7 @@ func (a *ProtoForkable) DebugBeginDirtyFilesRo() *forkableDirtyFilesRoTx {
 	for ok := iter.First(); ok; ok = iter.Next() {
 		item := iter.Item()
 		files = append(files, item)
-		if !item.frozen {
-			item.refcount.Add(1)
-		}
+		item.refcount.Add(1)
 	}
 	return &forkableDirtyFilesRoTx{
 		p:     a,
@@ -326,7 +321,7 @@ func (a *ProtoForkableTx) Close() {
 	a.files = nil
 	for i := range files {
 		src := files[i].src
-		if src == nil || src.frozen {
+		if src == nil {
 			continue
 		}
 		refCnt := src.refcount.Add(-1)

--- a/db/state/simple_accessor_builder.go
+++ b/db/state/simple_accessor_builder.go
@@ -134,10 +134,8 @@ func (s *SimpleAccessorBuilder) SetAccessorArgs(args *AccessorArgs) {
 	s.args = args
 }
 
-func (s *SimpleAccessorBuilder) GetInputDataQuery(decomp *seg.Decompressor, compressionUsed bool) (*DecompressorIndexInputDataQuery, error) {
-	//sgname := s.parser.DataFile(version.V1_0, from, to)
-	//decomp, _ := seg.NewDecompressorWithMetadata(sgname, true)
-	reader := seg.NewPagedReader(decomp.MakeGetter(), s.args.ValuesOnCompressedPage, compressionUsed)
+func (s *SimpleAccessorBuilder) GetInputDataQuery(getter *seg.Getter, compressionUsed bool) (*DecompressorIndexInputDataQuery, error) {
+	reader := seg.NewPagedReader(getter, s.args.ValuesOnCompressedPage, compressionUsed)
 	return NewDecompressorIndexInputDataQuery(reader)
 }
 
@@ -156,7 +154,12 @@ func (s *SimpleAccessorBuilder) Build(ctx context.Context, decomp *seg.Decompres
 		}
 	}()
 
-	iidq, err := s.GetInputDataQuery(decomp, s.isCompressionUsed(from, to))
+	seqView, err := decomp.OpenSequentialView(true)
+	if err != nil {
+		return nil, err
+	}
+	defer seqView.Close()
+	iidq, err := s.GetInputDataQuery(seqView.MakeGetter(), s.isCompressionUsed(from, to))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +194,6 @@ func (s *SimpleAccessorBuilder) Build(ctx context.Context, decomp *seg.Decompres
 	s.kf.Refresh()
 	defer s.kf.Close()
 
-	defer iidq.reader.MadvNormal().DisableReadAhead()
 	for {
 		iidq.Reset()
 		rs.SetProgress(p)

--- a/db/state/snap_config.go
+++ b/db/state/snap_config.go
@@ -74,14 +74,6 @@ func (s *SnapshotConfig) validate() {
 	}
 }
 
-func (s *SnapshotConfig) StepsInFrozenFile() uint64 {
-	if len(s.MergeStages) == 0 {
-		return s.MinimumSize / s.RootNumPerStep
-	}
-
-	return s.MergeStages[len(s.MergeStages)-1] / s.RootNumPerStep
-}
-
 func (s *SnapshotConfig) LoadPreverified(pre snapcfg.PreverifiedItems) {
 	if s.PreverifiedParsed != nil {
 		return

--- a/db/state/snap_repo.go
+++ b/db/state/snap_repo.go
@@ -434,7 +434,7 @@ func (f *SnapshotRepo) loadDirtyFiles(aps []string) {
 			f.logger.Trace("can't parse file name", "file", ap)
 			continue
 		}
-		dirtyFile := newFilesItemWithSnapConfig(fileInfo.From, fileInfo.To, f.cfg)
+		dirtyFile := newFilesItem(fileInfo.From, fileInfo.To)
 
 		if _, has := f.dirtyFiles.Get(dirtyFile); !has {
 			f.dirtyFiles.Set(dirtyFile)

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -161,7 +161,7 @@ func TestIntegrateDirtyFile(t *testing.T) {
 	err := repo.OpenFolder()
 	require.NoError(t, err)
 
-	filesItem := newFilesItemWithSnapConfig(0, 1024, repo.cfg)
+	filesItem := newFilesItem(0, 1024)
 	filename, _ := repo.schema.DataFile(version.V1_0, 0, 1024)
 	comp, err := seg.NewCompressor(t.Context(), t.Name(), filename, dirs.Tmp, seg.DefaultCfg, log.LvlDebug, log.New())
 	require.NoError(t, err)
@@ -495,7 +495,7 @@ func TestRecalcVisibleFilesAfterMerge(t *testing.T) {
 		items := repo.FilesInRange(mr, vf) // vf passed should ideally from rotx, but doesn't matter here
 		require.Len(t, items, nFilesInRange)
 
-		merged := newFilesItemWithSnapConfig(mr.from, mr.to, repo.cfg)
+		merged := newFilesItem(mr.from, mr.to)
 		repo.IntegrateDirtyFile(merged)
 		dirEntries, err := filesFromDir(repo.schema.DataDirectory())
 		require.NoError(t, err)

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -287,7 +287,6 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 				return err
 			}
 			sizeDelta += delta
-			cf.frozen = false
 			cf.closeFilesAndRemove()
 
 			squeezedPath := originalPath + sqExt

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -123,7 +123,7 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 	stepSize := at.StepSize()
 	dirs := at.Dirs()
 
-	commitmentUseReferencedBranches := at.a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues
+	commitmentUseReferencedBranches := at.a.referencesInCommitmentBranches()
 	if !commitmentUseReferencedBranches {
 		return nil
 	}
@@ -225,7 +225,11 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 				"progress", fmt.Sprintf("%d/%d", ri+1, len(ranges)), "compress_cfg", commitment.d.CompressCfg, "compress", compression)
 
 			originalPath := cf.decompressor.FilePath()
-			squeezedTmpPath := originalPath + sqExt + ".tmp"
+			// The squeeze re-references the file, so stamp the output with the flag-derived write
+			// version (v2.1) rather than reusing the input name, which may be a plain v2.2 file
+			// written during a flag-off rebuild window.
+			targetPath := commitment.d.kvNewFilePath(kv.Step(r.from/stepSize), kv.Step(r.to/stepSize))
+			squeezedTmpPath := targetPath + sqExt + ".tmp"
 
 			squeezedCompr, err := seg.NewCompressor(ctx, "squeeze", squeezedTmpPath, dirs.Tmp,
 				commitment.d.CompressCfg, log.LvlInfo, commitment.d.logger)
@@ -239,7 +243,7 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 			reader.Reset(0)
 
 			rng := MergeRange{needMerge: true, from: af.startTxNum, to: af.endTxNum}
-			vt, err := commitment.commitmentValTransformDomain(rng, accounts, storage, af, sf)
+			vt, err := commitment.commitmentValTransformDomain(rng, accounts, storage, af, sf, at.a.referencesInCommitmentBranches())
 			if err != nil {
 				return fmt.Errorf("failed to create commitment value transformer: %w", err)
 			}
@@ -289,7 +293,7 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 			sizeDelta += delta
 			cf.closeFilesAndRemove()
 
-			squeezedPath := originalPath + sqExt
+			squeezedPath := targetPath + sqExt
 			if err = os.Rename(squeezedTmpPath, squeezedPath); err != nil {
 				return err
 			}
@@ -323,8 +327,8 @@ func SqueezeCommitmentFiles(ctx context.Context, at *AggregatorRoTx, logger log.
 // to full plain keys by looking them up in the supplied account and storage domain files.
 //
 // This is the read-side counterpart of commitmentValTransformDomain. It assumes the caller has
-// already checked the prerequisites (non-empty branch, not KeyCommitmentState, ReplaceKeysInValues
-// enabled, threshold-reached range): expansion is unconditional. The caller is also responsible
+// already checked the prerequisites (non-empty branch, not KeyCommitmentState, and the input file
+// is referenced per the per-file version gate): expansion is unconditional. The caller is also responsible
 // for emitting per-key debug metrics; this function intentionally does not so that offline tools
 // like the commitment converter can reuse it without coupling to read-path observability.
 //
@@ -393,7 +397,7 @@ func CheckCommitmentForPrint(ctx context.Context, rwDb kv.TemporalRwDB) (string,
 	}
 	var s strings.Builder
 	s.WriteString(fmt.Sprintf("[commitment] Latest: blockNum: %d txNum: %d latestRootHash: %x\n", latestBlock, latestTx, rootHash))
-	s.WriteString(fmt.Sprintf("[commitment] stepSize %d, ReplaceKeysInValues enabled %t\n", rwTx.Debug().StepSize(), a.Cfg(kv.CommitmentDomain).ReplaceKeysInValues))
+	s.WriteString(fmt.Sprintf("[commitment] stepSize %d, ReferencesInCommitmentBranches enabled %t\n", rwTx.Debug().StepSize(), a.referencesInCommitmentBranches()))
 	return s.String(), nil
 }
 
@@ -490,8 +494,14 @@ func RebuildCommitmentFilesWithHistory(ctx context.Context, rwDb kv.TemporalRwDB
 	defer rwDb.Debug().EnableReadAhead().DisableReadAhead()
 	a.DisableInterDomainDependencies()
 
-	// Disable ReplaceKeysInValues before main loop; will be re-enabled for squeeze pass
-	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+	// Capture the resolved flag before we temporarily flip it off for the rebuild loop;
+	// the squeeze gate below uses the captured value, not process-global schema state.
+	wantsReferencesInBranches := a.referencesInCommitmentBranches()
+	// Restore the live flag on exit so the internal rebuild/squeeze toggles below don't leak out.
+	defer a.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, wantsReferencesInBranches)
+
+	// Disable ReferencesInCommitmentBranches before main loop; will be re-enabled for squeeze pass
+	a.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 
 	// Determine block range to process
 	var execProgress uint64
@@ -820,8 +830,8 @@ func RebuildCommitmentFilesWithHistory(ctx context.Context, rwDb kv.TemporalRwDB
 		}
 	}
 
-	// Squeeze pass: re-compress commitment files with ReplaceKeysInValues
-	if !squeeze && !statecfg.Schema.CommitmentDomain.ReplaceKeysInValues {
+	// Squeeze pass: re-compress commitment files with ReferencesInCommitmentBranches
+	if !squeeze && !wantsReferencesInBranches {
 		return latestRoot, nil
 	}
 	logger.Info("[rebuild_commitment_history] squeeze starting")
@@ -830,7 +840,7 @@ func RebuildCommitmentFilesWithHistory(ctx context.Context, rwDb kv.TemporalRwDB
 	a.recalcVisibleFiles(nil)
 	a.dirtyFilesLock.Unlock()
 
-	// Check if account files exist - squeeze requires them for ReplaceKeysInValues
+	// Check if account files exist - squeeze requires them for ReferencesInCommitmentBranches
 	actx := a.BeginFilesRo()
 	hasAccountFiles := len(actx.d[kv.AccountsDomain].files) > 0
 	if !hasAccountFiles {
@@ -840,7 +850,7 @@ func RebuildCommitmentFilesWithHistory(ctx context.Context, rwDb kv.TemporalRwDB
 	}
 	defer actx.Close()
 
-	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	a.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 
 	if err = SqueezeCommitmentFiles(ctx, actx, logger); err != nil {
 		logger.Warn("[rebuild_commitment_history] squeeze failed", "err", err)
@@ -870,12 +880,18 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 	// different visibleFiles
 	a.DisableAllDependencies()
 
-	// Disable ReplaceKeysInValues during rebuild. The merge loop after each range would
+	// Capture the resolved flag before we temporarily flip it off for the rebuild loop;
+	// the squeeze gate below uses the captured value, not process-global schema state.
+	wantsReferencesInBranches := a.referencesInCommitmentBranches()
+	// Restore the live flag on exit so the internal rebuild/squeeze toggles below don't leak out.
+	defer a.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, wantsReferencesInBranches)
+
+	// Disable ReferencesInCommitmentBranches during rebuild. The merge loop after each range would
 	// otherwise shorten keys in commitment branch data, embedding file-range references
 	// (e.g. storage.0-16) that become stale once those files are merged into larger ranges
 	// (storage.0-32). The squeeze pass at the end re-enables this flag and applies the
 	// shortening in one shot when all files are finalized.
-	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+	a.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 
 	acRo := a.BeginFilesRo() // this tx is used to read existing domain files and closed in the end
 	defer acRo.Close()
@@ -1116,7 +1132,7 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 
 	acRo.Close()
 
-	if !squeeze {
+	if !squeeze && !wantsReferencesInBranches {
 		return latestRoot, nil
 	}
 	logger.Info("[squeeze] starting")
@@ -1125,7 +1141,7 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 	a.dirtyFilesLock.Unlock()
 
 	logger.Info(fmt.Sprintf("[squeeze] latest root %x", latestRoot))
-	a.ForTestReplaceKeysInValues(kv.CommitmentDomain, squeeze)
+	a.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 
 	actx := a.BeginFilesRo()
 	defer actx.Close()

--- a/db/state/squeeze_concurrent_rebuild_test.go
+++ b/db/state/squeeze_concurrent_rebuild_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"os"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,13 +13,10 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
-	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/empty"
 	"github.com/erigontech/erigon/common/log/v3"
-	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
-	"github.com/erigontech/erigon/db/kv/temporal"
 	"github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/db/state/statecfg"
@@ -50,70 +45,9 @@ func envIntOr(key string, def uint64) uint64 {
 
 // collectCommitmentFiles returns a map of filename→size for all commitment .kv files
 // in the domain snapshot directory.
-func collectCommitmentFiles(t *testing.T, dirs datadir.Dirs) map[string]int64 {
-	t.Helper()
-	result := make(map[string]int64)
-	paths, err := dir.ListFiles(dirs.SnapDomain, ".kv")
-	require.NoError(t, err)
-	commitStr := kv.CommitmentDomain.String()
-	for _, p := range paths {
-		name := filepath.Base(p)
-		if !strings.Contains(name, commitStr) {
-			continue
-		}
-		info, err := os.Stat(p)
-		require.NoError(t, err)
-		result[name] = info.Size()
-	}
-	return result
-}
 
 // wipeCommitment removes all commitment state from both database tables and snapshot files,
 // then rescans the aggregator's file state.
-func wipeCommitment(t *testing.T, db kv.TemporalRwDB, agg *state.Aggregator, dirs datadir.Dirs) {
-	t.Helper()
-
-	// Clear commitment tables in the database.
-	rwTx, err := db.BeginRw(t.Context())
-	require.NoError(t, err)
-	defer rwTx.Rollback()
-
-	buckets, err := rwTx.ListTables()
-	require.NoError(t, err)
-
-	commitStr := kv.CommitmentDomain.String()
-	for _, b := range buckets {
-		if strings.Contains(strings.ToLower(b), commitStr) {
-			err = rwTx.ClearTable(b)
-			require.NoError(t, err)
-		}
-	}
-	require.NoError(t, rwTx.Commit())
-
-	// Delete commitment .kv files and their siblings (.kvi, .kvei, .bt).
-	paths, err := dir.ListFiles(dirs.SnapDomain, ".kv")
-	require.NoError(t, err, "listing snapshot domain files")
-	for _, p := range paths {
-		if !strings.Contains(filepath.Base(p), commitStr) {
-			continue
-		}
-		err = dir.RemoveFile(p)
-		require.NoError(t, err, "removing commitment file: %s", p)
-		// Remove sibling index/accessor files.
-		base := strings.TrimSuffix(p, ".kv")
-		for _, ext := range []string{".kvi", ".kvei", ".bt"} {
-			_ = dir.RemoveFile(base + ext) // best-effort, may not exist
-		}
-	}
-
-	// Rescan file state.
-	err = agg.OpenFolder()
-	require.NoError(t, err)
-
-	// Verify the wipe was complete — no commitment files should remain.
-	remaining := collectCommitmentFiles(t, dirs)
-	require.Empty(t, remaining, "commitment files must be fully removed after wipe")
-}
 
 // logComparison prints a summary comparing baseline, sequential, and concurrent rebuild results.
 func logComparison(t *testing.T, baseline, sequential, concurrent rebuildResult, originalSizes map[string]int64) {
@@ -171,17 +105,6 @@ func logComparison(t *testing.T, baseline, sequential, concurrent rebuildResult,
 
 // reopenAggregator closes the current aggregator and reopens it with a fresh temporal DB wrapper.
 // Returns the new temporal DB and aggregator.
-func reopenAggregator(t *testing.T, db kv.TemporalRwDB, agg *state.Aggregator, stepSize uint64) (kv.TemporalRwDB, *state.Aggregator) {
-	t.Helper()
-	dirs := agg.Dirs()
-	agg.Close()
-
-	newAgg := testAgg(t, db, dirs, stepSize, log.New())
-	newDB, err := temporal.New(db, newAgg)
-	require.NoError(t, err)
-
-	return newDB, newAgg
-}
 
 // TestConcurrentRebuildCommitment generates deterministic data, records a baseline state root,
 // then rebuilds commitment sequentially (ground truth) and concurrently (primary target),
@@ -226,7 +149,7 @@ func TestConcurrentRebuildCommitment(t *testing.T) {
 
 	// --- Create aggregator and DB ---
 	db, agg, dirs := testDbAndAggregatorForLargeData(t, stepSize, persistentDir)
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 
 	ctx := t.Context()
 
@@ -502,7 +425,7 @@ func TestConcurrentRebuildCommitmentNoSqueeze(t *testing.T) {
 
 	// --- Phase 1: Data generation ---
 	db, agg, dirs := testDbAndAggregatorForLargeData(t, stepSize, "")
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 
 	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)

--- a/db/state/squeeze_test.go
+++ b/db/state/squeeze_test.go
@@ -155,7 +155,7 @@ func testAgg(tb testing.TB, db kv.RwDB, dirs datadir.Dirs, aggStep uint64, logge
 func testDbAggregatorWithNoFiles(tb testing.TB, txCount int, cfg *testAggConfig) (kv.TemporalRwDB, *state.Aggregator) {
 	tb.Helper()
 	db, agg := testDbAndAggregatorv3(tb, cfg.stepSize)
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, !cfg.disableCommitmentBranchTransform)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, !cfg.disableCommitmentBranchTransform)
 
 	ctx := tb.Context()
 
@@ -230,7 +230,7 @@ func TestAggregator_SqueezeCommitment(t *testing.T) {
 	domains.Close()
 
 	// now do the squeeze
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 	err = state.SqueezeCommitmentFiles(t.Context(), state.AggTx(rwTx), log.New())
 	require.NoError(t, err)
 
@@ -673,7 +673,7 @@ func TestGenerateCommitmentRebuildData(t *testing.T) {
 	t.Logf("Keys: accounts=%d storage=%d code=%d total=%d", numAccounts, totalStorage, totalCode, totalKeys)
 
 	db, agg, dirs := testDbAndAggregatorForLargeData(t, stepSize, persistentDir)
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 
 	ctx := t.Context()
 

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/seg"
@@ -73,7 +74,6 @@ func Configure(Schema SchemaGen, a AggSetters, dirs datadir.Dirs, salt *uint32, 
 	return nil
 }
 
-const AggregatorSqueezeCommitmentValues = true
 const MaxNonFuriousDirtySpacePerTx = 64 * datasize.MB
 
 var dbgCommBtIndex = dbg.EnvBool("AGG_COMMITMENT_BT", false)
@@ -189,6 +189,15 @@ func (s *SchemaGen) GetBlockIdxFilesCfg(name string) BlockIdxFilesCfg {
 
 var ExperimentalConcurrentCommitment = false // set true to use concurrent commitment by default
 
+// commitmentKVWriteVersion stamps v2.1 on referenced commitment files (matching main's referenced
+// default) and v2.2 on plain ones; the read ceiling (DataKV.Current = v2.2) accepts both.
+func commitmentKVWriteVersion(c *DomainCfg) version.Version {
+	if c.ReferencesInCommitmentBranches {
+		return version.V2_1
+	}
+	return version.V2_2
+}
+
 // ExperimentalParallelCommitment toggles the ParallelPatriciaHashed trie path
 // (commitment.ModeParallel + VariantParallelHexPatricia). Default false.
 // Takes precedence over ExperimentalConcurrentCommitment when both are set.
@@ -269,8 +278,9 @@ var Schema = SchemaGen{
 		Name: kv.CommitmentDomain, ValuesTable: kv.TblCommitmentVals,
 		CompressCfg: DomainCompressCfg, Compression: seg.CompressKeys,
 
-		Accessors:           AccessorHashMap,
-		ReplaceKeysInValues: AggregatorSqueezeCommitmentValues, // when true, keys are replaced in values during merge once file range reaches threshold
+		Accessors:                      AccessorHashMap,
+		ReferencesInCommitmentBranches: config3.DefaultReferencesInCommitmentBranches, // when true, keys are replaced in values during merge once file range reaches threshold
+		KVWriteVersion:                 commitmentKVWriteVersion,
 
 		Hist: HistCfg{
 			ValuesTable:   kv.TblCommitmentHistoryVals,

--- a/db/state/statecfg/state_schema.go
+++ b/db/state/statecfg/state_schema.go
@@ -76,7 +76,7 @@ func Configure(Schema SchemaGen, a AggSetters, dirs datadir.Dirs, salt *uint32, 
 
 const MaxNonFuriousDirtySpacePerTx = 64 * datasize.MB
 
-var dbgCommBtIndex = dbg.EnvBool("AGG_COMMITMENT_BT", false)
+var dbgCommBtIndex = dbg.EnvBool("AGG_COMMITMENT_BT", true)
 
 func init() {
 	if dbgCommBtIndex {

--- a/db/state/statecfg/state_schema_test.go
+++ b/db/state/statecfg/state_schema_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package statecfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erigontech/erigon/db/config3"
+)
+
+func TestCommitmentReferencesDefault(t *testing.T) {
+	assert.True(t, config3.DefaultReferencesInCommitmentBranches)
+	assert.Equal(t, config3.DefaultReferencesInCommitmentBranches, Schema.CommitmentDomain.ReferencesInCommitmentBranches)
+}

--- a/db/state/statecfg/state_schema_test.go
+++ b/db/state/statecfg/state_schema_test.go
@@ -25,6 +25,6 @@ import (
 )
 
 func TestCommitmentReferencesDefault(t *testing.T) {
-	assert.True(t, config3.DefaultReferencesInCommitmentBranches)
+	assert.False(t, config3.DefaultReferencesInCommitmentBranches)
 	assert.Equal(t, config3.DefaultReferencesInCommitmentBranches, Schema.CommitmentDomain.ReferencesInCommitmentBranches)
 }

--- a/db/state/statecfg/statecfg.go
+++ b/db/state/statecfg/statecfg.go
@@ -16,15 +16,17 @@ type DomainCfg struct {
 	ValuesTable string    // bucket to store domain values; key -> inverted_step + values (Dupsort)
 	LargeValues bool
 
-	// replaceKeysInValues allows to replace commitment branch values with shorter keys.
-	// for commitment domain only
-	ReplaceKeysInValues bool
+	// Write shortened key references in commitment branch values; commitment domain only.
+	ReferencesInCommitmentBranches bool
 
 	ExistenceFilter ExistenceFilterMode
 
 	BuildAccessorsWorkers int // parallel workers for building .kvi accessors (recsplit)
 
 	FileVersion DomainVersionTypes
+
+	// KVWriteVersion derives the version stamped on a new .kv file from live config; nil => DataKV.Current.
+	KVWriteVersion func(*DomainCfg) version.Version
 }
 
 func (d DomainCfg) Tables() []string {

--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -21,7 +21,9 @@ func InitSchemasGen() {
 	Schema.CodeDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
+	Schema.CommitmentDomain.FileVersion.AccessorBT = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{version.Version{2, 2}, version.Version{1, 0}}
+	Schema.CommitmentDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
 	Schema.CommitmentDomain.FileVersion.AccessorKVI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.CommitmentDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.CommitmentDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}

--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -21,7 +21,7 @@ func InitSchemasGen() {
 	Schema.CodeDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
 	Schema.CodeDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
-	Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
+	Schema.CommitmentDomain.FileVersion.DataKV = version.Versions{version.Version{2, 2}, version.Version{1, 0}}
 	Schema.CommitmentDomain.FileVersion.AccessorKVI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.CommitmentDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.CommitmentDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 1}, version.Version{1, 0}}

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -59,7 +59,7 @@ code:
 commitment:
     domain:
         kv:
-            current: v2.1
+            current: v2.2
             min: v1.0
         kvi:
             current: v2.1

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -64,6 +64,12 @@ commitment:
         kvi:
             current: v2.1
             min: v1.0
+        bt:
+            current: v2.0
+            min: v1.0
+        kvei:
+            current: v1.2
+            min: v1.0
     hist:
         v:
             current: v2.0

--- a/db/state/trie_reader_integration_test.go
+++ b/db/state/trie_reader_integration_test.go
@@ -47,7 +47,7 @@ func TestTrieReader_IntegrationWithRealData(t *testing.T) {
 	totalTxs := uint64(stepSize * totalSteps)
 
 	db, agg := testDbAndAggregatorv3(t, stepSize)
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, false)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, false)
 
 	ctx := t.Context()
 	rwTx, err := db.BeginTemporalRw(ctx)

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -656,7 +656,7 @@ func TestAggregatorV3_MergeValTransform(t *testing.T) {
 	require.NoError(t, err)
 	defer rwTx.Rollback()
 
-	agg.ForTestReplaceKeysInValues(kv.CommitmentDomain, true)
+	agg.ForTestReferencesInCommitmentBranches(kv.CommitmentDomain, true)
 
 	domains, err := execctx.NewSharedDomains(t.Context(), rwTx, log.New())
 	require.NoError(t, err)

--- a/db/version/app.go
+++ b/db/version/app.go
@@ -34,7 +34,7 @@ const (
 	Minor                    = 6             // Minor version component of the current release
 	Micro                    = 0             // Patch version component of the current release
 	Modifier                 = "dev"         // Modifier component of the current release
-	DefaultSnapshotGitBranch = "release/3.4" // Branch of erigontech/erigon-snapshot to use in OtterSync.
+	DefaultSnapshotGitBranch = "release/3.6" // Branch of erigontech/erigon-snapshot to use in OtterSync.
 	VersionKeyCreated        = "ErigonVersionCreated"
 	VersionKeyFinished       = "ErigonVersionFinished"
 	ClientName               = "erigon"

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -61,6 +61,7 @@ var (
 	V1_2                Version  = Version{1, 2}
 	V2_0                Version  = Version{2, 0}
 	V2_1                Version  = Version{2, 1}
+	V2_2                Version  = Version{2, 2}
 	V1_0_standart       Versions = Versions{V1_0, V1_0}
 	V1_1_standart       Versions = Versions{V1_1, V1_0}
 	V1_2_standart       Versions = Versions{V1_2, V1_0}

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -800,6 +800,25 @@ func (branchData BranchData) String() string {
 	return sb.String()
 }
 
+var errShortenedKeyFound = errors.New("shortened key found")
+
+// HasShortenedKeys reports whether the branch carries any shortened (referenced) key — a key
+// field whose length is not length.Addr (account) / length.Addr+length.Hash (storage), i.e. a
+// varint file offset. A malformed branch reports true: treat as referenced, never under-report.
+func (branchData BranchData) HasShortenedKeys() bool {
+	_, err := branchData.ReplacePlainKeys(nil, func(key []byte, isStorage bool) ([]byte, error) {
+		if isStorage {
+			if len(key) != length.Addr+length.Hash {
+				return nil, errShortenedKeyFound
+			}
+		} else if len(key) != length.Addr {
+			return nil, errShortenedKeyFound
+		}
+		return nil, nil
+	})
+	return err != nil
+}
+
 // if fn returns nil, the original key will be kept from branchData.
 // Uses span-based lazy copy: unchanged regions of branchData are copied in bulk
 // only when a key actually changes. When no keys change, returns branchData as-is

--- a/execution/exec/state.go
+++ b/execution/exec/state.go
@@ -538,7 +538,7 @@ func NewWorkersPool(ctx context.Context, accumulator *shards.Accumulator, backgr
 	engine rules.Engine, workerCount int, metrics *WorkerMetrics, dirs datadir.Dirs, logger log.Logger) (reconWorkers []*Worker, applyWorker *Worker, rws *ResultsQueue, clear func(), wait func(), err error) {
 	reconWorkers = make([]*Worker, workerCount)
 
-	resultsSize := workerCount * 8
+	resultsSize := workerCount * 512
 	rws = NewResultsQueue(resultsSize, workerCount)
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1447,7 +1447,7 @@ func (pe *parallelExecutor) run(ctx context.Context) (context.Context, context.C
 	pe.blockExecutors = nil
 	// in is the per-transaction work queue consumed by OCC workers.
 	// 2048 entries keeps all workers saturated without unbounded accumulation.
-	pe.in = exec.NewQueueWithRetry(2_048)
+	pe.in = exec.NewQueueWithRetry(32_768)
 
 	pe.taskExecMetrics = exec.NewWorkerMetrics()
 	pe.blockExecMetrics = newBlockExecMetrics()

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -270,4 +270,5 @@ var DefaultFlags = []cli.Flag{
 	&utils.MCPPortFlag,
 
 	&utils.ErigondbDomainStepsInFrozenFileFlag,
+	&utils.CommitmentPlainValuesFlag,
 }

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -348,6 +348,15 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		},
 	}
 
+	// Seed erigondb.toml with the first-start commitment regime (--commitment.plainValues)
+	// before genesis-root computation. On a legacy datadir GenesisToBlock resolves erigondb
+	// settings against the real dir and would create erigondb.toml with the default regime,
+	// which the later flag-aware resolve in SetUpBlockReader then reads as pre-existing and
+	// drops the flag. Seeding here first makes --commitment.plainValues stick.
+	if _, err := state.ResolveErigonDBSettingsWithRefsDefault(dirs, logger, config.Snapshot.NoDownloader, config.CommitmentRefsFirstStart()); err != nil {
+		return nil, err
+	}
+
 	var chainConfig *chain.Config
 	var genesis *types.Block
 	if err := rawChainDB.Update(context.Background(), func(tx kv.RwTx) error {
@@ -1291,7 +1300,7 @@ func SetUpBlockReader(ctx context.Context, db kv.RwDB, dirs datadir.Dirs, snConf
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
-	erigonDBSettings, err := state.ResolveErigonDBSettings(dirs, logger, snConfig.Snapshot.NoDownloader)
+	erigonDBSettings, err := state.ResolveErigonDBSettingsWithRefsDefault(dirs, logger, snConfig.Snapshot.NoDownloader, snConfig.CommitmentRefsFirstStart())
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -280,11 +280,25 @@ type Config struct {
 	// directly as the cap in steps.
 	ErigondbDomainStepsInFrozenFile *uint64 `toml:",omitempty"`
 
+	// CommitmentPlainValues overrides the references_in_commitment_branches value written into a
+	// freshly created erigondb.toml (true => plain keys => references=false); nil = unset.
+	CommitmentPlainValues *bool `toml:",omitempty"`
+
 	// WarmupKzgCtxOnInit, when true, eagerly initialises the KZG trusted setup
 	// in the background on startup so the first block doesn't pay the ~2s init
 	// cost. Tests that don't need the trusted setup loaded leave this false
 	// to avoid the extra work.
 	WarmupKzgCtxOnInit bool
+}
+
+// CommitmentRefsFirstStart maps CommitmentPlainValues to a first-start
+// references_in_commitment_branches override (nil = use the config default).
+func (c *Config) CommitmentRefsFirstStart() *bool {
+	if c.CommitmentPlainValues == nil {
+		return nil
+	}
+	refs := !*c.CommitmentPlainValues
+	return &refs
 }
 
 type Sync struct {

--- a/node/ethconfig/config_test.go
+++ b/node/ethconfig/config_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package ethconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitmentRefsFirstStart(t *testing.T) {
+	t.Parallel()
+	tr, fa := true, false
+
+	require.Nil(t, (&Config{CommitmentPlainValues: nil}).CommitmentRefsFirstStart(), "unset => nil")
+
+	// plainValues=true => references=false
+	gotPlain := (&Config{CommitmentPlainValues: &tr}).CommitmentRefsFirstStart()
+	require.NotNil(t, gotPlain)
+	require.False(t, *gotPlain)
+
+	// plainValues=false => references=true
+	gotRefs := (&Config{CommitmentPlainValues: &fa}).CommitmentRefsFirstStart()
+	require.NotNil(t, gotRefs)
+	require.True(t, *gotRefs)
+}

--- a/node/ethconfig/gen_config.go
+++ b/node/ethconfig/gen_config.go
@@ -60,6 +60,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		FcuBackgroundCommit                 bool
 		MCPAddress                          string
 		ErigondbDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
+		CommitmentPlainValues               *bool   `toml:",omitempty"`
 		WarmupKzgCtxOnInit                  bool
 	}
 	var enc Config
@@ -100,6 +101,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.FcuBackgroundCommit = c.FcuBackgroundCommit
 	enc.MCPAddress = c.MCPAddress
 	enc.ErigondbDomainStepsInFrozenFile = c.ErigondbDomainStepsInFrozenFile
+	enc.CommitmentPlainValues = c.CommitmentPlainValues
 	enc.WarmupKzgCtxOnInit = c.WarmupKzgCtxOnInit
 	return &enc, nil
 }
@@ -144,6 +146,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		FcuBackgroundCommit                 *bool
 		MCPAddress                          *string
 		ErigondbDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
+		CommitmentPlainValues               *bool   `toml:",omitempty"`
 		WarmupKzgCtxOnInit                  *bool
 	}
 	var dec Config
@@ -260,6 +263,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.ErigondbDomainStepsInFrozenFile != nil {
 		c.ErigondbDomainStepsInFrozenFile = dec.ErigondbDomainStepsInFrozenFile
+	}
+	if dec.CommitmentPlainValues != nil {
+		c.CommitmentPlainValues = dec.CommitmentPlainValues
 	}
 	if dec.WarmupKzgCtxOnInit != nil {
 		c.WarmupKzgCtxOnInit = *dec.WarmupKzgCtxOnInit


### PR DESCRIPTION
Stacks three perf/format changes on `alex/bal-devnet-7_warmup` for the jochemnet warmup experiment.

## Commits
| commit | what |
|---|---|
| enlarge parallel-exec dispatch & results queues | `pe.in` 2048→32768, `resultsSize` ×8→×512 — removes dispatch starvation on high-txn blocks (#22127) |
| remove FilesItem.frozen field | cp #22126 — prerequisite for the noref version model |
| erigondb.toml as source of truth for commitment branch referencing | cp #21452 (noref config + per-file version) |
| default commitment references off (plain) | cp from #21376 |
| point snapshots to erigon36 webseeds | cp from #21376 |
| default commitment accessor to bt + kvei | flip default accessor .kvi → .bt+.kvei (AGG_COMMITMENT_BT=false restores .kvi) |

## Notes
- #22126 cherry-picked as a prerequisite so #21452's `frozen`→`version` filesItem model applies (base predated it).
- From #21376 only the two relevant commits were taken (plain-commitment default + erigon36 webseeds); the branch's merge + caplin commits were skipped.
- Base-adaptation: de-duplicated commitment test helpers that #21452 centralized (they already existed in the warmup branch's squeeze test).
- Builds clean (`make erigon`).
