### PR TITLE
ci: fix zizmor template-injection in remaining QA/CD workflows (#21132)

### DIFF
--- a/.github/workflows/backups-dashboards.yml
+++ b/.github/workflows/backups-dashboards.yml
@@ -100,15 +100,17 @@ jobs:
 
       - name: Bye ${{ github.actor }}
         if: always()
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
-          set +x 
+          set +x
           if [ "${{ needs.preparation.result }}" == "success" ] && [ "${{ needs.backup_dashboard.result }}" == "success" ]; then
             echo -e "${{ env.YELLOW }} --------------------------------------------------------------------------------------------------------------------- ${{ env.NOCOLOUR }}"       
-            echo -e "${{ env.YELLOW }}         *** It was a true pleasure to serve you ${{ github.actor }}, SEE YOU NEXT TIME!                               ${{ env.NOCOLOUR }}"      
+            echo -e "${{ env.YELLOW }}         *** It was a true pleasure to serve you $ACTOR, SEE YOU NEXT TIME!                               ${{ env.NOCOLOUR }}"      
             echo -e "${{ env.YELLOW }} --------------------------------------------------------------------------------------------------------------------- ${{ env.NOCOLOUR }}"       
           else
             echo -e "${{ env.RED }} --------------------------------------------------------------------------------------------------------------------- ${{ env.RED }}"       
-            echo -e "${{ env.RED }}         *** Sorry ${{ github.actor }}, it seems there was an error this time: just fix it and COME BACK!              ${{ env.RED }}"      
+            echo -e "${{ env.RED }}         *** Sorry $ACTOR, it seems there was an error this time: just fix it and COME BACK!              ${{ env.RED }}"      
             echo -e "${{ env.RED }} --------------------------------------------------------------------------------------------------------------------- ${{ env.RED }}"       
           fi
           

--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -54,8 +54,9 @@ jobs:
         ##   commit id image: erigontech/erigon:${tag_name}-${short_commit_id}
         env:
           CHECKOUT_REF: ${{ inputs.checkout_ref }}
+          BRANCH_REF: ${{ inputs.checkout_ref == '' && github.ref_name || inputs.checkout_ref }}
         run: |
-          branch_name="${{ inputs.checkout_ref == '' && github.ref_name || inputs.checkout_ref }}"
+          branch_name="$BRANCH_REF"
           case "$branch_name" in
             "main" )
               export tag_name='main';
@@ -112,29 +113,34 @@ jobs:
           DOCKER_PUBLISH_CONDITION: ${{ steps.def_docker_vars.outputs.keep_images > 0 && format('--tag {0}:{1} ', env.DOCKER_URL, env.BUILD_VERSION) || '' }}
           DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
           DOCKERFILE_PATH: Dockerfile
