### PR TITLE
ci: run eest benchmark shards without a ramdisk

### DIFF
--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -72,7 +72,8 @@ jobs:
         with:
           submodules: false
           cleanup-space: ${{ !inputs.cache-warming-only }}
-          ramdisk: ${{ !inputs.cache-warming-only }}
+          # matrix.no-ramdisk is absent (null, falsy) for shards without the key.
+          ramdisk: ${{ !inputs.cache-warming-only && !matrix.no-ramdisk }}
           cache-namespace: test-eest-spec
           # All non-race shards build the same evm binary and all race shards the
           # same evm.race, so the cache splits by class rather than by shard.
@@ -105,7 +106,13 @@ jobs:
         env:
           EEST_SPEC_MAX_FAILURES: ${{ matrix.max-allowed-failures }}
           EEST_SPEC_WORKERS: ${{ matrix.workers }}
-        run: make eest-spec-${{ matrix.shard }}
+          SHARD_NO_RAMDISK: ${{ matrix.no-ramdisk == true }}
+        run: |
+          if [ "$SHARD_NO_RAMDISK" = "true" ]; then
+            export ERIGON_EXECUTION_TESTS_TMPDIR="$RUNNER_TEMP/eest-datadirs"
+            mkdir -p "$ERIGON_EXECUTION_TESTS_TMPDIR"
+          fi
+          make eest-spec-${{ matrix.shard }}
 
       - name: Build evm binary (cache warming)
         if: inputs.cache-warming-only

--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -106,13 +106,7 @@ jobs:
         env:
           EEST_SPEC_MAX_FAILURES: ${{ matrix.max-allowed-failures }}
           EEST_SPEC_WORKERS: ${{ matrix.workers }}
-          SHARD_NO_RAMDISK: ${{ matrix.no-ramdisk == true }}
-        run: |
-          if [ "$SHARD_NO_RAMDISK" = "true" ]; then
-            export ERIGON_EXECUTION_TESTS_TMPDIR="$RUNNER_TEMP/eest-datadirs"
-            mkdir -p "$ERIGON_EXECUTION_TESTS_TMPDIR"
-          fi
-          make eest-spec-${{ matrix.shard }}
+        run: make eest-spec-${{ matrix.shard }}
 
       - name: Build evm binary (cache warming)
         if: inputs.cache-warming-only

--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -106,7 +106,8 @@ jobs:
         env:
           EEST_SPEC_MAX_FAILURES: ${{ matrix.max-allowed-failures }}
           EEST_SPEC_WORKERS: ${{ matrix.workers }}
-        run: make eest-spec-${{ matrix.shard }}
+          SHARD: ${{ matrix.shard }}
+        run: make "eest-spec-$SHARD"
 
       - name: Build evm binary (cache warming)
         if: inputs.cache-warming-only

--- a/tools/eest-spec-shards.yml
+++ b/tools/eest-spec-shards.yml
@@ -17,6 +17,15 @@
 #   max-allowed-failures  (required) — failure budget; bump only with a comment
 #                                      explaining why and a tracking issue.
 #   exec3-parallel        (optional, default false) — pins ERIGON_EXEC3_PARALLEL.
+#   no-ramdisk            (optional, default false) — true keeps the shard's
+#                                      datadirs on disk instead of a RAM-backed
+#                                      tmpfs. The benchmark shards use a few
+#                                      long-lived datadirs (up to ~7GB at 150M),
+#                                      so tmpfs buys no wall time there and its
+#                                      bytes compete with the evm process for
+#                                      the runner's RAM. Opt-in-true on purpose:
+#                                      a false-valued key is invisible to jq's
+#                                      // default and to GitHub's loose ==.
 #   run                   (optional) — blocktest --run fork regex for race shards.
 #                                      Read by run-eest-spec-test.sh (to filter the
 #                                      run) and tools/check-eest-shard-coverage.sh
@@ -53,52 +62,66 @@
 - shard: enginextests-benchmark-1m-sequential
   workers: 1
   max-allowed-failures: 0
+  no-ramdisk: true
 - shard: enginextests-benchmark-1m-parallel
   workers: 1
   max-allowed-failures: 0
   exec3-parallel: true
+  no-ramdisk: true
 - shard: enginextests-benchmark-5m-sequential
   workers: 1
   max-allowed-failures: 0
+  no-ramdisk: true
 - shard: enginextests-benchmark-5m-parallel
   workers: 1
   max-allowed-failures: 0
   exec3-parallel: true
+  no-ramdisk: true
 - shard: enginextests-benchmark-10m-sequential
   workers: 1
   max-allowed-failures: 0
+  no-ramdisk: true
 - shard: enginextests-benchmark-10m-parallel
   workers: 1
   max-allowed-failures: 0
   exec3-parallel: true
