### PR TITLE
rpc/rpchelper: invalidate cached pending block once the chain moves past it

### DIFF
--- a/rpc/rpchelper/filters.go
+++ b/rpc/rpchelper/filters.go
@@ -470,6 +470,7 @@ func (ff *Filters) HandlePendingBlock(reply *txpoolproto.OnPendingBlockReply) {
 	}
 	if err := rlp.DecodeBytes(reply.RplBlock, b); err != nil {
 		ff.logger.Warn("OnNewPendingBlock rpc filters, unprocessable payload", "err", err)
+		return
 	}
 
 	ff.mu.Lock()

--- a/rpc/rpchelper/filters.go
+++ b/rpc/rpchelper/filters.go
@@ -912,10 +912,27 @@ func (ff *Filters) onNewHeader(event *remoteproto.SubscribeReply) error {
 		return fmt.Errorf("unprocessable payload: %w", err)
 	}
 
+	ff.invalidateStalePendingBlock(&header)
+
 	return ff.headsSubs.Range(func(k HeadsSubID, v Sub[*types.Header]) error {
 		v.Send(&header)
 		return nil
 	})
+}
+
+// invalidateStalePendingBlock drops the cached pending block once the chain
+// moves on without it: a header at or above its height, or a competing block
+// replacing its parent. A stale pending block would otherwise pin "pending"
+// reads to an outdated height until this node builds a payload again.
+func (ff *Filters) invalidateStalePendingBlock(header *types.Header) {
+	ff.mu.Lock()
+	defer ff.mu.Unlock()
+	if ff.pendingBlock == nil {
+		return
+	}
+	if header.Number.Uint64()+1 >= ff.pendingBlock.NumberU64() && header.Hash() != ff.pendingBlock.ParentHash() {
+		ff.pendingBlock = nil
+	}
 }
 
 // OnReceipts handles a new receipt event from the remote and processes it.

--- a/rpc/rpchelper/filters_pending_block_test.go
+++ b/rpc/rpchelper/filters_pending_block_test.go
@@ -82,3 +82,21 @@ func TestFilters_PendingBlockInvalidatedByNewHeader(t *testing.T) {
 		})
 	}
 }
+
+// TestFilters_PendingBlockKeptOnUnparseablePayload pins that an unparseable
+// pending block payload is dropped instead of replacing the cached block with
+// a partially-decoded one.
+func TestFilters_PendingBlockKeptOnUnparseablePayload(t *testing.T) {
+	t.Parallel()
+
+	f := New(t.Context(), FiltersConfig{}, nil, nil, nil, func() {}, log.New(), nil)
+	pending := types.NewBlockWithHeader(&types.Header{Number: *uint256.NewInt(10)})
+	handlePendingBlock(t, f, pending)
+
+	f.HandlePendingBlock(&txpoolproto.OnPendingBlockReply{RplBlock: []byte("garbage")})
+
+	got := f.LastPendingBlock()
+	require.NotNil(t, got)
+	require.NotNil(t, got.HeaderNoCopy())
+	require.Equal(t, pending.Hash(), got.Hash())
+}