+          BINARIES: ${{ steps.def_docker_vars.outputs.binaries }}
+          IMAGE_REF: ${{ inputs.checkout_ref == '' && github.ref || inputs.checkout_ref }}
+          COMMIT_ID: ${{ steps.getCommitId.outputs.id }}
+          SHORT_COMMIT_ID: ${{ steps.getCommitId.outputs.short_commit_id }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           echo "Create build cache directories in case it is not yet extracted from existing cache"
-          echo "docker_build_tag=${{ env.BUILD_VERSION }}" >> $GITHUB_OUTPUT
+          echo "docker_build_tag=$BUILD_VERSION" >> $GITHUB_OUTPUT
           cd erigon
           docker buildx build \
-          --file ${{ env.DOCKERFILE_PATH }} \
-          --build-arg BINARIES='${{ steps.def_docker_vars.outputs.binaries }}' \
-          --build-arg BUILDER_IMAGE='${{ env.BUILDER_IMAGE }}' \
+          --file "$DOCKERFILE_PATH" \
+          --build-arg BINARIES="$BINARIES" \
+          --build-arg BUILDER_IMAGE="$BUILDER_IMAGE" \
           --attest type=provenance,mode=max \
           --no-cache \
           --sbom=true \
-          ${{ steps.def_docker_vars.outputs.keep_images > 0 && format('--tag {0}:{1} ', env.DOCKER_URL, env.BUILD_VERSION) || '' }} \
-          --tag ${{ env.DOCKER_URL }}:${{ env.BUILD_VERSION_LATEST }} \
+          ${DOCKER_PUBLISH_CONDITION} \
+          --tag "$DOCKER_URL:$BUILD_VERSION_LATEST" \
           --label org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
           --label org.opencontainers.image.authors="https://github.com/erigontech/erigon/graphs/contributors" \
-          --label org.opencontainers.image.url="https://github.com/erigontech/erigon/blob/${{ inputs.checkout_ref == '' && github.ref || inputs.checkout_ref }}/Dockerfile" \
+          --label org.opencontainers.image.url="https://github.com/erigontech/erigon/blob/$IMAGE_REF/Dockerfile" \
           --label org.opencontainers.image.documentation="https://docs.erigon.tech/" \
           --label org.opencontainers.image.source="https://github.com/erigontech/erigon" \
-          --label org.opencontainers.image.version=${{ steps.getCommitId.outputs.id }} \
-          --label org.opencontainers.image.revision=${{ steps.getCommitId.outputs.id }} \
-          --label org.opencontainers.image.vcs-ref-short=${{ steps.getCommitId.outputs.short_commit_id }} \
-          --label org.opencontainers.image.vendor="${{ github.repository_owner }}" \
-          --label org.opencontainers.image.description="${{ env.LABEL_DESCRIPTION }}" \
+          --label org.opencontainers.image.version="$COMMIT_ID" \
+          --label org.opencontainers.image.revision="$COMMIT_ID" \
+          --label org.opencontainers.image.vcs-ref-short="$SHORT_COMMIT_ID" \
+          --label org.opencontainers.image.vendor="$REPO_OWNER" \
+          --label org.opencontainers.image.description="$LABEL_DESCRIPTION" \
           --push \
           --platform linux/amd64,linux/arm64 .
           echo "Docker build and push done"
@@ -147,12 +153,14 @@ jobs:
           DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
           TAG_KEY: ${{ steps.def_docker_vars.outputs.tag_name }}
           KEEP_IMAGES: ${{ steps.def_docker_vars.outputs.keep_images }}
+          DH_USERNAME: ${{ secrets.DOCKERHUB_PUSH_USERNAME }}
+          DH_TOKEN: ${{ secrets.DOCKERHUB_PUSH_TOKEN }}
         run: |
           HTTP_RESP=$(curl -s -o ./resp1 -w "%{http_code}" \
             -X POST -H "Content-Type: application/json" \
             -d '{
-                  "identifier": "'"${{ secrets.DOCKERHUB_PUSH_USERNAME }}"'",
-                  "secret": "'"${{ secrets.DOCKERHUB_PUSH_TOKEN }}"'"
+                  "identifier": "'"$DH_USERNAME"'",
+                  "secret": "'"$DH_TOKEN"'"
                 }' \
             https://hub.docker.com/v2/auth/token/)
 
@@ -163,10 +171,10 @@ jobs:
           DOCKER_JWT=$(jq -r .access_token ./resp1)
           rm -f ./resp1
           echo The following docker images have been published:
-          echo "${{ env.DOCKERHUB_REPOSITORY }}:${{ env.BUILD_VERSION_LATEST }}"
-          echo "${{ steps.def_docker_vars.outputs.keep_images > 0 && format('{0}:{1} ',env.DOCKER_URL,env.BUILD_VERSION) || '' }} (empty, if keep_images is 0)"
+          echo "$DOCKERHUB_REPOSITORY:$BUILD_VERSION_LATEST"
+          echo "$BUILD_VERSION_CONDITION (empty, if keep_images is 0)"
           echo
-          echo "Cleanup old docker images matching pattern tag ~= ${{ env.TAG_KEY }}-XXXXXXX (where XXXXXXX is a short Commit IDs)"
+          echo "Cleanup old docker images matching pattern tag ~= $TAG_KEY-XXXXXXX (where XXXXXXX is a short Commit IDs)"
           echo "Only last $KEEP_IMAGES images will be kept."
           curl_cmd="curl -s -H \"Authorization: Bearer ${DOCKER_JWT}\" "
           dockerhub_url='https://hub.docker.com/v2/namespaces/erigontech/repositories/erigon'
@@ -176,17 +184,17 @@ jobs:
             next_page="$dockerhub_url/tags?page=1&page_size=100"
             while [ "$next_page" != "null" ]
               do
-              # Print tags and push dates for tags matching "${{ env.TAG_KEY }}-":
-              $curl_cmd $next_page | jq -r '.results|.[]|.name + " " + .tag_last_pushed' | grep '${{ env.TAG_KEY }}-' || true
+              # Print tags and push dates for tags matching "$TAG_KEY-":
+              $curl_cmd $next_page | jq -r '.results|.[]|.name + " " + .tag_last_pushed' | grep "$TAG_KEY-" || true
               next_page=`$curl_cmd $next_page | jq '.next' | sed -e 's/^\"//' -e 's/\"$//'`
             done
             }
             echo "DEBUG: full list of images:"
             my_list
             echo "DEBUG: end of the list."
