### PR TITLE
all: lint modernize interface{} to any across codebase and test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,7 +91,6 @@ linters:
           skipRecvDeref: true
     modernize:
       disable: # each disabled analyzer has an existing backlog; enable it once its findings are cleared
-        - any
         - atomictypes
         - forvar
         - mapsloop
@@ -107,6 +106,8 @@ linters:
         - stringscutprefix
         - testingcontext
         - waitgroupgo
+        - waitgroup
+        - fmtappendf
     govet:
       enable:
         - nilness
@@ -124,6 +125,9 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      - linters:
+          - modernize
+        path: _grpc\.pb\.go
       - linters:
           - errcheck
         text: not checked

--- a/cl/phase1/execution_client/execution_client_engine_test.go
+++ b/cl/phase1/execution_client/execution_client_engine_test.go
@@ -63,7 +63,7 @@ func TestBuildExecutionPayload_BlockAccessListGloasOnly(t *testing.T) {
 		raw, err := json.Marshal(ep)
 		require.NoError(t, err)
 
-		var m map[string]interface{}
+		var m map[string]any
 		require.NoError(t, json.Unmarshal(raw, &m))
 		_, ok := m["blockAccessList"]
 		require.False(t, ok, "blockAccessList must be absent from JSON for pre-Gloas blocks")
@@ -103,7 +103,7 @@ func TestBuildExecutionPayload_BlockAccessListGloasOnly(t *testing.T) {
 			raw, err := json.Marshal(ep)
 			require.NoError(t, err)
 
-			var m map[string]interface{}
+			var m map[string]any
 			require.NoError(t, json.Unmarshal(raw, &m))
 
 			bal, ok := m["blockAccessList"]

--- a/cl/validator/devvalidator/aggregate.go
+++ b/cl/validator/devvalidator/aggregate.go
@@ -64,7 +64,7 @@ func (s *Service) submitAggregateAndProof(
 		Message:   msg,
 		Signature: aggregatorSig,
 	}
-	if err := s.client.post(ctx, "/eth/v1/validator/aggregate_and_proofs", []interface{}{signed}); err != nil {
+	if err := s.client.post(ctx, "/eth/v1/validator/aggregate_and_proofs", []any{signed}); err != nil {
 		s.logger.Debug("[dev-validator] aggregate submit failed", "slot", slot, "err", err)
 	}
 }

--- a/cl/validator/devvalidator/aggregate_test.go
+++ b/cl/validator/devvalidator/aggregate_test.go
@@ -52,7 +52,7 @@ func TestSignedAggregateAndProof_RoundTrip(t *testing.T) {
 		Signature: common.Bytes96{0x04},
 	}
 
-	raw, err := json.Marshal([]interface{}{signed})
+	raw, err := json.Marshal([]any{signed})
 	require.NoError(t, err)
 
 	var decoded []*cltypes.SignedAggregateAndProof

--- a/cl/validator/devvalidator/attestation_submission.go
+++ b/cl/validator/devvalidator/attestation_submission.go
@@ -13,7 +13,7 @@ import (
 // attestation, which differs between the pre-Electra and Electra Beacon APIs.
 type attestationSubmission struct {
 	path    string
-	body    interface{}
+	body    any
 	version string // Eth-Consensus-Version header; empty for the pre-Electra V1 route
 }
 
@@ -30,7 +30,7 @@ func buildAttestationSubmission(
 	committeeLength, validatorPosition uint64,
 ) attestationSubmission {
 	if version >= clparams.ElectraVersion {
-		single := map[string]interface{}{
+		single := map[string]any{
 			"committee_index": strconv.FormatUint(committeeIndex, 10),
 			"attester_index":  strconv.FormatUint(validatorIndex, 10),
 			"data":            attData,
@@ -38,20 +38,20 @@ func buildAttestationSubmission(
 		}
 		return attestationSubmission{
 			path:    "/eth/v2/beacon/pool/attestations",
-			body:    []interface{}{single},
+			body:    []any{single},
 			version: version.String(),
 		}
 	}
 
 	aggBits := make([]byte, (committeeLength+7)/8)
 	aggBits[validatorPosition/8] |= 1 << (validatorPosition % 8)
-	legacy := map[string]interface{}{
+	legacy := map[string]any{
 		"aggregation_bits": hexutil.Encode(aggBits),
 		"data":             attData,
 		"signature":        hexutil.Encode(sig[:]),
 	}
 	return attestationSubmission{
 		path: "/eth/v1/beacon/pool/attestations",
-		body: []interface{}{legacy},
+		body: []any{legacy},
 	}
 }

--- a/cl/validator/devvalidator/client.go
+++ b/cl/validator/devvalidator/client.go
@@ -33,7 +33,7 @@ type beaconResponse struct {
 }
 
 // get performs a GET request and unmarshals the `data` field into dst.
-func (c *BeaconClient) get(ctx context.Context, path string, dst interface{}) error {
+func (c *BeaconClient) get(ctx context.Context, path string, dst any) error {
 	url := c.baseURL + path
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -60,7 +60,7 @@ func (c *BeaconClient) get(ctx context.Context, path string, dst interface{}) er
 }
 
 // post performs a POST request with a JSON body.
-func (c *BeaconClient) post(ctx context.Context, path string, body interface{}) error {
+func (c *BeaconClient) post(ctx context.Context, path string, body any) error {
 	url := c.baseURL + path
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
@@ -89,7 +89,7 @@ func (c *BeaconClient) post(ctx context.Context, path string, body interface{}) 
 // postAndDecode performs a POST request with a JSON body and unmarshals the
 // response `data` field into dst. This is needed for endpoints like
 // /eth/v1/validator/duties/attester/{epoch} which are POST-only per spec.
-func (c *BeaconClient) postAndDecode(ctx context.Context, path string, body interface{}, dst interface{}) error {
+func (c *BeaconClient) postAndDecode(ctx context.Context, path string, body any, dst any) error {
 	url := c.baseURL + path
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
@@ -122,7 +122,7 @@ func (c *BeaconClient) postAndDecode(ctx context.Context, path string, body inte
 }
 
 // postJSON performs a POST request with a JSON body and Eth-Consensus-Version header.
-func (c *BeaconClient) postJSON(ctx context.Context, path string, body interface{}, version string) error {
+func (c *BeaconClient) postJSON(ctx context.Context, path string, body any, version string) error {
 	url := c.baseURL + path
 	jsonBody, err := json.Marshal(body)
 	if err != nil {

--- a/cl/validator/devvalidator/client_test.go
+++ b/cl/validator/devvalidator/client_test.go
@@ -43,7 +43,7 @@ func TestPostAndDecode_AttesterDuties(t *testing.T) {
 		require.NotEmpty(t, indices)
 
 		// Return duties wrapped in standard Beacon API response.
-		resp := map[string]interface{}{"data": expectedDuties}
+		resp := map[string]any{"data": expectedDuties}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	})
@@ -71,7 +71,7 @@ func TestGet_AttesterDuties_Fails(t *testing.T) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		resp := map[string]interface{}{"data": []interface{}{}}
+		resp := map[string]any{"data": []any{}}
 		json.NewEncoder(w).Encode(resp)
 	})
 	srv := httptest.NewServer(mux)
@@ -81,7 +81,7 @@ func TestGet_AttesterDuties_Fails(t *testing.T) {
 	ctx := context.Background()
 
 	// GET must fail with 405 — this is the bug that postAndDecode fixes.
-	var duties []interface{}
+	var duties []any
 	err := client.get(ctx, "/eth/v1/validator/duties/attester/0", &duties)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "405")

--- a/cl/validator/devvalidator/service.go
+++ b/cl/validator/devvalidator/service.go
@@ -325,7 +325,7 @@ func (s *Service) proposeBlock(ctx context.Context, slot uint64, key *ValidatorK
 	// Submit the signed block. For Deneb+, wrap in DenebSignedBeaconBlock
 	// with empty blob sidecars.
 	versionStr := version.String()
-	var submitBody interface{} = block
+	var submitBody any = block
 	if version >= clparams.DenebVersion {
 		submitBody = &cltypes.DenebSignedBeaconBlock{
 			SignedBlock: block,

--- a/cl/validator/devvalidator/sync_committee.go
+++ b/cl/validator/devvalidator/sync_committee.go
@@ -12,8 +12,8 @@ import (
 
 // buildSyncCommitteeMessage constructs the JSON body for a single
 // SyncCommitteeMessage submitted to /eth/v1/beacon/pool/sync_committees.
-func buildSyncCommitteeMessage(slot uint64, blockRoot common.Hash, validatorIndex uint64, sig common.Bytes96) map[string]interface{} {
-	return map[string]interface{}{
+func buildSyncCommitteeMessage(slot uint64, blockRoot common.Hash, validatorIndex uint64, sig common.Bytes96) map[string]any {
+	return map[string]any{
 		"slot":              strconv.FormatUint(slot, 10),
 		"beacon_block_root": blockRoot.Hex(),
 		"validator_index":   strconv.FormatUint(validatorIndex, 10),
@@ -57,8 +57,8 @@ func (s *Service) maybeSyncCommittee(ctx context.Context, slot uint64) {
 
 	syncSubcommitteeSize := s.cfg.SyncCommitteeSize / s.cfg.SyncCommitteeSubnetCount
 
-	msgs := make([]interface{}, 0, len(duties))
-	contributions := make([]interface{}, 0, len(duties))
+	msgs := make([]any, 0, len(duties))
+	contributions := make([]any, 0, len(duties))
 	for _, duty := range duties {
 		validatorIndex, parseErr := strconv.ParseUint(duty.ValidatorIndex, 10, 64)
 		if parseErr != nil {
@@ -108,9 +108,9 @@ func (s *Service) buildContributions(
 	committeeIndicesStr []string,
 	syncSubcommitteeSize uint64,
 	sig common.Bytes96,
-) []interface{} {
+) []any {
 	seenSubcommittees := map[uint64]struct{}{}
-	out := make([]interface{}, 0, len(committeeIndicesStr))
+	out := make([]any, 0, len(committeeIndicesStr))
 	for _, posStr := range committeeIndicesStr {
 		pos, err := strconv.ParseUint(posStr, 10, 64)
 		if err != nil || syncSubcommitteeSize == 0 {

--- a/cl/validator/devvalidator/sync_committee_test.go
+++ b/cl/validator/devvalidator/sync_committee_test.go
@@ -17,7 +17,7 @@ func TestBuildSyncCommitteeMessage(t *testing.T) {
 	root := common.Hash{0xde, 0xad, 0xbe, 0xef}
 	sig := common.Bytes96{0x11, 0x22, 0x33}
 
-	body := []interface{}{buildSyncCommitteeMessage(42, root, 7, sig)}
+	body := []any{buildSyncCommitteeMessage(42, root, 7, sig)}
 
 	raw, err := json.Marshal(body)
 	require.NoError(t, err)

--- a/cl/validator/devvalidator/sync_contribution_test.go
+++ b/cl/validator/devvalidator/sync_contribution_test.go
@@ -33,7 +33,7 @@ func TestBuildContribution(t *testing.T) {
 		},
 		Signature: common.Bytes96{0x07},
 	}
-	raw, err := json.Marshal([]interface{}{signed})
+	raw, err := json.Marshal([]any{signed})
 	require.NoError(t, err)
 
 	var decoded []*cltypes.SignedContributionAndProof

--- a/cmd/pics/contracts/gen_token.go
+++ b/cmd/pics/contracts/gen_token.go
@@ -156,7 +156,7 @@ func bindToken(address common.Address, caller bind.ContractCaller, transactor bi
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Token *TokenRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Token *TokenRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Token.Contract.TokenCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Token *TokenRaw) Transfer(opts *bind.TransactOpts) (types.Transaction, er
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Token *TokenRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Token *TokenRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Token.Contract.TokenTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Token *TokenRaw) Transact(opts *bind.TransactOpts, method string, params 
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Token *TokenCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Token *TokenCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Token.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Token *TokenTransactorRaw) Transfer(opts *bind.TransactOpts) (types.Trans
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Token *TokenTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Token *TokenTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Token.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -194,7 +194,7 @@ func (_Token *TokenTransactorRaw) Transact(opts *bind.TransactOpts, method strin
 //
 // Solidity: function balanceOf(address ) view returns(uint256)
 func (_Token *TokenCaller) BalanceOf(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _Token.contract.Call(opts, &out, "balanceOf", arg0)
 
 	if err != nil {
@@ -225,7 +225,7 @@ func (_Token *TokenCallerSession) BalanceOf(arg0 common.Address) (*big.Int, erro
 //
 // Solidity: function minter() view returns(address)
 func (_Token *TokenCaller) Minter(opts *bind.CallOpts) (common.Address, error) {
-	var out []interface{}
+	var out []any
 	err := _Token.contract.Call(opts, &out, "minter")
 
 	if err != nil {
@@ -256,7 +256,7 @@ func (_Token *TokenCallerSession) Minter() (common.Address, error) {
 //
 // Solidity: function totalSupply() view returns(uint256)
 func (_Token *TokenCaller) TotalSupply(opts *bind.CallOpts) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _Token.contract.Call(opts, &out, "totalSupply")
 
 	if err != nil {

--- a/cmd/utils/app/snapshots_cmd_test.go
+++ b/cmd/utils/app/snapshots_cmd_test.go
@@ -1168,7 +1168,7 @@ func TestDUFormatJSON_EmptyResult(t *testing.T) {
 	err := duFormatJSON(&buf, result)
 	require.NoError(t, err)
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	err = json.Unmarshal(buf.Bytes(), &decoded)
 	require.NoError(t, err)
 	require.Equal(t, "unknown", decoded["chain"])

--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -435,7 +435,7 @@ func tableScanningPrune(
 
 		select {
 		case <-logEvery.C:
-			args := []interface{}{"name", filenameBase, "pruned values", stat.PruneCountValues}
+			args := []any{"name", filenameBase, "pruned values", stat.PruneCountValues}
 			if keysCursor != nil {
 				args = append(args, "pruned tx", stat.PruneCountTx)
 			}

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -1176,7 +1176,7 @@ func (rs *RecSplit) ForceCollisionOnce() {
 
 // bucketResultPool is a package-level sync.Pool for reusing bucketResult instances
 var bucketResultPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &bucketResult{}
 	},
 }

--- a/execution/abi/bind/template.go
+++ b/execution/abi/bind/template.go
@@ -266,7 +266,7 @@ var (
 	// sets the output to result. The result type might be a single field for simple
 	// returns, a slice of interfaces for anonymous returns and a struct for named
 	// returns.
-	func (_{{$contract.Type}} *{{$contract.Type}}Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	func (_{{$contract.Type}} *{{$contract.Type}}Raw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 		return _{{$contract.Type}}.Contract.{{$contract.Type}}Caller.contract.Call(opts, result, method, params...)
 	}
 
@@ -277,7 +277,7 @@ var (
 	}
 
 	// Transact invokes the (paid) contract method with params as input values.
-	func (_{{$contract.Type}} *{{$contract.Type}}Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+	func (_{{$contract.Type}} *{{$contract.Type}}Raw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 		return _{{$contract.Type}}.Contract.{{$contract.Type}}Transactor.contract.Transact(opts, method, params...)
 	}
 
@@ -285,7 +285,7 @@ var (
 	// sets the output to result. The result type might be a single field for simple
 	// returns, a slice of interfaces for anonymous returns and a struct for named
 	// returns.
-	func (_{{$contract.Type}} *{{$contract.Type}}CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	func (_{{$contract.Type}} *{{$contract.Type}}CallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 		return _{{$contract.Type}}.Contract.contract.Call(opts, result, method, params...)
 	}
 
@@ -296,7 +296,7 @@ var (
 	}
 
 	// Transact invokes the (paid) contract method with params as input values.
-	func (_{{$contract.Type}} *{{$contract.Type}}TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+	func (_{{$contract.Type}} *{{$contract.Type}}TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 		return _{{$contract.Type}}.Contract.contract.Transact(opts, method, params...)
 	}
 
@@ -305,7 +305,7 @@ var (
 		//
 		// Solidity: {{.Original.String}}
 		func (_{{$contract.Type}} *{{$contract.Type}}Caller) {{.Normalized.Name}}(opts *bind.CallOpts {{range .Normalized.Inputs}}, {{.Name}} {{bindtype .Type $structs}} {{end}}) ({{if .Structured}}struct{ {{range .Normalized.Outputs}}{{.Name}} {{bindtype .Type $structs}};{{end}} },{{else}}{{range .Normalized.Outputs}}{{bindtype .Type $structs}},{{end}}{{end}} error) {
-			var out []interface{}
+			var out []any
 			err := _{{$contract.Type}}.contract.Call(opts, &out, "{{.Original.Name}}" {{range .Normalized.Inputs}}, {{.Name}}{{end}})
 			{{if .Structured}}
 			outstruct := new(struct{ {{range .Normalized.Outputs}} {{.Name}} {{bindtype .Type $structs}}; {{end}} })
@@ -537,7 +537,7 @@ var (
 		// Solidity: {{.Original.String}}
  		func (_{{$contract.Type}} *{{$contract.Type}}Filterer) Filter{{.Normalized.Name}}(opts *bind.FilterOpts{{range .Normalized.Inputs}}{{if .Indexed}}, {{.Name}} []{{bindtype .Type $structs}}{{end}}{{end}}) (*{{$contract.Type}}{{.Normalized.Name}}Iterator, error) {
 			{{range .Normalized.Inputs}}
-			{{if .Indexed}}var {{.Name}}Rule []interface{}
+			{{if .Indexed}}var {{.Name}}Rule []any
 			for _, {{.Name}}Item := range {{.Name}} {
 				{{.Name}}Rule = append({{.Name}}Rule, {{.Name}}Item)
 			}{{end}}{{end}}
@@ -554,7 +554,7 @@ var (
 		// Solidity: {{.Original.String}}
 		func (_{{$contract.Type}} *{{$contract.Type}}Filterer) Watch{{.Normalized.Name}}(opts *bind.WatchOpts, sink chan<- *{{$contract.Type}}{{.Normalized.Name}}{{range .Normalized.Inputs}}{{if .Indexed}}, {{.Name}} []{{bindtype .Type $structs}}{{end}}{{end}}) (event.Subscription, error) {
 			{{range .Normalized.Inputs}}
-			{{if .Indexed}}var {{.Name}}Rule []interface{}
+			{{if .Indexed}}var {{.Name}}Rule []any
 			for _, {{.Name}}Item := range {{.Name}} {
 				{{.Name}}Rule = append({{.Name}}Rule, {{.Name}}Item)
 			}{{end}}{{end}}

--- a/execution/protocol/rules/aura/auraabi/gen_block_reward.go
+++ b/execution/protocol/rules/aura/auraabi/gen_block_reward.go
@@ -139,7 +139,7 @@ func bindBlockReward(address common.Address, caller bind.ContractCaller, transac
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_BlockReward *BlockRewardRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_BlockReward *BlockRewardRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _BlockReward.Contract.BlockRewardCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -150,7 +150,7 @@ func (_BlockReward *BlockRewardRaw) Transfer(opts *bind.TransactOpts) (types.Tra
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_BlockReward *BlockRewardRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_BlockReward *BlockRewardRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _BlockReward.Contract.BlockRewardTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -158,7 +158,7 @@ func (_BlockReward *BlockRewardRaw) Transact(opts *bind.TransactOpts, method str
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_BlockReward *BlockRewardCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_BlockReward *BlockRewardCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _BlockReward.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -169,7 +169,7 @@ func (_BlockReward *BlockRewardTransactorRaw) Transfer(opts *bind.TransactOpts) 
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_BlockReward *BlockRewardTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_BlockReward *BlockRewardTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _BlockReward.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/protocol/rules/aura/auraabi/gen_validator_set.go
+++ b/execution/protocol/rules/aura/auraabi/gen_validator_set.go
@@ -139,7 +139,7 @@ func bindValidatorSet(address common.Address, caller bind.ContractCaller, transa
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_ValidatorSet *ValidatorSetRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_ValidatorSet *ValidatorSetRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _ValidatorSet.Contract.ValidatorSetCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -150,7 +150,7 @@ func (_ValidatorSet *ValidatorSetRaw) Transfer(opts *bind.TransactOpts) (types.T
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_ValidatorSet *ValidatorSetRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_ValidatorSet *ValidatorSetRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _ValidatorSet.Contract.ValidatorSetTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -158,7 +158,7 @@ func (_ValidatorSet *ValidatorSetRaw) Transact(opts *bind.TransactOpts, method s
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_ValidatorSet *ValidatorSetCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_ValidatorSet *ValidatorSetCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _ValidatorSet.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -169,7 +169,7 @@ func (_ValidatorSet *ValidatorSetTransactorRaw) Transfer(opts *bind.TransactOpts
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_ValidatorSet *ValidatorSetTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_ValidatorSet *ValidatorSetTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _ValidatorSet.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -177,7 +177,7 @@ func (_ValidatorSet *ValidatorSetTransactorRaw) Transact(opts *bind.TransactOpts
 //
 // Solidity: function emitInitiateChangeCallable() view returns(bool)
 func (_ValidatorSet *ValidatorSetCaller) EmitInitiateChangeCallable(opts *bind.CallOpts) (bool, error) {
-	var out []interface{}
+	var out []any
 	err := _ValidatorSet.contract.Call(opts, &out, "emitInitiateChangeCallable")
 
 	if err != nil {
@@ -208,7 +208,7 @@ func (_ValidatorSet *ValidatorSetCallerSession) EmitInitiateChangeCallable() (bo
 //
 // Solidity: function getValidators() returns(address[] validators)
 func (_ValidatorSet *ValidatorSetCaller) GetValidators(opts *bind.CallOpts) ([]common.Address, error) {
-	var out []interface{}
+	var out []any
 	err := _ValidatorSet.contract.Call(opts, &out, "getValidators")
 
 	if err != nil {
@@ -239,7 +239,7 @@ func (_ValidatorSet *ValidatorSetCallerSession) GetValidators() ([]common.Addres
 //
 // Solidity: function shouldValidatorReport(address _reportingValidator, address _maliciousValidator, uint256 _blockNumber) view returns(bool)
 func (_ValidatorSet *ValidatorSetCaller) ShouldValidatorReport(opts *bind.CallOpts, _reportingValidator common.Address, _maliciousValidator common.Address, _blockNumber *big.Int) (bool, error) {
-	var out []interface{}
+	var out []any
 	err := _ValidatorSet.contract.Call(opts, &out, "shouldValidatorReport", _reportingValidator, _maliciousValidator, _blockNumber)
 
 	if err != nil {
@@ -391,7 +391,7 @@ func (_ValidatorSet *ValidatorSetFilterer) InitiateChangeEventID() common.Hash {
 // Solidity: event InitiateChange(bytes32 indexed _parent_hash, address[] _new_set)
 func (_ValidatorSet *ValidatorSetFilterer) FilterInitiateChange(opts *bind.FilterOpts, _parent_hash [][32]byte) (*ValidatorSetInitiateChangeIterator, error) {
 
-	var _parent_hashRule []interface{}
+	var _parent_hashRule []any
 	for _, _parent_hashItem := range _parent_hash {
 		_parent_hashRule = append(_parent_hashRule, _parent_hashItem)
 	}
@@ -408,7 +408,7 @@ func (_ValidatorSet *ValidatorSetFilterer) FilterInitiateChange(opts *bind.Filte
 // Solidity: event InitiateChange(bytes32 indexed _parent_hash, address[] _new_set)
 func (_ValidatorSet *ValidatorSetFilterer) WatchInitiateChange(opts *bind.WatchOpts, sink chan<- *ValidatorSetInitiateChange, _parent_hash [][32]byte) (event.Subscription, error) {
 
-	var _parent_hashRule []interface{}
+	var _parent_hashRule []any
 	for _, _parent_hashItem := range _parent_hash {
 		_parent_hashRule = append(_parent_hashRule, _parent_hashItem)
 	}

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -61,7 +61,7 @@ var (
 	errUint256Large  = errors.New("rlp: value too large for uint256")
 
 	streamPool = sync.Pool{
-		New: func() interface{} { return new(Stream) },
+		New: func() any { return new(Stream) },
 	}
 )
 
@@ -101,7 +101,7 @@ type Decoder interface {
 // panics cause by huge value sizes. If you need an input limit, use
 //
 //	NewStream(r, limit).Decode(val)
-func Decode(r io.Reader, val interface{}) error {
+func Decode(r io.Reader, val any) error {
 	stream := NewStreamFromPool(r, 0)
 	defer PutStream(stream)
 
@@ -110,7 +110,7 @@ func Decode(r io.Reader, val interface{}) error {
 
 // DecodeBytes parses RLP data from b into val. Please see package-level documentation for
 // the decoding rules. The input must contain exactly one value and no trailing data.
-func DecodeBytes(b []byte, val interface{}) error {
+func DecodeBytes(b []byte, val any) error {
 	stream := NewBytesStream(b)
 	defer PutStream(stream)
 
@@ -990,7 +990,7 @@ func (s *Stream) Uint256Bytes() ([]byte, error) {
 // Decode decodes a value and stores the result in the value pointed
 // to by val. Please see the documentation for the Decode function
 // to learn about the decoding rules.
-func (s *Stream) Decode(val interface{}) error {
+func (s *Stream) Decode(val any) error {
 	if val == nil {
 		return errDecodeIntoNil
 	}

--- a/execution/rlp/encbuffer.go
+++ b/execution/rlp/encbuffer.go
@@ -37,7 +37,7 @@ type encBuffer struct {
 
 // The global encBuffer pool.
 var encBufferPool = sync.Pool{
-	New: func() interface{} { return new(encBuffer) },
+	New: func() any { return new(encBuffer) },
 }
 
 func getEncBuffer() *encBuffer {
@@ -181,7 +181,7 @@ func (buf *encBuffer) listEnd(index int) {
 	}
 }
 
-func (buf *encBuffer) encode(val interface{}) error {
+func (buf *encBuffer) encode(val any) error {
 	rval := reflect.ValueOf(val)
 	writer, err := cachedWriter(rval.Type())
 	if err != nil {

--- a/execution/rlp/encode.go
+++ b/execution/rlp/encode.go
@@ -62,7 +62,7 @@ type Encoder interface {
 // buffered.
 //
 // Please see package-level documentation of encoding rules.
-func Encode(w io.Writer, val interface{}) error {
+func Encode(w io.Writer, val any) error {
 	// Optimization: reuse *encBuffer when called by EncodeRLP.
 	if buf := encBufferFromWriter(w); buf != nil {
 		return buf.encode(val)
@@ -78,7 +78,7 @@ func Encode(w io.Writer, val interface{}) error {
 
 // EncodeToBytes returns the RLP encoding of val.
 // Please see package-level documentation for the encoding rules.
-func EncodeToBytes(val interface{}) ([]byte, error) {
+func EncodeToBytes(val any) ([]byte, error) {
 	buf := getEncBuffer()
 	defer encBufferPool.Put(buf)
 
@@ -93,7 +93,7 @@ func EncodeToBytes(val interface{}) ([]byte, error) {
 // data.
 //
 // Please see the documentation of Encode for the encoding rules.
-func EncodeToReader(val interface{}) (size int, r io.Reader, err error) {
+func EncodeToReader(val any) (size int, r io.Reader, err error) {
 	buf := getEncBuffer()
 	if err := buf.encode(val); err != nil {
 		encBufferPool.Put(buf)

--- a/execution/state/contracts/gen_changer.go
+++ b/execution/state/contracts/gen_changer.go
@@ -156,7 +156,7 @@ func bindChanger(address common.Address, caller bind.ContractCaller, transactor 
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Changer *ChangerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Changer *ChangerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Changer.Contract.ChangerCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Changer *ChangerRaw) Transfer(opts *bind.TransactOpts) (types.Transaction
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Changer *ChangerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Changer *ChangerRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Changer.Contract.ChangerTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Changer *ChangerRaw) Transact(opts *bind.TransactOpts, method string, par
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Changer *ChangerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Changer *ChangerCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Changer.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Changer *ChangerTransactorRaw) Transfer(opts *bind.TransactOpts) (types.T
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Changer *ChangerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Changer *ChangerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Changer.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/state/contracts/gen_disperse.go
+++ b/execution/state/contracts/gen_disperse.go
@@ -156,7 +156,7 @@ func bindDisperse(address common.Address, caller bind.ContractCaller, transactor
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Disperse *DisperseRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Disperse *DisperseRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Disperse.Contract.DisperseCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Disperse *DisperseRaw) Transfer(opts *bind.TransactOpts) (types.Transacti
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Disperse *DisperseRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Disperse *DisperseRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Disperse.Contract.DisperseTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Disperse *DisperseRaw) Transact(opts *bind.TransactOpts, method string, p
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Disperse *DisperseCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Disperse *DisperseCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Disperse.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Disperse *DisperseTransactorRaw) Transfer(opts *bind.TransactOpts) (types
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Disperse *DisperseTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Disperse *DisperseTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Disperse.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/state/contracts/gen_phoenix.go
+++ b/execution/state/contracts/gen_phoenix.go
@@ -156,7 +156,7 @@ func bindPhoenix(address common.Address, caller bind.ContractCaller, transactor 
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Phoenix *PhoenixRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Phoenix *PhoenixRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Phoenix.Contract.PhoenixCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Phoenix *PhoenixRaw) Transfer(opts *bind.TransactOpts) (types.Transaction
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Phoenix *PhoenixRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Phoenix *PhoenixRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Phoenix.Contract.PhoenixTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Phoenix *PhoenixRaw) Transact(opts *bind.TransactOpts, method string, par
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Phoenix *PhoenixCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Phoenix *PhoenixCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Phoenix.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Phoenix *PhoenixTransactorRaw) Transfer(opts *bind.TransactOpts) (types.T
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Phoenix *PhoenixTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Phoenix *PhoenixTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Phoenix.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/state/contracts/gen_poly.go
+++ b/execution/state/contracts/gen_poly.go
@@ -156,7 +156,7 @@ func bindPoly(address common.Address, caller bind.ContractCaller, transactor bin
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Poly *PolyRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Poly *PolyRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Poly.Contract.PolyCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Poly *PolyRaw) Transfer(opts *bind.TransactOpts) (types.Transaction, erro
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Poly *PolyRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Poly *PolyRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Poly.Contract.PolyTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Poly *PolyRaw) Transact(opts *bind.TransactOpts, method string, params ..
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Poly *PolyCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Poly *PolyCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Poly.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Poly *PolyTransactorRaw) Transfer(opts *bind.TransactOpts) (types.Transac
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Poly *PolyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Poly *PolyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Poly.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/state/contracts/gen_proxy.go
+++ b/execution/state/contracts/gen_proxy.go
@@ -156,7 +156,7 @@ func bindProxy(address common.Address, caller bind.ContractCaller, transactor bi
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Proxy *ProxyRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Proxy *ProxyRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Proxy.Contract.ProxyCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Proxy *ProxyRaw) Transfer(opts *bind.TransactOpts) (types.Transaction, er
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Proxy *ProxyRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Proxy *ProxyRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Proxy.Contract.ProxyTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Proxy *ProxyRaw) Transact(opts *bind.TransactOpts, method string, params 
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Proxy *ProxyCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Proxy *ProxyCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Proxy.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Proxy *ProxyTransactorRaw) Transfer(opts *bind.TransactOpts) (types.Trans
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Proxy *ProxyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Proxy *ProxyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Proxy.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/state/contracts/gen_proxyfactory.go
+++ b/execution/state/contracts/gen_proxyfactory.go
@@ -156,7 +156,7 @@ func bindProxyFactory(address common.Address, caller bind.ContractCaller, transa
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_ProxyFactory *ProxyFactoryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_ProxyFactory *ProxyFactoryRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _ProxyFactory.Contract.ProxyFactoryCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_ProxyFactory *ProxyFactoryRaw) Transfer(opts *bind.TransactOpts) (types.T
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_ProxyFactory *ProxyFactoryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_ProxyFactory *ProxyFactoryRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _ProxyFactory.Contract.ProxyFactoryTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_ProxyFactory *ProxyFactoryRaw) Transact(opts *bind.TransactOpts, method s
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_ProxyFactory *ProxyFactoryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_ProxyFactory *ProxyFactoryCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _ProxyFactory.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_ProxyFactory *ProxyFactoryTransactorRaw) Transfer(opts *bind.TransactOpts
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_ProxyFactory *ProxyFactoryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_ProxyFactory *ProxyFactoryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _ProxyFactory.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/state/contracts/gen_revive.go
+++ b/execution/state/contracts/gen_revive.go
@@ -156,7 +156,7 @@ func bindRevive(address common.Address, caller bind.ContractCaller, transactor b
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Revive *ReviveRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Revive *ReviveRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Revive.Contract.ReviveCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Revive *ReviveRaw) Transfer(opts *bind.TransactOpts) (types.Transaction, 
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Revive *ReviveRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Revive *ReviveRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Revive.Contract.ReviveTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Revive *ReviveRaw) Transact(opts *bind.TransactOpts, method string, param
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Revive *ReviveCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Revive *ReviveCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Revive.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Revive *ReviveTransactorRaw) Transfer(opts *bind.TransactOpts) (types.Tra
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Revive *ReviveTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Revive *ReviveTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Revive.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/state/contracts/gen_revive2.go
+++ b/execution/state/contracts/gen_revive2.go
@@ -156,7 +156,7 @@ func bindRevive2(address common.Address, caller bind.ContractCaller, transactor 
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Revive2 *Revive2Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Revive2 *Revive2Raw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Revive2.Contract.Revive2Caller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Revive2 *Revive2Raw) Transfer(opts *bind.TransactOpts) (types.Transaction
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Revive2 *Revive2Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Revive2 *Revive2Raw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Revive2.Contract.Revive2Transactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Revive2 *Revive2Raw) Transact(opts *bind.TransactOpts, method string, par
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Revive2 *Revive2CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Revive2 *Revive2CallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Revive2.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Revive2 *Revive2TransactorRaw) Transfer(opts *bind.TransactOpts) (types.T
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Revive2 *Revive2TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Revive2 *Revive2TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Revive2.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/state/contracts/gen_selfdestruct.go
+++ b/execution/state/contracts/gen_selfdestruct.go
@@ -156,7 +156,7 @@ func bindSelfdestruct(address common.Address, caller bind.ContractCaller, transa
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Selfdestruct *SelfdestructRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Selfdestruct *SelfdestructRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Selfdestruct.Contract.SelfdestructCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Selfdestruct *SelfdestructRaw) Transfer(opts *bind.TransactOpts) (types.T
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Selfdestruct *SelfdestructRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Selfdestruct *SelfdestructRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Selfdestruct.Contract.SelfdestructTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Selfdestruct *SelfdestructRaw) Transact(opts *bind.TransactOpts, method s
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Selfdestruct *SelfdestructCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Selfdestruct *SelfdestructCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Selfdestruct.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Selfdestruct *SelfdestructTransactorRaw) Transfer(opts *bind.TransactOpts
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Selfdestruct *SelfdestructTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Selfdestruct *SelfdestructTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Selfdestruct.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/state/contracts/gen_statechurn.go
+++ b/execution/state/contracts/gen_statechurn.go
@@ -156,7 +156,7 @@ func bindStateChurn(address common.Address, caller bind.ContractCaller, transact
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_StateChurn *StateChurnRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_StateChurn *StateChurnRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _StateChurn.Contract.StateChurnCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_StateChurn *StateChurnRaw) Transfer(opts *bind.TransactOpts) (types.Trans
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_StateChurn *StateChurnRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_StateChurn *StateChurnRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _StateChurn.Contract.StateChurnTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_StateChurn *StateChurnRaw) Transact(opts *bind.TransactOpts, method strin
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_StateChurn *StateChurnCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_StateChurn *StateChurnCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _StateChurn.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_StateChurn *StateChurnTransactorRaw) Transfer(opts *bind.TransactOpts) (t
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_StateChurn *StateChurnTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_StateChurn *StateChurnTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _StateChurn.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -194,7 +194,7 @@ func (_StateChurn *StateChurnTransactorRaw) Transact(opts *bind.TransactOpts, me
 //
 // Solidity: function check() view returns(bool)
 func (_StateChurn *StateChurnCaller) Check(opts *bind.CallOpts) (bool, error) {
-	var out []interface{}
+	var out []any
 	err := _StateChurn.contract.Call(opts, &out, "check")
 
 	if err != nil {
@@ -225,7 +225,7 @@ func (_StateChurn *StateChurnCallerSession) Check() (bool, error) {
 //
 // Solidity: function computedSum() view returns(uint256 sum)
 func (_StateChurn *StateChurnCaller) ComputedSum(opts *bind.CallOpts) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _StateChurn.contract.Call(opts, &out, "computedSum")
 
 	if err != nil {
@@ -256,7 +256,7 @@ func (_StateChurn *StateChurnCallerSession) ComputedSum() (*big.Int, error) {
 //
 // Solidity: function cursor() view returns(uint256)
 func (_StateChurn *StateChurnCaller) Cursor(opts *bind.CallOpts) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _StateChurn.contract.Call(opts, &out, "cursor")
 
 	if err != nil {
@@ -287,7 +287,7 @@ func (_StateChurn *StateChurnCallerSession) Cursor() (*big.Int, error) {
 //
 // Solidity: function trackedSum() view returns(uint256)
 func (_StateChurn *StateChurnCaller) TrackedSum(opts *bind.CallOpts) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _StateChurn.contract.Call(opts, &out, "trackedSum")
 
 	if err != nil {

--- a/execution/tests/contracts/gen_selfDestructor.go
+++ b/execution/tests/contracts/gen_selfDestructor.go
@@ -156,7 +156,7 @@ func bindSelfDestructor(address common.Address, caller bind.ContractCaller, tran
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_SelfDestructor *SelfDestructorRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_SelfDestructor *SelfDestructorRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _SelfDestructor.Contract.SelfDestructorCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_SelfDestructor *SelfDestructorRaw) Transfer(opts *bind.TransactOpts) (typ
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_SelfDestructor *SelfDestructorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_SelfDestructor *SelfDestructorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _SelfDestructor.Contract.SelfDestructorTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_SelfDestructor *SelfDestructorRaw) Transact(opts *bind.TransactOpts, meth
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_SelfDestructor *SelfDestructorCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_SelfDestructor *SelfDestructorCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _SelfDestructor.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_SelfDestructor *SelfDestructorTransactorRaw) Transfer(opts *bind.Transact
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_SelfDestructor *SelfDestructorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_SelfDestructor *SelfDestructorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _SelfDestructor.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/execution/tests/contracts/gen_testcontract.go
+++ b/execution/tests/contracts/gen_testcontract.go
@@ -156,7 +156,7 @@ func bindTestcontract(address common.Address, caller bind.ContractCaller, transa
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Testcontract *TestcontractRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Testcontract *TestcontractRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Testcontract.Contract.TestcontractCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Testcontract *TestcontractRaw) Transfer(opts *bind.TransactOpts) (types.T
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Testcontract *TestcontractRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Testcontract *TestcontractRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Testcontract.Contract.TestcontractTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Testcontract *TestcontractRaw) Transact(opts *bind.TransactOpts, method s
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Testcontract *TestcontractCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Testcontract *TestcontractCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Testcontract.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Testcontract *TestcontractTransactorRaw) Transfer(opts *bind.TransactOpts
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Testcontract *TestcontractTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Testcontract *TestcontractTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Testcontract.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -194,7 +194,7 @@ func (_Testcontract *TestcontractTransactorRaw) Transact(opts *bind.TransactOpts
 //
 // Solidity: function balances(address ) view returns(uint256)
 func (_Testcontract *TestcontractCaller) Balances(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _Testcontract.contract.Call(opts, &out, "balances", arg0)
 
 	if err != nil {

--- a/node/app/component/component.go
+++ b/node/app/component/component.go
@@ -99,7 +99,7 @@ type Component[P any] interface {
 
 	Provider() *P
 
-	EventBus(key interface{}) *event.ManagedEventBus
+	EventBus(key any) *event.ManagedEventBus
 }
 
 type typedComponent[P any] struct {
@@ -138,10 +138,10 @@ func (c typedComponent[P]) Deactivate(ctx context.Context, handler ...ActivityHa
 var deactivatoinWaiters = struct {
 	sync.Mutex
 	*util.ChannelGroup
-	cmap   map[interface{}]*component
+	cmap   map[any]*component
 	cancel func()
 }{
-	cmap: map[interface{}]*component{},
+	cmap: map[any]*component{},
 }
 
 // relations is stored as []*component (not []relation) so pointer identity
@@ -301,7 +301,7 @@ type component struct {
 	state           State
 	dependents      relations
 	dependencies    relations
-	provider        interface{}
+	provider        any
 	log             app.Logger
 	flags           []cli.Flag
 	inbox           chan actorMsg // serializes activate/deactivate/stateChanged — prevents lock-ordering deadlocks
@@ -379,7 +379,7 @@ type componentOptions struct {
 	id           string
 	logLabels    []string
 	logLvl       liblog.Lvl
-	logCtx       []interface{}
+	logCtx       []any
 }
 
 func WithLogLevel(lvl liblog.Lvl) app.Option {
@@ -398,7 +398,7 @@ func WithLogLabels(labels ...string) app.Option {
 		})
 }
 
-func WithLogCtx(ctx ...interface{}) app.Option {
+func WithLogCtx(ctx ...any) app.Option {
 	return app.WithOption[componentOptions](
 		func(c *componentOptions) bool {
 			c.logCtx = ctx
@@ -1034,7 +1034,7 @@ func awaitDeactivationChannels() {
 	waiters := &deactivatoinWaiters
 	go func() {
 		myChannels.Wait(
-			func(ch interface{}, _ interface{}, _ bool) (bool, bool) {
+			func(ch any, _ any, _ bool) (bool, bool) {
 				waiters.Lock()
 				c, ok := waiters.cmap[ch]
 				delete(waiters.cmap, ch)
@@ -1155,7 +1155,7 @@ func (c *component) deactivateProvider(ctx context.Context, onActivity onActivit
 	return nil
 }
 
-func (c *component) EventBus(key interface{}) *event.ManagedEventBus {
+func (c *component) EventBus(key any) *event.ManagedEventBus {
 	return c.serviceBus().GetEventBus(key)
 }
 
@@ -1171,7 +1171,7 @@ func (c *component) serviceBus() *event.ServiceBus {
 
 func (c *component) setDomain(cm *componentDomain, domainLocked bool) error {
 	if c.componentDomain != cm {
-		var registrations []interface{}
+		var registrations []any
 
 		if c.componentDomain != nil {
 			registrations = c.serviceBus().Registrations(c)

--- a/node/app/component/componentdomain.go
+++ b/node/app/component/componentdomain.go
@@ -76,7 +76,7 @@ type componentDomain struct {
 
 type serviceManager interface {
 	ServiceBus() *event.ServiceBus
-	Post(args ...interface{})
+	Post(args ...any)
 }
 
 type domainOptions struct {

--- a/node/app/component/event_flow_test.go
+++ b/node/app/component/event_flow_test.go
@@ -65,7 +65,7 @@ type DownloadComplete struct{ Path string }
 
 type eventProvider struct {
 	name     string
-	received []interface{}
+	received []any
 	mu       sync.Mutex
 	tracker  *orderTracker
 }
@@ -102,10 +102,10 @@ func (p *eventProvider) HandleFileDeleted(evt FileDeleted) {
 	p.tracker.record(p.name + ":FileDeleted:" + evt.Path)
 }
 
-func (p *eventProvider) getReceived() []interface{} {
+func (p *eventProvider) getReceived() []any {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	out := make([]interface{}, len(p.received))
+	out := make([]any, len(p.received))
 	copy(out, p.received)
 	return out
 }

--- a/node/app/domain.go
+++ b/node/app/domain.go
@@ -54,7 +54,7 @@ type Domain interface {
 	RootId() DomainId
 	Name() string
 
-	CompareTo(other interface{}) int
+	CompareTo(other any) int
 	Matches(other Domain) bool
 	Equals(other Domain) bool
 	String() string
@@ -75,7 +75,7 @@ func (f DomainFactoryFunc) New(context context.Context) (Domain, error) {
 	return f(context)
 }
 
-func CompareDomains(a, b interface{}) int {
+func CompareDomains(a, b any) int {
 	ad := a.(Domain)
 	bd := b.(Domain)
 	return bytes.Compare(unique.Handle[ident](ad.Id()).Value().asBytes(), unique.Handle[ident](bd.Id()).Value().asBytes())
@@ -102,7 +102,7 @@ func withFeature[T any](applicator func(t *T)) domainFeature {
 	var t T
 	return domainFeature{
 		target:     reflect.TypeOf(t),
-		applicator: func(t interface{}) { applicator(t.(*T)) },
+		applicator: func(t any) { applicator(t.(*T)) },
 	}
 }
 
@@ -114,7 +114,7 @@ func WithInfo[T comparable](info map[any]any) domainFeature {
 	return withFeature[domain[T]](func(d *domain[T]) {
 		if len(info) > 0 {
 			if d.info == nil {
-				d.info = make(map[interface{}]interface{})
+				d.info = make(map[any]any)
 			}
 			for key, value := range info {
 				d.info[key] = value
@@ -215,7 +215,7 @@ func newDomain[T comparable](rootId ident, incarnation Incarnation, features ...
 		return domain, nil
 	}
 
-	var info map[interface{}]interface{}
+	var info map[any]any
 
 	d := &domain[T]{
 		id:          id,
@@ -237,7 +237,7 @@ func (d *domain[T]) Equals(domain Domain) bool {
 	return d.CompareTo(domain) == 0
 }
 
-func (d *domain[T]) CompareTo(other interface{}) int {
+func (d *domain[T]) CompareTo(other any) int {
 	if other == nil {
 		return 1
 	}
@@ -349,7 +349,7 @@ func (d *domain[T]) Source() string {
 	return ""
 }
 
-func (d *domain[T]) InfoValue(key interface{}) interface{} {
+func (d *domain[T]) InfoValue(key any) any {
 	if d.info != nil {
 		value, ok := d.info[key]
 		if ok {
@@ -364,9 +364,9 @@ func (d *domain[T]) IdGenerator() IdGenerator[T] {
 	return d.idGenerator
 }
 
-func (d *domain[T]) NewId(generationContext context.Context, entity ...interface{}) (Id, error) {
+func (d *domain[T]) NewId(generationContext context.Context, entity ...any) (Id, error) {
 	if d.idGenerator != nil {
-		var e interface{}
+		var e any
 
 		if len(entity) > 0 {
 			e = entity[0]

--- a/node/app/event/event.go
+++ b/node/app/event/event.go
@@ -28,7 +28,7 @@ type Cloneable[T any] interface {
 
 type event interface {
 	HasSource() bool
-	Source() interface{}
+	Source() any
 
 	SourceId() app.Id
 	HasSourceId() bool
@@ -36,7 +36,7 @@ type event interface {
 
 	Context() context.Context
 
-	setSource(source interface{})
+	setSource(source any)
 	setContext(context context.Context)
 }
 
@@ -45,7 +45,7 @@ type Event[E event] interface {
 	event
 
 	WithContext(context context.Context) E
-	WithSource(source interface{}) E
+	WithSource(source any) E
 }
 
 type UndeliveredEvent struct {
@@ -53,11 +53,11 @@ type UndeliveredEvent struct {
 
 type BaseEvent[E event] struct {
 	event
-	source  interface{}
+	source  any
 	context context.Context `json:"-"`
 }
 
-func NewBaseEvent[E event](eventContext context.Context, derived E, source interface{}) *BaseEvent[E] {
+func NewBaseEvent[E event](eventContext context.Context, derived E, source any) *BaseEvent[E] {
 	return &BaseEvent[E]{derived, source, eventContext}
 }
 
@@ -69,7 +69,7 @@ func (event *BaseEvent[E]) HasSource() bool {
 	return event.source != nil
 }
 
-func (event *BaseEvent[E]) Source() interface{} {
+func (event *BaseEvent[E]) Source() any {
 	return event.source
 }
 
@@ -103,11 +103,11 @@ func (event *BaseEvent[E]) HasSourceId() bool {
 	return event.SourceId() != nil
 }
 
-func (event *BaseEvent[E]) setSource(source interface{}) {
+func (event *BaseEvent[E]) setSource(source any) {
 	event.source = source
 }
 
-func (event *BaseEvent[E]) WithSource(source interface{}) E {
+func (event *BaseEvent[E]) WithSource(source any) E {
 	withSource := event.event.(Event[E]).Clone()
 	withSource.setSource(source)
 	return withSource

--- a/node/app/event/eventbus.go
+++ b/node/app/event/eventbus.go
@@ -29,16 +29,16 @@ import (
 
 // BusSubscriber defines subscription-related bus behavior
 type BusSubscriber interface {
-	Subscribe(fn interface{}) error
-	SubscribeAsync(fn interface{}) error
-	SubscribeOnce(fn interface{}) error
-	SubscribeOnceAsync(fn interface{}) error
-	Unsubscribe(handler interface{}) error
+	Subscribe(fn any) error
+	SubscribeAsync(fn any) error
+	SubscribeOnce(fn any) error
+	SubscribeOnceAsync(fn any) error
+	Unsubscribe(handler any) error
 }
 
 // BusPublisher defines publishing-related bus behavior
 type BusPublisher interface {
-	Publish(args ...interface{}) int
+	Publish(args ...any) int
 }
 
 // BusController defines bus control behavior (checking handler's presence, synchronization)
@@ -120,7 +120,7 @@ func (hmap *handlerMap) removeOnceHandler(callback reflect.Value) {
 	}
 }
 
-func (hmap *handlerMap) publish(bus *eventBus, args []interface{}, argIndex int) int {
+func (hmap *handlerMap) publish(bus *eventBus, args []any, argIndex int) int {
 	var pubcount int = 0
 
 	if argIndex < len(args) {
@@ -244,7 +244,7 @@ func newEventHandler(bus *eventBus, callBack reflect.Value, flagOnce, async bool
 	return h
 }
 
-func (handler *eventHandler) doPublish(bus *eventBus, logEnabled bool, args ...interface{}) {
+func (handler *eventHandler) doPublish(bus *eventBus, logEnabled bool, args ...any) {
 	passedArguments := make([]reflect.Value, len(args))
 	for i, arg := range args {
 		passedArguments[i] = reflect.ValueOf(arg)
@@ -291,7 +291,7 @@ func NewEventBus(execPool util.ExecPool) EventBus {
 
 // doSubscribe handles the subscription logic and is utilized by the public Subscribe functions.
 // Uses copy-on-write: clone the current root, mutate the clone, atomically swap it in.
-func (bus *eventBus) doSubscribe(fn interface{}, handler *eventHandler) error {
+func (bus *eventBus) doSubscribe(fn any, handler *eventHandler) error {
 	fnType := reflect.TypeOf(fn)
 	if !(fnType.Kind() == reflect.Func) {
 		return fmt.Errorf("%s is not of type reflect.Func", reflect.TypeOf(fn).Kind())
@@ -328,7 +328,7 @@ func (bus *eventBus) doSubscribe(fn interface{}, handler *eventHandler) error {
 
 // Subscribe subscribes to a topic.
 // Returns error if `fn` is not a function.
-func (bus *eventBus) Subscribe(fn interface{}) error {
+func (bus *eventBus) Subscribe(fn any) error {
 	return bus.doSubscribe(fn, newEventHandler(bus, reflect.ValueOf(fn), false, false))
 }
 
@@ -336,20 +336,20 @@ func (bus *eventBus) Subscribe(fn interface{}) error {
 // Transactional determines whether subsequent callbacks for a topic are
 // run serially (true) or concurrently (false)
 // Returns error if `fn` is not a function.
-func (bus *eventBus) SubscribeAsync(fn interface{}) error {
+func (bus *eventBus) SubscribeAsync(fn any) error {
 	return bus.doSubscribe(fn, newEventHandler(bus, reflect.ValueOf(fn), false, true))
 }
 
 // SubscribeOnce subscribes to a topic once. Handler will be removed after executing.
 // Returns error if `fn` is not a function.
-func (bus *eventBus) SubscribeOnce(fn interface{}) error {
+func (bus *eventBus) SubscribeOnce(fn any) error {
 	return bus.doSubscribe(fn, newEventHandler(bus, reflect.ValueOf(fn), true, false))
 }
 
 // SubscribeOnceAsync subscribes to a topic once with an asynchronous callback
 // Handler will be removed after executing.
 // Returns error if `fn` is not a function.
-func (bus *eventBus) SubscribeOnceAsync(fn interface{}) error {
+func (bus *eventBus) SubscribeOnceAsync(fn any) error {
 	return bus.doSubscribe(fn, newEventHandler(bus, reflect.ValueOf(fn), true, true))
 }
 
@@ -390,7 +390,7 @@ func (bus *eventBus) HasCallback(types ...reflect.Type) bool {
 // Unsubscribe removes callback defined for a topic.
 // Returns error if there are no callbacks subscribed to the topic.
 // Uses copy-on-write: clone the root, mutate the clone, atomically swap.
-func (bus *eventBus) Unsubscribe(fn interface{}) error {
+func (bus *eventBus) Unsubscribe(fn any) error {
 	bus.writerLock.Lock()
 	defer bus.writerLock.Unlock()
 
@@ -438,7 +438,7 @@ func (bus *eventBus) Unsubscribe(fn interface{}) error {
 // Re-entrant calls to Publish/Subscribe/Unsubscribe from inside a handler are safe — writers
 // operate on a separate cloned map that is CAS-swapped at the end.
 // Once-handlers are removed via copy-on-write in a compare-and-swap loop after execution.
-func (bus *eventBus) Publish(args ...interface{}) int {
+func (bus *eventBus) Publish(args ...any) int {
 	snapshot := bus.handlerMap.Load()
 	count := snapshot.publish(bus, args, 0)
 

--- a/node/app/event/eventmanager.go
+++ b/node/app/event/eventmanager.go
@@ -22,5 +22,5 @@ type EventManager interface {
 
 	IsActive() bool
 
-	EventBus(key interface{}) *ManagedEventBus
+	EventBus(key any) *ManagedEventBus
 }

--- a/node/app/event/managedeventbus.go
+++ b/node/app/event/managedeventbus.go
@@ -25,20 +25,20 @@ import (
 type ManagedEventBus struct {
 	serviceBus       *ServiceBus
 	eventBus         EventBus
-	key              interface{}
-	registrations    map[uintptr][]interface{}
+	key              any
+	registrations    map[uintptr][]any
 	registrationLock sync.Mutex
 }
 
-func NewManagedEventBus(serviceBus *ServiceBus, key interface{}) *ManagedEventBus {
-	return &ManagedEventBus{serviceBus, NewEventBus(serviceBus.execPool), key, make(map[uintptr][]interface{}), sync.Mutex{}}
+func NewManagedEventBus(serviceBus *ServiceBus, key any) *ManagedEventBus {
+	return &ManagedEventBus{serviceBus, NewEventBus(serviceBus.execPool), key, make(map[uintptr][]any), sync.Mutex{}}
 }
 
 func (bus *ManagedEventBus) String() string {
 	return fmt.Sprintf("ManagedEventBus [key=%v]", bus.key)
 }
 
-func (bus *ManagedEventBus) Register(object interface{}, fns ...interface{}) (err error) {
+func (bus *ManagedEventBus) Register(object any, fns ...any) (err error) {
 	objectVal := reflect.ValueOf(object)
 	if len(fns) == 0 {
 		for i := 0; i < objectVal.NumMethod(); i++ {
@@ -68,7 +68,7 @@ func (bus *ManagedEventBus) Register(object interface{}, fns ...interface{}) (er
 	return err
 }
 
-func (bus *ManagedEventBus) UnregisterAll(object interface{}) error {
+func (bus *ManagedEventBus) UnregisterAll(object any) error {
 	objectVal := reflect.ValueOf(object)
 	switch objectVal.Kind() {
 	case reflect.Pointer, reflect.Chan, reflect.Map, reflect.Func, reflect.Slice, reflect.UnsafePointer:
@@ -90,7 +90,7 @@ func (bus *ManagedEventBus) UnregisterAll(object interface{}) error {
 	return nil
 }
 
-func (bus *ManagedEventBus) Unregister(object interface{}, fn interface{}) error {
+func (bus *ManagedEventBus) Unregister(object any, fn any) error {
 	objectPtr := reflect.ValueOf(object).Pointer()
 	bus.registrationLock.Lock()
 	if registrations, ok := bus.registrations[objectPtr]; ok && len(registrations) > 0 {
@@ -100,11 +100,11 @@ func (bus *ManagedEventBus) Unregister(object interface{}, fn interface{}) error
 	return bus.eventBus.Unsubscribe(fn)
 }
 
-func (bus *ManagedEventBus) Post(args ...interface{}) int {
+func (bus *ManagedEventBus) Post(args ...any) int {
 	return bus.eventBus.Publish(args...)
 }
 
-func removeRegistration(registrations map[uintptr][]interface{}, objectPtr uintptr, idx int) {
+func removeRegistration(registrations map[uintptr][]any, objectPtr uintptr, idx int) {
 	if _, ok := registrations[objectPtr]; !ok || idx < 0 {
 		return
 	}
@@ -115,7 +115,7 @@ func removeRegistration(registrations map[uintptr][]interface{}, objectPtr uintp
 	registrations[objectPtr] = registrations[objectPtr][:l-1]
 }
 
-func findRegistrationIndex(registrations map[uintptr][]interface{}, objectPtr uintptr, fn interface{}) int {
+func findRegistrationIndex(registrations map[uintptr][]any, objectPtr uintptr, fn any) int {
 	if _, ok := registrations[objectPtr]; ok {
 		for idx, subscription := range registrations[objectPtr] {
 			//fmt.Printf("%v=%v (%v)\n", subscription, fn, reflect.ValueOf(subscription).Pointer() == reflect.ValueOf(fn).Pointer())

--- a/node/app/event/servicebus.go
+++ b/node/app/event/servicebus.go
@@ -28,17 +28,17 @@ import (
 type ServiceBus struct {
 	eventBus         EventBus
 	execPool         util.ExecPool
-	busMap           map[interface{}]*ManagedEventBus
+	busMap           map[any]*ManagedEventBus
 	mapLock          *sync.Mutex
-	registrations    map[uintptr][]interface{}
+	registrations    map[uintptr][]any
 	registrationLock sync.Mutex
 }
 
 func NewServiceBus(execPool util.ExecPool) *ServiceBus {
-	return &ServiceBus{NewEventBus(execPool), execPool, make(map[interface{}]*ManagedEventBus), &sync.Mutex{}, make(map[uintptr][]interface{}), sync.Mutex{}}
+	return &ServiceBus{NewEventBus(execPool), execPool, make(map[any]*ManagedEventBus), &sync.Mutex{}, make(map[uintptr][]any), sync.Mutex{}}
 }
 
-func (bus *ServiceBus) GetEventBus(key interface{}) *ManagedEventBus {
+func (bus *ServiceBus) GetEventBus(key any) *ManagedEventBus {
 	bus.mapLock.Lock()
 	defer bus.mapLock.Unlock()
 
@@ -63,7 +63,7 @@ func (bus *ServiceBus) Deactivate() { /*
 // objectPointer returns reflect.Value.Pointer() if object has a kind that
 // supports it (pointer-like). Returns false otherwise so callers can return a
 // descriptive error rather than panic inside reflect.
-func objectPointer(object interface{}) (uintptr, bool) {
+func objectPointer(object any) (uintptr, bool) {
 	v := reflect.ValueOf(object)
 	switch v.Kind() {
 	case reflect.Pointer, reflect.Chan, reflect.Map, reflect.Func, reflect.Slice, reflect.UnsafePointer:
@@ -73,7 +73,7 @@ func objectPointer(object interface{}) (uintptr, bool) {
 	}
 }
 
-func (bus *ServiceBus) Register(object interface{}, fns ...interface{}) (err error) {
+func (bus *ServiceBus) Register(object any, fns ...any) (err error) {
 	objectPtr, ok := objectPointer(object)
 	if !ok {
 		return fmt.Errorf("ServiceBus.Register: object kind %s is not supported; pass a pointer", reflect.ValueOf(object).Kind())
@@ -94,7 +94,7 @@ func (bus *ServiceBus) Register(object interface{}, fns ...interface{}) (err err
 	return err
 }
 
-func (bus *ServiceBus) UnregisterAll(object interface{}) error {
+func (bus *ServiceBus) UnregisterAll(object any) error {
 	objectPtr, ok := objectPointer(object)
 	if !ok {
 		return fmt.Errorf("ServiceBus.UnregisterAll: object kind %s is not supported; pass a pointer", reflect.ValueOf(object).Kind())
@@ -118,7 +118,7 @@ func (bus *ServiceBus) UnregisterAll(object interface{}) error {
 	return nil
 }
 
-func (bus *ServiceBus) Unregister(object interface{}, fns ...interface{}) error {
+func (bus *ServiceBus) Unregister(object any, fns ...any) error {
 	objectPtr, ok := objectPointer(object)
 	if !ok {
 		return fmt.Errorf("ServiceBus.Unregister: object kind %s is not supported; pass a pointer", reflect.ValueOf(object).Kind())
@@ -145,7 +145,7 @@ func (bus *ServiceBus) Unregister(object interface{}, fns ...interface{}) error 
 	return nil
 }
 
-func (bus *ServiceBus) Registrations(object interface{}) []interface{} {
+func (bus *ServiceBus) Registrations(object any) []any {
 	objectPtr, ok := objectPointer(object)
 	if !ok {
 		return nil
@@ -157,11 +157,11 @@ func (bus *ServiceBus) Registrations(object interface{}) []interface{} {
 	if len(src) == 0 {
 		return nil
 	}
-	out := make([]interface{}, len(src))
+	out := make([]any, len(src))
 	copy(out, src)
 	return out
 }
 
-func (bus *ServiceBus) Post(args ...interface{}) int {
+func (bus *ServiceBus) Post(args ...any) int {
 	return bus.eventBus.Publish(args...)
 }

--- a/node/app/generators.go
+++ b/node/app/generators.go
@@ -35,7 +35,7 @@ type sequentialGenerator[T constraints.Integer] struct {
 	mutex  sync.Mutex
 }
 
-func (generator *sequentialGenerator[T]) GenerateId(generationContext context.Context, entity ...interface{}) (T, error) {
+func (generator *sequentialGenerator[T]) GenerateId(generationContext context.Context, entity ...any) (T, error) {
 	generator.mutex.Lock()
 	id := generator.nextId
 	generator.nextId++
@@ -51,7 +51,7 @@ type fixedValueGenerator[T comparable] struct {
 	value T
 }
 
-func (generator *fixedValueGenerator[T]) GenerateId(generationContext context.Context, entity ...interface{}) (T, error) {
+func (generator *fixedValueGenerator[T]) GenerateId(generationContext context.Context, entity ...any) (T, error) {
 	return generator.value, nil
 }
 
@@ -62,7 +62,7 @@ func PassThroughGenerator[T comparable]() IdGenerator[T] {
 type passThroughGenerator[T comparable] struct {
 }
 
-func (generator *passThroughGenerator[T]) GenerateId(generationContext context.Context, entity ...interface{}) (T, error) {
+func (generator *passThroughGenerator[T]) GenerateId(generationContext context.Context, entity ...any) (T, error) {
 	return entity[0].(T), nil
 }
 
@@ -74,17 +74,17 @@ type randomGenerator[T comparable] struct {
 	len uint
 }
 
-func (generator *randomGenerator[T]) GenerateId(generationContext context.Context, entity ...interface{}) (T, error) {
+func (generator *randomGenerator[T]) GenerateId(generationContext context.Context, entity ...any) (T, error) {
 	var v T
 	t := reflect.TypeOf(v)
 
 	switch t.Kind() {
 	case reflect.String:
-		return ((interface{})(random.RandomString(generator.len))).(T), nil
+		return ((any)(random.RandomString(generator.len))).(T), nil
 	case reflect.Slice:
 		switch t.Elem().Kind() {
 		case reflect.Uint8:
-			return ((interface{})(random.RandomBytes(generator.len))).(T), nil
+			return ((any)(random.RandomBytes(generator.len))).(T), nil
 		}
 	}
 
@@ -99,15 +99,15 @@ func (generator *randomGenerator[T]) GenerateId(generationContext context.Contex
 //
 //	[]byte or string value it is returned as the id
 //	cri.IdGenerator it is called to generatan is
-func ContextualGenerator[T comparable](key interface{}) IdGenerator[T] {
+func ContextualGenerator[T comparable](key any) IdGenerator[T] {
 	return &contextualGenerator[T]{key}
 }
 
 type contextualGenerator[T comparable] struct {
-	key interface{}
+	key any
 }
 
-func (generator *contextualGenerator[T]) GenerateId(generationContext context.Context, entity ...interface{}) (T, error) {
+func (generator *contextualGenerator[T]) GenerateId(generationContext context.Context, entity ...any) (T, error) {
 	value := generationContext.Value(generator.key)
 
 	var zero T

--- a/node/app/id.go
+++ b/node/app/id.go
@@ -54,7 +54,7 @@ type Identifiable interface {
 }
 
 type IdGenerator[T comparable] interface {
-	GenerateId(context context.Context, values ...interface{}) (T, error)
+	GenerateId(context context.Context, values ...any) (T, error)
 }
 
 type components[T comparable] struct {
@@ -92,7 +92,7 @@ func (i id[T]) Keys() Keys {
 	return KeyArray{value.domain.Value(), value.value.Value()}
 }
 
-func (i id[T]) Test(context context.Context, entity interface{}) bool {
+func (i id[T]) Test(context context.Context, entity any) bool {
 	if entity, ok := entity.(id[T]); ok {
 		return i == entity
 	}
@@ -110,7 +110,7 @@ func (i id[T]) Matches(other Id) bool {
 	return i.Equals(other) // TODO
 }
 
-func (i id[T]) CompareTo(other interface{}) int {
+func (i id[T]) CompareTo(other any) int {
 	if other, ok := other.(id[T]); ok {
 		otherComponents := ((unique.Handle[components[T]])(other)).Value()
 		components := ((unique.Handle[components[T]])(i)).Value()

--- a/node/app/logging.go
+++ b/node/app/logging.go
@@ -45,12 +45,12 @@ type logger struct {
 // applog is the default package-level logger used when no logger is in context.
 var applog Logger = &logger{Logger: log.Root(), level: log.LvlInfo}
 
-func NewLogger(level log.Lvl, ctx []string, kvCtx interface{}) Logger {
-	var kv []interface{}
-	if kvPairs, ok := kvCtx.([]interface{}); ok && len(kvPairs) > 0 {
+func NewLogger(level log.Lvl, ctx []string, kvCtx any) Logger {
+	var kv []any
+	if kvPairs, ok := kvCtx.([]any); ok && len(kvPairs) > 0 {
 		kv = kvPairs
 	} else {
-		kv = make([]interface{}, 0, len(ctx)*2)
+		kv = make([]any, 0, len(ctx)*2)
 		for _, c := range ctx {
 			kv = append(kv, "module", c)
 		}
@@ -90,7 +90,7 @@ func (l *logger) DebugEnabled() bool {
 
 // LogInstance returns a human-readable string representation of a value,
 // suitable for use in log key-value pairs. It handles nil values safely.
-func LogInstance(value interface{}) string {
+func LogInstance(value any) string {
 	if value == nil {
 		return "<nil>"
 	}

--- a/node/app/options.go
+++ b/node/app/options.go
@@ -22,10 +22,10 @@ import (
 
 type Option struct {
 	target     reflect.Type
-	applicator func(t interface{}) bool
+	applicator func(t any) bool
 }
 
-func (o Option) Apply(t interface{}) bool {
+func (o Option) Apply(t any) bool {
 	return o.applicator(t)
 }
 
@@ -37,7 +37,7 @@ func WithOption[T any](applicator func(t *T) bool) Option {
 	var t T
 	return Option{
 		target:     reflect.TypeOf(t),
-		applicator: func(t interface{}) bool { return applicator(t.(*T)) },
+		applicator: func(t any) bool { return applicator(t.(*T)) },
 	}
 }
 

--- a/node/app/selector.go
+++ b/node/app/selector.go
@@ -30,7 +30,7 @@ type Keys interface {
 	IsMap() bool
 }
 
-type KeyArray []interface{}
+type KeyArray []any
 
 func (keys KeyArray) Len() int {
 	return len(keys)
@@ -44,7 +44,7 @@ func (keys KeyArray) IsMap() bool {
 	return false
 }
 
-type KeyMap map[interface{}]interface{}
+type KeyMap map[any]any
 
 func (keys KeyMap) Len() int {
 	return len(keys)
@@ -59,23 +59,23 @@ func (keys KeyMap) IsMap() bool {
 }
 
 type Selector interface {
-	Test(context context.Context, entity interface{}) bool
+	Test(context context.Context, entity any) bool
 }
 
 type KeyedSelector interface {
 	Keys() Keys
-	Test(context context.Context, entity interface{}) bool
+	Test(context context.Context, entity any) bool
 }
 
 // SelectorComparator provides a basic comparison on selectors by comparing
 // the values of the selectors keys
-func SelectorComparator(a, b interface{}) int {
+func SelectorComparator(a, b any) int {
 	aKeys := a.(KeyedSelector).Keys()
 	bKeys := b.(KeyedSelector).Keys()
 	aArray, aOk := aKeys.(KeyArray)
 	bArray, bOk := bKeys.(KeyArray)
 	if aOk && bOk {
-		return util.CompoundCompare([]interface{}(aArray), []interface{}(bArray))
+		return util.CompoundCompare([]any(aArray), []any(bArray))
 	}
 	return util.CompoundCompare(aKeys, bKeys)
 }
@@ -83,7 +83,7 @@ func SelectorComparator(a, b interface{}) int {
 type RangeSelector interface {
 	From() Keys
 	To() Keys
-	Test(context context.Context, entity interface{}) bool
+	Test(context context.Context, entity any) bool
 }
 
 const (
@@ -119,11 +119,11 @@ func (s all) Keys() Keys {
 	return KeyArray(nil)
 }
 
-func (s all) Test(context context.Context, entity interface{}) bool {
+func (s all) Test(context context.Context, entity any) bool {
 	return true
 }
 
-func (s all) CompareTo(entity interface{}) int {
+func (s all) CompareTo(entity any) int {
 	switch entity.(type) {
 	case all:
 		return 0
@@ -139,11 +139,11 @@ func (s none) Keys() Keys {
 	return KeyArray(nil)
 }
 
-func (s none) Test(context context.Context, entity interface{}) bool {
+func (s none) Test(context context.Context, entity any) bool {
 	return false
 }
 
-func (s none) CompareTo(entity interface{}) int {
+func (s none) CompareTo(entity any) int {
 	if _, ok := entity.(*none); ok {
 		return 0
 	}
@@ -171,7 +171,7 @@ func (selector *TypeSelector) Keys() Keys {
 	return KeyArray{selector.Type}
 }
 
-func (selector *TypeSelector) Test(context context.Context, entity interface{}) bool {
+func (selector *TypeSelector) Test(context context.Context, entity any) bool {
 	if selector.Type != nil {
 		return reflect.TypeOf(entity) == selector.Type
 	}

--- a/node/app/typeid.go
+++ b/node/app/typeid.go
@@ -25,8 +25,8 @@ import (
 var typeInitFunctions = []func(){}
 var typeInitMutex = sync.Mutex{}
 
-func LocalTypeInit(localIdInitialiser func(govalue interface{}) TypeId,
-	publicIdInitialiser func(domainValue interface{}, id []byte, idVersion Version) (TypeId, error)) {
+func LocalTypeInit(localIdInitialiser func(govalue any) TypeId,
+	publicIdInitialiser func(domainValue any, id []byte, idVersion Version) (TypeId, error)) {
 	typeInitMutex.Lock()
 	if NewLocalTypeId == nil {
 		NewLocalTypeId = localIdInitialiser
@@ -38,7 +38,7 @@ func LocalTypeInit(localIdInitialiser func(govalue interface{}) TypeId,
 	typeInitMutex.Unlock()
 }
 
-var NewLocalTypeId func(govalue interface{}) TypeId
+var NewLocalTypeId func(govalue any) TypeId
 
 var typeIds = map[string]TypeId{}
 var typeIdsMutex = &sync.RWMutex{}
@@ -132,7 +132,7 @@ func (a TypeArray) String() string {
 	return fmt.Sprintf("%s", argTypes)
 }
 
-func (a TypeArray) Type(at interface{}) TypeId {
+func (a TypeArray) Type(at any) TypeId {
 	return a[at.(int)]
 }
 
@@ -153,24 +153,24 @@ func (m TypeMap) String() string {
 	return fmt.Sprintf("%s", argTypes)
 }
 
-func (m TypeMap) Type(at interface{}) TypeId {
+func (m TypeMap) Type(at any) TypeId {
 	return m[at.(string)]
 }
 
 type ArgTypes interface {
 	Len() int
 	String() string
-	Type(at interface{}) TypeId
+	Type(at any) TypeId
 }
 
 type Args interface {
-	Arg(key interface{}) interface{}
+	Arg(key any) any
 	Len() int
 }
 
-type ArgArray []interface{}
+type ArgArray []any
 
-func (a ArgArray) Arg(at interface{}) interface{} {
+func (a ArgArray) Arg(at any) any {
 	return a[at.(int)]
 }
 
@@ -178,9 +178,9 @@ func (a ArgArray) Len() int {
 	return len(a)
 }
 
-type ArgMap map[string]interface{}
+type ArgMap map[string]any
 
-func (m ArgMap) Arg(at interface{}) interface{} {
+func (m ArgMap) Arg(at any) any {
 	return m[at.(string)]
 }
 
@@ -207,7 +207,7 @@ var Trace = false
 var typeids = map[reflect.Type]TypeId{}
 var typeidsMutex = &sync.RWMutex{}
 
-func TypeIdOf(govalue interface{}) TypeId {
+func TypeIdOf(govalue any) TypeId {
 	var err error
 	var gotype reflect.Type
 	var ok bool
@@ -329,7 +329,7 @@ func (info *typeInfo) LocalType() reflect.Type {
 	return info.localType
 }
 
-func TypeIdValues(typeIds interface{}) []TypeId {
+func TypeIdValues(typeIds any) []TypeId {
 	s := reflect.ValueOf(typeIds)
 
 	if s.Kind() == reflect.Pointer {

--- a/node/app/util/await.go
+++ b/node/app/util/await.go
@@ -148,7 +148,7 @@ func NewChannelGroup(waitContext context.Context) *ChannelGroup {
 	return mux
 }
 
-func (mux *ChannelGroup) Add(ichan interface{}) *ChannelGroup {
+func (mux *ChannelGroup) Add(ichan any) *ChannelGroup {
 	mux.mutex.Lock()
 	mux.pending = append(mux.pending, reflect.SelectCase{
 		Dir:  reflect.SelectRecv,
@@ -158,14 +158,14 @@ func (mux *ChannelGroup) Add(ichan interface{}) *ChannelGroup {
 	return mux
 }
 
-func (mux *ChannelGroup) Remove(ichan interface{}) *ChannelGroup {
+func (mux *ChannelGroup) Remove(ichan any) *ChannelGroup {
 	mux.mutex.Lock()
 	mux.pendingRemove = append(mux.pendingRemove, reflect.ValueOf(ichan))
 	mux.mutex.Unlock()
 	return mux
 }
 
-func (mux *ChannelGroup) Wait(chanFunc func(interface{}, interface{}, bool) (bool, bool), errorFunc func(error)) bool {
+func (mux *ChannelGroup) Wait(chanFunc func(any, any, bool) (bool, bool), errorFunc func(error)) bool {
 	if mux == nil {
 		return false
 	}

--- a/node/app/util/compare.go
+++ b/node/app/util/compare.go
@@ -23,7 +23,7 @@ import (
 )
 
 type Equatable interface {
-	Equals(other interface{}) bool
+	Equals(other any) bool
 }
 
 // Comparable implementers provide a comparable method to
@@ -35,14 +35,14 @@ type Equatable interface {
 //	zero     , if this == other
 //	positive , if this > other
 type Comparable interface {
-	CompareTo(other interface{}) int
+	CompareTo(other any) int
 }
 
 // Equal checks two values are equal via the Equatable or
 // Comparable interfaces available. If neither is implemented
 // and both values have a comparable type, falls back to ==.
 // For uncomparable types (slices, maps, funcs) uses reflect.DeepEqual.
-func Equal(a, b interface{}) bool {
+func Equal(a, b any) bool {
 	if ea, ok := a.(Equatable); ok {
 		return ea.Equals(b)
 	} else if ca, ok := a.(Comparable); ok {
@@ -62,7 +62,7 @@ func Equal(a, b interface{}) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-type Comparator func(a, b interface{}) int
+type Comparator func(a, b any) int
 
 // CompoundComparator is an array of comparators which provide comparison of an
 // array of values
@@ -73,7 +73,7 @@ type CompoundComparator []Comparator
 // both implement Comparable, otherwise if one is non comparable
 // a type comparison is undertaken otherwise if neither are comparable
 // a Pointer comparison is undertaken
-func Compare(a, b interface{}) int {
+func Compare(a, b any) int {
 	if a == nil {
 		if b == nil {
 			return 0
@@ -145,9 +145,9 @@ func Compare(a, b interface{}) int {
 	return 0
 }
 
-func CompoundCompare(a, b interface{}) int {
-	avals := a.([]interface{})
-	bvals := b.([]interface{})
+func CompoundCompare(a, b any) int {
+	avals := a.([]any)
+	bvals := b.([]any)
 
 	if len(avals) >= len(bvals) {
 		lenb := len(bvals)
@@ -181,14 +181,14 @@ func CompoundCompare(a, b interface{}) int {
 }
 
 // BytesComparator provides a basic comparison on []byte
-func BytesComparator(a, b interface{}) int {
+func BytesComparator(a, b any) int {
 	bytesa := a.([]byte)
 	bytesb := b.([]byte)
 	return bytes.Compare(bytesa, bytesb)
 }
 
 // BytesComparator provides a basic comparison on arrays of []byte
-func BytesArrayComparator(a, b interface{}) int {
+func BytesArrayComparator(a, b any) int {
 	b1 := a.([][]byte)
 	b2 := b.([][]byte)
 
@@ -215,12 +215,12 @@ func BytesArrayComparator(a, b interface{}) int {
 //	Compare implements the comparator function for a list of values
 //
 // passed as an array of interfaces
-func (comparators CompoundComparator) Compare(a, b interface{}) int {
-	var avals []interface{}
-	var bvals []interface{}
+func (comparators CompoundComparator) Compare(a, b any) int {
+	var avals []any
+	var bvals []any
 
-	avals = a.([]interface{})
-	bvals = b.([]interface{})
+	avals = a.([]any)
+	bvals = b.([]any)
 
 	//fmt.Printf("A=%v, b=%v\n", a, b)
 	if len(avals) >= len(bvals) {
@@ -255,7 +255,7 @@ func (comparators CompoundComparator) Compare(a, b interface{}) int {
 }
 
 // StringComparator provides a fast comparison on strings
-func StringComparator(a, b interface{}) int {
+func StringComparator(a, b any) int {
 	s1 := a.(string)
 	s2 := b.(string)
 	min := len(s2)
@@ -278,7 +278,7 @@ func StringComparator(a, b interface{}) int {
 	return 0
 }
 
-func StringsComparator(a, b interface{}) int {
+func StringsComparator(a, b any) int {
 	s1 := a.([]string)
 	s2 := b.([]string)
 	min := len(s2)

--- a/node/app/util/errors.go
+++ b/node/app/util/errors.go
@@ -80,7 +80,7 @@ type Error struct {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The stacktrace will point to the line of code that
 // called New.
-func NewError(e interface{}) *Error {
+func NewError(e any) *Error {
 	var err error
 
 	switch e := e.(type) {
@@ -102,7 +102,7 @@ func NewError(e interface{}) *Error {
 // error then it will be used directly, if not, it will be passed to
 // fmt.Errorf("%v"). The skip parameter indicates how far up the stack
 // to start the stacktrace. 0 is from the current call, 1 from its caller, etc.
-func WrapError(e interface{}, skip int) *Error {
+func WrapError(e any, skip int) *Error {
 	if e == nil {
 		return nil
 	}
@@ -132,7 +132,7 @@ func WrapError(e interface{}, skip int) *Error {
 // error message when calling Error(). The skip parameter indicates how far
 // up the stack to start the stacktrace. 0 is from the current call,
 // 1 from its caller, etc.
-func WrapPrefix(e interface{}, prefix string, skip int) *Error {
+func WrapPrefix(e any, prefix string, skip int) *Error {
 	if e == nil {
 		return nil
 	}
@@ -154,7 +154,7 @@ func WrapPrefix(e interface{}, prefix string, skip int) *Error {
 // Errorf creates a new error with the given message. You can use it
 // as a drop-in replacement for fmt.Errorf() to provide descriptive
 // errors in return values.
-func Errorf(format string, a ...interface{}) *Error {
+func Errorf(format string, a ...any) *Error {
 	return WrapError(fmt.Errorf(format, a...), 1)
 }
 
@@ -225,7 +225,7 @@ func (err *Error) TypeName() string {
 	return reflect.TypeOf(err.Err).Name()
 }
 
-func UnexpectedTypeError(expected interface{}, actual interface{}, message ...string) error {
+func UnexpectedTypeError(expected any, actual any, message ...string) error {
 	var expectedTypeName string
 	var actualTypeName string
 

--- a/node/app/util/result.go
+++ b/node/app/util/result.go
@@ -17,7 +17,7 @@
 package util
 
 type Result interface { // implements ListenableFuture<Value> {
-	Get() interface{}
+	Get() any
 	IsSuccess() bool
 }
 
@@ -54,8 +54,8 @@ const (
 )
 
 type result struct {
-	resultChannel chan interface{}
-	result        interface{}
+	resultChannel chan any
+	result        any
 	status        ResultStatus
 	reason        ResultStatusReason
 	statusInfo    string
@@ -252,7 +252,7 @@ func (result *result) Status() ResultStatus {
 	}
 */
 
-func (result *result) Get() interface{} {
+func (result *result) Get() any {
 	/*
 		try {
 			if (result==null) {

--- a/node/app/version.go
+++ b/node/app/version.go
@@ -39,7 +39,7 @@ type Version interface {
 	Validate() error
 }
 
-func NewVersion(major interface{}, minor ...uint64) Version {
+func NewVersion(major any, minor ...uint64) Version {
 	var pmajor *uint64
 
 	switch tmajor := major.(type) {

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -482,7 +482,7 @@ func nodeIDEqual[N nodeType](n1, n2 N) bool {
 
 // gen wraps quick.Value so it's easier to use.
 // it generates a random value of the given value's type.
-func gen(typ interface{}, rand *rand.Rand) interface{} {
+func gen(typ any, rand *rand.Rand) any {
 	v, ok := quick.Value(reflect.TypeOf(typ), rand)
 	if !ok {
 		panic(fmt.Sprintf("couldn't generate random value of type %T", typ))

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -87,7 +87,7 @@ type UDPv5 struct {
 	respTimeout  time.Duration
 
 	// misc buffers used during message handling
-	logcontext []interface{}
+	logcontext []any
 
 	// talkreq handler registry
 	talk *talkSystem

--- a/p2p/discover/v5wire/msg.go
+++ b/p2p/discover/v5wire/msg.go
@@ -39,7 +39,7 @@ type Packet interface {
 
 	// AppendLogInfo returns its argument 'ctx' with additional fields
 	// appended for logging purposes.
-	AppendLogInfo(ctx []interface{}) []interface{}
+	AppendLogInfo(ctx []any) []any
 }
 
 // Message types.
@@ -160,7 +160,7 @@ func (*Whoareyou) Kind() byte          { return WhoareyouPacket }
 func (*Whoareyou) RequestID() []byte   { return nil }
 func (*Whoareyou) SetRequestID([]byte) {}
 
-func (*Whoareyou) AppendLogInfo(ctx []interface{}) []interface{} {
+func (*Whoareyou) AppendLogInfo(ctx []any) []any {
 	return ctx
 }
 
@@ -169,7 +169,7 @@ func (*Unknown) Kind() byte          { return UnknownPacket }
 func (*Unknown) RequestID() []byte   { return nil }
 func (*Unknown) SetRequestID([]byte) {}
 
-func (*Unknown) AppendLogInfo(ctx []interface{}) []interface{} {
+func (*Unknown) AppendLogInfo(ctx []any) []any {
 	return ctx
 }
 
@@ -178,7 +178,7 @@ func (*Ping) Kind() byte               { return PingMsg }
 func (p *Ping) RequestID() []byte      { return p.ReqID }
 func (p *Ping) SetRequestID(id []byte) { p.ReqID = id }
 
-func (p *Ping) AppendLogInfo(ctx []interface{}) []interface{} {
+func (p *Ping) AppendLogInfo(ctx []any) []any {
 	return append(ctx, "req", hexutil.Bytes(p.ReqID), "enrseq", p.ENRSeq)
 }
 
@@ -187,7 +187,7 @@ func (*Pong) Kind() byte               { return PongMsg }
 func (p *Pong) RequestID() []byte      { return p.ReqID }
 func (p *Pong) SetRequestID(id []byte) { p.ReqID = id }
 
-func (p *Pong) AppendLogInfo(ctx []interface{}) []interface{} {
+func (p *Pong) AppendLogInfo(ctx []any) []any {
 	return append(ctx, "req", hexutil.Bytes(p.ReqID), "enrseq", p.ENRSeq)
 }
 
@@ -196,7 +196,7 @@ func (p *Findnode) Kind() byte             { return FindnodeMsg }
 func (p *Findnode) RequestID() []byte      { return p.ReqID }
 func (p *Findnode) SetRequestID(id []byte) { p.ReqID = id }
 
-func (p *Findnode) AppendLogInfo(ctx []interface{}) []interface{} {
+func (p *Findnode) AppendLogInfo(ctx []any) []any {
 	ctx = append(ctx, "req", hexutil.Bytes(p.ReqID))
 	if p.OpID != 0 {
 		ctx = append(ctx, "opid", p.OpID)
@@ -209,7 +209,7 @@ func (*Nodes) Kind() byte               { return NodesMsg }
 func (p *Nodes) RequestID() []byte      { return p.ReqID }
 func (p *Nodes) SetRequestID(id []byte) { p.ReqID = id }
 
-func (p *Nodes) AppendLogInfo(ctx []interface{}) []interface{} {
+func (p *Nodes) AppendLogInfo(ctx []any) []any {
 	return append(ctx,
 		"req", hexutil.Bytes(p.ReqID),
 		"tot", p.RespCount,
@@ -222,7 +222,7 @@ func (*TalkRequest) Kind() byte               { return TalkRequestMsg }
 func (p *TalkRequest) RequestID() []byte      { return p.ReqID }
 func (p *TalkRequest) SetRequestID(id []byte) { p.ReqID = id }
 
-func (p *TalkRequest) AppendLogInfo(ctx []interface{}) []interface{} {
+func (p *TalkRequest) AppendLogInfo(ctx []any) []any {
 	return append(ctx, "proto", p.Protocol, "req", hexutil.Bytes(p.ReqID), "len", len(p.Message))
 }
 
@@ -231,6 +231,6 @@ func (*TalkResponse) Kind() byte               { return TalkResponseMsg }
 func (p *TalkResponse) RequestID() []byte      { return p.ReqID }
 func (p *TalkResponse) SetRequestID(id []byte) { p.ReqID = id }
 
-func (p *TalkResponse) AppendLogInfo(ctx []interface{}) []interface{} {
+func (p *TalkResponse) AppendLogInfo(ctx []any) []any {
 	return append(ctx, "req", hexutil.Bytes(p.ReqID), "len", len(p.Message))
 }

--- a/rpc/jsonrpc/contracts/gen_poly.go
+++ b/rpc/jsonrpc/contracts/gen_poly.go
@@ -156,7 +156,7 @@ func bindPoly(address common.Address, caller bind.ContractCaller, transactor bin
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Poly *PolyRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Poly *PolyRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Poly.Contract.PolyCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Poly *PolyRaw) Transfer(opts *bind.TransactOpts) (types.Transaction, erro
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Poly *PolyRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Poly *PolyRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Poly.Contract.PolyTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Poly *PolyRaw) Transact(opts *bind.TransactOpts, method string, params ..
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Poly *PolyCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Poly *PolyCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Poly.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Poly *PolyTransactorRaw) Transfer(opts *bind.TransactOpts) (types.Transac
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Poly *PolyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Poly *PolyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Poly.Contract.contract.Transact(opts, method, params...)
 }
 

--- a/rpc/jsonrpc/contracts/gen_token.go
+++ b/rpc/jsonrpc/contracts/gen_token.go
@@ -156,7 +156,7 @@ func bindToken(address common.Address, caller bind.ContractCaller, transactor bi
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Token *TokenRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Token *TokenRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Token.Contract.TokenCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Token *TokenRaw) Transfer(opts *bind.TransactOpts) (types.Transaction, er
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Token *TokenRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Token *TokenRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Token.Contract.TokenTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Token *TokenRaw) Transact(opts *bind.TransactOpts, method string, params 
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Token *TokenCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Token *TokenCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Token.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Token *TokenTransactorRaw) Transfer(opts *bind.TransactOpts) (types.Trans
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Token *TokenTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Token *TokenTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Token.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -194,7 +194,7 @@ func (_Token *TokenTransactorRaw) Transact(opts *bind.TransactOpts, method strin
 //
 // Solidity: function balanceOf(address ) view returns(uint256)
 func (_Token *TokenCaller) BalanceOf(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _Token.contract.Call(opts, &out, "balanceOf", arg0)
 
 	if err != nil {
@@ -225,7 +225,7 @@ func (_Token *TokenCallerSession) BalanceOf(arg0 common.Address) (*big.Int, erro
 //
 // Solidity: function minter() view returns(address)
 func (_Token *TokenCaller) Minter(opts *bind.CallOpts) (common.Address, error) {
-	var out []interface{}
+	var out []any
 	err := _Token.contract.Call(opts, &out, "minter")
 
 	if err != nil {
@@ -256,7 +256,7 @@ func (_Token *TokenCallerSession) Minter() (common.Address, error) {
 //
 // Solidity: function totalSupply() view returns(uint256)
 func (_Token *TokenCaller) TotalSupply(opts *bind.CallOpts) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _Token.contract.Call(opts, &out, "totalSupply")
 
 	if err != nil {

--- a/txnprovider/shutter/internal/contracts/gen_key_broadcast_contract.go
+++ b/txnprovider/shutter/internal/contracts/gen_key_broadcast_contract.go
@@ -156,7 +156,7 @@ func bindKeyBroadcastContract(address common.Address, caller bind.ContractCaller
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_KeyBroadcastContract *KeyBroadcastContractRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_KeyBroadcastContract *KeyBroadcastContractRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _KeyBroadcastContract.Contract.KeyBroadcastContractCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_KeyBroadcastContract *KeyBroadcastContractRaw) Transfer(opts *bind.Transa
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_KeyBroadcastContract *KeyBroadcastContractRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_KeyBroadcastContract *KeyBroadcastContractRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _KeyBroadcastContract.Contract.KeyBroadcastContractTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_KeyBroadcastContract *KeyBroadcastContractRaw) Transact(opts *bind.Transa
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_KeyBroadcastContract *KeyBroadcastContractCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_KeyBroadcastContract *KeyBroadcastContractCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _KeyBroadcastContract.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_KeyBroadcastContract *KeyBroadcastContractTransactorRaw) Transfer(opts *b
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_KeyBroadcastContract *KeyBroadcastContractTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_KeyBroadcastContract *KeyBroadcastContractTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _KeyBroadcastContract.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -194,7 +194,7 @@ func (_KeyBroadcastContract *KeyBroadcastContractTransactorRaw) Transact(opts *b
 //
 // Solidity: function getEonKey(uint64 eon) view returns(bytes)
 func (_KeyBroadcastContract *KeyBroadcastContractCaller) GetEonKey(opts *bind.CallOpts, eon uint64) ([]byte, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyBroadcastContract.contract.Call(opts, &out, "getEonKey", eon)
 
 	if err != nil {

--- a/txnprovider/shutter/internal/contracts/gen_keyper_set.go
+++ b/txnprovider/shutter/internal/contracts/gen_keyper_set.go
@@ -173,7 +173,7 @@ func bindKeyperSet(address common.Address, caller bind.ContractCaller, transacto
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_KeyperSet *KeyperSetRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_KeyperSet *KeyperSetRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _KeyperSet.Contract.KeyperSetCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -184,7 +184,7 @@ func (_KeyperSet *KeyperSetRaw) Transfer(opts *bind.TransactOpts) (types.Transac
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_KeyperSet *KeyperSetRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_KeyperSet *KeyperSetRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _KeyperSet.Contract.KeyperSetTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -192,7 +192,7 @@ func (_KeyperSet *KeyperSetRaw) Transact(opts *bind.TransactOpts, method string,
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_KeyperSet *KeyperSetCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_KeyperSet *KeyperSetCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _KeyperSet.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -203,7 +203,7 @@ func (_KeyperSet *KeyperSetTransactorRaw) Transfer(opts *bind.TransactOpts) (typ
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_KeyperSet *KeyperSetTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_KeyperSet *KeyperSetTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _KeyperSet.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -211,7 +211,7 @@ func (_KeyperSet *KeyperSetTransactorRaw) Transact(opts *bind.TransactOpts, meth
 //
 // Solidity: function getMember(uint64 index) view returns(address)
 func (_KeyperSet *KeyperSetCaller) GetMember(opts *bind.CallOpts, index uint64) (common.Address, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSet.contract.Call(opts, &out, "getMember", index)
 
 	if err != nil {
@@ -242,7 +242,7 @@ func (_KeyperSet *KeyperSetCallerSession) GetMember(index uint64) (common.Addres
 //
 // Solidity: function getMembers() view returns(address[])
 func (_KeyperSet *KeyperSetCaller) GetMembers(opts *bind.CallOpts) ([]common.Address, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSet.contract.Call(opts, &out, "getMembers")
 
 	if err != nil {
@@ -273,7 +273,7 @@ func (_KeyperSet *KeyperSetCallerSession) GetMembers() ([]common.Address, error)
 //
 // Solidity: function getNumMembers() view returns(uint64)
 func (_KeyperSet *KeyperSetCaller) GetNumMembers(opts *bind.CallOpts) (uint64, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSet.contract.Call(opts, &out, "getNumMembers")
 
 	if err != nil {
@@ -304,7 +304,7 @@ func (_KeyperSet *KeyperSetCallerSession) GetNumMembers() (uint64, error) {
 //
 // Solidity: function getPublisher() view returns(address)
 func (_KeyperSet *KeyperSetCaller) GetPublisher(opts *bind.CallOpts) (common.Address, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSet.contract.Call(opts, &out, "getPublisher")
 
 	if err != nil {
@@ -335,7 +335,7 @@ func (_KeyperSet *KeyperSetCallerSession) GetPublisher() (common.Address, error)
 //
 // Solidity: function getThreshold() view returns(uint64)
 func (_KeyperSet *KeyperSetCaller) GetThreshold(opts *bind.CallOpts) (uint64, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSet.contract.Call(opts, &out, "getThreshold")
 
 	if err != nil {
@@ -366,7 +366,7 @@ func (_KeyperSet *KeyperSetCallerSession) GetThreshold() (uint64, error) {
 //
 // Solidity: function isAllowedToBroadcastEonKey(address a) view returns(bool)
 func (_KeyperSet *KeyperSetCaller) IsAllowedToBroadcastEonKey(opts *bind.CallOpts, a common.Address) (bool, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSet.contract.Call(opts, &out, "isAllowedToBroadcastEonKey", a)
 
 	if err != nil {
@@ -397,7 +397,7 @@ func (_KeyperSet *KeyperSetCallerSession) IsAllowedToBroadcastEonKey(a common.Ad
 //
 // Solidity: function isFinalized() view returns(bool)
 func (_KeyperSet *KeyperSetCaller) IsFinalized(opts *bind.CallOpts) (bool, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSet.contract.Call(opts, &out, "isFinalized")
 
 	if err != nil {
@@ -428,7 +428,7 @@ func (_KeyperSet *KeyperSetCallerSession) IsFinalized() (bool, error) {
 //
 // Solidity: function owner() view returns(address)
 func (_KeyperSet *KeyperSetCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSet.contract.Call(opts, &out, "owner")
 
 	if err != nil {
@@ -812,11 +812,11 @@ func (_KeyperSet *KeyperSetFilterer) OwnershipTransferredEventID() common.Hash {
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 func (_KeyperSet *KeyperSetFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*KeyperSetOwnershipTransferredIterator, error) {
 
-	var previousOwnerRule []interface{}
+	var previousOwnerRule []any
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
 	}
-	var newOwnerRule []interface{}
+	var newOwnerRule []any
 	for _, newOwnerItem := range newOwner {
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}
@@ -833,11 +833,11 @@ func (_KeyperSet *KeyperSetFilterer) FilterOwnershipTransferred(opts *bind.Filte
 // Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 func (_KeyperSet *KeyperSetFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *KeyperSetOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
 
-	var previousOwnerRule []interface{}
+	var previousOwnerRule []any
 	for _, previousOwnerItem := range previousOwner {
 		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
 	}
-	var newOwnerRule []interface{}
+	var newOwnerRule []any
 	for _, newOwnerItem := range newOwner {
 		newOwnerRule = append(newOwnerRule, newOwnerItem)
 	}

--- a/txnprovider/shutter/internal/contracts/gen_keyper_set_manager.go
+++ b/txnprovider/shutter/internal/contracts/gen_keyper_set_manager.go
@@ -156,7 +156,7 @@ func bindKeyperSetManager(address common.Address, caller bind.ContractCaller, tr
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_KeyperSetManager *KeyperSetManagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_KeyperSetManager *KeyperSetManagerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _KeyperSetManager.Contract.KeyperSetManagerCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_KeyperSetManager *KeyperSetManagerRaw) Transfer(opts *bind.TransactOpts) 
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_KeyperSetManager *KeyperSetManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_KeyperSetManager *KeyperSetManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _KeyperSetManager.Contract.KeyperSetManagerTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_KeyperSetManager *KeyperSetManagerRaw) Transact(opts *bind.TransactOpts, 
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_KeyperSetManager *KeyperSetManagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_KeyperSetManager *KeyperSetManagerCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _KeyperSetManager.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_KeyperSetManager *KeyperSetManagerTransactorRaw) Transfer(opts *bind.Tran
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_KeyperSetManager *KeyperSetManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_KeyperSetManager *KeyperSetManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _KeyperSetManager.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -194,7 +194,7 @@ func (_KeyperSetManager *KeyperSetManagerTransactorRaw) Transact(opts *bind.Tran
 //
 // Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
 func (_KeyperSetManager *KeyperSetManagerCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
 
 	if err != nil {
@@ -225,7 +225,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) DEFAULTADMINROLE() ([32]
 //
 // Solidity: function PAUSER_ROLE() view returns(bytes32)
 func (_KeyperSetManager *KeyperSetManagerCaller) PAUSERROLE(opts *bind.CallOpts) ([32]byte, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "PAUSER_ROLE")
 
 	if err != nil {
@@ -256,7 +256,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) PAUSERROLE() ([32]byte, 
 //
 // Solidity: function getKeyperSetActivationBlock(uint64 index) view returns(uint64)
 func (_KeyperSetManager *KeyperSetManagerCaller) GetKeyperSetActivationBlock(opts *bind.CallOpts, index uint64) (uint64, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "getKeyperSetActivationBlock", index)
 
 	if err != nil {
@@ -287,7 +287,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) GetKeyperSetActivationBl
 //
 // Solidity: function getKeyperSetAddress(uint64 index) view returns(address)
 func (_KeyperSetManager *KeyperSetManagerCaller) GetKeyperSetAddress(opts *bind.CallOpts, index uint64) (common.Address, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "getKeyperSetAddress", index)
 
 	if err != nil {
@@ -318,7 +318,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) GetKeyperSetAddress(inde
 //
 // Solidity: function getKeyperSetIndexByBlock(uint64 blockNumber) view returns(uint64)
 func (_KeyperSetManager *KeyperSetManagerCaller) GetKeyperSetIndexByBlock(opts *bind.CallOpts, blockNumber uint64) (uint64, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "getKeyperSetIndexByBlock", blockNumber)
 
 	if err != nil {
@@ -349,7 +349,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) GetKeyperSetIndexByBlock
 //
 // Solidity: function getNumKeyperSets() view returns(uint64)
 func (_KeyperSetManager *KeyperSetManagerCaller) GetNumKeyperSets(opts *bind.CallOpts) (uint64, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "getNumKeyperSets")
 
 	if err != nil {
@@ -380,7 +380,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) GetNumKeyperSets() (uint
 //
 // Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
 func (_KeyperSetManager *KeyperSetManagerCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "getRoleAdmin", role)
 
 	if err != nil {
@@ -411,7 +411,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) GetRoleAdmin(role [32]by
 //
 // Solidity: function hasRole(bytes32 role, address account) view returns(bool)
 func (_KeyperSetManager *KeyperSetManagerCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "hasRole", role, account)
 
 	if err != nil {
@@ -442,7 +442,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) HasRole(role [32]byte, a
 //
 // Solidity: function initializer() view returns(address)
 func (_KeyperSetManager *KeyperSetManagerCaller) Initializer(opts *bind.CallOpts) (common.Address, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "initializer")
 
 	if err != nil {
@@ -473,7 +473,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) Initializer() (common.Ad
 //
 // Solidity: function paused() view returns(bool)
 func (_KeyperSetManager *KeyperSetManagerCaller) Paused(opts *bind.CallOpts) (bool, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "paused")
 
 	if err != nil {
@@ -504,7 +504,7 @@ func (_KeyperSetManager *KeyperSetManagerCallerSession) Paused() (bool, error) {
 //
 // Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
 func (_KeyperSetManager *KeyperSetManagerCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
-	var out []interface{}
+	var out []any
 	err := _KeyperSetManager.contract.Call(opts, &out, "supportsInterface", interfaceId)
 
 	if err != nil {
@@ -1376,15 +1376,15 @@ func (_KeyperSetManager *KeyperSetManagerFilterer) RoleAdminChangedEventID() com
 // Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
 func (_KeyperSetManager *KeyperSetManagerFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*KeyperSetManagerRoleAdminChangedIterator, error) {
 
-	var roleRule []interface{}
+	var roleRule []any
 	for _, roleItem := range role {
 		roleRule = append(roleRule, roleItem)
 	}
-	var previousAdminRoleRule []interface{}
+	var previousAdminRoleRule []any
 	for _, previousAdminRoleItem := range previousAdminRole {
 		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
 	}
-	var newAdminRoleRule []interface{}
+	var newAdminRoleRule []any
 	for _, newAdminRoleItem := range newAdminRole {
 		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
 	}
@@ -1401,15 +1401,15 @@ func (_KeyperSetManager *KeyperSetManagerFilterer) FilterRoleAdminChanged(opts *
 // Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
 func (_KeyperSetManager *KeyperSetManagerFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *KeyperSetManagerRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
 
-	var roleRule []interface{}
+	var roleRule []any
 	for _, roleItem := range role {
 		roleRule = append(roleRule, roleItem)
 	}
-	var previousAdminRoleRule []interface{}
+	var previousAdminRoleRule []any
 	for _, previousAdminRoleItem := range previousAdminRole {
 		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
 	}
-	var newAdminRoleRule []interface{}
+	var newAdminRoleRule []any
 	for _, newAdminRoleItem := range newAdminRole {
 		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
 	}
@@ -1542,15 +1542,15 @@ func (_KeyperSetManager *KeyperSetManagerFilterer) RoleGrantedEventID() common.H
 // Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
 func (_KeyperSetManager *KeyperSetManagerFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*KeyperSetManagerRoleGrantedIterator, error) {
 
-	var roleRule []interface{}
+	var roleRule []any
 	for _, roleItem := range role {
 		roleRule = append(roleRule, roleItem)
 	}
-	var accountRule []interface{}
+	var accountRule []any
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
-	var senderRule []interface{}
+	var senderRule []any
 	for _, senderItem := range sender {
 		senderRule = append(senderRule, senderItem)
 	}
@@ -1567,15 +1567,15 @@ func (_KeyperSetManager *KeyperSetManagerFilterer) FilterRoleGranted(opts *bind.
 // Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
 func (_KeyperSetManager *KeyperSetManagerFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *KeyperSetManagerRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
 
-	var roleRule []interface{}
+	var roleRule []any
 	for _, roleItem := range role {
 		roleRule = append(roleRule, roleItem)
 	}
-	var accountRule []interface{}
+	var accountRule []any
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
-	var senderRule []interface{}
+	var senderRule []any
 	for _, senderItem := range sender {
 		senderRule = append(senderRule, senderItem)
 	}
@@ -1708,15 +1708,15 @@ func (_KeyperSetManager *KeyperSetManagerFilterer) RoleRevokedEventID() common.H
 // Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
 func (_KeyperSetManager *KeyperSetManagerFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*KeyperSetManagerRoleRevokedIterator, error) {
 
-	var roleRule []interface{}
+	var roleRule []any
 	for _, roleItem := range role {
 		roleRule = append(roleRule, roleItem)
 	}
-	var accountRule []interface{}
+	var accountRule []any
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
-	var senderRule []interface{}
+	var senderRule []any
 	for _, senderItem := range sender {
 		senderRule = append(senderRule, senderItem)
 	}
@@ -1733,15 +1733,15 @@ func (_KeyperSetManager *KeyperSetManagerFilterer) FilterRoleRevoked(opts *bind.
 // Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
 func (_KeyperSetManager *KeyperSetManagerFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *KeyperSetManagerRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
 
-	var roleRule []interface{}
+	var roleRule []any
 	for _, roleItem := range role {
 		roleRule = append(roleRule, roleItem)
 	}
-	var accountRule []interface{}
+	var accountRule []any
 	for _, accountItem := range account {
 		accountRule = append(accountRule, accountItem)
 	}
-	var senderRule []interface{}
+	var senderRule []any
 	for _, senderItem := range sender {
 		senderRule = append(senderRule, senderItem)
 	}

--- a/txnprovider/shutter/internal/contracts/gen_sequencer.go
+++ b/txnprovider/shutter/internal/contracts/gen_sequencer.go
@@ -156,7 +156,7 @@ func bindSequencer(address common.Address, caller bind.ContractCaller, transacto
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Sequencer *SequencerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Sequencer *SequencerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Sequencer.Contract.SequencerCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -167,7 +167,7 @@ func (_Sequencer *SequencerRaw) Transfer(opts *bind.TransactOpts) (types.Transac
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Sequencer *SequencerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Sequencer *SequencerRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Sequencer.Contract.SequencerTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -175,7 +175,7 @@ func (_Sequencer *SequencerRaw) Transact(opts *bind.TransactOpts, method string,
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_Sequencer *SequencerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_Sequencer *SequencerCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _Sequencer.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -186,7 +186,7 @@ func (_Sequencer *SequencerTransactorRaw) Transfer(opts *bind.TransactOpts) (typ
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_Sequencer *SequencerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_Sequencer *SequencerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _Sequencer.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -194,7 +194,7 @@ func (_Sequencer *SequencerTransactorRaw) Transact(opts *bind.TransactOpts, meth
 //
 // Solidity: function getTxCountForEon(uint64 eon) view returns(uint64)
 func (_Sequencer *SequencerCaller) GetTxCountForEon(opts *bind.CallOpts, eon uint64) (uint64, error) {
-	var out []interface{}
+	var out []any
 	err := _Sequencer.contract.Call(opts, &out, "getTxCountForEon", eon)
 
 	if err != nil {

--- a/txnprovider/shutter/internal/contracts/gen_validator_registry.go
+++ b/txnprovider/shutter/internal/contracts/gen_validator_registry.go
@@ -162,7 +162,7 @@ func bindValidatorRegistry(address common.Address, caller bind.ContractCaller, t
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_ValidatorRegistry *ValidatorRegistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_ValidatorRegistry *ValidatorRegistryRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _ValidatorRegistry.Contract.ValidatorRegistryCaller.contract.Call(opts, result, method, params...)
 }
 
@@ -173,7 +173,7 @@ func (_ValidatorRegistry *ValidatorRegistryRaw) Transfer(opts *bind.TransactOpts
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_ValidatorRegistry *ValidatorRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_ValidatorRegistry *ValidatorRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _ValidatorRegistry.Contract.ValidatorRegistryTransactor.contract.Transact(opts, method, params...)
 }
 
@@ -181,7 +181,7 @@ func (_ValidatorRegistry *ValidatorRegistryRaw) Transact(opts *bind.TransactOpts
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_ValidatorRegistry *ValidatorRegistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_ValidatorRegistry *ValidatorRegistryCallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _ValidatorRegistry.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -192,7 +192,7 @@ func (_ValidatorRegistry *ValidatorRegistryTransactorRaw) Transfer(opts *bind.Tr
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_ValidatorRegistry *ValidatorRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (types.Transaction, error) {
+func (_ValidatorRegistry *ValidatorRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (types.Transaction, error) {
 	return _ValidatorRegistry.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -200,7 +200,7 @@ func (_ValidatorRegistry *ValidatorRegistryTransactorRaw) Transact(opts *bind.Tr
 //
 // Solidity: function getNumUpdates() view returns(uint256)
 func (_ValidatorRegistry *ValidatorRegistryCaller) GetNumUpdates(opts *bind.CallOpts) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _ValidatorRegistry.contract.Call(opts, &out, "getNumUpdates")
 
 	if err != nil {
@@ -231,7 +231,7 @@ func (_ValidatorRegistry *ValidatorRegistryCallerSession) GetNumUpdates() (*big.
 //
 // Solidity: function getUpdate(uint256 i) view returns((bytes,bytes))
 func (_ValidatorRegistry *ValidatorRegistryCaller) GetUpdate(opts *bind.CallOpts, i *big.Int) (IValidatorRegistryUpdate, error) {
-	var out []interface{}
+	var out []any
 	err := _ValidatorRegistry.contract.Call(opts, &out, "getUpdate", i)
 
 	if err != nil {


### PR DESCRIPTION
This PR modernizes the codebase by enabling the `any` analyzer under the `modernize` linter in `.golangci.yml` and replacing all occurrences of `interface{}` with `any` across both production and test files. To support this transition for generated code, the code generation templates in the `abigen` tool (`execution/abi/bind/template.go`) have been updated to emit `any`, and all available ABI contract bindings (`gen_*.go` files) have been regenerated. Unrelated modernization checks like `waitgroup` and `fmtappendf` have been added to the disable list in `.golangci.yml` to keep the scope of this PR strictly focused.

Auto-generated files where code generation is out of our control have been excluded from this modernization. Specifically, `_grpc.pb.go` files are ignored via a new path exclusion rule in `.golangci.yml`, and `gencodec`-generated files (like `gen_config.go`) remain excluded. Additionally, raw Go code snippets embedded inside string literals in tests (such as in `bind_test.go`) have been left unchanged since they are treated as plain string constants by the AST parser.

part of https://github.com/erigontech/erigon/issues/22199
