### PR TITLE
execution/commitment: fix parallel deep-fold storage-root persistence

### DIFF
--- a/execution/commitment/deepfold_emptystorage_regression_test.go
+++ b/execution/commitment/deepfold_emptystorage_regression_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+)
+
+// A whale's storage is deleted ENTIRELY (deep fold, empty-storage case), then a LATER block
+// re-populates it. The deep fold used to persist the emptied account leaf with a storage-root hash of
+// empty.RootHash; single-trie leaves it with no storage-root hash (hashLen 0 — computeCellHash supplies
+// empty.RootHash at hash time). A stored empty.RootHash makes needUnfolding descend into the
+// storage-root branch record that was deleted when the storage emptied, so the re-populate fails with
+// "empty branch data read during unfold" on the parallel/streaming engines.
+//
+// The whale shares nibbles [7,8] with two siblings so its account leaf persists as a child of the
+// [7,8] branch record — carrying its (empty) storage-root hash — exactly as mainnet account
+// b4a038…e41 (hashed fd698ec0…) sits under the dense fd698e branch at block 5231408. A lone whale
+// instead propagates its leaf up a level, which hides the bug; the collapse tests keep a survivor slot
+// and never exercise the empty-storage branch at all.
+func TestDeepFold_EmptyStorageThenRepopulate(t *testing.T) {
+	t.Parallel()
+
+	w := findAddressForHexPrefix([]byte{7, 8, 1}, 101)
+	s1 := findAddressForHexPrefix([]byte{7, 8, 2}, 102)
+	s2 := findAddressForHexPrefix([]byte{7, 8, 3}, 103)
+	f0 := findAddressForHexPrefix([]byte{0}, 104)
+	ff := findAddressForHexPrefix([]byte{0xf}, 105)
+
+	const slots = 1500 // > deepStorageThreshold(1000) => the whale folds concurrently
+
+	locs := make([]string, slots)
+	for i := range locs {
+		locs[i] = common.Bytes2Hex(slotHashBytes(i))
+	}
+
+	// Batch 1: create the cluster; the whale gets a deep storage trie.
+	b1 := NewUpdateBuilder().
+		Balance(addrHex(w), 100).Balance(addrHex(s1), 5).Balance(addrHex(s2), 6).
+		Balance(addrHex(f0), 7).Balance(addrHex(ff), 8)
+	for _, loc := range locs {
+		b1.Storage(addrHex(w), loc, "01")
+	}
+	k1, u1 := b1.Build()
+
+	// Batch 2: keep the whale alive but delete every storage slot — the empty-storage deep-fold case.
+	b2 := NewUpdateBuilder().Balance(addrHex(w), 200)
+	for _, loc := range locs {
+		b2.DeleteStorage(addrHex(w), loc)
+	}
+	k2, u2 := b2.Build()
+
+	// Batch 3: re-populate every slot (again above the deep threshold), re-expanding the emptied whale.
+	b3 := NewUpdateBuilder()
+	for _, loc := range locs {
+		b3.Storage(addrHex(w), loc, "02")
+	}
+	k3, u3 := b3.Build()
+
+	batches := []engineBatch{{k1, u1}, {k2, u2}, {k3, u3}}
+
+	seqRoots, seqMs := runEngineBatches(t, modeSeq, 0, batches)
+	for _, tc := range []struct {
+		name string
+		mode runMode
+	}{
+		{"parallel", modeParallel},
+		{"streaming", modeStreaming},
+		{"streaming_scheduled", modeStreamingScheduled},
+	} {
+		for _, w := range []int{1, 4, 8} {
+			roots, ms := runEngineBatches(t, tc.mode, w, batches)
+			for i := range batches {
+				require.Equalf(t, seqRoots[i], roots[i], "%s(workers=%d) batch %d root != sequential", tc.name, w, i+1)
+			}
+			requireBranchParity(t, seqMs, ms)
+		}
+	}
+}