--- a/rpc/rpchelper/filters_pending_block_test.go
+++ b/rpc/rpchelper/filters_pending_block_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package rpchelper
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/node/gointerfaces/remoteproto"
+	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
+)
+
+func handleHeader(t *testing.T, f *Filters, header *types.Header) {
+	t.Helper()
+	payload, err := rlp.EncodeToBytes(header)
+	require.NoError(t, err)
+	f.OnNewEvent(&remoteproto.SubscribeReply{Type: remoteproto.Event_HEADER, Data: payload})
+}
+
+func handlePendingBlock(t *testing.T, f *Filters, block *types.Block) {
+	t.Helper()
+	payload, err := rlp.EncodeToBytes(block)
+	require.NoError(t, err)
+	f.HandlePendingBlock(&txpoolproto.OnPendingBlockReply{RplBlock: payload})
+}
+
+// TestFilters_PendingBlockInvalidatedByNewHeader pins that a cached pending
+// block stops being served once the chain moves without this node building:
+// a new header at or above the pending block's height, or a competing block
+// replacing its parent, must clear it, while headers that leave it extending
+// the head (its own parent, deeper ancestors) must not.
+func TestFilters_PendingBlockInvalidatedByNewHeader(t *testing.T) {
+	t.Parallel()
+
+	parent := &types.Header{Number: *uint256.NewInt(9), Extra: []byte("parent")}
+	pending := types.NewBlockWithHeader(&types.Header{Number: *uint256.NewInt(10), ParentHash: parent.Hash()})
+
+	cases := []struct {
+		name     string
+		header   *types.Header
+		wantKept bool
+	}{
+		{"deeper ancestor keeps it", &types.Header{Number: *uint256.NewInt(7)}, true},
+		{"its own parent keeps it", parent, true},
+		{"competing parent clears it", &types.Header{Number: *uint256.NewInt(9), Extra: []byte("competing")}, false},
+		{"same height clears it", &types.Header{Number: *uint256.NewInt(10)}, false},
+		{"higher head clears it", &types.Header{Number: *uint256.NewInt(14)}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := New(t.Context(), FiltersConfig{}, nil, nil, nil, func() {}, log.New(), nil)
+			handlePendingBlock(t, f, pending)
+			require.Equal(t, pending.Hash(), f.LastPendingBlock().Hash())
+
+			handleHeader(t, f, tc.header)
+
+			if tc.wantKept {
+				require.NotNil(t, f.LastPendingBlock())
+				require.Equal(t, pending.Hash(), f.LastPendingBlock().Hash())
+			} else {
+				require.Nil(t, f.LastPendingBlock())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #22299.

## Actual root cause (differs from the issue's hypothesis)

The issue hypothesized stale unwound transactions re-injected into the txpool. Instrumenting the repro (`TestEngineApiForkBounceStateChurn` from #22300 with the nonce-pinning workaround removed) shows the pool is innocent: after every bounce it is empty and consistent — the losing fork's transactions are delivered and correctly discarded as `NonceTooLow` against the post-reorg state (both forks confirm the same nonces), and every `OnNewBlock` completes with `err=nil`.

The stale answer comes from the RPC layer. `eth_getTransactionCount(pending)` first asks the pool, gets "not found" (pool empty), and falls through to a state read at the *pending block*, which `rpchelper.Filters` resolves via `LastPendingBlock()`:

```
DBG GetTransactionCount pending: pool miss, falling through to state read
DBG pending->LastPendingBlock  num=1 plainState=14
DBG GetTransactionCount state read  nonce=0
DBG validateTx NonceTooLow  senderNonce=13 txnNonce=0
```

`Filters` cache the last pending block broadcast by the block builder and never drop it. The victim node built exactly one payload (block 1, during test setup) and then advanced to block 14 purely via newPayload/FCU, so every `pending`-tagged state read kept resolving to block 1: nonce 0 instead of 13. The submission built on that nonce is then correctly rejected by the pool with `nonce too low`, and the retry loop keeps re-reading the same stale pending nonce. The wedge is durable because the cached pending block only refreshes when this node builds another payload — which, in the bind flow, first requires a successful submission.

The fork bounce in the repro is incidental: any node that builds a payload once and then follows the chain via newPayload/FCU (e.g. an EL behind a solo-staking validator after its proposal slot) pins all `pending` reads to that old height until its next proposal.

## Fix

Invalidate the cached pending block in `Filters.onNewHeader`: drop it when a header at or above its height arrives, or when a competing block replaces its parent. Its own parent and deeper ancestors (ascending batch replays) keep it, so a freshly built speculative block survives the notifications of the chain it extends. Pending reads then fall back to latest-executed state — matching what other clients serve when no block is currently being built (geth resets the miner's pending environment on chain-head events).

Known residual (self-healing): a reorg to a head *below* the pending block's parent keeps the cache until the new chain regrows to the parent's height, at which point the competing-parent clause clears it. Closing that window would require ancestry knowledge `Filters` doesn't have.

Also fixed in the same code path: `HandlePendingBlock` logged RLP decode errors but still stored the partially-decoded, header-less block — pending reads would then nil-panic in `Block.Hash()`. An unparseable payload is now dropped.

## Testing

- New `TestFilters_PendingBlockInvalidatedByNewHeader`: the three "clears it" cases are red on `main` (nothing ever invalidates the cache) and green with the fix; race-clean.
- New `TestFilters_PendingBlockKeptOnUnparseablePayload`: red before the missing `return` in `HandlePendingBlock` (a decode error left a header-less block in the cache), green after.
- `TestEngineApiForkBounceStateChurn` (#22300) with the nonce-pinning workaround removed: on `main` it fails after 30 s of `INTERNAL_ERROR: nonce too low` retries; with this fix it passes in ~1.5 s. The full `./execution/engineapi` package is green with the workaround removed, so the workaround in `churnAndAssert` can be dropped once both PRs are in.
- `./rpc/rpchelper`, `./rpc/jsonrpc`, `./txnprovider/txpool` green; `make lint` clean; `make erigon integration` builds.

