### PR TITLE
execution/stagedsync: fix worker starvation in high-tx-count blocks by optimizing parallel-exec dispatch

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3209,6 +3209,9 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 	// now (gate-rejected retry, or fresh with no free slot) are held aside and
 	// re-added after the loop so they aren't re-taken in the same call.
 	dispatch := func() (dispatched int) {
+		if be.execTasks.minPending() < 0 {
+			return 0
+		}
 		budget := pe.in.Capacity() - pe.in.NewTasksLen()
 		var holdBack sort.IntSlice
 		for be.execTasks.minPending() >= 0 {

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3201,37 +3201,25 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 		return drainMaxValidated >= tx-1 && (drainMinIP < 0 || drainMinIP >= tx)
 	})
 
-	// Refill only the queue's free slots; take-all + push-back-overflow per result
-	// is O(n²) churn that starves workers.
-	toExecute := make(sort.IntSlice, 0, 2)
-
-	if be.execTasks.minPending() >= 0 {
-		budget := pe.in.Capacity() - pe.in.NewTasksLen()
-		for budget > 0 && be.execTasks.minPending() >= 0 {
-			toExecute = append(toExecute, be.execTasks.takeNextPending())
-			budget--
-		}
-	}
-
-	// Forward-progress safety net: pending empty + no workers in flight
-	// means nothing will drive a subsequent maxComplete advance. Force-
-	// drain so the exec loop doesn't block on rws.ResultCh forever.
-	if len(toExecute) == 0 && be.execTasks.inProgressCount() == 0 {
-		be.execTasks.drainDeferred()
-		for be.execTasks.minPending() >= 0 {
-			toExecute = append(toExecute, be.execTasks.takeNextPending())
-		}
-	}
-
 	maxValidated := be.validateTasks.maxComplete()
