### PR TITLE
[r3.5] cl/antiquary: commit reconstructed state in bounded batches

### DIFF
--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -65,6 +65,10 @@ type Antiquary struct {
 	// set to nil
 	currentState *state.CachingBeaconState
 	balances32   []byte
+	// maxSlotsPerCommit bounds how many slots the antiquary accumulates into one
+	// mdbx transaction. A very large commit overflows libmdbx's gc_fill_returned
+	// while serializing the transaction's retired-page list; bounding it avoids that.
+	maxSlotsPerCommit uint64
 }
 
 func NewAntiquary(ctx context.Context, blobStorage blob_storage.BlobStorage, genesisState *state.CachingBeaconState, validatorsTable *state_accessors.StaticValidatorTable, cfg *clparams.BeaconChainConfig, dirs datadir.Dirs, downloaderClient downloader.Client, mainDB kv.RwDB, stateSn *snapshotsync.CaplinStateSnapshots, sn *freezeblocks.CaplinSnapshots, reader freezeblocks.BeaconSnapshotReader, syncedData synced_data.SyncedData, logger log.Logger, states, blocks, blobs, snapgen bool, snBuildSema *semaphore.Weighted) *Antiquary {
@@ -93,6 +97,8 @@ func NewAntiquary(ctx context.Context, blobStorage blob_storage.BlobStorage, gen
 		snapgen:         snapgen,
 		stateSn:         stateSn,
 		syncedData:      syncedData,
+
+		maxSlotsPerCommit: stateAntiquaryMaxSlotsPerCommit,
 	}
 }
 

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -193,6 +193,8 @@ func FillStaticValidatorsTableIfNeeded(ctx context.Context, logger log.Logger, s
 	return true, nil
 }
 
+const stateAntiquaryMaxSlotsPerCommit uint64 = 4 * clparams.SlotsPerDump
+
 func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 
 	// Check if you need to fill the static validators table
@@ -208,7 +210,7 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 	defer tx.Rollback()
 
 	// maps which validators changes
