### PR TITLE
[r3.5] rpc/jsonrpc: executionWitness keys[] completeness gate

### DIFF
--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -426,6 +426,13 @@ func (s *RecordingState) accountExists(addr common.Address) bool {
 	return err != nil || acc != nil
 }
 
+// existedPreBlock reports parent-state presence regardless of in-block deletion, so a
+// pre-existing-but-deleted account still contributes its witness-trie preimage.
+func (s *RecordingState) existedPreBlock(addr common.Address) bool {
+	acc, err := s.inner.ReadAccountData(accounts.InternAddress(addr))
+	return err != nil || acc != nil
+}
+
 // --- Query methods ---
 
 // GetAccessedKeys returns all accessed account addresses and storage keys (reads + writes)
@@ -940,7 +947,7 @@ func collectAccessedState(rs *RecordingState, mode witnessMode) *accessedState {
 	}
 	witnessKeys := make([]hexutil.Bytes, 0, len(out.Addresses)+len(slotSet))
 	for addr := range out.Addresses {
-		if !rs.accountExists(addr) {
+		if !rs.accountExists(addr) && !rs.existedPreBlock(addr) {
 			continue
 		}
 		witnessKeys = append(witnessKeys, bytes.Clone(addr[:]))
@@ -1277,7 +1284,7 @@ func (api *DebugAPIImpl) verifyWitnessStateless(
 		return fmt.Errorf("failed to get chain config: %w", err)
 	}
 
-	newStateRoot, _, err := execBlockStatelessly(result, block, chainCfg, fullEngine)
+	newStateRoot, stateless, err := execBlockStatelessly(result, block, chainCfg, fullEngine)
 	if err != nil {
 		return fmt.Errorf("[debug_executionWitness] stateless block execution failed: %w", err)
 	}
@@ -1287,8 +1294,52 @@ func (api *DebugAPIImpl) verifyWitnessStateless(
 		return fmt.Errorf("[debug_executionWitness] state root mismatch after stateless execution : got %x, expected %x", newStateRoot, expectedRoot)
 	}
 
+	if stateless != nil {
+		if err := checkWitnessKeysComplete(stateless.usedTrieAddrs, stateless.usedTrieSlots, result.Keys); err != nil {
+			return fmt.Errorf("[debug_executionWitness] %w", err)
+		}
+	}
+
 	log.Debug("[debug_executionWitness] witness verified", "blockNum", block.NumberU64())
 	return nil
+}
+
+// checkWitnessKeysComplete verifies result.Keys carries a preimage for every account
+// and storage leaf the stateless re-execution resolved from the witness trie. A missing
+// preimage means a verifier treating keys[] as the closed accessed set cannot route to a
+// leaf that is present in state[]. The protocol system address is exempt (intentionally
+// omitted from keys[] unless it really changes).
+func checkWitnessKeysComplete(usedAddrs map[common.Address]struct{}, usedSlots map[common.Hash]struct{}, keys []hexutil.Bytes) error {
+	keyAddrs := make(map[common.Address]struct{})
+	keySlots := make(map[common.Hash]struct{})
+	for _, k := range keys {
+		switch len(k) {
+		case 20:
+			keyAddrs[common.BytesToAddress(k)] = struct{}{}
+		case 32:
+			keySlots[common.BytesToHash(k)] = struct{}{}
+		}
+	}
+	sysAddr := common.Address(params.SystemAddress.Value())
+	var missing []string
+	for addr := range usedAddrs {
+		if addr == sysAddr {
+			continue
+		}
+		if _, ok := keyAddrs[addr]; !ok {
+			missing = append(missing, addr.Hex())
+		}
+	}
+	for slot := range usedSlots {
+		if _, ok := keySlots[slot]; !ok {
+			missing = append(missing, slot.Hex())
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	slices.Sort(missing)
+	return fmt.Errorf("witness keys[] incomplete: %d preimage(s) for leaves present in state[] missing: %v", len(missing), missing)
 }
 
 // buildExpectedPostState queries the actual state DB to build expected post-state for verification.
@@ -1417,6 +1468,10 @@ type witnessStateless struct {
 	trace          bool
 	strictVerify   bool // error on trie nodes missing from the witness
 
+	// preimages the witness trie actually supplied during re-exec; keys[] must cover these
+	usedTrieAddrs map[common.Address]struct{}
+	usedTrieSlots map[common.Hash]struct{}
+
 	// Debug: addresses to trace operations on
 	accountsToTrace map[common.Address]struct{}
 }
@@ -1475,6 +1530,8 @@ func newWitnessStateless(result *ExecutionWitnessResult) (*witnessStateless, err
 		created:        make(map[common.Address]struct{}),
 		trace:          false,
 		strictVerify:   dbg.EnvBool("WITNESS_STRICT_VERIFY", false),
+		usedTrieAddrs:  make(map[common.Address]struct{}),
+		usedTrieSlots:  make(map[common.Hash]struct{}),
 	}, nil
 }
 
@@ -1525,6 +1582,9 @@ func (s *witnessStateless) ReadAccountData(address accounts.Address) (*accounts.
 
 	// Read from trie
 	acc, ok := s.t.GetAccount(addrHash[:])
+	if ok && acc != nil {
+		s.usedTrieAddrs[addr] = struct{}{}
+	}
 	if s.tracing(addr) {
 		if ok && acc != nil {
 			fmt.Printf("[TRACE-S] ReadAccountData %s -> trie nonce=%d balance=%d codeHash=%x\n", addr.Hex(), acc.Nonce, &acc.Balance, acc.CodeHash)
@@ -1581,6 +1641,7 @@ func (s *witnessStateless) ReadAccountStorage(address accounts.Address, key acco
 	// Read from trie
 	cKey := dbutils.GenerateCompositeTrieKey(addrHash, seckey)
 	if enc, ok := s.t.Get(cKey); ok {
+		s.usedTrieSlots[keyValue] = struct{}{}
 		var res uint256.Int
 		res.SetBytes(enc)
 		if s.tracing(addr) {

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -409,9 +409,8 @@ func (s *RecordingState) CreateContract(address accounts.Address) error {
 }
 
 // accountExists reports whether the account exists in the post-state: present and
-// non-nil in the write overlay, otherwise not deleted and present in the inner
-// (pre-block) reader. The inner reader is read directly so the check does not
-// re-mark AccessedAccounts.
+// non-nil in the write overlay, otherwise not deleted and present in the pre-block
+// (inner) reader.
 func (s *RecordingState) accountExists(addr common.Address) bool {
 	if _, deleted := s.DeletedAccounts[addr]; deleted {
 		return false
@@ -419,18 +418,28 @@ func (s *RecordingState) accountExists(addr common.Address) bool {
 	if acc, ok := s.accountOverlay[addr]; ok {
 		return acc != nil
 	}
+	return s.innerExists(addr)
+}
+
+// innerExists reports parent-state (pre-block) presence by reading the inner reader
+// directly, so the check does not re-mark AccessedAccounts. A read error counts as
+// existence: over-inclusion is harmless, a dropped key would make the witness incomplete.
+func (s *RecordingState) innerExists(addr common.Address) bool {
 	acc, err := s.inner.ReadAccountData(accounts.InternAddress(addr))
-	// A read error is unexpected for an account accessed this block; include the key
-	// rather than silently drop it — over-inclusion is harmless, a missing key would
-	// make the witness incomplete.
 	return err != nil || acc != nil
 }
 
-// existedPreBlock reports parent-state presence regardless of in-block deletion, so a
-// pre-existing-but-deleted account still contributes its witness-trie preimage.
-func (s *RecordingState) existedPreBlock(addr common.Address) bool {
-	acc, err := s.inner.ReadAccountData(accounts.InternAddress(addr))
-	return err != nil || acc != nil
+// hasWitnessLeaf reports whether addr has a leaf in the witness trie needing a keys[]
+// preimage: it exists in the post-state, or it existed pre-block (so an account emptied
+// and EIP-161 state-cleared in-block still contributes its parent-trie leaf). The inner
+// reader is consulted at most once.
+func (s *RecordingState) hasWitnessLeaf(addr common.Address) bool {
+	if _, deleted := s.DeletedAccounts[addr]; !deleted {
+		if acc, ok := s.accountOverlay[addr]; ok && acc != nil {
+			return true
+		}
+	}
+	return s.innerExists(addr)
 }
 
 // --- Query methods ---
@@ -947,7 +956,7 @@ func collectAccessedState(rs *RecordingState, mode witnessMode) *accessedState {
 	}
 	witnessKeys := make([]hexutil.Bytes, 0, len(out.Addresses)+len(slotSet))
 	for addr := range out.Addresses {
-		if !rs.accountExists(addr) && !rs.existedPreBlock(addr) {
+		if !rs.hasWitnessLeaf(addr) {
 			continue
 		}
 		witnessKeys = append(witnessKeys, bytes.Clone(addr[:]))
@@ -1339,7 +1348,13 @@ func checkWitnessKeysComplete(usedAddrs map[common.Address]struct{}, usedSlots m
 		return nil
 	}
 	slices.Sort(missing)
-	return fmt.Errorf("witness keys[] incomplete: %d preimage(s) for leaves present in state[] missing: %v", len(missing), missing)
+	const maxListed = 16
+	listed, suffix := missing, ""
+	if len(missing) > maxListed {
+		listed = missing[:maxListed]
+		suffix = fmt.Sprintf(" (+%d more)", len(missing)-maxListed)
+	}
+	return fmt.Errorf("witness keys[] incomplete: %d preimage(s) for leaves present in state[] missing: %v%s", len(missing), listed, suffix)
 }
 
 // buildExpectedPostState queries the actual state DB to build expected post-state for verification.

--- a/rpc/jsonrpc/debug_execution_witness_test.go
+++ b/rpc/jsonrpc/debug_execution_witness_test.go
@@ -18,6 +18,7 @@ package jsonrpc
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -52,6 +53,37 @@ func (r *fakeStateReader) ReadAccountIncarnation(address accounts.Address) (uint
 func (r *fakeStateReader) SetTrace(_ bool, _ string) {}
 func (r *fakeStateReader) Trace() bool               { return false }
 func (r *fakeStateReader) TracePrefix() string       { return "" }
+
+// countingStateReader counts ReadAccountData calls per address so a test can pin that the
+// witness-keys gate consults the pre-block reader at most once.
+type countingStateReader struct {
+	*fakeStateReader
+	reads map[common.Address]int
+}
+
+func (r *countingStateReader) ReadAccountData(address accounts.Address) (*accounts.Account, error) {
+	r.reads[address.Value()]++
+	return r.fakeStateReader.ReadAccountData(address)
+}
+
+// TestRecordingState_hasWitnessLeaf_SingleInnerRead pins the gate's single-read property:
+// an account absent from both pre- and post-state is excluded with exactly one inner read,
+// not the two a plain accountExists() || existedPreBlock() composition would issue.
+func TestRecordingState_hasWitnessLeaf_SingleInnerRead(t *testing.T) {
+	never := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	reader := &countingStateReader{
+		fakeStateReader: &fakeStateReader{accounts: map[common.Address]*accounts.Account{}},
+		reads:           map[common.Address]int{},
+	}
+	rs := NewRecordingState(reader)
+
+	if rs.hasWitnessLeaf(never) {
+		t.Fatal("account absent from pre- and post-state must be excluded from keys[]")
+	}
+	if got := reader.reads[never]; got != 1 {
+		t.Fatalf("hasWitnessLeaf consulted the pre-block reader %d times, want 1", got)
+	}
+}
 
 func TestRecordingState_accountExists(t *testing.T) {
 	existing := common.HexToAddress("0x1111111111111111111111111111111111111111")
@@ -294,6 +326,28 @@ func TestCheckWitnessKeysComplete(t *testing.T) {
 		usedS := map[common.Hash]struct{}{slotS: {}}
 		if err := checkWitnessKeysComplete(nil, usedS, []hexutil.Bytes{key32(slotS)}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("large missing list truncated, total preserved", func(t *testing.T) {
+		used := make(map[common.Address]struct{})
+		for i := 0; i < 50; i++ {
+			var a common.Address
+			a[19] = byte(i)
+			used[a] = struct{}{}
+		}
+		err := checkWitnessKeysComplete(used, nil, nil)
+		if err == nil {
+			t.Fatal("expected error: 50 accessed account leaves missing from keys[]")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "50 preimage(s)") {
+			t.Errorf("error must report the full count; got: %s", msg)
+		}
+		if !strings.Contains(msg, "more)") {
+			t.Errorf("error must mark the list as truncated; got: %s", msg)
+		}
+		if n := strings.Count(msg, "0x"); n > 16 {
+			t.Errorf("error listed %d preimages; want the list capped at 16", n)
 		}
 	})
 }

--- a/rpc/jsonrpc/debug_execution_witness_test.go
+++ b/rpc/jsonrpc/debug_execution_witness_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
@@ -172,8 +174,9 @@ func TestCollectAccessedState_Legacy7702Designator(t *testing.T) {
 }
 
 // TestCollectAccessedState_KeysOnlyExistingAccounts asserts that a 20-byte address
-// key is emitted only for accounts that exist post-state; accessed-but-nonexistent
-// addresses are excluded, while their accessed storage slots are still emitted.
+// key is emitted only for accounts represented in the witness trie (present in pre-
+// or post-state); an address that exists in neither is excluded, while its accessed
+// storage slots are still emitted.
 func TestCollectAccessedState_KeysOnlyExistingAccounts(t *testing.T) {
 	existing := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	missing := common.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -209,6 +212,90 @@ func TestCollectAccessedState_KeysOnlyExistingAccounts(t *testing.T) {
 	if !sawSlot {
 		t.Error("expected storage slot key to still be emitted for nonexistent account")
 	}
+}
+
+// TestCollectAccessedState_KeysIncludeDeletedPreExisting is a regression test for the
+// missing-preimage bug: an account present in the parent state but emptied and
+// state-cleared in-block (EIP-161) keeps its leaf in the parent-state witness trie,
+// so its 20-byte preimage must stay in keys[] even though it no longer exists
+// post-state. An account that never existed pre-state and is deleted in-block has no
+// parent-trie leaf and stays excluded.
+func TestCollectAccessedState_KeysIncludeDeletedPreExisting(t *testing.T) {
+	preExistingDeleted := common.HexToAddress("0x16fd7629978addaf41c426601176c37977a0faa7")
+	createdThenDeleted := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	inner := &fakeStateReader{accounts: map[common.Address]*accounts.Account{
+		preExistingDeleted: {Balance: *uint256.NewInt(1)},
+	}}
+	rs := NewRecordingState(inner)
+	rs.AccessedAccounts[preExistingDeleted] = struct{}{}
+	rs.DeletedAccounts[preExistingDeleted] = struct{}{}
+	rs.AccessedAccounts[createdThenDeleted] = struct{}{}
+	rs.DeletedAccounts[createdThenDeleted] = struct{}{}
+
+	accessed := collectAccessedState(rs, witnessModeLegacy)
+
+	var sawPreExisting, sawCreatedThenDeleted bool
+	for _, k := range accessed.WitnessKeys {
+		if len(k) != 20 {
+			continue
+		}
+		switch common.BytesToAddress(k) {
+		case preExistingDeleted:
+			sawPreExisting = true
+		case createdThenDeleted:
+			sawCreatedThenDeleted = true
+		}
+	}
+	if !sawPreExisting {
+		t.Error("preimage for a pre-existing account deleted in-block must remain in keys[]")
+	}
+	if sawCreatedThenDeleted {
+		t.Error("preimage for an account that never existed pre-state and was deleted in-block must be excluded")
+	}
+}
+
+// TestCheckWitnessKeysComplete pins the internal verifier's keys[]-completeness check:
+// every account/storage leaf the stateless re-execution resolved from the witness trie
+// must have its preimage in keys[]; the protocol system address is exempt.
+func TestCheckWitnessKeysComplete(t *testing.T) {
+	addrA := common.HexToAddress("0x16fd7629978addaf41c426601176c37977a0faa7")
+	addrB := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	slotS := common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000aa")
+	sys := common.Address(params.SystemAddress.Value())
+	key20 := func(a common.Address) hexutil.Bytes { return bytes.Clone(a[:]) }
+	key32 := func(h common.Hash) hexutil.Bytes { return bytes.Clone(h[:]) }
+
+	t.Run("missing account preimage flagged", func(t *testing.T) {
+		used := map[common.Address]struct{}{addrA: {}}
+		if err := checkWitnessKeysComplete(used, nil, nil); err == nil {
+			t.Fatal("expected error: accessed account leaf missing from keys[]")
+		}
+	})
+	t.Run("present account preimage ok", func(t *testing.T) {
+		used := map[common.Address]struct{}{addrA: {}}
+		if err := checkWitnessKeysComplete(used, nil, []hexutil.Bytes{key20(addrA)}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("system address exempt", func(t *testing.T) {
+		used := map[common.Address]struct{}{sys: {}}
+		if err := checkWitnessKeysComplete(used, nil, nil); err != nil {
+			t.Fatalf("system address must not require a preimage: %v", err)
+		}
+	})
+	t.Run("missing slot preimage flagged", func(t *testing.T) {
+		usedS := map[common.Hash]struct{}{slotS: {}}
+		if err := checkWitnessKeysComplete(nil, usedS, []hexutil.Bytes{key20(addrB)}); err == nil {
+			t.Fatal("expected error: accessed storage leaf missing from keys[]")
+		}
+	})
+	t.Run("present slot preimage ok", func(t *testing.T) {
+		usedS := map[common.Hash]struct{}{slotS: {}}
+		if err := checkWitnessKeysComplete(nil, usedS, []hexutil.Bytes{key32(slotS)}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestResolveWitnessMode(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of #22000 (`4c7fd2235080`) and #22022 (`425af38ca402`) to `release/3.5`. RPC-only; independent of the parallel-commitment fold.