### PR TITLE
cl: close zstd frame in WriteBeaconBlock instead of flushing

### DIFF
--- a/cl/persistence/beacon_indicies/indicies.go
+++ b/cl/persistence/beacon_indicies/indicies.go
@@ -353,7 +353,7 @@ func WriteBeaconBlock(ctx context.Context, tx kv.RwTx, block *cltypes.SignedBeac
 	if err != nil {
 		return err
 	}
-	if err := encoder.Flush(); err != nil {
+	if err := encoder.Close(); err != nil {
 		return err
 	}
 	if err := tx.Put(kv.BeaconBlocks, dbutils.BlockBodyKey(block.Block.Slot, blockRoot), common.Copy(buf.Bytes())); err != nil {

--- a/cl/persistence/beacon_indicies/indicies_test.go
+++ b/cl/persistence/beacon_indicies/indicies_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -83,6 +84,34 @@ func TestWriteBlockRoot(t *testing.T) {
 	canonicalRoot, err = ReadCanonicalBlockRoot(tx, *retrievedSlot)
 	require.NoError(t, err)
 	require.Equal(t, common.Hash(blockRoot), canonicalRoot)
+}
+
+func TestWriteBeaconBlockStoresCompleteZstdFrame(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	tx, err := db.BeginRw(context.Background())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.Phase0Version)
+	block.Block.Slot = 42
+	block.EncodingSizeSSZ()
+
+	blockRoot, err := block.Block.HashSSZ()
+	require.NoError(t, err)
+	require.NoError(t, WriteBeaconBlock(context.Background(), tx, block))
+
+	stored, err := tx.GetOne(kv.BeaconBlocks, dbutils.BlockBodyKey(block.Block.Slot, blockRoot))
+	require.NoError(t, err)
+	require.NotEmpty(t, stored)
+
+	dec, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	defer dec.Close()
+	// DecodeAll reads the whole frame to EOF, so it fails on the unterminated frame
+	// a Flush()-only encoder leaves behind — pinning that WriteBeaconBlock closes it.
+	_, err = dec.DecodeAll(stored, nil)
+	require.NoError(t, err)
 }
 
 func TestReadParentBlockRoot(t *testing.T) {


### PR DESCRIPTION
WriteBeaconBlock finalized its pooled zstd encoder with `Flush()` rather than `Close()`. As a result the bytes persisted to `kv.BeaconBlocks` — and copied verbatim into caplin `.seg` snapshots — were **unterminated zstd frames**: no last-block marker, no content checksum.

It has round-tripped in practice only because every reader (`ReadBlockFromSnapshot`, and the snapshot dump path which copies the blob verbatim) parses a self-delimiting SSZ block and stops before it needs the frame terminator. Any consumer that decodes to EOF (`DecodeAll` / `io.ReadAll`) fails with `unexpected EOF`, and zstd cannot detect corruption of these blobs.

`Close()` writes the frame epilogue, producing a complete, standalone frame — matching every other zstd streaming site in the tree (`base_encoding/uint64_diff.go`, `base_encoding/rabbit.go`, `antiquary/beacon_states_collector.go`).

`PagedWriter` was also checked and is fine: it compresses via `compress.EncodeZstdIfNeed` → `EncodeAll` (one-shot, complete-frame API) and reads with `DecodeAll`; its own `Flush()` is a page-buffer flush, unrelated to zstd frame finalization.

Backward compatible: old `Flush`-written blobs (in DB and existing snapshots) remain readable via the streaming path, so no migration is needed.

Added `TestWriteBeaconBlockStoresCompleteZstdFrame`, which decodes the stored blob to EOF. Confirmed red→green: with `Flush()` it fails with `unexpected EOF`; with `Close()` it passes.