### PR TITLE
integration: restore stage_exec --unwind, dropped in f407544c59

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -705,6 +705,24 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 		}
 	}()
 
+	if unwind > 0 {
+		u := sync.NewUnwindState(stages.Execution, s.BlockNumber-unwind, s.BlockNumber, true, false)
+		doms, err := execctx.NewSharedDomains(ctx, tx, logger)
+		if err != nil {
+			return err
+		}
+		defer doms.Close()
+		if err := stagedsync.UnwindExecutionStage(u, s, doms, tx, ctx, cfg, logger); err != nil {
+			return err
+		}
+		if err := doms.Flush(ctx, tx); err != nil {
+			return err
+		}
+		err = tx.Commit()
+		tx = nil
+		return err
+	}
+
 	if pruneTo > 0 {
 		p, err := sync.PruneStageState(stages.Execution, s.BlockNumber, tx, true)
 		if err != nil {


### PR DESCRIPTION
## What

`integration stage_exec --unwind=N` has been a silent no-op since f407544c59 (#17783):
the refactor removed the `UnwindExecutionStage` call from `stageExec` while leaving the
`--unwind` flag and its `CanUnwindBeforeBlockNum` clamp in place. The command accepts
the flag, prints the stage progress, and exits successfully in milliseconds without
unwinding anything — `print_stages` confirms the progress is unchanged.

This is a standard recovery path for a wedged node, so silently doing nothing is
dangerous: an operator "unwinds", restarts, and misattributes the unchanged failure.

## How

Re-add the unwind branch after the rw tx is opened. `UnwindExecutionStage` now calls
`doms.ResetPendingUpdates()` unconditionally, so the pre-refactor `nil` doms argument
no longer works — create a `SharedDomains`, run the unwind, flush, then commit.

## Testing

The same change applied on v3.5.1 was used while recovering a wedged mainnet archive
node (#22423): `stage_exec --unwind=110` correctly logged
`[6/8 Execution] Unwind Execution from=25512110 to=25512013` (clamped by
`CanUnwindBeforeBlockNum`), did ~24s of real work, and `print_stages` showed the
lowered Execution progress. On this branch the patch compiles (`go build
./cmd/integration`); runtime-testing main against that datadir wasn't possible since
its DB schema is pinned to 3.5.

Fixes #22432
