### PR TITLE
cl/sentinel: lower undialable-peer discovery log from error to debug

### DIFF
--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -523,7 +523,7 @@ func (s *Sentinel) listenForPeers() {
 
 		peerInfo, _, err := p2p.ConvertToAddrInfo(node)
 		if err != nil {
-			log.Error("[Sentinel] Could not convert to peer info", "err", err)
+			log.Debug("[Sentinel] Could not convert to peer info", "err", err)
 			continue
 		}
 		s.pidToEnr.Store(peerInfo.ID, node)


### PR DESCRIPTION
## What

Lower the `[Sentinel] Could not convert to peer info` log in `listenForPeers()` from `error` to `debug`.

## Why

Caplin's Sentinel pulls random nodes from the discv5 DHT and, for each, tries to build a libp2p address — which requires a TCP port in the peer's ENR. discv5 only requires a **UDP** endpoint, so the `tcp` entry is optional; NAT'd, discovery-only, and IPv6-tcp-only nodes routinely omit it. Such records simply aren't dialable as CL peers and are correctly skipped — but this path logged one `error` line per skipped node:

```
[Sentinel] Could not convert to peer info err="node 9520ea19... does not provide a tcp port"
```

That is benign, expected discovery behavior, not an error. The two sibling paths that hit the identical `ConvertToSingleMultiAddr` failure already treat it as non-noteworthy:

- `ConvertToMultiAddr` (`cl/p2p/utils.go`) logs it at `debug`
- `findPeersForSubnets` (`cl/sentinel/discovery.go`) skips silently

This makes the third path consistent with them.

## Testing

Pure log-level change, no behavior change — mechanical, so no test added (per the repo's TDD guidance). `make lint` clean; `cl/sentinel` builds.
