### PR TITLE
[r3.5] db/downloader: lock torrentsByName write in AddNewSeedableFile

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -1306,6 +1306,11 @@ func (d *Downloader) addCompleteTorrent(
 		err = fmt.Errorf("loading metainfo from disk: %w", err)
 		return
 	}
+	// Hold d.lock only for the torrentsByName mutation, like the download add paths do,
+	// so it cannot race allActiveSnapshots' iteration (which holds only RLock). This is
+	// the sole caller path that reaches addTorrent without the caller already holding it.
+	d.lock.Lock()
+	defer d.lock.Unlock()
 	return d.addCompleteTorrentFromMetainfo(name, mi)
 }
 

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -96,6 +96,42 @@ func TestAllActiveSnapshotsConcurrentWithWrites(t *testing.T) {
 	}
 }
 
+// TestAddNewSeedableFileConcurrentWithAllActiveSnapshots pins that AddNewSeedableFile's
+// torrentsByName mutation holds d.lock, so it does not race allActiveSnapshots' iteration.
+// Without the lock the map write and the RLock'd read report a data race under -race — an
+// RLock cannot exclude a writer that holds no lock.
+func TestAddNewSeedableFileConcurrentWithAllActiveSnapshots(t *testing.T) {
+	test := newDownloaderTest(t)
+	d := test.downloader
+	ctx := t.Context()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				d.allActiveSnapshots()
+			}
+		}
+	}()
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
+
+	for i := range 64 {
+		name := fmt.Sprintf("v1-%06d-%06d-headers.seg", i, i+1)
+		require.NoError(t, os.WriteFile(filepath.Join(test.dirs.Snap, name), nil, 0o644))
+		require.NoError(t, d.AddNewSeedableFile(ctx, name))
+	}
+}
+
 func TestChangeInfoHashOfSameFile(t *testing.T) {
 	ctx := t.Context()
 	require := require.New(t)


### PR DESCRIPTION
Cherry-pick of #22192 to `release/3.5` — `1c7e33da296e`.