### PR TITLE
caplin: blobs download logs rounding speed too much

### DIFF
--- a/cl/phase1/network/blob_downloader.go
+++ b/cl/phase1/network/blob_downloader.go
@@ -267,7 +267,7 @@ func (b *BlobHistoryDownloader) downloadOnce(shouldLog bool) error {
 					}
 					b.logger.Info("[BlobHistoryDownloader] Downloading blobs backwards",
 						"slot", currentSlot, "to", targetSlot,
-						"slots/sec", fmt.Sprintf("%.1f", slotSec),
+						"slots/sec", fmt.Sprintf("%.2f", slotSec),
 						"progress", fmt.Sprintf("%.1f%%", progress),
 						"eta", utils.ETA(currentSlot-targetSlot, slotSec))
 				}


### PR DESCRIPTION
before: `blks/sec=0.0`
after: `blks/sec=0.05`