+  no-ramdisk: true
 - shard: enginextests-benchmark-30m-sequential
   workers: 1
   max-allowed-failures: 0
+  no-ramdisk: true
 - shard: enginextests-benchmark-30m-parallel
   workers: 1
   max-allowed-failures: 0
   exec3-parallel: true
+  no-ramdisk: true
 - shard: enginextests-benchmark-60m-sequential
   workers: 1
   max-allowed-failures: 0
+  no-ramdisk: true
 - shard: enginextests-benchmark-60m-parallel
   workers: 1
   max-allowed-failures: 0
   exec3-parallel: true
+  no-ramdisk: true
 - shard: enginextests-benchmark-100m-sequential
   workers: 1
   max-allowed-failures: 0
+  no-ramdisk: true
 - shard: enginextests-benchmark-100m-parallel
   workers: 1
   max-allowed-failures: 0
   exec3-parallel: true
+  no-ramdisk: true
 - shard: enginextests-benchmark-150m-sequential
   workers: 1
   max-allowed-failures: 0
+  no-ramdisk: true
 - shard: enginextests-benchmark-150m-parallel
   workers: 1
   max-allowed-failures: 0
   exec3-parallel: true
+  no-ramdisk: true
 - shard: blocktests-stable-race-pre-cancun-sequential
   workers: 12
   max-allowed-failures: 0

--- a/tools/run-eest-spec-test.sh
+++ b/tools/run-eest-spec-test.sh
@@ -83,12 +83,12 @@ base=test-fixtures-cache/$fixtures/fixtures
 # so adding a shard / tweaking a budget / changing a fork filter is a one-file
 # edit. yq converts YAML→JSON so it can be queried with jq.
 manifest=tools/eest-spec-shards.yml
-shard_row=$(yq -o=json '.' "$manifest" | jq -r --arg s "$shard" '.[] | select(.shard == $s) | "\(.workers)\t\(."max-allowed-failures")\t\(."exec3-parallel" // false)\t\(.run // "")"')
+shard_row=$(yq -o=json '.' "$manifest" | jq -r --arg s "$shard" '.[] | select(.shard == $s) | "\(.workers)\t\(."max-allowed-failures")\t\(."exec3-parallel" // false)\t\(."no-ramdisk" // false)\t\(.run // "")"')
 if [[ -z "$shard_row" ]]; then
 	echo "shard $shard not found in $manifest" >&2
 	exit 2
 fi
-IFS=$'\t' read -r default_workers default_max exec3_parallel run_regex <<<"$shard_row"
+IFS=$'\t' read -r default_workers default_max exec3_parallel shard_no_ramdisk run_regex <<<"$shard_row"
 # Always set ERIGON_EXEC3_PARALLEL explicitly (true or false) so the shard's
 # behaviour is pinned to the manifest, independent of whatever dbg.Exec3Parallel
 # defaults to at runtime. If the default flips, the shards still run the mode
@@ -167,7 +167,10 @@ trap cleanup EXIT
 # and never unmounts; CI gets the env var pre-set via the setup-erigon
 # action's ramdisk: true input. Local Linux users can opt in by exporting
 # ERIGON_EXECUTION_TESTS_TMPDIR or TMPDIR=/dev/shm.
-if [[ -z "${ERIGON_EXECUTION_TESTS_TMPDIR:-}" && "$(uname -s)" == "Darwin" ]]; then
+# Shards with no-ramdisk: true in the manifest skip the Darwin auto-ramdisk too:
+# their datadirs are few and long-lived, so tmpfs buys nothing — and the 150m
+# datadir (~7GB) doesn't even fit the default ramdisk size.
+if [[ "$shard_no_ramdisk" != "true" && -z "${ERIGON_EXECUTION_TESTS_TMPDIR:-}" && "$(uname -s)" == "Darwin" ]]; then
 	ramdisk=$(bash tools/create-ramdisk) || true
 	if [[ -n "$ramdisk" ]]; then
 		export ERIGON_EXECUTION_TESTS_TMPDIR="$ramdisk"


### PR DESCRIPTION
## Problem

