### PR TITLE
rpc: implement testing_commitBlockV1

### DIFF
--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -353,6 +353,9 @@ The following table shows the current implementation status of Erigon's RPC daem
 | engine_getBlobsV2                          | Yes     | Added in Fusaka                                       |
 | engine_getBlobsV3                          | Yes     | Added with BPO3                                       |
 |                                            |         |                                                       |
+| testing_buildBlockV1                       | Yes     | Testing environments only, disabled by default        |
+| testing_commitBlockV1                      | Yes     | Testing environments only, disabled by default        |
+|                                            |         |                                                       |
 | debug_accountRange                         | Yes     |                                                       |
 | debug_accountAt                            | Yes     |                                                       |
 | debug_getBadBlocks                         | Yes     |                                                       |

--- a/execution/builder/create_block.go
+++ b/execution/builder/create_block.go
@@ -176,6 +176,9 @@ func createBlock(ctx context.Context, sd *execctx.SharedDomains, tx kv.TemporalT
 
 	header.Coinbase = coinbase.Value()
 	header.Extra = cfg.builder.BuilderConfig.ExtraData
+	if cfg.blockBuilderParameters != nil && cfg.blockBuilderParameters.ExtraData != nil {
+		header.Extra = cfg.blockBuilderParameters.ExtraData
+	}
 
 	logger.Info(fmt.Sprintf("[%s] Start building", logPrefix), "block", executionAt+1, "baseFee", header.BaseFee, "gasLimit", header.GasLimit)
 	ibs := state.New(state.NewReaderV3(sd.AsGetter(tx)))

--- a/execution/builder/parameters.go
+++ b/execution/builder/parameters.go
@@ -37,4 +37,6 @@ type Parameters struct {
 	// CustomTxnProvider overrides the block's transaction source when non-nil.
 	// nil → use the injected TxnProvider (normal mempool path)
 	CustomTxnProvider txnprovider.TxnProvider
+	// ExtraData overrides the builder's configured extra data when non-nil.
+	ExtraData []byte
 }

--- a/execution/engineapi/testing_api.go
+++ b/execution/engineapi/testing_api.go
@@ -16,7 +16,8 @@
 
 package engineapi
 
-// testing_api.go implements the testing_ RPC namespace, specifically testing_buildBlockV1.
+// testing_api.go implements the testing_ RPC namespace (testing_buildBlockV1,
+// testing_commitBlockV1).
 // Enable via --http.api=...,testing (e.g. --http.api eth,erigon,testing).
 // This namespace MUST NOT be enabled on production networks.
 
@@ -34,6 +35,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	execctx "github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/builder"
+	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/state"
@@ -54,6 +56,13 @@ type TestingAPI interface {
 	//               []   → build an empty block (mempool bypassed, no txs)
 	//               [...] → build a block containing exactly these transactions (strict nonce check)
 	BuildBlockV1(ctx context.Context, parentHash common.Hash, payloadAttributes *engine_types.PayloadAttributes, transactions *[]hexutil.Bytes, extraData *hexutil.Bytes) (*engine_types.GetPayloadResponse, error)
+
+	// CommitBlockV1 builds a block on top of the current canonical head, inserts it into the
+	// chain, and sets it as the new head — the equivalent of BuildBlockV1 followed by
+	// engine_newPayload + engine_forkchoiceUpdated in a single call. Returns the hash of the
+	// committed block. On any failure the canonical head is left unchanged.
+	// The transactions parameter follows the same semantics as BuildBlockV1.
+	CommitBlockV1(ctx context.Context, payloadAttributes *engine_types.PayloadAttributes, transactions *[]hexutil.Bytes, extraData *hexutil.Bytes) (common.Hash, error)
 }
 
 // testingImpl is the concrete implementation of TestingAPI.
@@ -159,16 +168,160 @@ func (t *testingImpl) BuildBlockV1(
 		return nil, &rpc.InvalidParamsError{Message: "unknown parent hash"}
 	}
 
+	assembled, version, err := t.assembleTestingBlock(ctx, parentHash, parentHeader, payloadAttributes, transactions, extraData, t.slotDeadline(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := assembledBlockToPayloadResponse(assembled.Block, assembled.BlockValue, version)
+	if err != nil {
+		return nil, err
+	}
+	response.ShouldOverrideBuilder = false
+
+	return response, nil
+}
+
+// CommitBlockV1 implements TestingAPI.
+func (t *testingImpl) CommitBlockV1(
+	ctx context.Context,
+	payloadAttributes *engine_types.PayloadAttributes,
+	transactions *[]hexutil.Bytes,
+	extraData *hexutil.Bytes,
+) (common.Hash, error) {
+	if payloadAttributes == nil {
+		return common.Hash{}, &rpc.InvalidParamsError{Message: "payloadAttributes must not be null"}
+	}
+
+	parentHeader := t.server.chainRW.CurrentHeader(ctx)
+	if parentHeader == nil {
+		return common.Hash{}, errors.New("no canonical head available")
+	}
+
+	// Preserve the current safe and finalized hashes: committing only advances the head.
+	_, finalizedHash, safeHash, err := t.server.chainRW.GetForkChoice(ctx)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	deadline := t.slotDeadline(ctx)
+	assembled, _, err := t.assembleTestingBlock(ctx, parentHeader.Hash(), parentHeader, payloadAttributes, transactions, extraData, deadline)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	block := assembled.Block.Block
+	blockHash := block.Hash()
+	blockNumber := block.NumberU64()
+
+	var encodedBAL []byte
+	if assembled.Block.BlockAccessList != nil {
+		if encodedBAL, err = types.EncodeBlockAccessListBytes(assembled.Block.BlockAccessList); err != nil {
+			return common.Hash{}, err
+		}
+	}
+
+	t.server.lock.Lock()
+	err = t.server.chainRW.InsertBlock(ctx, block, encodedBAL)
+	t.server.lock.Unlock()
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	status, validationErr, busy, err := t.lockedStatusPoll(deadline, func() (execmodule.ExecutionStatus, *string, error) {
+		s, v, _, err := t.server.chainRW.ValidateChain(ctx, blockHash, blockNumber)
+		return s, v, err
+	})
+	if err != nil {
+		return common.Hash{}, err
+	}
+	if busy {
+		return common.Hash{}, errors.New("execution service is busy, cannot validate block")
+	}
+	if status != execmodule.ExecutionStatusSuccess {
+		return common.Hash{}, commitStatusError("block validation failed", status, validationErr)
+	}
+
+	status, validationErr, busy, err = t.lockedStatusPoll(deadline, func() (execmodule.ExecutionStatus, *string, error) {
+		s, v, _, err := t.server.chainRW.UpdateForkChoice(ctx, blockHash, safeHash, finalizedHash)
+		return s, v, err
+	})
+	if err != nil {
+		return common.Hash{}, err
+	}
+	if busy {
+		return common.Hash{}, errors.New("execution service is busy, cannot update fork choice")
+	}
+	switch status {
+	case execmodule.ExecutionStatusSuccess:
+	case execmodule.ExecutionStatusInvalidForkchoice:
+		return common.Hash{}, &engine_helpers.InvalidForkchoiceStateErr
+	case execmodule.ExecutionStatusReorgTooDeep:
+		return common.Hash{}, &engine_helpers.ReorgTooDeepErr
+	default:
+		return common.Hash{}, commitStatusError("fork choice update failed", status, validationErr)
+	}
+
+	return blockHash, nil
+}
+
+// lockedStatusPoll runs call under the engine lock, retrying while the execution
+// service reports busy, until the deadline expires.
+func (t *testingImpl) lockedStatusPoll(deadline time.Time, call func() (execmodule.ExecutionStatus, *string, error)) (status execmodule.ExecutionStatus, validationErr *string, busy bool, err error) {
+	t.server.lock.Lock()
+	defer t.server.lock.Unlock()
+	busy, err = waitForResponse(time.Until(deadline), func() (bool, error) {
+		var callErr error
+		status, validationErr, callErr = call()
+		if callErr != nil {
+			return false, callErr
+		}
+		return status == execmodule.ExecutionStatusBusy, nil
+	})
+	return status, validationErr, busy, err
+}
+
+func commitStatusError(what string, status execmodule.ExecutionStatus, validationErr *string) error {
+	msg := fmt.Sprintf("%s: %s", what, status)
+	if validationErr != nil {
+		msg = fmt.Sprintf("%s: %s", msg, *validationErr)
+	}
+	return &rpc.CustomError{Code: rpc.ErrCodeDefault, Message: msg}
+}
+
+// slotDeadline bounds the total wall-clock time of a testing_ call to one slot
+// (e.g. 12 s), honouring a shorter caller-supplied context deadline.
+func (t *testingImpl) slotDeadline(ctx context.Context) time.Time {
+	deadline := time.Now().Add(time.Duration(t.server.config.SecondsPerSlot()) * time.Second)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	return deadline
+}
+
+// assembleTestingBlock validates the payload attributes against the given parent and
+// synchronously assembles a block on top of it. Each build step acquires the engine
+// lock independently, matching production behaviour where ForkChoiceUpdated and
+// GetPayload are separate RPC calls; both share the supplied deadline.
+func (t *testingImpl) assembleTestingBlock(
+	ctx context.Context,
+	parentHash common.Hash,
+	parentHeader *types.Header,
+	payloadAttributes *engine_types.PayloadAttributes,
+	transactions *[]hexutil.Bytes,
+	extraData *hexutil.Bytes,
+	deadline time.Time,
+) (*execmodule.AssembledBlockResult, clparams.StateVersion, error) {
 	timestamp := uint64(payloadAttributes.Timestamp)
 
 	// Timestamp must be strictly greater than parent.
 	if parentHeader.Time >= timestamp {
-		return nil, &rpc.InvalidParamsError{Message: "payload timestamp must be greater than parent block timestamp"}
+		return nil, 0, &rpc.InvalidParamsError{Message: "payload timestamp must be greater than parent block timestamp"}
 	}
 
 	// Validate withdrawals presence.
 	if err := t.server.checkWithdrawalsPresence(timestamp, payloadAttributes.Withdrawals); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// Determine version from timestamp for proper fork handling.
@@ -188,31 +341,31 @@ func (t *testingImpl) BuildBlockV1(
 
 	// Validate parentBeaconBlockRoot presence for Cancun+.
 	if version >= clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot == nil {
-		return nil, &rpc.InvalidParamsError{Message: "parentBeaconBlockRoot required for Cancun and later forks"}
+		return nil, 0, &rpc.InvalidParamsError{Message: "parentBeaconBlockRoot required for Cancun and later forks"}
 	}
 	if version < clparams.DenebVersion && payloadAttributes.ParentBeaconBlockRoot != nil {
-		return nil, &rpc.InvalidParamsError{Message: "parentBeaconBlockRoot not supported before Cancun"}
+		return nil, 0, &rpc.InvalidParamsError{Message: "parentBeaconBlockRoot not supported before Cancun"}
 	}
 
 	// Validate slotNumber presence for Glamsterdam+.
 	if version >= clparams.GloasVersion && payloadAttributes.SlotNumber == nil {
-		return nil, &rpc.InvalidParamsError{Message: "slotNumber required for Glamsterdam and later forks"}
+		return nil, 0, &rpc.InvalidParamsError{Message: "slotNumber required for Glamsterdam and later forks"}
 	}
 	if version < clparams.GloasVersion && payloadAttributes.SlotNumber != nil {
-		return nil, &rpc.InvalidParamsError{Message: "slotNumber not supported before Glamsterdam"}
+		return nil, 0, &rpc.InvalidParamsError{Message: "slotNumber not supported before Glamsterdam"}
 	}
 
 	// Validate targetGasLimit presence for Glamsterdam+.
 	if version >= clparams.GloasVersion && payloadAttributes.TargetGasLimit == nil {
-		return nil, &rpc.InvalidParamsError{Message: "targetGasLimit required for Glamsterdam and later forks"}
+		return nil, 0, &rpc.InvalidParamsError{Message: "targetGasLimit required for Glamsterdam and later forks"}
 	}
 	if version < clparams.GloasVersion && payloadAttributes.TargetGasLimit != nil {
-		return nil, &rpc.InvalidParamsError{Message: "targetGasLimit not supported before Glamsterdam"}
+		return nil, 0, &rpc.InvalidParamsError{Message: "targetGasLimit not supported before Glamsterdam"}
 	}
 
 	customProvider, err := t.decodeTxnProvider(ctx, transactions, parentHeader.Number.Uint64()+1, timestamp)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// Build the AssembleBlock parameters (mirrors forkchoiceUpdated logic).
@@ -223,6 +376,9 @@ func (t *testingImpl) BuildBlockV1(
 		SuggestedFeeRecipient: payloadAttributes.SuggestedFeeRecipient,
 		CustomTxnProvider:     customProvider,
 	}
+	if extraData != nil {
+		assembleParams.ExtraData = *extraData
+	}
 	if version >= clparams.CapellaVersion {
 		assembleParams.Withdrawals = payloadAttributes.Withdrawals
 	}
@@ -232,16 +388,6 @@ func (t *testingImpl) BuildBlockV1(
 	if version >= clparams.GloasVersion {
 		assembleParams.SlotNumber = (*uint64)(payloadAttributes.SlotNumber)
 		assembleParams.TargetGasLimit = (*uint64)(payloadAttributes.TargetGasLimit)
-	}
-
-	// Both steps share a single slot-duration budget so the total wall-clock
-	// time of BuildBlockV1 is bounded to one slot (e.g. 12 s), not two.
-	// Each step acquires the lock independently, matching production behaviour
-	// where ForkChoiceUpdated and GetPayload are separate RPC calls.
-	// If the caller already set a context deadline shorter than one slot, honour it.
-	deadline := time.Now().Add(time.Duration(t.server.config.SecondsPerSlot()) * time.Second)
-	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
-		deadline = ctxDeadline
 	}
 
 	var payloadID uint64
@@ -262,10 +408,10 @@ func (t *testingImpl) BuildBlockV1(
 		return busy, err
 	}()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if execBusy {
-		return nil, errors.New("execution service is busy, cannot build block")
+		return nil, 0, errors.New("execution service is busy, cannot build block")
 	}
 
 	var assembled execmodule.AssembledBlockResult
@@ -284,28 +430,16 @@ func (t *testingImpl) BuildBlockV1(
 		return busy, err
 	}()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if execBusy {
-		return nil, errors.New("execution service is busy retrieving assembled block")
+		return nil, 0, errors.New("execution service is busy retrieving assembled block")
 	}
 	if assembled.Block == nil {
-		return nil, errors.New("no assembled block data available for payload ID")
+		return nil, 0, errors.New("no assembled block data available for payload ID")
 	}
 
-	response, err := assembledBlockToPayloadResponse(assembled.Block, assembled.BlockValue, version)
-	if err != nil {
-		return nil, err
-	}
-	response.ShouldOverrideBuilder = false
-	if extraData != nil {
-		h := types.CopyHeader(assembled.Block.Block.Header())
-		h.Extra = *extraData
-		response.ExecutionPayload.ExtraData = *extraData
-		response.ExecutionPayload.BlockHash = h.Hash()
-	}
-
-	return response, nil
+	return &assembled, version, nil
 }
 
 // staticTxnProvider is a TxnProvider that yields a fixed transaction list exactly once,

--- a/execution/engineapi/testing_api.go
+++ b/execution/engineapi/testing_api.go
@@ -38,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/execmodule"
+	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -60,7 +61,10 @@ type TestingAPI interface {
 	// CommitBlockV1 builds a block on top of the current canonical head, inserts it into the
 	// chain, and sets it as the new head — the equivalent of BuildBlockV1 followed by
 	// engine_newPayload + engine_forkchoiceUpdated in a single call. Returns the hash of the
-	// committed block. On any failure the canonical head is left unchanged.
+	// committed block. On any failure the canonical head is left unchanged, with one
+	// exception: the fork choice update runs asynchronously in the execution module, so a
+	// busy error returned when the slot budget expires mid fork choice does not stop the
+	// head from advancing afterwards.
 	// The transactions parameter follows the same semantics as BuildBlockV1.
 	CommitBlockV1(ctx context.Context, payloadAttributes *engine_types.PayloadAttributes, transactions *[]hexutil.Bytes, extraData *hexutil.Bytes) (common.Hash, error)
 }
@@ -89,12 +93,12 @@ func (t *testingImpl) decodeTxnProvider(ctx context.Context, transactions *[]hex
 	if t.db != nil {
 		dbTx, err := t.db.BeginTemporalRo(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("testing_buildBlockV1: could not begin temporal transaction: %w", err)
+			return nil, fmt.Errorf("could not begin temporal transaction: %w", err)
 		}
 		defer dbTx.Rollback()
 		sd, err := execctx.NewSharedDomains(ctx, dbTx, t.logger, execctx.WithoutDeferredBranchUpdates())
 		if err != nil {
-			return nil, fmt.Errorf("testing_buildBlockV1: NewSharedDomains error: %w", err)
+			return nil, fmt.Errorf("NewSharedDomains error: %w", err)
 		}
 		defer sd.Close()
 		reader = state.NewReaderV3(sd.AsGetter(dbTx))
@@ -118,7 +122,7 @@ func (t *testingImpl) decodeTxnProvider(ctx context.Context, transactions *[]hex
 			if reader != nil {
 				acc, err := reader.ReadAccountData(accounts.InternAddress(sender.Value()))
 				if err != nil {
-					return nil, fmt.Errorf("testing_buildBlockV1: ReadAccountData error: %w", err)
+					return nil, fmt.Errorf("ReadAccountData error: %w", err)
 				}
 				if acc != nil {
 					stateNonce = acc.Nonce
@@ -193,6 +197,8 @@ func (t *testingImpl) CommitBlockV1(
 		return common.Hash{}, &rpc.InvalidParamsError{Message: "payloadAttributes must not be null"}
 	}
 
+	deadline := t.slotDeadline(ctx)
+
 	parentHeader := t.server.chainRW.CurrentHeader(ctx)
 	if parentHeader == nil {
 		return common.Hash{}, errors.New("no canonical head available")
@@ -204,7 +210,6 @@ func (t *testingImpl) CommitBlockV1(
 		return common.Hash{}, err
 	}
 
-	deadline := t.slotDeadline(ctx)
 	assembled, _, err := t.assembleTestingBlock(ctx, parentHeader.Hash(), parentHeader, payloadAttributes, transactions, extraData, deadline)
 	if err != nil {
 		return common.Hash{}, err
@@ -221,9 +226,11 @@ func (t *testingImpl) CommitBlockV1(
 		}
 	}
 
-	t.server.lock.Lock()
-	err = t.server.chainRW.InsertBlock(ctx, block, encodedBAL)
-	t.server.lock.Unlock()
+	err = func() error {
+		t.server.lock.Lock()
+		defer t.server.lock.Unlock()
+		return t.server.chainRW.InsertBlock(ctx, block, encodedBAL)
+	}()
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -319,6 +326,10 @@ func (t *testingImpl) assembleTestingBlock(
 		return nil, 0, &rpc.InvalidParamsError{Message: "payload timestamp must be greater than parent block timestamp"}
 	}
 
+	if extraData != nil && uint64(len(*extraData)) > params.MaximumExtraDataSize {
+		return nil, 0, &rpc.InvalidParamsError{Message: fmt.Sprintf("extraData longer than %d bytes (%d)", params.MaximumExtraDataSize, len(*extraData))}
+	}
+
 	// Validate withdrawals presence.
 	if err := t.server.checkWithdrawalsPresence(timestamp, payloadAttributes.Withdrawals); err != nil {
 		return nil, 0, err
@@ -369,12 +380,15 @@ func (t *testingImpl) assembleTestingBlock(
 	}
 
 	// Build the AssembleBlock parameters (mirrors forkchoiceUpdated logic).
+	// ExtraData always overrides the builder's configured default (which varies by
+	// erigon version) to keep testing_ block hashes deterministic, matching geth.
 	assembleParams := &builder.Parameters{
 		ParentHash:            parentHash,
 		Timestamp:             timestamp,
 		PrevRandao:            payloadAttributes.PrevRandao,
 		SuggestedFeeRecipient: payloadAttributes.SuggestedFeeRecipient,
 		CustomTxnProvider:     customProvider,
+		ExtraData:             []byte{},
 	}
 	if extraData != nil {
 		assembleParams.ExtraData = *extraData

--- a/execution/engineapi/testing_api_commit_test.go
+++ b/execution/engineapi/testing_api_commit_test.go
@@ -1,0 +1,455 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engineapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/builder"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/rpc"
+)
+
+// commitRecorder captures the chain mutations performed by CommitBlockV1 so
+// tests can assert on what was inserted and which fork choice was applied.
+type commitRecorder struct {
+	inserted  []*types.RawBlock
+	validated []common.Hash
+	fcuCalled bool
+	fcuHead   common.Hash
+	fcuSafe   common.Hash
+	fcuFinal  common.Hash
+
+	// stub responses
+	safeHash    common.Hash
+	finalHash   common.Hash
+	validateRes execmodule.ValidationResult
+	fcuRes      execmodule.ForkChoiceResult
+	insertRes   execmodule.ExecutionStatus
+	insertErr   error
+}
+
+// newCommitStub wires a stubExecutionModule for the full CommitBlockV1 flow:
+// current head lookup, block assembly, insertion, validation and fork choice.
+func newCommitStub(parentHdr *types.Header, assembled *types.BlockWithReceipts, rec *commitRecorder) *stubExecutionModule {
+	return &stubExecutionModule{
+		currentHeaderFunc: func(_ context.Context) (*types.Header, error) {
+			return parentHdr, nil
+		},
+		assembleBlockFunc: func(_ context.Context, _ *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+			return execmodule.AssembleBlockResult{PayloadID: 7, Busy: false}, nil
+		},
+		getAssembledBlockFunc: func(_ context.Context, _ uint64) (execmodule.AssembledBlockResult, error) {
+			return execmodule.AssembledBlockResult{Block: assembled, BlockValue: uint256.NewInt(0), Busy: false}, nil
+		},
+		insertBlocksFunc: func(_ context.Context, blocks []*types.RawBlock) (execmodule.ExecutionStatus, error) {
+			rec.inserted = append(rec.inserted, blocks...)
+			return rec.insertRes, rec.insertErr
+		},
+		validateChainFunc: func(_ context.Context, hash common.Hash, _ uint64) (execmodule.ValidationResult, error) {
+			rec.validated = append(rec.validated, hash)
+			return rec.validateRes, nil
+		},
+		getForkChoiceFunc: func(_ context.Context) (execmodule.ForkChoiceState, error) {
+			return execmodule.ForkChoiceState{
+				HeadHash:      parentHdr.Hash(),
+				SafeHash:      rec.safeHash,
+				FinalizedHash: rec.finalHash,
+			}, nil
+		},
+		updateForkChoiceFunc: func(_ context.Context, head, safe, finalized common.Hash) (execmodule.ForkChoiceResult, error) {
+			rec.fcuCalled = true
+			rec.fcuHead = head
+			rec.fcuSafe = safe
+			rec.fcuFinal = finalized
+			return rec.fcuRes, nil
+		},
+	}
+}
+
+func successRecorder() *commitRecorder {
+	return &commitRecorder{
+		safeHash:    common.Hash{0x5a},
+		finalHash:   common.Hash{0xf1},
+		validateRes: execmodule.ValidationResult{ValidationStatus: execmodule.ExecutionStatusSuccess},
+		fcuRes:      execmodule.ForkChoiceResult{Status: execmodule.ExecutionStatusSuccess},
+		insertRes:   execmodule.ExecutionStatusSuccess,
+	}
+}
+
+func TestCommitBlockV1(t *testing.T) {
+	t.Parallel()
+
+	const parentTimestamp = 1000
+	parentHdr := makeParentHeader(parentTimestamp)
+	parentHash := parentHdr.Hash()
+	blockHash := common.HexToHash("0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+
+	defaultAssembled := func() *types.BlockWithReceipts {
+		return makeAssembledBlock(blockHash, parentHash, common.Hash{0xcc}, 101, parentTimestamp+1, nil, 30_000_000, 0, 0, 0)
+	}
+	// newEnv wires the default happy-path stack; tests mutate the returned
+	// recorder or stub before calling CommitBlockV1 to vary behaviour.
+	newEnv := func(assembled *types.BlockWithReceipts) (TestingAPI, *commitRecorder, *stubExecutionModule) {
+		rec := successRecorder()
+		stub := newCommitStub(parentHdr, assembled, rec)
+		return newTestingAPI(allForksChainConfig(), stub), rec, stub
+	}
+
+	t.Run("nil payloadAttributes", func(t *testing.T) {
+		t.Parallel()
+		api := newTestingAPI(allForksChainConfig(), &stubExecutionModule{})
+		hash, err := api.CommitBlockV1(context.Background(), nil, nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		var rpcErr *rpc.InvalidParamsError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Contains(t, rpcErr.Message, "payloadAttributes must not be null")
+	})
+
+	t.Run("no canonical head", func(t *testing.T) {
+		t.Parallel()
+		// Default stub CurrentHeader returns nil.
+		api := newTestingAPI(allForksChainConfig(), &stubExecutionModule{})
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		assert.Contains(t, err.Error(), "no canonical head")
+	})
+
+	t.Run("timestamp not greater than head", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(nil)
+		attrs := validPayloadAttrs(parentTimestamp)
+		attrs.Timestamp = hexutil.Uint64(parentTimestamp)
+		hash, err := api.CommitBlockV1(context.Background(), attrs, nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		var rpcErr *rpc.InvalidParamsError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Contains(t, rpcErr.Message, "payload timestamp must be greater than parent")
+		assert.Empty(t, rec.inserted)
+		assert.False(t, rec.fcuCalled)
+	})
+
+	t.Run("invalid transaction bytes", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(nil)
+		txs := []hexutil.Bytes{{0x01, 0x02}}
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), &txs, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		var rpcErr *rpc.InvalidParamsError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Contains(t, rpcErr.Message, "decode error")
+		assert.Empty(t, rec.inserted)
+		assert.False(t, rec.fcuCalled)
+	})
+
+	t.Run("happy path commits block and sets head", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(defaultAssembled())
+
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, blockHash, hash)
+
+		require.Len(t, rec.inserted, 1)
+		require.Equal(t, []common.Hash{blockHash}, rec.validated)
+		require.True(t, rec.fcuCalled)
+		assert.Equal(t, blockHash, rec.fcuHead)
+		assert.Equal(t, rec.safeHash, rec.fcuSafe, "safe hash must be preserved")
+		assert.Equal(t, rec.finalHash, rec.fcuFinal, "finalized hash must be preserved")
+	})
+
+	t.Run("extraData forwarded to the block builder", func(t *testing.T) {
+		t.Parallel()
+		api, rec, stub := newEnv(defaultAssembled())
+		var captured *builder.Parameters
+		stub.assembleBlockFunc = func(_ context.Context, params *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+			captured = params
+			return execmodule.AssembleBlockResult{PayloadID: 7, Busy: false}, nil
+		}
+
+		override := hexutil.Bytes("overridden-extra")
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, &override)
+		require.NoError(t, err)
+		assert.Equal(t, blockHash, hash)
+		require.NotNil(t, captured)
+		assert.Equal(t, []byte("overridden-extra"), captured.ExtraData)
+		require.True(t, rec.fcuCalled)
+		assert.Equal(t, blockHash, rec.fcuHead)
+	})
+
+	t.Run("insert failure leaves head untouched", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(defaultAssembled())
+		rec.insertRes = execmodule.ExecutionStatusBadBlock
+
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		assert.Empty(t, rec.validated)
+		assert.False(t, rec.fcuCalled)
+	})
+
+	t.Run("insert error leaves head untouched", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(defaultAssembled())
+		rec.insertErr = errors.New("disk full")
+
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		assert.False(t, rec.fcuCalled)
+	})
+
+	t.Run("bad block on validation leaves head untouched", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(defaultAssembled())
+		rec.validateRes = execmodule.ValidationResult{
+			ValidationStatus: execmodule.ExecutionStatusBadBlock,
+			ValidationError:  "intrinsic gas too low",
+		}
+
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		var rpcErr *rpc.CustomError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Equal(t, rpc.ErrCodeDefault, rpcErr.Code)
+		assert.Contains(t, rpcErr.Message, "intrinsic gas too low")
+		assert.False(t, rec.fcuCalled, "fork choice must not run after a bad block")
+	})
+
+	t.Run("invalid fork choice returns engine error code", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(defaultAssembled())
+		rec.fcuRes = execmodule.ForkChoiceResult{Status: execmodule.ExecutionStatusInvalidForkchoice}
+
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		require.Equal(t, -38002, err.(rpc.Error).ErrorCode())
+	})
+
+	t.Run("reorg too deep returns engine error code", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(defaultAssembled())
+		rec.fcuRes = execmodule.ForkChoiceResult{Status: execmodule.ExecutionStatusReorgTooDeep}
+
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		require.Equal(t, -38006, err.(rpc.Error).ErrorCode())
+	})
+
+	t.Run("bad block on fork choice returns error", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(defaultAssembled())
+		rec.fcuRes = execmodule.ForkChoiceResult{
+			Status:          execmodule.ExecutionStatusBadBlock,
+			ValidationError: "invalid chain after execution",
+		}
+
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		var rpcErr *rpc.CustomError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Equal(t, rpc.ErrCodeDefault, rpcErr.Code)
+		assert.Contains(t, rpcErr.Message, "invalid chain after execution")
+	})
+
+	t.Run("nil transactions uses mempool", func(t *testing.T) {
+		t.Parallel()
+		api, _, stub := newEnv(defaultAssembled())
+		var captured *builder.Parameters
+		stub.assembleBlockFunc = func(_ context.Context, params *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+			captured = params
+			return execmodule.AssembleBlockResult{PayloadID: 7, Busy: false}, nil
+		}
+
+		_, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, captured)
+		assert.Nil(t, captured.CustomTxnProvider, "nil transactions must draw from the mempool")
+	})
+
+	t.Run("nonce too high rejected before insertion", func(t *testing.T) {
+		t.Parallel()
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		// State nonce is 0 (no DB in tests), tx nonce 1 → too high.
+		rawTx := makeSignedRawTx(t, key, allForksChainConfig(), 1, 101, parentTimestamp+1)
+		api, rec, _ := newEnv(nil)
+
+		txs := []hexutil.Bytes{rawTx}
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), &txs, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		var rpcErr *rpc.CustomError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Contains(t, rpcErr.Message, "nonce too high")
+		assert.Empty(t, rec.inserted)
+		assert.False(t, rec.fcuCalled)
+	})
+
+	t.Run("missing parentBeaconBlockRoot for Cancun+", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(nil)
+		attrs := validPayloadAttrs(parentTimestamp)
+		attrs.ParentBeaconBlockRoot = nil
+		hash, err := api.CommitBlockV1(context.Background(), attrs, nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		var rpcErr *rpc.InvalidParamsError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Contains(t, rpcErr.Message, "parentBeaconBlockRoot required for Cancun")
+		assert.Empty(t, rec.inserted)
+	})
+
+	t.Run("missing withdrawals for Shanghai", func(t *testing.T) {
+		t.Parallel()
+		rec := successRecorder()
+		stub := newCommitStub(parentHdr, nil, rec)
+		api := newTestingAPI(preCancunChainConfig(), stub)
+		attrs := &engine_types.PayloadAttributes{
+			Timestamp:             hexutil.Uint64(parentTimestamp + 1),
+			PrevRandao:            common.Hash{0xaa},
+			SuggestedFeeRecipient: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+			Withdrawals:           nil,
+		}
+		hash, err := api.CommitBlockV1(context.Background(), attrs, nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		var rpcErr *rpc.InvalidParamsError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Contains(t, rpcErr.Message, "missing withdrawals")
+		assert.Empty(t, rec.inserted)
+	})
+
+	t.Run("no assembled block data", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(nil) // getAssembledBlock returns nil block
+
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		assert.Contains(t, err.Error(), "no assembled block data")
+		assert.Empty(t, rec.inserted)
+		assert.False(t, rec.fcuCalled)
+	})
+
+	t.Run("block access list propagated to insertion", func(t *testing.T) {
+		t.Parallel()
+		assembled := defaultAssembled()
+		assembled.BlockAccessList = types.BlockAccessList{}
+		api, rec, _ := newEnv(assembled)
+
+		_, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.NoError(t, err)
+		require.Len(t, rec.inserted, 1)
+		assert.NotEmpty(t, rec.inserted[0].BlockAccessList, "encoded BAL must reach the inserted raw block")
+	})
+
+	t.Run("busy on validation returns error without fork choice", func(t *testing.T) {
+		t.Parallel()
+		api, rec, stub := newEnv(defaultAssembled())
+		stub.validateChainFunc = func(_ context.Context, _ common.Hash, _ uint64) (execmodule.ValidationResult, error) {
+			return execmodule.ValidationResult{ValidationStatus: execmodule.ExecutionStatusBusy}, nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		hash, err := api.CommitBlockV1(ctx, validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		assert.Contains(t, err.Error(), "busy, cannot validate block")
+		assert.False(t, rec.fcuCalled)
+	})
+
+	t.Run("busy on fork choice returns error", func(t *testing.T) {
+		t.Parallel()
+		api, _, stub := newEnv(defaultAssembled())
+		stub.updateForkChoiceFunc = func(_ context.Context, _, _, _ common.Hash) (execmodule.ForkChoiceResult, error) {
+			return execmodule.ForkChoiceResult{Status: execmodule.ExecutionStatusBusy}, nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		hash, err := api.CommitBlockV1(ctx, validPayloadAttrs(parentTimestamp), nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		assert.Contains(t, err.Error(), "busy, cannot update fork choice")
+	})
+
+	t.Run("valid transaction list is committed", func(t *testing.T) {
+		t.Parallel()
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		cfg := allForksChainConfig()
+		rawTx0 := makeSignedRawTx(t, key, cfg, 0, 101, parentTimestamp+1)
+		rawTx1 := makeSignedRawTx(t, key, cfg, 1, 101, parentTimestamp+1)
+		api, rec, stub := newEnv(defaultAssembled())
+		var captured *builder.Parameters
+		stub.assembleBlockFunc = func(_ context.Context, params *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+			captured = params
+			return execmodule.AssembleBlockResult{PayloadID: 7, Busy: false}, nil
+		}
+
+		txs := []hexutil.Bytes{rawTx0, rawTx1}
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), &txs, nil)
+		require.NoError(t, err)
+		assert.Equal(t, blockHash, hash)
+		require.NotNil(t, captured)
+		require.NotNil(t, captured.CustomTxnProvider)
+		provided, err := captured.CustomTxnProvider.ProvideTxns(context.Background())
+		require.NoError(t, err)
+		assert.Len(t, provided, 2)
+		require.True(t, rec.fcuCalled)
+	})
+
+	t.Run("empty transaction list builds empty block via custom provider", func(t *testing.T) {
+		t.Parallel()
+		api, _, stub := newEnv(defaultAssembled())
+		var captured *builder.Parameters
+		stub.assembleBlockFunc = func(_ context.Context, params *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+			captured = params
+			return execmodule.AssembleBlockResult{PayloadID: 7, Busy: false}, nil
+		}
+
+		txs := []hexutil.Bytes{}
+		_, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), &txs, nil)
+		require.NoError(t, err)
+		require.NotNil(t, captured)
+		assert.NotNil(t, captured.CustomTxnProvider, "empty tx list must bypass the mempool")
+		assert.Equal(t, parentHash, captured.ParentHash, "block must be built on the canonical head")
+	})
+}

