### PR TITLE
ci: enforce 1h job timeout across all merge-queue workflows

### DIFF
--- a/.github/workflows/cache-warming-eest-fixtures.yml
+++ b/.github/workflows/cache-warming-eest-fixtures.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       # Probe for an exact-key hit without downloading the archive. cache-hit is
       # true only on the exact primary key, so a version bump (new key) reports a

--- a/.github/workflows/check-large-files.yml
+++ b/.github/workflows/check-large-files.yml
@@ -11,6 +11,7 @@ defaults:
 jobs:
   check:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/check-large-files.yml
+++ b/.github/workflows/check-large-files.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
+          persist-credentials: false
 
       - name: Check for large files in PR
         env:

--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -45,6 +45,7 @@ jobs:
           fetch-depth: 1
           ref: ${{ inputs.checkout_ref == '' && github.ref || inputs.checkout_ref }}
           path: 'erigon'
+          persist-credentials: false
 
       - name: Define variables
         id: def_docker_vars

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -43,6 +43,7 @@ jobs:
   # docs/site/** is touched.
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       code: ${{ steps.check.outputs.code }}
       docs_site: ${{ steps.check.outputs.docs_site }}
@@ -173,6 +174,7 @@ jobs:
       - repro
       - sonar
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       # cancelled() is only valid in `if:`, so capture it as a step output for
       # the gate logic below to read.

--- a/.github/workflows/docker-tags.yml
+++ b/.github/workflows/docker-tags.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
+          persist-credentials: false
 
       - name: dockerhub-login
         uses: docker/login-action@v4

--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -9,6 +9,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       # Defensive guard — skip silently only when docs/site/ is absent
       # (e.g. branches that predate the Docusaurus migration).

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ defaults:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout custom actions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install actionlint
         run: |

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Get Go version from go.mod
         id: goversion

--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Clean Erigon Build Directory
       run: |

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -17,6 +17,7 @@ jobs:
           - macos-15
           - windows-2025
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-erigon
         id: erigon

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-erigon
         id: erigon

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -20,6 +20,7 @@ defaults:
 jobs:
   sonar:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
 
     steps:
       - name: Checkout custom actions

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
       - id: load
         run: echo "groups=$(./tools/test-groups names)" >> $GITHUB_OUTPUT
 
@@ -67,6 +68,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-erigon
         id: erigon

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -14,6 +14,7 @@ jobs:
   # the test code (tools/test-groups), keeping CI and local runs in sync.
   load-matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       test-groups: ${{ steps.load.outputs.groups }}
     steps:
@@ -36,7 +37,7 @@ jobs:
 
   tests-linux:
     needs: load-matrix
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       # In merge_group: cancel sibling shards on first failure so ci-gate's
       # `needs` reach terminal state quickly and the broken PR can be evicted.

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -39,6 +39,7 @@ jobs:
             skip_execution_tests: 'true'
     name: tests-mac-linux (${{ matrix.os }}, ${{ matrix.exec_mode }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
       - name: Declare runners

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-erigon
         id: erigon

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-erigon
         id: erigon

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -24,6 +24,7 @@ jobs:
   benchmarks:
     name: benchmarks (${{ matrix.exec_mode }})
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       # In merge_group: cancel sibling shards on first failure so ci-gate's
       # `needs` reach terminal state quickly and the broken PR can be evicted.

--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -21,6 +21,7 @@ jobs:
   # blockchain_tests_engine_x/); re-add it there when the fixture lands.
   load-matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       matrix: ${{ steps.load.outputs.matrix }}
     steps:

--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
       # Warming runs replace the shard matrix with one build per cache class;
       # the -race suffix routes build-cache-extra-key below.
       - id: load
@@ -64,6 +65,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-erigon
         id: erigon
@@ -140,6 +142,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Restore EEST tarballs
         uses: actions/cache/restore@v6

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -124,6 +124,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: erigon-full
+          persist-credentials: false
 
       - name: Read pinned Hive ref
         id: hive-version
@@ -135,6 +136,7 @@ jobs:
           repository: ethereum/hive
           ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
+          persist-credentials: false
 
       - name: Conditional Docker Login
         # Only login if we can. Workflow works without it but we want to avoid

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -13,6 +13,7 @@ jobs:
   test-hive-eest:
     runs-on:
       group: hive
+    timeout-minutes: 60
     name: test-hive-eest (${{ matrix.shard }}, ${{ matrix.exec_mode }})
     strategy:
       # In merge_group: cancel sibling shards on first failure so ci-gate's

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -19,6 +19,7 @@ jobs:
       && !contains(github.event.pull_request.labels.*.name, 'skip-uncaching')) }}
     runs-on:
       group: hive