-	for i := 0; i < len(toExecute); i++ {
-		nextTx := toExecute[i]
-		execTask := be.tasks[nextTx]
-		isNextValidated := nextTx == maxValidated+1
-		if !isNextValidated {
-			txIndex := execTask.Version().TxIndex
-			if be.txIncarnations[nextTx] > 0 &&
-				(be.execTasks.isBlocked(nextTx) || !be.blockIO.HasReads(txIndex) ||
+
+	// dispatch drains pending, enqueuing each tx. Budget bounds only fresh
+	// (incarnation 0) enqueues, which occupy an input-channel slot; retries go
+	// to the retry heap (unbounded) and don't consume budget. Txs that can't go
+	// now (gate-rejected retry, or fresh with no free slot) are held aside and
+	// re-added after the loop so they aren't re-taken in the same call.
+	dispatch := func() (dispatched int) {
+		budget := pe.in.Capacity() - pe.in.NewTasksLen()
+		var holdBack sort.IntSlice
+		for be.execTasks.minPending() >= 0 {
+			nextTx := be.execTasks.takeNextPending()
+			execTask := be.tasks[nextTx]
+			isNextValidated := nextTx == maxValidated+1
+			incarnation := be.txIncarnations[nextTx]
+
+			if !isNextValidated && incarnation > 0 {
+				txIndex := execTask.Version().TxIndex
+				if be.execTasks.isBlocked(nextTx) || !be.blockIO.HasReads(txIndex) ||
 					be.versionMap.ValidateVersion(txIndex, be.blockIO,
 						func(_, writtenVersion state.Version) state.VersionValidity {
 							wi := writtenVersion.TxIndex + 1
@@ -3241,54 +3229,67 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 								return state.VersionValid
 							}
 							return state.VersionInvalid
-						}, false, "") != state.VersionValid) {
-				be.execTasks.pushPending(nextTx)
-				continue
-			}
-		}
-
-		tv := &taskVersion{
-			execTask:   execTask,
-			versionMap: be.versionMap,
-			profile:    be.profile,
-			stats:      be.stats,
-			statsMutex: &be.Mutex,
-		}
-
-		if incarnation := be.txIncarnations[nextTx]; incarnation == 0 {
-			tv.version = execTask.Version()
-			// Use TryAdd to avoid blocking the execLoop goroutine.
-			// If the input queue is full, return remaining tasks to
-			// pending — they will be scheduled on the next call to
-			// scheduleExecution (triggered by each processed result).
-			if !pe.in.TryAdd(tv) {
-				be.execTasks.pushPending(nextTx)
-				for j := i + 1; j < len(toExecute); j++ {
-					be.execTasks.pushPending(toExecute[j])
+						}, false, "") != state.VersionValid {
+					holdBack = append(holdBack, nextTx)
+					continue
 				}
-				return
 			}
-		} else {
-			version := execTask.Version()
-			version.Incarnation = incarnation
-			tv.version = version
-			pe.in.ReTry(tv)
-		}
 
-		// Commit side-effects only after successful enqueue. Record whether
-		// this dispatch runs against fully settled input (every predecessor
-		// already validated) so a genuine error from it can be classified
-		// without re-execution — see the settledInput field doc.
-		be.settledInput[nextTx] = isNextValidated
-		if !isNextValidated {
-			be.cntSpecExec++
-		}
+			tv := &taskVersion{
+				execTask:   execTask,
+				versionMap: be.versionMap,
+				profile:    be.profile,
+				stats:      be.stats,
+				statsMutex: &be.Mutex,
+			}
 
-		if dbg.TraceTransactionIO && be.txIncarnations[nextTx] > 1 {
-			fmt.Println(be.blockNum, "EXEC", nextTx, be.txIncarnations[nextTx], "maxValidated", maxValidated, be.blockIO.HasReads(nextTx), "failed", be.execFailed[nextTx], "aborted", be.execAborted[nextTx])
-		}
+			if incarnation == 0 {
+				// Fresh tx needs a free channel slot; stop once the queue is full
+				// (remaining pending stay put — no take-all/push-back churn).
+				if budget <= 0 {
+					holdBack = append(holdBack, nextTx)
+					break
+				}
+				tv.version = execTask.Version()
+				if !pe.in.TryAdd(tv) {
+					holdBack = append(holdBack, nextTx)
+					break
+				}
+				budget--
+			} else {
+				version := execTask.Version()
+				version.Incarnation = incarnation
+				tv.version = version
+				pe.in.ReTry(tv)
+			}
 
-		be.cntExec++
+			// Commit side-effects only after successful enqueue. Record whether
+			// this dispatch runs against fully settled input (every predecessor
+			// already validated) so a genuine error from it can be classified
+			// without re-execution — see the settledInput field doc.
+			be.settledInput[nextTx] = isNextValidated
+			if !isNextValidated {
+				be.cntSpecExec++
+			}
+			if dbg.TraceTransactionIO && be.txIncarnations[nextTx] > 1 {
+				fmt.Println(be.blockNum, "EXEC", nextTx, be.txIncarnations[nextTx], "maxValidated", maxValidated, be.blockIO.HasReads(nextTx), "failed", be.execFailed[nextTx], "aborted", be.execAborted[nextTx])
+			}
+			be.cntExec++
+			dispatched++
+		}
+		for _, tx := range holdBack {
+			be.execTasks.pushPending(tx)
+		}
+		return dispatched
+	}
+
+	// Forward-progress net: release deferred (past its predicate) only when nothing
+	// dispatched, pending is empty, and nothing is in flight. Guarded on empty
+	// pending because the next-to-validate tx is never gate-rejected, so non-empty
+	// pending is always dispatchable — the net must not force-drain past it.
+	if dispatch() == 0 && be.execTasks.minPending() < 0 && be.execTasks.inProgressCount() == 0 {
+		be.execTasks.drainDeferred()
+		dispatch()
 	}
 }
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3214,11 +3214,21 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 		}
 		budget := pe.in.Capacity() - pe.in.NewTasksLen()
 		var holdBack sort.IntSlice
