### PR TITLE
cl: reduce per-call hashing allocations in shuffling, sync committee, merkle proofs

### DIFF
--- a/cl/cltypes/blob_sidecar.go
+++ b/cl/cltypes/blob_sidecar.go
@@ -153,30 +153,24 @@ func VerifyCommitmentInclusionProof(commitment common.Bytes48, commitmentInclusi
 	if commitmentInclusionProof == nil || commitmentInclusionProof.Length() < bodyDepth+int(commitmentsDepth) {
 		return false
 	}
-	var buf [64]byte
+	var curr common.Hash
 	// Start by constructing the commitments subtree
 	for i := uint64(0); i < commitmentsDepth; i++ {
-		curr := commitmentInclusionProof.Get(int(i))
+		curr = commitmentInclusionProof.Get(int(i))
 		if (commitmentIndex / utils.PowerOf2(i) % 2) == 1 {
-			copy(buf[:32], curr[:])
-			copy(buf[32:], value[:])
+			value = utils.Sha256(curr[:], value[:])
 		} else {
-			copy(buf[:32], value[:])
-			copy(buf[32:], curr[:])
+			value = utils.Sha256(value[:], curr[:])
 		}
-		value = utils.Sha256(buf[:])
 	}
 	// Construct up the block giga tree
 	for i := uint64(0); i < uint64(bodyDepth); i++ {
-		curr := commitmentInclusionProof.Get(int(i + commitmentsDepth))
+		curr = commitmentInclusionProof.Get(int(i + commitmentsDepth))
 		if (bIndex / utils.PowerOf2(i) % 2) == 1 {
-			copy(buf[:32], curr[:])
-			copy(buf[32:], value[:])
+			value = utils.Sha256(curr[:], value[:])
 		} else {
-			copy(buf[:32], value[:])
-			copy(buf[32:], curr[:])
+			value = utils.Sha256(value[:], curr[:])
 		}
-		value = utils.Sha256(buf[:])
 	}
 	return value == bodyRoot
 }

--- a/cl/cltypes/blob_sidecar.go
+++ b/cl/cltypes/blob_sidecar.go
@@ -153,23 +153,30 @@ func VerifyCommitmentInclusionProof(commitment common.Bytes48, commitmentInclusi
 	if commitmentInclusionProof == nil || commitmentInclusionProof.Length() < bodyDepth+int(commitmentsDepth) {
 		return false
 	}
+	var buf [64]byte
 	// Start by constructing the commitments subtree
 	for i := uint64(0); i < commitmentsDepth; i++ {
 		curr := commitmentInclusionProof.Get(int(i))
 		if (commitmentIndex / utils.PowerOf2(i) % 2) == 1 {
-			value = utils.Sha256(append(curr[:], value[:]...))
+			copy(buf[:32], curr[:])
+			copy(buf[32:], value[:])
 		} else {
-			value = utils.Sha256(append(value[:], curr[:]...))
+			copy(buf[:32], value[:])
+			copy(buf[32:], curr[:])
 		}
+		value = utils.Sha256(buf[:])
 	}
 	// Construct up the block giga tree
 	for i := uint64(0); i < uint64(bodyDepth); i++ {
 		curr := commitmentInclusionProof.Get(int(i + commitmentsDepth))
 		if (bIndex / utils.PowerOf2(i) % 2) == 1 {
-			value = utils.Sha256(append(curr[:], value[:]...))
+			copy(buf[:32], curr[:])
+			copy(buf[32:], value[:])
 		} else {
-			value = utils.Sha256(append(value[:], curr[:]...))
+			copy(buf[:32], value[:])
+			copy(buf[32:], curr[:])
 		}
+		value = utils.Sha256(buf[:])
 	}
 	return value == bodyRoot
 }

