### PR TITLE
rpc: don't copy Header returned from Cache

### DIFF
--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -551,7 +551,7 @@ func TestAssembleBlock(t *testing.T) {
 	require.NoError(t, err)
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            chainPack.TopBlock.Header().MixDigest,
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -593,7 +593,7 @@ func TestAssembleBlockWithFreshlyAddedTxns(t *testing.T) {
 	require.NoError(t, err)
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            chainPack.TopBlock.Header().MixDigest,
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -766,7 +766,7 @@ func TestAssembleEmptyBlock(t *testing.T) {
 	// Don't add any txns to pool — assemble empty block.
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            chainPack.TopBlock.Header().MixDigest,
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -806,7 +806,7 @@ func TestAssembleBlockWithStateVerification(t *testing.T) {
 
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            chainPack.TopBlock.Header().MixDigest,
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -829,7 +829,7 @@ func TestAssembleBlockWithStateVerification(t *testing.T) {
 	addTwoTxnsToPool(ctx, 3, t, m, txpool, baseFee)
 	payloadId2, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            block.Hash(),
-		Timestamp:             block.Header().Time + 1,
+		Timestamp:             block.Time() + 1,
 		PrevRandao:            block.Header().MixDigest,
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -885,7 +885,7 @@ func TestAssembleBlockWithContractCreation(t *testing.T) {
 	// Assemble block.
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            chainPack.TopBlock.Header().MixDigest,
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -956,7 +956,7 @@ func TestAssembleBlockGasOverflow(t *testing.T) {
 	// Assemble block 2 — should be gas-limited.
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            chainPack.TopBlock.Header().MixDigest,
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -1050,7 +1050,7 @@ func TestAssembleBlockMixedTxTypes(t *testing.T) {
 	// Assemble block.
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            chainPack.TopBlock.Header().MixDigest,
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -1142,7 +1142,7 @@ func TestAssembleBlockWithWithdrawalRequest(t *testing.T) {
 	beaconRoot := randomHash()
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            randomHash(),
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -1255,7 +1255,7 @@ func TestAssembleBlockAmsterdamForkTransition(t *testing.T) {
 		require.NoError(t, addErr)
 		require.Equal(t, "success", r.Errors[0])
 
-		ts := topBlock.Header().Time + 1
+		ts := topBlock.Time() + 1
 		require.Less(t, ts, amsterdamTime) // still pre-Amsterdam
 		var prevRandao, beaconRoot common.Hash
 		_, _ = rand.Read(prevRandao[:])
@@ -1280,7 +1280,7 @@ func TestAssembleBlockAmsterdamForkTransition(t *testing.T) {
 		baseFee = block.BaseFee().Uint64()
 	}
 
-	require.Less(t, topBlock.Header().Time, amsterdamTime, "pre-Amsterdam blocks should have timestamp < amsterdamTime")
+	require.Less(t, topBlock.Time(), amsterdamTime, "pre-Amsterdam blocks should have timestamp < amsterdamTime")
 
 	// Add a contract deployment tx to the pool — exercises state gas (EIP-8037)
 	// more than simple EOA transfers.
@@ -1327,7 +1327,7 @@ func TestAssembleBlockAmsterdamForkTransition(t *testing.T) {
 	block, err := getAssembledBlock(ctx, exec, payloadId)
 	require.NoError(t, err)
 	require.NotNil(t, block, "first Amsterdam block should be built successfully")
-	require.True(t, cfg.IsAmsterdam(block.Header().Time), "block should be an Amsterdam block")
+	require.True(t, cfg.IsAmsterdam(block.Time()), "block should be an Amsterdam block")
 	require.GreaterOrEqual(t, len(block.Transactions()), 1, "block should contain txpool txns")
 
 	// Insert, validate, and update fork choice.
@@ -1515,7 +1515,7 @@ func TestAssembleBlockStateGasLimit(t *testing.T) {
 	parentBeaconBlockRoot := randomHash()
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            randomHash(),
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -1626,7 +1626,7 @@ func TestAssembleBlockStateGasLimitSSTORE(t *testing.T) {
 	parentBeaconBlockRoot := randomHash()
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            randomHash(),
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -1748,7 +1748,7 @@ func TestAssembleBlockGasPoolSnapshotRestoreBug(t *testing.T) {
 	parentBeaconBlockRoot := randomHash()
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            randomHash(),
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),
@@ -1880,7 +1880,7 @@ func TestAssembleBlockGasPoolMultiBatchInitBug(t *testing.T) {
 	parentBeaconBlockRoot := randomHash()
 	payloadId, err := assembleBlock(ctx, exec, &builder.Parameters{
 		ParentHash:            chainPack.TopBlock.Hash(),
-		Timestamp:             chainPack.TopBlock.Header().Time + 1,
+		Timestamp:             chainPack.TopBlock.Time() + 1,
 		PrevRandao:            randomHash(),
 		SuggestedFeeRecipient: common.Address{1},
 		Withdrawals:           make([]*types.Withdrawal, 0),

--- a/node/ethstats/ethstats.go
+++ b/node/ethstats/ethstats.go
@@ -563,7 +563,7 @@ func (s *Service) assembleBlockStats(block *types.Block, td *uint256.Int) *block
 		Number:     block.Header().Number,
 		Hash:       block.Hash(),
 		ParentHash: block.Header().ParentHash,
-		Timestamp:  new(big.Int).SetUint64(block.Header().Time),
+		Timestamp:  new(big.Int).SetUint64(block.Time()),
 		Miner:      block.Header().Coinbase,
 		GasUsed:    block.Header().GasUsed,
 		GasLimit:   block.Header().GasLimit,

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -612,7 +612,7 @@ func (api *BaseAPI) buildAccessedState(
 	ibs := state.New(recordingState)
 
 	// Get header for block context
-	header := block.Header()
+	header := block.HeaderNoCopy()
 
 	// Create EVM block context
 	blockCtx := transactions.NewEVMBlockContext(engine, header, true /* requireCanonical */, tx, api._blockReader, chainConfig)
@@ -1921,7 +1921,7 @@ func execBlockStatelessly(result *ExecutionWitnessResult, block *types.Block, ch
 
 	// Create the in-block state with the witness stateless as reader
 	ibs := state.New(stateless)
-	header := block.Header()
+	header := block.HeaderNoCopy()
 	blockNum := block.NumberU64()
 
 	// Create EVM block context - pass header.Coinbase as the author/beneficiary

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -339,7 +339,7 @@ func (api *BaseAPI) blockWithSenders(ctx context.Context, tx kv.Tx, hash common.
 func (api *BaseAPI) headerNumberByHash(ctx context.Context, tx kv.Tx, hash common.Hash) (uint64, error) {
 	if api.blocksLRU != nil {
 		if it, ok := api.blocksLRU.Get(hash); ok && it != nil {
-			return it.Header().Number.Uint64(), nil
+			return it.NumberU64(), nil
 		}
 	}
 	number, err := api._blockReader.HeaderNumber(ctx, tx, hash)
@@ -362,7 +362,7 @@ func (api *BaseAPI) headerByNumberOrHash(ctx context.Context, tx kv.Tx, blockNrO
 	}
 	if api.blocksLRU != nil {
 		if it, ok := api.blocksLRU.Get(hash); ok && it != nil {
-			return it.Header(), isLatest, nil
+			return it.HeaderNoCopy(), isLatest, nil
 		}
 	}
 
@@ -383,7 +383,7 @@ func (api *BaseAPI) headerByNumber(ctx context.Context, number rpc.BlockNumber, 
 
 	if api.blocksLRU != nil {
 		if it, ok := api.blocksLRU.Get(h); ok && it != nil {
-			return it.Header(), nil
+			return it.HeaderNoCopy(), nil
 		}
 	}
 	overlayTx := api.filters.WithOverlay(tx)
@@ -393,7 +393,7 @@ func (api *BaseAPI) headerByNumber(ctx context.Context, number rpc.BlockNumber, 
 func (api *BaseAPI) headerByHash(ctx context.Context, hash common.Hash, tx kv.Tx) (*types.Header, error) {
 	if api.blocksLRU != nil {
 		if it, ok := api.blocksLRU.Get(hash); ok && it != nil {
-			return it.Header(), nil
+			return it.HeaderNoCopy(), nil
 		}
 	}
 

--- a/rpc/jsonrpc/eth_callMany.go
+++ b/rpc/jsonrpc/eth_callMany.go
@@ -159,7 +159,7 @@ func (api *APIImpl) CallMany(ctx context.Context, bundles []Bundle, simulateCont
 
 	st := state.New(stateReader)
 
-	header := block.Header()
+	header := block.HeaderNoCopy()
 
 	if header == nil {
 		return nil, fmt.Errorf("block %d(%x) not found", blockNum, hash)

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -449,7 +449,7 @@ func TestGetBlockByTimestampLatestTime(t *testing.T) {
 		}
 	}
 
-	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(latestBlock.Header().Time), false)
+	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(latestBlock.Time()), false)
 	require.NoError(t, err)
 
 	require.Equal(t, response["timestamp"], block["timestamp"])
@@ -477,7 +477,7 @@ func TestGetBlockByTimestampOldestTime(t *testing.T) {
 		}
 	}
 
-	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(oldestBlock.Header().Time), false)
+	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(oldestBlock.Time()), false)
 	require.NoError(t, err)
 
 	require.Equal(t, response["timestamp"], block["timestamp"])
@@ -505,7 +505,7 @@ func TestGetBlockByTimeHigherThanLatestBlock(t *testing.T) {
 		}
 	}
 
-	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(latestBlock.Header().Time+999999999999), false)
+	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(latestBlock.Time()+999999999999), false)
 	require.NoError(t, err)
 
 	require.Equal(t, response["timestamp"], block["timestamp"])
@@ -539,7 +539,7 @@ func TestGetBlockByTimeMiddle(t *testing.T) {
 		}
 	}
 
-	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(middleBlock.Header().Time), false)
+	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(middleBlock.Time()), false)
 	require.NoError(t, err)
 	require.Equal(t, response["timestamp"], block["timestamp"])
 	require.Equal(t, response["hash"], block["hash"])
@@ -567,7 +567,7 @@ func TestGetBlockByTimestamp(t *testing.T) {
 		}
 	}
 
-	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(pickedBlock.Header().Time), false)
+	block, err := api.GetBlockByTimestamp(ctx, rpc.Timestamp(pickedBlock.Time()), false)
 	require.NoError(t, err)
 
 	require.Equal(t, response["timestamp"], block["timestamp"])

--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -166,7 +166,7 @@ func (api *OverlayAPIImpl) CallConstructor(ctx context.Context, address common.A
 
 	statedb := state.New(stateReader)
 
-	header := block.Header()
+	header := block.HeaderNoCopy()
 
 	if header == nil {
 		return nil, fmt.Errorf("block %d(%x) not found", blockNum, block.Hash())
@@ -448,7 +448,7 @@ func (api *OverlayAPIImpl) replayBlock(ctx context.Context, blockNum uint64, sta
 	replayTransactions = block.Transactions()
 	log.Debug("[replayBlock] replayTx", "length", len(replayTransactions))
 
-	header := block.Header()
+	header := block.HeaderNoCopy()
 
 	if header == nil {
 		return nil, fmt.Errorf("block %d(%x) not found", blockNum, hash)

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -632,7 +632,7 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 	// Hence, we need commitment history to correctly compute the `root` field for pre-Byzantium receipts
 	if dbg.AssertEnabled && (opts.CommitmentHistoryEnabled || cfg.IsByzantium(blockNum)) {
 		computedReceiptsRoot := types.DeriveSha(receipts)
-		blockReceiptsRoot := block.Header().ReceiptHash
+		blockReceiptsRoot := block.ReceiptHash()
 		if computedReceiptsRoot != blockReceiptsRoot {
 			panic(fmt.Sprintf("assert: computedReceiptsRoot=%s, blockReceiptsRoot=%s", computedReceiptsRoot.Hex(), blockReceiptsRoot.Hex()))
 		}

--- a/rpc/jsonrpc/tracing.go
+++ b/rpc/jsonrpc/tracing.go
@@ -204,7 +204,7 @@ func (api *DebugAPIImpl) traceBlock(ctx context.Context, blockNrOrHash rpc.Block
 				}
 
 				var _gasUsed uint64
-				_gasUsed, err = transactions.TraceTx(ctx, engine, txn, msg, blockCtx, txCtx, &block.Header().Number, block.Hash(), txnIndex, ibs, config, chainConfig, inner, api.evmCallTimeout, precompiles)
+				_gasUsed, err = transactions.TraceTx(ctx, engine, txn, msg, blockCtx, txCtx, &block.HeaderNoCopy().Number, block.Hash(), txnIndex, ibs, config, chainConfig, inner, api.evmCallTimeout, precompiles)
 				gasUsed += _gasUsed
 			}
 		}
@@ -352,7 +352,7 @@ func (api *DebugAPIImpl) TraceTransaction(ctx context.Context, hash common.Hash,
 	txCtx.TxHash = hash
 
 	// Trace the transaction and return
-	_, err = transactions.TraceTx(ctx, engine, block.Transactions()[txnIndex], msg, blockCtx, txCtx, &block.Header().Number, block.Hash(), txnIndex, ibs, config, chainConfig, stream, api.evmCallTimeout, precompiles)
+	_, err = transactions.TraceTx(ctx, engine, block.Transactions()[txnIndex], msg, blockCtx, txCtx, &block.HeaderNoCopy().Number, block.Hash(), txnIndex, ibs, config, chainConfig, stream, api.evmCallTimeout, precompiles)
 	return err
 }
 


### PR DESCRIPTION
`Header` is thread-safe and immutable (except block-building case) - it's oke to return pointer to them (even if block is in cache) instead of Copy
