### PR TITLE
cl: preallocate slices in hot alloc paths

### DIFF
--- a/cl/merkle_tree/list.go
+++ b/cl/merkle_tree/list.go
@@ -77,6 +77,9 @@ func BitvectorRootWithLimit(bits []byte, limit uint64) ([32]byte, error) {
 }
 
 func packBits(bytes []byte) [][32]byte {
+	if len(bytes) == 0 {
+		return nil
+	}
 	chunks := make([][32]byte, 0, (len(bytes)+31)/32)
 	for i := 0; i < len(bytes); i += 32 {
 		var chunk [32]byte

--- a/cl/merkle_tree/list.go
+++ b/cl/merkle_tree/list.go
@@ -77,7 +77,7 @@ func BitvectorRootWithLimit(bits []byte, limit uint64) ([32]byte, error) {
 }
 
 func packBits(bytes []byte) [][32]byte {
-	var chunks [][32]byte
+	chunks := make([][32]byte, 0, (len(bytes)+31)/32)
 	for i := 0; i < len(bytes); i += 32 {
 		var chunk [32]byte
 		copy(chunk[:], bytes[i:])

--- a/cl/phase1/core/state/accessors.go
+++ b/cl/phase1/core/state/accessors.go
@@ -152,6 +152,11 @@ func EligibleValidatorsIndicies(b abstract.BeaconState) (eligibleValidators []ui
 	}
 	wp.Execute()
 	// Merge the results from all threads.
+	total := 0
+	for i := range eligibleValidatorsShards {
+		total += len(eligibleValidatorsShards[i])
+	}
+	eligibleValidators = make([]uint64, 0, total)
 	for i := range eligibleValidatorsShards {
 		eligibleValidators = append(eligibleValidators, eligibleValidatorsShards[i]...)
 	}

--- a/cl/phase1/core/state/accessors.go
+++ b/cl/phase1/core/state/accessors.go
@@ -156,6 +156,9 @@ func EligibleValidatorsIndicies(b abstract.BeaconState) (eligibleValidators []ui
 	for i := range eligibleValidatorsShards {
 		total += len(eligibleValidatorsShards[i])
 	}
+	if total == 0 {
+		return nil
+	}
 	eligibleValidators = make([]uint64, 0, total)
 	for i := range eligibleValidatorsShards {
 		eligibleValidators = append(eligibleValidators, eligibleValidatorsShards[i]...)

--- a/cl/phase1/core/state/cache_accessors.go
+++ b/cl/phase1/core/state/cache_accessors.go
@@ -465,7 +465,7 @@ func (b *CachingBeaconState) GetAttestingIndicies(
 			)
 		}
 
-		attestingIndices := []uint64{}
+		attestingIndices := make([]uint64, 0, len(committee))
 		for i, member := range committee {
 			bitIndex := i % 8
 			sliceIndex := i / 8


### PR DESCRIPTION

<img width="1875" height="1230" alt="Screenshot 2026-07-11 at 15 30 48" src="https://github.com/user-attachments/assets/a227f6df-e923-4d77-9763-3519688294a1" />

Preallocate slices identified from an `alloc_space` heap profile. No behavior change.

| Function | File | alloc_space in profile |
|---|---|---|
| `packBits` | `cl/merkle_tree/list.go` | ~119 GB (9.3%) |
| `GetAttestingIndicies` | `cl/phase1/core/state/cache_accessors.go` | ~120 GB (9.4%) |
| `EligibleValidatorsIndicies` (shard merge) | `cl/phase1/core/state/accessors.go` | ~263 GB (20%) |

- `packBits`: final length is exactly `ceil(len(bytes)/32)`.
- `GetAttestingIndicies`: upper bound is `len(committee)`.
- `EligibleValidatorsIndicies`: sum the per-thread shard lengths, then allocate the merged result once instead of growing from `nil`.

Combined these target ~38% of total profiled `alloc_space`.
