### PR TITLE
[r3.5] sonar: exclude legacy-tests submodule, fix stale test-inclusion path

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.projectName=erigon
 sonar.sources=.
 sonar.exclusions=\
   .github/**,\
+  execution/tests/legacy-tests/**,\
   docs/**,\
   **/*.pb.go,\
   **/gen_*.go,\
@@ -18,7 +19,8 @@ sonar.exclusions=\
   execution/tracing/tracers/js/internal/tracers/**.js
 
 sonar.tests=.
-sonar.test.inclusions=**/*_test.go,tests/**
+sonar.test.inclusions=**/*_test.go,execution/tests/**
+sonar.test.exclusions=execution/tests/legacy-tests/**
 
 sonar.go.coverage.reportPaths=coverage-test-all.out
 


### PR DESCRIPTION
Cherry-pick of #22215 to `release/3.5`.

Fixes the failing SonarCloud Quality Gate on `release/3.5` ("E Security Rating on New Code"). The branch was still scanning the `ethereum/tests` submodule (`execution/tests/legacy-tests/**`) as first-party production code, so its blocker/critical findings counted against the new-code security rating; `main` already excludes that path via this change. Applies cleanly; no r3.5-specific adaptations.