### PR TITLE
db/snapshotsync: remove unused BlockRetire.Writer and RoSnapshots methods

### DIFF
--- a/db/kv/readahead.go
+++ b/db/kv/readahead.go
@@ -97,10 +97,7 @@ func NewReadAhead(ctx context.Context, db RoDB, table string, cfg ReadAheadCfg) 
 	if db == nil || len(cfg.Bounds) < 2 {
 		return nil // Close/SetPos are nil-safe
 	}
-	workers := cfg.Workers
-	if workers < 1 {
-		workers = 1
-	}
+	workers := max(1, cfg.Workers)
 	ctx, cancel := context.WithCancel(ctx)
 	r := &ReadAhead{cancel: cancel, done: make(chan struct{}), warmValues: cfg.WarmValues, bounds: cfg.Bounds}
 	r.turnCond = sync.NewCond(&r.mu)

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -203,8 +203,6 @@ func (br *BlockRetire) BorStore() (heimdall.Store, bridge.Store) {
 	return br.heimdallStore, br.bridgeStore
 }
 
-func (br *BlockRetire) Writer() *RoSnapshots { return br.blockReader.Snapshots().(*RoSnapshots) }
-
 func (br *BlockRetire) snapshots() *RoSnapshots { return br.blockReader.Snapshots().(*RoSnapshots) }
 
 func (br *BlockRetire) borSnapshots() *heimdall.RoSnapshots {

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -666,16 +666,6 @@ func (s *RoSnapshots) IndexBuilder(t snaptype.Type) snaptype.IndexBuilder {
 	return nil
 }
 
-func (s *RoSnapshots) SetIndexBuilder(t snaptype.Type, indexBuilder snaptype.IndexBuilder) {
-	if operators, ok := s.operators[t.Enum()]; ok {
-		operators.indexBuilder = indexBuilder
-	} else {
-		s.operators[t.Enum()] = &retireOperators{
-			indexBuilder: indexBuilder,
-		}
-	}
-}
-
 func (s *RoSnapshots) RangeExtractor(t snaptype.Type) snaptype.RangeExtractor {
 	if operators, ok := s.operators[t.Enum()]; ok {
 		return operators.rangeExtractor
@@ -763,18 +753,6 @@ func (s *RoSnapshots) MadvNormal() *RoSnapshots {
 		}
 	}
 
-	return s
-}
-
-func (s *RoSnapshots) EnableMadvWillNeed() *RoSnapshots {
-	v := s.View()
-	defer v.Close()
-
-	for _, t := range s.enums {
-		for _, sn := range v.segments[t].Segments {
-			sn.src.MadvWillNeed()
-		}
-	}
 	return s
 }
 
@@ -1505,26 +1483,6 @@ func (s *RoSnapshots) buildMissedIndices(logPrefix string, ctx context.Context, 
 		return newIdxBuilt, ie
 	case <-ctx.Done():
 		return newIdxBuilt, ctx.Err()
-	}
-}
-
-func (s *RoSnapshots) PrintDebug() {
-	v := s.View()
-	defer v.Close()
-	for _, t := range s.types {
-		fmt.Println("    == [dbg] Snapshots,", t.Enum().String())
-		printDebug := func(sn *DirtySegment) {
-			args := make([]any, 0, len(sn.Type().Indexes())+1)
-			args = append(args, sn.from)
-			for _, index := range sn.Type().Indexes() {
-				args = append(args, sn.Index(index) != nil)
-			}
-			fmt.Println(args...)
-		}
-		s.dirty[t.Enum()].Scan(func(sn *DirtySegment) bool {
-			printDebug(sn)
-			return true
-		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove `BlockRetire.Writer()` — no callers left (`snapshots()`/`Snapshots()` are the ones actually used).
- Remove `RoSnapshots.SetIndexBuilder`, `RoSnapshots.EnableMadvWillNeed`, and `RoSnapshots.PrintDebug` — all have zero call sites in the repo (index builders are set at construction via `snaptype.Type`, not through the setter).

Verified each removed method has no callers anywhere in the repo (including via interfaces — none of them are part of `services.BlockRetire` or `services.BlockSnapshots`) before deleting. `go build ./...` and `go test ./db/snapshotsync/...` pass.