### PR TITLE
[r3.5] db/state: fix clear StateCache on SharedDomains unwind below reorg window

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -512,6 +512,9 @@ func (sd *SharedDomains) GetDiffset(tx kv.RwTx, blockHash common.Hash, blockNumb
 
 func (sd *SharedDomains) Unwind(txNumUnwindTo uint64, changeset *[kv.DomainLen][]kv.DomainEntryDiff) {
 	sd.mem.Unwind(txNumUnwindTo, changeset)
+	if sd.stateCache != nil {
+		sd.stateCache.Clear()
+	}
 }
 
 func (sd *SharedDomains) Trace() bool {

--- a/execution/stagedsync/stage_execute_unwind_test.go
+++ b/execution/stagedsync/stage_execute_unwind_test.go
@@ -34,6 +34,7 @@ import (
 	dbstate "github.com/erigontech/erigon/db/state"
 	"github.com/erigontech/erigon/db/state/changeset"
 	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/cache"
 	"github.com/erigontech/erigon/execution/chain/networkname"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/node/ethconfig"
@@ -96,6 +97,10 @@ func TestUnwindExecutionStage_PrunesUncommittedOverlayWrite(t *testing.T) {
 	require.NoError(t, err)
 	defer doms.Close()
 	doms.SetChangesetAccumulator(&changeset.StateChangeSet{})
+
+	// Enable state cache to verify it is also pruned/unwound correctly
+	stateCache := cache.NewDefaultStateCache()
+	doms.SetStateCache(stateCache)
 
 	const (
 		committedBlock = uint64(5) // execution-stage progress (last flushed block)


### PR DESCRIPTION
#### Issue
In fact, once the changeset-isolation changes were backported in v3.5.1 (commit ab0af49016), we started seeing deterministic trie-root mismatches during sync. 

Basically, when block execution fails under the reorg window, we do a disc-noop overlay unwind. Since there are no saved changesets for these blocks, we pass a nil changeset to DOMs. Unwind(txNum, nil). 

The main issue is that the `SharedDomains.Unwind 'method' on the `release/3.5` branch is not hooked up to the `StateCache 'at all'. This also leaves dirty/uncommitted writes from the failed block in the cache. When Erigon restarts execution from the last committed block, it reads stale values from the cache instead of querying the DB, corrupting the state and creating a bad block root.

#### Answer
To fix this, we backported the invalidation logic from `main "but in a very simple and surgical way which fits the `release/3.5 'branch':
1. Inside SharedDomains. Unwind; we check if StateCache is active and just call Clear() on it. Unwinds are very rare, so clearing the cache is totally safe and makes sure that we don't propagate any dirty state.
2. The core protocol behaviour is unchanged. Database writes, in-memory overlay structures, and consensus rules are all the same. We are just purging the in-memory cache on execution unwinds.

#### Experiments
Updated `TestUnwindExecutionStage_PrunesUncommittedOverlayWrite` test to wire onto the shared domains context. 
- This test now verifies that stale cache values are properly cleared when an execution unwind occurs below the reorg window and that re-execution reads correct values from the database.

#### Why we don’t need this fix in the main branch
This fix is not needed on main as it has already been fixed structurally by the following changes on main: [`5874c5edbc`](https://github.com/erigontech/erigon/commit/5874c5edbc1bf494f62408eb4654e8741c8d3350) (`execution/cache: StateCache LRU + Mode + lazy unwind (txNum,epoch)`) **PR Ref:** #21386, #21752

#### Reason
On the `main` branch we have the uniform `(txNum, epoch) "lazy invalidation" model. Each cached entry contains a transaction number and epoch number. On unwind, `main it bumps the epoch and drops the floor in a $O(1)$ scan-free operation, dropping stale entries lazily on their next`Get`. Since we don’t have this epoch-based caching infrastructure in `release/3.5`, surgically calling `Clear()` on unwind is the safest way to ensure consensus correctness here.

Closes: https://github.com/erigontech/erigon/issues/22399