The `eest-spec-enginextests-benchmark-150m-{parallel,sequential}` jobs intermittently kill their runner — the job log ends with `make: *** Terminated` followed by `The runner has received a shutdown signal`, the hosted-runner presentation of the VM exhausting memory. 5 of the last 54 `benchmark-150m` job instances died this way (e.g. [this run on #22053](https://github.com/erigontech/erigon/actions/runs/29070572016/job/86291064304), [an unrelated branch the same morning](https://github.com/erigontech/erigon/actions/runs/29069679000), [a sequential-variant instance](https://github.com/erigontech/erigon/actions/runs/29067842538)), always at 95–100% of the test phase, independent of the PR under test.

Profiling the 150m shard (locally, pinned to CI parallelism) shows peak demand of **~16.8 GB against the runner's 16 GB**: a 9.9 GB evm process footprint (live heap 4.9 GB, roughly doubled by default GOGC; dominated by `opReturn` return-data buffers and `TemporalMemBatch` write-set clones during the `test_unchunkified_bytecode` cases, which allocate 10.6–12.1 GB each) plus a 6.9 GB MDBX datadir sitting on the 8 GB ramdisk — tmpfs bytes and process bytes compete for the same RAM. 1075 of the shard's 1077 tests share one `(fork, preAllocHash)` group, so a single node's datadir grows for essentially the whole run and the peak lands at the end. Whether a run survives comes down to GC timing and randomized test order — hence the flakiness.

## Prior investigation

#22325 (closed in favour of this PR) profiled the same OOM and pinned why the shard began flaking on Jul 7: the persistent code cache from #22154 grew the benchmark datadir by ~2 GB (5.65 → 7.40 GB peak), pushing the peak co-resident heap+datadir from ~12 GB to ~14+ GB — see [the profiling comment](https://github.com/erigontech/erigon/pull/22325#issuecomment-4915809868). The FCU-less CodeStore growth is being capped separately in #22335; with the datadir off RAM, that growth no longer threatens the runner either way — the two changes are complementary.

## Change

The ramdisk exists for shards that churn hundreds of short-lived datadirs, where create/unlink journaling dominates. The benchmark shards are the opposite shape (3 long-lived datadirs), so the ramdisk buys them no wall time — and costs them the RAM that OOMs the runner.

- `tools/eest-spec-shards.yml`: new per-shard key `no-ramdisk: true`, set on all 14 `enginextests-benchmark-*` shards. Opt-in-true on purpose: a `false`-valued key would be invisible to both jq's `//` default and GitHub expressions' loose `==` (`null == false` is true there).
- `.github/workflows/test-eest-spec.yml`: honors the key — skips creating the tmpfs. Nothing else sets `ERIGON_EXECUTION_TESTS_TMPDIR`/`TMPDIR` on Linux (the setup-erigon TMPDIR override is Windows-gated), so these shards exercise the env-var-unset path and their datadirs land in the runner's default temp dir (`/tmp`, on the same root SSD as `$RUNNER_TEMP`).
- `tools/run-eest-spec-test.sh`: the same key also skips the local (Darwin) auto-ramdisk for these shards — whose 2 GB default the 150m datadir (~7 GB) could not fit anyway. Local runs likewise fall through to the OS default temp dir.

Non-benchmark shards are unchanged.

## Wall-time evidence (A/B on identical runners)

[Dispatched run 29073818835](https://github.com/erigontech/erigon/actions/runs/29073818835) — the 150m shards with datadirs on SSD, vs the five most recent green ramdisk runs:

| | ramdisk (5 runs) | no ramdisk | delta |
|---|---|---|---|
| 150m-parallel, test phase | 16m40s – 17m06s | 17m09s | +1.8% vs mean |
| 150m-sequential, test phase | 11m14s – 13m06s | 13m22s | +8% vs mean, within the baseline's own ±8% spread |
| 150m-parallel, job total | 20.3 – 22.5 min | 20.0 min | inside range |
| 150m-sequential, job total | 17.0 – 17.7 min | 17.3 min | inside range |

Both A/B jobs passed, with ~7 GB more headroom at peak.

**Benchmark semantics note:** these are `--time` throughput shards, so datadirs-on-disk puts SSD writeback inside the measured path — per-test wall times (and any MGas/s derived from them) shift slightly at this PR's boundary; the A/B above bounds it at ~+1.8% for the 150m-parallel test phase. This is deliberate: production nodes run MDBX on SSD/NVMe with the OS page cache, so the post-PR numbers are more representative of real-world execution than tmpfs-backed ones. Treat pre-/post-PR timings as different baselines when comparing historical job logs.

## Verification

- `actionlint`, `shellcheck`, `bash -n` clean; `make lint` clean.
- Matrix render (`yq -o=json` of the manifest) carries `no-ramdisk` through to `matrix.*`; row parsing verified for benchmark, stable, and race-regex shards.
- `make eest-spec-enginextests-benchmark-1m-sequential` run locally on Darwin through the new path: no auto-ramdisk created, datadirs in the default temp dir, all tests pass (1076/1076); a stable-shard control still creates the ramdisk.
- On this PR's CI: every benchmark shard's `Create RAM disk` step is skipped and its log prints the default-tmpdir routing, while stable shards keep `tmpdir: /mnt/erigon-ramdisk`; the first CI Gate run had all eest shards green including both 150m jobs.
- The no-ramdisk configuration was also validated end-to-end by the A/B run above before this PR.

No Go code changes; this is CI/tooling configuration, so the TDD cycle does not apply.
