### PR TITLE
ci: fix empty docker tag + add Discord failure alert (regression from #22386)

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -54,7 +54,6 @@ jobs:
         ##   latest image:    erigontech/erigon:${tag_name}${latest_suffix}
         ##   commit id image: erigontech/erigon:${tag_name}-${short_commit_id}
         env:
-          CHECKOUT_REF: ${{ inputs.checkout_ref }}
           BRANCH_REF: ${{ inputs.checkout_ref == '' && github.ref_name || inputs.checkout_ref }}
         run: |
           branch_name="$BRANCH_REF"
@@ -73,7 +72,7 @@ jobs:
               ;;
             * )
               # use last string after last slash '/' by default if branch contains slash:
-              export tag_name=$(echo $CHECKOUT_REF | sed -e  's/.*\///g' );
+              export tag_name=$(echo "$branch_name" | sed -e 's/.*\///g');
               export keep_images=0;
               export latest_suffix=''
               export binaries="erigon"

--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -26,6 +26,7 @@ on:
 jobs:
 
   Build:
+    name: Build and publish docker image
     # runs-on: ubuntu-latest
     runs-on: [devops-01-self-hosted]
     environment: dockerhub-publish
@@ -207,3 +208,22 @@ jobs:
               fi
               echo "Done."
             done
+
+      - name: Notify Discord on failure
+        # Alert only on the automated main-branch builds; manual dispatch runs
+        # are watched by whoever triggered them. No-op when the webhook is unset.
+        if: ${{ failure() && github.event_name == 'push' }}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if [ -z "${DISCORD_WEBHOOK:-}" ]; then
+            echo "DISCORD_WEBHOOK not set — skipping Discord notification."
+            exit 0
+          fi
+          msg=":x: **CI-CD docker image build failed** on branch \`${BRANCH}\`\nRun: ${RUN_URL}"
+          payload=$(jq -nc --arg c "$msg" '{content: $c}')
+          curl -sS -f -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK" \
+            && echo "Discord notified." \
+            || echo "::warning::Discord notification failed (webhook unreachable or invalid)."

--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -110,7 +110,7 @@ jobs:
         env:
           BUILD_VERSION: "${{ steps.def_docker_vars.outputs.tag_name }}-${{ steps.getCommitId.outputs.short_commit_id }}"
           BUILD_VERSION_LATEST: "${{ steps.def_docker_vars.outputs.tag_name }}${{ steps.def_docker_vars.outputs.latest_suffix }}"
-          DOCKER_PUBLISH_CONDITION: ${{ steps.def_docker_vars.outputs.keep_images > 0 && format('--tag {0}:{1} ', env.DOCKER_URL, env.BUILD_VERSION) || '' }}
+          DOCKER_PUBLISH_CONDITION: ${{ steps.def_docker_vars.outputs.keep_images > 0 && format('--tag {0}:{1}-{2} ', env.DOCKERHUB_REPOSITORY, steps.def_docker_vars.outputs.tag_name, steps.getCommitId.outputs.short_commit_id) || '' }}
           DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
           DOCKERFILE_PATH: Dockerfile
           BINARIES: ${{ steps.def_docker_vars.outputs.binaries }}
@@ -149,7 +149,7 @@ jobs:
         env:
           BUILD_VERSION: "${{ steps.def_docker_vars.outputs.tag_name }}-${{ steps.getCommitId.outputs.short_commit_id }}"
           BUILD_VERSION_LATEST: "${{ steps.def_docker_vars.outputs.tag_name }}${{ steps.def_docker_vars.outputs.latest_suffix }}"
-          BUILD_VERSION_CONDITION: ${{ steps.def_docker_vars.outputs.keep_images > 0 && format('{0}:{1} ',env.DOCKER_URL,env.BUILD_VERSION) || '' }}
+          BUILD_VERSION_CONDITION: ${{ steps.def_docker_vars.outputs.keep_images > 0 && format('{0}:{1}-{2} ', env.DOCKERHUB_REPOSITORY, steps.def_docker_vars.outputs.tag_name, steps.getCommitId.outputs.short_commit_id) || '' }}
           DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY }}
           TAG_KEY: ${{ steps.def_docker_vars.outputs.tag_name }}
           KEEP_IMAGES: ${{ steps.def_docker_vars.outputs.keep_images }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -43,3 +43,9 @@ rules:
   # tracked in #21132.
   secrets-inherit:
     disable: true
+
+  # This workflow must build and publish an image for every triggering commit;
+  # a concurrency group would cancel intermediate queued runs and skip images.
+  concurrency-limits:
+    ignore:
+      - ci-cd-main-branch-docker-images.yml


### PR DESCRIPTION
Two changes to `ci-cd-main-branch-docker-images.yml`, in one PR.

## 1. Fix: empty docker tag broke the image build

The workflow was failing on `main` ([run 29223744087](https://github.com/erigontech/erigon/actions/runs/29223744087)):

```
DOCKER_PUBLISH_CONDITION: --tag :
ERROR: failed to build: invalid tag ":": invalid reference format
```

**Root cause:** `DOCKER_PUBLISH_CONDITION` / `BUILD_VERSION_CONDITION` computed their tag via `format(…, env.DOCKER_URL, env.BUILD_VERSION)`, but those are **sibling entries in the same `env:` block**, which GitHub evaluates to empty. The vars were previously unused (the run blocks computed the value inline, which works because run-block expressions see the merged env); #22386 switched the run blocks to reference the env vars and exposed the latent bug → `--tag :`.

**Fix:** reference the real sources instead of the siblings — top-level `env.DOCKERHUB_REPOSITORY` and the `steps.*` outputs (the same values `DOCKER_URL`/`BUILD_VERSION` derive from), both available at step-env eval time.

## 2. Discord failure notification

Posts to the repo `DISCORD_WEBHOOK` secret when the build fails on an automated push (manual dispatch runs are watched by whoever triggered them). Implemented as a `if: failure()` step inside the `Build` job so the secret stays scoped to the job's existing `environment: dockerhub-publish`. No-op when the webhook is unset. Mirrors the nightly Fuzz workflow's alert.

## zizmor

Runs clean at the **auditor persona** (strictest) after this PR:
- `anonymous-definition` → named the `Build` job.
- `secrets-outside-env` → the webhook is used inside the environment-scoped `Build` job.
- `concurrency-limits` → intentionally ignored in `.github/zizmor.yml` (documented): every triggering commit must build and publish, and a concurrency group would cancel intermediate queued runs.

Verification: `zizmor 1.24.1 --persona=auditor` → *No findings to report*; `actionlint` → 0 errors; default-persona full-repo gate unchanged (exit 12, passes).