### PR TITLE
ci: fix zizmor template-injection in 5 QA perf/sync workflows (#21132)

### DIFF
--- a/.github/workflows/qa-rpc-integration-tests-remote.yml
+++ b/.github/workflows/qa-rpc-integration-tests-remote.yml
@@ -43,9 +43,9 @@ jobs:
       - name: Set reference data dir based on branch
         run: |
           # For pull_request events base_ref is the target branch name; for push/dispatch parse from ref.
-          BRANCH="${{ github.base_ref }}"
+          BRANCH="$GITHUB_BASE_REF"
           if [ -z "$BRANCH" ]; then
-            BRANCH="${{ github.ref }}"
+            BRANCH="$GITHUB_REF"
             BRANCH="${BRANCH#refs/heads/}"
           fi
           if [[ "$BRANCH" == release/* ]]; then
@@ -149,16 +149,18 @@ jobs:
 
       - name: Run RPC Integration Tests
         id: test_step
+        env:
+          RUNNER_WS: ${{ runner.workspace }}
         run: |
           mkdir -p $RPC_PAST_TEST_DIR
-          commit=$(git -C ${{runner.workspace}}/erigon rev-parse --short HEAD)
+          commit=$(git -C "$RUNNER_WS/erigon" rev-parse --short HEAD)
           TEST_RESULT_DIR="$RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_integration_${commit}_http"
           echo "TEST_RESULT_DIR=$TEST_RESULT_DIR" >> $GITHUB_ENV
 
-          chmod +x ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_remote_ethereum.sh
-          
+          chmod +x "$RUNNER_WS/erigon/.github/workflows/scripts/run_rpc_tests_remote_ethereum.sh"
+
           set +e # Disable exit on error for test run
-          ${{ runner.workspace }}/erigon/.github/workflows/scripts/run_rpc_tests_remote_ethereum.sh ${{ runner.workspace }} $TEST_RESULT_DIR
+          "$RUNNER_WS/erigon/.github/workflows/scripts/run_rpc_tests_remote_ethereum.sh" "$RUNNER_WS" $TEST_RESULT_DIR
           test_exit_status=$? # Capture test runner script exit status
           set -e # Re-enable exit on error after test run
 
@@ -176,27 +178,30 @@ jobs:
 
       - name: Generate Summary
         if: always() && steps.test_step.outputs.test_executed == 'true'
+        env:
+          WORKFLOW: ${{ github.workflow }}
+          TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
         run: |
-          SUMMARY_FILE="${{ env.TEST_RESULT_DIR }}/summary.md"
-          LOG_FILE="${{ env.TEST_RESULT_DIR }}/output.log"
+          SUMMARY_FILE="$TEST_RESULT_DIR/summary.md"
+          LOG_FILE="$TEST_RESULT_DIR/output.log"
 
-          cat << 'EOF' > $SUMMARY_FILE
-          # ${{ github.workflow }} Report
+          {
+            echo "# $WORKFLOW Report"
+            echo
+            echo "## Test Configuration"
+            echo "- **Chain:** $CHAIN"
+            echo "- **Result:** $TEST_RESULT"
+            echo
+            echo "## Test Output"
+            echo '```'
+          } > "$SUMMARY_FILE"
 
-          ## Test Configuration
-          - **Chain:** ${{ env.CHAIN }}
-          - **Result:** ${{ steps.test_step.outputs.TEST_RESULT }}
+          cat "$LOG_FILE" >> "$SUMMARY_FILE"
 
-          ## Test Output
-          ```
-          EOF
+          echo '```' >> "$SUMMARY_FILE"
 
-          cat $LOG_FILE >> $SUMMARY_FILE
-
-          echo '```' >> $SUMMARY_FILE
-
-          cat $SUMMARY_FILE
-          cat $SUMMARY_FILE >> $GITHUB_STEP_SUMMARY
+          cat "$SUMMARY_FILE"
+          cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Stop Erigon & RpcDaemon
         if: always()
@@ -220,8 +225,10 @@ jobs:
 
       - name: Restore Erigon Chaindata Directory
         if: always()
+        env:
+          SAVE_CHAINDATA_OUTCOME: ${{ steps.save_chaindata_step.outcome }}
         run: |
-          if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "${{ steps.save_chaindata_step.outcome }}" == "success" ]; then
+          if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "$SAVE_CHAINDATA_OUTCOME" == "success" ]; then
           rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
           echo "Restore chaindata"
           mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
@@ -256,18 +263,20 @@ jobs:
           python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
             --repo erigon \
             --commit $(git rev-parse HEAD) \
-            --branch ${{ github.ref_name }} \
+            --branch "$GITHUB_REF_NAME" \
             --test_name rpc-integration-tests-remote \
             --chain $CHAIN \
-            --runner ${{ runner.name }} \
+            --runner "$RUNNER_NAME" \
             --db_version $db_version \
             --outcome $TEST_RESULT \
             --result_file $TEST_RESULT_DIR/results/test_report.json
 
       - name: Action to check failure condition
         if: failure()
+        env:
+          TEST_EXECUTED: ${{ steps.test_step.outputs.test_executed }}
         run: |
-          if [ "${{ steps.test_step.outputs.test_executed }}" != "true" ]; then
+          if [ "$TEST_EXECUTED" != "true" ]; then
             echo "::error::Test not executed, workflow failed for infrastructure reasons"
           fi
           exit 1

--- a/.github/workflows/qa-rpc-performance-comparison-tests.yml
+++ b/.github/workflows/qa-rpc-performance-comparison-tests.yml
@@ -73,21 +73,28 @@ jobs:
 
       - name: Print configuration (for logs)
         shell: bash
+        env:
+          RUN_ID: ${{ steps.vars.outputs.run_id }}
+          NETWORK: ${{ steps.vars.outputs.network }}
+          RUN_GETH: ${{ steps.vars.outputs.run_geth }}
         run: |
           set -euo pipefail
-          echo "Run ID:             ${{ steps.vars.outputs.run_id }}"
-          echo "Network:            ${{ steps.vars.outputs.network }}"
+          echo "Run ID:             $RUN_ID"
+          echo "Network:            $NETWORK"
           echo "Run Erigon:         true"
-          echo "Run Geth:           ${{ steps.vars.outputs.run_geth }}"
+          echo "Run Geth:           $RUN_GETH"
 
       - name: Prepare Redis database
         if: steps.vars.outputs.run_geth == 'true'
         shell: bash
         working-directory: ${{ env.ERIGON_QA_PATH }}/test_system/qa-tests/rpc-tests
+        env:
+          RUN_ID: ${{ steps.vars.outputs.run_id }}
+          NETWORK: ${{ steps.vars.outputs.network }}
         run: |
           set -euo pipefail
-          python3 coordinated_start.py --client "erigon" --run-id "${{ steps.vars.outputs.run_id }}" --chain "${{ steps.vars.outputs.network }}" --signal-creation
-          python3 coordinated_start.py --client "geth" --run-id "${{ steps.vars.outputs.run_id }}" --chain "${{ steps.vars.outputs.network }}" --signal-creation
+          python3 coordinated_start.py --client "erigon" --run-id "$RUN_ID" --chain "$NETWORK" --signal-creation
+          python3 coordinated_start.py --client "geth" --run-id "$RUN_ID" --chain "$NETWORK" --signal-creation
 
   test:
     name: Benchmark Latest ${{ matrix.client }}
@@ -116,9 +123,9 @@ jobs:
       - name: Set reference data dir based on branch
         run: |
           # For pull_request events base_ref is the target branch name; for push/dispatch parse from ref.
-          BRANCH="${{ github.base_ref }}"
+          BRANCH="$GITHUB_BASE_REF"
           if [ -z "$BRANCH" ]; then
-            BRANCH="${{ github.ref }}"
+            BRANCH="$GITHUB_REF"
             BRANCH="${BRANCH#refs/heads/}"
           fi
           if [[ "$BRANCH" == release/* ]]; then
@@ -148,10 +155,12 @@ jobs:
 
       - name: Checkout RPC Tests Repository
         if: matrix.client == 'erigon' || needs.setup.outputs.run_geth == 'true'
+        env:
+          RUNNER_WS: ${{ runner.workspace }}
         run: |
-          rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch main https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
-          cd ${{runner.workspace}}/rpc-tests
+          rm -rf "$RUNNER_WS/rpc-tests"
+          git -c advice.detachedHead=false clone --depth 1 --branch main https://github.com/erigontech/rpc-tests "$RUNNER_WS/rpc-tests"
+          cd "$RUNNER_WS/rpc-tests"
 
       - name: Clean Erigon Build Directory
         if: matrix.client == 'erigon'
@@ -263,13 +272,15 @@ jobs:
       - name: Run RPC Performance Tests
         id: test_step
         if: matrix.client == 'erigon' || needs.setup.outputs.run_geth == 'true'
+        env:
+          RUNNER_WS: ${{ runner.workspace }}
         run: |
           set +e # Disable exit on error
-          
+
           failed_test=0
-          
-          if [ "${{ matrix.client }}" == "erigon" ]; then
-            commit=$(git -C ${{runner.workspace}}/erigon rev-parse --short HEAD)
+
+          if [ "$CLIENT" == "erigon" ]; then
+            commit=$(git -C "$RUNNER_WS/erigon" rev-parse --short HEAD)
           else
             commit=$(git -C $GETH_INSTALL_DIR rev-parse --short HEAD)
           fi
@@ -285,12 +296,12 @@ jobs:
           mkdir -p $bin_past_test_dir
 
           # Define result_dir (same for all run_perf calls since workspace and network are constant)
-          result_dir=${{runner.workspace}}/rpc-tests/perf/reports/$CHAIN
+          result_dir="$RUNNER_WS/rpc-tests/perf/reports/$CHAIN"
           mkdir -p $result_dir
           echo "result_dir=$result_dir" >> $GITHUB_ENV
 
           # Initialize output log file in perf dir (moved to result_dir after all tests)
-          output_log=${{runner.workspace}}/rpc-tests/perf/output.log
+          output_log="$RUNNER_WS/rpc-tests/perf/output.log"
           > $output_log
           
           run_perf () {
@@ -360,7 +371,7 @@ jobs:
             echo "Save test result on DB"
 
             if [ "$client" == "erigon" ]; then
-              branch_name=${{ github.ref_name }}
+              branch_name="$GITHUB_REF_NAME"
               commit_hash=$(git -C $workspace/erigon rev-parse HEAD)
             else
               branch_name="release"
@@ -380,7 +391,7 @@ jobs:
               --commit $commit_hash \
               --test_name rpc-performance-test-latest${{ (matrix.client == 'erigon' && github.event.inputs.exec_mode == 'parallel' && '-parallel') || (matrix.client == 'erigon' && github.event.inputs.exec_mode == 'serial' && '-serial') || '' }}-$method \
               --chain $CHAIN \
-              --runner ${{ runner.name }} \
+              --runner "$RUNNER_NAME" \
               --db_version $db_version \
               --outcome $outcome \
               --result_file $result_dir/$result_file
@@ -401,9 +412,9 @@ jobs:
           # Launch the RPC performance test runner
 
           #run_perf <workspace> <chain> <method> <pattern> <load-sequence> <client>
-          #run_perf ${{runner.workspace}} $CHAIN eth_call stress_test_eth_call_001_latest 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
-          run_perf ${{runner.workspace}} $CHAIN eth_call stress_test_eth_call_002_latest 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
-          #run_perf ${{runner.workspace}} $CHAIN eth_getProof stress_test_eth_getProof_001_latest 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
+          #run_perf "$RUNNER_WS" $CHAIN eth_call stress_test_eth_call_001_latest 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
+          run_perf "$RUNNER_WS" $CHAIN eth_call stress_test_eth_call_002_latest 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
+          #run_perf "$RUNNER_WS" $CHAIN eth_getProof stress_test_eth_getProof_001_latest 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
           
           # Move output.log to result_dir after all tests
           mv $output_log $result_dir/
@@ -424,28 +435,31 @@ jobs:
 
       - name: Generate Summary
         if: always() && steps.test_step.outputs.test_executed == 'true'
+        env:
+          WORKFLOW: ${{ github.workflow }}
+          TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
         run: |
-          SUMMARY_FILE="${{ env.result_dir }}/summary.md"
-          LOG_FILE="${{ env.result_dir }}/output.log"
+          SUMMARY_FILE="$result_dir/summary.md"
+          LOG_FILE="$result_dir/output.log"
 
-          cat << 'EOF' > $SUMMARY_FILE
-          # ${{ github.workflow }} Report
+          {
+            echo "# $WORKFLOW Report"
+            echo
+            echo "## Test Configuration"
+            echo "- **Chain:** $CHAIN"
+            echo "- **Client:** $CLIENT"
+            echo "- **Result:** $TEST_RESULT"
+            echo
+            echo "## Test Output"
+            echo '```'
+          } > "$SUMMARY_FILE"
 
-          ## Test Configuration
-          - **Chain:** ${{ env.CHAIN }}
-          - **Client:** ${{ matrix.client }}
-          - **Result:** ${{ steps.test_step.outputs.TEST_RESULT }}
+          cat "$LOG_FILE" >> "$SUMMARY_FILE"
 
-          ## Test Output
-          ```
-          EOF
+          echo '```' >> "$SUMMARY_FILE"
 
-          cat $LOG_FILE >> $SUMMARY_FILE
-
-          echo '```' >> $SUMMARY_FILE
-
-          cat $SUMMARY_FILE
-          cat $SUMMARY_FILE >> $GITHUB_STEP_SUMMARY
+          cat "$SUMMARY_FILE"
+          cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload test results
         if: (matrix.client == 'erigon' || needs.setup.outputs.run_geth == 'true') && steps.test_step.outputs.test_executed == 'true'

--- a/.github/workflows/qa-rpc-performance-tests.yml
+++ b/.github/workflows/qa-rpc-performance-tests.yml
@@ -76,12 +76,16 @@ jobs:
 
       - name: Print configuration (for logs)
         shell: bash
+        env:
+          RUN_ID: ${{ steps.vars.outputs.run_id }}
+          NETWORK: ${{ steps.vars.outputs.network }}
+          RUN_GETH: ${{ steps.vars.outputs.run_geth }}
         run: |
           set -euo pipefail
-          echo "Run ID:             ${{ steps.vars.outputs.run_id }}"
-          echo "Network:            ${{ steps.vars.outputs.network }}"
+          echo "Run ID:             $RUN_ID"
+          echo "Network:            $NETWORK"
           echo "Run Erigon:         true"
-          echo "Run Geth:           ${{ steps.vars.outputs.run_geth }}"
+          echo "Run Geth:           $RUN_GETH"
 
   test:
     name: Benchmark Historic ${{ matrix.client }}
@@ -107,9 +111,9 @@ jobs:
       - name: Set reference data dir based on branch
         run: |
           # For pull_request events base_ref is the target branch name; for push/dispatch parse from ref.
-          BRANCH="${{ github.base_ref }}"
+          BRANCH="$GITHUB_BASE_REF"
           if [ -z "$BRANCH" ]; then
-            BRANCH="${{ github.ref }}"
+            BRANCH="$GITHUB_REF"
             BRANCH="${BRANCH#refs/heads/}"
           fi
           if [[ "$BRANCH" == release/* ]]; then
@@ -131,10 +135,12 @@ jobs:
 
       - name: Checkout RPC Tests Repository
         if: matrix.client == 'erigon' || needs.setup.outputs.run_geth == 'true'
+        env:
+          RUNNER_WS: ${{ runner.workspace }}
         run: |
-          rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v2.4.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
-          cd ${{runner.workspace}}/rpc-tests
+          rm -rf "$RUNNER_WS/rpc-tests"
+          git -c advice.detachedHead=false clone --depth 1 --branch v2.4.0 https://github.com/erigontech/rpc-tests "$RUNNER_WS/rpc-tests"
+          cd "$RUNNER_WS/rpc-tests"
           make rpc_perf
 
       - name: Set up job-scoped build temp dir
@@ -263,13 +269,15 @@ jobs:
       - name: Run RPC Performance Tests
         id: test_step
         if: matrix.client == 'erigon' || needs.setup.outputs.run_geth == 'true'
+        env:
+          RUNNER_WS: ${{ runner.workspace }}
         run: |
           set +e # Disable exit on error
-          
+
           failed_test=0
-          
-          if [ "${{ matrix.client }}" == "erigon" ]; then
-            commit=$(git -C ${{runner.workspace}}/erigon rev-parse --short HEAD)
+
+          if [ "$CLIENT" == "erigon" ]; then
+            commit=$(git -C "$RUNNER_WS/erigon" rev-parse --short HEAD)
           else
             commit=$(git -C $GETH_INSTALL_DIR rev-parse --short HEAD)
           fi
@@ -353,7 +361,7 @@ jobs:
             echo "Save test result on DB"
 
             if [ "$client" == "erigon" ]; then
-              branch_name=${{ github.ref_name }}
+              branch_name="$GITHUB_REF_NAME"
               commit_hash=$(git -C $workspace/erigon rev-parse HEAD)
             else
               branch_name="release"
@@ -373,7 +381,7 @@ jobs:
               --commit $commit_hash \
               --test_name rpc-performance-test-$client${{ (matrix.client == 'erigon' && github.event.inputs.exec_mode == 'parallel' && '-parallel') || (matrix.client == 'erigon' && github.event.inputs.exec_mode == 'serial' && '-serial') || '' }}-$method \
               --chain $CHAIN \
-              --runner ${{ runner.name }} \
+              --runner "$RUNNER_NAME" \
               --db_version $db_version \
               --outcome $outcome \
               --result_file $result_dir/$result_file
@@ -392,16 +400,16 @@ jobs:
           }
 
           # Launch the RPC performance test runner
-          run_perf ${{runner.workspace}} $CHAIN eth_call stress_test_eth_call_001_14M 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
-          run_perf ${{runner.workspace}} $CHAIN eth_getLogs stress_test_eth_getLogs_15M 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
-          run_perf ${{runner.workspace}} $CHAIN eth_getBalance stress_test_eth_getBalance_15M 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
-          run_perf ${{runner.workspace}} $CHAIN eth_getBlockByHash stress_test_eth_getBlockByHash_14M 1:1,100:30,1000:20,2500:20 $CLIENT
-          run_perf ${{runner.workspace}} $CHAIN eth_getBlockByNumber stress_test_eth_getBlockByNumber_13M 1:1,100:30,1000:20,2500:20 $CLIENT
-          run_perf ${{runner.workspace}} $CHAIN eth_getTransactionByHash stress_test_eth_getTransactionByHash_13M 1:1,100:30,1000:20,10000:20 $CLIENT
-          run_perf ${{runner.workspace}} $CHAIN eth_getTransactionReceipt stress_test_eth_getTransactionReceipt_14M 1:1,100:30,1000:20,5000:20,10000:20,20000:20 $CLIENT
-          run_perf ${{runner.workspace}} $CHAIN eth_createAccessList stress_test_eth_createAccessList_16M 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT          
-          run_perf ${{runner.workspace}} $CHAIN debug_traceTransaction stress_test_debug_trace_transaction_21M 1:1,100:30,1000:20,2500:20 $CLIENT          
-          run_perf ${{runner.workspace}} $CHAIN debug_storageRangeAt stress_test_debug_storageRangeAt_20M 1:1,100:30,1000:20,1800:20 $CLIENT          
+          run_perf "$RUNNER_WS" $CHAIN eth_call stress_test_eth_call_001_14M 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
+          run_perf "$RUNNER_WS" $CHAIN eth_getLogs stress_test_eth_getLogs_15M 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
+          run_perf "$RUNNER_WS" $CHAIN eth_getBalance stress_test_eth_getBalance_15M 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT
+          run_perf "$RUNNER_WS" $CHAIN eth_getBlockByHash stress_test_eth_getBlockByHash_14M 1:1,100:30,1000:20,2500:20 $CLIENT
+          run_perf "$RUNNER_WS" $CHAIN eth_getBlockByNumber stress_test_eth_getBlockByNumber_13M 1:1,100:30,1000:20,2500:20 $CLIENT
+          run_perf "$RUNNER_WS" $CHAIN eth_getTransactionByHash stress_test_eth_getTransactionByHash_13M 1:1,100:30,1000:20,10000:20 $CLIENT
+          run_perf "$RUNNER_WS" $CHAIN eth_getTransactionReceipt stress_test_eth_getTransactionReceipt_14M 1:1,100:30,1000:20,5000:20,10000:20,20000:20 $CLIENT
+          run_perf "$RUNNER_WS" $CHAIN eth_createAccessList stress_test_eth_createAccessList_16M 1:1,100:30,1000:20,10000:20,20000:20 $CLIENT          
+          run_perf "$RUNNER_WS" $CHAIN debug_traceTransaction stress_test_debug_trace_transaction_21M 1:1,100:30,1000:20,2500:20 $CLIENT          
+          run_perf "$RUNNER_WS" $CHAIN debug_storageRangeAt stress_test_debug_storageRangeAt_20M 1:1,100:30,1000:20,1800:20 $CLIENT          
           
           # Save the subsection reached status
           
@@ -439,8 +447,10 @@ jobs:
 
       - name: Restore Erigon Chaindata Directory
         if: always() && matrix.client == 'erigon' && steps.save_chaindata_step.outputs.datadir_saved == 'true'
+        env:
+          SAVE_CHAINDATA_OUTCOME: ${{ steps.save_chaindata_step.outcome }}
         run: |
-          if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "${{ steps.save_chaindata_step.outcome }}" == "success" ]; then
+          if [ -d "$ERIGON_TESTBED_AREA/chaindata-prev" ] && [ "$SAVE_CHAINDATA_OUTCOME" == "success" ]; then
           rm -rf $ERIGON_REFERENCE_DATA_DIR/chaindata
           echo "Restore chaindata"
           mv $ERIGON_TESTBED_AREA/chaindata-prev $ERIGON_REFERENCE_DATA_DIR/chaindata
@@ -475,8 +485,10 @@ jobs:
 
       - name: Action to check failure condition
         if: failure()
+        env:
+          TEST_EXECUTED: ${{ steps.test_step.outputs.test_executed }}
         run: |
-          if [ "${{ steps.test_step.outputs.test_executed }}" != "true" ]; then
+          if [ "$TEST_EXECUTED" != "true" ]; then
             echo "::error::Test not executed, workflow failed for infrastructure reasons"
           fi
           exit 1

--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -79,7 +79,7 @@ jobs:
 
         # Run Erigon, wait sync and check ability to maintain sync
         python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-          ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
+          "$GITHUB_WORKSPACE/build/bin" $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN
 
         # Capture monitoring script exit status
         test_exit_status=$?
@@ -114,12 +114,12 @@ jobs:
         python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
           --repo erigon \
           --commit $(git rev-parse HEAD) \
-          --branch ${{ github.ref_name }} \
+          --branch "$GITHUB_REF_NAME" \
           --test_name sync-from-scratch \
           --chain $CHAIN \
-          --runner ${{ runner.name }} \
+          --runner "$RUNNER_NAME" \
           --outcome $TEST_RESULT \
-          --result_file ${{ github.workspace }}/result-$CHAIN.json
+          --result_file "$GITHUB_WORKSPACE/result-$CHAIN.json"
 
     - name: Upload test results
       if: ${{ always() && steps.test_step.outputs.test_executed == 'true' }}
@@ -154,16 +154,18 @@ jobs:
     - name: Run RPC Integration Tests
       id: rpc_test_step
       if: ${{ matrix.rpc_tests_supported && steps.test_step.outputs.TEST_RESULT == 'success' }}
+      env:
+        RUNNER_WS: ${{ runner.workspace }}
       run: |
         commit=$(git rev-parse --short HEAD)
-        RPC_TEST_RESULT_DIR="${{ github.workspace }}/rpc-test-results/${CHAIN}_$(date +%Y%m%d_%H%M%S)_post_sync_${commit}"
+        RPC_TEST_RESULT_DIR="$GITHUB_WORKSPACE/rpc-test-results/${CHAIN}_$(date +%Y%m%d_%H%M%S)_post_sync_${commit}"
         echo "RPC_TEST_RESULT_DIR=$RPC_TEST_RESULT_DIR" >> $GITHUB_ENV
 
         set +e
-        ${{ github.workspace }}/.github/workflows/scripts/run_rpc_tests_local.sh \
+        "$GITHUB_WORKSPACE/.github/workflows/scripts/run_rpc_tests_local.sh" \
           --datadir "$ERIGON_DATA_DIR" \
           --chain "$CHAIN" \
-          --workspace "${{ runner.workspace }}" \
+          --workspace "$RUNNER_WS" \
           --result-dir "$RPC_TEST_RESULT_DIR" \
           --skip-backup
         rpc_exit_status=$?
@@ -195,12 +197,12 @@ jobs:
         python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
           --repo erigon \
           --commit $(git rev-parse HEAD) \
-          --branch ${{ github.ref_name }} \
+          --branch "$GITHUB_REF_NAME" \
           --test_name rpc-integration-tests \
           --chain $CHAIN \
-          --runner ${{ runner.name }} \
+          --runner "$RUNNER_NAME" \
           --outcome $RPC_TEST_RESULT \
-          --result_file ${{ env.RPC_TEST_RESULT_DIR }}/results/test_report.json
+          --result_file "$RPC_TEST_RESULT_DIR/results/test_report.json"
 
     - name: Clean up Erigon data directory
       if: always()

--- a/.github/workflows/qa-txpool-performance-test.yml
+++ b/.github/workflows/qa-txpool-performance-test.yml
@@ -75,7 +75,7 @@ jobs:
         id: parse_kurtosis_output
         run: |
           # Find the folder starting with 'assertoor--'
-          assertoor_folder=$(find ${{ runner.temp }}/${{ env.ENCLAVE_NAME }}/dump -type d -name 'assertoor--*' | head -n 1)
+          assertoor_folder=$(find "$RUNNER_TEMP/$ENCLAVE_NAME/dump" -type d -name 'assertoor--*' | head -n 1)
 
           # Exit if no assertoor folder is found
           if [ -z "$assertoor_folder" ]; then
@@ -88,7 +88,7 @@ jobs:
           echo "Parsing file: $output_log"
 
           # Create an empty JSON file if there are no results
-          output_json="${{ github.workspace }}/outputs_kurtosis.json"
+          output_json="$GITHUB_WORKSPACE/outputs_kurtosis.json"
           echo "{}" > $output_json
 
           # Create a temporary directory
@@ -282,16 +282,21 @@ jobs:
           python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
             --repo erigon \
             --commit $(git rev-parse HEAD) \
-            --branch ${{ github.ref_name }} \
+            --branch "$GITHUB_REF_NAME" \
             --test_name txpool-performance \
-            --runner ${{ runner.name }} \
+            --runner "$RUNNER_NAME" \
             --outcome $TEST_RESULT \
-            --result_file ${{ github.workspace }}/outputs_kurtosis.json
+            --result_file "$GITHUB_WORKSPACE/outputs_kurtosis.json"
 
       - name: Report results in run summary
         if: always()
+        env:
+          TEST_RESULT: ${{ steps.erigon_kurtosis_test.outputs.test_result || 'failure' }}
+          RAW_JSON_URL: ${{ steps.upload_outputs_kurtosis_json.outputs.artifact-url }}
+          LATENCY_PLOTS_URL: ${{ steps.upload_latency_plots.outputs.artifact-url }}
+          THROUGHPUT_PLOTS_URL: ${{ steps.upload_throughput_plots.outputs.artifact-url }}
         run: |
-          output_json="${{ github.workspace }}/outputs_kurtosis.json"
+          output_json="$GITHUB_WORKSPACE/outputs_kurtosis.json"
 
           # Start building the summary
           echo "# TxPool Performance Test Results" >> $GITHUB_STEP_SUMMARY
@@ -304,7 +309,7 @@ jobs:
           fi
 
           # Extract test result status
-          test_result="${{ steps.erigon_kurtosis_test.outputs.test_result || 'failure' }}"
+          test_result="$TEST_RESULT"
           if [ "$test_result" = "success" ]; then
             echo "✅ **Overall Test Status:** PASSED" >> $GITHUB_STEP_SUMMARY
           else
@@ -403,17 +408,17 @@ jobs:
 
           # Add link to raw JSON results if available
           if [ -f "$output_json" ]; then
-            echo "- [Raw JSON Results](${{ steps.upload_outputs_kurtosis_json.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [Raw JSON Results]($RAW_JSON_URL)" >> $GITHUB_STEP_SUMMARY
           fi
 
           # Add link to latency plots if they were generated
-          if [ "${{ steps.upload_latency_plots.outputs.artifact-url }}" != "" ]; then
-            echo "- [Latency Distribution Plots](${{ steps.upload_latency_plots.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+          if [ "$LATENCY_PLOTS_URL" != "" ]; then
+            echo "- [Latency Distribution Plots]($LATENCY_PLOTS_URL)" >> $GITHUB_STEP_SUMMARY
           fi
 
           # Add link to throughput plots if they were generated
-          if [ "${{ steps.upload_throughput_plots.outputs.artifact-url }}" != "" ]; then
-            echo "- [Throughput Analysis Plots](${{ steps.upload_throughput_plots.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+          if [ "$THROUGHPUT_PLOTS_URL" != "" ]; then
+            echo "- [Throughput Analysis Plots]($THROUGHPUT_PLOTS_URL)" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Clean test results

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -13,12 +13,7 @@ rules:
       - ci-cd-main-branch-docker-images.yml
       - ci-gate.yml               # toJSON(needs) is not user-controllable
       - docker-image-remove.yml
-      - qa-rpc-integration-tests-remote.yml
-      - qa-rpc-performance-comparison-tests.yml
-      - qa-rpc-performance-tests.yml
       - qa-sync-from-scratch-full-node.yml
-      - qa-sync-from-scratch.yml
-      - qa-txpool-performance-test.yml
       - release.yml
       - test-all-erigon-race.yml
 


### PR DESCRIPTION
Part of #21132 — template-injection cleanup, batch 4 (5 files).

Removes the following from the `template-injection` ignore list in `.github/zizmor.yml` after fixing every finding in each:

- `qa-rpc-integration-tests-remote.yml`
- `qa-rpc-performance-tests.yml`
- `qa-rpc-performance-comparison-tests.yml`
- `qa-txpool-performance-test.yml`
- `qa-sync-from-scratch.yml`

## What changed

`${{ … }}` expansions inside `run:` blocks are substituted into the script text *before* the shell parses it, so an attacker-influenced value could inject shell code. Each flagged expansion now arrives as **data**, not code:

- **Built-ins**: `github.base_ref`/`github.ref` → `$GITHUB_BASE_REF`/`$GITHUB_REF`; `github.ref_name` → `$GITHUB_REF_NAME`; `runner.name` → `$RUNNER_NAME`; `runner.temp` → `$RUNNER_TEMP`; `github.workspace` → `$GITHUB_WORKSPACE`.
- **Step-level `env:`** for contexts with no built-in: `runner.workspace` → `RUNNER_WS`; `steps.*.outputs.*` / `steps.*.outcome` → `TEST_RESULT`/`TEST_EXECUTED`/`SAVE_CHAINDATA_OUTCOME`/`RUN_ID`/`NETWORK`/`RUN_GETH`/`RAW_JSON_URL`/`LATENCY_PLOTS_URL`/`THROUGHPUT_PLOTS_URL`; `github.workflow` → `WORKFLOW`.
- **Already-env / matrix contexts** referenced directly (`$TEST_RESULT_DIR`, `$CHAIN`, `$CLIENT`, `$ENCLAVE_NAME`).

The two `Generate Summary` steps that built their report via a quoted heredoc are rewritten as `{ echo …; } > file` blocks (a quoted heredoc can't expand the routed `$VAR`s, and unquoting it would run the ```` ``` ```` fence as command substitution). Output is byte-identical.

Constrained conditional expressions (`matrix.exec_mode == 'parallel' && '-parallel' || …`) and trusted command substitutions (`$(git rev-parse HEAD)`) are left as-is — zizmor does not flag them.

## Verification

- `zizmor 1.24.1` with the repo config: **0 template-injection findings** across all five files; full-repo exit code unchanged at **12** (< 14, passes the CI gate).
- `actionlint`: **0 errors** for every file. Remaining SC2086 (info-level shellcheck, which CI ignores) are on pre-existing unquoted variables; every routed variable this PR introduces is quoted or used inside double quotes.