-            my_list | tail -n+${{ env.KEEP_IMAGES }} | while read line; do
+            my_list | tail -n+"$KEEP_IMAGES" | while read line; do
               echo -n "Removing docker image/published - $line "
-              current_image=$(echo $line | sed -e 's/^\(${{ env.TAG_KEY }}-.\{7\}\) .*/\1/')
+              current_image=$(echo $line | sed -e "s/^\(${TAG_KEY}-.\{7\}\) .*/\1/")
               output_code=$(curl --write-out %{http_code} --output curl-output.log \
                     -s -X DELETE -H "Accept: application/json" \
                     -H "Authorization: Bearer ${DOCKER_JWT}" \

--- a/.github/workflows/docker-image-remove.yml
+++ b/.github/workflows/docker-image-remove.yml
@@ -34,13 +34,13 @@ jobs:
         run: |
           output_code=$(curl --write-out %{http_code} --output curl-output.log \
                     -s -X DELETE -H "Accept: application/json" \
-                    -H "Authorization: JWT ${{ env.TOKEN }}" \
-                    ${{ env.API_URL }}/$DOCKER_IMAGE_TAG )
+                    -H "Authorization: JWT $TOKEN" \
+                    "$API_URL/$DOCKER_IMAGE_TAG" )
           if [ $output_code -ne 204 ]; then
-            echo "ERROR: failed to remove docker image ${{ env.DOCKERHUB_REPOSITORY }}:$DOCKER_IMAGE_TAG"
+            echo "ERROR: failed to remove docker image $DOCKERHUB_REPOSITORY:$DOCKER_IMAGE_TAG"
             echo "ERROR: API response: $(cat curl-output.log)."
             exit 1
           else
-            echo "SUCCESS: docker image ${{ env.DOCKERHUB_REPOSITORY }}:$DOCKER_IMAGE_TAG removed."
+            echo "SUCCESS: docker image $DOCKERHUB_REPOSITORY:$DOCKER_IMAGE_TAG removed."
             exit 0
           fi

--- a/.github/workflows/qa-sync-from-scratch-full-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-full-node.yml
@@ -59,7 +59,7 @@ jobs:
 
           # Run Erigon, wait sync and check ability to maintain sync
           python3 $ERIGON_QA_PATH/test_system/qa-tests/tip-tracking/run_and_check_tip_tracking.py \
-            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN $NODE_TYPE
+            "$GITHUB_WORKSPACE/build/bin" $ERIGON_DATA_DIR $TRACKING_TIME_SECONDS $TOTAL_TIME_SECONDS Erigon3 $CHAIN $NODE_TYPE
 
           # Capture monitoring script exit status
           test_exit_status=$?
@@ -94,12 +94,12 @@ jobs:
           python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
             --repo erigon \
             --commit $(git rev-parse HEAD) \
-            --branch ${{ github.ref_name }} \
+            --branch "$GITHUB_REF_NAME" \
             --test_name sync-from-scratch-full-node \
             --chain $CHAIN \
-            --runner ${{ runner.name }} \
+            --runner "$RUNNER_NAME" \
             --outcome $TEST_RESULT \
-            --result_file ${{ github.workspace }}/result-$CHAIN.json
+            --result_file "$GITHUB_WORKSPACE/result-$CHAIN.json"
 
       - name: Upload test results
         if: ${{ always() && steps.test_step.outputs.test_executed == 'true' }}
@@ -135,7 +135,7 @@ jobs:
           # du -sB1 = actual disk blocks used, in bytes (NOT --apparent-size).
           BYTES=$(du -sB1 "$ERIGON_DATA_DIR" | awk '{print $1}')
           echo "Disk usage for $CHAIN $MODE: ${BYTES} bytes"
-          echo "$BYTES" > ${{ github.workspace }}/disk-usage-${{ env.CHAIN }}-${{ env.MODE }}.txt
+          echo "$BYTES" > "$GITHUB_WORKSPACE/disk-usage-$CHAIN-$MODE.txt"
 
       - name: Upload disk usage
         if: ${{ always() && steps.test_step.outputs.test_executed == 'true' }}

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -90,7 +90,8 @@ jobs:
           # in common/dbg/dbg_env.go auto-prepends ERIGON_, so this maps to
           # the EXEC3_PARALLEL flag declared in common/dbg/experiments.go.
           ERIGON_EXEC3_PARALLEL: ${{ matrix.exec_mode == 'parallel' && 'true' || 'false' }}
