### PR TITLE
[r3.5] execution: mid-block resume follow-ups with non-fatal prior-receipt reconstruction

### DIFF
--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -172,7 +172,9 @@ func ExecuteBlockEphemerally(
 
 	var bloom types.Bloom
 	if !vmConfig.NoReceipts {
-		bloom = types.CreateBloom(receipts)
+		// ApplyTransaction populated each receipt's Bloom, so merge those
+		// instead of hashing all logs again.
+		bloom = receipts.MergedBloom()
 		if !vmConfig.StatelessExec && bloom != header.Bloom {
 			return nil, fmt.Errorf("bloom computed by execution: %x, in header: %x", bloom, header.Bloom)
 		}

--- a/execution/receipts/derive.go
+++ b/execution/receipts/derive.go
@@ -143,12 +143,16 @@ func DeriveBlockReceipts(
 	return DeriveForRange(ctx, cfg, engine, header, txns, 0, len(txns), ibs, gp, getHeader)
 }
 
-// DeriveFields populates BlockHash and FirstLogIndexWithinBlock on each receipt.
-// ApplyTransactionWithEVM sets most receipt fields, but BlockHash and the
-// per-receipt first-log-index need a second pass once all receipts are known.
+// DeriveFields populates BlockHash, FirstLogIndexWithinBlock, and (when
+// missing) Bloom on each receipt. ApplyTransactionWithEVM sets most receipt
+// fields, but the first-log-index needs a second pass once all receipts are
+// known, and finalize-produced or cache-read receipts arrive without a bloom.
 func DeriveFields(receipts types.Receipts, blockHash common.Hash) {
 	for i, receipt := range receipts {
 		receipt.BlockHash = blockHash
+		if receipt.Bloom.IsEmpty() && len(receipt.Logs) > 0 {
+			receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+		}
 		if len(receipt.Logs) > 0 {
 			receipt.FirstLogIndexWithinBlock = uint32(receipt.Logs[0].Index)
 		} else if i > 0 {

--- a/execution/receipts/derive_test.go
+++ b/execution/receipts/derive_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package receipts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// DeriveFields must fill Bloom: finalize-produced and cache-read receipts
+// arrive without one, and the notification path publishes the set as-is.
+func TestDeriveFieldsSetsBloom(t *testing.T) {
+	withLogs := &types.Receipt{
+		Logs: []*types.Log{{
+			Address: common.HexToAddress("0x01"),
+			Topics:  []common.Hash{common.HexToHash("0x02")},
+		}},
+	}
+	noLogs := &types.Receipt{}
+	blockHash := common.HexToHash("0xabc")
+
+	DeriveFields(types.Receipts{withLogs, noLogs}, blockHash)
+
+	assert.NotEqual(t, types.Bloom{}, withLogs.Bloom)
+	assert.Equal(t, types.CreateBloom(types.Receipts{withLogs}), withLogs.Bloom)
+	assert.Equal(t, types.Bloom{}, noLogs.Bloom)
+	assert.Equal(t, blockHash, withLogs.BlockHash)
+	assert.Equal(t, blockHash, noLogs.BlockHash)
+}
+
+// Replay-produced receipts arrive with Bloom already computed; DeriveFields
+// must reuse it instead of hashing the same logs again.
+func TestDeriveFieldsPreservesExistingBloom(t *testing.T) {
+	var preset types.Bloom
+	preset[0] = 0x80
+	preset[types.BloomByteLength-1] = 0x01
+	withPresetBloom := &types.Receipt{
+		Bloom: preset,
+		Logs: []*types.Log{{
+			Address: common.HexToAddress("0x01"),
+			Topics:  []common.Hash{common.HexToHash("0x02")},
+		}},
+	}
+
+	DeriveFields(types.Receipts{withPresetBloom}, common.HexToHash("0xabc"))
+
+	assert.Equal(t, preset, withPresetBloom.Bloom)
+}

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -454,8 +454,15 @@ func (te *txExecutor) getHeader(ctx context.Context, hash common.Hash, number ui
 }
 
 // reconstructPriorReceipts re-derives receipts of a resumed block's prefix txs
-// (executed in an earlier batch): Finalize and the notification cache need the
-// block's full receipt set.
+// (executed in an earlier batch) so Finalize and the notification cache can see
+// the block's full receipt set.
+//
+// Best-effort. At a mid-block step boundary the committed domain latest is the
+// step-edge value, not the block-start pre-state, so the prefix is not always
+// reconstructable (and minimal nodes retain no receipts at all). Callers MUST
+// treat a failure as non-fatal: the node still resumes from a mid-step boundary
+// and the block's own receipts and cumulative gas stay correct — only the prior
+// receipts are absent (block then left not receipts-complete).
 func (te *txExecutor) reconstructPriorReceipts(ctx context.Context, applyTx kv.TemporalTx, header *types.Header, txs types.Transactions, startTxIndex int, blockStartTxNum uint64) (types.Receipts, error) {
 	priorIbs := state.New(state.NewHistoryReaderV3(applyTx, blockStartTxNum))
 	defer priorIbs.Release(true)

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -44,6 +44,7 @@ import (
 	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/receipts"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tracing"
@@ -450,6 +451,23 @@ func (te *txExecutor) getHeader(ctx context.Context, hash common.Hash, number ui
 	}
 
 	return h, nil
+}
+
+// reconstructPriorReceipts re-derives receipts of a resumed block's prefix txs
+// (executed in an earlier batch): Finalize and the notification cache need the
+// block's full receipt set.
+func (te *txExecutor) reconstructPriorReceipts(ctx context.Context, applyTx kv.TemporalTx, header *types.Header, txs types.Transactions, startTxIndex int, blockStartTxNum uint64) (types.Receipts, error) {
+	priorIbs := state.New(state.NewHistoryReaderV3(applyTx, blockStartTxNum))
+	defer priorIbs.Release(true)
+	priorGp := protocol.NewGasPool(header.GasLimit, te.cfg.chainConfig.GetMaxBlobGasPerBlock(header.Time))
+	getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
+		return te.cfg.blockReader.Header(ctx, applyTx, hash, number)
+	}
+	priorReceipts, err := receipts.DerivePriorReceipts(ctx, te.cfg.chainConfig, te.cfg.engine, header, txs, startTxIndex, blockStartTxNum, applyTx, priorIbs, priorGp, getHeader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconstruct prior receipts for partial block %d (startTxIndex %d): %w", header.Number.Uint64(), startTxIndex, err)
+	}
+	return priorReceipts, nil
 }
 
 func (te *txExecutor) onBlockStart(ctx context.Context, blockNum uint64, blockHash common.Hash) {

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/execution/exec"
 	"github.com/erigontech/erigon/execution/protocol"
 	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/receipts"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/tests/chaos_monkey"
 	"github.com/erigontech/erigon/execution/tracing"
@@ -572,7 +573,7 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 
 					}
 
-					if applyResult.BlockNum > 0 && !applyResult.isPartial && !execStage.CurrentSyncCycle.IsInitialCycle && applyResult.Header != nil {
+					if applyResult.BlockNum > 0 && applyResult.receiptsComplete && !execStage.CurrentSyncCycle.IsInitialCycle && applyResult.Header != nil {
 						pe.cfg.notifications.RecentReceipts.Add(applyResult.Receipts, applyResult.Txs, applyResult.Header)
 					}
 
@@ -1501,27 +1502,28 @@ func (pe *parallelExecutor) wait(ctx context.Context) error {
 type applyResult any
 
 type blockResult struct {
-	BlockNum        uint64
-	BlockTime       uint64
-	BlockHash       common.Hash
-	ParentHash      common.Hash
-	StateRoot       common.Hash
-	Err             error
-	BlockGasUsed    uint64
-	BlobGasUsed     uint64
-	lastTxNum       uint64
-	complete        bool
-	isPartial       bool
-	ApplyCount      int
-	TxIO            *state.VersionedIO
-	Receipts        types.Receipts
-	Stats           map[int]ExecutionStat
-	Deps            *state.DAG
-	AllDeps         map[int]map[int]bool
-	Exhausted       *ErrLoopExhausted
-	Header          *types.Header      // for accumulator.StartChange in apply loop
-	Txs             types.Transactions // for accumulator.StartChange in apply loop
-	blockStateCache *state.BlockStateCache
+	BlockNum         uint64
+	BlockTime        uint64
+	BlockHash        common.Hash
+	ParentHash       common.Hash
+	StateRoot        common.Hash
+	Err              error
+	BlockGasUsed     uint64
+	BlobGasUsed      uint64
+	lastTxNum        uint64
+	complete         bool
+	isPartial        bool
+	receiptsComplete bool
+	ApplyCount       int
+	TxIO             *state.VersionedIO
+	Receipts         types.Receipts
+	Stats            map[int]ExecutionStat
+	Deps             *state.DAG
+	AllDeps          map[int]map[int]bool
+	Exhausted        *ErrLoopExhausted
+	Header           *types.Header      // for accumulator.StartChange in apply loop
+	Txs              types.Transactions // for accumulator.StartChange in apply loop
+	blockStateCache  *state.BlockStateCache
 }
 
 type txResult struct {
@@ -1529,7 +1531,6 @@ type txResult struct {
 	blockHash             common.Hash
 	txNum                 uint64
 	blockGasUsed          int64
-	blobGasUsed           uint64
 	cumulativeBlobGasUsed uint64
 	receipt               *types.Receipt
 	logs                  []*types.Log
@@ -2488,12 +2489,21 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 				var cumulativeGasUsed uint64
 				var firstLogIndex uint32
-				if txVersion.TxIndex > 0 && !txTask.IsBlockEnd() {
-					if tx > 0 && be.tasks[tx-1].Task.Version().TxIndex >= 0 {
-						if prevRes := be.finalizedResults[tx-1]; prevRes != nil && prevRes.Receipt != nil {
-							cumulativeGasUsed = prevRes.Receipt.CumulativeGasUsed
-							firstLogIndex = prevRes.Receipt.FirstLogIndexWithinBlock + uint32(len(prevRes.Receipt.Logs))
+				// Receipt offsets only exist for real chain txs — finalize()
+				// skips receipt creation for other task types (tests), whose
+				// results legitimately carry no receipt.
+				_, isChainTx := txTask.(*exec.TxTask)
+				if isChainTx && txVersion.TxIndex > 0 && !txTask.IsBlockEnd() {
+					if tx > 0 {
+						// In-order finalization guarantees the previous regular tx
+						// already has its receipt; a miss means corrupted offsets
+						// would be persisted, so fail loudly instead.
+						prevRes := be.finalizedResults[tx-1]
+						if prevRes == nil || prevRes.Receipt == nil {
+							return nil, fmt.Errorf("parallel exec: missing finalized receipt for tx %d (task %d) in block %d", txVersion.TxIndex-1, tx-1, be.blockNum)
 						}
+						cumulativeGasUsed = prevRes.Receipt.CumulativeGasUsed
+						firstLogIndex = prevRes.Receipt.FirstLogIndexWithinBlock + uint32(len(prevRes.Receipt.Logs))
 					} else {
 						cumGasUsed, cumBlobGasUsed, logIndexAfterTx, err := rawtemporaldb.ReceiptAsOf(applyTx, txVersion.TxNum)
 						if err != nil {
@@ -2690,10 +2700,6 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				cumulativeBlobGasUsed: result.cumulativeBlobGasUsed,
 			}
 
-			if tx := result.Tx(); tx != nil {
-				applyResult.blobGasUsed = tx.GetBlobGas()
-			}
-
 			if result.Receipt != nil {
 				// EIP-8037 / EIP-7778: block-level gas is max(cum regular,
 				// cum state) — NOT sum of per-tx receipt gas. Receipt gas
@@ -2763,10 +2769,10 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 		txTask := be.tasks[len(be.tasks)-1].Task
 
-		var receipts types.Receipts
+		var blockReceipts types.Receipts
 		for _, txResult := range be.results {
 			if receipt := txResult.Receipt; receipt != nil {
-				receipts = append(receipts, receipt)
+				blockReceipts = append(blockReceipts, receipt)
 			}
 		}
 
@@ -2775,6 +2781,26 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 		if tt, ok := txTask.(*exec.TxTask); ok {
 			header = tt.Header
 			txs = tt.Txs
+		}
+
+		receiptsComplete := !isPartial
+		if isPartial && be.blockNum > 0 && header != nil {
+			startTxIndex := be.tasks[0].Version().TxIndex
+			receiptsComplete = startTxIndex == 0
+			if startTxIndex > 0 && len(txs) > 0 {
+				blockStartTxNum := be.tasks[0].Version().TxNum - uint64(startTxIndex)
+				priorReceipts, err := pe.reconstructPriorReceipts(ctx, applyTx, header, txs, startTxIndex, blockStartTxNum)
+				if err != nil {
+					return nil, err
+				}
+				blockReceipts = append(priorReceipts, blockReceipts...)
+				receiptsComplete = true
+			}
+			// The post-exec validator, which fills receipt blooms for full
+			// blocks, skips partial ones — complete the published set here.
+			if receiptsComplete {
+				receipts.DeriveFields(blockReceipts, be.blockHash)
+			}
 		}
 
 		// Block finalize: run engine.Finalize + MakeWriteSet on the producer
@@ -2834,7 +2860,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 
 				chainReader := consensuschain.NewReader(pe.cfg.chainConfig, applyTx, pe.cfg.blockReader, pe.logger)
 				if _, err := pe.cfg.engine.Finalize(
-					pe.cfg.chainConfig, types.CopyHeader(tt.Header), ibs, tt.Uncles, receipts,
+					pe.cfg.chainConfig, types.CopyHeader(tt.Header), ibs, tt.Uncles, blockReceipts,
 					tt.Withdrawals, chainReader, syscall, false, pe.logger); err != nil {
 					return be.invalidBlockResult(fmt.Errorf("%w: can't finalize block %d: %v", rules.ErrInvalidBlock, be.blockNum, err)), nil
 				}
@@ -2893,26 +2919,27 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 		}
 
 		be.result = &blockResult{
-			BlockNum:        be.blockNum,
-			BlockTime:       txTask.BlockTime(),
-			BlockHash:       txTask.BlockHash(),
-			ParentHash:      txTask.ParentHash(),
-			StateRoot:       txTask.BlockRoot(),
-			BlockGasUsed:    be.blockGasUsed,
-			BlobGasUsed:     be.blobGasUsed,
-			lastTxNum:       txTask.Version().TxNum,
-			complete:        true,
-			isPartial:       isPartial,
-			ApplyCount:      be.applyCount,
-			TxIO:            be.blockIO,
-			Receipts:        receipts,
-			Stats:           be.stats,
-			Deps:            &deps,
-			AllDeps:         allDeps,
-			Exhausted:       be.exhausted,
-			Header:          header,
-			Txs:             txs,
-			blockStateCache: be.blockStateCache,
+			BlockNum:         be.blockNum,
+			BlockTime:        txTask.BlockTime(),
+			BlockHash:        txTask.BlockHash(),
+			ParentHash:       txTask.ParentHash(),
+			StateRoot:        txTask.BlockRoot(),
+			BlockGasUsed:     be.blockGasUsed,
+			BlobGasUsed:      be.blobGasUsed,
+			lastTxNum:        txTask.Version().TxNum,
+			complete:         true,
+			isPartial:        isPartial,
+			ApplyCount:       be.applyCount,
+			TxIO:             be.blockIO,
+			Receipts:         blockReceipts,
+			receiptsComplete: receiptsComplete,
+			Stats:            be.stats,
+			Deps:             &deps,
+			AllDeps:          allDeps,
+			Exhausted:        be.exhausted,
+			Header:           header,
+			Txs:              txs,
+			blockStateCache:  be.blockStateCache,
 		}
 		return be.result, nil
 	}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2791,16 +2791,17 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				blockStartTxNum := be.tasks[0].Version().TxNum - uint64(startTxIndex)
 				priorReceipts, err := pe.reconstructPriorReceipts(ctx, applyTx, header, txs, startTxIndex, blockStartTxNum)
 				if err != nil {
-					return nil, err
+					pe.logger.Warn("["+pe.logPrefix+"] failed to reconstruct prior receipts for partial block",
+						"block", be.blockNum, "startTxIndex", startTxIndex, "err", err)
+				} else {
+					blockReceipts = append(priorReceipts, blockReceipts...)
+					receiptsComplete = true
 				}
-				blockReceipts = append(priorReceipts, blockReceipts...)
-				receiptsComplete = true
 			}
 			// The post-exec validator, which fills receipt blooms for full
-			// blocks, skips partial ones — complete the published set here.
-			if receiptsComplete {
-				receipts.DeriveFields(blockReceipts, be.blockHash)
-			}
+			// blocks, skips partial ones — do it here, even when prior receipts
+			// couldn't be reconstructed (the suffix receipts still need blooms).
+			receipts.DeriveFields(blockReceipts, be.blockHash)
 		}
 
 		// Block finalize: run engine.Finalize + MakeWriteSet on the producer

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dir"
@@ -1354,41 +1355,75 @@ func BenchmarkDexScenarioWithMetadata(b *testing.B) {
 	testExecutorCombWithMetadata(b, totalTxs, numReads, numWrites, numNonIO, taskRunner, logger)
 }
 
-func TestParallelResumeBoundaryAndNotifications(t *testing.T) {
+// newResumeTestDB builds the temporal DB stack the resume tests run against.
+func newResumeTestDB(t *testing.T) kv.TemporalRwDB {
 	if runtime.GOOS == "windows" {
-		t.Skip()
+		t.Skip("mdbx InMem test databases are not supported on windows")
 	}
-	assert := assert.New(t)
 	logger := log.New()
-	tmpDir, err := os.MkdirTemp("", "erigon-parallel-test-*")
-	assert.NoError(err)
-	defer dir.RemoveAll(tmpDir)
-
-	dirs := datadir.New(tmpDir)
+	dirs := datadir.New(t.TempDir())
 	rawDb := mdbx.New(dbcfg.ChainDB, logger).InMem(t, dirs.Chaindata).MustOpen()
-	defer rawDb.Close()
+	t.Cleanup(rawDb.Close)
 
 	agg, err := dbstate.NewTest(dirs).StepSize(16).Logger(logger).Open(context.Background(), rawDb)
-	assert.NoError(err)
-	defer agg.Close()
+	require.NoError(t, err)
+	t.Cleanup(agg.Close)
 
 	db, err := temporal.New(rawDb, agg)
-	assert.NoError(err)
+	require.NoError(t, err)
+	return db
+}
 
-	// Write mock receipt for transaction 0 in the database at txNum = 1
-	err = db.UpdateTemporal(context.Background(), func(rwTx kv.TemporalRwTx) error {
-		domains, err := execctx.NewSharedDomains(context.Background(), rwTx, logger)
+func seedResumeTestDB(t *testing.T, db kv.TemporalRwDB, seed func(putter kv.TemporalPutDel) error) {
+	err := db.UpdateTemporal(context.Background(), func(rwTx kv.TemporalRwTx) error {
+		domains, err := execctx.NewSharedDomains(context.Background(), rwTx, log.New())
 		if err != nil {
 			return err
 		}
 		defer domains.Close()
-		putter := domains.AsPutDel(rwTx)
-		if err := rawtemporaldb.AppendReceipt(putter, 5, 21000, 12000, 1); err != nil {
+		if err := seed(domains.AsPutDel(rwTx)); err != nil {
 			return err
 		}
 		return domains.Flush(context.Background(), rwTx)
 	})
-	assert.NoError(err)
+	require.NoError(t, err)
+}
+
+// newResumeTestExec opens a read view over db (call after seeding) and wires a
+// parallelExecutor around it.
+func newResumeTestExec(t *testing.T, db kv.TemporalRwDB, config *chain.Config) (*parallelExecutor, kv.TemporalTx) {
+	logger := log.New()
+	roTx, err := db.BeginTemporalRo(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(roTx.Rollback)
+
+	domains, err := execctx.NewSharedDomains(context.Background(), roTx, logger)
+	require.NoError(t, err)
+	t.Cleanup(domains.Close)
+
+	pe := &parallelExecutor{
+		txExecutor: txExecutor{
+			cfg: ExecuteBlockCfg{
+				chainConfig: config,
+				db:          db,
+				engine:      ethash.NewFaker(),
+			},
+			doms:   domains,
+			rs:     state.NewStateV3Buffered(state.NewStateV3(domains, false, logger)),
+			logger: logger,
+		},
+	}
+	return pe, roTx
+}
+
+func TestParallelResumeBoundaryOffsets(t *testing.T) {
+	assert := assert.New(t)
+	db := newResumeTestDB(t)
+
+	// Write mock receipt for transaction 0 in the database at txNum = 1
+	seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
+		return rawtemporaldb.AppendReceipt(putter, 5, 21000, 12000, 1)
+	})
 
 	chainSpec, _ := chainspec.ChainSpecByName(networkname.Mainnet)
 
@@ -1409,32 +1444,10 @@ func TestParallelResumeBoundaryAndNotifications(t *testing.T) {
 		},
 	}
 
-	// Open read transaction for execution
-	roTx, err := db.BeginTemporalRo(context.Background())
-	assert.NoError(err)
-	defer roTx.Rollback()
-
-	domains, err := execctx.NewSharedDomains(context.Background(), roTx, logger)
-	assert.NoError(err)
-	defer domains.Close()
-
-	pe := &parallelExecutor{
-		txExecutor: txExecutor{
-			cfg: ExecuteBlockCfg{
-				chainConfig: chainSpec.Config,
-				db:          db,
-				engine:      ethash.NewFaker(),
-			},
-			doms:   domains,
-			rs:     state.NewStateV3Buffered(state.NewStateV3(domains, false, logger)),
-			logger: logger,
-		},
-		workerCount: runtime.NumCPU() - 1,
-	}
+	pe, roTx := newResumeTestExec(t, db, chainSpec.Config)
 
 	gasPool := new(protocol.GasPool).AddGas(10_000_000)
 
-	// Run nextResult
 	be := newBlockExec(0, common.Hash{}, gasPool, nil, make(chan applyResult, 1), nil, false, nil)
 	eTask := &execTask{
 		Task:  txTask,
@@ -1443,8 +1456,6 @@ func TestParallelResumeBoundaryAndNotifications(t *testing.T) {
 	be.tasks = []*execTask{eTask}
 	be.results = []*execResult{nil}
 	be.execTasks.inProgress = []int{0}
-	be.validateTasks.inProgress = []int{0}
-	be.publishTasks.pending = []int{0}
 
 	tVersion := &taskVersion{
 		execTask: eTask,
@@ -1456,16 +1467,13 @@ func TestParallelResumeBoundaryAndNotifications(t *testing.T) {
 		},
 	}
 
-	// Populate a mock test result in be.results[0]
 	txResult := &exec.TxResult{
 		Task: tVersion,
 		ExecutionResult: evmtypes.ExecutionResult{
 			ReceiptGasUsed: 10000,
 		},
 	}
-	be.results[0] = &execResult{TxResult: txResult}
 
-	// execute nextResult sequentially
 	res, err := be.nextResult(context.Background(), pe, txResult, roTx)
 	assert.NoError(err)
 	assert.NotNil(res)
@@ -1478,6 +1486,217 @@ func TestParallelResumeBoundaryAndNotifications(t *testing.T) {
 	assert.Equal(uint32(5), txResult.Receipt.FirstLogIndexWithinBlock)
 	assert.Equal(uint64(12000), be.blobGasUsed)
 
-	// Verify notification behavior: since it's a partial block, it should be marked as partial
+	// The resumed block is flagged partial; with no prefix reconstruction
+	// (blockNum 0 skips it) its receipts stay incomplete, which is what gates
+	// RecentReceipts.Add in the apply loop.
 	assert.True(res.isPartial)
+	assert.False(res.receiptsComplete)
+}
+
+// TestParallelResumeReconstructsPriorReceipts pins the block-end prefix
+// reconstruction for resumed blocks: receipts of transactions executed in an
+// earlier batch are re-derived so that engine.Finalize and the notification
+// cache see the complete set, mirroring the serial executor.
+func TestParallelResumeReconstructsPriorReceipts(t *testing.T) {
+	assert := assert.New(t)
+	db := newResumeTestDB(t)
+
+	config := chain.TestChainBerlinConfig
+	tx0 := signSelfSendTx(t, 0, 0, 1, 21000, config, 0)
+	tx1 := signSelfSendTx(t, 1, 0, 1, 21000, config, 0)
+
+	// Fund the sender at txNum 0 and store tx0's receipt values at txNum 1,
+	// simulating a batch that committed mid-block after tx0.
+	seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
+		acc := accounts.NewAccount()
+		acc.Balance = *uint256.NewInt(1_000_000_000)
+		if err := putter.DomainPut(kv.AccountsDomain, senderIsCoinbaseKey.rawAddress[:], accounts.SerialiseV3(&acc), 0, nil); err != nil {
+			return err
+		}
+		return rawtemporaldb.AppendReceipt(putter, 0, 21000, 0, 1)
+	})
+
+	txTask := &exec.TxTask{
+		Header: &types.Header{
+			Number:   *uint256.NewInt(1),
+			GasLimit: 10_000_000,
+		},
+		TxNum:   2,
+		TxIndex: 1,
+		Config:  config,
+		Txs:     []types.Transaction{tx0, tx1},
+	}
+
+	pe, roTx := newResumeTestExec(t, db, config)
+
+	gasPool := new(protocol.GasPool).AddGas(10_000_000)
+
+	be := newBlockExec(1, common.Hash{}, gasPool, nil, make(chan applyResult, 4), nil, false, nil)
+	eTask := &execTask{
+		Task:  txTask,
+		index: 0,
+	}
+	be.tasks = []*execTask{eTask}
+	be.results = []*execResult{nil}
+	be.execTasks.inProgress = []int{0}
+
+	tVersion := &taskVersion{
+		execTask: eTask,
+		version: state.Version{
+			BlockNum:    1,
+			TxIndex:     1,
+			Incarnation: 1,
+			TxNum:       2,
+		},
+	}
+
+	txResult := &exec.TxResult{
+		Task: tVersion,
+		ExecutionResult: evmtypes.ExecutionResult{
+			ReceiptGasUsed: 10000,
+		},
+	}
+
+	res, err := be.nextResult(context.Background(), pe, txResult, roTx)
+	assert.NoError(err)
+	assert.NotNil(res)
+
+	assert.True(res.isPartial)
+	assert.True(res.receiptsComplete)
+	if assert.Len(res.Receipts, 2) {
+		assert.Equal(uint(0), res.Receipts[0].TransactionIndex)
+		assert.Equal(uint64(21000), res.Receipts[0].CumulativeGasUsed)
+		assert.Equal(uint(1), res.Receipts[1].TransactionIndex)
+		assert.Equal(uint64(31000), res.Receipts[1].CumulativeGasUsed)
+	}
+}
+
+// TestParallelResumeReconstructionFailureErrors pins the failure policy when
+// prior receipts cannot be reconstructed: the batch must fail with the
+// reconstruction error instead of proceeding into a receipts-dependent
+// Finalize (post-Prague requests hash, AuRa epoch signal) that would
+// misclassify the valid block as invalid.
+func TestParallelResumeReconstructionFailureErrors(t *testing.T) {
+	assert := assert.New(t)
+	db := newResumeTestDB(t)
+
+	config := chain.TestChainBerlinConfig
+	tx0 := signSelfSendTx(t, 0, 0, 1, 21000, config, 0)
+	tx1 := signSelfSendTx(t, 1, 0, 1, 21000, config, 0)
+
+	// Store tx0's receipt values but leave the sender unfunded: the RCacheV2
+	// probe misses and the prefix replay fails on insufficient funds.
+	seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
+		return rawtemporaldb.AppendReceipt(putter, 0, 21000, 0, 1)
+	})
+
+	txTask := &exec.TxTask{
+		Header: &types.Header{
+			Number:   *uint256.NewInt(1),
+			GasLimit: 10_000_000,
+		},
+		TxNum:   2,
+		TxIndex: 1,
+		Config:  config,
+		Txs:     []types.Transaction{tx0, tx1},
+	}
+
+	pe, roTx := newResumeTestExec(t, db, config)
+
+	gasPool := new(protocol.GasPool).AddGas(10_000_000)
+
+	be := newBlockExec(1, common.Hash{}, gasPool, nil, make(chan applyResult, 4), nil, false, nil)
+	eTask := &execTask{
+		Task:  txTask,
+		index: 0,
+	}
+	be.tasks = []*execTask{eTask}
+	be.results = []*execResult{nil}
+	be.execTasks.inProgress = []int{0}
+
+	tVersion := &taskVersion{
+		execTask: eTask,
+		version: state.Version{
+			BlockNum:    1,
+			TxIndex:     1,
+			Incarnation: 1,
+			TxNum:       2,
+		},
+	}
+
+	txResult := &exec.TxResult{
+		Task: tVersion,
+		ExecutionResult: evmtypes.ExecutionResult{
+			ReceiptGasUsed: 10000,
+		},
+	}
+
+	res, err := be.nextResult(context.Background(), pe, txResult, roTx)
+	assert.ErrorContains(err, "reconstruct prior receipts")
+	assert.Nil(res)
+}
+
+// TestParallelFinalizeMissingPrevReceiptErrors pins the failure mode when the
+// in-order finalize invariant is broken: a missing previous receipt must fail
+// loudly instead of silently writing zero-based offsets — the corruption class
+// the resume-boundary fallback eliminates.
+func TestParallelFinalizeMissingPrevReceiptErrors(t *testing.T) {
+	assert := assert.New(t)
+	db := newResumeTestDB(t)
+
+	config := chain.TestChainBerlinConfig
+	signedTx := signSelfSendTx(t, 0, 0, 1, 21000, config, 0)
+
+	header := &types.Header{
+		Number:   *uint256.NewInt(1),
+		GasLimit: 10_000_000,
+	}
+	mkTask := func(index, txIndex int, txNum uint64) (*execTask, *taskVersion) {
+		eTask := &execTask{
+			Task: &exec.TxTask{
+				Header:  header,
+				TxNum:   txNum,
+				TxIndex: txIndex,
+				Config:  config,
+				Txs:     []types.Transaction{signedTx, signedTx, signedTx},
+			},
+			index: index,
+		}
+		return eTask, &taskVersion{
+			execTask: eTask,
+			version: state.Version{
+				TxIndex:     txIndex,
+				Incarnation: 1,
+				TxNum:       txNum,
+			},
+		}
+	}
+	eTask0, tVersion0 := mkTask(0, 1, 2)
+	eTask1, tVersion1 := mkTask(1, 2, 3)
+
+	pe, roTx := newResumeTestExec(t, db, config)
+
+	gasPool := new(protocol.GasPool).AddGas(10_000_000)
+
+	be := newBlockExec(0, common.Hash{}, gasPool, nil, make(chan applyResult, 1), nil, false, nil)
+	be.tasks = []*execTask{eTask0, eTask1}
+	be.results = []*execResult{nil, nil}
+	// tx 0 was "finalized" without a receipt — the invariant nextResult
+	// relies on for the in-memory prev-receipt lookup is broken.
+	be.finalizedResults[0] = &execResult{TxResult: &exec.TxResult{Task: tVersion0}}
+	be.execTasks.complete = []int{0}
+	be.execTasks.inProgress = []int{1}
+
+	txResult1 := &exec.TxResult{
+		Task: tVersion1,
+		ExecutionResult: evmtypes.ExecutionResult{
+			ReceiptGasUsed: 10000,
+		},
+	}
+
+	res, err := be.nextResult(context.Background(), pe, txResult1, roTx)
+	// The message must name the block-level tx index (prev tx = TxIndex 1),
+	// not the batch-local task index (0).
+	assert.ErrorContains(err, "missing finalized receipt for tx 1")
+	assert.Nil(res)
 }

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1571,12 +1571,11 @@ func TestParallelResumeReconstructsPriorReceipts(t *testing.T) {
 	}
 }
 
-// TestParallelResumeReconstructionFailureErrors pins the failure policy when
-// prior receipts cannot be reconstructed: the batch must fail with the
-// reconstruction error instead of proceeding into a receipts-dependent
-// Finalize (post-Prague requests hash, AuRa epoch signal) that would
-// misclassify the valid block as invalid.
-func TestParallelResumeReconstructionFailureErrors(t *testing.T) {
+// TestParallelResumeReconstructionFailureIsNonFatal pins the failure policy when
+// prior receipts cannot be reconstructed: reconstruction is best-effort, so the
+// batch proceeds (prior receipts absent, block left not receipts-complete)
+// rather than halting the node mid-step. See reconstructPriorReceipts.
+func TestParallelResumeReconstructionFailureIsNonFatal(t *testing.T) {
 	assert := assert.New(t)
 	db := newResumeTestDB(t)
 
@@ -1632,8 +1631,10 @@ func TestParallelResumeReconstructionFailureErrors(t *testing.T) {
 	}
 
 	res, err := be.nextResult(context.Background(), pe, txResult, roTx)
-	assert.ErrorContains(err, "reconstruct prior receipts")
-	assert.Nil(res)
+	assert.NoError(err)
+	if assert.NotNil(res) {
+		assert.False(res.receiptsComplete)
+	}
 }
 
 // TestParallelFinalizeMissingPrevReceiptErrors pins the failure mode when the

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -393,27 +393,21 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 
 				chainReader := consensuschain.NewReader(se.cfg.chainConfig, se.applyTx, se.cfg.blockReader, se.logger)
 
-				// For partial blocks (resuming from snapshot boundary), reconstruct
-				// prior receipts so Finalize receives the full receipt set for requests
-				// hash computation (deposit extraction from logs). See #20452.
 				finalizeReceipts := blockReceipts
+				priorComplete := startTxIndex == 0
 				if startTxIndex > 0 && len(txTask.Txs) > 0 {
 					firstTask := tasks[0].(*exec.TxTask)
 					blockStartTxNum := firstTask.TxNum - uint64(firstTask.TxIndex)
-					reader := state.NewHistoryReaderV3(se.applyTx, blockStartTxNum)
-					priorIbs := state.New(reader)
-					defer priorIbs.Release(true)
-					priorGp := protocol.NewGasPool(txTask.Header.GasLimit, se.cfg.chainConfig.GetMaxBlobGasPerBlock(txTask.Header.Time))
-					getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
-						return se.cfg.blockReader.Header(ctx, se.applyTx, hash, number)
-					}
-					priorReceipts, priorErr := receipts.DerivePriorReceipts(ctx, se.cfg.chainConfig, se.cfg.engine, txTask.Header, txTask.Txs, startTxIndex, blockStartTxNum, se.applyTx, priorIbs, priorGp, getHeader)
+					priorReceipts, priorErr := se.reconstructPriorReceipts(ctx, se.applyTx, txTask.Header, txTask.Txs, startTxIndex, blockStartTxNum)
 					if priorErr != nil {
-						se.logger.Warn(fmt.Sprintf("[%s] failed to reconstruct prior receipts for partial block", se.logPrefix),
-							"block", txTask.BlockNumber(), "startTxIndex", startTxIndex, "err", priorErr)
-					} else {
-						finalizeReceipts = append(priorReceipts, blockReceipts...)
+						return priorErr
 					}
+					finalizeReceipts = append(priorReceipts, blockReceipts...)
+					// The post-exec validator, which fills receipt blooms for
+					// full blocks, runs only when startTxIndex == 0 — complete
+					// the published set here.
+					receipts.DeriveFields(finalizeReceipts, txTask.BlockHash())
+					priorComplete = true
 				}
 
 				_, err = se.cfg.engine.Finalize(
@@ -424,8 +418,8 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err)
 				}
 
-				if startTxIndex == 0 && !isInitialCycle {
-					se.cfg.notifications.RecentReceipts.Add(blockReceipts, txTask.Txs, txTask.Header)
+				if priorComplete && !isInitialCycle {
+					se.cfg.notifications.RecentReceipts.Add(finalizeReceipts, txTask.Txs, txTask.Header)
 				}
 				checkBloom := !se.cfg.vmConfig.StatelessExec && !se.cfg.vmConfig.NoReceipts
 				checkReceipts := checkBloom && se.cfg.chainConfig.IsByzantium(txTask.BlockNumber())
@@ -457,10 +451,13 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					}
 				} else if txTask.TxIndex > 0 {
 					// reconstruct receipt from previous receipt values
-					cumGasUsed, _, logIndexAfterTx, err := rawtemporaldb.ReceiptAsOf(se.applyTx, txTask.TxNum)
+					cumGasUsed, cumBlobGasUsed, logIndexAfterTx, err := rawtemporaldb.ReceiptAsOf(se.applyTx, txTask.TxNum)
 					if err != nil {
 						return err
 					}
+					// This tx's own blob gas was accumulated above; fold in the
+					// pre-resume cumulative so ApplyTxIndexes persists correct values.
+					se.blobGasUsed += cumBlobGasUsed
 					receipt, err = result.CreateReceipt(txTask.TxIndex, cumGasUsed+result.ExecutionResult.ReceiptGasUsed, logIndexAfterTx)
 					if err != nil {
 						return err

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -400,14 +400,16 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					blockStartTxNum := firstTask.TxNum - uint64(firstTask.TxIndex)
 					priorReceipts, priorErr := se.reconstructPriorReceipts(ctx, se.applyTx, txTask.Header, txTask.Txs, startTxIndex, blockStartTxNum)
 					if priorErr != nil {
-						return priorErr
+						se.logger.Warn(fmt.Sprintf("[%s] failed to reconstruct prior receipts for partial block", se.logPrefix),
+							"block", txTask.BlockNumber(), "startTxIndex", startTxIndex, "err", priorErr)
+					} else {
+						finalizeReceipts = append(priorReceipts, blockReceipts...)
+						priorComplete = true
 					}
-					finalizeReceipts = append(priorReceipts, blockReceipts...)
-					// The post-exec validator, which fills receipt blooms for
-					// full blocks, runs only when startTxIndex == 0 — complete
-					// the published set here.
+					// The post-exec validator, which fills receipt blooms for full
+					// blocks, skips partial ones — do it here, even when prior
+					// receipts couldn't be reconstructed (suffix still needs blooms).
 					receipts.DeriveFields(finalizeReceipts, txTask.BlockHash())
-					priorComplete = true
 				}
 
 				_, err = se.cfg.engine.Finalize(

--- a/execution/types/bloom9.go
+++ b/execution/types/bloom9.go
@@ -125,6 +125,16 @@ func (b *Bloom) UnmarshalText(input []byte) error {
 	return hexutil.UnmarshalFixedText("Bloom", input, b[:])
 }
 
+// MergedBloom ORs the per-receipt blooms together. Cheaper than CreateBloom
+// when every receipt already carries its Bloom — callers must ensure that.
+func (rs Receipts) MergedBloom() Bloom {
+	var bin Bloom
+	for _, receipt := range rs {
+		bin.Or(&receipt.Bloom)
+	}
+	return bin
+}
+
 func CreateBloom(receipts Receipts) Bloom {
 	var (
 		bin Bloom

--- a/execution/types/bloom9_test.go
+++ b/execution/types/bloom9_test.go
@@ -226,6 +226,31 @@ func BenchmarkCreateBloom(b *testing.B) {
 	})
 }
 
+func TestReceiptsMergedBloom(t *testing.T) {
+	t.Parallel()
+	receipts := Receipts{
+		{Logs: Logs{
+			{Address: common.HexToAddress("0x1111111111111111111111111111111111111111"), Topics: []common.Hash{common.HexToHash("0x01"), common.HexToHash("0x02")}},
+			{Address: common.HexToAddress("0x2222222222222222222222222222222222222222"), Topics: []common.Hash{common.HexToHash("0x03")}},
+		}},
+		{Logs: Logs{
+			{Address: common.HexToAddress("0x3333333333333333333333333333333333333333"), Topics: []common.Hash{common.HexToHash("0x04")}},
+		}},
+		{},
+	}
+	for _, r := range receipts {
+		r.Bloom = CreateBloom(Receipts{r})
+	}
+
+	merged := receipts.MergedBloom()
+	if merged.IsEmpty() {
+		t.Fatal("expected non-empty merged bloom")
+	}
+	if want := CreateBloom(receipts); merged != want {
+		t.Fatalf("merged bloom mismatch: got %x, want %x", merged, want)
+	}
+}
+
 func TestIsEmpty(t *testing.T) {
 	t.Parallel()
 	var b Bloom

--- a/execution/types/ethutils/receipt.go
+++ b/execution/types/ethutils/receipt.go
@@ -57,6 +57,13 @@ func MarshalReceipt(
 		from, _ = txn.Sender(*signer)
 	}
 
+	// Reuse a Bloom the receipt's source already computed; hash the logs only
+	// when it was left unset (e.g. cache reads that skip bloom derivation).
+	logsBloom := receipt.Bloom
+	if logsBloom.IsEmpty() && len(receipt.Logs) > 0 {
+		logsBloom = types.CreateBloom(types.Receipts{receipt})
+	}
+
 	var logsToMarshal any
 
 	if withBlockTimestamp {
@@ -89,7 +96,7 @@ func MarshalReceipt(
 		"cumulativeGasUsed": hexutil.Uint64(receipt.CumulativeGasUsed),
 		"contractAddress":   nil,
 		"logs":              logsToMarshal,
-		"logsBloom":         types.CreateBloom(types.Receipts{receipt}),
+		"logsBloom":         logsBloom,
 	}
 
 	if !chainConfig.IsLondon(header.Number.Uint64()) {

--- a/execution/types/ethutils/receipt_test.go
+++ b/execution/types/ethutils/receipt_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package ethutils
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// MarshalReceipt must reuse a Bloom the receipt already carries instead of
+// hashing the logs again on every call, and compute it only when unset.
+func TestMarshalReceiptReusesReceiptBloom(t *testing.T) {
+	var preset types.Bloom
+	preset[0] = 0x80
+	preset[types.BloomByteLength-1] = 0x01
+	receipt := &types.Receipt{
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: 21_000,
+		Bloom:             preset,
+		Logs: []*types.Log{{
+			Address: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+			Topics:  []common.Hash{common.HexToHash("0x01")},
+		}},
+		BlockNumber:      uint256.NewInt(1),
+		TransactionIndex: 0,
+	}
+	txn := &types.LegacyTx{
+		CommonTx: types.CommonTx{GasLimit: 21_000},
+		GasPrice: *uint256.NewInt(1),
+	}
+	header := &types.Header{Number: *uint256.NewInt(1)}
+	config := chain.TestChainBerlinConfig
+
+	fields := MarshalReceipt(receipt, txn, config, header, common.HexToHash("0xbeef"), false, false)
+	assert.Equal(t, preset, fields["logsBloom"])
+
+	receipt.Bloom = types.Bloom{}
+	fields = MarshalReceipt(receipt, txn, config, header, common.HexToHash("0xbeef"), false, false)
+	assert.Equal(t, types.CreateBloom(types.Receipts{receipt}), fields["logsBloom"])
+}


### PR DESCRIPTION
Backport of #22315 to `release/3.5` (re-applies #22235 with non-fatal reconstruction + DeriveFields for partial blocks). Cherry-picks its two commits; compiles + tests build on 3.5 (which already has `DerivePriorReceipts`). Tracks #22315 — will align to its final squash-sha once it merges to main.