### PR TITLE
all: lint enable atomictypes, forvar, and mapsloop analyzers under modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,8 +91,6 @@ linters:
           skipRecvDeref: true
     modernize:
       disable: # each disabled analyzer has an existing backlog; enable it once its findings are cleared
-        - atomictypes
-        - forvar
         - mapsloop
         - omitzero
         - rangeint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,7 +91,6 @@ linters:
           skipRecvDeref: true
     modernize:
       disable: # each disabled analyzer has an existing backlog; enable it once its findings are cleared
-        - mapsloop
         - omitzero
         - rangeint
         - reflecttypefor

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sort"
 	"time"
 
@@ -374,9 +375,7 @@ func fetchParentEnvelopes(ctx context.Context, cfg *Cfg, roots [][32]byte) map[c
 			log.Debug("[chainTipSync] envelope fetch attempt failed", "err", err, "attempt", attempt+1, "remaining", len(remaining))
 			continue
 		}
-		for k, v := range result {
-			envelopes[k] = v
-		}
+		maps.Copy(envelopes, result)
 		// Recalculate remaining
 		var stillMissing [][32]byte
 		for _, root := range remaining {

--- a/cmd/utils/cmdtest/test_cmd.go
+++ b/cmd/utils/cmdtest/test_cmd.go
@@ -60,12 +60,12 @@ type TestCmd struct {
 	Err error
 }
 
-var id int32
+var id atomic.Int32
 
 // Run exec's the current binary using name as argv[0] which will trigger the
 // reexec init function for that name (e.g. "geth-test" in cmd/geth/run_test.go)
 func (tt *TestCmd) Run(name string, args ...string) {
-	id := atomic.AddInt32(&id, 1)
+	id := id.Add(1)
 	tt.stderr = &testlogger{t: tt.T, name: strconv.FormatUint(uint64(id), 10)}
 	tt.cmd = &exec.Cmd{
 		Path:   reexec.Self(),

--- a/db/downloader/chaintoml_consumer.go
+++ b/db/downloader/chaintoml_consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"sort"
@@ -52,9 +53,7 @@ func BuildTomlFromMap(m map[string]string) []byte {
 // conflict (same key). Returns the merged map and the count of genuinely new entries.
 func MergeChainToml(existing, discovered map[string]string) (merged map[string]string, newCount int) {
 	merged = make(map[string]string, len(existing)+len(discovered))
-	for k, v := range existing {
-		merged[k] = v
-	}
+	maps.Copy(merged, existing)
 	for k, v := range discovered {
 		if _, exists := merged[k]; !exists {
 			merged[k] = v

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -207,7 +207,7 @@ func TestAggregatorV3_ReplaceCommittedKeys(t *testing.T) {
 	require.NoError(t, err)
 	defer domains.Close()
 
-	var latestCommitTxNum uint64
+	var latestCommitTxNum atomic.Uint64
 	commit := func(txn uint64) error {
 		err = domains.Flush(ctx, tx)
 		require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestAggregatorV3_ReplaceCommittedKeys(t *testing.T) {
 
 		domains, err = execctx.NewSharedDomains(t.Context(), tx, log.New())
 		require.NoError(t, err)
-		atomic.StoreUint64(&latestCommitTxNum, txn)
+		latestCommitTxNum.Store(txn)
 		return nil
 	}
 

--- a/execution/commitment/parallel_streaming_bench_test.go
+++ b/execution/commitment/parallel_streaming_bench_test.go
@@ -280,7 +280,6 @@ func Benchmark_StorageConcurrency(b *testing.B) {
 						b.StartTimer()
 						var eg errgroup.Group
 						for _, r := range rs {
-							r := r
 							eg.Go(r.process)
 						}
 						require.NoError(b, eg.Wait())

--- a/execution/protocol/rules/ethash/algorithm.go
+++ b/execution/protocol/rules/ethash/algorithm.go
@@ -198,7 +198,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 	rows := int(size) / hashBytes
 
 	// Start a monitoring goroutine to report progress on low end devices
-	var progress uint32
+	var progress atomic.Uint32
 
 	done := make(chan struct{})
 	defer close(done)
@@ -209,7 +209,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 			case <-done:
 				return
 			case <-time.After(3 * time.Second):
-				logger.Info("Generating ethash verification cache", "percentage", atomic.LoadUint32(&progress)*100/uint32(rows)/4, "elapsed", common.PrettyDuration(time.Since(start)))
+				logger.Info("Generating ethash verification cache", "percentage", progress.Load()*100/uint32(rows)/4, "elapsed", common.PrettyDuration(time.Since(start)))
 			}
 		}
 	}()
@@ -220,7 +220,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 	keccak512(cache, seed)
 	for offset := uint64(hashBytes); offset < size; offset += hashBytes {
 		keccak512(cache[offset:], cache[offset-hashBytes:offset])
-		atomic.AddUint32(&progress, 1)
+		progress.Add(1)
 	}
 	// Use a low-round version of randmemohash
 	tempRef := bytes64Pool.Get().(*[]byte)
@@ -237,7 +237,7 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 			subtle.XORBytes(temp, cache[srcOff:srcOff+hashBytes], cache[xorOff:xorOff+hashBytes])
 			keccak512(cache[dstOff:], temp)
 
-			atomic.AddUint32(&progress, 1)
+			progress.Add(1)
 		}
 	}
 	// Swap the byte order on big endian systems and return
@@ -355,7 +355,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 	var pend sync.WaitGroup
 	pend.Add(threads)
 
-	var progress uint64
+	var progress atomic.Uint64
 	for i := 0; i < threads; i++ {
 		go func(id int) {
 			defer dbg.LogPanic()
@@ -378,7 +378,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 					copy(dataset[index*hashBytes:], item)
 				})
 
-				if status := atomic.AddUint64(&progress, 1); status%percent == 0 {
+				if status := progress.Add(1); status%percent == 0 {
 					logger.Info("Generating DAG in progress", "percentage", (status*100)/(size/hashBytes), "elapsed", common.PrettyDuration(time.Since(start)))
 				}
 			}

--- a/execution/protocol/rules/ethash/meter.go
+++ b/execution/protocol/rules/ethash/meter.go
@@ -173,7 +173,7 @@ func (ma *meterArbiter) tickMeters() {
 // of uncounted events and processes them on each tick.  It uses the
 // sync/atomic package to manage uncounted events.
 type ewma struct {
-	uncounted atomic.Int64 // /!\ this should be the first member to ensure 64-bit alignment
+	uncounted atomic.Int64
 	alpha     float64
 	rate      float64
 	init      bool

--- a/execution/protocol/rules/ethash/meter.go
+++ b/execution/protocol/rules/ethash/meter.go
@@ -69,7 +69,7 @@ type hashRateMeter struct {
 	snapshot  *meterSnapshot
 	a1        *ewma
 	startTime time.Time
-	stopped   uint32
+	stopped   atomic.Uint32
 }
 
 func newMeter() *hashRateMeter {
@@ -82,7 +82,7 @@ func newMeter() *hashRateMeter {
 
 // Stop stops the meter, Mark() will be a no-op if you use it after being stopped.
 func (m *hashRateMeter) Stop() {
-	stopped := atomic.SwapUint32(&m.stopped, 1)
+	stopped := m.stopped.Swap(1)
 	if stopped != 1 {
 		arbiter.mu.Lock()
 		delete(arbiter.meters, m)
@@ -173,7 +173,7 @@ func (ma *meterArbiter) tickMeters() {
 // of uncounted events and processes them on each tick.  It uses the
 // sync/atomic package to manage uncounted events.
 type ewma struct {
-	uncounted int64 // /!\ this should be the first member to ensure 64-bit alignment
+	uncounted atomic.Int64 // /!\ this should be the first member to ensure 64-bit alignment
 	alpha     float64
 	rate      float64
 	init      bool
@@ -190,8 +190,8 @@ func (a *ewma) Rate() float64 {
 // Tick ticks the clock to update the moving average.  It assumes it is called
 // every five seconds.
 func (a *ewma) Tick() {
-	count := atomic.LoadInt64(&a.uncounted)
-	atomic.AddInt64(&a.uncounted, -count)
+	count := a.uncounted.Load()
+	a.uncounted.Add(-count)
 	instantRate := float64(count) / float64(5*time.Second)
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
@@ -205,5 +205,5 @@ func (a *ewma) Tick() {
 
 // Update adds n uncounted events.
 func (a *ewma) Update(n int64) {
-	atomic.AddInt64(&a.uncounted, n)
+	a.uncounted.Add(n)
 }

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -140,12 +140,8 @@ func (aa AccessSet) Merge(other AccessSet) AccessSet {
 		return aa
 	}
 	dst := make(AccessSet, len(aa)+len(other))
-	for addr, opt := range aa {
-		dst[addr] = opt
-	}
-	for addr, opt := range other {
-		dst[addr] = opt
-	}
+	maps.Copy(dst, aa)
+	maps.Copy(dst, other)
 	return dst
 }
 
@@ -2369,9 +2365,7 @@ func (sdb *IntraBlockState) AccessedAddresses() AccessSet {
 		return nil
 	}
 	out := make(AccessSet, len(sdb.addressAccess))
-	for addr, opts := range sdb.addressAccess {
-		out[addr] = opts
-	}
+	maps.Copy(out, sdb.addressAccess)
 	sdb.recordAccess = false
 	sdb.addressAccess = nil
 	return out

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -2081,9 +2081,7 @@ func (io *VersionedIO) RecordAccesses(txVersion Version, addresses AccessSet) {
 		io.accessed = append(io.accessed, make([]AccessSet, txVersion.TxIndex+2-len(io.accessed))...)
 	}
 	dest := make(AccessSet, len(addresses))
-	for addr, opt := range addresses {
-		dest[addr] = opt
-	}
+	maps.Copy(dest, addresses)
 	io.accessed[txVersion.TxIndex+1] = dest
 }
 

--- a/node/app/domain.go
+++ b/node/app/domain.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding"
 	"errors"
+	"maps"
 	"reflect"
 	"strconv"
 	"strings"
@@ -116,9 +117,7 @@ func WithInfo[T comparable](info map[any]any) domainFeature {
 			if d.info == nil {
 				d.info = make(map[any]any)
 			}
-			for key, value := range info {
-				d.info[key] = value
-			}
+			maps.Copy(d.info, info)
 		}
 	})
 }

--- a/node/app/event/eventbus.go
+++ b/node/app/event/eventbus.go
@@ -18,6 +18,7 @@ package event
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -85,9 +86,7 @@ func (hmap *handlerMap) clone() *handlerMap {
 		nextArgInterfaces: make(map[reflect.Type]int, len(hmap.nextArgInterfaces)),
 		nextArgMap:        make(map[reflect.Type]*handlerMap, len(hmap.nextArgMap)),
 	}
-	for k, v := range hmap.nextArgInterfaces {
-		cloned.nextArgInterfaces[k] = v
-	}
+	maps.Copy(cloned.nextArgInterfaces, hmap.nextArgInterfaces)
 	if len(hmap.handlers) > 0 {
 		cloned.handlers = make([]*eventHandler, len(hmap.handlers))
 		copy(cloned.handlers, hmap.handlers)

--- a/node/app/workerpool/workerpool.go
+++ b/node/app/workerpool/workerpool.go
@@ -91,7 +91,7 @@ type WorkerPool struct {
 	stopLock     sync.Mutex
 	stopOnce     sync.Once
 	stopped      bool
-	waiting      int32
+	waiting      atomic.Int32
 	wait         bool
 }
 
@@ -184,7 +184,7 @@ func (p *WorkerPool) SubmitWait(task func()) {
 
 // WaitingQueueSize returns the count of tasks in the waiting queue.
 func (p *WorkerPool) WaitingQueueSize() int {
-	return int(atomic.LoadInt32(&p.waiting))
+	return int(p.waiting.Load())
 }
 
 // Pause causes all workers to wait on the given Context, thereby making them
@@ -258,7 +258,7 @@ Loop:
 				} else {
 					// Enqueue task to be executed by next available worker.
 					p.waitingQueue.PushBack(task)
-					atomic.StoreInt32(&p.waiting, int32(p.waitingQueue.Len()))
+					p.waiting.Store(int32(p.waitingQueue.Len()))
 				}
 			}
 			idle = false
@@ -334,7 +334,7 @@ func (p *WorkerPool) processWaitingQueue() bool {
 		// A worker was ready, so gave task to worker.
 		p.waitingQueue.PopFront()
 	}
-	atomic.StoreInt32(&p.waiting, int32(p.waitingQueue.Len()))
+	p.waiting.Store(int32(p.waitingQueue.Len()))
 	return true
 }
 
@@ -355,6 +355,6 @@ func (p *WorkerPool) runQueuedTasks() {
 	for p.waitingQueue.Len() != 0 {
 		// A worker is ready, so give task to worker.
 		p.workerQueue <- p.waitingQueue.PopFront()
-		atomic.StoreInt32(&p.waiting, int32(p.waitingQueue.Len()))
+		p.waiting.Store(int32(p.waitingQueue.Len()))
 	}
 }

--- a/node/app/workerpool/workerpool_test.go
+++ b/node/app/workerpool/workerpool_test.go
@@ -35,7 +35,6 @@ func TestExample(t *testing.T) {
 
 	rspChan := make(chan string, len(requests))
 	for _, r := range requests {
-		r := r
 		wp.Submit(func() {
 			rspChan <- r
 		})

--- a/node/cli/config_file.go
+++ b/node/cli/config_file.go
@@ -19,6 +19,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -98,9 +99,7 @@ func flattenConfig(m map[string]any, prefix string) map[string]any {
 			key = prefix + "." + k
 		}
 		if nested, ok := v.(map[string]any); ok {
-			for fk, fv := range flattenConfig(nested, key) {
-				result[fk] = fv
-			}
+			maps.Copy(result, flattenConfig(nested, key))
 		} else {
 			result[key] = v
 		}

--- a/node/rpcstack_gzip_bench_test.go
+++ b/node/rpcstack_gzip_bench_test.go
@@ -266,7 +266,6 @@ func fetchPayload(t testing.TB, blockTag string) []byte {
 
 func TestGzipHandlerLatency(t *testing.T) {
 	for _, blk := range historicalBlocks {
-		blk := blk
 		t.Run(blk.desc, func(t *testing.T) {
 			payload := fetchPayload(t, blk.tag)
 			if payload == nil {
@@ -290,7 +289,6 @@ func TestRPCDaemonLatency(t *testing.T) {
 	var sb strings.Builder
 
 	for _, blk := range historicalBlocks {
-		blk := blk
 		t.Run(blk.desc, func(t *testing.T) {
 			stat := measureRPCLatency(t, rpcEndpoint, blk.tag)
 			line := fmt.Sprintf("%-52s  %s\n", blk.desc, stat)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -83,7 +83,7 @@ type Client struct {
 	methodAllowList AllowList
 	batchLimit      int // batch size limit
 
-	idCounter uint32
+	idCounter atomic.Uint32
 
 	// This function, if non-nil, is called when the connection is lost.
 	reconnectFunc reconnectFunc
@@ -249,7 +249,7 @@ func (c *Client) RegisterName(name string, receiver any) error {
 }
 
 func (c *Client) nextID() json.RawMessage {
-	id := atomic.AddUint32(&c.idCounter, 1)
+	id := c.idCounter.Add(1)
 	return strconv.AppendUint(nil, uint64(id), 10)
 }
 

--- a/rpc/gasprice/feehistory.go
+++ b/rpc/gasprice/feehistory.go
@@ -334,13 +334,14 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 	}
 
 	var (
-		next         = oldestBlock
 		blockResults = make([]blockResult, blocks)
 		reward       = make([][]*big.Int, blocks)
 		baseFee      = make([]*uint256.Int, blocks+1)
 		gasUsedRatio = make([]float64, blocks)
 		blobBaseFee  = make([]*uint256.Int, blocks+1)
 	)
+	var next atomic.Uint64
+	next.Store(oldestBlock)
 
 	// Pre-fetch chain config once using the main backend (safe: single goroutine).
 	chainconfig := oracle.backend.ChainConfig()
@@ -373,7 +374,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 				if err := fetchCtx.Err(); err != nil {
 					return err
 				}
-				blockNumber := atomic.AddUint64(&next, 1) - 1
+				blockNumber := next.Add(1) - 1
 				if blockNumber > lastBlock {
 					return nil
 				}

--- a/rpc/gasprice/feehistory.go
+++ b/rpc/gasprice/feehistory.go
@@ -351,7 +351,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 	// to using the main backend sequentially; the others exit immediately to
 	// avoid concurrent access on the shared transaction.
 	g, fetchCtx := errgroup.WithContext(ctx)
-	var seqOnce int32 // CAS flag: 0 = available, 1 = sequential mode claimed
+	var seqOnce atomic.Int32 // CAS flag: 0 = available, 1 = sequential mode claimed
 	for range maxBlockFetchers {
 		g.Go(func() error {
 			localBackend, cleanup, forkErr := oracle.backend.Fork(fetchCtx)
@@ -361,7 +361,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 			if localBackend == nil {
 				// Fork not supported: allow exactly one goroutine to proceed
 				// sequentially on the shared backend; the others exit.
-				if !atomic.CompareAndSwapInt32(&seqOnce, 0, 1) {
+				if !seqOnce.CompareAndSwap(0, 1) {
 					return nil
 				}
 				localBackend = oracle.backend

--- a/rpc/gasprice/gasprice.go
+++ b/rpc/gasprice/gasprice.go
@@ -228,8 +228,8 @@ func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*uint256.Int, error) {
 func (oracle *Oracle) fetchBlockPricesParallel(ctx context.Context, head uint64, count int) ([][]*uint256.Int, error) {
 	results := make([][]*uint256.Int, count)
 	var (
-		nextIdx uint64
-		seqOnce int32 // CAS flag: 0 = available, 1 = sequential mode claimed
+		nextIdx atomic.Uint64
+		seqOnce atomic.Int32 // CAS flag: 0 = available, 1 = sequential mode claimed
 	)
 	g, fetchCtx := errgroup.WithContext(ctx)
 	for range min(maxBlockFetchers, count) {
@@ -241,7 +241,7 @@ func (oracle *Oracle) fetchBlockPricesParallel(ctx context.Context, head uint64,
 			if localBackend == nil {
 				// Fork not supported: allow exactly one goroutine to proceed
 				// sequentially on the shared backend; the others exit.
-				if !atomic.CompareAndSwapInt32(&seqOnce, 0, 1) {
+				if !seqOnce.CompareAndSwap(0, 1) {
 					return nil
 				}
 				localBackend = oracle.backend
@@ -252,7 +252,7 @@ func (oracle *Oracle) fetchBlockPricesParallel(ctx context.Context, head uint64,
 				if err := fetchCtx.Err(); err != nil {
 					return err
 				}
-				idx := int(atomic.AddUint64(&nextIdx, 1)) - 1
+				idx := int(nextIdx.Add(1)) - 1
 				if idx >= count {
 					return nil
 				}

--- a/rpc/rpchelper/filter_id.go
+++ b/rpc/rpchelper/filter_id.go
@@ -34,13 +34,13 @@ type (
 	ReceiptsSubID     SubscriptionID
 )
 
-var globalSubscriptionId uint64
+var globalSubscriptionId atomic.Uint64
 
 func generateSubscriptionID() SubscriptionID {
 	id := [16]byte{}
 	sb := new(strings.Builder)
 	hex := hex.NewEncoder(sb)
-	binary.LittleEndian.PutUint64(id[:], atomic.AddUint64(&globalSubscriptionId, 1))
+	binary.LittleEndian.PutUint64(id[:], globalSubscriptionId.Add(1))
 	// try 4 times to generate an id
 	for i := 0; i < 4; i++ {
 		_, err := rand.Read(id[8:])

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -1933,9 +1934,7 @@ func (p *TxPool) sweepDormantQueued(ctx context.Context, currentBlock uint64, lo
 
 		// Snapshot the map for DB persistence while still holding the lock.
 		snapshot = make(map[uint64]uint64, len(p.senderLastActivity))
-		for k, v := range p.senderLastActivity {
-			snapshot[k] = v
-		}
+		maps.Copy(snapshot, p.senderLastActivity)
 	}()
 
 	if evictedSenders > 0 {


### PR DESCRIPTION
This PR enables the `atomictypes`, `forvar`, and `mapsloop` modernisation checkers in the `modernise` linter section of `.golangci.yml`, and modernises their usage across the code base.

In particular, the following modernisations were introduced:
1. **Loop Variable Scoping (`forvar`)**: Removed redundant loop-local copies of variables (obsolete in Go 1.22+) throughout the codebase.
2. **Map Copying (`mapsloop`)**: Manual map copy loop structures are replaced with standard `maps.Copy` of Go 1.21 in entire codebase.
3. **Atomic Types (`atomictypes`)**: Modernized legacy `sync/atomic` helper functions to standard Go 1.19+ atomic types in whole codebase

part of #22199