--- a/execution/engineapi/testing_api_commit_test.go
+++ b/execution/engineapi/testing_api_commit_test.go
@@ -172,6 +172,20 @@ func TestCommitBlockV1(t *testing.T) {
 		assert.False(t, rec.fcuCalled)
 	})
 
+	t.Run("extraData longer than 32 bytes", func(t *testing.T) {
+		t.Parallel()
+		api, rec, _ := newEnv(defaultAssembled())
+		tooLong := hexutil.Bytes(make([]byte, 33))
+		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, &tooLong)
+		require.Error(t, err)
+		assert.Equal(t, common.Hash{}, hash)
+		var rpcErr *rpc.InvalidParamsError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Contains(t, rpcErr.Message, "extraData")
+		assert.Empty(t, rec.inserted)
+		assert.False(t, rec.fcuCalled)
+	})
+
 	t.Run("happy path commits block and sets head", func(t *testing.T) {
 		t.Parallel()
 		api, rec, _ := newEnv(defaultAssembled())
@@ -205,6 +219,22 @@ func TestCommitBlockV1(t *testing.T) {
 		assert.Equal(t, []byte("overridden-extra"), captured.ExtraData)
 		require.True(t, rec.fcuCalled)
 		assert.Equal(t, blockHash, rec.fcuHead)
+	})
+
+	t.Run("nil extraData builds with empty extra data", func(t *testing.T) {
+		t.Parallel()
+		api, _, stub := newEnv(defaultAssembled())
+		var captured *builder.Parameters
+		stub.assembleBlockFunc = func(_ context.Context, params *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+			captured = params
+			return execmodule.AssembleBlockResult{PayloadID: 7, Busy: false}, nil
+		}
+
+		_, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, captured)
+		require.NotNil(t, captured.ExtraData, "nil extraData must force empty extra data, not the builder's configured default")
+		assert.Empty(t, captured.ExtraData)
 	})
 
 	t.Run("insert failure leaves head untouched", func(t *testing.T) {
@@ -256,7 +286,9 @@ func TestCommitBlockV1(t *testing.T) {
 		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Error(t, err)
 		assert.Equal(t, common.Hash{}, hash)
-		require.Equal(t, -38002, err.(rpc.Error).ErrorCode())
+		var rpcErr rpc.Error
+		require.ErrorAs(t, err, &rpcErr)
+		require.Equal(t, -38002, rpcErr.ErrorCode())
 	})
 
 	t.Run("reorg too deep returns engine error code", func(t *testing.T) {
@@ -267,7 +299,9 @@ func TestCommitBlockV1(t *testing.T) {
 		hash, err := api.CommitBlockV1(context.Background(), validPayloadAttrs(parentTimestamp), nil, nil)
 		require.Error(t, err)
 		assert.Equal(t, common.Hash{}, hash)
-		require.Equal(t, -38006, err.(rpc.Error).ErrorCode())
+		var rpcErr rpc.Error
+		require.ErrorAs(t, err, &rpcErr)
+		require.Equal(t, -38006, rpcErr.ErrorCode())
 	})
 
 	t.Run("bad block on fork choice returns error", func(t *testing.T) {

--- a/execution/engineapi/testing_api_test.go
+++ b/execution/engineapi/testing_api_test.go
@@ -54,6 +54,10 @@ type stubExecutionModule struct {
 	assembleBlockFunc     func(ctx context.Context, params *builder.Parameters) (execmodule.AssembleBlockResult, error)
 	getAssembledBlockFunc func(ctx context.Context, payloadID uint64) (execmodule.AssembledBlockResult, error)
 	getForkChoiceFunc     func(ctx context.Context) (execmodule.ForkChoiceState, error)
+	currentHeaderFunc     func(ctx context.Context) (*types.Header, error)
+	insertBlocksFunc      func(ctx context.Context, blocks []*types.RawBlock) (execmodule.ExecutionStatus, error)
+	validateChainFunc     func(ctx context.Context, blockHash common.Hash, blockNumber uint64) (execmodule.ValidationResult, error)
+	updateForkChoiceFunc  func(ctx context.Context, headHash, safeHash, finalizedHash common.Hash) (execmodule.ForkChoiceResult, error)
 }
 
 var _ execmodule.ExecutionModule = (*stubExecutionModule)(nil)
@@ -81,13 +85,22 @@ func (s *stubExecutionModule) GetAssembledBlock(ctx context.Context, payloadID u
 
 // --- No-op implementations for the rest of the interface ---
 
-func (s *stubExecutionModule) InsertBlocks(_ context.Context, _ []*types.RawBlock) (execmodule.ExecutionStatus, error) {
+func (s *stubExecutionModule) InsertBlocks(ctx context.Context, blocks []*types.RawBlock) (execmodule.ExecutionStatus, error) {
+	if s.insertBlocksFunc != nil {
+		return s.insertBlocksFunc(ctx, blocks)
+	}
 	return execmodule.ExecutionStatusSuccess, nil
 }
-func (s *stubExecutionModule) ValidateChain(_ context.Context, _ common.Hash, _ uint64) (execmodule.ValidationResult, error) {
+func (s *stubExecutionModule) ValidateChain(ctx context.Context, blockHash common.Hash, blockNumber uint64) (execmodule.ValidationResult, error) {
+	if s.validateChainFunc != nil {
+		return s.validateChainFunc(ctx, blockHash, blockNumber)
+	}
 	return execmodule.ValidationResult{}, nil
 }
-func (s *stubExecutionModule) UpdateForkChoice(_ context.Context, _, _, _ common.Hash) (execmodule.ForkChoiceResult, error) {
+func (s *stubExecutionModule) UpdateForkChoice(ctx context.Context, headHash, safeHash, finalizedHash common.Hash) (execmodule.ForkChoiceResult, error) {
+	if s.updateForkChoiceFunc != nil {
+		return s.updateForkChoiceFunc(ctx, headHash, safeHash, finalizedHash)
+	}
 	return execmodule.ForkChoiceResult{}, nil
 }
 func (s *stubExecutionModule) GetForkChoice(ctx context.Context) (execmodule.ForkChoiceState, error) {
@@ -96,7 +109,10 @@ func (s *stubExecutionModule) GetForkChoice(ctx context.Context) (execmodule.For
 	}
 	return execmodule.ForkChoiceState{}, nil
 }
-func (s *stubExecutionModule) CurrentHeader(_ context.Context) (*types.Header, error) {
+func (s *stubExecutionModule) CurrentHeader(ctx context.Context) (*types.Header, error) {
+	if s.currentHeaderFunc != nil {
+		return s.currentHeaderFunc(ctx)
+	}
 	return nil, nil
 }
 func (s *stubExecutionModule) GetBody(_ context.Context, _ *common.Hash, _ *uint64) (*types.RawBody, error) {
@@ -615,15 +631,17 @@ func TestBuildBlockV1(t *testing.T) {
 		assert.Equal(t, "12345", resp.BlockValue.ToInt().String())
 	})
 
-	t.Run("happy path with extraData override", func(t *testing.T) {
+	t.Run("extraData forwarded to the block builder", func(t *testing.T) {
 		t.Parallel()
+		var captured *builder.Parameters
 		stub := &stubExecutionModule{
 			getHeaderFunc: getHeaderReturning(parentHash, parentHdr),
-			assembleBlockFunc: func(_ context.Context, _ *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+			assembleBlockFunc: func(_ context.Context, params *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+				captured = params
 				return execmodule.AssembleBlockResult{PayloadID: 1, Busy: false}, nil
 			},
 			getAssembledBlockFunc: func(_ context.Context, _ uint64) (execmodule.AssembledBlockResult, error) {
-				blk := makeAssembledBlock(common.Hash{0x01}, parentHash, common.Hash{}, 101, parentTimestamp+1, []byte("original"), 30_000_000, 0, 0, 0)
+				blk := makeAssembledBlock(common.Hash{0x01}, parentHash, common.Hash{}, 101, parentTimestamp+1, []byte("overridden-extra"), 30_000_000, 0, 0, 0)
 				return execmodule.AssembledBlockResult{
 					Block:      blk,
 					BlockValue: uint256.NewInt(0),
@@ -636,6 +654,8 @@ func TestBuildBlockV1(t *testing.T) {
 		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, &overrideData)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
+		require.NotNil(t, captured)
+		assert.Equal(t, []byte("overridden-extra"), captured.ExtraData)
 		assert.Equal(t, hexutil.Bytes("overridden-extra"), resp.ExecutionPayload.ExtraData)
 	})
 

--- a/execution/engineapi/testing_api_test.go
+++ b/execution/engineapi/testing_api_test.go
@@ -44,9 +44,10 @@ import (
 
 // ---------------------------------------------------------------------------
 // Minimal stub implementing execmodule.ExecutionModule for unit tests.
-// Only the methods called by BuildBlockV1 (GetHeader, AssembleBlock,
-// GetAssembledBlock) are wired to configurable closures; everything else
-// is a no-op that satisfies the interface.
+// The methods called by BuildBlockV1 and CommitBlockV1 (GetHeader,
+// AssembleBlock, GetAssembledBlock, CurrentHeader, InsertBlocks,
+// ValidateChain, UpdateForkChoice, GetForkChoice) are wired to configurable
+// closures; everything else is a no-op that satisfies the interface.
 // ---------------------------------------------------------------------------
 
 type stubExecutionModule struct {
@@ -433,6 +434,21 @@ func TestBuildBlockV1(t *testing.T) {
 		assert.Contains(t, rpcErr.Message, "payload timestamp must be greater than parent")
 	})
 
+	t.Run("extraData longer than 32 bytes", func(t *testing.T) {
+		t.Parallel()
+		stub := &stubExecutionModule{
+			getHeaderFunc: getHeaderReturning(parentHash, parentHdr),
+		}
+		api := newTestingAPI(allForksChainConfig(), stub)
+		tooLong := hexutil.Bytes(make([]byte, 33))
+		resp, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, &tooLong)
+		require.Nil(t, resp)
+		require.Error(t, err)
+		var rpcErr *rpc.InvalidParamsError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.Contains(t, rpcErr.Message, "extraData")
+	})
+
 	t.Run("missing parentBeaconBlockRoot for Cancun+", func(t *testing.T) {
 		t.Parallel()
 		stub := &stubExecutionModule{
@@ -657,6 +673,28 @@ func TestBuildBlockV1(t *testing.T) {
 		require.NotNil(t, captured)
 		assert.Equal(t, []byte("overridden-extra"), captured.ExtraData)
 		assert.Equal(t, hexutil.Bytes("overridden-extra"), resp.ExecutionPayload.ExtraData)
+	})
+
+	t.Run("nil extraData builds with empty extra data", func(t *testing.T) {
+		t.Parallel()
+		var captured *builder.Parameters
+		stub := &stubExecutionModule{
+			getHeaderFunc: getHeaderReturning(parentHash, parentHdr),
+			assembleBlockFunc: func(_ context.Context, params *builder.Parameters) (execmodule.AssembleBlockResult, error) {
+				captured = params
+				return execmodule.AssembleBlockResult{PayloadID: 1, Busy: false}, nil
+			},
+			getAssembledBlockFunc: func(_ context.Context, _ uint64) (execmodule.AssembledBlockResult, error) {
+				blk := makeAssembledBlock(common.Hash{0x01}, parentHash, common.Hash{}, 101, parentTimestamp+1, []byte{}, 30_000_000, 0, 0, 0)
+				return execmodule.AssembledBlockResult{Block: blk, BlockValue: uint256.NewInt(0), Busy: false}, nil
+			},
+		}
+		api := newTestingAPI(allForksChainConfig(), stub)
+		_, err := api.BuildBlockV1(context.Background(), parentHash, validPayloadAttrs(parentTimestamp), nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, captured)
+		require.NotNil(t, captured.ExtraData, "nil extraData must force empty extra data, not the builder's configured default")
+		assert.Empty(t, captured.ExtraData)
 	})
 
 	t.Run("missing withdrawals for Shanghai", func(t *testing.T) {


### PR DESCRIPTION
Closes #22392

Implements `testing_commitBlockV1`, the write companion to `testing_buildBlockV1`, in the `testing_` RPC namespace (enabled via `--http.api=...,testing`, never on production networks).

## Spec conformance

Follows the execution-apis proposal [ethereum/execution-apis#801](https://github.com/ethereum/execution-apis/pull/801):

- Parameters: `payloadAttributes` (required), `transactions` (`array | null`), `extraData` (optional) — no `parentHash`: the block is always built on top of the current canonical head, as the spec mandates ("the client MUST build a new execution payload on top of its current canonical head").
- `transactions = []` → builds an empty block (mempool bypassed); `null` → builds from the local mempool; non-empty array → exactly those transactions, in order, with a strict nonce pre-check against state.
- On success the block is inserted, validated, and set as the canonical head through the standard fork-choice path, so the same chain events fire as for any new head; safe and finalized hashes are preserved. Returns the new head's block hash.
- On any failure the canonical head is left unchanged (fork choice is the last step, structurally), with one exception: `UpdateForkChoice` runs asynchronously in the execution module, so if the slot budget expires mid fork choice the call returns a busy error but the head can still advance afterwards.
- Error codes: `-32602` invalid params (including `extraData` over 32 bytes), `-32000` for nonce/validation failures, `-38002`/`-38006` for invalid fork choice / too-deep reorg.

## Parity with go-ethereum

Mirrors geth's implementation ([ethereum/go-ethereum#34995](https://github.com/ethereum/go-ethereum/pull/34995)): same signature (`payloadAttributes, *[]hexutil.Bytes, *hexutil.Bytes` → `common.Hash`), same build → insert → set-canonical flow (erigon-native equivalent: `AssembleBlock`/`GetAssembledBlock` → `InsertBlock` → `ValidateChain` → `UpdateForkChoice`), same extraData handling through the block builder. Erigon is additionally stricter than geth: it validates timestamp > parent and pre-checks nonces, returning a clear error instead of a failed build.

As in geth, `extraData` is applied by the block builder itself: it is now a `builder.Parameters` field consumed in `create_block.go` (nil-guarded for the production engine path, which never sets it and is unchanged). This also fixes `testing_buildBlockV1`, which previously patched extraData onto its response after the fact instead of building the block with it. Within the `testing_` namespace, a `nil` `extraData` now forces empty extra data rather than falling back to the builder's configured default (which embeds the erigon version) — matching geth's testing path and keeping block hashes deterministic across erigon versions. `extraData` longer than 32 bytes is rejected up front with `-32602` instead of building and inserting an uncommittable block.

## Unit tests (TDD)

Written before the implementation (red → green). 24 sub-tests in `testing_api_commit_test.go`:

- **Validation**: nil payloadAttributes; no canonical head; timestamp not greater than head; invalid transaction bytes; nonce too high (rejected before insertion); missing parentBeaconBlockRoot for Cancun+; missing withdrawals for Shanghai; extraData longer than 32 bytes
- **Happy paths**: commit with mempool build; empty transaction list via custom provider; explicit valid transaction list (order + exclusivity via the provider); extraData forwarded to the block builder; nil extraData forces empty (deterministic) extra data; block access list propagated to insertion (Amsterdam+)
- **Head immutability on failure**: insert failure; insert error; bad block on validation (fork choice never runs); fork choice failure
- **Error codes**: `-38002` invalid fork choice; `-38006` reorg too deep; `-32000` with validation error message
- **Busy handling**: busy on validation; busy on fork choice (deadline-bounded polling)

Plus updated `BuildBlockV1` tests covering the shared assembly/validation path and the builder-level extraData propagation (including the same extraData size and determinism cases).

`InsertBlock` is guarded with the closure+`defer` idiom used elsewhere in the file, so a panic can't leave the engine lock held. `slotDeadline` is computed up front in `CommitBlockV1`, before `CurrentHeader`/`GetForkChoice`, so those calls are covered by the one-slot budget too.

## Verification

- `make lint` clean, `make test-short` green (only pre-existing unrelated failure: `cmd/rpcdaemon/graphql`)
- Full `execution/engineapi` suite green (serial exec mode), including the engineapitester end-to-end block-production tests that exercise the `create_block.go` change
- Coverage on the new code: 89–100% per function
- **Non-regression on the hive chain**: the full hive `rpc-compat` suite was run against an erigon image built from this branch — **234 tests, 0 failures**, confirming no regression across the whole RPC surface, `testing_` namespace included
- **Cross-client validation against geth**: six dedicated rpc-tests were written for the local hive chain that exercise the `testing_` namespace on both clients and compare erigon's responses against geth's, verifying the two implementations behave identically

## Related

- Cross-client integration tests: [erigontech/rpc-tests#585](https://github.com/erigontech/rpc-tests/pull/585)