--- a/cl/phase1/core/state/cache_accessors.go
+++ b/cl/phase1/core/state/cache_accessors.go
@@ -376,6 +376,17 @@ func (b *CachingBeaconState) ComputeNextSyncCommittee() (*solid.SyncCommittee, e
 	syncCommitteeSize := int(beaconConfig.SyncCommitteeSize)
 	syncCommitteePubKeys := make([]common.Bytes48, 0, syncCommitteeSize)
 	preInputs := shuffling.ComputeShuffledIndexPreInputs(b.BeaconConfig(), seed)
+	maxEffectiveBalance := beaconConfig.MaxEffectiveBalanceForVersion(b.Version())
+	isElectra := b.Version() >= clparams.ElectraVersion
+	// Electra hashes seed+i/16 (one hash per 16 indices), pre-Electra seed+i/32.
+	groupSize := uint64(32)
+	if isElectra {
+		groupSize = 16
+	}
+	var buf [40]byte
+	copy(buf[:32], seed[:])
+	var cachedHash [32]byte
+	cachedGroup := ^uint64(0)
 	for len(syncCommitteePubKeys) < syncCommitteeSize {
 		shuffledIndex, err := shuffling.ComputeShuffledIndex(
 			b.BeaconConfig(),
@@ -394,27 +405,21 @@ func (b *CachingBeaconState) ComputeNextSyncCommittee() (*solid.SyncCommittee, e
 		if err != nil {
 			return nil, err
 		}
-		if b.Version() >= clparams.ElectraVersion {
-			// electra and after
-			// random_bytes = hash(seed + uint_to_bytes(i // 16))
-			// offset = i % 16 * 2
-			// random_value = bytes_to_uint64(random_bytes[offset:offset + 2])
-			buf := make([]byte, 8)
-			binary.LittleEndian.PutUint64(buf, i/16)
-			input := append(seed[:], buf...)
-			randomBytes := utils.Sha256(input)
+		// random_bytes = hash(seed + uint_to_bytes(i // groupSize)); one hash covers a whole group.
+		if group := i / groupSize; group != cachedGroup {
+			binary.LittleEndian.PutUint64(buf[32:], group)
+			cachedHash = optimizedHashFunc(buf[:])
+			cachedGroup = group
+		}
+		if isElectra {
 			offset := (i % 16) * 2
-			randomValue := binary.LittleEndian.Uint16(randomBytes[offset : offset+2])
-			if validator.EffectiveBalance()*math.MaxUint16 >= beaconConfig.MaxEffectiveBalanceForVersion(b.Version())*uint64(randomValue) {
+			randomValue := binary.LittleEndian.Uint16(cachedHash[offset : offset+2])
+			if validator.EffectiveBalance()*math.MaxUint16 >= maxEffectiveBalance*uint64(randomValue) {
 				syncCommitteePubKeys = append(syncCommitteePubKeys, validator.PublicKey())
 			}
 		} else {
-			// Compute random byte.
-			buf := make([]byte, 8)
-			binary.LittleEndian.PutUint64(buf, i/32)
-			input := append(seed[:], buf...)
-			randomByte := uint64(utils.Sha256(input)[i%32])
-			if validator.EffectiveBalance()*math.MaxUint8 >= beaconConfig.MaxEffectiveBalanceForVersion(b.Version())*randomByte {
+			randomByte := uint64(cachedHash[i%32])
+			if validator.EffectiveBalance()*math.MaxUint8 >= maxEffectiveBalance*randomByte {
 				syncCommitteePubKeys = append(syncCommitteePubKeys, validator.PublicKey())
 			}
 		}

--- a/cl/phase1/core/state/shuffling/util.go
+++ b/cl/phase1/core/state/shuffling/util.go
@@ -61,8 +61,11 @@ func ComputeShuffledIndex(conf *clparams.BeaconChainConfig, ind, ind_count uint6
 
 func ComputeShuffledIndexPreInputs(conf *clparams.BeaconChainConfig, seed [32]byte) [][32]byte {
 	ret := make([][32]byte, conf.ShuffleRoundCount)
+	var buf [33]byte
+	copy(buf[:32], seed[:])
 	for i := range ret {
-		ret[i] = utils.Sha256(append(seed[:], byte(i)))
+		buf[32] = byte(i)
+		ret[i] = utils.Sha256(buf[:])
 	}
 	return ret
 }

--- a/cl/utils/merkle.go
+++ b/cl/utils/merkle.go
@@ -23,9 +23,9 @@ func IsValidMerkleBranch(leaf common.Hash, branch []common.Hash, depth uint64, i
 	value := leaf
 	for i := uint64(0); i < depth; i++ {
 		if (index / PowerOf2(i) % 2) == 1 {
-			value = Sha256(append(branch[i][:], value[:]...))
+			value = Sha256(branch[i][:], value[:])
 		} else {
-			value = Sha256(append(value[:], branch[i][:]...))
+			value = Sha256(value[:], branch[i][:])
 		}
 	}
 	return value == root


### PR DESCRIPTION
Several Caplin hot paths heap-allocate a hash or scratch buffer on every call — a per-iteration `append`/`make` in sync-committee selection, merkle-branch verification, blob inclusion proofs, and shuffling pre-inputs. Follow-up to #22390, which removed the same per-call allocation in `ComputeShuffledIndicies`.

Pure allocation refactor, no behavior change (identical bytes hashed); covered by the existing shuffling / merkle_proof / fork-upgrade / finality spectests.

## Changes
- `ComputeNextSyncCommittee`: reuse a stack seed buffer and cache the random-bytes hash per group (`i/16` Electra, `i/32` pre-Electra) instead of allocating and re-hashing every iteration — mirrors `ComputeBalanceWeightedSelection`.
- `IsValidMerkleBranch`: hash operands via `Sha256`'s `extras` argument instead of `append`.
- `VerifyCommitmentInclusionProof`: hash from a reused 64-byte buffer.
- `ComputeShuffledIndexPreInputs`: reuse a 33-byte seed buffer.

`IsValidMerkleBranch` at depth 33: 67 → 34 allocs/op, 3201 → 1088 B/op.
