### PR TITLE
[r3.5] execution/state: delete stale CodeDomain entry on EIP-7702 delegation clear

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2064,8 +2064,11 @@ func updateAccount(EIP161Enabled bool, isAura bool, stateWriter StateWriter, add
 	}
 	if isDirty && (stateObject.createdContract || !stateObject.selfdestructed) && !emptyRemoval {
 		stateObject.deleted = false
-		// Write any contract code associated with the state object
-		if stateObject.code != nil && stateObject.dirtyCode {
+		// Write any contract code associated with the state object; dirtyCode is
+		// set only when code actually changed, so a clear-to-empty (e.g. removing
+		// an EIP-7702 delegation) must still write through, keeping CodeDomain
+		// consistent with the empty codeHash.
+		if stateObject.dirtyCode {
 			if err := stateWriter.UpdateAccountCode(addr, stateObject.data.Incarnation, stateObject.data.CodeHash, stateObject.code); err != nil {
 				return err
 			}

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -89,6 +89,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 			incarnation    *uint64
 			codeHash       *accounts.CodeHash
 			code           []byte
+			codeWritten    bool
 			selfDestruct   bool
 			createContract bool
 			storage        []storageItem
@@ -119,6 +120,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 				d.codeHash = &v
 			case CodePath:
 				d.code = w.Val.([]byte)
+				d.codeWritten = true
 			case SelfDestructPath:
 				d.selfDestruct = w.Val.(bool)
 			case CreateContractPath:
@@ -196,7 +198,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 				}
 			}
 
-			if d.balance != nil || d.nonce != nil || d.incarnation != nil || d.codeHash != nil || d.code != nil {
+			if d.balance != nil || d.nonce != nil || d.incarnation != nil || d.codeHash != nil || d.codeWritten {
 				// LightCollector emits only fields that changed vs the per-TX
 				// `original` snapshot, so missing fields here mean "unchanged"
 				// — we must read the current base (from blockCache when present,
@@ -225,7 +227,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 				}
 				if d.codeHash != nil {
 					acc.CodeHash = *d.codeHash
-				} else if d.code != nil {
+				} else if d.codeWritten {
 					acc.CodeHash = accounts.InternCodeHash(crypto.Keccak256Hash(d.code))
 				}
 				if dbg.TraceApply && (rs.trace.Load() || dbg.TraceAccount(addr.Handle())) {
@@ -244,7 +246,7 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 				}
 			}
 
-			if d.code != nil {
+			if d.codeWritten {
 				if dbg.TraceApply && (rs.trace.Load() || dbg.TraceAccount(addr.Handle())) {
 					code := d.code
 					if len(code) > 40 {
@@ -256,6 +258,10 @@ func (rs *StateV3) applyVersionedWrites(roTx kv.TemporalTx, blockNum, txNum uint
 					blockCache.WriteCode(addr, d.code, txNum)
 					if !domains.InlineTouchKeyDisabled() {
 						domains.GetCommitmentContext().TouchKey(kv.CodeDomain, string(address[:]), d.code)
+					}
+				} else if len(d.code) == 0 {
+					if err := domains.DomainDel(kv.CodeDomain, roTx, address[:], txNum, nil); err != nil {
+						return err
 					}
 				} else {
 					if err := domains.DomainPut(kv.CodeDomain, roTx, address[:], d.code, txNum, nil); err != nil {
@@ -901,7 +907,11 @@ func (w *Writer) UpdateAccountCode(address accounts.Address, incarnation uint64,
 		fmt.Printf("code: %x, %x, valLen: %d\n", address, codeHash, len(code))
 	}
 	addressValue := address.Value()
-	if err := w.tx.DomainPut(kv.CodeDomain, addressValue[:], code, w.txNum, nil); err != nil {
+	if len(code) == 0 {
+		if err := w.tx.DomainDel(kv.CodeDomain, addressValue[:], w.txNum, nil); err != nil {
+			return err
+		}
+	} else if err := w.tx.DomainPut(kv.CodeDomain, addressValue[:], code, w.txNum, nil); err != nil {
 		return err
 	}
 	if w.accumulator != nil {
@@ -1286,7 +1296,11 @@ func (c *BlockStateCache) Flush(domains *execctx.SharedDomains, roTx kv.Temporal
 				return err
 			}
 		case bcOpPutCode:
-			if err := domains.DomainPut(kv.CodeDomain, roTx, addrVal[:], op.val, op.txNum, nil); err != nil {
+			if len(op.val) == 0 {
+				if err := domains.DomainDel(kv.CodeDomain, roTx, addrVal[:], op.txNum, nil); err != nil {
+					return err
+				}
+			} else if err := domains.DomainPut(kv.CodeDomain, roTx, addrVal[:], op.val, op.txNum, nil); err != nil {
 				return err
 			}
 		case bcOpPutStorage:

--- a/execution/tests/setcode_clear_delegation_test.go
+++ b/execution/tests/setcode_clear_delegation_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package executiontests
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+func signAuthorization(t *testing.T, key *ecdsa.PrivateKey, chainID uint256.Int, delegate common.Address, nonce uint64) types.Authorization {
+	t.Helper()
+	auth := types.Authorization{ChainID: chainID, Address: delegate, Nonce: nonce}
+	payloadLen := rlp.Uint256Len(auth.ChainID) + 1 + length.Addr + rlp.U64Len(auth.Nonce)
+	var buf [32]byte
+	data := bytes.NewBuffer(nil)
+	require.NoError(t, rlp.EncodeListPrefix(payloadLen, data, buf[:]))
+	require.NoError(t, rlp.EncodeUint256(auth.ChainID, data, buf[:]))
+	require.NoError(t, types.EncodeOptionalAddress(&auth.Address, data, buf[:]))
+	require.NoError(t, rlp.EncodeU64(auth.Nonce, data, buf[:]))
+	sighash := crypto.Keccak256Hash(append([]byte{params.SetCodeMagicPrefix}, data.Bytes()...))
+	sig, err := crypto.Sign(sighash[:], key)
+	require.NoError(t, err)
+	auth.R.SetBytes(sig[:32])
+	auth.S.SetBytes(sig[32:64])
+	auth.YParity = sig[64]
+	recovered, err := auth.RecoverSigner(bytes.NewBuffer(nil), buf[:])
+	require.NoError(t, err)
+	require.Equal(t, crypto.PubkeyToAddress(key.PublicKey), *recovered)
+	return auth
+}
+
+// TestSetCodeClearDelegationPurgesCodeDomain pins the account↔code domain
+// invariant across the EIP-7702 delegation lifecycle: setting a delegation
+// stores the designator in CodeDomain; clearing it (authorization to the zero
+// address) must delete that CodeDomain entry rather than leave the stale
+// designator alongside an account whose code hash says "no code".
+func TestSetCodeClearDelegationPurgesCodeDomain(t *testing.T) {
+	// mutates dbg.Exec3Parallel per sub-test; not safe for t.Parallel
+	for _, mode := range []struct {
+		name     string
+		parallel bool
+	}{
+		{"serial", false},
+		{"parallel", true},
+	} {
+		t.Run(mode.name, func(t *testing.T) {
+			prev := dbg.Exec3Parallel
+			dbg.Exec3Parallel = mode.parallel
+			t.Cleanup(func() { dbg.Exec3Parallel = prev })
+
+			senderKey, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+			require.NoError(t, err)
+			authorityKey, err := crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+			require.NoError(t, err)
+			sender := crypto.PubkeyToAddress(senderKey.PublicKey)
+			authority := crypto.PubkeyToAddress(authorityKey.PublicKey)
+			delegate := common.HexToAddress("0x000000000000000000000000000000000000cafe")
+
+			cfg := &chain.Config{
+				ChainID:                       uint256.NewInt(1337),
+				Rules:                         chain.EtHashRules,
+				HomesteadBlock:                common.NewUint64(0),
+				TangerineWhistleBlock:         common.NewUint64(0),
+				SpuriousDragonBlock:           common.NewUint64(0),
+				ByzantiumBlock:                common.NewUint64(0),
+				ConstantinopleBlock:           common.NewUint64(0),
+				PetersburgBlock:               common.NewUint64(0),
+				IstanbulBlock:                 common.NewUint64(0),
+				MuirGlacierBlock:              common.NewUint64(0),
+				BerlinBlock:                   common.NewUint64(0),
+				LondonBlock:                   common.NewUint64(0),
+				ArrowGlacierBlock:             common.NewUint64(0),
+				GrayGlacierBlock:              common.NewUint64(0),
+				TerminalTotalDifficulty:       uint256.NewInt(0),
+				TerminalTotalDifficultyPassed: true,
+				ShanghaiTime:                  common.NewUint64(0),
+				CancunTime:                    common.NewUint64(0),
+				PragueTime:                    common.NewUint64(0),
+				DepositContract:               common.HexToAddress("0x00000000219ab540356cBB839Cbe05303d7705Fa"),
+				Ethash:                        new(chain.EthashConfig),
+			}
+			gspec := &types.Genesis{
+				Config: cfg,
+				Alloc: types.GenesisAlloc{
+					sender: {Balance: big.NewInt(1_000_000_000_000_000_000)},
+				},
+			}
+			m := execmoduletester.New(t, execmoduletester.WithGenesisSpec(gspec), execmoduletester.WithKey(senderKey))
+
+			signer := types.LatestSignerForChainID(cfg.ChainID)
+			mkSetCodeTx := func(nonce uint64, auth types.Authorization) types.Transaction {
+				to := common.HexToAddress("0x000000000000000000000000000000000000beef")
+				txn := &types.SetCodeTransaction{
+					DynamicFeeTransaction: types.DynamicFeeTransaction{
+						CommonTx: types.CommonTx{Nonce: nonce, GasLimit: 500_000, To: &to},
+						ChainID:  *cfg.ChainID,
+						TipCap:   *uint256.NewInt(1_000_000_000),
+						FeeCap:   *uint256.NewInt(10_000_000_000),
+					},
+					Authorizations: []types.Authorization{auth},
+				}
+				signed, err := types.SignTx(txn, *signer, senderKey)
+				require.NoError(t, err)
+				return signed
+			}
+
+			chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 2, func(i int, b *blockgen.BlockGen) {
+				b.SetCoinbase(common.Address{1})
+				switch i {
+				case 0:
+					b.AddTx(mkSetCodeTx(b.TxNonce(sender), signAuthorization(t, authorityKey, *cfg.ChainID, delegate, 0)))
+				case 1:
+					b.AddTx(mkSetCodeTx(b.TxNonce(sender), signAuthorization(t, authorityKey, *cfg.ChainID, common.Address{}, 1)))
+				}
+			})
+			require.NoError(t, err)
+
+			readAuthority := func() (accounts.Account, []byte) {
+				var acc accounts.Account
+				var code []byte
+				require.NoError(t, m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
+					accEnc, _, _ := tx.GetLatest(kv.AccountsDomain, authority[:])
+					if len(accEnc) > 0 {
+						if err := accounts.DeserialiseV3(&acc, accEnc); err != nil {
+							return err
+						}
+					}
+					code, _, _ = tx.GetLatest(kv.CodeDomain, authority[:])
+					return nil
+				}))
+				return acc, code
+			}
+
+			require.NoError(t, m.InsertChain(chainPack.Slice(0, 1)))
+			acc, code := readAuthority()
+			require.EqualValues(t, 1, acc.Nonce, "set authorization must have been applied")
+			require.Equal(t, types.AddressToDelegation(accounts.InternAddress(delegate)), code)
+			require.False(t, acc.IsEmptyCodeHash())
+
+			require.NoError(t, m.InsertChain(chainPack.Slice(1, 2)))
+			acc, code = readAuthority()
+			require.EqualValues(t, 2, acc.Nonce, "clear authorization must have been applied")
+			require.True(t, acc.IsEmptyCodeHash(), "account code hash must be empty after delegation clear")
+			require.Empty(t, code, "CodeDomain must not retain the delegation designator after clear")
+		})
+	}
+}


### PR DESCRIPTION
Targeted backport of the clear-to-empty code write-through that landed on `main` inside the #21536 refactor (not a cherry-pick — this extracts just the behavioral fix). Part of #22321; sibling of #22328 (release/3.4).

## What

Clearing an EIP-7702 delegation (authorization to the zero address) runs `SetCode(authority, nil)`. The `stateObject.code != nil` guard in `updateAccount` skipped `UpdateAccountCode` for nil code, so the account was written with the empty code hash while `CodeDomain` kept the old delegation designator. Every delegation clear executed by a v3.5.0 node leaves such a residue in the datadir. With assertions enabled (`ERIGON_ASSERT=true`, as in the QA workflows) commitment then fails with `code hash mismatch` on the next touch of the account — the #22321 failure mode. Consensus and RPC are unaffected: commitment uses the account's own code hash, and EVM/RPC code reads gate on the empty code hash before consulting CodeDomain.

Changes (mirroring `main`'s post-#21536 shape):

- `updateAccount`: write code through on `dirtyCode` alone.
- `Writer.UpdateAccountCode`: translate empty code into `DomainDel(CodeDomain)` instead of putting an empty value.
- `applyVersionedWrites` (parallel executor): add the `codeWritten` flag (as on `main`) so a nil-code write is distinguishable from "code untouched", derive the code hash and emit the CodeDomain delete accordingly.
- `BlockStateCache.Flush`: translate an empty buffered code write into `DomainDel`.

## r3.5-specific adaptations

- Unlike `main` at the time of #21536, **both** executors on release/3.5 dropped the clear (verified by the regression test failing in serial *and* parallel before this fix): the parallel apply gated every code consumer on `d.code != nil`, so the nil-code versioned write was discarded. Hence the `codeWritten`/flush changes here in addition to the guard and `Writer` fixes.
- Includes the regression test from #22327 with a minor API adaptation (`TemporalTx.GetLatest` returns `ok` instead of `error` on this branch). Red before the fix in both exec modes, green after.

## Note

This stops *new* residues. Residues already written persist in datadirs until the affected address receives another code write; see #22321 for the QA reference-datadir implications and #22329 for the repair tool.