+    timeout-minutes: 60
     strategy:
       # In merge_group: cancel sibling shards on first failure so ci-gate's
       # `needs` reach terminal state quickly and the broken PR can be evicted.

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: erigon-full
+          persist-credentials: false
 
       - name: Read pinned versions
         id: hive-version
@@ -104,6 +105,7 @@ jobs:
           # version hive and update periodically/on-demand to prevent upstream changes in Hive affecting us with red CI
           ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
+          persist-credentials: false
 
       - name: Setup go env and cache
         uses: actions/setup-go@v6

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -14,6 +14,7 @@ jobs:
         #        disable macos-15 until https://github.com/erigontech/erigon/issues/8789
         os: [ ubuntu-24.04 ] # required check includes runner version. Do not change it only here.
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
       - name: Checkout custom actions
@@ -64,6 +65,7 @@ jobs:
       matrix:
         os: [ windows-2025 ]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
       - name: Checkout custom actions

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-erigon
         id: erigon
@@ -72,6 +73,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-erigon
         id: erigon

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -63,6 +63,7 @@ jobs:
     name: build-erigon-image
     if: ${{ !inputs.cl-images-only && !contains(github.event.pull_request.labels.*.name, 'skip-uncaching') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Fast checkout git repository
         uses: actions/checkout@v7
@@ -180,6 +181,7 @@ jobs:
   warm-third-party-images:
     if: ${{ inputs.cl-images-only }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Conditional Docker Login
         if: |
@@ -310,6 +312,7 @@ jobs:
     # cache; there's nothing for the matrix to do (the test step is skipped).
     if: ${{ !inputs.cache-warming-only && !inputs.cl-images-only && !contains(github.event.pull_request.labels.*.name, 'skip-uncaching') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       # In merge_group: cancel sibling shards on first failure so ci-gate's
       # `needs` reach terminal state quickly and the broken PR can be evicted.

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - name: Fast checkout git repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Conditional Docker Login
         # Only login if we can. Workflow works without it but we want to avoid
@@ -198,6 +200,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           sparse-checkout: .github/workflows/kurtosis
+          persist-credentials: false
 
       - name: Load image versions from the .io files (single source of truth)
         run: |
@@ -377,6 +380,8 @@ jobs:
     steps:
       - name: Fast checkout git repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Conditional Docker Login
         # Only login if we can. Workflow works without it but we want to avoid


### PR DESCRIPTION
A merge-queue bench job recently ran for 3h17m before being manually cancelled (https://github.com/erigontech/erigon/actions/runs/28995664276/job/86044573195), where it normally finishes in ~33 min. GitHub's default job timeout is 6 hours, so a single hung job can stall the merge queue for hours. The root cause of that hang will be addressed separately; this PR caps the damage.

Every job in `ci-gate.yml` and the reusable workflows it calls now carries `timeout-minutes: 60` (`timeout-minutes` cannot be set on a `uses:` job, so it has to live on each job inside the reusable workflows).

Duration data from the last 15 successful merge-queue CI Gate runs confirms 60 min is safe: the slowest job apart from bench outliers peaked at 33 min, so every job has ~2x headroom. Bench itself normally runs 30–40 min; the 114–194 min cases were sporadic hangs of the same kind as the cancelled run, which this timeout is meant to kill. This also matches CI-GUIDELINES.md, which targets 15–30 min for merge-queue jobs.

Two pre-existing timeouts were touched or deliberately kept:
- `test-all-erigon-race.yml` `tests-linux`: reduced 90 → 60. The 90 predates the test-group sharding speedup (#19138); shards now peak at 25 min.
- `test-eest-spec.yml`: `eest-spec-tests` already had 60 and `eest-shard-coverage` keeps its tighter 15.

The kurtosis `assertoor_test` step-level caps (`matrix.test_timeout_minutes`, max 50) remain the effective limit there; the job-level 60 is a backstop around setup/teardown. `check-large-files.yml` only runs on PRs, not in the queue, but gets the same cap for consistency since it is part of ci-gate.

Verified with `actionlint` and `zizmor` using the same flags/config as the lint workflow.

## zizmor artipacked cleanup

The lint job's zizmor scan annotates PRs with pre-existing `artipacked` warnings (checkout steps that leave the git token persisted in the workspace). This PR also sets `persist-credentials: false` on every flagged checkout in the files it touches, plus the handful of other read-only workflows GitHub was surfacing in the annotation list (manifest, docker-tags, ci-cd-main-branch-docker-images, qa-clean-exit-block-downloading, cache-warming-eest-fixtures). All of these only build/test from the checkout; none push via git.

Deliberately left alone: `claude.yml` (the action pushes commits to branches it creates) and `backups-dashboards.yml` (production backup flow with its own git credential setup), plus the wider QA/release sweep — those stay tracked in #21132. Repo-wide emitted findings drop from 59 low to 33 low; the files in this PR are clean.
