### PR TITLE
execution/commitment: cap storage-fold fan-out at GOMAXPROCS

### DIFF
--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -118,8 +118,9 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 		cells   [16]cell
 		present [16]bool
 	)
+	foldSem := newFoldSem()
 	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(p.numWorkers)
+	g.SetLimit(min(p.numWorkers, maxFoldConcurrency()))
 
 	childIdx := 0
 	for bm := root.bitmap; bm != 0; {
@@ -151,7 +152,7 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 			path = append(path, byte(ni))
 			path = append(path, ch.ext...)
 			buildErr := dfsSubtreeDeep(w, ch, path, func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
-				return foldStorageRoot(gctx, p.numWorkers, p.newStorageWorker, pu, n, pth, accountFresh)
+				return foldStorageRoot(gctx, foldSem, p.newStorageWorker, pu, n, pth, accountFresh)
 			})
 			if buildErr != nil {
 				w.resetForReuse()

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -27,6 +27,7 @@ import (
 	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
@@ -665,8 +666,9 @@ func (o *overlayContext) Storage(plainKey []byte) (*Update, error) { return o.ba
 // base, recording which slots were folded; it never applies or merges.
 func (sc *StreamingCommitter) foldPresentSplits(ctx context.Context, base *HexPatriciaHashed, root *prefixNode) ([16]bool, error) {
 	var present [16]bool
+	foldSem := newFoldSem()
 	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(sc.numWorkers)
+	g.SetLimit(min(sc.numWorkers, maxFoldConcurrency()))
 
 	childIdx := 0
 	for bm := root.bitmap; bm != 0; {
@@ -688,7 +690,7 @@ func (sc *StreamingCommitter) foldPresentSplits(ctx context.Context, base *HexPa
 			continue
 		}
 		ch := child
-		g.Go(func() error { return sc.foldSplit(gctx, base, s, ch) })
+		g.Go(func() error { return sc.foldSplit(gctx, foldSem, base, s, ch) })
 		childIdx++
 		bm &^= uint16(1) << nib
 	}
@@ -740,7 +742,7 @@ func stitchSplitCells(base *HexPatriciaHashed, cells *[16]cell, present *[16]boo
 // foldSplit re-folds one top-nibble subtree on a worker mounted at the unfolded
 // base, to the split cell rather than the root, replacing the split's cell and
 // deferred set.
-func (sc *StreamingCommitter) foldSplit(ctx context.Context, base *HexPatriciaHashed, s *splitState, child *prefixNode) error {
+func (sc *StreamingCommitter) foldSplit(ctx context.Context, foldSem *semaphore.Weighted, base *HexPatriciaHashed, s *splitState, child *prefixNode) error {
 	ni := s.prefix[0]
 	w := sc.workerPool.Get().(*HexPatriciaHashed)
 	w.mountTo(base, int(ni))
@@ -762,7 +764,7 @@ func (sc *StreamingCommitter) foldSplit(ctx context.Context, base *HexPatriciaHa
 	path = append(path, ni)
 	path = append(path, child.ext...)
 	deepStorageRoot := func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
-		sr, err := foldStorageRoot(ctx, sc.numWorkers, sc.newStorageWorker, &pu, n, pth, accountFresh)
+		sr, err := foldStorageRoot(ctx, foldSem, sc.newStorageWorker, &pu, n, pth, accountFresh)
 		if err == nil {
 			sc.deepLocalFolds.Add(1)
 		}

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -22,14 +22,25 @@ import (
 	"fmt"
 	"io"
 	"math/bits"
+	"runtime"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/empty"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
+
+// maxFoldConcurrency caps the whale-storage fold fan-out at the CPUs the process
+// may run on. The account-mount and whale-storage fan-outs nest, so an unshared
+// per-level limit of numWorkers permits ~numWorkers² runnable leaf goroutines; one
+// shared budget of this size caps that product. GOMAXPROCS, not numWorkers, which
+// would starve cores when numWorkers < GOMAXPROCS and several whales fold at once.
+func maxFoldConcurrency() int { return max(1, runtime.GOMAXPROCS(0)) }
+
+func newFoldSem() *semaphore.Weighted { return semaphore.NewWeighted(int64(maxFoldConcurrency())) }
 
 // errStorageBaseNotBranch: no on-disk branch exactly at the account prefix (its
 // storage top is a deeper extension); callers fall back to streaming recursion.
@@ -128,7 +139,9 @@ func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storage
 }
 
 // Storage-root analogue of the account mount fold: parallelize a whale's storage by first nibble.
-func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte, accountFresh bool) (common.Hash, error) {
+// sem is the shared fold-concurrency budget: acquired per first-nibble worker so that
+// this whale's fan-out plus every other concurrently-folding subtree stays within the core count.
+func foldStorageRoot(ctx context.Context, sem *semaphore.Weighted, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte, accountFresh bool) (common.Hash, error) {
 	accPrefix := append([]byte(nil), path...)
 
 	base, releaseBase := newWorker()
@@ -156,7 +169,6 @@ func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*Hex
 
 	var children [16]cell
 	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(numWorkers)
 	childIdx := 0
 	for bm := node.bitmap; bm != 0; {
 		nib := int(bits.TrailingZeros16(bm))
@@ -168,9 +180,10 @@ func foldStorageRoot(ctx context.Context, numWorkers int, newWorker func() (*Hex
 		childPrefix = append(childPrefix, ch.ext...)
 		group := collectSubtreeKeys(ch, childPrefix)
 		g.Go(func() error {
-			if err := gctx.Err(); err != nil {
+			if err := sem.Acquire(gctx, 1); err != nil {
 				return err
 			}
+			defer sem.Release(1)
 			w, release := newWorker()
 			if w.traceW != nil {
 				w.SetTraceWriter(tracePrefix(w.traceW, accTag))


### PR DESCRIPTION
The account-mount fan-out (`processMounted` / `foldPresentSplits`) and the whale-storage fan-out (`foldStorageRoot`) each capped their errgroup at `numWorkers` independently, so a whale-heavy block nested to ~`numWorkers²` runnable leaf-fold goroutines on `numWorkers` cores — each holding a worker + MDBX ro-tx + grid buffers.

## Changes
- `foldStorageRoot` draws each first-nibble leaf from one shared semaphore sized at `GOMAXPROCS`, replacing the per-whale `errgroup.SetLimit(numWorkers)`.
- Outer dispatch capped at `min(numWorkers, GOMAXPROCS)` in `processMounted` and `foldPresentSplits`.
- `GOMAXPROCS`, not `numWorkers`: a `numWorkers`-sized shared budget starves cores when `numWorkers < GOMAXPROCS` with several whales.

Scheduling only — roots unchanged, parity tests pass under `-race`. Throughput is neutral at `numWorkers = NumCPU` (the fold is core-bound); the win is bounded workers/ro-txs and lower peak memory on whale-heavy blocks (−5% to −19% B/op at high worker counts).
