### PR TITLE
cmd/evm, tools: bound enginextest tester datadir to fix eest 150m benchmark OOM

### DIFF
--- a/cmd/evm/enginexrunner.go
+++ b/cmd/evm/enginexrunner.go
@@ -358,7 +358,9 @@ func runEngineXGroup(
 // grown past maxBytes. Engine-x tests never advance the head, so blocks imported
 // by earlier tests in the group are throwaway; dropping them bounds datadir
 // (tmpfs on CI) and heap growth on large-state groups. maxBytes <= 0 disables
-// the check. Returns whether an eviction happened so the caller can rebuild.
+// the check. Returns whether an eviction happened so the caller can rebuild —
+// true even when Evict reports a cleanup error, since the cache entry is
+// removed regardless.
 func resetTesterIfOversized(runner *engineapitester.EngineXTestRunner, key engineXGroupKey, maxBytes int64) (bool, error) {
 	if maxBytes <= 0 {
 		return false, nil

--- a/cmd/evm/enginexrunner.go
+++ b/cmd/evm/enginexrunner.go
@@ -64,6 +64,7 @@ var engineXTestCommand = cli.Command{
 		&TimeFlag,
 		&VerbosityFlag,
 		&WorkersFlag,
+		&ResetTesterMaxDataDirMBFlag,
 		&cli.StringFlag{
 			Name:  "pprof.cpu",
 			Usage: "directory in which to write one CPU profile per engine API request",
@@ -174,13 +175,14 @@ func engineXTestCmd(ctx context.Context, cliCtx *cli.Command) error {
 	resultCh := make(chan testResult, totalTests)
 
 	timeIt := cliCtx.Bool(TimeFlag.Name)
+	maxDataDirMB := cliCtx.Uint64(ResetTesterMaxDataDirMBFlag.Name)
 	var wg sync.WaitGroup
 	for w := uint64(0); w < workers; w++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for key := range groupCh {
-				runEngineXGroup(ctx, runner, key, groups[key], timeIt, resultCh)
+				runEngineXGroup(ctx, runner, key, groups[key], timeIt, maxDataDirMB, resultCh)
 			}
 		}()
 	}
@@ -285,9 +287,11 @@ func isUnderPreAlloc(p string) bool {
 	return false
 }
 
-// runEngineXGroup executes every test in the group sequentially on a single
-// tester (created lazily by the runner) then evicts the tester to free its
-// node and temp directory before returning. Results are streamed to resultCh
+// runEngineXGroup executes every test in the group sequentially on a tester
+// created lazily by the runner. When maxDataDirMB > 0 the tester is evicted and
+// rebuilt once its datadir grows past that size (see resetTesterIfOversized),
+// bounding datadir/heap growth on large-state groups. The tester is evicted at
+// the end to free its node and temp directory. Results are streamed to resultCh
 // so the parent goroutine can collect across all workers. When timeIt is
 // true, each test's single Run is wrapped in timedExec so wall-time and
 // memstats land on the JSON output.
@@ -297,6 +301,7 @@ func runEngineXGroup(
 	key engineXGroupKey,
 	tests []engineXNamedTest,
 	timeIt bool,
+	maxDataDirMB uint64,
 	resultCh chan<- testResult,
 ) {
 	defer func() {
@@ -305,7 +310,22 @@ func runEngineXGroup(
 			fmt.Fprintf(os.Stderr, "evict fork=%s preAllocHash=%s: %v\n", key.fork, key.hash, err)
 		}
 	}()
-	for _, t := range tests {
+	maxDataDirBytes := int64(maxDataDirMB) * 1024 * 1024
+	for i, t := range tests {
+		if i > 0 {
+			reset, err := resetTesterIfOversized(runner, key, maxDataDirBytes)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "reset check fork=%s preAllocHash=%s: %v\n", key.fork, key.hash, err)
+			}
+			if reset {
+				// Rebuild now so the reset isn't charged to this test's --time
+				// measurement (EnsureTester runs outside the timed section below).
+				err := runner.EnsureTester(t.def)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "rebuild fork=%s preAllocHash=%s: %v\n", key.fork, key.hash, err)
+				}
+			}
+		}
 		r := testResult{Name: t.name, Pass: true}
 		// timedExec(bench=false): single execution with memstats. We
 		// deliberately don't expose bench=true (testing.Benchmark loop) for
@@ -332,6 +352,53 @@ func runEngineXGroup(
 		}
 		resultCh <- r
 	}
+}
+
+// resetTesterIfOversized evicts the group's cached tester when its datadir has
+// grown past maxBytes. Engine-x tests never advance the head, so blocks imported
+// by earlier tests in the group are throwaway; dropping them bounds datadir
+// (tmpfs on CI) and heap growth on large-state groups. maxBytes <= 0 disables
+// the check. Returns whether an eviction happened so the caller can rebuild.
+func resetTesterIfOversized(runner *engineapitester.EngineXTestRunner, key engineXGroupKey, maxBytes int64) (bool, error) {
+	if maxBytes <= 0 {
+		return false, nil
+	}
+	dataDir, ok := runner.TesterDataDir(key.fork, key.hash)
+	if !ok {
+		return false, nil
+	}
+	size, err := dirSizeBytes(dataDir)
+	if err != nil {
+		return false, err
+	}
+	if size <= maxBytes {
+		return false, nil
+	}
+	return true, runner.Evict(key.fork, key.hash)
+}
+
+// dirSizeBytes returns the total size of the regular files under root, or 0 if
+// root does not exist.
+func dirSizeBytes(root string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(root, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	return total, err
 }
 
 // safeFilenameRe matches characters that are unsafe in filenames across

--- a/cmd/evm/enginexrunner.go
+++ b/cmd/evm/enginexrunner.go
@@ -377,11 +377,15 @@ func resetTesterIfOversized(runner *engineapitester.EngineXTestRunner, key engin
 	return true, runner.Evict(key.fork, key.hash)
 }
 
-// dirSizeBytes returns the total size of the regular files under root, or 0 if
-// root does not exist.
+// dirSizeBytes returns the total size of the regular files under root.
+// Entries that vanish mid-walk are skipped rather than zeroing the count;
+// a missing root yields 0.
 func dirSizeBytes(root string) (int64, error) {
 	var total int64
 	err := filepath.WalkDir(root, func(_ string, d os.DirEntry, err error) error {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
 		if err != nil {
 			return err
 		}
@@ -389,15 +393,15 @@ func dirSizeBytes(root string) (int64, error) {
 			return nil
 		}
 		info, err := d.Info()
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
 		if err != nil {
 			return err
 		}
 		total += info.Size()
 		return nil
 	})
-	if errors.Is(err, os.ErrNotExist) {
-		return 0, nil
-	}
 	return total, err
 }
 

--- a/cmd/evm/enginexrunner_test.go
+++ b/cmd/evm/enginexrunner_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDirSizeBytes(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a"), make([]byte, 1000), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b"), make([]byte, 2000), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := dirSizeBytes(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 3000 {
+		t.Fatalf("dirSizeBytes = %d, want 3000", got)
+	}
+
+	// A missing root reports 0, not an error, so the size check is a no-op
+	// before any tester has been created.
+	got, err = dirSizeBytes(filepath.Join(root, "does-not-exist"))
+	if err != nil {
+		t.Fatalf("missing dir should not error, got %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("dirSizeBytes(missing) = %d, want 0", got)
+	}
+}
+
+func TestResetTesterIfOversizedDisabled(t *testing.T) {
+	// maxBytes <= 0 disables the check and must not touch the runner (nil here).
+	reset, err := resetTesterIfOversized(nil, engineXGroupKey{}, 0)
+	if err != nil || reset {
+		t.Fatalf("disabled check: got (reset=%v, err=%v), want (false, nil)", reset, err)
+	}
+}

--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -146,6 +146,11 @@ var (
 		Value: 1,
 		Usage: "Number of workers to execute tests in parallel (must be >= 1)",
 	}
+	ResetTesterMaxDataDirMBFlag = cli.Uint64Flag{
+		Name:  "reset-tester-max-datadir-mb",
+		Value: 0,
+		Usage: "enginextest: evict and rebuild a (fork,preAllocHash) group's tester once its datadir exceeds this many MB, to bound datadir/heap growth (0 = never)",
+	}
 	JSONOutputFlag = cli.BoolFlag{
 		Name:  "jsonout",
 		Usage: "Output results as JSON array instead of human-readable format",

--- a/execution/engineapi/engineapitester/engine_x_test_runner.go
+++ b/execution/engineapi/engineapitester/engine_x_test_runner.go
@@ -196,6 +196,16 @@ func (extr *EngineXTestRunner) evict(entry testerEntry) error {
 	return errors.Join(errs...)
 }
 
+// TesterDataDir returns the temp datadir of the cached (fork, preAllocHash)
+// tester, or ("", false) when none is cached. Callers use it to check a
+// long-lived tester's on-disk growth and decide whether to evict it.
+func (extr *EngineXTestRunner) TesterDataDir(fork Fork, preAllocHash PreAllocHash) (string, bool) {
+	extr.mu.Lock()
+	defer extr.mu.Unlock()
+	entry, ok := extr.testers[fork][preAllocHash]
+	return entry.dataDir, ok
+}
+
 // testNameKey is the unexported context key callers use to attach a test name
 // to the ctx passed into Run. The profile hook embeds the name in per-request
 // profile ids so callers can route profiles into named files.

--- a/tools/run-eest-spec-test.sh
+++ b/tools/run-eest-spec-test.sh
@@ -131,7 +131,12 @@ case "$shard_route" in
 		printf -v gas_dir 'for_osaka_at_%04dM' "$gas_num"
 		cmd=enginextest
 		path="$base/blockchain_tests_engine_x/$gas_dir"
-		extra=(--pre-alloc-dir "$base/blockchain_tests_engine_x/pre_alloc" --time) ;;
+		# --reset-tester-max-datadir-mb bounds datadir(tmpfs)/heap growth: each test
+		# imports a throwaway 150M-gas block onto the shared genesis, so without a
+		# reset one tester accumulates the whole group's branch state and OOMs the
+		# 16GB CI runner (worst on the high-gas parallel shards).
+		extra=(--pre-alloc-dir "$base/blockchain_tests_engine_x/pre_alloc" --time \
+			--reset-tester-max-datadir-mb "${EEST_ENGINEX_MAX_TESTER_DATADIR_MB:-5120}") ;;
 	zkevm-witness*)
 		# Whole eest_zkevm blockchain_tests corpus; the "-race" variant differs
 		# only in the binary (evm.race, picked by the Makefile), not the fixtures.


### PR DESCRIPTION
## Problem

`eest-spec-tests / eest-spec-enginextests-benchmark-150m-parallel` fails intermittently in CI with `make: *** Terminated` / `The runner has received a shutdown signal` ~16-18 min in. It's an out-of-memory kill on the 16 GB GitHub-hosted runner, **not** a test failure: it reproduces across unrelated commits, and successful runs of the same shard take ~20-22 min while the failures die mid-run. The flake started on Jul 7; a merge-queue scan back through June shows no earlier root-cause failure of this job.

## Root cause

*(Rewritten after the profiling pass — full data in the comments below.)*

Each engine-x test imports its blocks via `engine_newPayload` on top of a shared pre-alloc genesis. The runner never calls `forkchoiceUpdated`, so every block is an independent, non-canonical branch — throwaway once its test finishes. But one `EngineXTestRunner` tester serves a whole `(fork, preAllocHash)` group and is only evicted at the group's end, so those branch blocks (plus receipts / history / commitment) accumulate in a single node's MDBX.

The heavy hitters are the 7 `test_unchunkified_bytecode` tests: each carries a 275 **billion** gas setup block with 18,440 transactions deploying ~18k max-size contracts (~440 MB of code), then the measured 150M block. Those 7 tests alone take the datadir from ~0.75 GB to its peak and drive the Go heap to its ~7.5 GB peak at the same time (the block's own write-set plus executor/EVM allocation churn — profile in the comments). The datadir lives on the workflow's 8 GB tmpfs RAM disk, so it **is** RAM; heap + datadir peak co-resident at ~14 GB on current main, which plus runner overhead sits on the 16 GB ceiling. Flaky because the peak varies run-to-run with GC timing and Go-map group order. Both executors hit it (workload-driven, not parallel-specific); the parallel shard dwells longer near the peak.

Two components stack up to that 14 GB:

- **Workload-inherent (~12 GB co-resident, unchanged since at least Jun 29):** the setup-block write-set, commitment, and executor churn above.
- **+2 GB co-resident regression from #22154 (merged Jul 7 18:44 UTC; first OOM 19:53 the same day):** the persistent code cache's MDBX tier (`TblCodeCache`) is only evicted in the FCU prune loop, which this FCU-less workload never reaches — it accumulates 1.29 GB of decompressed code (~1.7 GB of tmpfs including MDBX page overhead). #22335 enforces the cap on the commit write path, but this workload sits just under the 1 GiB cap in key+value bytes while paying ~1.7 GB in pages, so bounding the datadir is still needed.

## Fix

Add an opt-in `--reset-tester-max-datadir-mb` flag to `evm enginextest`: before each test, if the group's tester datadir has grown past the limit, evict and rebuild it (only at a test boundary, so within-test payload sequences stay intact). Because the accumulated blocks are throwaway, this is safe and drops that state, bounding **both** the tmpfs datadir and the heap. It's size-based rather than a fixed count, so only heavy groups ever rebuild — light groups never reach the limit and pay nothing.

Enabled for the `enginextests-benchmark-*` shards at 5 GiB (`tools/run-eest-spec-test.sh`, env-overridable via `EEST_ENGINEX_MAX_TESTER_DATADIR_MB`). The flag defaults to 0 (disabled), so every other enginextest invocation is byte-for-byte unchanged.

## Validation

Local repro, `GOMAXPROCS=4` (matching the runner) and `GODEBUG=gctrace=1` (true Go heap, excluding the DB mmap that inflates RSS). Full 1077-test shard without the reset, plus the 7-test unchunkified repro (which reproduces the full footprint) at two reset thresholds:

|          | peak datadir (= tmpfs RAM on CI) | peak co-resident (heap + datadir at the same instant) | tests |
|----------|--:|--:|--:|
| main, no reset (full shard)   | 7.4 GB (grows monotonically) | 14.1 GB | 1077 pass |
| reset @ 5 GiB | 5.5 GB (sawtooths) | **12.1 GB** | pass |
| reset @ 3 GiB | 3.7 GB (sawtooths) | **11.3 GB** | pass |

The reset converts the datadir from unbounded monotonic growth into a bounded sawtooth and, at the default 5 GiB, restores the ~12 GB co-resident peak (and ~2.5 GB margin) the job ran with in June before the #22154 regression. Tester rebuilds briefly spike the heap, but only while the datadir is small, so the co-resident peak is unaffected. Dropping the env knob to 3 GiB buys another ~0.8 GB of margin if it's ever needed. Wall time is ~13% higher on the full shard (rebuilds on the heavy group only).

An earlier revision of this description attributed the heap spike to genesis commit and claimed a lower co-resident peak on that basis — the profiling pass showed genesis is only ~50 MB MDBX / ~0.6 GB heap, the spike is the unchunkified setup blocks, and it coincides with the datadir peak; the table above uses the measured co-resident values.

If more headroom is ever needed, moving these shards to a larger-RAM runner is the natural follow-up.

## TDD note

Red→green doesn't apply cleanly here: this is a resource-bounding change, not a functional one (test pass/fail is unchanged). The new `dirSizeBytes` helper and the disabled-path short-circuit are unit-tested; the memory bound itself is verified empirically above, per the repo's TDD-pragmatism guidance for performance/resource changes.
