### PR TITLE
rlp: to not allocate closure on every steam get from pool

### DIFF
--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -685,6 +685,7 @@ func NewBytesStream(b []byte) *Stream {
 // PutStream returns a Stream to the pool.
 func PutStream(stream *Stream) {
 	stream.sliceRdr = nil // release caller's backing array
+	stream.r = nil        // release caller's reader (may hold a large backing slice)
 	streamPool.Put(stream)
 }
 

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -30,8 +30,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/erigontech/erigon/execution/rlp/internal/rlpstruct"
 	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/execution/rlp/internal/rlpstruct"
 )
 
 //lint:ignore ST1012 EOL is not an error.
@@ -659,8 +660,7 @@ func NewStream(r io.Reader, inputLimit uint64) *Stream {
 	return s
 }
 
-// NewStreamFromPool returns a pooled Stream reading from r. The caller MUST
-// return it via PutStream once done. Pair as:
+// NewStreamFromPool returns a pooled Stream:
 //
 //	s := rlp.NewStreamFromPool(r, limit)
 //	defer rlp.PutStream(s)

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -111,15 +111,13 @@ func Decode(r io.Reader, val interface{}) error {
 // DecodeBytes parses RLP data from b into val. Please see package-level documentation for
 // the decoding rules. The input must contain exactly one value and no trailing data.
 func DecodeBytes(b []byte, val interface{}) error {
-	r := (*sliceReader)(&b)
-
-	stream := NewStreamFromPool(r, uint64(len(b)))
+	stream := NewBytesStream(b)
 	defer PutStream(stream)
 
 	if err := stream.Decode(val); err != nil {
 		return err
 	}
-	if len(b) > 0 {
+	if stream.Remaining() > 0 {
 		return ErrMoreThanOneValue
 	}
 	return nil
@@ -183,9 +181,7 @@ func addErrorContext(err error, ctx string) error {
 // DecodeBytesPartial parses RLP data from b into val.
 // Unlike DecodeBytes, it does not require that all bytes are consumed.
 func DecodeBytesPartial(b []byte, val any) error {
-	r := (*sliceReader)(&b)
-
-	stream := NewStreamFromPool(r, uint64(len(b)))
+	stream := NewBytesStream(b)
 	defer PutStream(stream)
 
 	return stream.Decode(val)

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -103,7 +103,7 @@ type Decoder interface {
 //	NewStream(r, limit).Decode(val)
 func Decode(r io.Reader, val interface{}) error {
 	stream := streamPool.Get().(*Stream)
-	defer streamPool.Put(stream)
+	defer PutStream(stream)
 
 	stream.Reset(r, 0)
 	return stream.Decode(val)
@@ -115,7 +115,7 @@ func DecodeBytes(b []byte, val interface{}) error {
 	r := (*sliceReader)(&b)
 
 	stream := streamPool.Get().(*Stream)
-	defer streamPool.Put(stream)
+	defer PutStream(stream)
 
 	stream.Reset(r, uint64(len(b)))
 	if err := stream.Decode(val); err != nil {
@@ -188,7 +188,7 @@ func DecodeBytesPartial(b []byte, val any) error {
 	r := (*sliceReader)(&b)
 
 	stream := streamPool.Get().(*Stream)
-	defer streamPool.Put(stream)
+	defer PutStream(stream)
 
 	stream.Reset(r, uint64(len(b)))
 	return stream.Decode(val)

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -102,10 +102,9 @@ type Decoder interface {
 //
 //	NewStream(r, limit).Decode(val)
 func Decode(r io.Reader, val interface{}) error {
-	stream := streamPool.Get().(*Stream)
+	stream := NewStreamFromPool(r, 0)
 	defer PutStream(stream)
 
-	stream.Reset(r, 0)
 	return stream.Decode(val)
 }
 
@@ -114,10 +113,9 @@ func Decode(r io.Reader, val interface{}) error {
 func DecodeBytes(b []byte, val interface{}) error {
 	r := (*sliceReader)(&b)
 
-	stream := streamPool.Get().(*Stream)
+	stream := NewStreamFromPool(r, uint64(len(b)))
 	defer PutStream(stream)
 
-	stream.Reset(r, uint64(len(b)))
 	if err := stream.Decode(val); err != nil {
 		return err
 	}
@@ -187,10 +185,9 @@ func addErrorContext(err error, ctx string) error {
 func DecodeBytesPartial(b []byte, val any) error {
 	r := (*sliceReader)(&b)
 
-	stream := streamPool.Get().(*Stream)
+	stream := NewStreamFromPool(r, uint64(len(b)))
 	defer PutStream(stream)
 
-	stream.Reset(r, uint64(len(b)))
 	return stream.Decode(val)
 }
 

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -659,13 +659,15 @@ func NewStream(r io.Reader, inputLimit uint64) *Stream {
 	return s
 }
 
-// NewStreamFromPool returns a Stream from the pool.
-func NewStreamFromPool(r io.Reader, inputLimit uint64) (stream *Stream, done func()) {
-	stream = streamPool.Get().(*Stream)
+// NewStreamFromPool returns a pooled Stream reading from r. The caller MUST
+// return it via PutStream once done. Pair as:
+//
+//	s := rlp.NewStreamFromPool(r, limit)
+//	defer rlp.PutStream(s)
+func NewStreamFromPool(r io.Reader, inputLimit uint64) *Stream {
+	stream := streamPool.Get().(*Stream)
 	stream.Reset(r, inputLimit)
-	return stream, func() {
-		streamPool.Put(stream)
-	}
+	return stream
 }
 
 // NewBytesStream returns a pooled Stream reading from b. The caller MUST

--- a/execution/rlp/decode_alloc_test.go
+++ b/execution/rlp/decode_alloc_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package rlp
+
+import "testing"
+
+type decodeAllocProbe struct {
+	A uint64
+	B uint64
+	C uint64
+}
+
+// TestDecodeBytesAllocs guards the allocation cost of the pooled-Stream decode
+// path. NewBytesStream keeps the input slice in the Stream's inline sliceRdr,
+// so the borrow/return cycle must not allocate and the input must not escape.
+// DecodeBytes then adds only the single allocation inherent to reflect-based
+// decoding; a regression here (e.g. reintroducing an escaping reader) would
+// push the counts above the asserted bounds.
+func TestDecodeBytesAllocs(t *testing.T) {
+	enc, err := EncodeToBytes(&decodeAllocProbe{A: 1, B: 2, C: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out decodeAllocProbe
+	if err := DecodeBytes(enc, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out != (decodeAllocProbe{A: 1, B: 2, C: 3}) {
+		t.Fatalf("unexpected decode result: %+v", out)
+	}
+
+	if got := testing.AllocsPerRun(1000, func() {
+		PutStream(NewBytesStream(enc))
+	}); got != 0 {
+		t.Fatalf("NewBytesStream/PutStream allocated %v times/op, want 0 (input must not escape)", got)
+	}
+
+	if got := testing.AllocsPerRun(1000, func() {
+		out = decodeAllocProbe{}
+		_ = DecodeBytes(enc, &out)
+	}); got > 1 {
+		t.Fatalf("DecodeBytes allocated %v times/op, want <= 1", got)
+	}
+}

--- a/execution/rlp/streambench_test.go
+++ b/execution/rlp/streambench_test.go
@@ -41,8 +41,8 @@ func encodeStringRLP(payload []byte) []byte {
 func BenchmarkStreamBytes_64B(b *testing.B) {
 	payload := bytes.Repeat([]byte{0xab}, 64)
 	encoded := encodeStringRLP(payload)
-	stream, done := NewStreamFromPool(bytes.NewReader(encoded), uint64(len(encoded)))
-	defer done()
+	stream := NewStreamFromPool(bytes.NewReader(encoded), uint64(len(encoded)))
+	defer PutStream(stream)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -58,8 +58,8 @@ func BenchmarkStreamBytes_64B(b *testing.B) {
 func BenchmarkStreamBytes_4KB(b *testing.B) {
 	payload := bytes.Repeat([]byte{0xab}, 4096)
 	encoded := encodeStringRLP(payload)
-	stream, done := NewStreamFromPool(bytes.NewReader(encoded), uint64(len(encoded)))
-	defer done()
+	stream := NewStreamFromPool(bytes.NewReader(encoded), uint64(len(encoded)))
+	defer PutStream(stream)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -75,8 +75,8 @@ func BenchmarkStreamBytes_4KB(b *testing.B) {
 func BenchmarkStreamReadBytes_64B(b *testing.B) {
 	payload := bytes.Repeat([]byte{0xab}, 64)
 	encoded := encodeStringRLP(payload)
-	stream, done := NewStreamFromPool(bytes.NewReader(encoded), uint64(len(encoded)))
-	defer done()
+	stream := NewStreamFromPool(bytes.NewReader(encoded), uint64(len(encoded)))
+	defer PutStream(stream)
 	dst := make([]byte, 64)
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -208,8 +208,8 @@ func DecodeWrappedTransaction(data []byte) (Transaction, error) {
 	if data[0] < 0x80 { // the encoding is canonical, not RLP
 		return UnmarshalTransactionFromBinary(data, blobTxnsAreWrappedWithBlobs)
 	}
-	s, done := rlp.NewStreamFromPool(bytes.NewReader(data), uint64(len(data)))
-	defer done()
+	s := rlp.NewStreamFromPool(bytes.NewReader(data), uint64(len(data)))
+	defer rlp.PutStream(s)
 	return DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs)
 }
 
@@ -222,8 +222,8 @@ func DecodeTransaction(data []byte) (Transaction, error) {
 	if data[0] < 0x80 { // the encoding is canonical, not RLP
 		return UnmarshalTransactionFromBinary(data, blobTxnsAreWrappedWithBlobs)
 	}
-	s, done := rlp.NewStreamFromPool(bytes.NewReader(data), uint64(len(data)))
-	defer done()
+	s := rlp.NewStreamFromPool(bytes.NewReader(data), uint64(len(data)))
+	defer rlp.PutStream(s)
 	tx, err := DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs)
 	if err != nil {
 		return nil, err
@@ -236,8 +236,8 @@ func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs boo
 	if len(data) <= 1 {
 		return nil, fmt.Errorf("short input: %v", len(data))
 	}
-	s, done := rlp.NewStreamFromPool(bytes.NewReader(data[1:]), uint64(len(data)-1))
-	defer done()
+	s := rlp.NewStreamFromPool(bytes.NewReader(data[1:]), uint64(len(data)-1))
+	defer rlp.PutStream(s)
 	var t Transaction
 	switch data[0] {
 	case AccessListTxType:

--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -208,7 +208,7 @@ func DecodeWrappedTransaction(data []byte) (Transaction, error) {
 	if data[0] < 0x80 { // the encoding is canonical, not RLP
 		return UnmarshalTransactionFromBinary(data, blobTxnsAreWrappedWithBlobs)
 	}
-	s := rlp.NewStreamFromPool(bytes.NewReader(data), uint64(len(data)))
+	s := rlp.NewBytesStream(data)
 	defer rlp.PutStream(s)
 	return DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs)
 }
@@ -222,7 +222,7 @@ func DecodeTransaction(data []byte) (Transaction, error) {
 	if data[0] < 0x80 { // the encoding is canonical, not RLP
 		return UnmarshalTransactionFromBinary(data, blobTxnsAreWrappedWithBlobs)
 	}
-	s := rlp.NewStreamFromPool(bytes.NewReader(data), uint64(len(data)))
+	s := rlp.NewBytesStream(data)
 	defer rlp.PutStream(s)
 	tx, err := DecodeRLPTransaction(s, blobTxnsAreWrappedWithBlobs)
 	if err != nil {
@@ -236,7 +236,7 @@ func UnmarshalTransactionFromBinary(data []byte, blobTxnsAreWrappedWithBlobs boo
 	if len(data) <= 1 {
 		return nil, fmt.Errorf("short input: %v", len(data))
 	}
-	s := rlp.NewStreamFromPool(bytes.NewReader(data[1:]), uint64(len(data)-1))
+	s := rlp.NewBytesStream(data[1:])
 	defer rlp.PutStream(s)
 	var t Transaction
 	switch data[0] {

--- a/txnprovider/txpool/pool_txn_parser.go
+++ b/txnprovider/txpool/pool_txn_parser.go
@@ -111,8 +111,8 @@ func (ctx *TxnParseContext) decodeTxn(txBytes []byte) (types.Transaction, error)
 	// Legacy transactions: full RLP list starting with 0xc0..0xff
 	if txBytes[0] >= 0xc0 {
 		ctx.bytesReader.Reset(txBytes)
-		s, done := rlp.NewStreamFromPool(&ctx.bytesReader, uint64(len(txBytes)))
-		defer done()
+		s := rlp.NewStreamFromPool(&ctx.bytesReader, uint64(len(txBytes)))
+		defer rlp.PutStream(s)
 		legacy := &types.LegacyTx{}
 		if err := legacy.DecodeRLP(s); err != nil {
 			return nil, err
@@ -137,8 +137,8 @@ func (ctx *TxnParseContext) decodeTxn(txBytes []byte) (types.Transaction, error)
 	}
 
 	ctx.bytesReader.Reset(txBytes[1:]) // skip type byte
-	s, done := rlp.NewStreamFromPool(&ctx.bytesReader, uint64(len(txBytes)-1))
-	defer done()
+	s := rlp.NewStreamFromPool(&ctx.bytesReader, uint64(len(txBytes)-1))
+	defer rlp.PutStream(s)
 	if err := txn.DecodeRLP(s); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<img width="784" height="551" alt="Screenshot 2026-07-11 at 12 47 14" src="https://github.com/user-attachments/assets/e307168e-e46c-4472-af5a-f97812c75dd9" />

reason:  
```
func() {
		streamPool.Put(stream)
	}
```
closure creation (escaped) is an allocation