### PR TITLE
feat: update Engine API REST-SSZ (EIP-8178) to the latest spec

### DIFF
--- a/execution/engineapi/engine_api_methods.go
+++ b/execution/engineapi/engine_api_methods.go
@@ -74,6 +74,8 @@ var ourCapabilities = []string{
 	"GET /engine/v4/payloads/{payload_id}",
 	"GET /engine/v5/payloads/{payload_id}",
 	"GET /engine/v6/payloads/{payload_id}",
+	"POST /engine/v1/payloads/bodies/by-hash",
+	"POST /engine/v1/payloads/bodies/by-range",
 	"POST /engine/v1/forkchoice",
 	"POST /engine/v2/forkchoice",
 	"POST /engine/v3/forkchoice",

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -250,7 +250,65 @@ func (e *EngineServer) handleSSZGetPayload(w http.ResponseWriter, r *http.Reques
 }
 
 func (e *EngineServer) handleSSZGetBodies(w http.ResponseWriter, r *http.Request, version int, filterBy string) {
-	
+	if version != 1 {
+		writeSSZError(w, http.StatusNotFound, "unsupported get payload bodies version")
+		return
+	}
+
+	if filterBy != "by-hash" && filterBy != "by-range" {
+		writeSSZError(w, http.StatusNotFound, "unsupported filtering method")
+		return
+	}
+
+	body, err := readSSZBody(r)
+	if err != nil {
+		writeSSZError(w, http.StatusRequestEntityTooLarge, err.Error())
+		return
+	}
+
+	switch filterBy {
+	case "by-hash":
+		hashes, err := decodeGetPayloadBodiesByHashRequest(body)
+		if err != nil {
+			writeSSZError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		bodies, err := e.GetPayloadBodiesByHashV1(r.Context(), hashes)
+		if err != nil {
+			writeEngineError(w, err)
+			return
+		}
+
+		out, err := encodePayloadBodiesV1Response(bodies)
+		if err != nil {
+			writeSSZError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		e.logger.Info("[SSZ-REST] handled get payload bodies", "path", r.URL.Path)
+		writeSSZBytes(w, out)
+
+	case "by-range":
+		start, count, err := decodeGetPayloadBodiesByRangeRequest(body)
+		if err != nil {
+			writeSSZError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		bodies, err := e.GetPayloadBodiesByRangeV1(r.Context(), hexutil.Uint64(start), hexutil.Uint64(count))
+		if err != nil {
+			writeEngineError(w, err)
+			return
+		}
+
+		out, err := encodePayloadBodiesV1Response(bodies)
+		if err != nil {
+			writeSSZError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		e.logger.Info("[SSZ-REST] handled get payload bodies", "path", r.URL.Path)
+		writeSSZBytes(w, out)
+	}
 }
 
 func callGetPayload(ctx context.Context, e *EngineServer, version int, id hexutil.Bytes) (*engine_types.GetPayloadResponse, error) {

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -59,6 +59,8 @@ func (e *EngineServer) handleSSZREST(w http.ResponseWriter, r *http.Request) {
 		e.handleSSZNewPayload(w, r, version)
 	case r.Method == http.MethodGet && len(parts) == 4 && parts[2] == "payloads":
 		e.handleSSZGetPayload(w, r, version, parts[3])
+	case r.Method == http.MethodPost && len(parts) == 5 && parts[2] == "payloads" && parts[3] == "bodies":
+		e.handleSSZGetBodies(w, r, version, parts[4])
 	case r.Method == http.MethodPost && len(parts) == 3 && parts[2] == "forkchoice":
 		e.handleSSZForkchoice(w, r, version)
 	case r.Method == http.MethodPost && len(parts) == 3 && parts[2] == "blobs":
@@ -245,6 +247,10 @@ func (e *EngineServer) handleSSZGetPayload(w http.ResponseWriter, r *http.Reques
 		e.logger.Info("[SSZ-REST] handled get payload", "path", r.URL.Path)
 		writeSSZBytes(w, out)
 	}
+}
+
+func (e *EngineServer) handleSSZGetBodies(w http.ResponseWriter, r *http.Request, version int, filterBy string) {
+	
 }
 
 func callGetPayload(ctx context.Context, e *EngineServer, version int, id hexutil.Bytes) (*engine_types.GetPayloadResponse, error) {

--- a/execution/engineapi/sszrest_test.go
+++ b/execution/engineapi/sszrest_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	ssz2 "github.com/erigontech/erigon/cl/ssz"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/clonable"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
@@ -369,6 +370,8 @@ func TestExchangeCapabilitiesAdvertisesJSONRPCAndSSZREST(t *testing.T) {
 	require.Contains(t, caps, "engine_getPayloadV6")
 	require.Contains(t, caps, "POST /engine/v1/capabilities")
 	require.Contains(t, caps, "GET /engine/v6/payloads/{payload_id}")
+	require.Contains(t, caps, "POST /engine/v1/payloads/bodies/by-hash")
+	require.Contains(t, caps, "POST /engine/v1/payloads/bodies/by-range")
 	require.NotContains(t, caps, "engine_exchangeCapabilities")
 }
 
@@ -379,6 +382,97 @@ func TestSSZRESTGetPayloadIDPathParsing(t *testing.T) {
 
 	_, err = parsePayloadIDPath("0x01")
 	require.Error(t, err)
+}
+
+func TestSSZRESTGetBodiesRequestCodecsRoundTrip(t *testing.T) {
+	t.Run("by-hash", func(t *testing.T) {
+		hashes := []common.Hash{common.HexToHash("0x01"), common.HexToHash("0x02")}
+		list := solid.NewHashList(sszMaxPayloadBodiesRequest)
+		for _, h := range hashes {
+			list.Append(h)
+		}
+		enc, err := ssz2.MarshalSSZ(nil, list)
+		require.NoError(t, err)
+
+		out, err := decodeGetPayloadBodiesByHashRequest(enc)
+		require.NoError(t, err)
+		require.Equal(t, hashes, out)
+	})
+
+	t.Run("by-range", func(t *testing.T) {
+		start, count := uint64(1000), uint64(64)
+		enc, err := ssz2.MarshalSSZ(nil, &start, &count)
+		require.NoError(t, err)
+
+		gotStart, gotCount, err := decodeGetPayloadBodiesByRangeRequest(enc)
+		require.NoError(t, err)
+		require.Equal(t, start, gotStart)
+		require.Equal(t, count, gotCount)
+	})
+}
+
+// testPayloadBodiesEntry mirrors the List[ExecutionPayloadBodyV1, 1] inner element so the
+// PayloadBodiesV1Response can be decoded in tests: the production code only encodes it, and
+// decoding the bare *ListSSZ element panics on its nil-pointer Clone.
+type testPayloadBodiesEntry struct {
+	list *solid.ListSSZ[*executionPayloadBodyV1SSZ]
+}
+
+func newTestPayloadBodiesEntry() *testPayloadBodiesEntry {
+	return &testPayloadBodiesEntry{list: solid.NewDynamicListSSZ[*executionPayloadBodyV1SSZ](1)}
+}
+
+func (e *testPayloadBodiesEntry) EncodeSSZ(dst []byte) ([]byte, error) { return e.list.EncodeSSZ(dst) }
+func (e *testPayloadBodiesEntry) DecodeSSZ(buf []byte, v int) error    { return e.list.DecodeSSZ(buf, v) }
+func (e *testPayloadBodiesEntry) EncodingSizeSSZ() int                 { return e.list.EncodingSizeSSZ() }
+func (e *testPayloadBodiesEntry) HashSSZ() ([32]byte, error)           { return e.list.HashSSZ() }
+func (e *testPayloadBodiesEntry) Clone() clonable.Clonable             { return newTestPayloadBodiesEntry() }
+
+func TestSSZRESTPayloadBodiesV1ResponseCodecRoundTrip(t *testing.T) {
+	known := &engine_types.ExecutionPayloadBody{
+		Transactions: []hexutil.Bytes{{0x01, 0x02}, {0x03}},
+		Withdrawals: []*types.Withdrawal{
+			{Index: 1, Validator: 2, Address: common.HexToAddress("0x1234"), Amount: 100},
+		},
+	}
+	enc, err := encodePayloadBodiesV1Response([]*engine_types.ExecutionPayloadBody{known, nil})
+	require.NoError(t, err)
+
+	outer := solid.NewDynamicListSSZ[*testPayloadBodiesEntry](sszMaxPayloadBodiesRequest)
+	require.NoError(t, ssz2.UnmarshalSSZ(enc, 0, outer))
+	require.Equal(t, 2, outer.Len())
+	require.Equal(t, 1, outer.Get(0).list.Len(), "known block has exactly one body")
+	require.Equal(t, 0, outer.Get(1).list.Len(), "unknown block has an empty inner list")
+
+	gotBody := outer.Get(0).list.Get(0)
+	require.Equal(t, [][]byte{{0x01, 0x02}, {0x03}}, gotBody.transactions.UnderlyngReference())
+	require.Equal(t, 1, gotBody.withdrawals.Len())
+	gotWd := gotBody.withdrawals.Get(0)
+	require.Equal(t, uint64(1), gotWd.Index)
+	require.Equal(t, uint64(2), gotWd.Validator)
+	require.Equal(t, common.HexToAddress("0x1234"), gotWd.Address)
+	require.Equal(t, uint64(100), gotWd.Amount)
+}
+
+func TestSSZRESTGetBodiesRoute(t *testing.T) {
+	srv := NewEngineServer(log.New(), &chain.Config{}, nil, nil, false, true, false, false, nil, nil, 0, 0)
+	for _, route := range []struct {
+		name string
+		path string
+		code int
+	}{
+		{"unsupported version", "/engine/v2/payloads/bodies/by-hash", http.StatusNotFound},
+		{"unsupported filter", "/engine/v1/payloads/bodies/by-nothing", http.StatusNotFound},
+		{"bad by-hash ssz", "/engine/v1/payloads/bodies/by-hash", http.StatusBadRequest},
+		{"bad by-range ssz", "/engine/v1/payloads/bodies/by-range", http.StatusBadRequest},
+	} {
+		t.Run(route.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, route.path, strings.NewReader("bad-ssz"))
+			rec := httptest.NewRecorder()
+			srv.SSZRESTHandler().ServeHTTP(rec, req)
+			require.Equal(t, route.code, rec.Code)
+		})
+	}
 }
 
 func TestSSZRESTErrorMapping(t *testing.T) {

--- a/execution/engineapi/sszrest_wire.go
+++ b/execution/engineapi/sszrest_wire.go
@@ -18,20 +18,23 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/merkle_tree"
 	ssz2 "github.com/erigontech/erigon/cl/ssz"
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/clonable"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 )
 
 const (
-	sszMaxBlobHashes          = 4096
-	sszMaxGetBlobHashes       = 128
-	sszMaxCapabilityNameBytes = 64
-	sszMaxCapabilities        = 64
-	sszBlobBytes              = 0x20000
-	sszKZGBytes               = 48
-	sszCellsPerExtBlob        = 128
+	sszMaxBlobHashes           = 4096
+	sszMaxGetBlobHashes        = 128
+	sszMaxCapabilityNameBytes  = 64
+	sszMaxCapabilities         = 64
+	sszBlobBytes               = 0x20000
+	sszKZGBytes                = 48
+	sszCellsPerExtBlob         = 128
+	sszMaxPayloadBodiesRequest = 32
 )
 
 func hashListValues(l solid.HashListSSZ) []common.Hash {
@@ -208,6 +211,77 @@ func encodeClientVersionResponse(versions []engine_types.ClientVersionV1) ([]byt
 		list.Append(&versions[i])
 	}
 	return ssz2.MarshalSSZ(nil, list)
+}
+
+func decodeGetPayloadBodiesByHashRequest(buf []byte) ([]common.Hash, error) {
+	hashes := solid.NewHashList(sszMaxPayloadBodiesRequest)
+	if err := ssz2.UnmarshalSSZ(buf, 0, hashes); err != nil {
+		return nil, err
+	}
+	return hashListValues(hashes), nil
+}
+
+func decodeGetPayloadBodiesByRangeRequest(buf []byte) (start, count uint64, err error) {
+	if err = ssz2.UnmarshalSSZ(buf, 0, &start, &count); err != nil {
+		return 0, 0, err
+	}
+	return start, count, nil
+}
+
+type executionPayloadBodyV1SSZ struct {
+	transactions *solid.TransactionsSSZ
+	withdrawals  *solid.ListSSZ[*cltypes.Withdrawal]
+}
+
+func newExecutionPayloadBodyV1SSZ(body *engine_types.ExecutionPayloadBody) *executionPayloadBodyV1SSZ {
+	b := &executionPayloadBodyV1SSZ{
+		transactions: solid.NewTransactionsSSZFromTransactions(nil),
+		withdrawals:  solid.NewStaticListSSZ[*cltypes.Withdrawal](int(clparams.MainnetBeaconConfig.MaxWithdrawalsPerPayload), 44),
+	}
+	if body == nil {
+		return b
+	}
+	txs := make([][]byte, len(body.Transactions))
+	for i := range body.Transactions {
+		txs[i] = body.Transactions[i]
+	}
+	b.transactions = solid.NewTransactionsSSZFromTransactions(txs)
+	for _, w := range body.Withdrawals {
+		b.withdrawals.Append(&cltypes.Withdrawal{Index: w.Index, Validator: w.Validator, Address: w.Address, Amount: w.Amount})
+	}
+	return b
+}
+
+func (b *executionPayloadBodyV1SSZ) EncodeSSZ(dst []byte) ([]byte, error) {
+	return ssz2.MarshalSSZ(dst, b.transactions, b.withdrawals)
+}
+
+func (b *executionPayloadBodyV1SSZ) DecodeSSZ(buf []byte, version int) error {
+	return ssz2.UnmarshalSSZ(buf, version, b.transactions, b.withdrawals)
+}
+
+func (b *executionPayloadBodyV1SSZ) EncodingSizeSSZ() int {
+	return 8 + b.transactions.EncodingSizeSSZ() + b.withdrawals.EncodingSizeSSZ()
+}
+
+func (b *executionPayloadBodyV1SSZ) HashSSZ() ([32]byte, error) {
+	return merkle_tree.HashTreeRoot(b.transactions, b.withdrawals)
+}
+
+func (b *executionPayloadBodyV1SSZ) Clone() clonable.Clonable {
+	return newExecutionPayloadBodyV1SSZ(nil)
+}
+
+func encodePayloadBodiesV1Response(bodies []*engine_types.ExecutionPayloadBody) ([]byte, error) {
+	payloadBodies := solid.NewDynamicListSSZ[*solid.ListSSZ[*executionPayloadBodyV1SSZ]](sszMaxPayloadBodiesRequest)
+	for _, body := range bodies {
+		entry := solid.NewDynamicListSSZ[*executionPayloadBodyV1SSZ](1)
+		if body != nil {
+			entry.Append(newExecutionPayloadBodyV1SSZ(body))
+		}
+		payloadBodies.Append(entry)
+	}
+	return ssz2.MarshalSSZ(nil, payloadBodies)
 }
 
 func decodeClientVersionRequest(buf []byte) (*engine_types.ClientVersionV1, error) {


### PR DESCRIPTION
Adds, advertises and tests the REST-SSZ `getPayloadBodies` endpoints defined by EIP-8178, the only spec routes to not exist in the current implementation:

- `POST /engine/v1/payloads/bodies/by-hash`
- `POST /engine/v1/payloads/bodies/by-range`