-	var changedValidators sync.Map
+	changedValidators := &sync.Map{}
 
 	if refilledStaticValidators {
 		s.validatorsTable.ForEach(func(validatorIndex uint64, validator *state_accessors.StaticValidator) bool {
@@ -349,7 +351,54 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 
 	startLoop := time.Now()
 
+	commitBatch := func() error {
+		rwTx, err := s.mainDB.BeginRw(ctx)
+		if err != nil {
+			return err
+		}
+		defer rwTx.Rollback()
+		if err := stateAntiquaryCollector.flush(ctx, rwTx); err != nil {
+			return err
+		}
+		if err := state_accessors.SetStateProcessingProgress(rwTx, s.currentState.Slot()); err != nil {
+			return err
+		}
+		s.validatorsTable.SetSlot(s.currentState.Slot())
+		buf := &bytes.Buffer{}
+		var writeErr error
+		s.validatorsTable.ForEach(func(validatorIndex uint64, validator *state_accessors.StaticValidator) bool {
+			if _, ok := changedValidators.Load(validatorIndex); !ok {
+				return true
+			}
+			buf.Reset()
+			if writeErr = validator.WriteTo(buf); writeErr != nil {
+				return false
+			}
+			if writeErr = rwTx.Put(kv.StaticValidators, base_encoding.Encode64ToBytes4(validatorIndex), common.Copy(buf.Bytes())); writeErr != nil {
+				return false
+			}
+			return true
+		})
+		if writeErr != nil {
+			return writeErr
+		}
+		return rwTx.Commit()
+	}
+	lastCommitSlot := slot
+
 	for ; slot < to && startLoop.Add(timeBeforeCommit).After(time.Now()); slot++ {
+		// Bound each mdbx commit: once maxSlotsPerCommit slots have accumulated,
+		// flush + commit them and start a fresh collector, so no single commit
+		// carries a huge retired-page list.
+		if slot-lastCommitSlot >= s.maxSlotsPerCommit {
+			if err := commitBatch(); err != nil {
+				return err
+			}
+			stateAntiquaryCollector.close()
+			stateAntiquaryCollector = newBeaconStatesCollector(s.cfg, s.dirs.Tmp, s.logger)
+			changedValidators = &sync.Map{}
+			lastCommitSlot = slot
+		}
 		slashingOccurred = false // Set this to false at the beginning of each slot.
 
 		isDumpSlot := slot%clparams.SlotsPerDump == 0
@@ -527,42 +576,9 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 	log.Debug("Finished beacon state iteration", "elapsed", time.Since(start))
 
 	log.Log(logLvl, "Stopped Caplin to load states")
-	rwTx, err := s.mainDB.BeginRw(ctx)
-	if err != nil {
-		return err
-	}
-	defer rwTx.Rollback()
-
 	start = time.Now()
-	// We now need to store the state
-	if err := stateAntiquaryCollector.flush(ctx, rwTx); err != nil {
-		return err
-	}
-
-	if err := state_accessors.SetStateProcessingProgress(rwTx, s.currentState.Slot()); err != nil {
-		return err
-	}
-
-	s.validatorsTable.SetSlot(s.currentState.Slot())
-
-	buf := &bytes.Buffer{}
-	s.validatorsTable.ForEach(func(validatorIndex uint64, validator *state_accessors.StaticValidator) bool {
-		if _, ok := changedValidators.Load(validatorIndex); !ok {
-			return true
-		}
-		buf.Reset()
-		if err = validator.WriteTo(buf); err != nil {
-			return false
-		}
-		if err = rwTx.Put(kv.StaticValidators, base_encoding.Encode64ToBytes4(validatorIndex), common.Copy(buf.Bytes())); err != nil {
-			return false
-		}
-		return true
-	})
-	if err != nil {
-		return err
-	}
-	if err := rwTx.Commit(); err != nil {
+	// Flush + commit the remaining slots since the last in-loop commit.
+	if err := commitBatch(); err != nil {
 		return err
 	}
 	endTime := time.Since(start)

--- a/cl/antiquary/state_antiquary_test.go
+++ b/cl/antiquary/state_antiquary_test.go
@@ -18,6 +18,7 @@ package antiquary
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
 )
@@ -63,4 +65,63 @@ func TestStateAntiquaryBellatrix(t *testing.T) {
 func TestStateAntiquaryPhase0(t *testing.T) {
 	blocks, preState, postState := tests.GetPhase0Random()
 	runTest(t, blocks, preState, postState)
+}
+
+type commitCountingDB struct {
+	kv.RwDB
+	commits *atomic.Int64
+}
+
+func (d *commitCountingDB) BeginRw(ctx context.Context) (kv.RwTx, error) {
+	tx, err := d.RwDB.BeginRw(ctx) //nolint:gocritic // wrapper returns the tx to the caller; it owns Rollback
+	if err != nil {
+		return nil, err
+	}
+	return &commitCountingTx{RwTx: tx, commits: d.commits}, nil
+}
+
+type commitCountingTx struct {
+	kv.RwTx
+	commits *atomic.Int64
+}
+
+func (t *commitCountingTx) Commit() error {
+	t.commits.Add(1)
+	return t.RwTx.Commit()
+}
+
+// A single antiquary run must reconstruct the same slots whether committed in
+// one big transaction or in maxSlotsPerCommit-bounded batches, and the bounded
+// run must flush more often — bounding the per-commit retired-page list is what
+// keeps libmdbx's gc_fill_returned from overflowing on large DBs.
+func TestStateAntiquaryCommitIsBounded(t *testing.T) {
+	blocks, preState, postState := tests.GetCapellaRandom()
+	to := blocks[len(blocks)-1].Block.Slot + 33
+
+	run := func(maxSlotsPerCommit uint64) (commits int64, progress uint64) {
+		db := memdb.NewTestDB(t, dbcfg.ChainDB)
+		reader := tests.LoadChain(blocks, postState, db, t)
+		sn := synced_data.NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+		sn.OnHeadState(postState)
+		ctx := context.Background()
+		vt := state_accessors.NewStaticValidatorTable()
+		counter := &atomic.Int64{}
+		countingDB := &commitCountingDB{RwDB: db, commits: counter}
+		a := NewAntiquary(ctx, nil, preState, vt, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, countingDB, nil, nil, reader, sn, log.New(), true, true, true, false, nil)
+		a.maxSlotsPerCommit = maxSlotsPerCommit
+		require.NoError(t, a.IncrementBeaconState(ctx, to))
+		require.NoError(t, db.View(ctx, func(tx kv.Tx) error {
+			var e error
+			progress, e = state_accessors.GetStateProcessingProgress(tx)
+			return e
+		}))
+		return counter.Load(), progress
+	}
+
+	singleCommits, singleProgress := run(1 << 62)
+	boundedCommits, boundedProgress := run(8)
+
+	require.Equal(t, singleProgress, boundedProgress)
+	require.Greater(t, boundedCommits, singleCommits)
+	require.GreaterOrEqual(t, boundedCommits, singleCommits+2)
 }


### PR DESCRIPTION
Cherry-pick of #22347 to `release/3.5`.

`IncrementBeaconState` committed up to 30 min of replayed beacon state in a single mdbx transaction. On large caplin archive DBs (100+ GB) that commit overflows libmdbx's `gc_fill_returned` while serializing the retired-page list and faults with `SIGSEGV (SEGV_ACCERR)` in `txn_basal_commit`. Applies cleanly; no r3.5-specific adaptations. Package builds and `TestStateAntiquaryCommitIsBounded` passes on `release/3.5`.
