### PR TITLE
.claude/rules: update branch-naming for the 3.5 release line

### DIFF
--- a/.claude/rules/branch-naming.md
+++ b/.claude/rules/branch-naming.md
@@ -3,8 +3,11 @@
 ## Release branches
 
 - `release/3.3` — Stable 3.3.x
-- `release/3.4` — Stable 3.4.x (current)
-- `main` — Next feature release (3.5)
+- `release/3.4` — Stable 3.4.x
+- `release/3.5` — Stable 3.5.x (current)
+- `main` — Next feature release (3.6)
+
+The "current" marker goes stale: before choosing a backport base, verify against `gh release list --repo erigontech/erigon --limit 5` (the Latest tag) and the recent `[rX.Y]`-prefixed PR stream, and update this file if it disagrees.
 
 ## Developer branches
 
@@ -21,7 +24,7 @@ When creating a branch for someone else, sample their recent branches first (`gi
 
 ### Optional variants
 
-Some contributors append a release-number suffix to mark which release the branch targets — Alex's convention is `alex/<short_desc>_<release_num>[_suffix]` (e.g. `alex/seg_header_meta2_34`, `alex/all7_34_dbg`). Release number is two digits without the dot: `34` = release/3.4, `35` = main, `33` = release/3.3. Suffixes: `_dbg` (debug), `_auto` (automated), `_<n>` (revision). This is one contributor's personal scheme — do not apply it to others.
+Some contributors append a release-number suffix to mark which release the branch targets — Alex's convention is `alex/<short_desc>_<release_num>[_suffix]` (e.g. `alex/seg_header_meta2_34`, `alex/all7_34_dbg`). Release number is two digits without the dot: `35` = release/3.5, `36` = main, `34` = release/3.4. Suffixes: `_dbg` (debug), `_auto` (automated), `_<n>` (revision). This is one contributor's personal scheme — do not apply it to others.
 
 Non-personal prefixes that show up for cross-cutting work:
 
@@ -31,6 +34,7 @@ Non-personal prefixes that show up for cross-cutting work:
 
 ## Choosing a base branch
 
-- Bug for current stable release → base on `release/3.4`
+- Bug for current stable release → base on `release/3.5`
 - New feature → base on `main`
-- Backport / cherry-pick → branch off the target release branch, prefix the PR title with `[rX.Y]` (dominant form `[r3.4]`)
+- Backport / cherry-pick → branch off the target release branch, prefix the PR title with `[rX.Y]` (e.g. `[r3.5]`)
+- A bug present on several maintained release lines may need a backport per line — check each `release/X.Y` for the affected code before assuming one backport covers it


### PR DESCRIPTION
## What

Updates `.claude/rules/branch-naming.md` to reflect the current release lines: `release/3.5` (v3.5.0, released 2026-06-26) is the current stable and `main` is now the 3.6-next branch. Also updates the two-digit suffix mapping in the personal-branch-variant note, adds a hint to verify the 'current' marker against `gh release list` before choosing a backport base, and a reminder that a bug present on several maintained lines may need one backport per line.

## Why

The file still marked `release/3.4` as current (it predates the v3.5.0 cut), which steered an agent backport for #22321 to `release/3.4` (#22328) while v3.5.0 ships the same bug. Doc-only change; no code affected.