### PR TITLE
[r3.4] execution/state: delete stale CodeDomain entry on EIP-7702 delegation clear

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1847,8 +1847,11 @@ func updateAccount(EIP161Enabled bool, isAura bool, stateWriter StateWriter, add
 	}
 	if isDirty && (stateObject.createdContract || !stateObject.selfdestructed) && !emptyRemoval {
 		stateObject.deleted = false
-		// Write any contract code associated with the state object
-		if stateObject.code != nil && stateObject.dirtyCode {
+		// Write any contract code associated with the state object; dirtyCode is
+		// set only when code actually changed, so a clear-to-empty (e.g. removing
+		// an EIP-7702 delegation) must still write through, keeping CodeDomain
+		// consistent with the empty codeHash.
+		if stateObject.dirtyCode {
 			if err := stateWriter.UpdateAccountCode(addr, stateObject.data.Incarnation, stateObject.data.CodeHash, stateObject.code); err != nil {
 				return err
 			}

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -90,16 +90,25 @@ func (rs *StateV3) applyUpdates(roTx kv.TemporalTx, blockNum, txNum uint64, stat
 				}
 
 				if update.code != nil {
-					if dbg.TraceApply && (rs.trace || dbg.TraceAccount(update.address.Handle())) {
-						code := update.code
-						if len(code) > 40 {
-							code = code[:40]
-						}
-						fmt.Printf("%d apply:put code: %x %x\n", blockNum, update.address, code)
-					}
 					address := update.address.Value()
-					if err = domains.DomainPut(kv.CodeDomain, roTx, address[:], update.code, txNum, nil); err != nil {
-						return false
+					if len(update.code) == 0 {
+						if dbg.TraceApply && (rs.trace || dbg.TraceAccount(update.address.Handle())) {
+							fmt.Printf("%d apply:del code: %x\n", blockNum, update.address)
+						}
+						if err = domains.DomainDel(kv.CodeDomain, roTx, address[:], txNum, nil); err != nil {
+							return false
+						}
+					} else {
+						if dbg.TraceApply && (rs.trace || dbg.TraceAccount(update.address.Handle())) {
+							code := update.code
+							if len(code) > 40 {
+								code = code[:40]
+							}
+							fmt.Printf("%d apply:put code: %x %x\n", blockNum, update.address, code)
+						}
+						if err = domains.DomainPut(kv.CodeDomain, roTx, address[:], update.code, txNum, nil); err != nil {
+							return false
+						}
 					}
 				}
 
@@ -495,6 +504,12 @@ func (w *BufferedWriter) UpdateAccountCode(address accounts.Address, incarnation
 	if w.accumulator != nil {
 		w.accumulator.ChangeCode(address.Value(), incarnation, code)
 	}
+	if code == nil {
+		// nil marks "code untouched" in stateUpdate/bufferedAccount; a non-nil
+		// empty slice keeps a clear-to-empty distinguishable so applyUpdates
+		// deletes the stale CodeDomain entry.
+		code = []byte{}
+	}
 
 	if update, ok := w.writeSet.Get(&stateUpdate{address: address}); !ok {
 		w.writeSet.Set(&stateUpdate{&bufferedAccount{code: code}, address, false})
@@ -650,7 +665,11 @@ func (w *Writer) UpdateAccountCode(address accounts.Address, incarnation uint64,
 		fmt.Printf("code: %x, %x, valLen: %d\n", address, codeHash, len(code))
 	}
 	addressValue := address.Value()
-	if err := w.tx.DomainPut(kv.CodeDomain, addressValue[:], code, w.txNum, nil); err != nil {
+	if len(code) == 0 {
+		if err := w.tx.DomainDel(kv.CodeDomain, addressValue[:], w.txNum, nil); err != nil {
+			return err
+		}
+	} else if err := w.tx.DomainPut(kv.CodeDomain, addressValue[:], code, w.txNum, nil); err != nil {
 		return err
 	}
 	if w.accumulator != nil {

--- a/execution/tests/setcode_clear_delegation_test.go
+++ b/execution/tests/setcode_clear_delegation_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package executiontests
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+func signAuthorization(t *testing.T, key *ecdsa.PrivateKey, chainID uint256.Int, delegate common.Address, nonce uint64) types.Authorization {
+	t.Helper()
+	auth := types.Authorization{ChainID: chainID, Address: delegate, Nonce: nonce}
+	payloadLen := rlp.Uint256Len(auth.ChainID) + 1 + length.Addr + rlp.U64Len(auth.Nonce)
+	var buf [32]byte
+	data := bytes.NewBuffer(nil)
+	require.NoError(t, rlp.EncodeStructSizePrefix(payloadLen, data, buf[:]))
+	require.NoError(t, rlp.EncodeUint256(auth.ChainID, data, buf[:]))
+	require.NoError(t, rlp.EncodeOptionalAddress(&auth.Address, data, buf[:]))
+	require.NoError(t, rlp.EncodeInt(auth.Nonce, data, buf[:]))
+	sighash := crypto.Keccak256Hash(append([]byte{params.SetCodeMagicPrefix}, data.Bytes()...))
+	sig, err := crypto.Sign(sighash[:], key)
+	require.NoError(t, err)
+	auth.R.SetBytes(sig[:32])
+	auth.S.SetBytes(sig[32:64])
+	auth.YParity = sig[64]
+	recovered, err := auth.RecoverSigner(bytes.NewBuffer(nil), buf[:])
+	require.NoError(t, err)
+	require.Equal(t, crypto.PubkeyToAddress(key.PublicKey), *recovered)
+	return auth
+}
+
+// TestSetCodeClearDelegationPurgesCodeDomain pins the account↔code domain
+// invariant across the EIP-7702 delegation lifecycle: setting a delegation
+// stores the designator in CodeDomain; clearing it (authorization to the zero
+// address) must delete that CodeDomain entry rather than leave the stale
+// designator alongside an account whose code hash says "no code".
+func TestSetCodeClearDelegationPurgesCodeDomain(t *testing.T) {
+	// mutates dbg.Exec3Parallel per sub-test; not safe for t.Parallel
+	for _, mode := range []struct {
+		name     string
+		parallel bool
+	}{
+		{"serial", false},
+		{"parallel", true},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			prev := dbg.Exec3Parallel
+			dbg.Exec3Parallel = mode.parallel
+			t.Cleanup(func() { dbg.Exec3Parallel = prev })
+
+			senderKey, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+			require.NoError(t, err)
+			authorityKey, err := crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+			require.NoError(t, err)
+			sender := crypto.PubkeyToAddress(senderKey.PublicKey)
+			authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+			delegate := common.HexToAddress("0x000000000000000000000000000000000000cafe")
+
+			cfg := &chain.Config{
+				ChainID:                       big.NewInt(1337),
+				HomesteadBlock:                big.NewInt(0),
+				TangerineWhistleBlock:         big.NewInt(0),
+				SpuriousDragonBlock:           big.NewInt(0),
+				ByzantiumBlock:                big.NewInt(0),
+				ConstantinopleBlock:           big.NewInt(0),
+				PetersburgBlock:               big.NewInt(0),
+				IstanbulBlock:                 big.NewInt(0),
+				MuirGlacierBlock:              big.NewInt(0),
+				BerlinBlock:                   big.NewInt(0),
+				LondonBlock:                   big.NewInt(0),
+				ArrowGlacierBlock:             big.NewInt(0),
+				GrayGlacierBlock:              big.NewInt(0),
+				TerminalTotalDifficulty:       big.NewInt(0),
+				TerminalTotalDifficultyPassed: true,
+				ShanghaiTime:                  big.NewInt(0),
+				CancunTime:                    big.NewInt(0),
+				PragueTime:                    big.NewInt(0),
+				Ethash:                        new(chain.EthashConfig),
+			}
+			gspec := &types.Genesis{
+				Config: cfg,
+				Alloc: types.GenesisAlloc{
+					sender: {Balance: big.NewInt(1_000_000_000_000_000_000)},
+				},
+			}
+			m := execmoduletester.New(t, execmoduletester.WithGenesisSpec(gspec), execmoduletester.WithKey(senderKey))
+
+			signer := types.LatestSignerForChainID(cfg.ChainID)
+			mkSetCodeTx := func(nonce uint64, auth types.Authorization) types.Transaction {
+				to := common.HexToAddress("0x000000000000000000000000000000000000beef")
+				txn := &types.SetCodeTransaction{
+					DynamicFeeTransaction: types.DynamicFeeTransaction{
+						CommonTx: types.CommonTx{Nonce: nonce, GasLimit: 500_000, To: &to},
+						ChainID:  uint256.NewInt(1337),
+						TipCap:   uint256.NewInt(1_000_000_000),
+						FeeCap:   uint256.NewInt(10_000_000_000),
+					},
+					Authorizations: []types.Authorization{auth},
+				}
+				signed, err := types.SignTx(txn, *signer, senderKey)
+				require.NoError(t, err)
+				return signed
+			}
+
+			chainID := *uint256.NewInt(1337)
+			chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 2, func(i int, b *blockgen.BlockGen) {
+				b.SetCoinbase(common.Address{1})
+				switch i {
+				case 0:
+					b.AddTx(mkSetCodeTx(b.TxNonce(sender), signAuthorization(t, authorityKey, chainID, delegate, 0)))
+				case 1:
+					b.AddTx(mkSetCodeTx(b.TxNonce(sender), signAuthorization(t, authorityKey, chainID, common.Address{}, 1)))
+				}
+			})
+			require.NoError(t, err)
+
+			readAuthority := func() (accounts.Account, []byte) {
+				var acc accounts.Account
+				var code []byte
+				require.NoError(t, m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
+					accEnc, _, err := tx.GetLatest(kv.AccountsDomain, authority[:])
+					if err != nil {
+						return err
+					}
+					if len(accEnc) > 0 {
+						if err := accounts.DeserialiseV3(&acc, accEnc); err != nil {
+							return err
+						}
+					}
+					code, _, err = tx.GetLatest(kv.CodeDomain, authority[:])
+					return err
+				}))
+				return acc, code
+			}
+
+			require.NoError(t, m.InsertChain(chainPack.Slice(0, 1)))
+			acc, code := readAuthority()
+			require.EqualValues(t, 1, acc.Nonce, "set authorization must have been applied")
+			require.Equal(t, types.AddressToDelegation(accounts.InternAddress(delegate)), code)
+			require.False(t, acc.IsEmptyCodeHash())
+
+			require.NoError(t, m.InsertChain(chainPack.Slice(1, 2)))
+			acc, code = readAuthority()
+			require.EqualValues(t, 2, acc.Nonce, "clear authorization must have been applied")
+			require.True(t, acc.IsEmptyCodeHash(), "account code hash must be empty after delegation clear")
+			require.Empty(t, code, "CodeDomain must not retain the delegation designator after clear")
+		})
+	}
+}


### PR DESCRIPTION
Targeted backport of the clear-to-empty code write-through that landed on `main` inside the #21536 refactor. Not a cherry-pick — #21536 is a large typed-vio refactor; this extracts just the behavioral fix. Part of #22321.

## What

Clearing an EIP-7702 delegation (authorization to the zero address) runs `SetCode(authority, nil)`. The `stateObject.code != nil` guard in `updateAccount` skipped `UpdateAccountCode` for nil code, so the account was written with the empty code hash while `CodeDomain` kept the old delegation designator. Every delegation clear executed by a 3.4 node leaves such a residue in the datadir. With assertions enabled (`ERIGON_ASSERT=true`, as in the QA workflows) commitment then fails with `code hash mismatch` on the next touch of the account — the failure mode of #22321, where the QA testbed inherits these residues from the reference datadir maintained by a v3.4.3 node. Consensus and RPC are unaffected: commitment uses the account's own code hash, and EVM/RPC code reads gate on the empty code hash before consulting CodeDomain.

Changes:

- `updateAccount`: write code through on `dirtyCode` alone.
- serial `Writer.UpdateAccountCode`: translate empty code into `DomainDel(CodeDomain)` instead of putting an empty value.
- parallel/buffered path (`BufferedWriter` + `applyUpdates`): represent clear-to-empty as a non-nil empty slice (nil still means "code untouched") and emit the CodeDomain delete on apply.

## r3.4-specific adaptations

- On 3.4 both executors route through `updateAccount`, so serial **and** parallel were affected; the buffered-apply fix has no direct `main` equivalent (`main`'s `applyVersionedWrites` and `BlockStateCache.Flush` already translate empty code into deletes).
- Includes the regression test from #22327, adapted to 3.4 APIs (`execution/tests/setcode_clear_delegation_test.go`). Red before the fix in both exec modes, green after.

## Note

This stops *new* residues. Residues already written by ≤3.4.3 persist in datadirs until the affected address receives another code write; see #22321 for the QA reference-datadir cleanup and the follow-up repair-tool issue.
