### PR TITLE
db/state/execctx: enforce CodeStore table cap on the commit write path

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -960,6 +960,14 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 			return err
 		}
 	}
+	// Enforce the store's byte cap on the path that grows it: flows that never
+	// reach the forkchoice prune loop (its other Evict site) would otherwise
+	// grow the table without bound.
+	if len(codeStoreWrites) > 0 {
+		if err := sd.codeStore.Evict(tx); err != nil {
+			return err
+		}
+	}
 	if err := runValidate(); err != nil {
 		return err
 	}

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -960,16 +960,17 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 			return err
 		}
 	}
+	if err := runValidate(); err != nil {
+		return err
+	}
 	// Enforce the store's byte cap on the path that grows it: flows that never
 	// reach the forkchoice prune loop (its other Evict site) would otherwise
-	// grow the table without bound.
+	// grow the table without bound. Runs after validation so a validate failure
+	// doesn't roll back eviction's in-memory size accounting with the tx.
 	if len(codeStoreWrites) > 0 {
 		if err := sd.codeStore.Evict(tx); err != nil {
 			return err
 		}
-	}
-	if err := runValidate(); err != nil {
-		return err
 	}
 	// Adaptive pin promotions/demotions run on the in-flight (pre-Commit) tx so
 	// the preload sees the just-flushed bytes.

--- a/db/state/execctx/flush_code_store_test.go
+++ b/db/state/execctx/flush_code_store_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execctx_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/cache"
+)
+
+// Pins that Commit enforces the CodeStore MDBX-tier byte cap on the write path.
+// The only other Evict site is the forkchoice prune loop, which flows that
+// never issue FCU (engine-x fixture imports, long side-chain stretches) don't
+// reach — without eviction here the table grows unbounded with every deployed
+// contract.
+func TestCommit_EnforcesCodeStoreTableCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	const stepSize = uint64(16)
+	ctx := t.Context()
+	db := newTestDb(t, stepSize)
+
+	const tableCap = 8 * 1024
+	cs := cache.NewCodeStore(1<<20, tableCap)
+
+	rwTx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback() // safety net; Rollback after a successful Commit is a no-op
+
+	sd, err := execctx.NewSharedDomains(ctx, rwTx, log.New())
+	require.NoError(t, err)
+	defer sd.Close()
+
+	sd.SetCodeStore(cs)
+	sd.SetTxNum(1)
+
+	// Write several distinct contract codes totalling well past the cap.
+	code := make([]byte, 4*1024)
+	for i := range 5 {
+		addr := make([]byte, 20)
+		addr[0] = byte(i + 1)
+		code[0] = byte(i + 1)
+		require.NoError(t, sd.DomainPut(kv.CodeDomain, rwTx, addr, append([]byte(nil), code...), 1, nil))
+	}
+	require.NoError(t, sd.Commit(ctx, rwTx))
+
+	roTx, err := db.BeginRo(ctx)
+	require.NoError(t, err)
+	defer roTx.Rollback()
+	c, err := roTx.Cursor(kv.TblCodeCache)
+	require.NoError(t, err)
+	defer c.Close()
+	var total int
+	for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
+		require.NoError(t, err)
+		total += len(k) + len(v)
+	}
+	require.LessOrEqual(t, total, tableCap,
+		"Commit must keep the CodeStore MDBX tier within its byte cap; unbounded growth on FCU-less flows was the bug")
+}

--- a/db/state/execctx/flush_code_store_test.go
+++ b/db/state/execctx/flush_code_store_test.go
@@ -73,10 +73,14 @@ func TestCommit_EnforcesCodeStoreTableCap(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 	var total int
-	for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
-		require.NoError(t, err)
+	// A cursor error returns k=nil, exiting the loop — check err after, not
+	// inside, or an errored scan false-passes with total=0.
+	k, v, err := c.First()
+	for k != nil {
 		total += len(k) + len(v)
+		k, v, err = c.Next()
 	}
+	require.NoError(t, err)
 	require.LessOrEqual(t, total, tableCap,
 		"Commit must keep the CodeStore MDBX tier within its byte cap; unbounded growth on FCU-less flows was the bug")
 }


### PR DESCRIPTION
## Problem

The persistent code cache introduced in #22154 caps its MDBX tier (`TblCodeCache`) at 1 GiB, but the only `Evict` call site is the forkchoiceUpdated prune loop. Flows that never issue FCU — `evm enginextest` engine-x fixture imports (newPayload-only branch blocks), long side-chain stretches — grow the table without bound.

Profiling the eest `enginextests-benchmark-150m` OOM flake (#22325) surfaced this concretely: the benchmark's `unchunkified_bytecode` family (each test carries a 275B-gas setup block deploying ~18k max-size contracts) accumulates **1.29 GB** of decompressed code in `TblCodeCache`, which lands on the CI runner's 8 GB tmpfs and is the bulk of the job's +2 GB co-resident regression since Jul 7 (full A/B data on #22325).

## Fix

Enforce the cap where the table grows: `SharedDomains.Commit` calls `Evict` after the `PutByHash` loop and the validate hooks (so a validate failure can't roll back eviction's size accounting with the tx), on the same tx, only on flushes that actually wrote code. Under the cap this is one atomic load; the first call per process seeds the size counter with a table scan (~40k entries at the cap).

Production behaviour is unchanged in practice — nodes at tip evict via the FCU prune loop anyway; this closes the FCU-less corner.

## Note on the 150m flake

This alone does not de-flake the 150m benchmark: that workload's code volume sits just *under* the 1 GiB cap (~0.97 GiB key+value bytes), while its real tmpfs cost is ~1.7 GB (MDBX pages + free-page fragmentation). Bounding the tester datadir (#22325) remains the mitigation for the job; this PR restores the store's intended invariant so bigger corpora can't grow it unboundedly.

## TDD

Red first: `TestCommit_EnforcesCodeStoreTableCap` writes 5×4 KiB codes through the `SharedDomains.Commit` flush path against an 8 KiB-cap store and asserts the table stays within cap — failed with 20640 > 8192 before the fix, green after.
