### PR TITLE
cl, execution: don't log context canceled on shutdown

### DIFF
--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -18,6 +18,7 @@ package stages
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync/atomic"
@@ -378,7 +379,9 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 
 		for !cfg.downloader.Finished() {
 			if err := cfg.downloader.RequestMore(ctx); err != nil {
-				log.Warn("closing backfilling routine", "err", err)
+				if !errors.Is(err, context.Canceled) {
+					log.Warn("closing backfilling routine", "err", err)
+				}
 				return
 			}
 		}

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -713,7 +713,7 @@ func (e *ExecModule) Start(ctx context.Context, hook *stageloop.Hook) {
 		}
 		e.forkValidator.NotifyCurrentHeight(progress)
 		return nil
-	}); err != nil {
+	}); err != nil && !errors.Is(err, context.Canceled) {
 		e.logger.Warn("Could not notify fork validator of current height", "err", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Silence the `closing backfilling routine` WARN in `cl/phase1/stages/stage_history_download.go` when it fires because of a canceled context (normal shutdown), not an actual downloader failure.
- Same fix for `Could not notify fork validator of current height` in `execution/execmodule/exec_module.go`, matching the `errors.Is(err, context.Canceled)` convention already used twice earlier in the same `Start` function for the semaphore-acquire and `ProcessFrozenBlocks` error paths.

No behavior change beyond suppressing the log line — control flow and return values are unchanged.

TDD note: skipped per the pragmatism carve-out in CLAUDE.md — this is a narrow, mechanical consistency fix (extends an already-established local pattern) with no functional behavior change, so a dedicated regression test would require disproportionate harness/log-capture scaffolding relative to the 3-line diff.