### PR TITLE
docs: make the live v3.4 archive self-contained (+ archive-link guard)

### DIFF
--- a/docs/site/scripts/fix-archive-links.py
+++ b/docs/site/scripts/fix-archive-links.py
@@ -83,13 +83,16 @@ def _iter_scannable(text: str):
     fence = None
     for ln in text.splitlines(keepends=True):
         stripped = ln.lstrip()
-        m = re.match(r"(```+|~~~+)", stripped)
+        m = re.match(r"(`{3,}|~{3,})", stripped)
         if m:
-            tok = m.group(1)[0] * 3
+            char, length = m.group(1)[0], len(m.group(1))
             if fence is None:
-                fence = tok
-            elif stripped.startswith(fence):
+                # opening fence (an info string may follow, e.g. ```python)
+                fence = (char, length)
+            elif char == fence[0] and length >= fence[1] and stripped[length:].strip() == "":
+                # closing fence: same char, at least as long, nothing else on the line
                 fence = None
+            # a shorter/different fence marker while open is just code content
             yield ln, True
             continue
         yield ln, fence is not None

--- a/docs/site/scripts/fix-archive-links.py
+++ b/docs/site/scripts/fix-archive-links.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Make archived doc versions self-contained.
+
+Current docs (`docs/`) legitimately use unversioned absolute links like
+`/get-started/` because the current version is served at the site root. When
+`docusaurus docs:version vX.Y` freezes those pages into
+`versioned_docs/version-vX.Y/`, the same absolute links resolve to the
+*current* version instead of the archived one — a reader browsing the v3.4
+docs is bounced into v3.6. (See erigontech/erigon#22416.)
+
+Per archived version this rewrites, for every link-bearing syntax below:
+  * same-page anchors written as absolute routes -> local `#frag`
+  * every other *unversioned absolute intra-docs* link -> `/vX.Y`-prefixed
+
+A link is left untouched when it is external, a static asset (`/img/…`), the
+site root / home (`/`), the separate unversioned Help Center
+(`/help-center/…`), or already version-prefixed (`/vX.Y/…`). Anything else
+that is an absolute route is treated as a leak — including links into a
+section that was renamed or removed since the archive was cut (that page no
+longer exists at the current route, so leaving it absolute silently sends the
+reader to the wrong version). The current `docs/` tree is never touched, and
+links inside fenced code blocks are ignored.
+
+Run after cutting a version:
+    python3 docs/site/scripts/fix-archive-links.py            # rewrite in place
+    python3 docs/site/scripts/fix-archive-links.py --check    # CI: fail if any remain
+"""
+import argparse
+import os
+import re
+import sys
+
+_VERDIR = re.compile(r"^version-(v\d+\.\d+)$")
+
+# Link-bearing syntaxes. Each captures <pre><url><post> so the match can be
+# rebuilt with only the URL changed.
+_PATTERNS = (
+    # Markdown inline link: ](URL) or ](URL "title") / ](URL 'title')
+    re.compile(r'(?P<pre>\]\()(?P<url>/[^)\s]+)(?P<post>(?:\s+(?:"[^"]*"|\'[^\']*\'))?\))'),
+    # Markdown reference definition:  [label]: URL
+    re.compile(r'(?P<pre>^[ \t]*\[[^\]]+\]:[ \t]*)(?P<url>/\S+)(?P<post>)'),
+    # JSX/HTML attribute: href=/to=  "URL" | 'URL' | {"URL"} | {'URL'}  (spaces ok)
+    re.compile(r'(?P<pre>(?<![\w-])(?:href|to)\s*=\s*\{?\s*(?P<q>["\']))'
+               r'(?P<url>/[^"\'\s}]*)(?P<post>(?P=q)\s*\}?)'),
+)
+
+
+def _excluded(path: str) -> bool:
+    p = path.split("#", 1)[0]
+    if p in ("", "/"):                                   # site root / home
+        return True
+    if p.startswith("/img/"):                            # static assets
+        return True
+    if p == "/help-center" or p.startswith("/help-center/"):  # separate unversioned instance
+        return True
+    if re.match(r"^/v\d+\.\d+(/|$)", p):                 # already version-prefixed
+        return True
+    return False
+
+
+def _self_route(relpath: str) -> str:
+    p = re.sub(r"\.(md|mdx)$", "", relpath)
+    p = re.sub(r"(^|/)index$", "", p)
+    p = p.strip("/")
+    return "/" + p if p else "/"
+
+
+def _transform(url: str, route: str, prefix: str):
+    """Return (new_url, changed)."""
+    path_part, _, frag = url.partition("#")
+    frag = "#" + frag if frag else ""
+    base = path_part.rstrip("/") or "/"
+    # same-page anchor -> local (checked before exclusions so home-page `/#x` works)
+    if frag and base == route:
+        return frag, True
+    if _excluded(url):
+        return url, False
+    return prefix + path_part + frag, True
+
+
+def _iter_scannable(text: str):
+    """Yield (line, is_fenced); callers skip fenced code blocks."""
+    fence = None
+    for ln in text.splitlines(keepends=True):
+        stripped = ln.lstrip()
+        m = re.match(r"(```+|~~~+)", stripped)
+        if m:
+            tok = m.group(1)[0] * 3
+            if fence is None:
+                fence = tok
+            elif stripped.startswith(fence):
+                fence = None
+            yield ln, True
+            continue
+        yield ln, fence is not None
+
+
+def _process_file(path, relpath, prefix, check):
+    route = _self_route(relpath)
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read()
+    violations = []
+    out = []
+
+    def repl(m):
+        new_url, changed = _transform(m.group("url"), route, prefix)
+        if not changed:
+            return m.group(0)
+        violations.append(m.group("url"))
+        return m.group("pre") + new_url + m.group("post")
+
+    for line, fenced in _iter_scannable(text):
+        if not fenced:
+            for pat in _PATTERNS:
+                line = pat.sub(repl, line)
+        out.append(line)
+
+    if violations and not check:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("".join(out))
+    return violations
+
+
+def scan(versioned_root, check):
+    total = {}
+    if not os.path.isdir(versioned_root):
+        return total
+    for ver in sorted(os.listdir(versioned_root)):
+        m = _VERDIR.match(ver)
+        if not m:
+            continue
+        prefix = "/" + m.group(1)  # /v3.4
+        vroot = os.path.join(versioned_root, ver)
+        for dp, _, files in os.walk(vroot):
+            for fn in files:
+                if not fn.endswith((".md", ".mdx")):
+                    continue
+                fp = os.path.join(dp, fn)
+                v = _process_file(fp, os.path.relpath(fp, vroot), prefix, check)
+                if v:
+                    total[f"{ver}/{os.path.relpath(fp, vroot)}"] = v
+    return total
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("versioned_root", nargs="?", help="path to versioned_docs/ (default: sibling of this script)")
+    ap.add_argument("--check", action="store_true", help="report violations and exit 1; do not rewrite")
+    args = ap.parse_args(argv)
+    here = os.path.dirname(os.path.abspath(__file__))
+    root = args.versioned_root or os.path.normpath(os.path.join(here, "..", "versioned_docs"))
+    found = scan(root, args.check)
+    n = sum(len(v) for v in found.values())
+    if args.check:
+        if found:
+            print(f"FAIL: {n} unversioned absolute link(s) in archived docs across {len(found)} file(s):")
+            for f, links in sorted(found.items()):
+                for link in links:
+                    print(f"  {f}: {link}")
+            print("\nFix with: python3 docs/site/scripts/fix-archive-links.py")
+            sys.exit(1)
+        print("OK: all archived doc versions are self-contained")
+    else:
+        print(f"rewrote {n} link(s) across {len(found)} file(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/site/scripts/test_archive_links.py
+++ b/docs/site/scripts/test_archive_links.py
@@ -1,0 +1,47 @@
+"""Guard: archived doc versions must be self-contained.
+
+Fails if any `versioned_docs/version-vX.Y/` page links to another docs page via
+an unversioned absolute route (e.g. `/get-started/`), which would bounce a
+reader from the archive into the current version. See erigontech/erigon#22416.
+
+Run from repo root:
+  python3 -m unittest discover docs/site/scripts -v
+  python3 docs/site/scripts/test_archive_links.py     # direct invocation also works
+
+Fix violations with:
+  python3 docs/site/scripts/fix-archive-links.py
+"""
+import importlib.util
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).parent
+_spec = importlib.util.spec_from_file_location(
+    "fix_archive_links", _HERE / "fix-archive-links.py"
+)
+fal = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fal)
+
+_VERSIONED = _HERE.parent / "versioned_docs"
+
+
+class ArchiveLinksSelfContained(unittest.TestCase):
+    def test_no_unversioned_absolute_links_in_archives(self):
+        found = fal.scan(str(_VERSIONED), check=True)
+        if found:
+            lines = [
+                f"  {f}: {link}"
+                for f, links in sorted(found.items())
+                for link in links
+            ]
+            self.fail(
+                "Archived doc versions must be self-contained, but found "
+                f"{sum(len(v) for v in found.values())} unversioned absolute "
+                "link(s) that would leak to the current version:\n"
+                + "\n".join(lines)
+                + "\n\nFix with: python3 docs/site/scripts/fix-archive-links.py"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/site/scripts/test_fix_archive_links.py
+++ b/docs/site/scripts/test_fix_archive_links.py
@@ -1,0 +1,128 @@
+"""Unit tests for fix-archive-links.py — the archive link fixer/guard.
+
+Covers each link syntax and edge case so the CI guard genuinely prevents
+recurrence (erigontech/erigon#22416), not just the two forms seen today.
+
+Run from repo root:
+  python3 -m unittest discover docs/site/scripts -v
+  python3 docs/site/scripts/test_fix_archive_links.py
+"""
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).parent
+_spec = importlib.util.spec_from_file_location("fix_archive_links", _HERE / "fix-archive-links.py")
+fal = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fal)
+
+
+def _fix(body, relpath="fundamentals/page.md", prefix="/v3.4"):
+    """Write body as a v3.4 archive page, run the fixer, return new text + violations."""
+    with tempfile.TemporaryDirectory() as d:
+        vroot = os.path.join(d, "versioned_docs", "version-v3.4")
+        fp = os.path.join(vroot, relpath)
+        os.makedirs(os.path.dirname(fp), exist_ok=True)
+        open(fp, "w").write(body)
+        found = fal.scan(os.path.join(d, "versioned_docs"), check=False)
+        return open(fp).read(), sum(found.values(), [])
+
+
+class SyntaxCoverage(unittest.TestCase):
+    def test_markdown_inline(self):
+        out, v = _fix("See [x](/get-started/foo).")
+        self.assertIn("(/v3.4/get-started/foo)", out)
+        self.assertTrue(v)
+
+    def test_markdown_inline_with_title(self):
+        out, _ = _fix('[x](/get-started/foo "Title").')
+        self.assertIn('(/v3.4/get-started/foo "Title")', out)
+
+    def test_markdown_reference_definition(self):
+        out, v = _fix("[x]\n\n[x]: /get-started/foo")
+        self.assertIn("[x]: /v3.4/get-started/foo", out)
+        self.assertTrue(v)
+
+    def test_jsx_link_double_quote(self):
+        out, _ = _fix('<Link to="/get-started/">go</Link>')
+        self.assertIn('to="/v3.4/get-started/"', out)
+
+    def test_jsx_link_single_quote(self):
+        out, _ = _fix("<Link to='/get-started/'>go</Link>")
+        self.assertIn("to='/v3.4/get-started/'", out)
+
+    def test_jsx_expression_braces(self):
+        out, _ = _fix('<Link to={"/get-started/"}>go</Link>')
+        self.assertIn('to={"/v3.4/get-started/"}', out)
+
+    def test_html_anchor_href(self):
+        out, v = _fix('<a href="/get-started/foo">go</a>')
+        self.assertIn('href="/v3.4/get-started/foo"', out)
+        self.assertTrue(v)
+
+    def test_spaced_attr(self):
+        out, _ = _fix('<Link to = "/get-started/">go</Link>')
+        self.assertIn('/v3.4/get-started/', out)
+
+
+class Exclusions(unittest.TestCase):
+    def _unchanged(self, body):
+        out, v = _fix(body)
+        self.assertEqual(out, body)
+        self.assertEqual(v, [])
+
+    def test_leaves_images(self):
+        self._unchanged("![i](/img/logo.svg)")
+
+    def test_leaves_help_center(self):
+        self._unchanged("[h](/help-center/faq)")
+
+    def test_leaves_site_root(self):
+        self._unchanged('<Link to="/">home</Link>')
+
+    def test_leaves_already_versioned(self):
+        self._unchanged("[x](/v3.4/get-started/foo)")
+
+    def test_leaves_external(self):
+        self._unchanged("[x](https://erigon.tech/get-started/)")
+
+    def test_leaves_relative(self):
+        self._unchanged("[x](../get-started/foo) and [y](eth.md)")
+
+
+class EdgeCases(unittest.TestCase):
+    def test_word_boundary_not_photo_attr(self):
+        # `to="` must not match inside `photo="`, `auto="`, `data-goto="`
+        self.assertEqual(*[_fix('<img photo="/get-started/pic.png"/>')[0],
+                           '<img photo="/get-started/pic.png"/>'])
+
+    def test_skips_fenced_code(self):
+        body = "prose [x](/get-started/foo)\n```\ncode [y](/get-started/bar)\n```\n"
+        out, _ = _fix(body)
+        self.assertIn("[x](/v3.4/get-started/foo)", out)   # prose fixed
+        self.assertIn("[y](/get-started/bar)", out)         # code sample untouched
+
+    def test_same_page_anchor_localized(self):
+        out, _ = _fix("[s](/fundamentals/page#sec)", relpath="fundamentals/page.md")
+        self.assertIn("[s](#sec)", out)
+
+    def test_root_index_home_anchor_localized(self):
+        out, _ = _fix("[top](/#intro)", relpath="index.mdx")
+        self.assertIn("[top](#intro)", out)
+
+    def test_renamed_section_still_flagged(self):
+        # a link into a section not present in the archive must still be caught
+        _, v = _fix("[x](/removed-section/page)")
+        self.assertTrue(v)
+
+    def test_idempotent(self):
+        once, _ = _fix("[x](/get-started/foo)")
+        twice, v2 = _fix(once)
+        self.assertEqual(once, twice)
+        self.assertEqual(v2, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/site/scripts/test_fix_archive_links.py
+++ b/docs/site/scripts/test_fix_archive_links.py
@@ -25,9 +25,11 @@ def _fix(body, relpath="fundamentals/page.md", prefix="/v3.4"):
         vroot = os.path.join(d, "versioned_docs", "version-v3.4")
         fp = os.path.join(vroot, relpath)
         os.makedirs(os.path.dirname(fp), exist_ok=True)
-        open(fp, "w").write(body)
+        with open(fp, "w", encoding="utf-8") as fh:
+            fh.write(body)
         found = fal.scan(os.path.join(d, "versioned_docs"), check=False)
-        return open(fp).read(), sum(found.values(), [])
+        with open(fp, encoding="utf-8") as fh:
+            return fh.read(), sum(found.values(), [])
 
 
 class SyntaxCoverage(unittest.TestCase):
@@ -103,6 +105,23 @@ class EdgeCases(unittest.TestCase):
         out, _ = _fix(body)
         self.assertIn("[x](/v3.4/get-started/foo)", out)   # prose fixed
         self.assertIn("[y](/get-started/bar)", out)         # code sample untouched
+
+    def test_skips_four_backtick_fence_with_inner_triple(self):
+        # a 4-backtick fence whose body contains a 3-backtick line must not
+        # close early at the inner ``` (regression for the fence-length bug)
+        body = (
+            "before [a](/get-started/x)\n"
+            "````md\n"
+            "```\n"
+            "[b](/get-started/y)\n"
+            "```\n"
+            "````\n"
+            "after [c](/get-started/z)\n"
+        )
+        out, _ = _fix(body)
+        self.assertIn("[a](/v3.4/get-started/x)", out)   # prose before fixed
+        self.assertIn("[b](/get-started/y)", out)         # inside 4-fence untouched
+        self.assertIn("[c](/v3.4/get-started/z)", out)   # prose after fixed
 
     def test_same_page_anchor_localized(self):
         out, _ = _fix("[s](/fundamentals/page#sec)", relpath="fundamentals/page.md")

--- a/docs/site/versioned_docs/version-v3.4/about/index.mdx
+++ b/docs/site/versioned_docs/version-v3.4/about/index.mdx
@@ -14,7 +14,7 @@ import Link from '@docusaurus/Link';
 
 <div className="lp-grid">
 
-<Link className="lp-card" to="/about/contributing">
+<Link className="lp-card" to="/v3.4/about/contributing">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <line x1="6" y1="3" x2="6" y2="15"/>
     <circle cx="18" cy="6" r="3"/>
@@ -25,7 +25,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">How to contribute code, report bugs, write docs, and submit pull requests to the Erigon project.</div>
 </Link>
 
-<Link className="lp-card" to="/about/disclaimer">
+<Link className="lp-card" to="/v3.4/about/disclaimer">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
     <line x1="12" y1="9" x2="12" y2="13"/>
@@ -35,7 +35,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Important notices about software maturity, stability expectations, and intended use.</div>
 </Link>
 
-<Link className="lp-card" to="/about/license">
+<Link className="lp-card" to="/v3.4/about/license">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
     <polyline points="14 2 14 8 20 8"/>

--- a/docs/site/versioned_docs/version-v3.4/fundamentals/basic-usage.mdx
+++ b/docs/site/versioned_docs/version-v3.4/fundamentals/basic-usage.mdx
@@ -20,7 +20,7 @@ erigon [options]
 ```
 </TabItem>
 <TabItem value="docker" label="Docker">
-* You can use Docker Compose like in this [example](/get-started/easy-nodes/how-to-run-an-ethereum-node#a-create-the-configuration-file)
+* You can use Docker Compose like in this [example](/v3.4/get-started/easy-nodes/how-to-run-an-ethereum-node#a-create-the-configuration-file)
 *   Alternatively you can use the Docker syntax, for example:
 
     `docker run -it erigontech/erigon:v{ERIGON_VERSION} [options]`

--- a/docs/site/versioned_docs/version-v3.4/fundamentals/configuring-erigon/index.mdx
+++ b/docs/site/versioned_docs/version-v3.4/fundamentals/configuring-erigon/index.mdx
@@ -9,9 +9,9 @@ description: "Complete CLI flag reference for Erigon — all startup options, en
 
 The Erigon CLI has a wide range of flags that can be used to customize its behavior. There are 3 ways to configure Erigon, listed by priority:
 
-* [Command line options](/fundamentals/configuring-erigon/#command-line-options) (flags)
-* [Configuration file](/fundamentals/configuring-erigon/#configuration-file)
-* [Environment variables](/fundamentals/configuring-erigon/#environment-variables)
+* [Command line options](#command-line-options) (flags)
+* [Configuration file](#configuration-file)
+* [Environment variables](#environment-variables)
 
 :::tip
 In order to see all the available options (flags) you must run the command:
@@ -42,7 +42,7 @@ These flags cover the general behavior and configuration of the Erigon client.
 * `--config value`: Sets Erigon flags using a YAML/TOML file.
 * `--version, -v`: Prints the version information.
 * `--help, -h`: Displays help information.
-* `--chain value`: Sets the name of the [network](/fundamentals/supported-networks) to join.
+* `--chain value`: Sets the name of the [network](/v3.4/fundamentals/supported-networks) to join.
   * Default: `mainnet`
 * `--networkid value`: Explicitly sets the network ID.
   * Default: `1`
@@ -97,7 +97,7 @@ Flags for managing how old chain data is handled and stored.
   * Default: `0`
 * `--prune.distance.blocks value`: Keeps block history for the latest `N` blocks.
   * Default: `0`
-* `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: Enables fast `eth_getProof` for executed blocks by storing commitment history. Requires +32 GB RAM. See [`eth_getProof`](/interacting-with-erigon/eth#eth_getproof).
+* `--prune.include-commitment-history, --prune.experimental.include-commitment-history, --experimental.commitment-history`: Enables fast `eth_getProof` for executed blocks by storing commitment history. Requires +32 GB RAM. See [`eth_getProof`](/v3.4/interacting-with-erigon/eth#eth_getproof).
   * Default: `false`
 * `--snap.skip-state-snapshot-download`: Skips state download and starts from genesis.
   * Default: `false`

--- a/docs/site/versioned_docs/version-v3.4/fundamentals/index.mdx
+++ b/docs/site/versioned_docs/version-v3.4/fundamentals/index.mdx
@@ -14,7 +14,7 @@ import Link from '@docusaurus/Link';
 
 <div className="lp-grid">
 
-<Link className="lp-card" to="/fundamentals/basic-usage">
+<Link className="lp-card" to="/v3.4/fundamentals/basic-usage">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polyline points="4 17 10 11 4 5"/>
     <line x1="12" y1="19" x2="20" y2="19"/>
@@ -33,7 +33,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Full, minimal, and archive sync explained — choose the right mode for your use case.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/configuring-erigon/">
+<Link className="lp-card" to="/v3.4/fundamentals/configuring-erigon/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="12" cy="12" r="3"/>
     <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
@@ -42,7 +42,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Full CLI flag reference, config file format, and per-component tuning options.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/supported-networks">
+<Link className="lp-card" to="/v3.4/fundamentals/supported-networks">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="12" cy="12" r="10"/>
     <line x1="2" y1="12" x2="22" y2="12"/>
@@ -52,7 +52,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">All chains and testnets supported by Erigon, with network-specific flags and notes.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/optimizing-storage">
+<Link className="lp-card" to="/v3.4/fundamentals/optimizing-storage">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <ellipse cx="12" cy="5" rx="9" ry="3"/>
     <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/>
@@ -62,7 +62,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Pruning, snapshots, and techniques to minimize disk footprint.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/docker-compose">
+<Link className="lp-card" to="/v3.4/fundamentals/docker-compose">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polygon points="12 2 2 7 12 12 22 7 12 2"/>
     <polyline points="2 17 12 22 22 17"/>
@@ -72,7 +72,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Run Erigon and all its modules together with Docker Compose.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/security">
+<Link className="lp-card" to="/v3.4/fundamentals/security">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
   </svg>
@@ -80,7 +80,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Firewall rules, API exposure best practices, and hardening recommendations.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/modules/">
+<Link className="lp-card" to="/v3.4/fundamentals/modules/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <rect x="3" y="3" width="7" height="7"/>
     <rect x="14" y="3" width="7" height="7"/>

--- a/docs/site/versioned_docs/version-v3.4/fundamentals/modules/index.mdx
+++ b/docs/site/versioned_docs/version-v3.4/fundamentals/modules/index.mdx
@@ -14,7 +14,7 @@ import Link from '@docusaurus/Link';
 
 <div className="lp-grid">
 
-<Link className="lp-card" to="/fundamentals/modules/rpc-daemon">
+<Link className="lp-card" to="/v3.4/fundamentals/modules/rpc-daemon">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <rect x="2" y="3" width="20" height="14" rx="2"/>
     <line x1="8" y1="21" x2="16" y2="21"/>
@@ -24,7 +24,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Serve JSON-RPC requests as a separate, remoteable process — the most battle-tested external component.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/modules/txpool">
+<Link className="lp-card" to="/v3.4/fundamentals/modules/txpool">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <line x1="8" y1="6" x2="21" y2="6"/>
     <line x1="8" y1="12" x2="21" y2="12"/>
@@ -37,7 +37,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Manage the pending transaction pool as a standalone service, decoupled from the main node process.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/modules/sentry">
+<Link className="lp-card" to="/v3.4/fundamentals/modules/sentry">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="12" cy="12" r="2"/>
     <path d="M16.24 7.76a6 6 0 0 1 0 8.49m-8.48-.01a6 6 0 0 1 0-8.49m11.31-2.82a10 10 0 0 1 0 14.14m-14.14 0a10 10 0 0 1 0-14.14"/>
@@ -46,7 +46,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Erigon's network-facing peer-to-peer communication layer, isolatable for security or multi-node setups.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/modules/downloader">
+<Link className="lp-card" to="/v3.4/fundamentals/modules/downloader">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polyline points="8 17 12 21 16 17"/>
     <line x1="12" y1="12" x2="12" y2="21"/>

--- a/docs/site/versioned_docs/version-v3.4/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/index.md
+++ b/docs/site/versioned_docs/version-v3.4/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/index.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 
 ## 1. Prerequisites Check
 
-1. Confirm your machine meets the necessary [Hardware Requirements](/get-started/hardware-requirements) based on your desired prune mode.
+1. Confirm your machine meets the necessary [Hardware Requirements](/v3.4/get-started/hardware-requirements) based on your desired prune mode.
 2. **Install Docker**:
    * For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
    * For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
@@ -65,13 +65,13 @@ docker compose up
 
 * `--chain=gnosis` specifies to run on Gnosis Chain, use `--chain=chiado` for Chiado testnet
 * Add `--prune.mode=minimal` to run minimal [Prune Mode](/v3.4/fundamentals/prune-modes) or `--prune.mode=archive` to run an archive node
-* `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet)
+* `--http.addr="0.0.0.0" --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/v3.4/fundamentals/web3-wallet)
 * `--torrent.download.rate=512mb` to increase download speed. While the default downloading speed is 128mb, with this flag Erigon will use as much download speed as it can, up to a maximum of 512 megabytes per second. This means it will try to download data as quickly as possible, but it won't exceed the 512 MB/s limit you've set
 
-When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or run a Gnosis node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl).
+When you get familiar with running Erigon from CLI you may also consider [staking](/v3.4/staking/caplin) and/or run a Gnosis node with an [external Consensus Layer](/v3.4/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/gnosis-with-an-external-cl).
 
 :::tip
 Press `Ctrl+C` in your terminal to stop Erigon.
 :::
 
-Additional flags can be added to [configure](/fundamentals/configuring-erigon/) Erigon with several options.
+Additional flags can be added to [configure](/v3.4/fundamentals/configuring-erigon/) Erigon with several options.

--- a/docs/site/versioned_docs/version-v3.4/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
+++ b/docs/site/versioned_docs/version-v3.4/get-started/easy-nodes/how-to-run-an-ethereum-node/index.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 
 ## 1. Prerequisites Check
 
-1. Confirm your machine meets the necessary [Hardware Requirements](/get-started/hardware-requirements) based on your desired prune mode.
+1. Confirm your machine meets the necessary [Hardware Requirements](/v3.4/get-started/hardware-requirements) based on your desired prune mode.
 2. **Install Docker**:
    * For Linux, install [Docker Engine](https://docs.docker.com/engine/install).
    * For macOS or Windows, install [Docker Desktop](https://docs.docker.com/desktop/).
@@ -65,13 +65,13 @@ docker compose up
 
 * `--chain=mainnet` specifies to run on Ethereum mainnet
 * Add `--prune.mode=minimal` to run minimal [Prune Mode](/v3.4/fundamentals/prune-modes) or `--prune.mode=archive` to run an archive node
-* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/fundamentals/web3-wallet)
+* `--http.addr=0.0.0.0 --http.api=eth,web3,net,debug,trace,txpool` to use RPC and e.g. be able to connect your [web3 wallet](/v3.4/fundamentals/web3-wallet)
 * `--torrent.download.rate` sets the torrent download rate cap. The default is `512mb` (megabytes per second). During initial sync Erigon will use the full allowance — on a dedicated machine this is fine, but if you share the machine with other work you may want to lower it (e.g. `--torrent.download.rate=128mb`). Set `--torrent.download.rate=Inf` to remove the limit entirely.
 
-When you get familiar with running Erigon from CLI you may also consider [staking](/staking/caplin) and/or running an Ethereum node with an [external Consensus Layer](/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
+When you get familiar with running Erigon from CLI you may also consider [staking](/v3.4/staking/caplin) and/or running an Ethereum node with an [external Consensus Layer](/v3.4/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
 
 :::tip
 Press `Ctrl+C` in your terminal to stop Erigon.
 :::
 
-Additional flags can be added to [configure](/fundamentals/configuring-erigon/) Erigon with several options.
+Additional flags can be added to [configure](/v3.4/fundamentals/configuring-erigon/) Erigon with several options.

--- a/docs/site/versioned_docs/version-v3.4/get-started/easy-nodes/index.mdx
+++ b/docs/site/versioned_docs/version-v3.4/get-started/easy-nodes/index.mdx
@@ -14,19 +14,19 @@ import Link from '@docusaurus/Link';
 
 <div className="lp-grid">
 
-<Link className="lp-card" to="/get-started/easy-nodes/how-to-run-an-ethereum-node/">
+<Link className="lp-card" to="/v3.4/get-started/easy-nodes/how-to-run-an-ethereum-node/">
   <img src="/img/eth.svg" className="lp-icon" alt="Ethereum" />
   <div className="lp-card-title">Ethereum Node</div>
   <div className="lp-card-desc">Run a full Ethereum mainnet node using Caplin (built-in consensus layer) or connect an external CL client.</div>
 </Link>
 
-<Link className="lp-card" to="/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/">
+<Link className="lp-card" to="/v3.4/get-started/easy-nodes/how-to-run-a-gnosis-chain-node/">
   <img src="/img/gno.svg" className="lp-icon" alt="Gnosis Chain" />
   <div className="lp-card-title">Gnosis Chain Node</div>
   <div className="lp-card-desc">Run a full Gnosis Chain node with Erigon's embedded consensus layer or an external CL client.</div>
 </Link>
 
-<Link className="lp-card" to="/get-started/easy-nodes/how-to-run-a-polygon-node">
+<Link className="lp-card" to="/v3.4/get-started/easy-nodes/how-to-run-a-polygon-node">
   <img src="/img/pol.svg" className="lp-icon" alt="Polygon" />
   <div className="lp-card-title">Polygon Node</div>
   <div className="lp-card-desc">Step-by-step guide to running an Erigon node on the Polygon PoS network.</div>

--- a/docs/site/versioned_docs/version-v3.4/get-started/index.mdx
+++ b/docs/site/versioned_docs/version-v3.4/get-started/index.mdx
@@ -14,7 +14,7 @@ import Link from '@docusaurus/Link';
 
 <div className="lp-grid">
 
-<Link className="lp-card" to="/get-started/why-using-erigon">
+<Link className="lp-card" to="/v3.4/get-started/why-using-erigon">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
   </svg>
@@ -22,7 +22,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Performance benchmarks, disk savings, and architecture advantages over other Ethereum clients.</div>
 </Link>
 
-<Link className="lp-card" to="/get-started/hardware-requirements">
+<Link className="lp-card" to="/v3.4/get-started/hardware-requirements">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <rect x="4" y="4" width="16" height="16" rx="2"/>
     <rect x="9" y="9" width="6" height="6"/>
@@ -39,7 +39,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Minimum and recommended specs for mainnet, testnets, and archive mode.</div>
 </Link>
 
-<Link className="lp-card" to="/get-started/installation/">
+<Link className="lp-card" to="/v3.4/get-started/installation/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
     <polyline points="7 10 12 15 17 10"/>
@@ -49,7 +49,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Binary releases, building from source, Docker images, and upgrade instructions.</div>
 </Link>
 
-<Link className="lp-card" to="/get-started/easy-nodes/">
+<Link className="lp-card" to="/v3.4/get-started/easy-nodes/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
   </svg>
@@ -57,7 +57,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">One-command guided setup for Ethereum, Gnosis Chain, and Polygon nodes with sensible defaults.</div>
 </Link>
 
-<Link className="lp-card" to="/get-started/migrating-from-geth">
+<Link className="lp-card" to="/v3.4/get-started/migrating-from-geth">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polyline points="17 1 21 5 17 9"/>
     <path d="M3 11V9a4 4 0 0 1 4-4h14"/>
@@ -68,7 +68,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Switch from go-ethereum to Erigon — what changes, what stays the same, and how to preserve your data.</div>
 </Link>
 
-<Link className="lp-card" to="/interacting-with-erigon/">
+<Link className="lp-card" to="/v3.4/interacting-with-erigon/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polyline points="16 18 22 12 16 6"/>
     <polyline points="8 6 2 12 8 18"/>

--- a/docs/site/versioned_docs/version-v3.4/get-started/installation/index.mdx
+++ b/docs/site/versioned_docs/version-v3.4/get-started/installation/index.mdx
@@ -121,7 +121,7 @@ _(Note: The container itself is built on multi-platform Linux architectures (lin
 * Images are stored at [https://hub.docker.com/r/erigontech/erigon](https://hub.docker.com/r/erigontech/erigon).
 
 :::warning
-**Windows**: note that Docker on Windows is affected by [WSL2 Performance and Data Storage](/get-started/installation/#install-wsl).
+**Windows**: note that Docker on Windows is affected by [WSL2 Performance and Data Storage](#install-wsl).
 :::
 
 #### **Download and start Erigon in Docker**
@@ -164,7 +164,7 @@ docker run -it erigontech/erigon:v{ERIGON_VERSION} --chain=hoodi --prune.mode=mi
 
 * `-v` connects a folder on your computer to the container (must have authorization)
 * `-it` lets you see what's happening and interact with Erigon
-* `--chain=hoodi` specifies which [network](/fundamentals/supported-networks) to sync
+* `--chain=hoodi` specifies which [network](/v3.4/fundamentals/supported-networks) to sync
 * `--prune.mode=minimal` tells Erigon to use minimal [Prune Mode](/v3.4/fundamentals/prune-modes)
 * `--datadir` tells Erigon where to store data inside the container
 
@@ -521,7 +521,7 @@ WSL enables you to run a complete GNU/Linux environment natively within Windows,
 
 **Building Erigon**
 
-Once WSL2 is set up, you can build and run Erigon exactly as you would on a regular [Linux/macOS](/get-started/installation/#linuxmacos) distribution.
+Once WSL2 is set up, you can build and run Erigon exactly as you would on a regular [Linux/macOS](#linuxmacos) distribution.
 
 **Performance and Data Storage**
 
@@ -553,4 +553,4 @@ If you need to connect to Erigon from an external network (e.g., opening a port 
 
 </details>
 
-Once you have Erigon installed, you can see [Basic Usage](/fundamentals/basic-usage) to configure your node and confirm it is syncing.
+Once you have Erigon installed, you can see [Basic Usage](/v3.4/fundamentals/basic-usage) to configure your node and confirm it is syncing.

--- a/docs/site/versioned_docs/version-v3.4/index.mdx
+++ b/docs/site/versioned_docs/version-v3.4/index.mdx
@@ -14,7 +14,7 @@ import Link from '@docusaurus/Link';
 
 <div className="lp-grid">
 
-<Link className="lp-card" to="/get-started/">
+<Link className="lp-card" to="/v3.4/get-started/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polygon points="5 3 19 12 5 21 5 3"/>
   </svg>
@@ -22,7 +22,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Hardware requirements, installation options, and first-run guides to get your node online fast.</div>
 </Link>
 
-<Link className="lp-card" to="/get-started/easy-nodes/">
+<Link className="lp-card" to="/v3.4/get-started/easy-nodes/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
   </svg>
@@ -30,7 +30,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">One-command guided setup for Ethereum mainnet, Gnosis Chain, and Polygon nodes with sensible defaults.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/">
+<Link className="lp-card" to="/v3.4/fundamentals/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
     <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
@@ -39,7 +39,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Prune modes, configuration, Docker, JWT, logging, storage optimization, and day-to-day operations.</div>
 </Link>
 
-<Link className="lp-card" to="/fundamentals/modules/">
+<Link className="lp-card" to="/v3.4/fundamentals/modules/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <rect x="3" y="3" width="7" height="7"/>
     <rect x="14" y="3" width="7" height="7"/>
@@ -50,7 +50,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Run RPC Daemon, TxPool, Sentry, and Downloader as independent processes for scalable cluster setups.</div>
 </Link>
 
-<Link className="lp-card" to="/staking/">
+<Link className="lp-card" to="/v3.4/staking/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <rect x="2" y="13" width="20" height="9" rx="2"/>
     <rect x="9" y="12" width="6" height="2" rx="1"/>
@@ -62,7 +62,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Solo staking with Caplin (built-in consensus layer) or pair Erigon with any external consensus client.</div>
 </Link>
 
-<Link className="lp-card" to="/interacting-with-erigon/">
+<Link className="lp-card" to="/v3.4/interacting-with-erigon/">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polyline points="16 18 22 12 16 6"/>
     <polyline points="8 6 2 12 8 18"/>
@@ -73,7 +73,7 @@ import Link from '@docusaurus/Link';
 
 <Link
   className="lp-card"
-  to="/get-started/why-using-erigon"
+  to="/v3.4/get-started/why-using-erigon"
   style={{gridColumn:'1 / -1', flexDirection:'row', alignItems:'center', gap:'1.5rem', padding:'1.5rem 2rem'}}
 >
   <svg className="lp-icon" style={{width:'2.5rem', height:'2.5rem', flexShrink:0, marginBottom:0}} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/docs/site/versioned_docs/version-v3.4/interacting-with-erigon/index.md
+++ b/docs/site/versioned_docs/version-v3.4/interacting-with-erigon/index.md
@@ -6,30 +6,30 @@ description: "Complete API reference for Erigon — JSON-RPC namespaces, GraphQL
 
 # RPC Service
 
-The Erigon RPC Service, managed by Erigon's modular [RPC Daemon](/fundamentals/modules/rpc-daemon), supports various API namespaces, which can be enabled or disabled using the `--http.api` flag. The available namespaces include:
+The Erigon RPC Service, managed by Erigon's modular [RPC Daemon](/v3.4/fundamentals/modules/rpc-daemon), supports various API namespaces, which can be enabled or disabled using the `--http.api` flag. The available namespaces include:
 
-* [`eth`](/interacting-with-erigon/eth): Standard Ethereum API.
-* [`erigon`](/interacting-with-erigon/erigon): Erigon-specific extensions.
-* [`engine`](/interacting-with-erigon/engine): The JSON-RPC Interface for Execution and Consensus Layer Communication.
-* [`web3`](/interacting-with-erigon/web3): Web3 compatibility API.
-* [`net`](/interacting-with-erigon/net): Network information API.
-* [`debug`](/interacting-with-erigon/debug): Debugging and tracing API.
-* [`trace`](/interacting-with-erigon/trace): Transaction tracing API.
-* [`txpool`](/interacting-with-erigon/txpool): Transaction pool API.
-* [`admin`](/interacting-with-erigon/admin): Node administration API
-* [`bor`](/interacting-with-erigon/bor): Polygon Bor-specific API (when running on Polygon)
-* [`ots`](/interacting-with-erigon/ots): These methods are specifically tailored for use with Otterscan, an open-source, fast block explorer.
-* [`internal`](/interacting-with-erigon/internal): Erigon specific API for development and debugging purposes.
-* [`gRPC`](/interacting-with-erigon/grpc): API for lower-level data access.
-* [`overlay`](/interacting-with-erigon/overlay): Erigon-specific overlay API for replaying blocks with state overrides (archive nodes only).
-* [`parity`](/interacting-with-erigon/parity): Partial OpenEthereum compatibility (`parity_listStorageKeys`).
-* [`graphql`](/interacting-with-erigon/graphql): GraphQL endpoint following EIP-1767.
+* [`eth`](/v3.4/interacting-with-erigon/eth): Standard Ethereum API.
+* [`erigon`](/v3.4/interacting-with-erigon/erigon): Erigon-specific extensions.
+* [`engine`](/v3.4/interacting-with-erigon/engine): The JSON-RPC Interface for Execution and Consensus Layer Communication.
+* [`web3`](/v3.4/interacting-with-erigon/web3): Web3 compatibility API.
+* [`net`](/v3.4/interacting-with-erigon/net): Network information API.
+* [`debug`](/v3.4/interacting-with-erigon/debug): Debugging and tracing API.
+* [`trace`](/v3.4/interacting-with-erigon/trace): Transaction tracing API.
+* [`txpool`](/v3.4/interacting-with-erigon/txpool): Transaction pool API.
+* [`admin`](/v3.4/interacting-with-erigon/admin): Node administration API
+* [`bor`](/v3.4/interacting-with-erigon/bor): Polygon Bor-specific API (when running on Polygon)
+* [`ots`](/v3.4/interacting-with-erigon/ots): These methods are specifically tailored for use with Otterscan, an open-source, fast block explorer.
+* [`internal`](/v3.4/interacting-with-erigon/internal): Erigon specific API for development and debugging purposes.
+* [`gRPC`](/v3.4/interacting-with-erigon/grpc): API for lower-level data access.
+* [`overlay`](/v3.4/interacting-with-erigon/overlay): Erigon-specific overlay API for replaying blocks with state overrides (archive nodes only).
+* [`parity`](/v3.4/interacting-with-erigon/parity): Partial OpenEthereum compatibility (`parity_listStorageKeys`).
+* [`graphql`](/v3.4/interacting-with-erigon/graphql): GraphQL endpoint following EIP-1767.
 
 For a complete reference on the standard Ethereum JSON-RPC methods, especially those in the `eth`, `net`, and `web3` namespaces, it is recommended to consult the general documentation on [ethereum.org's JSON-RPC API page](https://ethereum.org/en/developers/docs/apis/json-rpc/). Additionally, for the formal specification of the `debug`, `engine`, and `eth` namespaces, including unique, detailed descriptions for methods like `eth_getProof` and `eth_simulateV1`, refer to the [Execution APIs documentation](https://ethereum.github.io/execution-apis).
 
 ## Erigon RPC Transports
 
-Erigon supports [HTTP](/interacting-with-erigon/#http), [HTTPS](/interacting-with-erigon/#https), [WebSockets](/interacting-with-erigon/#websockets), [IPC](/interacting-with-erigon/#ipc), [gRPC](/interacting-with-erigon/#grpc) and [GraphQL](/interacting-with-erigon/#graphql) through its RPC Daemon.
+Erigon supports [HTTP](#http), [HTTPS](#https), [WebSockets](#websockets), [IPC](#ipc), [gRPC](#grpc) and [GraphQL](#graphql) through its RPC Daemon.
 
 ### HTTP
 

--- a/docs/site/versioned_docs/version-v3.4/staking/index.mdx
+++ b/docs/site/versioned_docs/version-v3.4/staking/index.mdx
@@ -14,7 +14,7 @@ import Link from '@docusaurus/Link';
 
 <div className="lp-grid">
 
-<Link className="lp-card" to="/staking/caplin">
+<Link className="lp-card" to="/v3.4/staking/caplin">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="12" cy="12" r="2"/>
     <path d="M16.24 7.76a6 6 0 0 1 0 8.49m-8.48-.01a6 6 0 0 1 0-8.49m11.31-2.82a10 10 0 0 1 0 14.14m-14.14 0a10 10 0 0 1 0-14.14"/>
@@ -23,7 +23,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Configure Erigon's embedded consensus layer as a full validator — no external CL dependency required.</div>
 </Link>
 
-<Link className="lp-card" to="/staking/external-consensus-client-as-validator">
+<Link className="lp-card" to="/v3.4/staking/external-consensus-client-as-validator">
   <svg className="lp-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
     <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
@@ -32,7 +32,7 @@ import Link from '@docusaurus/Link';
   <div className="lp-card-desc">Connect Lighthouse, Prysm, Teku, or Nimbus via the Engine API for split EL/CL validator setups.</div>
 </Link>
 
-<Link className="lp-card" to="/staking/shutter-network">
+<Link className="lp-card" to="/v3.4/staking/shutter-network">
   <img src="/img/shutter.svg" className="lp-icon" alt="Shutter Network" />
   <div className="lp-card-title">Shutter Network</div>
   <div className="lp-card-desc">Privacy-preserving mempool protection — shield validator transactions from front-running and MEV.</div>


### PR DESCRIPTION
## What

The frozen **v3.4 archive** used unversioned absolute links (e.g. `/get-started/`) that were copied from the current docs. Inside an archived version those resolve to the **current** version, so a reader browsing the v3.4 docs is silently bounced into v3.5/v3.6. GitHub Copilot flagged this on #22420; the root cause is tracked in #22416. The v3.3 archive was already self-contained — v3.4 was the outlier (#22062 only fixed the links that broke the build).

**Fix (76 links / 13 files):** cross-page absolute links → `/v3.4/`-prefixed (matching v3.3); same-page anchors → local `#frag`. Left `/` (home), `/help-center/…` (separate unversioned instance), `/img/…`, external, and already-`/vX.Y/` links untouched.

## Prevention (so future version cuts can't reintroduce this)

Three files under `docs/site/scripts/`:

- **`fix-archive-links.py`** — reusable fixer + `--check`. Per archived version it prefixes any unversioned absolute intra-docs link and localizes same-page anchors. Handles markdown inline/reference, JSX `<Link>`, and HTML `<a href>` forms; skips fenced code; and flags links into **renamed/removed** sections (the silent-leak case `onBrokenLinks` can miss). Run it right after `docusaurus docs:version vX.Y`.
- **`test_archive_links.py`** — the guard: fails if any `versioned_docs/version-*/` page has an unversioned absolute intra-docs link. It **auto-runs in CI** via the existing `python3 -m unittest discover docs/site/scripts` step in `docs-site-build.yml` (PR) and `docs-deploy.yml` (push) — **no workflow change**, and it runs before the npm build so neither path can bypass it.
- **`test_fix_archive_links.py`** — unit tests for each link syntax and edge case.

## Verification

- `docs/site` build **green** (`onBrokenLinks`/`onBrokenAnchors`/`onBrokenMarkdownLinks` all `'throw'`).
- `generate-llms.py --check` unchanged (74 pages — generator ignores `versioned_docs/`).
- **62 unittests pass**; the guard catches all **76** links on the pre-fix archive (has teeth); fixer is idempotent and reproducible.
- v3.3 archive already passes the guard.

## Review

Adversarially reviewed by ChatGPT 5.5 + Fable (both APPROVE-WITH-CHANGES). All findings folded in: broadened link-form coverage, catch-all detection (fixes the renamed-section blind spot), fenced-code skipping, `to=` word boundary (won't match `photo=`/`auto=`), root-`index` `/#frag` localization, and `argparse`.

Companion: #22420 carries the same corrected v3.4 archive + these scripts to `main`. Refs #22416, #22420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
