### PR TITLE
[r3.5] db/version: app version 3.5.1

### DIFF
--- a/db/version/app.go
+++ b/db/version/app.go
@@ -32,7 +32,7 @@ var (
 const (
 	Major                    = 3             // Major version component of the current release
 	Minor                    = 5             // Minor version component of the current release
-	Micro                    = 0             // Patch version component of the current release
+	Micro                    = 1             // Patch version component of the current release
 	Modifier                 = ""            // Modifier component of the current release
 	DefaultSnapshotGitBranch = "release/3.4" // Branch of erigontech/erigon-snapshot to use in OtterSync.
 	VersionKeyCreated        = "ErigonVersionCreated"


### PR DESCRIPTION
## Summary
- Bumps `Micro` version from 0 → 1, making the release version `3.5.1`