### PR TITLE
cl: `ComputeShuffledIndicies` to not alloc hash on every call

### DIFF
--- a/cl/phase1/core/state/shuffling/util.go
+++ b/cl/phase1/core/state/shuffling/util.go
@@ -80,8 +80,9 @@ func ComputeShuffledIndicies(beaconConfig *clparams.BeaconChainConfig, mix commo
 	hashFunc := utils.OptimizedSha256NotThreadSafe()
 	epoch := slot / beaconConfig.SlotsPerEpoch
 	seed := GetSeed(beaconConfig, mix, epoch, beaconConfig.DomainBeaconAttester)
+	var hashed common.Hash
 	eth2ShuffleHashFunc := func(data []byte) []byte {
-		hashed := hashFunc(data)
+		hashed = hashFunc(data)
 		return hashed[:]
 	}
 	eth2shuffle.UnshuffleList(eth2ShuffleHashFunc, out, uint8(beaconConfig.ShuffleRoundCount), seed)


### PR DESCRIPTION
<img width="755" height="555" alt="Screenshot 2026-07-11 at 12 55 16" src="https://github.com/user-attachments/assets/668a0e13-dcb7-425e-81db-44296a137455" />

## What

`ComputeShuffledIndicies` passes a closure to `eth2shuffle.UnshuffleList` as the hash function. The closure declared `hashed` **inside its body** and returned `hashed[:]`:

```go
eth2ShuffleHashFunc := func(data []byte) []byte {
    hashed := hashFunc(data)   // fresh local, escapes → heap alloc every call
    return hashed[:]
}
```

The fix hoists `hashed` into the enclosing function's scope so it is allocated once and reused:

```go
var hashed common.Hash
eth2ShuffleHashFunc := func(data []byte) []byte {
    hashed = hashFunc(data)    // copy 32 bytes into the captured buffer, no alloc
    return hashed[:]
}
```

## Why it helps

Both versions heap-allocate `hashed` — `return hashed[:]` hands a slice pointing into `hashed` back to `UnshuffleList`, which reads it after the closure returns, so the array must outlive the call and escape analysis moves it to the heap. The difference is **frequency**:

- **Before** — `hashed` is declared inside the closure body, so a fresh one is created and escapes on **every invocation**. `UnshuffleList` calls the closure `ShuffleRoundCount` (90) × pivots times per `ComputeShuffledIndicies`, i.e. thousands of allocations per call.
- **After** — `hashed` is captured from the outer scope, so it is heap-allocated **once** when the closure is created. Every invocation then just copies 32 bytes into that one buffer.

Rule of thumb: an escaping variable is allocated every time the scope it's *declared* in runs. Moving the declaration up one scope turned thousands of allocations into one.

## Why reuse is safe

`innerShuffleList` reads each hash result immediately and overwrites it on the next call — it never retains a previous result. Reusing a single backing array across calls is therefore correct, and the hash output bytes are byte-for-byte identical. No consensus semantics change.

## Impact

In a CPU/heap profile of Caplin historical-state reconstruction, this closure (`ComputeShuffledIndicies.func1`) was the single largest allocator in the whole process — **~1.17B objects, ~24.5% of all heap allocations** — and fed GC pressure back into the shuffle CPU cost. Committee shuffling also runs constantly during live attestation validation, so this helps the live node, not just archive reconstruction.

Micro-benchmark of one `ComputeShuffledIndicies` call over 300k validators:

| | allocs/op | B/op | ns/op |
|---|---|---|---|
| before | 52,974 | 1,696,403 | 48.4M |
| after  | 9      | 494       | 43.4M |

`moved to heap: hashed` now points at the outer `var` (allocated once), and `func literal does not escape`.