-        run: make test-group TEST_GROUP=${{ matrix.test-group }} GO_FLAGS="-race -timeout=60m"
+          TEST_GROUP: ${{ matrix.test-group }}
+        run: make test-group TEST_GROUP="$TEST_GROUP" GO_FLAGS="-race -timeout=60m"
 
       - uses: ./.github/actions/cleanup-erigon
         if: always()

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,13 +9,7 @@ rules:
   # tracked in issue #21132. Files not listed here still get full coverage.
   template-injection:
     ignore:
-      - backups-dashboards.yml
-      - ci-cd-main-branch-docker-images.yml
-      - ci-gate.yml               # toJSON(needs) is not user-controllable
-      - docker-image-remove.yml
-      - qa-sync-from-scratch-full-node.yml
       - release.yml
-      - test-all-erigon-race.yml
 
   # Cache-poisoning (artipacked) findings in these workflows are intentional;
   # tracked in issue #21132.


### PR DESCRIPTION
Part of #21132 — template-injection cleanup, final batch (all remaining files except `release.yml`).

After this PR the `template-injection` ignore list in `.github/zizmor.yml` contains **only** `release.yml` (deferred — it needs a release-pipeline change).

Files fixed / dropped from the ignore list:

- `backups-dashboards.yml`
- `ci-cd-main-branch-docker-images.yml`
- `ci-gate.yml` — already clean at the regular persona (its `toJSON(needs)` is already routed through an `env:` block); just removed the stale ignore entry.
- `docker-image-remove.yml`
- `qa-sync-from-scratch-full-node.yml`
- `test-all-erigon-race.yml`

## What changed

`${{ … }}` expansions inside `run:` blocks are substituted into the script text *before* the shell parses it, so an attacker-influenced value could inject shell code. Each flagged expansion now arrives as **data**, not code:

- **Built-ins**: `github.ref_name` → `$GITHUB_REF_NAME`; `runner.name` → `$RUNNER_NAME`; `github.workspace` → `$GITHUB_WORKSPACE`.
- **Step-level `env:`** for everything else: `inputs.checkout_ref`/`github.ref` conditionals → `BRANCH_REF`/`IMAGE_REF`; `steps.*.outputs.*` → `BINARIES`/`COMMIT_ID`/`SHORT_COMMIT_ID`/`BUILD_VERSION*`/`TAG_KEY`/`KEEP_IMAGES`; `github.actor` → `ACTOR`; `matrix.test-group` → `TEST_GROUP`; `github.repository_owner` → `REPO_OWNER`; the already-defined `env.CHAIN`/`env.MODE`/`env.TAG_KEY`/`env.DOCKER_URL`/… referenced as plain `$VAR`.

### Security hardening beyond the raw findings

In `ci-cd-main-branch-docker-images.yml` and `docker-image-remove.yml`, DockerHub push credentials were interpolated directly into `run:` text (`"'"${{ secrets.… }}"'"`, `JWT ${{ env.TOKEN }}`). A secret containing a shell metacharacter could have broken out of the surrounding quoting. These now travel through step `env:` (`DH_USERNAME`/`DH_TOKEN`/`TOKEN`) and are referenced as shell variables, so the secret value never lands in script text.

### Notes

- The `--tag` publish flag in the docker build is produced by `${DOCKER_PUBLISH_CONDITION}`, left **intentionally unquoted** so it word-splits into `--tag <url>:<ver>` (or expands to nothing) — exactly reproducing the previous template behavior. Quoting it would change the docker invocation.
- The cleanup `sed` pattern is translated to double quotes so only `${TAG_KEY}` expands; `\(`, `\{7\}`, `\1` remain literal.
- Constrained expressions (`matrix.exec_mode == 'parallel' && … || …`, `needs.*.result`) and trusted command substitutions (`$(git rev-parse HEAD)`) are left as-is — zizmor does not flag them.
- Workflow-level `run-name:` and step `name:` expansions are display strings, not shell, and are not flagged.

## Verification

- `zizmor 1.24.1` (regular persona = CI's) with the repo config: **0 template-injection findings** across all six files; full-repo exit code unchanged at **12** (< 14, passes the CI gate).
- `actionlint`: **0 errors** for every file. The only net-new SC2086 (info-level, CI-ignored) is the intentional `${DOCKER_PUBLISH_CONDITION}` word-split noted above; every other variable this PR introduces is quoted.