### PR TITLE
cl: repair permanently-truncated caplin static validators table

### DIFF
--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -155,7 +155,7 @@ func FillStaticValidatorsTableIfNeeded(ctx context.Context, logger log.Logger, s
 			continue
 		}
 		event := state_accessors.NewStateEventsFromBytes(buf)
-		state_accessors.ReplayEvents(
+		if err := state_accessors.ReplayEvents(
 			func(validatorIndex uint64, validator solid.Validator) error {
 				return validatorsTable.AddValidator(validator, validatorIndex, slot)
 			},
@@ -178,7 +178,9 @@ func FillStaticValidatorsTableIfNeeded(ctx context.Context, logger log.Logger, s
 				return validatorsTable.AddSlashed(validatorIndex, slot, slashed)
 			},
 			event,
-		)
+		); err != nil {
+			return false, fmt.Errorf("replay validator events at slot %d: %w", slot, err)
+		}
 		lastSlot = slot
 	}
 	validatorsTable.SetSlot(lastSlot)
@@ -224,13 +226,17 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 			return err
 		}
 		// Mark all validators as touched because we just initizialized the whole state.
+		var addErr error
 		s.currentState.ForEachValidator(func(v solid.Validator, index, total int) bool {
 			changedValidators.Store(uint64(index), struct{}{})
-			if err = s.validatorsTable.AddValidator(v, uint64(index), 0); err != nil {
+			if addErr = s.validatorsTable.AddValidator(v, uint64(index), 0); addErr != nil {
 				return false
 			}
 			return true
 		})
+		if addErr != nil {
+			return fmt.Errorf("genesis validators table init: %w", addErr)
+		}
 	}
 	s.validatorsTable.SetSlot(s.currentState.Slot())
 
@@ -378,6 +384,12 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		return rwTx.Commit()
 	}
 	lastCommitSlot := slot
+
+	// A restored table shorter than the state it tracks is truncated; fail rather
+	// than silently mis-handle validators past the cut.
+	if got, want := s.validatorsTable.Length(), s.currentState.ValidatorLength(); got < want {
+		return fmt.Errorf("static validators table has %d entries, state at slot %d has %d validators (truncated table)", got, s.currentState.Slot(), want)
+	}
 
 	for ; slot < to && startLoop.Add(timeBeforeCommit).After(time.Now()); slot++ {
 		// Bound each mdbx commit: once maxSlotsPerCommit slots have accumulated,

--- a/cl/persistence/state/static_validator_table.go
+++ b/cl/persistence/state/static_validator_table.go
@@ -18,6 +18,7 @@ package state_accessors
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 
@@ -287,13 +288,16 @@ func NewStaticValidatorTable() *StaticValidatorTable {
 func (s *StaticValidatorTable) AddValidator(v solid.Validator, validatorIndex, slot uint64) error {
 	s.sync.Lock()
 	defer s.sync.Unlock()
-	if slot <= s.slot && s.slot != 0 {
+	// Idempotency is by index, not slot: guarding on slot leaves a table restored
+	// short (fewer entries than the set) permanently unfillable, since the genesis
+	// re-adds all arrive at slot 0.
+	if validatorIndex < uint64(len(s.validatorTable)) {
 		return nil
 	}
-	s.validatorTable = append(s.validatorTable, NewStaticValidatorFromValidator(v, slot))
-	if validatorIndex != uint64(len(s.validatorTable))-1 {
-		return errors.New("validator index mismatch")
+	if validatorIndex != uint64(len(s.validatorTable)) {
+		return fmt.Errorf("validator index gap: index %d with table length %d", validatorIndex, len(s.validatorTable))
 	}
+	s.validatorTable = append(s.validatorTable, NewStaticValidatorFromValidator(v, slot))
 	return nil
 }
 
@@ -456,4 +460,10 @@ func (s *StaticValidatorTable) Slot() uint64 {
 	s.sync.RLock()
 	defer s.sync.RUnlock()
 	return s.slot
+}
+
+func (s *StaticValidatorTable) Length() int {
+	s.sync.RLock()
+	defer s.sync.RUnlock()
+	return len(s.validatorTable)
 }

--- a/cl/persistence/state/static_validator_table_repair_test.go
+++ b/cl/persistence/state/static_validator_table_repair_test.go
@@ -1,0 +1,62 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_accessors
+
+import (
+	"testing"
+
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/stretchr/testify/require"
+)
+
+func staticTableLen(tbl *StaticValidatorTable) int {
+	n := 0
+	tbl.ForEach(func(uint64, *StaticValidator) bool { n++; return true })
+	return n
+}
+
+// A table restored short (slot advanced past 0) must be refilled by the genesis
+// re-add at slot 0, not skipped — else lookups past the cut fail forever.
+func TestStaticValidatorTable_RefillsRestoredShortTable(t *testing.T) {
+	const full = 10
+	const persisted = 6
+
+	vals := make([]solid.Validator, full)
+	for i := range vals {
+		vals[i] = solid.NewValidator()
+	}
+
+	table := NewStaticValidatorTable()
+	for i := 0; i < persisted; i++ {
+		require.NoError(t, table.AddValidator(vals[i], uint64(i), 0))
+	}
+	// Simulate a restore where the processing slot advanced past genesis.
+	table.SetSlot(1000)
+	require.Equal(t, persisted, staticTableLen(table))
+
+	for i := 0; i < full; i++ {
+		require.NoError(t, table.AddValidator(vals[i], uint64(i), 0))
+	}
+	require.Equal(t, full, staticTableLen(table))
+}
+
+// A genuine index gap must error, not silently corrupt the table.
+func TestStaticValidatorTable_AddValidatorRejectsGap(t *testing.T) {
+	table := NewStaticValidatorTable()
+	require.NoError(t, table.AddValidator(solid.NewValidator(), 0, 0))
+	require.Error(t, table.AddValidator(solid.NewValidator(), 5, 0))
+}


### PR DESCRIPTION
Caplin historical-state reconstruction can loop forever. The `StaticValidatorTable` is persisted to `kv.StaticValidators` and restored at startup with `slot = StateProcessingProgress`. Once it is persisted incomplete (fewer entries than the validator set — e.g. a partial `Fill` off empty state-event snapshots that then advanced the slot), it becomes permanently unrepairable: `FillStaticValidatorsTableIfNeeded` early-returns when `slot != 0`, and genesis-init's `AddValidator(slot=0)` is skipped by the `slot <= s.slot` guard once the table slot has advanced. Reconstruction then fails at the first proposer slashing of a validator beyond the truncation and retries from genesis forever (seen on hoodi at slot 66082, validator 975067; genesis has 1,060,000 validators).

## Changes
- `AddValidator`: idempotency by index rather than slot — skip already-tracked indices, append the next, error on a gap. A restored-short table is refilled by the genesis re-add instead of skipped.
- `FillStaticValidatorsTableIfNeeded` and genesis-init propagate the `AddValidator` error instead of swallowing it, so a truncated table can no longer be silently persisted with an advanced slot.
- `IncrementBeaconState` refuses to start reconstruction on a table shorter than the state it tracks.