--- a/execution/commitment/deepfold_regression_test.go
+++ b/execution/commitment/deepfold_regression_test.go
@@ -75,7 +75,7 @@ func TestDeepFold_InjectedRootClearsStaleStorage(t *testing.T) {
 	require.True(t, hph.root.loaded.storage(), "precondition: root is flagged storage-loaded")
 
 	acct := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
-	setAccountStorageRoot(hph, KeyToHexNibbleHash(acct[:]), common.HexToHash("0x1234"))
+	setAccountStorageRoot(hph, KeyToHexNibbleHash(acct[:]), cell{hash: common.HexToHash("0x1234"), hashLen: 32})
 
 	require.Zerof(t, hph.root.storageAddrLen,
 		"injecting a storage root must clear the stale storage plain key (got len=%d)", hph.root.storageAddrLen)
@@ -98,7 +98,7 @@ func TestDeepFold_InjectedStorageRootWins(t *testing.T) {
 
 	clean := NewHexPatriciaHashed(length.Addr, NewMockState(t), DefaultTrieConfig())
 	clean.updateCell(acct[:], accHashed, &accUpd)
-	setAccountStorageRoot(clean, accHashed, injectedSR)
+	setAccountStorageRoot(clean, accHashed, cell{hash: injectedSR, hashLen: 32})
 	cleanHash, err := clean.computeCellHash(&clean.root, 0, nil)
 	require.NoError(t, err)
 
@@ -107,7 +107,7 @@ func TestDeepFold_InjectedStorageRootWins(t *testing.T) {
 	stale := NewHexPatriciaHashed(length.Addr, NewMockState(t), DefaultTrieConfig())
 	addStorageToCell(&stale.root, staleAddr, staleLoc, []byte{0xAA, 0xBB, 0xCC, 0xDD})
 	stale.updateCell(acct[:], accHashed, &accUpd)
-	setAccountStorageRoot(stale, accHashed, injectedSR)
+	setAccountStorageRoot(stale, accHashed, cell{hash: injectedSR, hashLen: 32})
 	staleHash, err := stale.computeCellHash(&stale.root, 0, nil)
 	require.NoError(t, err)
 

--- a/execution/commitment/deepfold_regression_test.go
+++ b/execution/commitment/deepfold_regression_test.go
@@ -115,6 +115,49 @@ func TestDeepFold_InjectedStorageRootWins(t *testing.T) {
 		"account hash must be driven by the injected storage root, not a stale storage slot")
 }
 
+// A whale that deep-folds to a single-child storage root (extension) in one block and to a hash-only
+// root (multi-child or empty) in the next reuses the same account cell. The hash-only injection must
+// clear the extension the single-child collapse left, or computeCellHash hashes extension(oldExt, sr)
+// instead of sr and produces a wrong account/state root.
+func TestDeepFold_HashOnlyRootClearsStaleExtension(t *testing.T) {
+	t.Parallel()
+
+	acct := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	accHashed := KeyToHexNibbleHash(acct[:])
+	accUpd := Update{Flags: BalanceUpdate | NonceUpdate}
+	accUpd.Balance.SetUint64(1_000_000)
+	accUpd.Nonce = 3
+
+	var singleChildSR cell
+	singleChildSR.hash = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	singleChildSR.hashLen = 32
+	singleChildSR.extLen = 3
+	singleChildSR.extension[0], singleChildSR.extension[1], singleChildSR.extension[2] = 0x0a, 0x0b, 0x0c
+
+	var multiSR cell
+	multiSR.hash = common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222")
+	multiSR.hashLen = 32
+
+	reused := NewHexPatriciaHashed(length.Addr, NewMockState(t), DefaultTrieConfig())
+	reused.updateCell(acct[:], accHashed, &accUpd)
+	setAccountStorageRoot(reused, accHashed, singleChildSR)
+	require.NotZero(t, reused.root.extLen, "single-child collapse must set the storage extension")
+	setAccountStorageRoot(reused, accHashed, multiSR)
+	require.Zerof(t, reused.root.extLen,
+		"a hash-only storage root must clear the prior single-child extension (got len=%d)", reused.root.extLen)
+	reusedHash, err := reused.computeCellHash(&reused.root, 0, nil)
+	require.NoError(t, err)
+
+	clean := NewHexPatriciaHashed(length.Addr, NewMockState(t), DefaultTrieConfig())
+	clean.updateCell(acct[:], accHashed, &accUpd)
+	setAccountStorageRoot(clean, accHashed, multiSR)
+	cleanHash, err := clean.computeCellHash(&clean.root, 0, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, cleanHash, reusedHash,
+		"a reused cell's stale storage extension must not change the account hash")
+}
+
 type engineBatch struct {
 	keys [][]byte
 	upds []Update

--- a/execution/commitment/deepfold_retouch_regression_test.go
+++ b/execution/commitment/deepfold_retouch_regression_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A whale's touched storage collapses to a single surviving first-nibble (deep fold, single-child),
+// then a LATER block re-touches its storage. The deep fold persists the collapsed storage root as a
+// bare hash on the account leaf, dropping the extension navigation, so the re-touch unfold demands a
+// storage-root branch record at the 64-nibble account prefix that the single-child collapse never
+// wrote — "empty branch data read during unfold" on the parallel/streaming engines. Sequential folds
+// the storage in place (fillFromLowerCell keeps the extension) and stays correct, so this only
+// surfaces on a re-touch after the collapse — the existing collapse tests stop at the collapse block.
+func TestDeepFold_SurvivorCollapseThenRetouch(t *testing.T) {
+	t.Parallel()
+
+	addr, _, _, _, wk1, wu1, groups := whaleByNibble(30_000)
+
+	surv := -1
+	for x := 0; x < 16; x++ {
+		if len(groups[x]) >= 2 {
+			surv = x
+			break
+		}
+	}
+	require.GreaterOrEqual(t, surv, 0, "need a survivor nibble with >=2 slots")
+
+	// Batch 2: touch the account and delete every non-survivor slot (>>deepStorageThreshold), so the
+	// storage root collapses onto the single survivor nibble. Remember one deleted slot to re-add.
+	wk2 := [][]byte{addr}
+	wu2 := []Update{{Flags: BalanceUpdate | NonceUpdate}}
+	wu2[0].Balance.SetUint64(99)
+	wu2[0].Nonce = 7
+	var reAdd storKV
+	haveReAdd := false
+	for x := 0; x < 16; x++ {
+		if x == surv {
+			continue
+		}
+		for _, kv := range groups[x] {
+			wk2 = append(wk2, kv.pk)
+			wu2 = append(wu2, Update{Flags: DeleteUpdate})
+			if !haveReAdd {
+				reAdd = kv
+				haveReAdd = true
+			}
+		}
+	}
+	require.True(t, haveReAdd, "need a deleted slot to re-add")
+
+	// Batch 3: re-add the deleted slot under its (non-survivor) nibble, re-expanding the storage — this
+	// unfolds the account's storage subtree from the persisted (collapsed) state.
+	wk3 := [][]byte{reAdd.pk}
+	wu3 := []Update{reAdd.upd}
+
+	// Surround the whale with a dense account trie so it is a child in a branch record whose persisted
+	// cell must carry the storage extension.
+	mk, mu := buildMixedCorpus(0xC0FFEE, 4000)
+	k1 := append(append([][]byte{}, mk...), wk1...)
+	u1 := append(append([]Update{}, mu...), wu1...)
+
+	batches := []engineBatch{{k1, u1}, {wk2, wu2}, {wk3, wu3}}
+
+	seqRoots, seqMs := runEngineBatches(t, modeSeq, 0, batches)
+	for _, tc := range []struct {
+		name string
+		mode runMode
+	}{
+		{"parallel", modeParallel},
+		{"streaming", modeStreaming},
+		{"streaming_scheduled", modeStreamingScheduled},
+	} {
+		for _, w := range []int{1, 4, 8} {
+			roots, ms := runEngineBatches(t, tc.mode, w, batches)
+			for i := range batches {
+				require.Equalf(t, seqRoots[i], roots[i], "%s(workers=%d) batch %d root != sequential", tc.name, w, i+1)
+			}
+			requireBranchParity(t, seqMs, ms)
+		}
+	}
+}

--- a/execution/commitment/deepfold_single_slot_survivor_test.go
+++ b/execution/commitment/deepfold_single_slot_survivor_test.go
@@ -57,9 +57,9 @@ func TestDeepFold_SingleSlotSurvivorNotLoaded(t *testing.T) {
 	f0 := findAddressForHexPrefix([]byte{0}, 203)
 	ff := findAddressForHexPrefix([]byte{0xf}, 204)
 
-	survLoc := storageLocsForNibble(0x1, 1, 1)[0]      // one untouched slot under nibble 1
-	delB := storageLocsForNibble(0x2, 700, 1000)       // 700 slots under nibble 2
-	delC := storageLocsForNibble(0x3, 700, 1000000)    // 700 slots under nibble 3
+	survLoc := storageLocsForNibble(0x1, 1, 1)[0]   // one untouched slot under nibble 1
+	delB := storageLocsForNibble(0x2, 700, 1000)    // 700 slots under nibble 2
+	delC := storageLocsForNibble(0x3, 700, 1000000) // 700 slots under nibble 3
 
 	b1 := NewUpdateBuilder().
 		Balance(addrHex(w), 100).Balance(addrHex(s1), 5).

--- a/execution/commitment/deepfold_single_slot_survivor_test.go
+++ b/execution/commitment/deepfold_single_slot_survivor_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"encoding/binary"
+	"testing"
+
+	keccak "github.com/erigontech/fastkeccak"
+
+	"github.com/erigontech/erigon/common"
+)
+
+// storageLocsForNibble returns n distinct storage locations whose hashed key (keccak of the slot)
+// starts with the given first nibble, so a whale's storage can be laid out under chosen first-nibble
+// subtrees. The first storage nibble is the high nibble of keccak(slot)[0] (see KeyToHexNibbleHash).
+func storageLocsForNibble(nibble byte, n, seed int) []string {
+	out := make([]string, 0, n)
+	var s [32]byte
+	for i := seed; len(out) < n; i++ {
+		binary.BigEndian.PutUint64(s[24:], uint64(i))
+		h := keccak.Sum256(s[:])
+		if (h[0]>>4)&0xf == nibble {
+			out = append(out, common.Bytes2Hex(s[:]))
+		}
+	}
+	return out
+}
+
+// A whale's storage collapses (deep fold) to a SINGLE untouched slot under one first nibble: the other
+// first-nibble groups are deleted (crossing deepStorageThreshold across >=2 nibbles), leaving the lone
+// slot as the surviving child. That survivor is decoded from the on-disk account-prefix branch — it
+// carries a cached stateHash and its value is not loaded — so storageRootFromSingleChild returns it as
+// a raw leaf. If setAccountStorageRoot drops the cached hash, the later account-leaf hash recompute has
+// neither a loaded value nor a memoized hash and fails "storage ... was not loaded as expected".
+// Distinct from TestDeepFold_LeafSurvivorCollapse, whose survivor nibble has several slots so its value
+// gets loaded during the fold.
+func TestDeepFold_SingleSlotSurvivorNotLoaded(t *testing.T) {
+	t.Parallel()
+
+	w := findAddressForHexPrefix([]byte{7, 8, 1}, 201)
+	s1 := findAddressForHexPrefix([]byte{7, 8, 2}, 202)
+	f0 := findAddressForHexPrefix([]byte{0}, 203)
+	ff := findAddressForHexPrefix([]byte{0xf}, 204)
+
+	survLoc := storageLocsForNibble(0x1, 1, 1)[0]      // one untouched slot under nibble 1
+	delB := storageLocsForNibble(0x2, 700, 1000)       // 700 slots under nibble 2
+	delC := storageLocsForNibble(0x3, 700, 1000000)    // 700 slots under nibble 3
+
+	b1 := NewUpdateBuilder().
+		Balance(addrHex(w), 100).Balance(addrHex(s1), 5).
+		Balance(addrHex(f0), 7).Balance(addrHex(ff), 8).
+		Storage(addrHex(w), survLoc, "01")
+	for _, loc := range delB {
+		b1.Storage(addrHex(w), loc, "01")
+	}
+	for _, loc := range delC {
+		b1.Storage(addrHex(w), loc, "01")
+	}
+	k1, u1 := b1.Build()
+
+	// Batch 2: delete every nibble-2/3 slot (1400 > deepStorageThreshold across 2 nibbles => deep fold),
+	// keeping the untouched nibble-1 slot as the single surviving child.
+	b2 := NewUpdateBuilder().Balance(addrHex(w), 200)
+	for _, loc := range delB {
+		b2.DeleteStorage(addrHex(w), loc)
+	}
+	for _, loc := range delC {
+		b2.DeleteStorage(addrHex(w), loc)
+	}
+	k2, u2 := b2.Build()
+
+	for _, wk := range []int{1, 4, 8} {
+		requireAllEnginesParity(t, k1, u1, k2, u2, wk)
+	}
+}

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -262,7 +262,9 @@ func setAccountStorageRoot(w *HexPatriciaHashed, accHash []byte, sr cell) {
 	c.loaded &^= cellLoadStorage
 	// Carry sr's navigation onto the account leaf: a single-child collapse's extension (or a single
 	// leaf's plain key) must persist, or a later re-touch unfolds to a storage-root branch record the
-	// collapse never wrote.
+	// collapse never wrote. computeCellHash reads c.extLen as the storage-root extension, so a hash-only
+	// root (multi-child or empty) must clear any extension a prior single-child collapse left on a reused
+	// cell, otherwise the leaf hashes extension(oldExt, sr.hash) instead of sr.hash.
 	if sr.storageAddrLen > 0 {
 		c.storageAddrLen = sr.storageAddrLen
 		copy(c.storageAddr[:], sr.storageAddr[:sr.storageAddrLen])
@@ -272,8 +274,8 @@ func setAccountStorageRoot(w *HexPatriciaHashed, accHash []byte, sr cell) {
 		}
 		c.loaded |= sr.loaded & cellLoadStorage
 	}
+	c.extLen = sr.extLen
 	if sr.extLen > 0 {
-		c.extLen = sr.extLen
 		copy(c.extension[:], sr.extension[:sr.extLen])
 	}
 	c.hashLen = sr.hashLen

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
-
-	"github.com/erigontech/erigon/common"
 )
 
 var cmtTiming = os.Getenv("ERIGON_CMT_TIMING") == "1"
@@ -141,7 +139,7 @@ func (p *ParallelPatriciaHashed) processMounted(ctx context.Context, updates *Up
 			path := make([]byte, 0, 144)
 			path = append(path, byte(ni))
 			path = append(path, ch.ext...)
-			buildErr := dfsSubtreeDeep(w, ch, path, func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
+			buildErr := dfsSubtreeDeep(w, ch, path, func(n *prefixNode, pth []byte, accountFresh bool) (cell, error) {
 				return foldStorageRoot(gctx, foldSem, p.newStorageWorker, pu, n, pth, accountFresh)
 			})
 			if buildErr != nil {
@@ -248,21 +246,39 @@ func (p *ParallelPatriciaHashed) newStorageWorker() (*HexPatriciaHashed, func())
 	return newDeferredStorageWorker(&p.workerPool, p.trieCtxFactory, traceW)
 }
 
-// setAccountStorageRoot sets the account leaf's storage root to sr; computeCellHash uses cell.hash as the storageRoot when no storage cell was processed.
-func setAccountStorageRoot(w *HexPatriciaHashed, accHash []byte, sr common.Hash) {
+// setAccountStorageRoot writes the folded storage-root cell sr onto the account leaf.
+func setAccountStorageRoot(w *HexPatriciaHashed, accHash []byte, sr cell) {
 	var c *cell
 	if w.activeRows == 0 {
 		c = &w.root
 	} else {
 		c = &w.grid[w.activeRows-1][accHash[w.currentKeyLen]]
 	}
-	// sr already covers the whole storage subtree, so a stale storage plain key on this cell must
-	// go, or computeCellHash rehashes it as a singleton from the stale slot and discards sr.
+	// Drop any stale storage plain key so computeCellHash does not rehash the account's storage from
+	// a leftover slot instead of sr.
 	c.storageAddrLen = 0
 	c.StorageLen = 0
 	c.Flags &^= StorageUpdate
 	c.loaded &^= cellLoadStorage
-	c.hash = sr
-	c.hashLen = 32
+	// Carry sr's navigation onto the account leaf: a single-child collapse's extension (or a single
+	// leaf's plain key) must persist, or a later re-touch unfolds to a storage-root branch record the
+	// collapse never wrote.
+	if sr.storageAddrLen > 0 {
+		c.storageAddrLen = sr.storageAddrLen
+		copy(c.storageAddr[:], sr.storageAddr[:sr.storageAddrLen])
+		c.StorageLen = sr.StorageLen
+		if sr.StorageLen > 0 {
+			copy(c.Storage[:], sr.Storage[:sr.StorageLen])
+		}
+		c.loaded |= sr.loaded & cellLoadStorage
+	}
+	if sr.extLen > 0 {
+		c.extLen = sr.extLen
+		copy(c.extension[:], sr.extension[:sr.extLen])
+	}
+	c.hashLen = sr.hashLen
+	if sr.hashLen > 0 {
+		copy(c.hash[:], sr.hash[:sr.hashLen])
+	}
 	c.stateHashLen = 0
 }

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -721,7 +721,7 @@ func (sc *StreamingCommitter) foldSplit(ctx context.Context, foldSem *semaphore.
 	path := make([]byte, 0, 144)
 	path = append(path, ni)
 	path = append(path, child.ext...)
-	deepStorageRoot := func(n *prefixNode, pth []byte, accountFresh bool) (common.Hash, error) {
+	deepStorageRoot := func(n *prefixNode, pth []byte, accountFresh bool) (cell, error) {
 		sr, err := foldStorageRoot(ctx, foldSem, sc.newStorageWorker, &pu, n, pth, accountFresh)
 		if err == nil {
 			sc.deepLocalFolds.Add(1)

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/erigontech/erigon/common/empty"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
 
@@ -214,12 +213,12 @@ func foldStorageRoot(ctx context.Context, sem *semaphore.Weighted, newWorker fun
 	if deferred := base.TakeDeferredUpdates(); len(deferred) > 0 {
 		pu.appendDeferred(deferred)
 	}
-	// A fully collapsed aggregate means a storage-less account: empty-trie root, not zero.
+	// A storage-less account must leave the account leaf's storage-root hashLen at 0, not
+	// empty.RootHash: computeCellHash supplies empty.RootHash at hash time, so the root is the
+	// same, but a stored hash makes needUnfolding descend into a storage-root branch that was
+	// never written, failing a later storage re-touch with "empty branch data read during unfold".
 	if sr.IsEmpty() {
-		var e cell
-		e.hashLen = 32
-		copy(e.hash[:], empty.RootHash[:])
-		return e, nil
+		return cell{}, nil
 	}
 	return sr, nil
 }

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/empty"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
@@ -94,7 +93,7 @@ func isDeepStorageAccount(node *prefixNode, depth int) bool {
 
 // dfsSubtreeDeep walks node's subtree applying each key to w, but at a big-storage
 // account it injects storageRoot's result instead of streaming the slots.
-func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storageRoot func(node *prefixNode, path []byte, accountFresh bool) (common.Hash, error)) error {
+func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storageRoot func(node *prefixNode, path []byte, accountFresh bool) (cell, error)) error {
 	if node == nil {
 		return nil
 	}
@@ -141,7 +140,7 @@ func dfsSubtreeDeep(w *HexPatriciaHashed, node *prefixNode, path []byte, storage
 // Storage-root analogue of the account mount fold: parallelize a whale's storage by first nibble.
 // sem is the shared fold-concurrency budget: acquired per first-nibble worker so that
 // this whale's fan-out plus every other concurrently-folding subtree stays within the core count.
-func foldStorageRoot(ctx context.Context, sem *semaphore.Weighted, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte, accountFresh bool) (common.Hash, error) {
+func foldStorageRoot(ctx context.Context, sem *semaphore.Weighted, newWorker func() (*HexPatriciaHashed, func()), pu *parallelUpdate, node *prefixNode, path []byte, accountFresh bool) (cell, error) {
 	accPrefix := append([]byte(nil), path...)
 
 	base, releaseBase := newWorker()
@@ -163,7 +162,7 @@ func foldStorageRoot(ctx context.Context, sem *semaphore.Weighted, newWorker fun
 		// A fresh account proves nothing exists on disk beneath accPrefix, so the reset
 		// (empty) wall rows unfoldStorageBase left behind are the correct seed.
 		if !accountFresh || !errors.Is(err, errStorageBaseNotBranch) {
-			return common.Hash{}, fmt.Errorf("unfold storage root: %w", err)
+			return cell{}, fmt.Errorf("unfold storage root: %w", err)
 		}
 	}
 
@@ -205,21 +204,24 @@ func foldStorageRoot(ctx context.Context, sem *semaphore.Weighted, newWorker fun
 		bm &^= uint16(1) << nib
 	}
 	if err := g.Wait(); err != nil {
-		return common.Hash{}, err
+		return cell{}, err
 	}
 
 	sr, err := aggregateMountedStorageRoot(base, &children, node.bitmap)
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("storage branch fold: %w", err)
+		return cell{}, fmt.Errorf("storage branch fold: %w", err)
 	}
 	if deferred := base.TakeDeferredUpdates(); len(deferred) > 0 {
 		pu.appendDeferred(deferred)
 	}
 	// A fully collapsed aggregate means a storage-less account: empty-trie root, not zero.
 	if sr.IsEmpty() {
-		return empty.RootHash, nil
+		var e cell
+		e.hashLen = 32
+		copy(e.hash[:], empty.RootHash[:])
+		return e, nil
 	}
-	return sr.hash, nil
+	return sr, nil
 }
 
 func aggregateMountedStorageRoot(base *HexPatriciaHashed, children *[16]cell, bitmap uint16) (cell, error) {
@@ -248,7 +250,11 @@ func aggregateMountedStorageRoot(base *HexPatriciaHashed, children *[16]cell, bi
 	if err := base.fold(); err != nil {
 		return cell{}, err
 	}
-	return base.root, nil
+	// A multi-child storage root's subtree persists as branch records, so the account leaf references
+	// it by hash without an extension; a single-child collapse (handled above) carries one instead.
+	out := base.root
+	out.extLen = 0
+	return out, nil
 }
 
 // storageRootFromSingleChild builds the storage root for a single-surviving-child collapse — an
@@ -275,14 +281,7 @@ func storageRootFromSingleChild(base *HexPatriciaHashed) (cell, error) {
 	} else {
 		root = child // single storage leaf: rehashed from its full storage key at depth 64
 	}
-	h, err := base.computeCellHash(&root, 64, nil)
-	if err != nil {
-		return cell{}, err
-	}
-	var out cell
-	out.hashLen = int16(len(h) - 1)
-	copy(out.hash[:], h[1:])
-	return out, nil
+	return root, nil
 }
 
 // newDeferredStorageWorker yields a pooled trie worker for a deferring storage fold


### PR DESCRIPTION
Parallel commitment (`--experimental.parallel-commitment`) crashes rebuilding mainnet from genesis at block 5231408: `empty branch data read during unfold`. The parallel deep-storage fold recorded an account's storage root on its leaf differently from single-trie, so a later storage re-touch unfolds into a branch record that no longer exists.

## Changes
- Empty storage: the deep-fold empty case stored `empty.RootHash` as the leaf's storage-root hash. Single-trie stores nothing (hashLen 0; `computeCellHash` supplies `empty.RootHash` at hash time, so the root is unchanged), so `needUnfolding` does not read a storage-root branch that was deleted when the storage emptied. Return an empty cell.
- Single-child collapse: carry the surviving child's extension onto the account leaf, and clear a stale extension when a reused leaf later folds hash-only.