### PR TITLE
db/state: skip guaranteed-miss history-file probe in HistorySeek

### DIFF
--- a/db/state/history.go
+++ b/db/state/history.go
@@ -1215,12 +1215,17 @@ func (ht *HistoryRoTx) HistorySeek(key []byte, txNum uint64, roTx kv.Tx) ([]byte
 		return nil, false, nil
 	}
 
-	v, ok, err := ht.historySeekInFiles(key, txNum)
-	if err != nil {
-		return nil, false, err
-	}
-	if ok {
-		return v, true, nil
+	// Files cover history only below iit.files.EndTxNum(); at or beyond that
+	// boundary no file record can be >= txNum, so the files probe is a
+	// guaranteed miss — skip it and read DB history directly.
+	if txNum < ht.iit.files.EndTxNum() {
+		v, ok, err := ht.historySeekInFiles(key, txNum)
+		if err != nil {
+			return nil, false, err
+		}
+		if ok {
+			return v, true, nil
+		}
 	}
 
 	return ht.historySeekInDB(key, txNum, roTx)


### PR DESCRIPTION
Implements the on-disk shortcut requested in #20955.

`HistorySeek` always probes history files before the DB. When `txNum >= iit.files.EndTxNum()` no frozen file can hold a record at `txNum' >= txNum`, so that probe is a **guaranteed miss** — this skips it and reads DB history directly. Behavior-identical (the probe would miss and fall through to DB anyway), and it stays clear of the post-prune file/DB overlap (we only skip in the DB-authoritative region). This is the safe, general form of the `dt.files.EndTxNum()` shortcut @AskAlexSharov suggested on the issue.

## Why it matters

The parallel commitment calculator reads sibling account/storage as-of the block boundary via `GetAsOf`. Instrumented on the sstore_bloated (300M) block:

| domain | on-disk `GetAsOf` fallbacks | resolved via history | resolved via `GetLatest` | `.ef` probes (before) | `.ef` probes (after) |
|---|---:|---:|---:|---:|---:|
| accounts | 31,119 | 0 | 31,119 | 31,119 | **0** |
| storage | 1,814 | 0 | 1,814 | 1,814 | **0** |

Every fallback resolves via `GetLatest`; each one first paid an `.ef` inverted-index probe that never found anything. With this change those probes drop to 0, the state root is unchanged, and the test still passes.

The I/O win scales with how cold/large the history `.ef` files are — a no-op on hot-index datadirs, ~2 GiB on the perf-devnet-3 datadir measured in #20955.

## Testing

Behavior-preserving; covered by existing `db/state` history/domain tests (`TestHistoryAsOfWithPrune`, `TestHistoryAfterPrune`, `TestHistoryHistory`, ...), all green. `make lint` clean.
