### PR TITLE
cl/antiquary: prune caplin state indexing DB after freezing to snapshots

### DIFF
--- a/cl/agents.md
+++ b/cl/agents.md
@@ -15,6 +15,7 @@ Caplin is Erigon's embedded Beacon Chain client implementing Ethereum's proof-of
 | `sentinel/` | libp2p P2P networking |
 | `pool/` | Operations pools (attestations, slashings) |
 | `validator/` | Attestation producer |
+| `antiquary/` | Freezes history to snapshots; prunes frozen state rows from the indexing DB |
 
 ## Key Components
 
@@ -39,6 +40,11 @@ Bridge to execution layer:
 - libp2p-based P2P networking
 - GossipSub for block/attestation propagation
 - Peer scoring and discovery
+
+### Antiquary (`antiquary/`)
+- Freezes historical blocks/states into `.seg` snapshots and prunes the frozen rows from the indexing DB
+- State-prune invariant: a state table's rows may be deleted only below that table's contiguous-from-genesis snapshot coverage (`CaplinStateSnapshots.ContiguousCoverageEnd`); the state reader resolves per-table, segment-first, so covered DB rows are unreachable
+- Progress markers in `kv.StatesPruneProgress`; kill-switch `CAPLIN_STATE_PRUNE_DISABLE`
 
 ## Beacon API (`beacon/handler/`)
 

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -87,7 +87,7 @@ type Antiquary struct {
 
 	statePruneStartIdx   int
 	statePruneDisabled   bool
-	statePruneTables     []string
+	statePruneTimeout    time.Duration
 	statePruneBoundaryFn func(table string) uint64
 }
 
@@ -120,6 +120,7 @@ func NewAntiquary(ctx context.Context, blobStorage blob_storage.BlobStorage, gen
 
 		maxSlotsPerCommit:  stateAntiquaryMaxSlotsPerCommit,
 		statePruneDisabled: dbg.EnvBool("CAPLIN_STATE_PRUNE_DISABLE", false),
+		statePruneTimeout:  dbg.EnvDuration("CAPLIN_STATE_PRUNE_TIMEOUT", 0),
 	}
 }
 

--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -33,6 +33,7 @@ import (
 	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/downloader"
@@ -83,6 +84,11 @@ type Antiquary struct {
 	// mdbx transaction. A very large commit overflows libmdbx's gc_fill_returned
 	// while serializing the transaction's retired-page list; bounding it avoids that.
 	maxSlotsPerCommit uint64
+
+	statePruneStartIdx   int
+	statePruneDisabled   bool
+	statePruneTables     []string
+	statePruneBoundaryFn func(table string) uint64
 }
 
 func NewAntiquary(ctx context.Context, blobStorage blob_storage.BlobStorage, genesisState *state.CachingBeaconState, validatorsTable *state_accessors.StaticValidatorTable, cfg *clparams.BeaconChainConfig, dirs datadir.Dirs, downloaderClient downloader.Client, mainDB kv.RwDB, stateSn *snapshotsync.CaplinStateSnapshots, sn *freezeblocks.CaplinSnapshots, reader freezeblocks.BeaconSnapshotReader, syncedData synced_data.SyncedData, logger log.Logger, states, blocks, blobs, snapgen bool, snBuildSema *semaphore.Weighted) *Antiquary {
@@ -112,7 +118,8 @@ func NewAntiquary(ctx context.Context, blobStorage blob_storage.BlobStorage, gen
 		stateSn:         stateSn,
 		syncedData:      syncedData,
 
-		maxSlotsPerCommit: stateAntiquaryMaxSlotsPerCommit,
+		maxSlotsPerCommit:  stateAntiquaryMaxSlotsPerCommit,
+		statePruneDisabled: dbg.EnvBool("CAPLIN_STATE_PRUNE_DISABLE", false),
 	}
 }
 

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -215,8 +215,16 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 	stateAntiquaryCollector := newBeaconStatesCollector(s.cfg, s.dirs.Tmp, s.logger)
 	defer stateAntiquaryCollector.close()
 
+	freshState := s.currentState == nil
 	if err := s.initializeStateAntiquaryIfNeeded(ctx, tx); err != nil {
 		return err
+	}
+	if freshState {
+		// A reconstruction resumed with backoff can re-flush rows the prune
+		// marker already passed; floor the markers so those rows stay prunable.
+		if err := s.floorStatePruneMarkers(ctx, s.currentState.Slot()); err != nil {
+			return err
+		}
 	}
 	if s.currentState.Slot() == s.genesisState.Slot() {
 		// Collect genesis state if we are at genesis
@@ -587,6 +595,9 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 			return err
 		}
 	}
+	// At tip this is the only prune site that runs on every call: the in-loop
+	// site needs a maxSlotsPerCommit batch and the snapgen site a fresh dump.
+	s.pruneFrozenStateTables(ctx)
 
 	if s.snapgen {
 		blocksPerStatefulFile := uint64(snaptype.CaplinMergeLimit * 5)

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -399,7 +399,7 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 			stateAntiquaryCollector = newBeaconStatesCollector(s.cfg, s.dirs.Tmp, s.logger)
 			changedValidators = &sync.Map{}
 			lastCommitSlot = slot
-			s.pruneFrozenStateTables(ctx)
+			s.pruneFrozenStateTables(ctx, s.currentState.Slot())
 		}
 		slashingOccurred = false // Set this to false at the beginning of each slot.
 
@@ -597,7 +597,7 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 	}
 	// At tip this is the only prune site that runs on every call: the in-loop
 	// site needs a maxSlotsPerCommit batch and the snapgen site a fresh dump.
-	s.pruneFrozenStateTables(ctx)
+	s.pruneFrozenStateTables(ctx, s.currentState.Slot())
 
 	if s.snapgen {
 		blocksPerStatefulFile := uint64(snaptype.CaplinMergeLimit * 5)
@@ -631,7 +631,7 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 			return err
 		}
 		// Prune only after OpenFolder: coverage must include the just-frozen range.
-		s.pruneFrozenStateTables(ctx)
+		s.pruneFrozenStateTables(ctx, s.currentState.Slot())
 		if s.downloader != nil {
 			paths := s.stateSn.SegFileNames(0, to)
 			// Notify bittorent to seed the new snapshots

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -391,6 +391,7 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 			stateAntiquaryCollector = newBeaconStatesCollector(s.cfg, s.dirs.Tmp, s.logger)
 			changedValidators = &sync.Map{}
 			lastCommitSlot = slot
+			s.pruneFrozenStateTables(ctx)
 		}
 		slashingOccurred = false // Set this to false at the beginning of each slot.
 
@@ -618,6 +619,8 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 		if err := s.stateSn.OpenFolder(); err != nil {
 			return err
 		}
+		// Prune only after OpenFolder: coverage must include the just-frozen range.
+		s.pruneFrozenStateTables(ctx)
 		if s.downloader != nil {
 			paths := s.stateSn.SegFileNames(0, to)
 			// Notify bittorent to seed the new snapshots

--- a/cl/antiquary/state_prune.go
+++ b/cl/antiquary/state_prune.go
@@ -89,6 +89,7 @@ func (s *Antiquary) statePruneBacklog(ctx context.Context, tables []string, boun
 		}
 		return nil
 	}); err != nil {
+		s.logger.Warn("[Antiquary] Failed to compute state prune backlog", "err", err)
 		return 0
 	}
 	return backlog

--- a/cl/antiquary/state_prune.go
+++ b/cl/antiquary/state_prune.go
@@ -23,7 +23,6 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/persistence/base_encoding"
 	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
