### PR TITLE
[r3.5] db/snapshotsync: remove overlapping caplin state snapshots on retire

### DIFF
--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -594,7 +594,6 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		}
 		if err := s.stateSn.DumpCaplinState(
 			ctx,
-			s.stateSn.BlocksAvailable()+1,
 			to,
 			blocksPerStatefulFile,
 			s.sn.Salt,
@@ -605,15 +604,17 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		); err != nil {
 			return err
 		}
-		paths := s.stateSn.SegFileNames(from, to)
+		// Open the new files before collecting paths so the seeder sees them;
+		// seed from 0 since a per-type resume can dump a new type from genesis.
+		if err := s.stateSn.OpenFolder(); err != nil {
+			return err
+		}
 		if s.downloader != nil {
+			paths := s.stateSn.SegFileNames(0, to)
 			// Notify bittorent to seed the new snapshots
 			if err := s.downloader.Seed(s.ctx, paths); err != nil {
 				s.logger.Warn("[Antiquary] Failed to add items to bittorent", "err", err)
 			}
-		}
-		if err := s.stateSn.OpenFolder(); err != nil {
-			return err
 		}
 	}
 

--- a/cmd/capcli/cli.go
+++ b/cmd/capcli/cli.go
@@ -1390,7 +1390,7 @@ func (c *DumpStateSnapshots) Run(ctx *Context) error {
 	r, _ := stateSn.Get(kv.BlockRoot, 999424)
 	fmt.Printf("%x\n", r)
 
-	if err := stateSn.DumpCaplinState(ctx, stateSn.BlocksAvailable(), to, c.StepSize, salt, dirs, runtime.NumCPU(), log.LvlInfo, log.Root()); err != nil {
+	if err := stateSn.DumpCaplinState(ctx, to, c.StepSize, salt, dirs, runtime.NumCPU(), log.LvlInfo, log.Root()); err != nil {
 		return err
 	}
 	if err := stateSn.OpenFolder(); err != nil {

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3324,7 +3324,7 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	cfg := ethconfig.NewSnapCfg(false, true, true, chainConfig.ChainName)
 
 	res, clean, err := openSnaps(ctx, cfg, dirs, db, logger)
-	caplinSnaps, br, agg := res.CaplinSnaps, res.BlockRetire, res.Aggregator
+	caplinSnaps, caplinStateSnaps, br, agg := res.CaplinSnaps, res.CaplinStateSnaps, res.BlockRetire, res.Aggregator
 	if err != nil {
 		return err
 	}
@@ -3372,6 +3372,10 @@ func doRetireCommand(cliCtx *cli.Context, dirs datadir.Dirs) error {
 	}
 
 	if err := br.RemoveOverlaps(nil); err != nil {
+		return err
+	}
+
+	if err := caplinStateSnaps.RemoveOverlaps(); err != nil {
 		return err
 	}
 

--- a/db/snapshotsync/caplin_state_dump_test.go
+++ b/db/snapshotsync/caplin_state_dump_test.go
@@ -1,0 +1,127 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshotsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func firstJobFrom(jobs []caplinStateDumpJob, name string) (uint64, bool) {
+	for _, j := range jobs {
+		if j.name == name {
+			return j.from, true
+		}
+	}
+	return 0, false
+}
+
+func countJobs(jobs []caplinStateDumpJob, name string) uint64 {
+	var n uint64
+	for _, j := range jobs {
+		if j.name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// overlapsCoverage reports whether any job lands inside an existing covered range.
+func overlapsCoverage(jobs []caplinStateDumpJob, name string, covered []Range) bool {
+	for _, j := range jobs {
+		if j.name != name {
+			continue
+		}
+		for _, r := range covered {
+			if j.from < r.to && r.from < j.to {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// A new state-snapshot type added to an already-populated datadir must not drag
+// the dump back to genesis for types that are already caught up: only missing
+// ranges are scheduled, so a full base file is never re-sliced into overlaps.
+func TestPlanStateDumpResumesPerType(t *testing.T) {
+	const blocksPerFile = 50_000
+	coverage := map[string][]Range{
+		"Covered": {{from: 0, to: 10_400_000}}, // already at head
+		"Lagging": {{from: 0, to: 2_700_000}},  // newly added type, behind
+		"Empty":   nil,                         // brand-new type, nothing on disk
+	}
+
+	jobs := planStateDump(coverage, 10_400_000, blocksPerFile)
+
+	for _, j := range jobs {
+		require.Equal(t, blocksPerFile, int(j.to-j.from), "every job must be exactly one full file")
+	}
+	for name, cov := range coverage {
+		require.False(t, overlapsCoverage(jobs, name, cov), "type %s scheduled a job overlapping existing coverage", name)
+	}
+
+	require.Zero(t, countJobs(jobs, "Covered"), "caught-up type must not be re-dumped")
+
+	laggingFrom, ok := firstJobFrom(jobs, "Lagging")
+	require.True(t, ok, "lagging type must be dumped")
+	require.Equal(t, uint64(2_700_000), laggingFrom, "lagging type must resume at its coverage end")
+	require.Equal(t, uint64((10_400_000-2_700_000)/blocksPerFile), countJobs(jobs, "Lagging"))
+
+	emptyFrom, ok := firstJobFrom(jobs, "Empty")
+	require.True(t, ok, "empty type must be dumped from genesis")
+	require.Equal(t, uint64(0), emptyFrom)
+	require.Equal(t, uint64(10_400_000/blocksPerFile), countJobs(jobs, "Empty"))
+}
+
+// A gap between existing segments must be filled, without re-dumping (and thus
+// overlapping) a larger already-present segment that follows the gap.
+func TestPlanStateDumpFillsGapWithoutOverlap(t *testing.T) {
+	const blocksPerFile = 50_000
+	covered := []Range{
+		{from: 0, to: 7_150_000},
+		{from: 7_200_000, to: 10_400_000}, // 7.15M..7.2M missing; tail is one large segment
+	}
+	jobs := planStateDump(map[string][]Range{"X": covered}, 10_400_000, blocksPerFile)
+
+	require.Equal(t, uint64(1), countJobs(jobs, "X"), "only the single missing file should be scheduled")
+	from, _ := firstJobFrom(jobs, "X")
+	require.Equal(t, uint64(7_150_000), from)
+	require.False(t, overlapsCoverage(jobs, "X", covered))
+}
+
+// An unaligned coverage tail must resume exactly at its end, never flooring to a
+// file boundary below it (which would overlap the existing tail).
+func TestPlanStateDumpUnalignedResumeHasNoOverlap(t *testing.T) {
+	const blocksPerFile = 50_000
+	covered := []Range{{from: 0, to: 2_725_000}}
+	jobs := planStateDump(map[string][]Range{"X": covered}, 2_825_000, blocksPerFile)
+
+	from, ok := firstJobFrom(jobs, "X")
+	require.True(t, ok)
+	require.Equal(t, uint64(2_725_000), from, "must resume at coverage end, not floor below it")
+	require.False(t, overlapsCoverage(jobs, "X", covered))
+}
+
+func TestMissingRanges(t *testing.T) {
+	require.Equal(t, []Range(nil), missingRanges([]Range{{from: 0, to: 100}}, 100), "fully covered → nothing missing")
+	require.Equal(t, []Range{{from: 0, to: 100}}, missingRanges(nil, 100), "empty → all missing")
+	require.Equal(t, []Range{{from: 70, to: 100}}, missingRanges([]Range{{from: 0, to: 70}}, 100), "trailing tail")
+	require.Equal(t, []Range{{from: 50, to: 60}}, missingRanges([]Range{{from: 0, to: 50}, {from: 60, to: 100}}, 100), "interior gap only")
+	require.Equal(t, []Range(nil), missingRanges([]Range{{from: 0, to: 200}}, 100), "coverage beyond toSlot → nothing missing")
+}

--- a/db/snapshotsync/caplin_state_overlap_test.go
+++ b/db/snapshotsync/caplin_state_overlap_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshotsync
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dir2 "github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/recsplit"
+	"github.com/erigontech/erigon/db/seg"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/chain/networkname"
+	"github.com/erigontech/erigon/node/ethconfig"
+)
+
+func writeCaplinStateFixture(t *testing.T, dir, table string, from, to uint64, logger log.Logger) (segPath, idxPath string) {
+	t.Helper()
+	segName := strings.ReplaceAll(snaptype.BeaconBlocks.FileName(version.ZeroVersion, from, to), "beaconblocks", table)
+	segPath = filepath.Join(dir, segName)
+
+	compressCfg := seg.DefaultCfg
+	compressCfg.MinPatternScore = 100
+	c, err := seg.NewCompressor(t.Context(), "test", segPath, dir, compressCfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	defer c.Close()
+	c.DisableFsync()
+	require.NoError(t, c.AddWord([]byte{1}))
+	require.NoError(t, c.Compress())
+
+	idxPath = strings.ReplaceAll(segPath, ".seg", ".idx")
+	idx, err := recsplit.NewRecSplit(recsplit.RecSplitArgs{
+		KeyCount:   1,
+		BucketSize: 10,
+		TmpDir:     dir,
+		IndexFile:  idxPath,
+		LeafSize:   8,
+		BaseDataID: from,
+	}, logger)
+	require.NoError(t, err)
+	defer idx.Close()
+	idx.DisableFsync()
+	require.NoError(t, idx.AddKey([]byte{1}, 0))
+	require.NoError(t, idx.Build(t.Context()))
+	return segPath, idxPath
+}
+
+// hasDiskOverlap mirrors the publishable integrity check (cmd/utils/app/publishable_check.go):
+// it walks the real directory, sorts by (from,to), and reports whether any file's range
+// starts before the previous file's end.
+func hasDiskOverlap(t *testing.T, dir, table string) bool {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	type rng struct{ from, to uint64 }
+	var rs []rng
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) != ".seg" {
+			continue
+		}
+		fi, _, ok := snaptype.ParseFileName(dir, e.Name())
+		if !ok || fi.CaplinTypeString != table {
+			continue
+		}
+		rs = append(rs, rng{fi.From, fi.To})
+	}
+	sort.Slice(rs, func(i, j int) bool {
+		return rs[i].from < rs[j].from || (rs[i].from == rs[j].from && rs[i].to < rs[j].to)
+	})
+	for i := 1; i < len(rs); i++ {
+		if rs[i].from < rs[i-1].to {
+			return true
+		}
+	}
+	return false
+}
+
+func openTestCaplinStateSnapshots(t *testing.T, dirs datadir.Dirs, table string, logger log.Logger) *CaplinStateSnapshots {
+	t.Helper()
+	types := SnapshotTypes{
+		KeyValueGetters: map[string]KeyValueGetter{table: nil},
+		Compression:     map[string]bool{},
+	}
+	s := NewCaplinStateSnapshots(ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}, nil, dirs, types, logger)
+	t.Cleanup(s.Close)
+	require.NoError(t, s.OpenFolder())
+	return s
+}
+
+// A genesis-rooted superset that fully covers an interior/trailing subset must not
+// appear as two separate covered ranges: DirtySegmentLess sorts the superset first,
+// so the interior subset is the case the visible-list subset check must still hide.
+func TestCaplinStateRecalcHidesInteriorSubset(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 150_000, logger)
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 150_000, logger)
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+
+	ranges := s.coveredRangesForType(table)
+	require.Len(t, ranges, 1, "interior subset must be hidden by the covering superset")
+	require.Equal(t, Range{from: 0, to: 150_000}, ranges[0])
+}
+
+// RemoveOverlaps must physically delete a subset .seg/.idx that is fully covered by a
+// larger indexed segment of the same type, so the on-disk publishable check stops
+// reporting an overlap. Reproduces the Gnosis PendingDepositsDump failure.
+func TestCaplinStateRemoveOverlaps(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	// Published shape: genesis-rooted superset, an interior orphan subset that must
+	// go, and an abutting forward chunk that must stay (it is not a subset).
+	supSeg, supIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 150_000, logger)
+	subSeg, subIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 150_000, logger)
+	tailSeg, tailIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 150_000, 200_000, logger)
+
+	require.True(t, hasDiskOverlap(t, dirs.SnapCaplin, table), "fixture must reproduce the on-disk overlap")
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.NoError(t, s.RemoveOverlaps())
+
+	require.NoFileExists(t, subSeg)
+	require.NoFileExists(t, subIdx)
+	require.FileExists(t, supSeg)
+	require.FileExists(t, supIdx)
+	require.FileExists(t, tailSeg, "abutting non-subset chunk must be kept")
+	require.FileExists(t, tailIdx)
+	require.False(t, hasDiskOverlap(t, dirs.SnapCaplin, table), "overlap must be gone after RemoveOverlaps")
+
+	ranges := s.coveredRangesForType(table)
+	require.Equal(t, []Range{{from: 0, to: 150_000}, {from: 150_000, to: 200_000}}, ranges)
+}
+
+// A covered subset whose .idx is missing (e.g. a process killed between the .seg and
+// .idx writes) must still be removed, without panicking on the nil index entry.
+func TestCaplinStateRemoveOverlapsSubsetMissingIndex(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	supSeg, _ := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 150_000, logger)
+	subSeg, subIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 150_000, logger)
+	require.NoError(t, dir2.RemoveFile(subIdx)) // subset .seg present, .idx missing
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.NoError(t, s.RemoveOverlaps())
+
+	require.NoFileExists(t, subSeg, "covered subset must be removed even without its index")
+	require.FileExists(t, supSeg)
+	require.False(t, hasDiskOverlap(t, dirs.SnapCaplin, table))
+}
+
+// A subset must be kept when no fully-present indexed superset covers it: deleting it
+// would drop data. Here the "superset" lacks its .idx, so it is not usable yet.
+func TestCaplinStateRemoveOverlapsKeepsSubsetWithoutIndexedSuperset(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	supSeg, supIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 150_000, logger)
+	subSeg, _ := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 150_000, logger)
+	require.NoError(t, dir2.RemoveFile(supIdx)) // superset not indexed → not a valid cover
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.NoError(t, s.RemoveOverlaps())
+
+	require.FileExists(t, subSeg, "subset must survive when its superset is not indexed")
+	require.FileExists(t, supSeg)
+}

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -441,6 +441,9 @@ func (s *CaplinStateSnapshots) recalcVisibleFiles() {
 				if !isIndexed(sn) {
 					continue
 				}
+				if n := len(newVisibleSegments); n > 0 && sn.isSubSetOf(newVisibleSegments[n-1].src) {
+					continue
+				}
 				for len(newVisibleSegments) > 0 && newVisibleSegments[len(newVisibleSegments)-1].src.isSubSetOf(sn) {
 					newVisibleSegments[len(newVisibleSegments)-1].src = nil
 					newVisibleSegments = newVisibleSegments[:len(newVisibleSegments)-1]
@@ -463,6 +466,58 @@ func (s *CaplinStateSnapshots) recalcVisibleFiles() {
 		s.visible.Store(k, getNewVisibleSegments(s.dirty[k.(string)]))
 		return true
 	})
+}
+
+// RemoveOverlaps deletes state segment files that are fully covered by a larger
+// indexed segment of the same type, so the on-disk publishable check stops flagging
+// them as overlapping. Offline maintenance only: it munmaps and unlinks files, so no
+// CaplinStateView may be open concurrently.
+func (s *CaplinStateSnapshots) RemoveOverlaps() error {
+	if s == nil {
+		return nil
+	}
+	s.dirtySegmentsLock.Lock()
+
+	var toRemove []*DirtySegment
+	for _, dirtySegments := range s.dirty {
+		var indexed []*DirtySegment
+		dirtySegments.Walk(func(segments []*DirtySegment) bool {
+			for _, sn := range segments {
+				if isIndexed(sn) {
+					indexed = append(indexed, sn)
+				}
+			}
+			return true
+		})
+
+		var rm []*DirtySegment
+		dirtySegments.Walk(func(segments []*DirtySegment) bool {
+			for _, sn := range segments {
+				for _, sup := range indexed {
+					if sn != sup && sn.isSubSetOf(sup) {
+						rm = append(rm, sn)
+						break
+					}
+				}
+			}
+			return true
+		})
+
+		for _, sn := range rm {
+			dirtySegments.Delete(sn)
+		}
+		toRemove = append(toRemove, rm...)
+	}
+
+	s.dirtySegmentsLock.Unlock()
+
+	s.recalcVisibleFiles()
+
+	for _, sn := range toRemove {
+		s.logger.Info("[caplin-state] removing overlapped segment", "file", sn.FileName())
+		sn.closeAndRemoveFiles()
+	}
+	return nil
 }
 
 func (s *CaplinStateSnapshots) idxAvailability() uint64 {

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -262,6 +263,25 @@ func (s *CaplinStateSnapshots) SegFileNames(from, to uint64) []string {
 
 func (s *CaplinStateSnapshots) BlocksAvailable() uint64 {
 	return min(s.segmentsMax.Load(), s.idxMax.Load())
+}
+
+func (s *CaplinStateSnapshots) coveredRangesForType(name string) []Range {
+	s.visibleLock.RLock()
+	defer s.visibleLock.RUnlock()
+
+	v, ok := s.visible.Load(name)
+	if !ok {
+		return nil
+	}
+	segs, ok := v.([]*VisibleSegment)
+	if !ok {
+		return nil
+	}
+	ranges := make([]Range, 0, len(segs))
+	for _, seg := range segs {
+		ranges = append(ranges, seg.Range)
+	}
+	return ranges
 }
 
 func (s *CaplinStateSnapshots) Close() {
@@ -745,20 +765,65 @@ func simpleIdx(ctx context.Context, sn snaptype.FileInfo, salt uint32, tmpDir st
 	return nil
 }
 
-func (s *CaplinStateSnapshots) DumpCaplinState(ctx context.Context, fromSlot, toSlot, blocksPerFile uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
-	fromSlot = (fromSlot / blocksPerFile) * blocksPerFile
+type caplinStateDumpJob struct {
+	name     string
+	from, to uint64
+}
+
+// missingRanges returns the sub-ranges of [0, toSlot) not covered by `covered`
+// (the type's existing segment ranges, sorted by `from`).
+func missingRanges(covered []Range, toSlot uint64) []Range {
+	var missing []Range
+	var cur uint64
+	for _, r := range covered {
+		if r.from > cur {
+			gapEnd := min(r.from, toSlot)
+			missing = append(missing, Range{from: cur, to: gapEnd})
+		}
+		cur = max(cur, r.to)
+		if cur >= toSlot {
+			return missing
+		}
+	}
+	if cur < toSlot {
+		missing = append(missing, Range{from: cur, to: toSlot})
+	}
+	return missing
+}
+
+// planStateDump schedules only the ranges each type is missing within
+// [0, toSlot), starting every full file at a gap boundary so it fills holes and
+// the trailing tail without overlapping an existing segment.
+func planStateDump(coverage map[string][]Range, toSlot, blocksPerFile uint64) []caplinStateDumpJob {
 	toSlot = (toSlot / blocksPerFile) * blocksPerFile
-	for snapName, kvGetter := range s.snapshotTypes.KeyValueGetters {
-		for i := fromSlot; i < toSlot; i += blocksPerFile {
-			if toSlot-i < blocksPerFile {
-				break
+
+	names := make([]string, 0, len(coverage))
+	for name := range coverage {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	jobs := make([]caplinStateDumpJob, 0)
+	for _, name := range names {
+		for _, gap := range missingRanges(coverage[name], toSlot) {
+			for i := gap.from; i+blocksPerFile <= gap.to; i += blocksPerFile {
+				jobs = append(jobs, caplinStateDumpJob{name: name, from: i, to: i + blocksPerFile})
 			}
-			// keep beaconblocks here but whatever....
-			to := i + blocksPerFile
-			logger.Log(lvl, "Dumping "+snapName, "from", i, "to", to)
-			if err := dumpCaplinState(ctx, snapName, kvGetter, i, to, blocksPerFile, salt, dirs, workers, lvl, logger, s.snapshotTypes.Compression[snapName]); err != nil {
-				return err
-			}
+		}
+	}
+	return jobs
+}
+
+func (s *CaplinStateSnapshots) DumpCaplinState(ctx context.Context, toSlot, blocksPerFile uint64, salt uint32, dirs datadir.Dirs, workers int, lvl log.Lvl, logger log.Logger) error {
+	coverage := make(map[string][]Range, len(s.snapshotTypes.KeyValueGetters))
+	for name := range s.snapshotTypes.KeyValueGetters {
+		coverage[name] = s.coveredRangesForType(name)
+	}
+
+	for _, job := range planStateDump(coverage, toSlot, blocksPerFile) {
+		logger.Log(lvl, "Dumping "+job.name, "from", job.from, "to", job.to)
+		if err := dumpCaplinState(ctx, job.name, s.snapshotTypes.KeyValueGetters[job.name], job.from, job.to, blocksPerFile, salt, dirs, workers, lvl, logger, s.snapshotTypes.Compression[job.name]); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -402,6 +402,9 @@ func (s *DirtySegment) closeSeg() {
 
 func (s *DirtySegment) closeIdx() {
 	for _, index := range s.indexes {
+		if index == nil {
+			continue
+		}
 		index.Close()
 	}
 
@@ -420,6 +423,9 @@ func (s *DirtySegment) closeAndRemoveFiles() {
 		toRemove := make([]string, 0, 1+len(s.indexes))
 		toRemove = append(toRemove, s.FilePath())
 		for _, index := range s.indexes {
+			if index == nil {
+				continue
+			}
 			toRemove = append(toRemove, index.FilePath())
 		}
 		s.closeIdx()


### PR DESCRIPTION
Cherry-pick of #22256 (`e21f40c3dbab`) to `release/3.5`.

## r3.5-specific adaptations
Also cherry-picks its prerequisite #21901 (`270a20b084`, `coveredRangesForType`) — not present on release/3.5, needed for the test to typecheck.