### PR TITLE
[r3.5] cl/phase1/forkchoice: replace latestMessagesStore interning with a flat per-validator slice

### DIFF
--- a/cl/phase1/forkchoice/latest_messages_store.go
+++ b/cl/phase1/forkchoice/latest_messages_store.go
@@ -2,78 +2,46 @@ package forkchoice
 
 import "sync"
 
-// latestMessagesStore keeps in memory an inverted index
+// latestMessagesStore tracks each validator's latest attestation vote by
+// validator index. The zero LatestMessage means "no vote seen": a real vote
+// always carries a nonzero block root.
 type latestMessagesStore struct {
-	messageByIdx    map[uint16]LatestMessage
-	idxByMessage    map[LatestMessage]uint16
-	countOfMessages map[LatestMessage]int
-	latestMessages  []uint16
-	currID          uint16 // can overflow by design
-	mu              sync.RWMutex
+	latestMessages []LatestMessage
+	mu             sync.RWMutex
 }
 
 func newLatestMessagesStore(size int) *latestMessagesStore {
 	return &latestMessagesStore{
-		messageByIdx:    map[uint16]LatestMessage{},
-		idxByMessage:    map[LatestMessage]uint16{},
-		countOfMessages: map[LatestMessage]int{},
-		latestMessages:  make([]uint16, size, (size*3)/2),
+		latestMessages: make([]LatestMessage, size),
 	}
 }
 
 func (l *latestMessagesStore) set(idx int, m LatestMessage) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	_, isPresent := l.idxByMessage[m]
-	if !isPresent {
-		l.currID++
-		l.idxByMessage[m] = l.currID
-		l.messageByIdx[l.currID] = m
-	}
-	messageID := l.idxByMessage[m]
 	if idx >= len(l.latestMessages) {
 		if idx >= cap(l.latestMessages) {
-			l.latestMessages = make([]uint16, idx+1, ((idx+1)*3)/2)
+			tmp := make([]LatestMessage, idx+1, ((idx+1)*3)/2)
+			copy(tmp, l.latestMessages)
+			l.latestMessages = tmp
 		}
 		l.latestMessages = l.latestMessages[:idx+1]
 	}
-
-	prev := l.messageByIdx[l.latestMessages[idx]]
-	if prev != (LatestMessage{}) && l.countOfMessages[prev] > 0 {
-		l.countOfMessages[prev]--
-	}
-	l.latestMessages[idx] = messageID
-	l.countOfMessages[m]++
-
-	l.doPrune()
-}
-
-func (l *latestMessagesStore) doPrune() {
-	pruneMessages := []LatestMessage{}
-	// try to clean up old stuff
-	for message, count := range l.countOfMessages {
-		if count == 0 {
-			pruneMessages = append(pruneMessages, message)
-		}
-	}
-	for _, msg := range pruneMessages {
-		idx := l.idxByMessage[msg]
-		delete(l.messageByIdx, idx)
-		delete(l.idxByMessage, msg)
-		delete(l.countOfMessages, msg)
-	}
+	l.latestMessages[idx] = m
 }
 
 func (l *latestMessagesStore) get(idx int) (LatestMessage, bool) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
-	if idx >= len(l.latestMessages) {
+	if idx < 0 || idx >= len(l.latestMessages) {
 		return LatestMessage{}, false
 	}
-	msg, ok := l.messageByIdx[l.latestMessages[idx]]
-	return msg, ok
+	msg := l.latestMessages[idx]
+	return msg, msg != (LatestMessage{})
 }
 
 func (l *latestMessagesStore) latestMessagesCount() int {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	return len(l.latestMessages)
 }

--- a/cl/phase1/forkchoice/latest_messages_store_test.go
+++ b/cl/phase1/forkchoice/latest_messages_store_test.go
@@ -1,0 +1,60 @@
+package forkchoice
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+)
+
+// A validator's stored vote must survive any number of other validators'
+// distinct messages (more than fit in a 16-bit id space).
+func TestLatestMessagesStoreSetSurvivesDistinctMessageChurn(t *testing.T) {
+	l := newLatestMessagesStore(2)
+
+	pinned := LatestMessage{Epoch: 1, Root: common.Hash{0x01}}
+	l.set(0, pinned)
+
+	got, ok := l.get(0)
+	require.True(t, ok)
+	require.Equal(t, pinned, got)
+
+	for i := 0; i < math.MaxUint16+2; i++ {
+		l.set(1, LatestMessage{Epoch: uint64(i + 2), Root: common.Hash{0xff}, Slot: uint64(i)})
+	}
+
+	got, ok = l.get(0)
+	require.True(t, ok)
+	require.Equal(t, pinned, got)
+}
+
+// Growing the store past its capacity must preserve previously stored votes.
+func TestLatestMessagesStoreGrowthPreservesEntries(t *testing.T) {
+	l := newLatestMessagesStore(2)
+
+	pinned := LatestMessage{Epoch: 1, Root: common.Hash{0x01}}
+	l.set(0, pinned)
+	l.set(100, LatestMessage{Epoch: 2, Root: common.Hash{0x02}})
+
+	require.Equal(t, 101, l.latestMessagesCount())
+	got, ok := l.get(0)
+	require.True(t, ok)
+	require.Equal(t, pinned, got)
+
+	_, ok = l.get(50)
+	require.False(t, ok)
+}
+
+// One validator updates its vote while many other validators hold distinct votes.
+func BenchmarkLatestMessagesStoreSetWithPinnedMessages(b *testing.B) {
+	l := newLatestMessagesStore(100_000)
+	for i := 0; i < 10_000; i++ {
+		l.set(i, LatestMessage{Epoch: uint64(i + 1), Root: common.Hash{byte(i), byte(i >> 8), 0x01}, Slot: uint64(i)})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.set(50_000, LatestMessage{Epoch: uint64(i + 20_000), Root: common.Hash{0xaa}, Slot: uint64(i)})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #22352 to release/3.5 (applied cleanly, no adaptations needed). Fix for #22351.

Note: #22352 is not merged on main yet; this backport tracks it.