-	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/diagnostics/metrics"
@@ -39,24 +38,25 @@ const statePruneBatchLimit = 1000
 func statePruneBudget(cfg *clparams.BeaconChainConfig, backlogSlots uint64) time.Duration {
 	base := time.Duration(cfg.SecondsPerSlot*1000/3) * time.Millisecond
 	maxBudget := time.Duration(cfg.SecondsPerSlot*2000/3) * time.Millisecond
-	budget := min(base+time.Duration(backlogSlots/100)*200*time.Millisecond, maxBudget)
-	return dbg.EnvDuration("CAPLIN_STATE_PRUNE_TIMEOUT", budget)
+	return min(base+time.Duration(backlogSlots/100)*200*time.Millisecond, maxBudget)
 }
 
 func (s *Antiquary) pruneFrozenStateTables(ctx context.Context) {
 	if s.statePruneDisabled || s.stateSn == nil {
 		return
 	}
-	if s.statePruneTables == nil {
-		s.statePruneTables = s.stateSn.TypeNames()
-	}
+	tables := s.stateSn.TypeNames()
 	boundaryFn := s.statePruneBoundaryFn
 	if boundaryFn == nil {
 		boundaryFn = s.stateSn.ContiguousCoverageEnd
 	}
-	ctx, cancel := context.WithTimeout(ctx, statePruneBudget(s.cfg, s.statePruneBacklog(ctx)))
+	budget := statePruneBudget(s.cfg, s.statePruneBacklog(ctx, tables, boundaryFn))
+	if s.statePruneTimeout > 0 {
+		budget = s.statePruneTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, budget)
 	defer cancel()
-	next, err := pruneStateTables(ctx, s.mainDB, s.statePruneTables, boundaryFn, s.statePruneStartIdx, statePruneBatchLimit, s.logger)
+	next, err := pruneStateTables(ctx, s.mainDB, tables, boundaryFn, s.statePruneStartIdx, statePruneBatchLimit, s.logger)
 	if err != nil {
 		s.logger.Warn("[Antiquary] Failed to prune state tables", "err", err)
 		return
@@ -64,25 +64,50 @@ func (s *Antiquary) pruneFrozenStateTables(ctx context.Context) {
 	s.statePruneStartIdx = next
 }
 
-func (s *Antiquary) statePruneBacklog(ctx context.Context) uint64 {
-	if s.currentState == nil {
-		return 0
-	}
-	head := s.currentState.Slot()
-	minMarker := head
+func (s *Antiquary) statePruneBacklog(ctx context.Context, tables []string, boundaryFn func(table string) uint64) uint64 {
+	var backlog uint64
 	if err := s.mainDB.View(ctx, func(tx kv.Tx) error {
-		for _, table := range s.statePruneTables {
+		for _, table := range tables {
+			boundary := boundaryFn(table)
+			if boundary == 0 {
+				continue
+			}
 			marker, err := state_accessors.ReadStatePruneProgress(tx, table)
 			if err != nil {
 				return err
 			}
-			minMarker = min(minMarker, marker)
+			if marker < boundary {
+				backlog += boundary - marker
+			}
 		}
 		return nil
 	}); err != nil {
 		return 0
 	}
-	return head - minMarker
+	return backlog
+}
+
+// floorStatePruneMarkers lowers each table's prune marker to replayFrom, so rows
+// re-flushed by a reconstruction that resumed below an already-pruned range are
+// revisited by later prune passes instead of leaking behind the marker.
+func (s *Antiquary) floorStatePruneMarkers(ctx context.Context, replayFrom uint64) error {
+	if s.stateSn == nil {
+		return nil
+	}
+	return s.mainDB.Update(ctx, func(tx kv.RwTx) error {
+		for _, table := range s.stateSn.TypeNames() {
+			marker, err := state_accessors.ReadStatePruneProgress(tx, table)
+			if err != nil {
+				return err
+			}
+			if marker > replayFrom {
+				if err := state_accessors.SetStatePruneProgress(tx, table, replayFrom); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
 }
 
 // pruneStateTables deletes state rows below each table's boundary, visiting

--- a/cl/antiquary/state_prune.go
+++ b/cl/antiquary/state_prune.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package antiquary
+
+import (
+	"context"
+	"time"
+
+	"github.com/erigontech/erigon/cl/persistence/base_encoding"
+	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/diagnostics/metrics"
+)
+
+var (
+	mxAntiquaryStatePruneBatchSeconds = metrics.GetOrCreateSummary(`caplin_antiquary_batch_seconds{phase="state_prune"}`)
+	mxAntiquaryPrunedStateRows        = metrics.GetOrCreateCounter("caplin_antiquary_pruned_state_rows_total")
+)
+
+// pruneStateTables deletes state rows below each table's boundary, visiting
+// tables once starting at startIdx and wrapping. Deletes are committed in
+// batchLimit-sized transactions with the per-table marker persisted in the same
+// transaction. ctx is checked only between transactions; on expiry the current
+// table index is returned as nextStartIdx so the next call resumes there.
+func pruneStateTables(ctx context.Context, db kv.RwDB, tables []string, boundaryFn func(table string) uint64, startIdx, batchLimit int, logger log.Logger) (nextStartIdx int, err error) {
+	if len(tables) == 0 {
+		return 0, nil
+	}
+	if startIdx < 0 || startIdx >= len(tables) {
+		startIdx = 0
+	}
+	for i := range tables {
+		idx := (startIdx + i) % len(tables)
+		table := tables[idx]
+		if ctx.Err() != nil {
+			return idx, nil
+		}
+		boundary := boundaryFn(table)
+		if boundary == 0 {
+			continue
+		}
+		var marker uint64
+		if err := db.View(ctx, func(tx kv.Tx) error {
+			var err error
+			marker, err = state_accessors.ReadStatePruneProgress(tx, table)
+			return err
+		}); err != nil {
+			if ctx.Err() != nil {
+				return idx, nil
+			}
+			return idx, err
+		}
+		if marker >= boundary {
+			continue
+		}
+		pruneFrom := marker
+		totalDeleted := 0
+		for marker < boundary {
+			deleted, newMarker, err := pruneStateBatch(ctx, db, table, marker, boundary, batchLimit, logger)
+			if err != nil {
+				if ctx.Err() != nil {
+					return idx, nil
+				}
+				return idx, err
+			}
+			totalDeleted += deleted
+			marker = newMarker
+			if marker < boundary && ctx.Err() != nil {
+				return idx, nil
+			}
+		}
+		logger.Info("[Antiquary] Pruned state table to boundary", "table", table, "from", pruneFrom, "boundary", boundary, "deleted", totalDeleted)
+	}
+	return startIdx, nil
+}
+
+func pruneStateBatch(ctx context.Context, db kv.RwDB, table string, marker, boundary uint64, batchLimit int, logger log.Logger) (deleted int, newMarker uint64, err error) {
+	start := time.Now()
+	tx, err := db.BeginRw(ctx)
+	if err != nil {
+		return 0, marker, err
+	}
+	defer tx.Rollback()
+
+	c, err := tx.RwCursor(table)
+	if err != nil {
+		return 0, marker, err
+	}
+	defer c.Close()
+
+	newMarker = marker
+	k, _, err := c.Seek(base_encoding.Encode64ToBytes4(marker))
+	for {
+		if err != nil {
+			return deleted, marker, err
+		}
+		if k == nil || base_encoding.Decode64FromBytes4(k) >= boundary {
+			// no keys left below boundary: jump the marker to it, or tables
+			// with sparse/rounded keys would be rescanned as backlog forever
+			newMarker = boundary
+			break
+		}
+		slot := base_encoding.Decode64FromBytes4(k)
+		if err = c.DeleteCurrent(); err != nil {
+			return deleted, marker, err
+		}
+		deleted++
+		newMarker = slot + 1
+		if deleted >= batchLimit {
+			break
+		}
+		k, _, err = c.Next()
+	}
+	c.Close()
+	if err = state_accessors.SetStatePruneProgress(tx, table, newMarker); err != nil {
+		return deleted, marker, err
+	}
+	if err = tx.Commit(); err != nil {
+		return deleted, marker, err
+	}
+	mxAntiquaryStatePruneBatchSeconds.ObserveDuration(start)
+	if deleted > 0 {
+		mxAntiquaryPrunedStateRows.AddInt(deleted)
+	}
+	logger.Debug("[Antiquary] Pruned state batch", "table", table, "from", marker, "to", newMarker, "deleted", deleted, "elapsed", time.Since(start))
+	return deleted, newMarker, nil
+}

--- a/cl/antiquary/state_prune.go
+++ b/cl/antiquary/state_prune.go
@@ -41,14 +41,21 @@ func statePruneBudget(cfg *clparams.BeaconChainConfig, backlogSlots uint64) time
 	return min(base+time.Duration(backlogSlots/100)*200*time.Millisecond, maxBudget)
 }
 
-func (s *Antiquary) pruneFrozenStateTables(ctx context.Context) {
+// flushedThrough caps the prune boundary to the highest slot already re-written
+// to the DB. A resumed reconstruction re-flushes the below-coverage window in
+// batches; without the cap an early pass would jump the marker to full coverage
+// and strand the rows later batches still write below it.
+func (s *Antiquary) pruneFrozenStateTables(ctx context.Context, flushedThrough uint64) {
 	if s.statePruneDisabled || s.stateSn == nil {
 		return
 	}
 	tables := s.stateSn.TypeNames()
-	boundaryFn := s.statePruneBoundaryFn
-	if boundaryFn == nil {
-		boundaryFn = s.stateSn.ContiguousCoverageEnd
+	coverageFn := s.statePruneBoundaryFn
+	if coverageFn == nil {
+		coverageFn = s.stateSn.ContiguousCoverageEnd
+	}
+	boundaryFn := func(table string) uint64 {
+		return min(coverageFn(table), flushedThrough)
 	}
 	budget := statePruneBudget(s.cfg, s.statePruneBacklog(ctx, tables, boundaryFn))
 	if s.statePruneTimeout > 0 {

--- a/cl/antiquary/state_prune.go
+++ b/cl/antiquary/state_prune.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/persistence/base_encoding"
 	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/diagnostics/metrics"
@@ -31,6 +33,57 @@ var (
 	mxAntiquaryStatePruneBatchSeconds = metrics.GetOrCreateSummary(`caplin_antiquary_batch_seconds{phase="state_prune"}`)
 	mxAntiquaryPrunedStateRows        = metrics.GetOrCreateCounter("caplin_antiquary_pruned_state_rows_total")
 )
+
+const statePruneBatchLimit = 1000
+
+func statePruneBudget(cfg *clparams.BeaconChainConfig, backlogSlots uint64) time.Duration {
+	base := time.Duration(cfg.SecondsPerSlot*1000/3) * time.Millisecond
+	maxBudget := time.Duration(cfg.SecondsPerSlot*2000/3) * time.Millisecond
+	budget := min(base+time.Duration(backlogSlots/100)*200*time.Millisecond, maxBudget)
+	return dbg.EnvDuration("CAPLIN_STATE_PRUNE_TIMEOUT", budget)
+}
+
+func (s *Antiquary) pruneFrozenStateTables(ctx context.Context) {
+	if s.statePruneDisabled || s.stateSn == nil {
+		return
+	}
+	if s.statePruneTables == nil {
+		s.statePruneTables = s.stateSn.TypeNames()
+	}
+	boundaryFn := s.statePruneBoundaryFn
+	if boundaryFn == nil {
+		boundaryFn = s.stateSn.ContiguousCoverageEnd
+	}
+	ctx, cancel := context.WithTimeout(ctx, statePruneBudget(s.cfg, s.statePruneBacklog(ctx)))
+	defer cancel()
+	next, err := pruneStateTables(ctx, s.mainDB, s.statePruneTables, boundaryFn, s.statePruneStartIdx, statePruneBatchLimit, s.logger)
+	if err != nil {
+		s.logger.Warn("[Antiquary] Failed to prune state tables", "err", err)
+		return
+	}
+	s.statePruneStartIdx = next
+}
+
+func (s *Antiquary) statePruneBacklog(ctx context.Context) uint64 {
+	if s.currentState == nil {
+		return 0
+	}
+	head := s.currentState.Slot()
+	minMarker := head
+	if err := s.mainDB.View(ctx, func(tx kv.Tx) error {
+		for _, table := range s.statePruneTables {
+			marker, err := state_accessors.ReadStatePruneProgress(tx, table)
+			if err != nil {
+				return err
+			}
+			minMarker = min(minMarker, marker)
+		}
+		return nil
+	}); err != nil {
+		return 0
+	}
+	return head - minMarker
+}
 
 // pruneStateTables deletes state rows below each table's boundary, visiting
 // tables once starting at startIdx and wrapping. Deletes are committed in

--- a/cl/antiquary/state_prune.go
+++ b/cl/antiquary/state_prune.go
@@ -57,9 +57,9 @@ func (s *Antiquary) pruneFrozenStateTables(ctx context.Context, flushedThrough u
 	boundaryFn := func(table string) uint64 {
 		return min(coverageFn(table), flushedThrough)
 	}
-	budget := statePruneBudget(s.cfg, s.statePruneBacklog(ctx, tables, boundaryFn))
-	if s.statePruneTimeout > 0 {
-		budget = s.statePruneTimeout
+	budget := s.statePruneTimeout
+	if budget <= 0 {
+		budget = statePruneBudget(s.cfg, s.statePruneBacklog(ctx, tables, boundaryFn))
 	}
 	ctx, cancel := context.WithTimeout(ctx, budget)
 	defer cancel()

--- a/cl/antiquary/state_prune_reader_test.go
+++ b/cl/antiquary/state_prune_reader_test.go
@@ -146,11 +146,21 @@ func TestPruneStateHistoricalReadsServedFromSegments(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, next)
 
-	// the whole chain sits below the boundary: every state table must be empty
-	for _, table := range []string{kv.SlotData, kv.BalancesDump, kv.ValidatorBalance, kv.BlockRoot, kv.EpochData} {
+	// the whole chain sits below the boundary: every covered table must be
+	// empty with its marker at the boundary, and uncovered tables untouched
+	covered := 0
+	for _, table := range stateSn.TypeNames() {
+		end := stateSn.ContiguousCoverageEnd(table)
+		if end == 0 {
+			require.Zero(t, pruneMarker(t, db, table), "table %s", table)
+			continue
+		}
+		covered++
+		require.Equal(t, boundary, end, "table %s", table)
 		require.Empty(t, tableSlots(t, db, table), "table %s", table)
-		require.Equal(t, boundary, pruneMarker(t, db, table))
+		require.Equal(t, boundary, pruneMarker(t, db, table), "table %s", table)
 	}
+	require.GreaterOrEqual(t, covered, 5)
 
 	require.Equal(t, midRootBefore, env.readRoot(t, ctx, midSlot))
 	require.Equal(t, stateRootOf(t, blocks, headSlot), env.readRoot(t, ctx, headSlot))
@@ -226,6 +236,7 @@ func TestPruneStateBalancesForwardAndReverseDumpPaths(t *testing.T) {
 	}
 	compressor, err := zstd.NewWriter(nil)
 	require.NoError(t, err)
+	defer compressor.Close()
 	dump := func(slot uint64) []byte { return compressor.EncodeAll(balancesAt(slot), nil) }
 	slotData := func() []byte {
 		var b bytes.Buffer

--- a/cl/antiquary/state_prune_reader_test.go
+++ b/cl/antiquary/state_prune_reader_test.go
@@ -82,6 +82,7 @@ func runStateAntiquaryWithSnapshots(t *testing.T, ctx context.Context, blocks []
 	vt := state_accessors.NewStaticValidatorTable()
 	dirs := datadir.New(t.TempDir())
 	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, cfg, dirs, snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	t.Cleanup(stateSn.Close)
 	a := NewAntiquary(ctx, nil, preState, vt, cfg, dirs, nil, db, stateSn, nil, reader, sd, log.New(), true, true, true, false, nil)
 	require.NoError(t, a.IncrementBeaconState(ctx, blocks[len(blocks)-1].Block.Slot+33))
 	return &historicalReadEnv{db: db, reader: reader, genesis: preState, stateSn: stateSn, sd: sd}, dirs
@@ -268,6 +269,7 @@ func TestPruneStateBalancesForwardAndReverseDumpPaths(t *testing.T) {
 
 	dirs := datadir.New(t.TempDir())
 	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, cfg, dirs, snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	t.Cleanup(stateSn.Close)
 	require.NoError(t, stateSn.DumpCaplinState(ctx, boundary, statePruneTestFileSlots, 0, dirs, 1, log.LvlDebug, log.New()))
 	require.NoError(t, stateSn.OpenFolder())
 	require.Equal(t, boundary, stateSn.ContiguousCoverageEnd(kv.ValidatorBalance))

--- a/cl/antiquary/state_prune_reader_test.go
+++ b/cl/antiquary/state_prune_reader_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package antiquary
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/antiquary/tests"
+	"github.com/erigontech/erigon/cl/beacon/synced_data"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/persistence/base_encoding"
+	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
+	"github.com/erigontech/erigon/cl/persistence/state/historical_states_reader"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/snapshotsync"
+	"github.com/erigontech/erigon/node/ethconfig"
+)
+
+// Segment file names floor slot ranges to 1000-slot units, so every frozen
+// range in these tests is a multiple of 1000.
+const statePruneTestFileSlots = uint64(1_000)
+
+type historicalReadEnv struct {
+	db      kv.RwDB
+	reader  *tests.MockBlockReader
+	genesis *state.CachingBeaconState
+	stateSn *snapshotsync.CaplinStateSnapshots
+	sd      synced_data.SyncedData
+}
+
+func (e *historicalReadEnv) readRoot(t *testing.T, ctx context.Context, slot uint64) common.Hash {
+	t.Helper()
+	tx, err := e.db.BeginRo(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	vt := state_accessors.NewStaticValidatorTable()
+	require.NoError(t, state_accessors.ReadValidatorsTable(tx, vt))
+	hr := historical_states_reader.NewHistoricalStatesReader(&clparams.MainnetBeaconConfig, e.reader, vt, e.genesis, e.stateSn, e.sd)
+	s, err := hr.ReadHistoricalState(ctx, tx, slot)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	root, err := s.HashSSZ()
+	require.NoError(t, err)
+	return common.Hash(root)
+}
+
+func runStateAntiquaryWithSnapshots(t *testing.T, ctx context.Context, blocks []*cltypes.SignedBeaconBlock, preState, postState *state.CachingBeaconState) (*historicalReadEnv, datadir.Dirs) {
+	t.Helper()
+	cfg := &clparams.MainnetBeaconConfig
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	reader := tests.LoadChain(blocks, postState, db, t)
+	sd := synced_data.NewSyncedDataManager(cfg, true)
+	sd.OnHeadState(postState)
+	vt := state_accessors.NewStaticValidatorTable()
+	dirs := datadir.New(t.TempDir())
+	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, cfg, dirs, snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	a := NewAntiquary(ctx, nil, preState, vt, cfg, dirs, nil, db, stateSn, nil, reader, sd, log.New(), true, true, true, false, nil)
+	require.NoError(t, a.IncrementBeaconState(ctx, blocks[len(blocks)-1].Block.Slot+33))
+	return &historicalReadEnv{db: db, reader: reader, genesis: preState, stateSn: stateSn, sd: sd}, dirs
+}
+
+func stateRootOf(t *testing.T, blocks []*cltypes.SignedBeaconBlock, slot uint64) common.Hash {
+	t.Helper()
+	for _, b := range blocks {
+		if b.Block.Slot == slot {
+			return b.Block.StateRoot
+		}
+	}
+	t.Fatalf("no block at slot %d", slot)
+	return common.Hash{}
+}
+
+// A historical state at a slot below the prune boundary must reconstruct from
+// segments exactly as it did from the DB rows the prune deleted.
+func TestPruneStateHistoricalReadsServedFromSegments(t *testing.T) {
+	blocks, preState, postState := tests.GetBellatrixRandom()
+	ctx := context.Background()
+	env, dirs := runStateAntiquaryWithSnapshots(t, ctx, blocks, preState, postState)
+	db, stateSn := env.db, env.stateSn
+
+	boundary := statePruneTestFileSlots
+	midSlot, headSlot := uint64(100), blocks[len(blocks)-1].Block.Slot
+
+	midRootBefore := env.readRoot(t, ctx, midSlot)
+	require.Equal(t, stateRootOf(t, blocks, headSlot), env.readRoot(t, ctx, headSlot))
+
+	// The fixture chain starts past slot 0, so the dense root tables have no
+	// rows outside the transitioned window and would refuse to freeze. Backfill
+	// synthetic roots (never read back: history reads stay within the window)
+	// to make the whole [0, boundary) range freezable, as it is in production.
+	require.NoError(t, db.Update(ctx, func(tx kv.RwTx) error {
+		for _, table := range []string{kv.BlockRoot, kv.StateRoot} {
+			for slot := uint64(0); slot < boundary; slot++ {
+				key := base_encoding.Encode64ToBytes4(slot)
+				v, err := tx.GetOne(table, key)
+				if err != nil {
+					return err
+				}
+				if len(v) != 0 {
+					continue
+				}
+				pad := common.Hash{0xba, 0xdd, byte(slot), byte(slot >> 8)}
+				if err := tx.Put(table, key, pad[:]); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}))
+
+	require.NoError(t, stateSn.DumpCaplinState(ctx, boundary, statePruneTestFileSlots, 0, dirs, 1, log.LvlDebug, log.New()))
+	require.NoError(t, stateSn.OpenFolder())
+	for _, table := range []string{kv.SlotData, kv.BalancesDump, kv.BlockRoot} {
+		require.Equal(t, boundary, stateSn.ContiguousCoverageEnd(table))
+	}
+
+	next, err := pruneStateTables(ctx, db, stateSn.TypeNames(), stateSn.ContiguousCoverageEnd, 0, 1000, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 0, next)
+
+	// the whole chain sits below the boundary: every state table must be empty
+	for _, table := range []string{kv.SlotData, kv.BalancesDump, kv.ValidatorBalance, kv.BlockRoot, kv.EpochData} {
+		require.Empty(t, tableSlots(t, db, table), "table %s", table)
+		require.Equal(t, boundary, pruneMarker(t, db, table))
+	}
+
+	require.Equal(t, midRootBefore, env.readRoot(t, ctx, midSlot))
+	require.Equal(t, stateRootOf(t, blocks, headSlot), env.readRoot(t, ctx, headSlot))
+}
+
+// A historical state at a tail slot above coverage keeps reading its own rows
+// from the DB while its below-boundary dependencies (the balance dumps rounded
+// down to a pruned slot) are served from segments.
+func TestPruneStateTailReadsAboveCoverage(t *testing.T) {
+	blocks, preState, postState := tests.GetCapellaRandom()
+	ctx := context.Background()
+	env, dirs := runStateAntiquaryWithSnapshots(t, ctx, blocks, preState, postState)
+	db, stateSn := env.db, env.stateSn
+
+	boundary := uint64(8_000)
+	dumpSlot := preState.Slot() - preState.Slot()%clparams.SlotsPerDump
+	require.Less(t, dumpSlot, boundary)
+	firstSlot, headSlot := blocks[0].Block.Slot, blocks[len(blocks)-1].Block.Slot
+
+	firstRootBefore := env.readRoot(t, ctx, firstSlot)
+	require.Equal(t, stateRootOf(t, blocks, headSlot), env.readRoot(t, ctx, headSlot))
+
+	require.NoError(t, stateSn.DumpCaplinState(ctx, boundary, statePruneTestFileSlots, 0, dirs, 1, log.LvlDebug, log.New()))
+	require.NoError(t, stateSn.OpenFolder())
+	require.Equal(t, boundary, stateSn.ContiguousCoverageEnd(kv.BalancesDump))
+	// dense root tables have no rows below the chain start, refuse to freeze,
+	// and must stay unprunable
+	require.Zero(t, stateSn.ContiguousCoverageEnd(kv.BlockRoot))
+
+	next, err := pruneStateTables(ctx, db, stateSn.TypeNames(), stateSn.ContiguousCoverageEnd, 0, 1000, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 0, next)
+
+	// the genesis-rounded dumps were the only rows below the boundary: gone
+	// from the DB, still visible through the segment
+	require.NotContains(t, tableSlots(t, db, kv.BalancesDump), dumpSlot)
+	require.NotContains(t, tableSlots(t, db, kv.EffectiveBalancesDump), dumpSlot)
+	fromSeg, err := stateSn.Get(kv.BalancesDump, dumpSlot)
+	require.NoError(t, err)
+	require.NotEmpty(t, fromSeg)
+	// tail rows above coverage are untouched
+	require.Contains(t, tableSlots(t, db, kv.SlotData), headSlot)
+	require.Contains(t, tableSlots(t, db, kv.BlockRoot), firstSlot)
+
+	require.Equal(t, firstRootBefore, env.readRoot(t, ctx, firstSlot))
+	require.Equal(t, stateRootOf(t, blocks, headSlot), env.readRoot(t, ctx, headSlot))
+}
+
+// Pins both balance-reconstruction paths against a pruned DB: the forward path
+// must fetch its base dump from the segment once the DB row is pruned, and the
+// reverse (next-dump) path must combine the above-boundary dump from the DB
+// with below-boundary diffs from the segment. Each path's epoch-diff chain is
+// seeded only for that path, so taking the wrong branch cannot pass.
+func TestPruneStateBalancesForwardAndReverseDumpPaths(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	ctx := context.Background()
+	const valCount = uint64(4)
+	boundary := statePruneTestFileSlots
+	const forwardSlot, reverseSlot = uint64(500), uint64(900)
+
+	balancesAt := func(slot uint64) []byte {
+		raw := make([]byte, valCount*8)
+		for v := uint64(0); v < valCount; v++ {
+			binary.LittleEndian.PutUint64(raw[v*8:], 32_000_000_000+v*1_000+slot*13)
+		}
+		return raw
+	}
+	epochDiff := func(oldSlot, newSlot uint64) []byte {
+		var b bytes.Buffer
+		require.NoError(t, base_encoding.ComputeCompressedSerializedUint64ListDiff(&b, balancesAt(oldSlot), balancesAt(newSlot)))
+		return common.Copy(b.Bytes())
+	}
+	compressor, err := zstd.NewWriter(nil)
+	require.NoError(t, err)
+	dump := func(slot uint64) []byte { return compressor.EncodeAll(balancesAt(slot), nil) }
+	slotData := func() []byte {
+		var b bytes.Buffer
+		sdata := &state_accessors.SlotData{Version: clparams.BellatrixVersion, ValidatorLength: valCount, Eth1Data: &cltypes.Eth1Data{}, Fork: &cltypes.Fork{}}
+		require.NoError(t, sdata.WriteTo(&b))
+		return common.Copy(b.Bytes())
+	}
+
+	require.NoError(t, db.Update(ctx, func(tx kv.RwTx) error {
+		put := func(table string, slot uint64, v []byte) {
+			require.NoError(t, tx.Put(table, base_encoding.Encode64ToBytes4(slot), v))
+		}
+		put(kv.BalancesDump, 0, dump(0))
+		put(kv.BalancesDump, clparams.SlotsPerDump, dump(clparams.SlotsPerDump))
+		for i := cfg.SlotsPerEpoch; i <= cfg.RoundSlotToEpoch(forwardSlot); i += cfg.SlotsPerEpoch {
+			put(kv.ValidatorBalance, i, epochDiff(i-cfg.SlotsPerEpoch, i))
+		}
+		put(kv.ValidatorBalance, forwardSlot, epochDiff(cfg.RoundSlotToEpoch(forwardSlot), forwardSlot))
+		for i := cfg.RoundSlotToEpoch(reverseSlot) + cfg.SlotsPerEpoch; i <= clparams.SlotsPerDump; i += cfg.SlotsPerEpoch {
+			put(kv.ValidatorBalance, i, epochDiff(i-cfg.SlotsPerEpoch, i))
+		}
+		put(kv.ValidatorBalance, reverseSlot, epochDiff(cfg.RoundSlotToEpoch(reverseSlot), reverseSlot))
+		put(kv.SlotData, forwardSlot, slotData())
+		put(kv.SlotData, reverseSlot, slotData())
+		// progress past the next dump is what selects the reverse path for
+		// slots deep in the dump window
+		return state_accessors.SetStateProcessingProgress(tx, clparams.SlotsPerDump+forwardSlot)
+	}))
+
+	dirs := datadir.New(t.TempDir())
+	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, cfg, dirs, snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	require.NoError(t, stateSn.DumpCaplinState(ctx, boundary, statePruneTestFileSlots, 0, dirs, 1, log.LvlDebug, log.New()))
+	require.NoError(t, stateSn.OpenFolder())
+	require.Equal(t, boundary, stateSn.ContiguousCoverageEnd(kv.ValidatorBalance))
+	require.Equal(t, boundary, stateSn.ContiguousCoverageEnd(kv.BalancesDump))
+
+	next, err := pruneStateTables(ctx, db, stateSn.TypeNames(), stateSn.ContiguousCoverageEnd, 0, 1000, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 0, next)
+
+	require.Equal(t, []uint64{clparams.SlotsPerDump}, tableSlots(t, db, kv.BalancesDump))
+	for _, s := range tableSlots(t, db, kv.ValidatorBalance) {
+		require.GreaterOrEqual(t, s, boundary)
+	}
+
+	checkBalances := func(slot uint64) {
+		tx, err := db.BeginRo(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback()
+		view := stateSn.View()
+		defer view.Close()
+
+		hr := historical_states_reader.NewHistoricalStatesReader(cfg, nil, nil, nil, stateSn, nil)
+		balances, err := hr.ReadValidatorsBalances(tx, state_accessors.GetValFnTxAndSnapshot(tx, view), slot)
+		require.NoError(t, err)
+		require.NotNil(t, balances)
+		expected := balancesAt(slot)
+		require.Equal(t, int(valCount), balances.Length())
+		for v := uint64(0); v < valCount; v++ {
+			require.Equal(t, binary.LittleEndian.Uint64(expected[v*8:]), balances.Get(int(v)))
+		}
+	}
+	checkBalances(forwardSlot)
+	checkBalances(reverseSlot)
+}

--- a/cl/antiquary/state_prune_test.go
+++ b/cl/antiquary/state_prune_test.go
@@ -75,6 +75,9 @@ func pruneMarker(t *testing.T, db kv.RwDB, table string) uint64 {
 }
 
 func slotRange(from, to uint64) []uint64 {
+	if to <= from {
+		return nil
+	}
 	slots := make([]uint64, 0, to-from)
 	for s := from; s < to; s++ {
 		slots = append(slots, s)

--- a/cl/antiquary/state_prune_test.go
+++ b/cl/antiquary/state_prune_test.go
@@ -268,6 +268,7 @@ func TestFloorStatePruneMarkers(t *testing.T) {
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
 	ctx := context.Background()
 	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	t.Cleanup(stateSn.Close)
 	a := NewAntiquary(ctx, nil, nil, nil, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, stateSn, nil, nil, nil, log.New(), true, true, true, false, nil)
 	require.NoError(t, db.Update(ctx, func(tx kv.RwTx) error {
 		if err := state_accessors.SetStatePruneProgress(tx, kv.BlockRoot, 100); err != nil {
@@ -286,6 +287,7 @@ func TestStatePruneKillSwitch(t *testing.T) {
 	seedStateSlots(t, db, kv.BlockRoot, slotRange(0, 100))
 	ctx := context.Background()
 	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	t.Cleanup(stateSn.Close)
 	a := NewAntiquary(ctx, nil, nil, nil, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, stateSn, nil, nil, nil, log.New(), true, true, true, false, nil)
 	a.statePruneBoundaryFn = func(string) uint64 { return 50 }
 
@@ -294,10 +296,14 @@ func TestStatePruneKillSwitch(t *testing.T) {
 	require.Equal(t, slotRange(0, 100), tableSlots(t, db, kv.BlockRoot))
 	require.Zero(t, pruneMarker(t, db, kv.BlockRoot))
 
-	// an already-expired timeout override must stop the pass before any delete
+	// an expired timeout override must stop the pass before any delete; an
+	// already-cancelled parent makes the deadline expire deterministically
+	// instead of racing a nanosecond timer
 	a.statePruneDisabled = false
 	a.statePruneTimeout = time.Nanosecond
-	a.pruneFrozenStateTables(ctx, math.MaxUint64)
+	expiredCtx, cancelExpired := context.WithCancel(ctx)
+	cancelExpired()
+	a.pruneFrozenStateTables(expiredCtx, math.MaxUint64)
 	require.Equal(t, slotRange(0, 100), tableSlots(t, db, kv.BlockRoot))
 	require.Zero(t, pruneMarker(t, db, kv.BlockRoot))
 
@@ -312,6 +318,7 @@ func TestPruneFrozenStateTablesCapsBoundaryToFlushed(t *testing.T) {
 	seedStateSlots(t, db, kv.BlockRoot, slotRange(0, 100))
 	ctx := context.Background()
 	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	t.Cleanup(stateSn.Close)
 	a := NewAntiquary(ctx, nil, nil, nil, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, stateSn, nil, nil, nil, log.New(), true, true, true, false, nil)
 	a.statePruneBoundaryFn = func(string) uint64 { return 80 }
 
@@ -346,6 +353,7 @@ func TestStatePruneWiredIntoAntiquaryCycle(t *testing.T) {
 		ctx := context.Background()
 		vt := state_accessors.NewStaticValidatorTable()
 		stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+		t.Cleanup(stateSn.Close)
 		a := NewAntiquary(ctx, nil, preState, vt, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, stateSn, nil, reader, sn, log.New(), true, true, true, false, nil)
 		a.maxSlotsPerCommit = 8
 		a.statePruneDisabled = disabled

--- a/cl/antiquary/state_prune_test.go
+++ b/cl/antiquary/state_prune_test.go
@@ -18,6 +18,7 @@ package antiquary
 
 import (
 	"context"
+	"math"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -289,21 +290,44 @@ func TestStatePruneKillSwitch(t *testing.T) {
 	a.statePruneBoundaryFn = func(string) uint64 { return 50 }
 
 	a.statePruneDisabled = true
-	a.pruneFrozenStateTables(ctx)
+	a.pruneFrozenStateTables(ctx, math.MaxUint64)
 	require.Equal(t, slotRange(0, 100), tableSlots(t, db, kv.BlockRoot))
 	require.Zero(t, pruneMarker(t, db, kv.BlockRoot))
 
 	// an already-expired timeout override must stop the pass before any delete
 	a.statePruneDisabled = false
 	a.statePruneTimeout = time.Nanosecond
-	a.pruneFrozenStateTables(ctx)
+	a.pruneFrozenStateTables(ctx, math.MaxUint64)
 	require.Equal(t, slotRange(0, 100), tableSlots(t, db, kv.BlockRoot))
 	require.Zero(t, pruneMarker(t, db, kv.BlockRoot))
 
 	a.statePruneTimeout = 0
-	a.pruneFrozenStateTables(ctx)
+	a.pruneFrozenStateTables(ctx, math.MaxUint64)
 	require.Equal(t, slotRange(50, 100), tableSlots(t, db, kv.BlockRoot))
 	require.Equal(t, uint64(50), pruneMarker(t, db, kv.BlockRoot))
+}
+
+func TestPruneFrozenStateTablesCapsBoundaryToFlushed(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedStateSlots(t, db, kv.BlockRoot, slotRange(0, 100))
+	ctx := context.Background()
+	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	a := NewAntiquary(ctx, nil, nil, nil, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, stateSn, nil, nil, nil, log.New(), true, true, true, false, nil)
+	a.statePruneBoundaryFn = func(string) uint64 { return 80 }
+
+	// Coverage says 80, but a resumed reconstruction has only re-flushed rows
+	// below 30 so far. The pass must stop at 30 and leave [30,80) for later
+	// passes rather than jump the marker to 80 and strand the rows the
+	// reconstruction still writes below coverage.
+	a.pruneFrozenStateTables(ctx, 30)
+	require.Equal(t, slotRange(30, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(30), pruneMarker(t, db, kv.BlockRoot))
+
+	// Once the rest of the below-coverage window is flushed, the next pass
+	// resumes from 30 and drains up to coverage.
+	a.pruneFrozenStateTables(ctx, 80)
+	require.Equal(t, slotRange(80, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(80), pruneMarker(t, db, kv.BlockRoot))
 }
 
 func TestStatePruneWiredIntoAntiquaryCycle(t *testing.T) {

--- a/cl/antiquary/state_prune_test.go
+++ b/cl/antiquary/state_prune_test.go
@@ -20,15 +20,22 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/cl/antiquary/tests"
+	"github.com/erigontech/erigon/cl/beacon/synced_data"
+	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/persistence/base_encoding"
 	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/snapshotsync"
+	"github.com/erigontech/erigon/node/ethconfig"
 )
 
 func seedStateSlots(t *testing.T, db kv.RwDB, table string, slots []uint64) {
@@ -165,6 +172,61 @@ func TestPruneStateTablesBatchCommits(t *testing.T) {
 	require.Empty(t, tableSlots(t, db, kv.BlockRoot))
 	require.Equal(t, uint64(100), pruneMarker(t, db, kv.BlockRoot))
 	require.GreaterOrEqual(t, commits.Load(), int64(10))
+}
+
+func TestStatePruneBudget(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig // 12s slots: base 4s, cap 8s
+
+	require.Equal(t, 4*time.Second, statePruneBudget(cfg, 0))
+	require.Equal(t, 6*time.Second, statePruneBudget(cfg, 1000))
+	require.Equal(t, 8*time.Second, statePruneBudget(cfg, 1_000_000))
+
+	t.Setenv("CAPLIN_STATE_PRUNE_TIMEOUT", "150ms")
+	require.Equal(t, 150*time.Millisecond, statePruneBudget(cfg, 1000))
+}
+
+func TestStatePruneKillSwitch(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedStateSlots(t, db, kv.BlockRoot, slotRange(0, 100))
+	ctx := context.Background()
+	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	a := NewAntiquary(ctx, nil, nil, nil, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, stateSn, nil, nil, nil, log.New(), true, true, true, false, nil)
+	a.statePruneBoundaryFn = func(string) uint64 { return 50 }
+
+	a.statePruneDisabled = true
+	a.pruneFrozenStateTables(ctx)
+	require.Equal(t, slotRange(0, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Zero(t, pruneMarker(t, db, kv.BlockRoot))
+
+	a.statePruneDisabled = false
+	a.pruneFrozenStateTables(ctx)
+	require.Equal(t, slotRange(50, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(50), pruneMarker(t, db, kv.BlockRoot))
+}
+
+func TestStatePruneWiredIntoAntiquaryCycle(t *testing.T) {
+	blocks, preState, postState := tests.GetCapellaRandom()
+	to := blocks[len(blocks)-1].Block.Slot + 33
+
+	run := func(disabled bool) int64 {
+		db := memdb.NewTestDB(t, dbcfg.ChainDB)
+		reader := tests.LoadChain(blocks, postState, db, t)
+		sn := synced_data.NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+		sn.OnHeadState(postState)
+		ctx := context.Background()
+		vt := state_accessors.NewStaticValidatorTable()
+		stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+		a := NewAntiquary(ctx, nil, preState, vt, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, stateSn, nil, reader, sn, log.New(), true, true, true, false, nil)
+		a.maxSlotsPerCommit = 8
+		a.statePruneDisabled = disabled
+		calls := &atomic.Int64{}
+		a.statePruneBoundaryFn = func(string) uint64 { calls.Add(1); return 0 }
+		require.NoError(t, a.IncrementBeaconState(ctx, to))
+		return calls.Load()
+	}
+
+	require.Zero(t, run(true))
+	require.Positive(t, run(false))
 }
 
 func TestPruneStateTablesRotationAndZeroBoundary(t *testing.T) {

--- a/cl/antiquary/state_prune_test.go
+++ b/cl/antiquary/state_prune_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package antiquary
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/persistence/base_encoding"
+	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+)
+
+func seedStateSlots(t *testing.T, db kv.RwDB, table string, slots []uint64) {
+	t.Helper()
+	require.NoError(t, db.Update(t.Context(), func(tx kv.RwTx) error {
+		for _, s := range slots {
+			if err := tx.Put(table, base_encoding.Encode64ToBytes4(s), []byte{1}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+}
+
+func tableSlots(t *testing.T, db kv.RwDB, table string) []uint64 {
+	t.Helper()
+	slots := []uint64{}
+	require.NoError(t, db.View(t.Context(), func(tx kv.Tx) error {
+		return tx.ForEach(table, nil, func(k, _ []byte) error {
+			slots = append(slots, base_encoding.Decode64FromBytes4(k))
+			return nil
+		})
+	}))
+	return slots
+}
+
+func pruneMarker(t *testing.T, db kv.RwDB, table string) uint64 {
+	t.Helper()
+	var m uint64
+	require.NoError(t, db.View(t.Context(), func(tx kv.Tx) error {
+		var err error
+		m, err = state_accessors.ReadStatePruneProgress(tx, table)
+		return err
+	}))
+	return m
+}
+
+func slotRange(from, to uint64) []uint64 {
+	slots := make([]uint64, 0, to-from)
+	for s := from; s < to; s++ {
+		slots = append(slots, s)
+	}
+	return slots
+}
+
+func TestPruneStateTablesBelowBoundary(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedStateSlots(t, db, kv.BlockRoot, slotRange(0, 100))
+	boundaryFn := func(string) uint64 { return 50 }
+
+	next, err := pruneStateTables(t.Context(), db, []string{kv.BlockRoot}, boundaryFn, 0, 1000, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 0, next)
+	require.Equal(t, slotRange(50, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(50), pruneMarker(t, db, kv.BlockRoot))
+
+	// second call is a no-op: marker already at boundary, no RW txn opened
+	commits := &atomic.Int64{}
+	counting := &commitCountingDB{RwDB: db, commits: commits}
+	next, err = pruneStateTables(t.Context(), counting, []string{kv.BlockRoot}, boundaryFn, 0, 1000, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 0, next)
+	require.Zero(t, commits.Load())
+	require.Equal(t, slotRange(50, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(50), pruneMarker(t, db, kv.BlockRoot))
+}
+
+func TestPruneStateTablesSparseKeysJumpToBoundary(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedStateSlots(t, db, kv.BlockRoot, []uint64{0, 32, 64})
+
+	next, err := pruneStateTables(t.Context(), db, []string{kv.BlockRoot}, func(string) uint64 { return 50 }, 0, 1000, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 0, next)
+	require.Equal(t, []uint64{64}, tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(50), pruneMarker(t, db, kv.BlockRoot))
+}
+
+type cancelOnCommitDB struct {
+	kv.RwDB
+	onCommit func()
+}
+
+func (d *cancelOnCommitDB) BeginRw(ctx context.Context) (kv.RwTx, error) {
+	tx, err := d.RwDB.BeginRw(ctx) //nolint:gocritic // wrapper returns the tx to the caller; it owns Rollback
+	if err != nil {
+		return nil, err
+	}
+	return &cancelOnCommitTx{RwTx: tx, onCommit: d.onCommit}, nil
+}
+
+type cancelOnCommitTx struct {
+	kv.RwTx
+	onCommit func()
+}
+
+func (t *cancelOnCommitTx) Commit() error {
+	err := t.RwTx.Commit()
+	t.onCommit()
+	return err
+}
+
+func TestPruneStateTablesResumesAfterDeadline(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedStateSlots(t, db, kv.BlockRoot, slotRange(0, 100))
+	boundaryFn := func(string) uint64 { return 50 }
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	interrupted := &cancelOnCommitDB{RwDB: db, onCommit: cancel}
+
+	next, err := pruneStateTables(ctx, interrupted, []string{kv.BlockRoot}, boundaryFn, 0, 10, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 0, next)
+	require.Equal(t, slotRange(10, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(10), pruneMarker(t, db, kv.BlockRoot))
+
+	next, err = pruneStateTables(t.Context(), db, []string{kv.BlockRoot}, boundaryFn, next, 10, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 0, next)
+	require.Equal(t, slotRange(50, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(50), pruneMarker(t, db, kv.BlockRoot))
+}
+
+func TestPruneStateTablesBatchCommits(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedStateSlots(t, db, kv.BlockRoot, slotRange(0, 100))
+	commits := &atomic.Int64{}
+	counting := &commitCountingDB{RwDB: db, commits: commits}
+
+	next, err := pruneStateTables(t.Context(), counting, []string{kv.BlockRoot}, func(string) uint64 { return 100 }, 0, 10, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 0, next)
+	require.Empty(t, tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(100), pruneMarker(t, db, kv.BlockRoot))
+	require.GreaterOrEqual(t, commits.Load(), int64(10))
+}
+
+func TestPruneStateTablesRotationAndZeroBoundary(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedStateSlots(t, db, kv.BlockRoot, slotRange(0, 100))
+	seedStateSlots(t, db, kv.StateRoot, slotRange(0, 100))
+	seedStateSlots(t, db, kv.EpochData, slotRange(0, 10))
+	boundaries := map[string]uint64{kv.BlockRoot: 50, kv.StateRoot: 70, kv.EpochData: 0}
+	boundaryFn := func(table string) uint64 { return boundaries[table] }
+	tables := []string{kv.BlockRoot, kv.StateRoot, kv.EpochData}
+
+	next, err := pruneStateTables(t.Context(), db, tables, boundaryFn, 1, 1000, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 1, next)
+	require.Equal(t, slotRange(50, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, slotRange(70, 100), tableSlots(t, db, kv.StateRoot))
+	require.Equal(t, slotRange(0, 10), tableSlots(t, db, kv.EpochData))
+	require.Zero(t, pruneMarker(t, db, kv.EpochData))
+}

--- a/cl/antiquary/state_prune_test.go
+++ b/cl/antiquary/state_prune_test.go
@@ -171,7 +171,50 @@ func TestPruneStateTablesBatchCommits(t *testing.T) {
 	require.Equal(t, 0, next)
 	require.Empty(t, tableSlots(t, db, kv.BlockRoot))
 	require.Equal(t, uint64(100), pruneMarker(t, db, kv.BlockRoot))
-	require.GreaterOrEqual(t, commits.Load(), int64(10))
+	require.Equal(t, int64(10), commits.Load())
+}
+
+func TestPruneStateTablesResumesAtInterruptedTable(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	tables := []string{kv.BlockRoot, kv.StateRoot, kv.EpochData}
+	for _, table := range tables {
+		seedStateSlots(t, db, table, slotRange(0, 100))
+	}
+	boundaryFn := func(string) uint64 { return 50 }
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	interrupted := &cancelOnCommitDB{RwDB: db, onCommit: cancel}
+
+	// the first commit finishes kv.BlockRoot and cancels: the index of the next
+	// unvisited table must come back so the following pass starts there
+	next, err := pruneStateTables(ctx, interrupted, tables, boundaryFn, 0, 1000, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 1, next)
+	require.Equal(t, slotRange(50, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, slotRange(0, 100), tableSlots(t, db, kv.StateRoot))
+	require.Equal(t, slotRange(0, 100), tableSlots(t, db, kv.EpochData))
+
+	next, err = pruneStateTables(t.Context(), db, tables, boundaryFn, next, 1000, log.New())
+	require.NoError(t, err)
+	require.Equal(t, 1, next)
+	for _, table := range tables {
+		require.Equal(t, slotRange(50, 100), tableSlots(t, db, table), "table %s", table)
+		require.Equal(t, uint64(50), pruneMarker(t, db, table), "table %s", table)
+	}
+}
+
+func TestPruneStateTablesErrorReturnsFailingTable(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	seedStateSlots(t, db, kv.BlockRoot, slotRange(0, 100))
+	tables := []string{kv.BlockRoot, "NonexistentTable"}
+
+	next, err := pruneStateTables(t.Context(), db, tables, func(string) uint64 { return 50 }, 0, 1000, log.New())
+	require.Error(t, err)
+	require.Equal(t, 1, next)
+	// the healthy table was still pruned before the failure
+	require.Equal(t, slotRange(50, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(50), pruneMarker(t, db, kv.BlockRoot))
 }
 
 func TestStatePruneBudget(t *testing.T) {
@@ -180,9 +223,61 @@ func TestStatePruneBudget(t *testing.T) {
 	require.Equal(t, 4*time.Second, statePruneBudget(cfg, 0))
 	require.Equal(t, 6*time.Second, statePruneBudget(cfg, 1000))
 	require.Equal(t, 8*time.Second, statePruneBudget(cfg, 1_000_000))
+}
 
+func TestStatePruneEnvConfig(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	newA := func() *Antiquary {
+		return NewAntiquary(context.Background(), nil, nil, nil, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, nil, nil, nil, nil, log.New(), true, true, true, false, nil)
+	}
+	require.False(t, newA().statePruneDisabled)
+	require.Zero(t, newA().statePruneTimeout)
+
+	t.Setenv("CAPLIN_STATE_PRUNE_DISABLE", "true")
 	t.Setenv("CAPLIN_STATE_PRUNE_TIMEOUT", "150ms")
-	require.Equal(t, 150*time.Millisecond, statePruneBudget(cfg, 1000))
+	a := newA()
+	require.True(t, a.statePruneDisabled)
+	require.Equal(t, 150*time.Millisecond, a.statePruneTimeout)
+}
+
+func TestStatePruneBacklog(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	ctx := context.Background()
+	a := NewAntiquary(ctx, nil, nil, nil, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, nil, nil, nil, nil, log.New(), true, true, true, false, nil)
+	require.NoError(t, db.Update(ctx, func(tx kv.RwTx) error {
+		if err := state_accessors.SetStatePruneProgress(tx, kv.BlockRoot, 10); err != nil {
+			return err
+		}
+		return state_accessors.SetStatePruneProgress(tx, kv.EpochData, 70)
+	}))
+	boundaries := map[string]uint64{kv.BlockRoot: 50, kv.StateRoot: 100, kv.EpochData: 0}
+	tables := []string{kv.BlockRoot, kv.StateRoot, kv.EpochData}
+
+	// (50-10) + (100-0); zero-boundary tables contribute nothing
+	backlog := a.statePruneBacklog(ctx, tables, func(table string) uint64 { return boundaries[table] })
+	require.Equal(t, uint64(140), backlog)
+
+	// a marker at or past the boundary contributes nothing
+	boundaries[kv.EpochData] = 70
+	backlog = a.statePruneBacklog(ctx, tables, func(table string) uint64 { return boundaries[table] })
+	require.Equal(t, uint64(140), backlog)
+}
+
+func TestFloorStatePruneMarkers(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	ctx := context.Background()
+	stateSn := snapshotsync.NewCaplinStateSnapshots(ethconfig.BlocksFreezing{}, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), snapshotsync.MakeCaplinStateSnapshotsTypes(db), log.New())
+	a := NewAntiquary(ctx, nil, nil, nil, &clparams.MainnetBeaconConfig, datadir.New(t.TempDir()), nil, db, stateSn, nil, nil, nil, log.New(), true, true, true, false, nil)
+	require.NoError(t, db.Update(ctx, func(tx kv.RwTx) error {
+		if err := state_accessors.SetStatePruneProgress(tx, kv.BlockRoot, 100); err != nil {
+			return err
+		}
+		return state_accessors.SetStatePruneProgress(tx, kv.StateRoot, 30)
+	}))
+
+	require.NoError(t, a.floorStatePruneMarkers(ctx, 50))
+	require.Equal(t, uint64(50), pruneMarker(t, db, kv.BlockRoot))
+	require.Equal(t, uint64(30), pruneMarker(t, db, kv.StateRoot))
 }
 
 func TestStatePruneKillSwitch(t *testing.T) {
@@ -198,7 +293,14 @@ func TestStatePruneKillSwitch(t *testing.T) {
 	require.Equal(t, slotRange(0, 100), tableSlots(t, db, kv.BlockRoot))
 	require.Zero(t, pruneMarker(t, db, kv.BlockRoot))
 
+	// an already-expired timeout override must stop the pass before any delete
 	a.statePruneDisabled = false
+	a.statePruneTimeout = time.Nanosecond
+	a.pruneFrozenStateTables(ctx)
+	require.Equal(t, slotRange(0, 100), tableSlots(t, db, kv.BlockRoot))
+	require.Zero(t, pruneMarker(t, db, kv.BlockRoot))
+
+	a.statePruneTimeout = 0
 	a.pruneFrozenStateTables(ctx)
 	require.Equal(t, slotRange(50, 100), tableSlots(t, db, kv.BlockRoot))
 	require.Equal(t, uint64(50), pruneMarker(t, db, kv.BlockRoot))
@@ -207,10 +309,14 @@ func TestStatePruneKillSwitch(t *testing.T) {
 func TestStatePruneWiredIntoAntiquaryCycle(t *testing.T) {
 	blocks, preState, postState := tests.GetCapellaRandom()
 	to := blocks[len(blocks)-1].Block.Slot + 33
+	// the fixture chain sits far above this boundary, so the cycle never
+	// re-flushes rows below it and the seeded rows are the only prunable ones
+	const boundary = uint64(10)
 
-	run := func(disabled bool) int64 {
+	run := func(disabled bool) (int64, []uint64) {
 		db := memdb.NewTestDB(t, dbcfg.ChainDB)
 		reader := tests.LoadChain(blocks, postState, db, t)
+		seedStateSlots(t, db, kv.BlockRoot, slotRange(0, boundary))
 		sn := synced_data.NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
 		sn.OnHeadState(postState)
 		ctx := context.Background()
@@ -220,13 +326,30 @@ func TestStatePruneWiredIntoAntiquaryCycle(t *testing.T) {
 		a.maxSlotsPerCommit = 8
 		a.statePruneDisabled = disabled
 		calls := &atomic.Int64{}
-		a.statePruneBoundaryFn = func(string) uint64 { calls.Add(1); return 0 }
+		a.statePruneBoundaryFn = func(table string) uint64 {
+			calls.Add(1)
+			if table == kv.BlockRoot {
+				return boundary
+			}
+			return 0
+		}
 		require.NoError(t, a.IncrementBeaconState(ctx, to))
-		return calls.Load()
+		var belowBoundary []uint64
+		for _, s := range tableSlots(t, db, kv.BlockRoot) {
+			if s < boundary {
+				belowBoundary = append(belowBoundary, s)
+			}
+		}
+		return calls.Load(), belowBoundary
 	}
 
-	require.Zero(t, run(true))
-	require.Positive(t, run(false))
+	calls, below := run(true)
+	require.Zero(t, calls)
+	require.Equal(t, slotRange(0, boundary), below)
+
+	calls, below = run(false)
+	require.Positive(t, calls)
+	require.Empty(t, below)
 }
 
 func TestPruneStateTablesRotationAndZeroBoundary(t *testing.T) {

--- a/cl/persistence/state/state_accessors.go
+++ b/cl/persistence/state/state_accessors.go
@@ -57,6 +57,21 @@ func SetStateProcessingProgress(tx kv.RwTx, progress uint64) error {
 	return tx.Put(kv.StatesProcessingProgress, kv.StatesProcessingKey, base_encoding.Encode64ToBytes4(progress))
 }
 
+func ReadStatePruneProgress(tx kv.Tx, table string) (uint64, error) {
+	v, err := tx.GetOne(kv.StatesPruneProgress, []byte(table))
+	if err != nil {
+		return 0, err
+	}
+	if len(v) == 0 {
+		return 0, nil
+	}
+	return base_encoding.Decode64FromBytes4(v), nil
+}
+
+func SetStatePruneProgress(tx kv.RwTx, table string, slot uint64) error {
+	return tx.Put(kv.StatesPruneProgress, []byte(table), base_encoding.Encode64ToBytes4(slot))
+}
+
 func ReadSlotData(getFn GetValFn, slot uint64, cfg *clparams.BeaconChainConfig) (*SlotData, error) {
 	sd := &SlotData{}
 	v, err := getFn(kv.SlotData, base_encoding.Encode64ToBytes4(slot))

--- a/cl/persistence/state/state_prune_progress_test.go
+++ b/cl/persistence/state/state_prune_progress_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_accessors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+)
+
+func TestStatePruneProgress(t *testing.T) {
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	tx, err := db.BeginRw(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	got, err := ReadStatePruneProgress(tx, kv.BlockRoot)
+	require.NoError(t, err)
+	require.Zero(t, got)
+
+	require.NoError(t, SetStatePruneProgress(tx, kv.BlockRoot, 123))
+	require.NoError(t, SetStatePruneProgress(tx, kv.StateRoot, 456))
+
+	got, err = ReadStatePruneProgress(tx, kv.BlockRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(123), got)
+
+	got, err = ReadStatePruneProgress(tx, kv.StateRoot)
+	require.NoError(t, err)
+	require.Equal(t, uint64(456), got)
+
+	got, err = ReadStatePruneProgress(tx, kv.EpochData)
+	require.NoError(t, err)
+	require.Zero(t, got)
+}

--- a/db/kv/tables.go
+++ b/db/kv/tables.go
@@ -279,6 +279,7 @@ const (
 	// End GLOAS
 
 	StatesProcessingProgress = "StatesProcessingProgress"
+	StatesPruneProgress      = "StatesPruneProgress" // table name => slot
 
 	//Diagnostics tables
 	DiagSystemInfo = "DiagSystemInfo"
@@ -430,6 +431,7 @@ var ChaindataTables = []string{
 	RandaoMixes,
 	Proposers,
 	StatesProcessingProgress,
+	StatesPruneProgress,
 	InactivityScores,
 	NextSyncCommittee,
 	CurrentSyncCommittee,

--- a/db/snapshotsync/caplin_state_coverage_test.go
+++ b/db/snapshotsync/caplin_state_coverage_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshotsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+)
+
+func TestCaplinStateContiguousCoverageEndContiguous(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.BlockRoot
+
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 50_000, logger)
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 50_000, 100_000, logger)
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.Equal(t, uint64(100_000), s.ContiguousCoverageEnd(table))
+}
+
+func TestCaplinStateContiguousCoverageEndStopsAtGap(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.BlockRoot
+
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 50_000, logger)
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 60_000, 100_000, logger)
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.Equal(t, uint64(50_000), s.ContiguousCoverageEnd(table))
+}
+
+func TestCaplinStateContiguousCoverageEndNoCoverage(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.BlockRoot
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.Zero(t, s.ContiguousCoverageEnd(table))
+	require.Zero(t, s.ContiguousCoverageEnd("unknown-type"))
+}
+
+func TestCaplinStateContiguousCoverageEndNotRootedAtGenesis(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.BlockRoot
+
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 50_000, 100_000, logger)
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.Zero(t, s.ContiguousCoverageEnd(table))
+}

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -265,6 +265,15 @@ func (s *CaplinStateSnapshots) BlocksAvailable() uint64 {
 	return min(s.segmentsMax.Load(), s.idxMax.Load())
 }
 
+func (s *CaplinStateSnapshots) TypeNames() []string {
+	names := make([]string, 0, len(s.snapshotTypes.KeyValueGetters))
+	for name := range s.snapshotTypes.KeyValueGetters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func (s *CaplinStateSnapshots) coveredRangesForType(name string) []Range {
 	s.visibleLock.RLock()
 	defer s.visibleLock.RUnlock()

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -284,6 +284,23 @@ func (s *CaplinStateSnapshots) coveredRangesForType(name string) []Range {
 	return ranges
 }
 
+// ContiguousCoverageEnd returns the end of the unbroken visible-segment run that
+// starts at slot 0 for the given type, or 0 when coverage is not rooted at genesis.
+func (s *CaplinStateSnapshots) ContiguousCoverageEnd(typeName string) uint64 {
+	ranges := s.coveredRangesForType(typeName)
+	sort.Slice(ranges, func(i, j int) bool { return ranges[i].from < ranges[j].from })
+	var end uint64
+	for _, r := range ranges {
+		if r.from > end {
+			break
+		}
+		if r.to > end {
+			end = r.to
+		}
+	}
+	return end
+}
+
 func (s *CaplinStateSnapshots) Close() {
 	if s == nil {
 		return

--- a/docs/plans/20260711-caplin-state-prune-impl.md
+++ b/docs/plans/20260711-caplin-state-prune-impl.md
@@ -25,12 +25,12 @@ source.
 
 Add the per-table prune-progress marker.
 
-- `db/kv/tables.go`: add `StatesPruneProgress = "StatesPruneProgress"` next to
+- [x] `db/kv/tables.go`: add `StatesPruneProgress = "StatesPruneProgress"` next to
   `StatesProcessingProgress` (:281) and register it in the SAME table list that
   registers `StatesProcessingProgress` (find where `StatesProcessingProgress` is
   added to the tables slice, ~:432, and add there — this is the caplin indexing DB
   config).
-- `cl/persistence/state/state_accessors.go`: add
+- [x] `cl/persistence/state/state_accessors.go`: add
   `ReadStatePruneProgress(tx kv.Tx, table string) (uint64, error)` and
   `SetStatePruneProgress(tx kv.RwTx, table string, slot uint64) error`. Key =
   `[]byte(table)`. Value encoding = same as `SetStateProcessingProgress`
@@ -48,7 +48,7 @@ Acceptance: test green; `make erigon` builds.
 
 Expose the safe prune boundary per type.
 
-- `db/snapshotsync/caplin_state_snapshots.go`: add
+- [ ] `db/snapshotsync/caplin_state_snapshots.go`: add
   `(s *CaplinStateSnapshots) ContiguousCoverageEnd(typeName string) uint64`. Use
   `coveredRangesForType(typeName)` (:268). Ranges are `Range{From,To}`. Sort by
   `From`, walk from slot 0, and return the `To` of the first unbroken run (a run
@@ -57,9 +57,9 @@ Expose the safe prune boundary per type.
 TDD: unit test in `db/snapshotsync` — drive `coveredRangesForType` via the existing
 visible-segments test setup (see `caplin_state_overlap_test.go` /
 `caplin_state_visibility_test.go` for how tests construct segments). Cases:
-- contiguous `[0,50),[50,100)` → 100
-- gap `[0,50),[60,100)` → 50
-- no coverage / first range not at 0 → 0
+- [ ] contiguous `[0,50),[50,100)` → 100
+- [ ] gap `[0,50),[60,100)` → 50
+- [ ] no coverage / first range not at 0 → 0
 
 Acceptance: test green.
 
@@ -81,36 +81,36 @@ func pruneStateTables(
 ) (nextStartIdx int, err error)
 ```
 
-- Iterate `tables` starting at `startIdx` (rotating), wrapping once.
-- Per table: `boundary = boundaryFn(table)`; `marker = ReadStatePruneProgress`; if
+- [ ] Iterate `tables` starting at `startIdx` (rotating), wrapping once.
+- [ ] Per table: `boundary = boundaryFn(table)`; `marker = ReadStatePruneProgress`; if
   `marker >= boundary` continue. Else open an RW txn, cursor-seek to `marker`, and
   `DeleteCurrent` while `key < boundary`, counting; at `batchLimit` deletions
   commit, persist the marker to the last-deleted-slot+1, and start a new txn.
   Keys are `base_encoding.Encode64ToBytes4(slot)`; decode to compare against
   `boundary`.
-- **Fully-drained tables must jump the marker to `boundary`.** Most frozen tables
+- [ ] **Fully-drained tables must jump the marker to `boundary`.** Most frozen tables
   are sparse / rounded-key (EpochData rounds to epoch; `*Dump` round to
   `SlotsPerDump`; sync committees round to period — `cl/antiquary/beacon_states_collector.go`).
   After the last delete, a seek from `marker` returns nil or a key `>= boundary`
   even though `marker < boundary`. In that no-more-keys-below-boundary case,
   persist `marker = boundary` — otherwise the table is treated as backlog every
   cycle and inflates the budget forever.
-- Check `ctx.Err()` only at txn boundaries (never mid-txn). On deadline: commit the
+- [ ] Check `ctx.Err()` only at txn boundaries (never mid-txn). On deadline: commit the
   in-flight batch, return the current table index as `nextStartIdx`, nil error.
-- No ranged truncate in mdbx — cursor delete only. `batchLimit` keeps txns small.
-- Log per committed batch at `LvlDebug` (table, from→to slot, count, duration);
+- [ ] No ranged truncate in mdbx — cursor delete only. `batchLimit` keeps txns small.
+- [ ] Log per committed batch at `LvlDebug` (table, from→to slot, count, duration);
   per-table summary at `LvlInfo` when a table is fully drained to its boundary.
-- Add prometheus counters mirroring `mxAntiquaryPrunedBlocks` /
+- [ ] Add prometheus counters mirroring `mxAntiquaryPrunedBlocks` /
   `mxAntiquaryPruneBatchSeconds` (see `cl/antiquary/antiquary.go`).
 
 TDD: unit test in `cl/antiquary` with an mdbx test DB and an injected `boundaryFn`
 (no real `CaplinStateSnapshots` needed):
-- seed `kv.BlockRoot` with slots `0..99`; `boundaryFn → 50`; prune with a large
+- [ ] seed `kv.BlockRoot` with slots `0..99`; `boundaryFn → 50`; prune with a large
   deadline; assert slots `<50` gone, `>=50` present, marker == 50.
-- second call is a no-op (marker already at boundary).
-- tiny deadline (e.g. cancel after first batch): assert partial delete, marker
+- [ ] second call is a no-op (marker already at boundary).
+- [ ] tiny deadline (e.g. cancel after first batch): assert partial delete, marker
   advanced partially, and a follow-up call finishes the rest (resumable).
-- `batchLimit = 10` over 100 rows commits in ≥10 txns (assert via marker stepping
+- [ ] `batchLimit = 10` over 100 rows commits in ≥10 txns (assert via marker stepping
   or a commit counter).
 
 Acceptance: tests green; `make erigon` builds.
@@ -119,26 +119,26 @@ Acceptance: tests green; `make erigon` builds.
 
 ### Task 4: budget, kill-switch, wire into the antiquary cadence
 
-- `cl/antiquary/state_prune.go`:
+- [ ] `cl/antiquary/state_prune.go`:
   - `func statePruneBudget(cfg *clparams.BeaconChainConfig, backlogSlots uint64) time.Duration`
     mirroring EL (`execution/execmodule/forkchoice.go:915-917`):
     `base = SecondsPerSlot/3`, `max = SecondsPerSlot*2/3`,
     `budget = min(base + (backlogSlots/100)*200ms, max)`. Override the whole thing
     with `dbg.EnvDuration("CAPLIN_STATE_PRUNE_TIMEOUT", <computed>)`
     (`dbg_env.go:119`) when the env var is set.
-- `Antiquary` struct: add `statePruneStartIdx int` and `statePruneDisabled bool`.
+- [ ] `Antiquary` struct: add `statePruneStartIdx int` and `statePruneDisabled bool`.
   Initialize `statePruneDisabled` in `NewAntiquary` from
   `dbg.EnvBool("CAPLIN_STATE_PRUNE_DISABLE", false)` (`common/dbg/dbg_env.go:69`).
   It is a **field, not a package var**, so tests can toggle it directly without
   mutating process env (which would not take effect after init anyway).
-- Deterministic table list: build once from `snapshotTypes.KeyValueGetters` keys,
+- [ ] Deterministic table list: build once from `snapshotTypes.KeyValueGetters` keys,
   sorted (add a small accessor on `CaplinStateSnapshots` if needed).
-- **Gate: `if !s.statePruneDisabled && s.stateSn != nil`. Do NOT gate on
+- [ ] **Gate: `if !s.statePruneDisabled && s.stateSn != nil`. Do NOT gate on
   `s.snapgen`** — `snapgen` only gates local dumping; an archive-state node that
   *downloaded* state snapshots must prune too. The natural scope is already
   archive-state (this loop only runs when `ArchiveStates`), and
   `ContiguousCoverageEnd == 0` makes a node with no visible coverage a safe no-op.
-- Two wire points in `cl/antiquary/state_antiquary.go`:
+- [ ] Two wire points in `cl/antiquary/state_antiquary.go`:
   1. **After each `commitBatch()` + fresh collector** (after ~:404) — drains
      already-visible backlog frozen by prior calls.
   2. **After `DumpCaplinState` succeeds AND `s.stateSn.OpenFolder()`** (after
@@ -168,13 +168,13 @@ Acceptance: `make erigon` builds; `go test ./cl/antiquary/...` green; a prune
 Prove the invariant end to end. In `cl/antiquary` (reuse the
 `state_antiquary_test.go` harness) or `historical_states_reader`:
 
-- run the state antiquary far enough to freeze at least one range to `.seg`
+- [ ] run the state antiquary far enough to freeze at least one range to `.seg`
   segments, then call `pruneStateTables` below coverage.
-- read a historical state at a **pruned** slot → must reconstruct correctly (served
+- [ ] read a historical state at a **pruned** slot → must reconstruct correctly (served
   from segments).
-- read a historical state at a **tail** slot (above coverage) → correct (served
+- [ ] read a historical state at a **tail** slot (above coverage) → correct (served
   from DB; not pruned).
-- balances edge (make it deterministic): `reconstructBalances`
+- [ ] balances edge (make it deterministic): `reconstructBalances`
   (`cl/persistence/state/historical_states_reader/historical_states_reader.go:648-660`)
   picks the *next* dump instead of the previous when
   `slot % SlotsPerDump > SlotsPerDump/2` and progress is past it — which would read
@@ -191,9 +191,9 @@ Acceptance: both cases green.
 
 ### Task 6: lint, build, package tests
 
-- `make lint` (repeat until clean).
-- `make erigon`.
-- `go test ./cl/antiquary/... ./cl/persistence/state/... ./db/snapshotsync/...`
+- [ ] `make lint` (repeat until clean).
+- [ ] `make erigon`.
+- [ ] `go test ./cl/antiquary/... ./cl/persistence/state/... ./db/snapshotsync/...`
 
 Acceptance: all green, lint clean.
 

--- a/docs/plans/20260711-caplin-state-prune-impl.md
+++ b/docs/plans/20260711-caplin-state-prune-impl.md
@@ -81,36 +81,36 @@ func pruneStateTables(
 ) (nextStartIdx int, err error)
 ```
 
-- [ ] Iterate `tables` starting at `startIdx` (rotating), wrapping once.
-- [ ] Per table: `boundary = boundaryFn(table)`; `marker = ReadStatePruneProgress`; if
+- [x] Iterate `tables` starting at `startIdx` (rotating), wrapping once.
+- [x] Per table: `boundary = boundaryFn(table)`; `marker = ReadStatePruneProgress`; if
   `marker >= boundary` continue. Else open an RW txn, cursor-seek to `marker`, and
   `DeleteCurrent` while `key < boundary`, counting; at `batchLimit` deletions
   commit, persist the marker to the last-deleted-slot+1, and start a new txn.
   Keys are `base_encoding.Encode64ToBytes4(slot)`; decode to compare against
   `boundary`.
-- [ ] **Fully-drained tables must jump the marker to `boundary`.** Most frozen tables
+- [x] **Fully-drained tables must jump the marker to `boundary`.** Most frozen tables
   are sparse / rounded-key (EpochData rounds to epoch; `*Dump` round to
   `SlotsPerDump`; sync committees round to period — `cl/antiquary/beacon_states_collector.go`).
   After the last delete, a seek from `marker` returns nil or a key `>= boundary`
   even though `marker < boundary`. In that no-more-keys-below-boundary case,
   persist `marker = boundary` — otherwise the table is treated as backlog every
   cycle and inflates the budget forever.
-- [ ] Check `ctx.Err()` only at txn boundaries (never mid-txn). On deadline: commit the
+- [x] Check `ctx.Err()` only at txn boundaries (never mid-txn). On deadline: commit the
   in-flight batch, return the current table index as `nextStartIdx`, nil error.
-- [ ] No ranged truncate in mdbx — cursor delete only. `batchLimit` keeps txns small.
-- [ ] Log per committed batch at `LvlDebug` (table, from→to slot, count, duration);
+- [x] No ranged truncate in mdbx — cursor delete only. `batchLimit` keeps txns small.
+- [x] Log per committed batch at `LvlDebug` (table, from→to slot, count, duration);
   per-table summary at `LvlInfo` when a table is fully drained to its boundary.
-- [ ] Add prometheus counters mirroring `mxAntiquaryPrunedBlocks` /
+- [x] Add prometheus counters mirroring `mxAntiquaryPrunedBlocks` /
   `mxAntiquaryPruneBatchSeconds` (see `cl/antiquary/antiquary.go`).
 
 TDD: unit test in `cl/antiquary` with an mdbx test DB and an injected `boundaryFn`
 (no real `CaplinStateSnapshots` needed):
-- [ ] seed `kv.BlockRoot` with slots `0..99`; `boundaryFn → 50`; prune with a large
+- [x] seed `kv.BlockRoot` with slots `0..99`; `boundaryFn → 50`; prune with a large
   deadline; assert slots `<50` gone, `>=50` present, marker == 50.
-- [ ] second call is a no-op (marker already at boundary).
-- [ ] tiny deadline (e.g. cancel after first batch): assert partial delete, marker
+- [x] second call is a no-op (marker already at boundary).
+- [x] tiny deadline (e.g. cancel after first batch): assert partial delete, marker
   advanced partially, and a follow-up call finishes the rest (resumable).
-- [ ] `batchLimit = 10` over 100 rows commits in ≥10 txns (assert via marker stepping
+- [x] `batchLimit = 10` over 100 rows commits in ≥10 txns (assert via marker stepping
   or a commit counter).
 
 Acceptance: tests green; `make erigon` builds.

--- a/docs/plans/20260711-caplin-state-prune-impl.md
+++ b/docs/plans/20260711-caplin-state-prune-impl.md
@@ -191,9 +191,9 @@ Acceptance: both cases green.
 
 ### Task 6: lint, build, package tests
 
-- [ ] `make lint` (repeat until clean).
-- [ ] `make erigon`.
-- [ ] `go test ./cl/antiquary/... ./cl/persistence/state/... ./db/snapshotsync/...`
+- [x] `make lint` (repeat until clean).
+- [x] `make erigon`.
+- [x] `go test ./cl/antiquary/... ./cl/persistence/state/... ./db/snapshotsync/...`
 
 Acceptance: all green, lint clean.
 

--- a/docs/plans/20260711-caplin-state-prune-impl.md
+++ b/docs/plans/20260711-caplin-state-prune-impl.md
@@ -119,26 +119,26 @@ Acceptance: tests green; `make erigon` builds.
 
 ### Task 4: budget, kill-switch, wire into the antiquary cadence
 
-- [ ] `cl/antiquary/state_prune.go`:
+- [x] `cl/antiquary/state_prune.go`:
   - `func statePruneBudget(cfg *clparams.BeaconChainConfig, backlogSlots uint64) time.Duration`
     mirroring EL (`execution/execmodule/forkchoice.go:915-917`):
     `base = SecondsPerSlot/3`, `max = SecondsPerSlot*2/3`,
     `budget = min(base + (backlogSlots/100)*200ms, max)`. Override the whole thing
     with `dbg.EnvDuration("CAPLIN_STATE_PRUNE_TIMEOUT", <computed>)`
     (`dbg_env.go:119`) when the env var is set.
-- [ ] `Antiquary` struct: add `statePruneStartIdx int` and `statePruneDisabled bool`.
+- [x] `Antiquary` struct: add `statePruneStartIdx int` and `statePruneDisabled bool`.
   Initialize `statePruneDisabled` in `NewAntiquary` from
   `dbg.EnvBool("CAPLIN_STATE_PRUNE_DISABLE", false)` (`common/dbg/dbg_env.go:69`).
   It is a **field, not a package var**, so tests can toggle it directly without
   mutating process env (which would not take effect after init anyway).
-- [ ] Deterministic table list: build once from `snapshotTypes.KeyValueGetters` keys,
+- [x] Deterministic table list: build once from `snapshotTypes.KeyValueGetters` keys,
   sorted (add a small accessor on `CaplinStateSnapshots` if needed).
-- [ ] **Gate: `if !s.statePruneDisabled && s.stateSn != nil`. Do NOT gate on
+- [x] **Gate: `if !s.statePruneDisabled && s.stateSn != nil`. Do NOT gate on
   `s.snapgen`** — `snapgen` only gates local dumping; an archive-state node that
   *downloaded* state snapshots must prune too. The natural scope is already
   archive-state (this loop only runs when `ArchiveStates`), and
   `ContiguousCoverageEnd == 0` makes a node with no visible coverage a safe no-op.
-- [ ] Two wire points in `cl/antiquary/state_antiquary.go`:
+- [x] Two wire points in `cl/antiquary/state_antiquary.go`:
   1. **After each `commitBatch()` + fresh collector** (after ~:404) — drains
      already-visible backlog frozen by prior calls.
   2. **After `DumpCaplinState` succeeds AND `s.stateSn.OpenFolder()`** (after

--- a/docs/plans/20260711-caplin-state-prune-impl.md
+++ b/docs/plans/20260711-caplin-state-prune-impl.md
@@ -168,13 +168,13 @@ Acceptance: `make erigon` builds; `go test ./cl/antiquary/...` green; a prune
 Prove the invariant end to end. In `cl/antiquary` (reuse the
 `state_antiquary_test.go` harness) or `historical_states_reader`:
 
-- [ ] run the state antiquary far enough to freeze at least one range to `.seg`
+- [x] run the state antiquary far enough to freeze at least one range to `.seg`
   segments, then call `pruneStateTables` below coverage.
-- [ ] read a historical state at a **pruned** slot → must reconstruct correctly (served
+- [x] read a historical state at a **pruned** slot → must reconstruct correctly (served
   from segments).
-- [ ] read a historical state at a **tail** slot (above coverage) → correct (served
+- [x] read a historical state at a **tail** slot (above coverage) → correct (served
   from DB; not pruned).
-- [ ] balances edge (make it deterministic): `reconstructBalances`
+- [x] balances edge (make it deterministic): `reconstructBalances`
   (`cl/persistence/state/historical_states_reader/historical_states_reader.go:648-660`)
   picks the *next* dump instead of the previous when
   `slot % SlotsPerDump > SlotsPerDump/2` and progress is past it — which would read

--- a/docs/plans/20260711-caplin-state-prune-impl.md
+++ b/docs/plans/20260711-caplin-state-prune-impl.md
@@ -1,0 +1,207 @@
+# Plan: prune the caplin indexing DB after state freezing
+
+Design rationale, ground truth, and code pointers live in
+`docs/plans/20260711-caplin-state-snapshot-tiering-and-prune.md` (the handoff).
+This plan is implementation-only — it does not repeat the design. Read the handoff
+first; every "why" is there.
+
+Scope: the **prune** piece only. The `10k→100k→1m` re-tier is a separate later PR
+and is out of scope here.
+
+Branch: `awskii/caplin-state-prune` (off `origin/main`). Repo build/test:
+`make lint` (repeat until clean — non-deterministic), `make erigon`, and package
+tests below. TDD is mandatory (red → green); write the failing test first and
+confirm it fails for the right reason.
+
+Invariant that must hold at every step: **never delete a state row at slot ≥ that
+table's contiguous-from-genesis visible coverage.** Below coverage the reader
+(`GetValFnTxAndSnapshot`, `cl/persistence/state/state_accessors.go:32`) always
+serves the segment, so the DB row is unreachable. Above it, the DB is the only
+source.
+
+---
+
+### Task 1: marker table + accessors
+
+Add the per-table prune-progress marker.
+
+- `db/kv/tables.go`: add `StatesPruneProgress = "StatesPruneProgress"` next to
+  `StatesProcessingProgress` (:281) and register it in the SAME table list that
+  registers `StatesProcessingProgress` (find where `StatesProcessingProgress` is
+  added to the tables slice, ~:432, and add there — this is the caplin indexing DB
+  config).
+- `cl/persistence/state/state_accessors.go`: add
+  `ReadStatePruneProgress(tx kv.Tx, table string) (uint64, error)` and
+  `SetStatePruneProgress(tx kv.RwTx, table string, slot uint64) error`. Key =
+  `[]byte(table)`. Value encoding = same as `SetStateProcessingProgress`
+  (`base_encoding.Encode64ToBytes4`). Empty value → 0.
+
+TDD: unit test in `cl/persistence/state` — open an mdbx test DB, write markers for
+two distinct table names, read them back, assert per-table isolation and that an
+unset table reads 0.
+
+Acceptance: test green; `make erigon` builds.
+
+---
+
+### Task 2: per-type contiguous coverage helper
+
+Expose the safe prune boundary per type.
+
+- `db/snapshotsync/caplin_state_snapshots.go`: add
+  `(s *CaplinStateSnapshots) ContiguousCoverageEnd(typeName string) uint64`. Use
+  `coveredRangesForType(typeName)` (:268). Ranges are `Range{From,To}`. Sort by
+  `From`, walk from slot 0, and return the `To` of the first unbroken run (a run
+  breaks at the first gap). If the first range does not start at 0, return 0.
+
+TDD: unit test in `db/snapshotsync` — drive `coveredRangesForType` via the existing
+visible-segments test setup (see `caplin_state_overlap_test.go` /
+`caplin_state_visibility_test.go` for how tests construct segments). Cases:
+- contiguous `[0,50),[50,100)` → 100
+- gap `[0,50),[60,100)` → 50
+- no coverage / first range not at 0 → 0
+
+Acceptance: test green.
+
+---
+
+### Task 3: prune core
+
+New file `cl/antiquary/state_prune.go`.
+
+```
+func pruneStateTables(
+    ctx context.Context,          // carries the per-pass deadline
+    db kv.RwDB,
+    tables []string,              // deterministic, sorted schema table names
+    boundaryFn func(table string) uint64,
+    startIdx int,
+    batchLimit int,               // 1000
+    logger log.Logger,
+) (nextStartIdx int, err error)
+```
+
+- Iterate `tables` starting at `startIdx` (rotating), wrapping once.
+- Per table: `boundary = boundaryFn(table)`; `marker = ReadStatePruneProgress`; if
+  `marker >= boundary` continue. Else open an RW txn, cursor-seek to `marker`, and
+  `DeleteCurrent` while `key < boundary`, counting; at `batchLimit` deletions
+  commit, persist the marker to the last-deleted-slot+1, and start a new txn.
+  Keys are `base_encoding.Encode64ToBytes4(slot)`; decode to compare against
+  `boundary`.
+- **Fully-drained tables must jump the marker to `boundary`.** Most frozen tables
+  are sparse / rounded-key (EpochData rounds to epoch; `*Dump` round to
+  `SlotsPerDump`; sync committees round to period — `cl/antiquary/beacon_states_collector.go`).
+  After the last delete, a seek from `marker` returns nil or a key `>= boundary`
+  even though `marker < boundary`. In that no-more-keys-below-boundary case,
+  persist `marker = boundary` — otherwise the table is treated as backlog every
+  cycle and inflates the budget forever.
+- Check `ctx.Err()` only at txn boundaries (never mid-txn). On deadline: commit the
+  in-flight batch, return the current table index as `nextStartIdx`, nil error.
+- No ranged truncate in mdbx — cursor delete only. `batchLimit` keeps txns small.
+- Log per committed batch at `LvlDebug` (table, from→to slot, count, duration);
+  per-table summary at `LvlInfo` when a table is fully drained to its boundary.
+- Add prometheus counters mirroring `mxAntiquaryPrunedBlocks` /
+  `mxAntiquaryPruneBatchSeconds` (see `cl/antiquary/antiquary.go`).
+
+TDD: unit test in `cl/antiquary` with an mdbx test DB and an injected `boundaryFn`
+(no real `CaplinStateSnapshots` needed):
+- seed `kv.BlockRoot` with slots `0..99`; `boundaryFn → 50`; prune with a large
+  deadline; assert slots `<50` gone, `>=50` present, marker == 50.
+- second call is a no-op (marker already at boundary).
+- tiny deadline (e.g. cancel after first batch): assert partial delete, marker
+  advanced partially, and a follow-up call finishes the rest (resumable).
+- `batchLimit = 10` over 100 rows commits in ≥10 txns (assert via marker stepping
+  or a commit counter).
+
+Acceptance: tests green; `make erigon` builds.
+
+---
+
+### Task 4: budget, kill-switch, wire into the antiquary cadence
+
+- `cl/antiquary/state_prune.go`:
+  - `func statePruneBudget(cfg *clparams.BeaconChainConfig, backlogSlots uint64) time.Duration`
+    mirroring EL (`execution/execmodule/forkchoice.go:915-917`):
+    `base = SecondsPerSlot/3`, `max = SecondsPerSlot*2/3`,
+    `budget = min(base + (backlogSlots/100)*200ms, max)`. Override the whole thing
+    with `dbg.EnvDuration("CAPLIN_STATE_PRUNE_TIMEOUT", <computed>)`
+    (`dbg_env.go:119`) when the env var is set.
+- `Antiquary` struct: add `statePruneStartIdx int` and `statePruneDisabled bool`.
+  Initialize `statePruneDisabled` in `NewAntiquary` from
+  `dbg.EnvBool("CAPLIN_STATE_PRUNE_DISABLE", false)` (`common/dbg/dbg_env.go:69`).
+  It is a **field, not a package var**, so tests can toggle it directly without
+  mutating process env (which would not take effect after init anyway).
+- Deterministic table list: build once from `snapshotTypes.KeyValueGetters` keys,
+  sorted (add a small accessor on `CaplinStateSnapshots` if needed).
+- **Gate: `if !s.statePruneDisabled && s.stateSn != nil`. Do NOT gate on
+  `s.snapgen`** — `snapgen` only gates local dumping; an archive-state node that
+  *downloaded* state snapshots must prune too. The natural scope is already
+  archive-state (this loop only runs when `ArchiveStates`), and
+  `ContiguousCoverageEnd == 0` makes a node with no visible coverage a safe no-op.
+- Two wire points in `cl/antiquary/state_antiquary.go`:
+  1. **After each `commitBatch()` + fresh collector** (after ~:404) — drains
+     already-visible backlog frozen by prior calls.
+  2. **After `DumpCaplinState` succeeds AND `s.stateSn.OpenFolder()`** (after
+     ~:620, not after the final flush) — only there is the just-frozen range
+     visible in coverage; pruning before `OpenFolder` sees stale coverage and
+     cannot prune what it just froze.
+  At each: compute `backlog` (cheap approximation, e.g. `currentState.Slot() -
+  min-marker`), `ctx, cancel := context.WithTimeout(ctx, statePruneBudget(...))`,
+  call `pruneStateTables` with `boundaryFn = s.stateSn.ContiguousCoverageEnd` and
+  `startIdx = s.statePruneStartIdx`, store the returned `nextStartIdx`, `cancel()`.
+  `commitBatch`/`DumpCaplinState` hold no open txn at these points, so
+  `pruneStateTables` can `BeginRw` freely.
+
+TDD: kill-switch is testable via the field. Add a focused test: construct the
+antiquary with `statePruneDisabled = true`, run a cycle, assert no rows deleted;
+then `false`, assert rows below coverage deleted. **No `t.Skip`** — the field makes
+the path directly injectable (repo forbids agent-added skips). Broader wiring is
+covered by Task 5.
+
+Acceptance: `make erigon` builds; `go test ./cl/antiquary/...` green; a prune
+`LvlInfo` line is emitted on an archive-state run.
+
+---
+
+### Task 5: reader-correctness integration test
+
+Prove the invariant end to end. In `cl/antiquary` (reuse the
+`state_antiquary_test.go` harness) or `historical_states_reader`:
+
+- run the state antiquary far enough to freeze at least one range to `.seg`
+  segments, then call `pruneStateTables` below coverage.
+- read a historical state at a **pruned** slot → must reconstruct correctly (served
+  from segments).
+- read a historical state at a **tail** slot (above coverage) → correct (served
+  from DB; not pruned).
+- balances edge (make it deterministic): `reconstructBalances`
+  (`cl/persistence/state/historical_states_reader/historical_states_reader.go:648-660`)
+  picks the *next* dump instead of the previous when
+  `slot % SlotsPerDump > SlotsPerDump/2` and progress is past it — which would read
+  an *above*-boundary dump and never exercise the pruned below-boundary path. So:
+  - forward case: choose a slot with `slot % SlotsPerDump <= SlotsPerDump/2` (or
+    pin `StatesProcessingProgress`) so the base dump is the below-boundary one, and
+    assert it is served from the segment after its DB row was pruned.
+  - reverse case: a slot that selects the next-dump path, asserting correctness
+    there too.
+
+Acceptance: both cases green.
+
+---
+
+### Task 6: lint, build, package tests
+
+- `make lint` (repeat until clean).
+- `make erigon`.
+- `go test ./cl/antiquary/... ./cl/persistence/state/... ./db/snapshotsync/...`
+
+Acceptance: all green, lint clean.
+
+---
+
+## Out of scope (do not implement here)
+
+- The `10k→100k→1m` state snapshot re-tier and the state segment merger.
+- Trimming `safetyMargin`.
+- mdbx file compaction (prune bounds growth; the file does not shrink — expected).
+- Any CLI flag (kill-switch is env-only by design).

--- a/docs/plans/20260711-caplin-state-prune-impl.md
+++ b/docs/plans/20260711-caplin-state-prune-impl.md
@@ -48,7 +48,7 @@ Acceptance: test green; `make erigon` builds.
 
 Expose the safe prune boundary per type.
 
-- [ ] `db/snapshotsync/caplin_state_snapshots.go`: add
+- [x] `db/snapshotsync/caplin_state_snapshots.go`: add
   `(s *CaplinStateSnapshots) ContiguousCoverageEnd(typeName string) uint64`. Use
   `coveredRangesForType(typeName)` (:268). Ranges are `Range{From,To}`. Sort by
   `From`, walk from slot 0, and return the `To` of the first unbroken run (a run
@@ -57,9 +57,9 @@ Expose the safe prune boundary per type.
 TDD: unit test in `db/snapshotsync` — drive `coveredRangesForType` via the existing
 visible-segments test setup (see `caplin_state_overlap_test.go` /
 `caplin_state_visibility_test.go` for how tests construct segments). Cases:
-- [ ] contiguous `[0,50),[50,100)` → 100
-- [ ] gap `[0,50),[60,100)` → 50
-- [ ] no coverage / first range not at 0 → 0
+- [x] contiguous `[0,50),[50,100)` → 100
+- [x] gap `[0,50),[60,100)` → 50
+- [x] no coverage / first range not at 0 → 0
 
 Acceptance: test green.
 

--- a/docs/plans/20260711-caplin-state-snapshot-tiering-and-prune.md
+++ b/docs/plans/20260711-caplin-state-snapshot-tiering-and-prune.md
@@ -1,0 +1,189 @@
+# Caplin state snapshotting: merge-tier + indexing-DB prune — handoff
+
+Date: 2026-07-11. Ground-truthed against `origin/main` @ `4aad1d8899` (worktree
+`caplin-vtable-repair` = main + the vtable fix, PR #22385).
+
+Two coupled pieces came out of investigating "caplin DBs grow unbounded" (gnosis
+v36 indexing DB +50 GB/night):
+
+1. **Prune** the caplin indexing DB after freezing (the load-bearing fix — nothing
+   prunes state today; converged design below, ready to implement).
+2. **Re-tier** state snapshots `10k → 100k → 1m` (replaces the underthought flat
+   50k; shrinks the DB floor prune leaves and keeps steady-state file count low).
+
+---
+
+## Problem
+
+- Caplin indexing DB (`/erigon-data/caplin/indexing/mdbx.dat`, = the antiquary's
+  `mainDB`, `cmd/caplin/caplin1/run.go:561`) holds the entire per-slot state
+  history. Nothing deletes it after freezing to `.seg`.
+- The reader `GetValFnTxAndSnapshot` (`cl/persistence/state/state_accessors.go:32-43`)
+  reads a segment for any covered slot and only falls through to `tx.GetOne` for
+  the un-frozen tail. So every DB row below the frozen watermark is dead weight.
+- Result on gnosis (mid from-genesis reconstruction, frozen to slot ~13.9M of ~29M):
+  indexing DB **112 GB** shadowing **79 GB** of snapshots, still climbing.
+- Only beacon **blocks** are pruned (`pruneBeaconBlocksAndWriteProgress`,
+  `cl/antiquary/antiquary.go:327` → `PruneBlocksLimit`). State tables: no prune
+  anywhere (grepped `cl/`).
+
+---
+
+## Ground truth: how state snapshotting works today
+
+- **Flat 50k files, no merge tier.** `blocksPerStatefulFile = CaplinMergeLimit*5 =
+  50_000` (`cl/antiquary/state_antiquary.go:603`). `planStateDump`
+  (`db/snapshotsync/caplin_state_snapshots.go:779`) tiles fixed `blocksPerFile`
+  jobs across missing ranges. `RemoveOverlaps` (caplin_state_snapshots.go:474)
+  only deletes fully-covered dupes — it does **not** merge small → large. So a
+  state segment merger does not exist yet.
+- **One file per type per range.** 33 types on disk (`MakeCaplinStateSnapshotsTypes`,
+  caplin_state_snapshots.go:97-137 lists 34; one has no data yet). gnosis: 9,669
+  `.seg` + 9,669 `.idx` at slot ~13.9M (~19k+19k projected at tip).
+- **One type dominates.** Per 50k range: `ValidatorBalance` **311 MB (~88%)**,
+  `BalancesDump` 20 MB, `SlotData` 7.7 MB, everything else ≲6 MB. Both snapshot
+  bytes and the DB tail floor are essentially "N slots of ValidatorBalance diffs."
+- **Watermark.** `BlocksAvailable() = min(segmentsMax, idxMax)`
+  (caplin_state_snapshots.go:264). `idxMax = idxAvailability()` (522-550) is the
+  real per-type min (walks every type's highest visible `.to`, takes the min; 0 if
+  any type empty). `segmentsMax` (317-368) is a sloppy last-file-wins scalar — do
+  not key anything off it; use `idxMax` / `coveredRangesForType` (268).
+- **Never-frozen tail floor** = `safetyMargin + blocksPerStatefulFile` =
+  `20_000 + 50_000 = 70k slots`. `safetyMargin = 20_000` (antiquary.go:47). This is
+  the irreducible DB floor even with perfect pruning — dominated by ValidatorBalance.
+- **Dump cadence.** Freezes only when `from + blocksPerStatefulFile + safetyMargin
+  <= currentSlot` (state_antiquary.go:602-640). `SlotsPerDump = 1536`
+  (`cl/clparams/config.go:129`) is unrelated — it's how often a full
+  BalancesDump/EffectiveBalancesDump *row* is written, not a file boundary.
+- **State snapshots are not manifest-pinned** — generated + seeded by snapgen nodes
+  (`s.downloader.Seed`), not a hardcoded preverified hash list. So the tier is
+  outward-facing (fleet publishes different files) but not a coordinated hard-fork
+  of the manifest. Verify before shipping.
+
+---
+
+## Proposed re-tier: 10k → 100k → 1m, 20k locked from tip
+
+50k flat is underthought. Replace with a real merge ladder (mirrors block snapshots):
+
+- **Dump at 10k** near tip (base = `CaplinMergeLimit`, not `*5`).
+- **20k locked from tip** — keep `safetyMargin = 20_000`; freeze the newest complete
+  10k range below `tip - 20k`.
+- **Merge 10 × 10k → 100k**, then **10 × 100k → 1m**.
+- Uniform across all 33 types (one file size / one row layout per level — no
+  per-type-selective tiering).
+
+Why:
+- Finer freezing edge → tail floor `70k → 30k slots` (`20k + 10k`). ~2.3× smaller
+  floor (capped at 2.3×, not 5×, because the fixed 20k `safetyMargin` dominates
+  once the file chunk drops from 50k to 10k). The win lands on ValidatorBalance.
+- Merge ladder keeps **steady-state file count low** (1m files) while giving the
+  fine edge — avoids the flat-10k penalty of 5× files (~96k `.seg` + 96k `.idx`/chain).
+- Tier changes **zero bytes** — same ValidatorBalance data, just chunked differently.
+  Its only DB effect is the smaller tail floor.
+
+What must be built (does not exist today):
+- A **state segment merger**: build a combined `.seg` from N smaller same-type
+  segments, rebuild one `.idx` over the merged range, then `RemoveOverlaps` deletes
+  the now-covered smaller files. Visibility already supersedes small by large via
+  `isSubSetOf` (caplin_state_snapshots.go:443-448), so reads are correct during/after
+  merge.
+- Merge trigger in the antiquary cycle (analog of block `antiquate()`).
+- `blocksPerStatefulFile` is local to state_antiquary.go (only 603-619) — the dump-
+  size change is nearly one line; the merger is the real work.
+
+Mixed 10k/50k/100k/1m coexist fine (visibility dedups). Prune is size-agnostic
+(keys off per-type coverage), so it composes with any tier layout.
+
+---
+
+## Prune design (converged, ready to implement)
+
+- **Prune set = `snapshotTypes.KeyValueGetters`** (the 34 frozen tables, derived —
+  not a hand-list). `kv.StaticValidators`, progress markers, and `beacon_indicies`
+  are excluded by construction (they are not frozen types). Self-correcting: add a
+  frozen type later and it is auto-covered.
+- **Boundary = per-table contiguous-from-genesis visible coverage**
+  (`coveredRangesForType(T)` → end of the first unbroken run from slot 0). Safe with
+  zero cross-table coordination: every `GetValFn(table, slot)` checks *that table's*
+  segment, so pruning T below T's coverage can never be read. Even the balances
+  reader (BalancesDump base + ValidatorBalance diffs) is safe — each sub-read
+  resolves per-table. Per-table (not global `idxMax`) because during reconstruction
+  types freeze at different rates (`errIncompleteStateRange` skips incomplete
+  ranges); an ahead type must not wait on the slowest.
+- **Mechanism.** No ranged truncate in mdbx (only whole-table `ClearBucket`, N/A —
+  tail is retained). So: cursor-seek from the per-table marker, `DeleteCurrent`
+  while `key < boundary`, **cap 1000 keys / RW txn**, commit, repeat. mdbx hates big
+  txns; 1k keeps them small.
+- **Cadence: on the antiquary's periodic-commit cadence** (every
+  `stateAntiquaryMaxSlotsPerCommit = 4*SlotsPerDump = 6144` slots), **not** gated on
+  the rare 50k/10k dump. Coverage only advances at dumps, but prune drains the
+  backlog across the many commits between dumps. This is what lets a small EL-style
+  budget keep up. Runs inline (no separate goroutine — single-writer means a
+  separate goroutine's batches serialize anyway).
+- **Timeout = EL's, per-chain, adaptive.** EL: `base = SecondsPerSlot/3`, `+200ms
+  per 100 slots backlog`, cap `2/3·SecondsPerSlot` (`execution/execmodule/forkchoice.go:915-917`).
+  Mirror it; default derived from `beaconCfg.SecondsPerSlot`. Override:
+  `dbg.EnvDuration("CAPLIN_STATE_PRUNE_TIMEOUT", <computed>)`. Deadline checked at
+  txn boundaries only → committed batches always consistent, resume next cycle.
+- **Markers.** `kv.StatesPruneProgress`, keyed **per table name** → last-pruned
+  slot. Matches the sibling `kv.StatesProcessingProgress` (db/kv/tables.go:281) —
+  codebase convention is "Progress", not "Markers", and no `Caplin` prefix.
+- **Fairness.** Per-cycle time budget + 34 tables: persist a rotating start-index so
+  each cycle resumes where the last budget ran out. With per-table markers → natural
+  round-robin.
+- **Unconditional**, scoped by `ArchiveStates`. Single kill-switch:
+  `dbg.EnvBool("CAPLIN_STATE_PRUNE_DISABLE", false)`. No CLI flag (caplin has enough
+  tunables). Idiom: `common/dbg/dbg_env.go:69/119`.
+- **Resume path safe as-is — no change to `computeSlotToBeRequested`.**
+  `findNearestSlotBackwards` (`cl/antiquary/utils.go:26`) reads only
+  `beacon_indicies.ReadCanonicalBlockRoot` (not a state-prune table). State load is
+  `historicalReader.ReadHistoricalState` (state_antiquary.go:679) via the snapshot-
+  first getter. Verified: **0** raw `tx.GetOne` in the historical reader; all 21
+  state reads go through `kvGetter`.
+- **Instrumentation.** Per-batch `LvlDebug` (table, from→to, keys deleted, duration);
+  per-sweep `LvlInfo` summary; prometheus counters mirroring
+  `mxAntiquaryPrunedBlocks` / `mxAntiquaryPruneBatchSeconds`.
+- **mdbx reality.** Prune frees pages for *reuse*; the file does not shrink. Prune
+  bounds *future* growth (the fix). Existing 112 GB bloat rides (ample headroom) or
+  gets a one-off offline `mdbx_copy -c`. Out of scope.
+
+TDD (repo requires red-first):
+1. dump → prune → read a pruned slot (from segment) + tail slot (from DB), both correct.
+2. read just above the boundary whose base BalancesDump sits below it — correct after prune.
+3. E2E reconstruction with prune on = byte-identical roots to prune off.
+
+---
+
+## How they interact
+
+- **Prune is load-bearing**: converts unbounded growth → a bounded ~70k-slot floor.
+  Do it first; it alone solves "+50 GB/night".
+- **Tier is secondary**: halves the floor (70k → 30k) and keeps file count sane via
+  the merge ladder. Outward-facing → its own PR.
+- `safetyMargin = 20k` is the larger remaining floor term after the tier. Trimming it
+  (state is finalized, won't reorg below finality) is a cheaper floor-reducer than
+  the tier, but carries its own reorg-safety call. Separate decision.
+
+## Sequencing
+
+1. Prune (this session's converged design) — PR, Codex-review like #22385.
+2. State merge-tier `10k → 100k → 1m` — separate outward-facing PR (needs the merger).
+3. (Optional) revisit `safetyMargin`.
+
+## Key pointers
+
+- Dump trigger + size: `cl/antiquary/state_antiquary.go:602-640`
+- `planStateDump` / `DumpCaplinState`: `db/snapshotsync/caplin_state_snapshots.go:779-816`
+- `RemoveOverlaps` (dupes, not merge): `caplin_state_snapshots.go:474`
+- Schema / prune set: `caplin_state_snapshots.go:97-137`
+- Watermark: `caplin_state_snapshots.go:264` (`idxAvailability` 522-550; `segmentsMax` 317-368)
+- `coveredRangesForType`: `caplin_state_snapshots.go:268`
+- Reader snapshot-first: `cl/persistence/state/state_accessors.go:32-43`
+- Resume: `state_antiquary.go:645-719`; `cl/antiquary/utils.go:26`
+- Beacon-block prune analog: `cl/antiquary/antiquary.go:327`
+- EL prune timeout: `execution/execmodule/forkchoice.go:915-917`
+- Consts: `CaplinMergeLimit=10_000` (`db/snaptype/files.go:393`); `safetyMargin=20_000`
+  (`cl/antiquary/antiquary.go:47`); `SlotsPerDump=1536` (`cl/clparams/config.go:129`)
+- kv sibling name: `db/kv/tables.go:281`
+- dbg env idiom: `common/dbg/dbg_env.go:69` (Bool) / `:119` (Duration)

--- a/docs/site/docs/fundamentals/caplin.md
+++ b/docs/site/docs/fundamentals/caplin.md
@@ -26,6 +26,8 @@ In addition, Caplin can backfill recent blobs for an op-node or other uses with 
 
 * `--caplin.blobs-immediate-backfill`: Backfills the last 18 days' worth of blobs to quickly populate historical blob data for operational needs or analytics.
 
+With state archival enabled, Caplin's indexing database (`<datadir>/caplin/indexing`) is pruned automatically: state rows already frozen into snapshots are deleted on the antiquary cadence, so the database holds only the un-frozen tail. The `mdbx.dat` file does not shrink when rows are pruned — freed pages are reused, bounding future growth. Set `CAPLIN_STATE_PRUNE_DISABLE=true` to turn pruning off.
+
 ### PeerDAS Data Column Retention
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -559,6 +559,8 @@ Erigon supports configuration through environment variables, primarily for exper
 * `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
 * `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
 * `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
+* `CAPLIN_STATE_PRUNE_DISABLE` - Disables pruning of Caplin's state indexing DB after ranges are frozen into snapshots (default: `false`)
+* `CAPLIN_STATE_PRUNE_TIMEOUT` - Overrides the per-pass time budget for Caplin state pruning (a duration, e.g. `500ms`; default derived from the chain's slot time)
 
 **Execution and Processing:**
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -1842,6 +1842,8 @@ In addition, Caplin can backfill recent blobs for an op-node or other uses with 
 
 * `--caplin.blobs-immediate-backfill`: Backfills the last 18 days' worth of blobs to quickly populate historical blob data for operational needs or analytics.
 
+With state archival enabled, Caplin's indexing database (`<datadir>/caplin/indexing`) is pruned automatically: state rows already frozen into snapshots are deleted on the antiquary cadence, so the database holds only the un-frozen tail. The `mdbx.dat` file does not shrink when rows are pruned — freed pages are reused, bounding future growth. Set `CAPLIN_STATE_PRUNE_DISABLE=true` to turn pruning off.
+
 ### PeerDAS Data Column Retention
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
@@ -2424,6 +2426,8 @@ Erigon supports configuration through environment variables, primarily for exper
 * `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
 * `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
 * `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
+* `CAPLIN_STATE_PRUNE_DISABLE` - Disables pruning of Caplin's state indexing DB after ranges are frozen into snapshots (default: `false`)
+* `CAPLIN_STATE_PRUNE_TIMEOUT` - Overrides the per-pass time budget for Caplin state pruning (a duration, e.g. `500ms`; default derived from the chain's slot time)
 
 **Execution and Processing:**
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1842,6 +1842,8 @@ In addition, Caplin can backfill recent blobs for an op-node or other uses with 
 
 * `--caplin.blobs-immediate-backfill`: Backfills the last 18 days' worth of blobs to quickly populate historical blob data for operational needs or analytics.
 
+With state archival enabled, Caplin's indexing database (`<datadir>/caplin/indexing`) is pruned automatically: state rows already frozen into snapshots are deleted on the antiquary cadence, so the database holds only the un-frozen tail. The `mdbx.dat` file does not shrink when rows are pruned — freed pages are reused, bounding future growth. Set `CAPLIN_STATE_PRUNE_DISABLE=true` to turn pruning off.
+
 ### PeerDAS Data Column Retention
 
 For nodes participating in PeerDAS (EIP-7594), Caplin retains data column sidecars for a configurable window:
@@ -2424,6 +2426,8 @@ Erigon supports configuration through environment variables, primarily for exper
 * `NO_MERGE` - Disables merging operations (flag equivalent: `--exec.no-merge`)
 * `PRUNE_TOTAL_DIFFICULTY` - Controls total difficulty pruning (default: `true`)
 * `MAX_REORG_DEPTH` - Sets maximum reorganization depth (default: `96`)
+* `CAPLIN_STATE_PRUNE_DISABLE` - Disables pruning of Caplin's state indexing DB after ranges are frozen into snapshots (default: `false`)
+* `CAPLIN_STATE_PRUNE_TIMEOUT` - Overrides the per-pass time budget for Caplin state pruning (a duration, e.g. `500ms`; default derived from the chain's slot time)
 
 **Execution and Processing:**
 


### PR DESCRIPTION
Caplin's indexing DB keeps the entire per-slot state history even after those ranges are frozen to state snapshots. The historical reader serves any covered slot from the `.seg` segment and only falls back to the DB for the un-frozen tail, so every frozen row is dead weight. Nothing pruned it — only beacon *blocks* were pruned, never state — so the DB grows unbounded (a gnosis snapshotter reached ~112GB shadowing ~79GB of the same data already in snapshots).

## Changes

- Prune the frozen state tables from the indexing DB on the antiquary's commit cadence and after each dump.
- Boundary is per-table contiguous-from-genesis snapshot coverage (`ContiguousCoverageEnd`): a row is deleted only when its slot is below the point where every read for that table is already served by an indexed visible segment. Fully-drained sparse/rounded-key tables jump their marker straight to the boundary.
- Deletes run as batched cursor deletes (1000 keys/txn — mdbx dislikes large txns) under an EL-style adaptive time budget, with per-table progress markers (`StatesPruneProgress`) so a pass is resumable and the deadline is only checked at txn boundaries.
- Unconditional under archive-state; `CAPLIN_STATE_PRUNE_DISABLE` turns it off and `CAPLIN_STATE_PRUNE_TIMEOUT` overrides the budget (env only, no new CLI flag).

Prune bounds future growth; it does not shrink the mdbx file (deleted pages are reused, not returned to the OS). The prune set is derived from the state-snapshot schema, so `StaticValidators` and progress markers are excluded by construction.