-		for be.execTasks.minPending() >= 0 {
-			nextTx := be.execTasks.takeNextPending()
+		for {
+			nextTx := be.execTasks.minPending()
+			if nextTx < 0 {
+				break
+			}
+			incarnation := be.txIncarnations[nextTx]
+			// A fresh tx needs a free input-channel slot. If none, leave it in
+			// pending (peek, don't take): taking then re-inserting the lowest
+			// index at the front would be O(pending) shift churn per call.
+			if incarnation == 0 && budget <= 0 {
+				break
+			}
+			be.execTasks.takeNextPending()
 			execTask := be.tasks[nextTx]
 			isNextValidated := nextTx == maxValidated+1
-			incarnation := be.txIncarnations[nextTx]
 
 			if !isNextValidated && incarnation > 0 {
 				txIndex := execTask.Version().TxIndex
@@ -3247,12 +3257,6 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 			}
 
 			if incarnation == 0 {
-				// Fresh tx needs a free channel slot; stop once the queue is full
-				// (remaining pending stay put — no take-all/push-back churn).
-				if budget <= 0 {
-					holdBack = append(holdBack, nextTx)
-					break
-				}
 				tv.version = execTask.Version()
 				if !pe.in.TryAdd(tv) {
 					holdBack = append(holdBack, nextTx)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3195,7 +3195,6 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 	// at index < N is in flight. Lower-indexed workers' flushes land at
 	// indices visible to N's reads via vm.Read's floor(N-1); higher-indexed
 	// ones don't. Non-deferred txs keep dispatching via pending.
-	// invariant across the drain (it only moves deferred->pending): hoist out of the predicate.
 	drainMaxValidated := be.validateTasks.maxComplete()
 	drainMinIP := be.execTasks.minInProgress()
 	be.execTasks.drainDeferredIfReady(func(tx int) bool {

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3195,18 +3195,25 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 	// at index < N is in flight. Lower-indexed workers' flushes land at
 	// indices visible to N's reads via vm.Read's floor(N-1); higher-indexed
 	// ones don't. Non-deferred txs keep dispatching via pending.
+	// maxValidated and minIP are invariant across the drain (it only moves txs
+	// deferred->pending, changing neither complete nor inProgress) — hoist them
+	// out of the per-deferred-tx predicate.
+	drainMaxValidated := be.validateTasks.maxComplete()
+	drainMinIP := be.execTasks.minInProgress()
 	be.execTasks.drainDeferredIfReady(func(tx int) bool {
-		if be.validateTasks.maxComplete() < tx-1 {
-			return false
-		}
-		minIP := be.execTasks.minInProgress()
-		return minIP < 0 || minIP >= tx
+		return drainMaxValidated >= tx-1 && (drainMinIP < 0 || drainMinIP >= tx)
 	})
 
+	// Refill only the queue's free slots: taking the whole pending set per result
+	// and pushing the overflow back is O(n²) churn that starves workers.
 	toExecute := make(sort.IntSlice, 0, 2)
 
-	for be.execTasks.minPending() >= 0 {
-		toExecute = append(toExecute, be.execTasks.takeNextPending())
+	if be.execTasks.minPending() >= 0 {
+		budget := pe.in.Capacity() - pe.in.NewTasksLen()
+		for budget > 0 && be.execTasks.minPending() >= 0 {
+			toExecute = append(toExecute, be.execTasks.takeNextPending())
+			budget--
+		}
 	}
 
 	// Forward-progress safety net: pending empty + no workers in flight

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3195,17 +3195,15 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 	// at index < N is in flight. Lower-indexed workers' flushes land at
 	// indices visible to N's reads via vm.Read's floor(N-1); higher-indexed
 	// ones don't. Non-deferred txs keep dispatching via pending.
-	// maxValidated and minIP are invariant across the drain (it only moves txs
-	// deferred->pending, changing neither complete nor inProgress) — hoist them
-	// out of the per-deferred-tx predicate.
+	// invariant across the drain (it only moves deferred->pending): hoist out of the predicate.
 	drainMaxValidated := be.validateTasks.maxComplete()
 	drainMinIP := be.execTasks.minInProgress()
 	be.execTasks.drainDeferredIfReady(func(tx int) bool {
 		return drainMaxValidated >= tx-1 && (drainMinIP < 0 || drainMinIP >= tx)
 	})
 
-	// Refill only the queue's free slots: taking the whole pending set per result
-	// and pushing the overflow back is O(n²) churn that starves workers.
+	// Refill only the queue's free slots; take-all + push-back-overflow per result
+	// is O(n²) churn that starves workers.
 	toExecute := make(sort.IntSlice, 0, 2)
 
 	if be.execTasks.minPending() >= 0 {

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1577,7 +1577,7 @@ func TestParallelResumeReconstructsPriorReceipts(t *testing.T) {
 	}
 	be.tasks = []*execTask{eTask}
 	be.results = []*execResult{nil}
-	be.execTasks.inProgress = []int{0}
+	be.execTasks.setInProgress(0)
 
 	tVersion := &taskVersion{
 		execTask: eTask,
@@ -1650,7 +1650,7 @@ func TestParallelResumeReconstructionFailureIsNonFatal(t *testing.T) {
 	}
 	be.tasks = []*execTask{eTask}
 	be.results = []*execResult{nil}
-	be.execTasks.inProgress = []int{0}
+	be.execTasks.setInProgress(0)
 
 	tVersion := &taskVersion{
 		execTask: eTask,
@@ -1724,8 +1724,8 @@ func TestParallelFinalizeMissingPrevReceiptErrors(t *testing.T) {
 	// tx 0 was "finalized" without a receipt — the invariant nextResult
 	// relies on for the in-memory prev-receipt lookup is broken.
 	be.finalizedResults[0] = &execResult{TxResult: &exec.TxResult{Task: tVersion0}}
-	be.execTasks.complete = []int{0}
-	be.execTasks.inProgress = []int{1}
+	be.execTasks.setComplete(0)
+	be.execTasks.setInProgress(1)
 
 	txResult1 := &exec.TxResult{
 		Task: tVersion1,

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -444,11 +444,11 @@ func checkNoStatusOverlap(pe *parallelExecutor) error {
 	defer pe.RUnlock()
 
 	for blockNum, blockStatus := range pe.blockExecutors {
-		for _, tx := range blockStatus.execTasks.complete {
+		for _, tx := range blockStatus.execTasks.completeList() {
 			seen[tx] = "complete"
 		}
 
-		for _, tx := range blockStatus.execTasks.inProgress {
+		for _, tx := range blockStatus.execTasks.inProgressList() {
 			if v, ok := seen[tx]; ok {
 				return fmt.Errorf("blk %d, tx %v is in both %v and inProgress", blockNum, v, tx)
 			}
@@ -1494,7 +1494,7 @@ func TestParallelResumeBoundaryOffsets(t *testing.T) {
 	}
 	be.tasks = []*execTask{eTask}
 	be.results = []*execResult{nil}
-	be.execTasks.inProgress = []int{0}
+	be.execTasks.setInProgress(0)
 
 	tVersion := &taskVersion{
 		execTask: eTask,

--- a/execution/stagedsync/exec3_status.go
+++ b/execution/stagedsync/exec3_status.go
@@ -2,6 +2,7 @@ package stagedsync
 
 import (
 	"errors"
+	"slices"
 	"sort"
 	"time"
 )
@@ -28,12 +29,12 @@ type execStatusList struct {
 }
 
 func (m *execStatusList) ensureLen(tx int) {
-	if tx < len(m.complete) {
+	n := tx + 1
+	if n <= len(m.complete) {
 		return
 	}
-	grow := tx + 1 - len(m.complete)
-	m.complete = append(m.complete, make([]bool, grow)...)
-	m.inProgress = append(m.inProgress, make([]bool, grow)...)
+	m.complete = slices.Grow(m.complete, n-len(m.complete))[:n]
+	m.inProgress = slices.Grow(m.inProgress, n-len(m.inProgress))[:n]
 }
 
 func insertInList(l []int, v int) []int {

--- a/execution/stagedsync/exec3_status.go
+++ b/execution/stagedsync/exec3_status.go
@@ -15,25 +15,25 @@ type ExecutionStat struct {
 // complete/inProgress use dense []bool (O(1)) rather than sorted []int: completions
 // arrive out of tx order, so slice insert/delete would be O(n²) per block.
 type execStatusList struct {
-	pending       []int
-	deferred      []int // txs whose retry waits on a directed-delay predicate
-	inProg        []bool
-	comp          []bool
-	dependency    map[int]map[int]bool
-	blocker       map[int]map[int]bool
-	inProgCnt     int
-	compCnt       int
-	completeUpTo  int // completeUpTo-1 == maxComplete (contiguous-from-zero complete prefix)
-	minInProgHint int // lower bound on the lowest in-progress index; lazily advanced on query
+	pending           []int
+	deferred          []int // txs whose retry waits on a directed-delay predicate
+	inProgress        []bool
+	complete          []bool
+	dependency        map[int]map[int]bool
+	blocker           map[int]map[int]bool
+	inProgressCnt     int
+	completeCnt       int
+	completeUpTo      int // completeUpTo-1 == maxComplete (contiguous-from-zero complete prefix)
+	minInProgressHint int // lower bound on the lowest in-progress index; lazily advanced on query
 }
 
 func (m *execStatusList) ensureLen(tx int) {
-	if tx < len(m.comp) {
+	if tx < len(m.complete) {
 		return
 	}
-	grow := tx + 1 - len(m.comp)
-	m.comp = append(m.comp, make([]bool, grow)...)
-	m.inProg = append(m.inProg, make([]bool, grow)...)
+	grow := tx + 1 - len(m.complete)
+	m.complete = append(m.complete, make([]bool, grow)...)
+	m.inProgress = append(m.inProgress, make([]bool, grow)...)
 }
 
 func insertInList(l []int, v int) []int {
@@ -59,12 +59,12 @@ func (m *execStatusList) takeNextPending() int {
 	x := m.pending[0]
 	m.pending = m.pending[1:]
 	m.ensureLen(x)
-	if !m.inProg[x] {
-		m.inProg[x] = true
-		m.inProgCnt++
+	if !m.inProgress[x] {
+		m.inProgress[x] = true
+		m.inProgressCnt++
 	}
-	if x < m.minInProgHint {
-		m.minInProgHint = x
+	if x < m.minInProgressHint {
+		m.minInProgressHint = x
 	}
 
 	return x
@@ -112,37 +112,49 @@ func (m *execStatusList) drainDeferredIfReady(ready func(tx int) bool) {
 
 func (m *execStatusList) setInProgress(tx int) {
 	m.ensureLen(tx)
-	if !m.inProg[tx] {
-		m.inProg[tx] = true
-		m.inProgCnt++
+	if !m.inProgress[tx] {
+		m.inProgress[tx] = true
+		m.inProgressCnt++
 	}
-	if tx < m.minInProgHint {
-		m.minInProgHint = tx
+	if tx < m.minInProgressHint {
+		m.minInProgressHint = tx
 	}
 }
 
-func (m *execStatusList) inProgressCount() int { return m.inProgCnt }
+func (m *execStatusList) setComplete(tx int) {
+	m.ensureLen(tx)
+	if !m.complete[tx] {
+		m.complete[tx] = true
+		m.completeCnt++
+	}
+	if tx == m.completeUpTo {
+		for m.completeUpTo < len(m.complete) && m.complete[m.completeUpTo] {
+			m.completeUpTo++
+		}
+	}
+}
+
+func (m *execStatusList) inProgressCount() int { return m.inProgressCnt }
 
 // minInProgress returns the lowest in-progress tx index, or -1 if empty.
 func (m *execStatusList) minInProgress() int {
-	if m.inProgCnt == 0 {
+	if m.inProgressCnt == 0 {
 		return -1
 	}
-	// in-progress txs are always >= completeUpTo, so jump the hint past the known
-	// complete prefix, then lazily advance it past cleared entries. The hint only
-	// moves backward when a lower index is (re-)dispatched, so queries amortize O(1).
-	if m.minInProgHint < m.completeUpTo {
-		m.minInProgHint = m.completeUpTo
+	// in-progress txs are >= completeUpTo; advancing the hint lazily from there
+	// (it only moves back when a lower index is re-dispatched) is amortized O(1).
+	if m.minInProgressHint < m.completeUpTo {
+		m.minInProgressHint = m.completeUpTo
 	}
-	for m.minInProgHint < len(m.inProg) && !m.inProg[m.minInProgHint] {
-		m.minInProgHint++
+	for m.minInProgressHint < len(m.inProgress) && !m.inProgress[m.minInProgressHint] {
+		m.minInProgressHint++
 	}
-	return m.minInProgHint
+	return m.minInProgressHint
 }
 
 func removeFromList(l []int, v int, expect bool) []int {
 	x := sort.SearchInts(l, v)
-	if x == -1 || x >= len(l) || l[x] != v {
+	if x >= len(l) || l[x] != v {
 		if expect {
 			panic(errors.New("should not happen - element expected in list"))
 		}
@@ -162,17 +174,17 @@ func removeFromList(l []int, v int, expect bool) []int {
 
 func (m *execStatusList) markComplete(tx int) {
 	m.ensureLen(tx)
-	if !m.inProg[tx] {
+	if !m.inProgress[tx] {
 		panic(errors.New("should not happen - element expected in list"))
 	}
-	m.inProg[tx] = false
-	m.inProgCnt--
-	if !m.comp[tx] {
-		m.comp[tx] = true
-		m.compCnt++
+	m.inProgress[tx] = false
+	m.inProgressCnt--
+	if !m.complete[tx] {
+		m.complete[tx] = true
+		m.completeCnt++
 	}
 	if tx == m.completeUpTo {
-		for m.completeUpTo < len(m.comp) && m.comp[m.completeUpTo] {
+		for m.completeUpTo < len(m.complete) && m.complete[m.completeUpTo] {
 			m.completeUpTo++
 		}
 	}
@@ -187,7 +199,7 @@ func (m *execStatusList) minPending() int {
 }
 
 func (m *execStatusList) countComplete() int {
-	return m.compCnt
+	return m.completeCnt
 }
 
 func (m *execStatusList) addDependency(blocker int, dependent int) bool {
@@ -252,15 +264,15 @@ func (m *execStatusList) removeDependency(tx int) {
 }
 
 func (m *execStatusList) clearInProgress(tx int) {
-	if tx >= len(m.inProg) || !m.inProg[tx] {
+	if tx >= len(m.inProgress) || !m.inProgress[tx] {
 		panic(errors.New("should not happen - element expected in list"))
 	}
-	m.inProg[tx] = false
-	m.inProgCnt--
+	m.inProgress[tx] = false
+	m.inProgressCnt--
 }
 
 func (m *execStatusList) checkInProgress(tx int) bool {
-	return tx >= 0 && tx < len(m.inProg) && m.inProg[tx]
+	return tx >= 0 && tx < len(m.inProgress) && m.inProgress[tx]
 }
 
 func (m *execStatusList) checkPending(tx int) bool {
@@ -273,7 +285,7 @@ func (m *execStatusList) checkPending(tx int) bool {
 }
 
 func (m *execStatusList) checkComplete(tx int) bool {
-	return tx >= 0 && tx < len(m.comp) && m.comp[tx]
+	return tx >= 0 && tx < len(m.complete) && m.complete[tx]
 }
 
 // getRevalidationRange: this range will be all tasks from tx (inclusive) that are not currently in progress up to the
@@ -301,9 +313,9 @@ func (m *execStatusList) pushPendingSet(set []int) {
 }
 
 func (m *execStatusList) clearComplete(tx int) {
-	if tx >= 0 && tx < len(m.comp) && m.comp[tx] {
-		m.comp[tx] = false
-		m.compCnt--
+	if tx >= 0 && tx < len(m.complete) && m.complete[tx] {
+		m.complete[tx] = false
+		m.completeCnt--
 	}
 	if tx < m.completeUpTo {
 		m.completeUpTo = tx
@@ -315,8 +327,8 @@ func (m *execStatusList) clearPending(tx int) {
 }
 
 func (m *execStatusList) completeList() []int {
-	out := make([]int, 0, m.compCnt)
-	for i, v := range m.comp {
+	out := make([]int, 0, m.completeCnt)
+	for i, v := range m.complete {
 		if v {
 			out = append(out, i)
 		}
@@ -325,8 +337,8 @@ func (m *execStatusList) completeList() []int {
 }
 
 func (m *execStatusList) inProgressList() []int {
-	out := make([]int, 0, m.inProgCnt)
-	for i, v := range m.inProg {
+	out := make([]int, 0, m.inProgressCnt)
+	for i, v := range m.inProgress {
 		if v {
 			out = append(out, i)
 		}

--- a/execution/stagedsync/exec3_status.go
+++ b/execution/stagedsync/exec3_status.go
@@ -12,13 +12,28 @@ type ExecutionStat struct {
 	Duration    time.Duration
 }
 
+// complete/inProgress use dense []bool (O(1)) rather than sorted []int: completions
+// arrive out of tx order, so slice insert/delete would be O(n²) per block.
 type execStatusList struct {
-	pending    []int
-	inProgress []int
-	deferred   []int // txs whose retry waits on a directed-delay predicate
-	complete   []int
-	dependency map[int]map[int]bool
-	blocker    map[int]map[int]bool
+	pending       []int
+	deferred      []int // txs whose retry waits on a directed-delay predicate
+	inProg        []bool
+	comp          []bool
+	dependency    map[int]map[int]bool
+	blocker       map[int]map[int]bool
+	inProgCnt     int
+	compCnt       int
+	completeUpTo  int // completeUpTo-1 == maxComplete (contiguous-from-zero complete prefix)
+	minInProgHint int // lower bound on the lowest in-progress index; lazily advanced on query
+}
+
+func (m *execStatusList) ensureLen(tx int) {
+	if tx < len(m.comp) {
+		return
+	}
+	grow := tx + 1 - len(m.comp)
+	m.comp = append(m.comp, make([]bool, grow)...)
+	m.inProg = append(m.inProg, make([]bool, grow)...)
 }
 
 func insertInList(l []int, v int) []int {
@@ -43,32 +58,24 @@ func (m *execStatusList) takeNextPending() int {
 
 	x := m.pending[0]
 	m.pending = m.pending[1:]
-	m.inProgress = insertInList(m.inProgress, x)
+	m.ensureLen(x)
+	if !m.inProg[x] {
+		m.inProg[x] = true
+		m.inProgCnt++
+	}
+	if x < m.minInProgHint {
+		m.minInProgHint = x
+	}
 
 	return x
 }
 
-func hasNoGap(l []int) bool {
-	return l[0]+len(l) == l[len(l)-1]+1
-}
-
 func (m execStatusList) maxComplete() int {
-	if len(m.complete) == 0 || m.complete[0] != 0 {
-		return -1
-	} else if m.complete[len(m.complete)-1] == len(m.complete)-1 {
-		return m.complete[len(m.complete)-1]
-	} else {
-		for i := len(m.complete) - 2; i >= 0; i-- {
-			if hasNoGap(m.complete[:i+1]) {
-				return m.complete[i]
-			}
-		}
-	}
-
-	return -1
+	return m.completeUpTo - 1
 }
 
 func (m *execStatusList) pushPending(tx int) {
+	m.ensureLen(tx)
 	m.pending = insertInList(m.pending, tx)
 }
 
@@ -103,19 +110,39 @@ func (m *execStatusList) drainDeferredIfReady(ready func(tx int) bool) {
 	m.deferred = kept
 }
 
-func (m *execStatusList) inProgressCount() int { return len(m.inProgress) }
+func (m *execStatusList) setInProgress(tx int) {
+	m.ensureLen(tx)
+	if !m.inProg[tx] {
+		m.inProg[tx] = true
+		m.inProgCnt++
+	}
+	if tx < m.minInProgHint {
+		m.minInProgHint = tx
+	}
+}
+
+func (m *execStatusList) inProgressCount() int { return m.inProgCnt }
 
 // minInProgress returns the lowest in-progress tx index, or -1 if empty.
 func (m *execStatusList) minInProgress() int {
-	if len(m.inProgress) == 0 {
+	if m.inProgCnt == 0 {
 		return -1
 	}
-	return m.inProgress[0]
+	// in-progress txs are always >= completeUpTo, so jump the hint past the known
+	// complete prefix, then lazily advance it past cleared entries. The hint only
+	// moves backward when a lower index is (re-)dispatched, so queries amortize O(1).
+	if m.minInProgHint < m.completeUpTo {
+		m.minInProgHint = m.completeUpTo
+	}
+	for m.minInProgHint < len(m.inProg) && !m.inProg[m.minInProgHint] {
+		m.minInProgHint++
+	}
+	return m.minInProgHint
 }
 
 func removeFromList(l []int, v int, expect bool) []int {
 	x := sort.SearchInts(l, v)
-	if x == -1 || l[x] != v {
+	if x == -1 || x >= len(l) || l[x] != v {
 		if expect {
 			panic(errors.New("should not happen - element expected in list"))
 		}
@@ -134,8 +161,21 @@ func removeFromList(l []int, v int, expect bool) []int {
 }
 
 func (m *execStatusList) markComplete(tx int) {
-	m.inProgress = removeFromList(m.inProgress, tx, true)
-	m.complete = insertInList(m.complete, tx)
+	m.ensureLen(tx)
+	if !m.inProg[tx] {
+		panic(errors.New("should not happen - element expected in list"))
+	}
+	m.inProg[tx] = false
+	m.inProgCnt--
+	if !m.comp[tx] {
+		m.comp[tx] = true
+		m.compCnt++
+	}
+	if tx == m.completeUpTo {
+		for m.completeUpTo < len(m.comp) && m.comp[m.completeUpTo] {
+			m.completeUpTo++
+		}
+	}
 }
 
 func (m *execStatusList) minPending() int {
@@ -147,7 +187,7 @@ func (m *execStatusList) minPending() int {
 }
 
 func (m *execStatusList) countComplete() int {
-	return len(m.complete)
+	return m.compCnt
 }
 
 func (m *execStatusList) addDependency(blocker int, dependent int) bool {
@@ -212,16 +252,15 @@ func (m *execStatusList) removeDependency(tx int) {
 }
 
 func (m *execStatusList) clearInProgress(tx int) {
-	m.inProgress = removeFromList(m.inProgress, tx, true)
+	if tx >= len(m.inProg) || !m.inProg[tx] {
+		panic(errors.New("should not happen - element expected in list"))
+	}
+	m.inProg[tx] = false
+	m.inProgCnt--
 }
 
 func (m *execStatusList) checkInProgress(tx int) bool {
-	x := sort.SearchInts(m.inProgress, tx)
-	if x < len(m.inProgress) && m.inProgress[x] == tx {
-		return true
-	}
-
-	return false
+	return tx >= 0 && tx < len(m.inProg) && m.inProg[tx]
 }
 
 func (m *execStatusList) checkPending(tx int) bool {
@@ -234,12 +273,7 @@ func (m *execStatusList) checkPending(tx int) bool {
 }
 
 func (m *execStatusList) checkComplete(tx int) bool {
-	x := sort.SearchInts(m.complete, tx)
-	if x < len(m.complete) && m.complete[x] == tx {
-		return true
-	}
-
-	return false
+	return tx >= 0 && tx < len(m.comp) && m.comp[tx]
 }
 
 // getRevalidationRange: this range will be all tasks from tx (inclusive) that are not currently in progress up to the
@@ -267,9 +301,35 @@ func (m *execStatusList) pushPendingSet(set []int) {
 }
 
 func (m *execStatusList) clearComplete(tx int) {
-	m.complete = removeFromList(m.complete, tx, false)
+	if tx >= 0 && tx < len(m.comp) && m.comp[tx] {
+		m.comp[tx] = false
+		m.compCnt--
+	}
+	if tx < m.completeUpTo {
+		m.completeUpTo = tx
+	}
 }
 
 func (m *execStatusList) clearPending(tx int) {
 	m.pending = removeFromList(m.pending, tx, false)
+}
+
+func (m *execStatusList) completeList() []int {
+	out := make([]int, 0, m.compCnt)
+	for i, v := range m.comp {
+		if v {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func (m *execStatusList) inProgressList() []int {
+	out := make([]int, 0, m.inProgCnt)
+	for i, v := range m.inProg {
+		if v {
+			out = append(out, i)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
Removes the O(n²) coordinator dispatch churn in the parallel executor so a normal-sized input queue keeps workers fed.

## Problem
`scheduleExecution` runs after every result and took the **entire** pending set, dispatched what the input queue accepted, then pushed the overflow back. For high-tx-count blocks (~14k txs, e.g. `ether_transfers`) that's O(n²) take-all/push-back churn per block: the coordinator shuffles `pending`↔`inProgress` instead of applying results + refilling, so workers drain the queue and starve (effective concurrency ~0.5 of 6 cores).

## Change
- **`execStatusList`**: `complete`/`inProgress` move from sorted `[]int` (O(n) insert/delete, O(n²)/block since completions arrive out of tx order) to dense `[]bool` membership + counters + a cached contiguous-complete counter (O(1) `maxComplete`). `pending`/`deferred` stay slices (filled in order, popped from the front).
- **`scheduleExecution`**: cap the take-loop to the queue's free slots → O(free) refill per result instead of take-all/push-back-most.
- **drain predicate**: take the loop-invariant `maxComplete()`/`minInProgress()` out of the per-deferred-tx closure; 
- `minInProgress` scans from the "complete state frontier" with a lazily-advanced cached hint (amortized O(1)) instead of from index 0.

## Complexity
- Dispatch/scheduling is now **O(Σ txids dispatched)** = O(n + re-executions).
- **Conflict-free blocks (abort=0 — all BAL-driven regimes incl. `ether_transfers`): O(n).**
- Under conflicts the take-all/push-back churn is gone in all cases, but scheduling isn't strictly O(n): a residual `O(deferred × calls)` deferred-rescan term remains (plus OCC's intrinsic re-execution count). Not exercised by the abort=0 benchmarks.

## Result — jochemnet `ether_transfers` (300M-gas blocks, 6-core cpuset)
| | exec throughput |
|---|---|
| before | 58.8 MGas/s |
| **this PR** | **253 MGas/s** |

Full jochemnet regime set (ext_account, sload/sstore_bloated, storage_sload, ether_transfers) — **no regressions**; two small gains (ext_account +16%, storage_sload[T] +11%).
