### PR TITLE
ci: fix zizmor template-injection in release + bisection/fuzz workflows (#21132)

### DIFF
--- a/.github/workflows/qa-rpc-test-bisection-tool.yml
+++ b/.github/workflows/qa-rpc-test-bisection-tool.yml
@@ -147,6 +147,9 @@ jobs:
 
       - name: Output Offending Commit
         if: success()
+        env:
+          BISECT_COMMIT: ${{ steps.bisect_result.outputs.BISECT_COMMIT }}
+          BISECT_MESSAGE: ${{ steps.bisect_result.outputs.BISECT_MESSAGE }}
         run: |
-          echo "The first bad commit is ${{ steps.bisect_result.outputs.BISECT_COMMIT }}"
-          echo "Commit message: ${{ steps.bisect_result.outputs.BISECT_MESSAGE }}"
+          echo "The first bad commit is $BISECT_COMMIT"
+          echo "Commit message: $BISECT_MESSAGE"

--- a/.github/workflows/qa-sync-test-bisection-tool.yml
+++ b/.github/workflows/qa-sync-test-bisection-tool.yml
@@ -114,9 +114,12 @@ jobs:
 
       - name: Output Offending Commit
         if: success()
+        env:
+          BISECT_COMMIT: ${{ steps.bisect_result.outputs.BISECT_COMMIT }}
+          BISECT_MESSAGE: ${{ steps.bisect_result.outputs.BISECT_MESSAGE }}
         run: |
-          echo "The first bad commit is ${{ steps.bisect_result.outputs.BISECT_COMMIT }}"
-          echo "Commit message: ${{ steps.bisect_result.outputs.BISECT_MESSAGE }}"
+          echo "The first bad commit is $BISECT_COMMIT"
+          echo "Commit message: $BISECT_MESSAGE"
 
       - name: Clean up Erigon data directory
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,8 @@ jobs:
           RELEASE_VERSION: ${{ inputs.release_version }}
           DOCKER_URL: ${{ env.DOCKERHUB_REPOSITORY_DEV }}
           CHECKOUT_REF: ${{ inputs.checkout_ref }}
+          COMMIT_ID: ${{ steps.getCommitId.outputs.commit-id }}
+          SHORT_COMMIT_ID: ${{ steps.getCommitId.outputs.short-commit-id }}
         run: |
           cd erigon;
           docker buildx build \
@@ -227,8 +229,8 @@ jobs:
             --label org.opencontainers.image.documentation="https://docs.erigon.tech/" \
             --label org.opencontainers.image.source="https://github.com/erigontech/erigon" \
             --label org.opencontainers.image.version=${RELEASE_VERSION} \
-            --label org.opencontainers.image.revision=${{ steps.getCommitId.outputs.commit-id }} \
-            --label org.opencontainers.image.vcs-ref-short=${{ steps.getCommitId.outputs.short-commit-id }} \
+            --label org.opencontainers.image.revision="${COMMIT_ID}" \
+            --label org.opencontainers.image.vcs-ref-short="${SHORT_COMMIT_ID}" \
             --label org.opencontainers.image.vendor="${{ github.repository_owner }}" \
             --label org.opencontainers.image.description="${{ env.LABEL_DESCRIPTION }}" \
             --label org.opencontainers.image.base.name="${{ env.TARGET_BASE_IMAGE }}" \
@@ -580,15 +582,15 @@ jobs:
         DOCKER_URL_TMP: ${{ env.DOCKERHUB_REPOSITORY_DEV }}
         PUBLISH_LATEST_TAG: ${{ inputs.publish_latest_tag }}
       run: |
-        echo Publishing docker image: 
-        skopeo copy --multi-arch all docker://${{ env.DOCKER_URL_TMP }}:${RELEASE_VERSION} docker://${{ env.DOCKER_URL }}:${RELEASE_VERSION}
+        echo Publishing docker image:
+        skopeo copy --multi-arch all "docker://${DOCKER_URL_TMP}:${RELEASE_VERSION}" "docker://${DOCKER_URL}:${RELEASE_VERSION}"
         if [ "x${PUBLISH_LATEST_TAG}" == "xtrue" ]; then
           echo Publishing latest tag:
-          skopeo copy --multi-arch all docker://${{ env.DOCKER_URL_TMP }}:${RELEASE_VERSION} docker://${{ env.DOCKER_URL }}:latest
+          skopeo copy --multi-arch all "docker://${DOCKER_URL_TMP}:${RELEASE_VERSION}" "docker://${DOCKER_URL}:latest"
         fi
         echo -n "Deleting temporary image: "
         set +e
-        skopeo delete docker://${{ env.DOCKER_URL_TMP }}:${RELEASE_VERSION}
+        skopeo delete "docker://${DOCKER_URL_TMP}:${RELEASE_VERSION}"
         SKOPEO_DELETE_EXIT=$?
         set -e
         if [ $SKOPEO_DELETE_EXIT -ne 0 ]; then
@@ -710,6 +712,7 @@ jobs:
         GH_REPO: ${{ github.repository }}
         RELEASE_VERSION: ${{ inputs.release_version }}
         DOCKER_TAGS: "${{ env.DOCKERHUB_REPOSITORY }}:${{ inputs.release_version }}"
+        TARGET_COMMIT: ${{ needs.build-release.outputs.commit-id }}
       run: |
         cd dist
         for archive in *.tar; do gzip $archive; echo "Artifact $archive compressed"; done
@@ -743,7 +746,7 @@ jobs:
           echo "  cd dist"
           echo "  gh release create \\"
           echo "    --repo ${{ env.APP_REPO }} \\"
-          echo "    --target ${{ needs.build-release.outputs.commit-id }} \\"
+          echo "    --target ${TARGET_COMMIT} \\"
           echo "    --draft=true \\"
           echo "    --title \"${RELEASE_VERSION}\" \\"
           echo "    \"${RELEASE_VERSION}\" \\"

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -104,8 +104,9 @@ jobs:
       - name: Fuzz ${{ matrix.fn }}
         env:
           FUZZTIME: ${{ inputs.fuzztime || '120s' }}
+          ERIGON_BUILD: ${{ steps.erigon.outputs.build }}
         run: |
-          mkdir -p "${{ steps.erigon.outputs.build }}/fuzz"
+          mkdir -p "$ERIGON_BUILD/fuzz"
           echo "::group::go test -fuzz ${{ matrix.fn }} (./${{ matrix.pkg }}, ${FUZZTIME})"
           go test "./${{ matrix.pkg }}/" -run '^$' -fuzz "^${{ matrix.fn }}$" -fuzztime "${FUZZTIME}"
           echo "::endgroup::"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,12 +5,6 @@ rules:
   unpinned-uses:
     disable: true
 
-  # Pre-existing template-injection findings need a dedicated cleanup pass;
-  # tracked in issue #21132. Files not listed here still get full coverage.
-  template-injection:
-    ignore:
-      - release.yml
-
   # Cache-poisoning (artipacked) findings in these workflows are intentional;
   # tracked in issue #21132.
   cache-poisoning:


### PR DESCRIPTION
Final batch of the #21132 template-injection cleanup. After this PR the repo has **zero template-injection findings** and the `template-injection` ignore block is removed from `.github/zizmor.yml` entirely — the audit runs with full coverage.

## Files

- `release.yml` — image `revision`/`vcs-ref-short` labels (`steps.getCommitId.outputs.*`), the skopeo copy/delete tags (`env.DOCKER_URL*`), and the manual-release `--target` (`needs.build-release.outputs.commit-id`) now travel through step `env:` and are referenced as shell variables.
- `qa-rpc-test-bisection-tool.yml`, `qa-sync-test-bisection-tool.yml` — the "Output Offending Commit" step routes `steps.bisect_result.outputs.*` through env.
- `test-fuzz.yml` — the fuzz build dir (`steps.erigon.outputs.build`) routed through env.
- `.github/zizmor.yml` — dropped the now-empty `template-injection` ignore list.

## Notes

- These three non-release workflows were never in the ignore list; their findings were low-severity (`help`) and didn't trip the default-persona gate, but they're fixed here to close the category.
- `skopeo` `docker://…` args and the commit-id labels are quoted while routing, so no new shellcheck SC2086 is introduced.
- Constrained expressions and trusted command substitutions (`$(git rev-parse HEAD)`) are left as-is — zizmor does not flag them.

## Verification

- `zizmor 1.24.1` full-repo sweep: **0 template-injection findings** anywhere; full-repo exit code unchanged at **12** (< 14, passes the CI gate) with the ignore block removed.
- `actionlint`: 0 errors on all four workflows.