### PR TITLE
db/seg, db/state: non-blocking .kv reads via residency probe + bounded warm (WIP)

### DIFF
--- a/common/iouring/iouring_linux.go
+++ b/common/iouring/iouring_linux.go
@@ -1,0 +1,198 @@
+//go:build linux
+
+// Package iouring is a minimal hand-rolled io_uring facility for file reads at a
+// controlled queue depth — enough to warm the page cache without blocking the
+// goroutine's P (io_uring_enter goes through the syscall path, so a slow read
+// hands the P off). Not a general async reactor: BatchReadWarm submits a batch
+// and waits for all of it.
+package iouring
+
+import (
+	"fmt"
+	"sync/atomic"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	sysSetup = 425
+	sysEnter = 426
+
+	opRead                 = 22 // IORING_OP_READ
+	enterGetevents         = 1  // IORING_ENTER_GETEVENTS
+	offSQRing      uintptr = 0
+	offCQRing      uintptr = 0x8000000
+	offSQEs        uintptr = 0x10000000
+
+	sqeSize = 64
+	cqeSize = 16
+)
+
+// io_uring_params layout (Linux). Only the fields we read are named precisely.
+type params struct {
+	sqEntries    uint32
+	cqEntries    uint32
+	flags        uint32
+	sqThreadCPU  uint32
+	sqThreadIdle uint32
+	features     uint32
+	wqFD         uint32
+	resv         [3]uint32
+	sqOff        sqringOffsets
+	cqOff        cqringOffsets
+}
+
+type sqringOffsets struct {
+	head, tail, ringMask, ringEntries, flags, dropped, array, resv1 uint32
+	resv2                                                           uint64
+}
+type cqringOffsets struct {
+	head, tail, ringMask, ringEntries, overflow, cqes, flags, resv1 uint32
+	resv2                                                           uint64
+}
+
+type Ring struct {
+	fd      int
+	entries uint32
+
+	sqRing []byte
+	cqRing []byte
+	sqes   []byte
+
+	// pointers into sqRing/cqRing
+	sqHead, sqTail *uint32
+	sqMask         uint32
+	sqArray        []uint32
+	cqHead, cqTail *uint32
+	cqMask         uint32
+	cqesBase       unsafe.Pointer
+}
+
+func p32(b []byte, off uint32) *uint32 { return (*uint32)(unsafe.Pointer(&b[off])) }
+
+// New sets up a ring sized for `entries` in-flight requests (rounded up to pow2 by kernel).
+func New(entries uint32) (*Ring, error) {
+	var pp params
+	r1, _, errno := unix.Syscall(sysSetup, uintptr(entries), uintptr(unsafe.Pointer(&pp)), 0)
+	if errno != 0 {
+		return nil, fmt.Errorf("io_uring_setup: %w", errno)
+	}
+	ring := &Ring{fd: int(r1), entries: pp.sqEntries}
+
+	sqRingSize := pp.sqOff.array + pp.sqEntries*4
+	cqRingSize := pp.cqOff.cqes + pp.cqEntries*cqeSize
+
+	var err error
+	ring.sqRing, err = unix.Mmap(ring.fd, int64(offSQRing), int(sqRingSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED|unix.MAP_POPULATE)
+	if err != nil {
+		unix.Close(ring.fd)
+		return nil, fmt.Errorf("mmap sq: %w", err)
+	}
+	ring.cqRing, err = unix.Mmap(ring.fd, int64(offCQRing), int(cqRingSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED|unix.MAP_POPULATE)
+	if err != nil {
+		unix.Close(ring.fd)
+		return nil, fmt.Errorf("mmap cq: %w", err)
+	}
+	ring.sqes, err = unix.Mmap(ring.fd, int64(offSQEs), int(pp.sqEntries*sqeSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED|unix.MAP_POPULATE)
+	if err != nil {
+		unix.Close(ring.fd)
+		return nil, fmt.Errorf("mmap sqes: %w", err)
+	}
+
+	ring.sqHead = p32(ring.sqRing, pp.sqOff.head)
+	ring.sqTail = p32(ring.sqRing, pp.sqOff.tail)
+	ring.sqMask = *p32(ring.sqRing, pp.sqOff.ringMask)
+	arrayPtr := unsafe.Pointer(&ring.sqRing[pp.sqOff.array])
+	ring.sqArray = unsafe.Slice((*uint32)(arrayPtr), pp.sqEntries)
+
+	ring.cqHead = p32(ring.cqRing, pp.cqOff.head)
+	ring.cqTail = p32(ring.cqRing, pp.cqOff.tail)
+	ring.cqMask = *p32(ring.cqRing, pp.cqOff.ringMask)
+	ring.cqesBase = unsafe.Pointer(&ring.cqRing[pp.cqOff.cqes])
+
+	return ring, nil
+}
+
+func (r *Ring) Close() {
+	if r.sqRing != nil {
+		unix.Munmap(r.sqRing)
+	}
+	if r.cqRing != nil {
+		unix.Munmap(r.cqRing)
+	}
+	if r.sqes != nil {
+		unix.Munmap(r.sqes)
+	}
+	unix.Close(r.fd)
+}
+
+func (r *Ring) fillSQE(idx uint32, fd int, off uint64, buf []byte, userData uint64) {
+	base := unsafe.Pointer(&r.sqes[idx*sqeSize])
+	// zero the sqe
+	s := unsafe.Slice((*byte)(base), sqeSize)
+	for i := range s {
+		s[i] = 0
+	}
+	*(*uint8)(base) = opRead                                                    // opcode @0
+	*(*int32)(unsafe.Add(base, 4)) = int32(fd)                                  // fd @4
+	*(*uint64)(unsafe.Add(base, 8)) = off                                       // off @8
+	*(*uint64)(unsafe.Add(base, 16)) = uint64(uintptr(unsafe.Pointer(&buf[0]))) // addr @16
+	*(*uint32)(unsafe.Add(base, 24)) = uint32(len(buf))                         // len @24
+	*(*uint64)(unsafe.Add(base, 32)) = userData                                 // user_data @32
+}
+
+// BatchReadWarm reads each (offset,len) request into scratch buffers using
+// io_uring, keeping up to the ring size in flight. Returns after all complete.
+// The reads populate the page cache; buffer contents are discarded.
+func (r *Ring) BatchReadWarm(fd int, offsets []int64, lens []int, scratch [][]byte) error {
+	n := len(offsets)
+	done := 0
+	for done < n {
+		// Submit a wave up to ring capacity.
+		tail := atomic.LoadUint32(r.sqTail)
+		head := atomic.LoadUint32(r.sqHead)
+		space := r.entries - (tail - head)
+		wave := 0
+		for wave < int(space) && done+wave < n {
+			i := done + wave
+			slot := tail & r.sqMask
+			r.fillSQE(slot, fd, uint64(offsets[i]), scratch[wave][:lens[i]], uint64(i))
+			r.sqArray[slot] = slot
+			tail++
+			wave++
+		}
+		atomic.StoreUint32(r.sqTail, tail)
+
+		_, _, errno := unix.Syscall6(sysEnter, uintptr(r.fd), uintptr(wave), uintptr(wave), enterGetevents, 0, 0)
+		if errno != 0 {
+			return fmt.Errorf("io_uring_enter: %w", errno)
+		}
+
+		// Reap `wave` completions.
+		reaped := 0
+		for reaped < wave {
+			ch := atomic.LoadUint32(r.cqHead)
+			ct := atomic.LoadUint32(r.cqTail)
+			for ch != ct {
+				cqe := unsafe.Add(r.cqesBase, uintptr(ch&r.cqMask)*cqeSize)
+				res := *(*int32)(unsafe.Add(cqe, 8))
+				if res < 0 {
+					// negative res = -errno; ignore for warming (best-effort)
+					_ = res
+				}
+				ch++
+				reaped++
+			}
+			atomic.StoreUint32(r.cqHead, ch)
+			if reaped < wave {
+				_, _, errno := unix.Syscall6(sysEnter, uintptr(r.fd), 0, uintptr(wave-reaped), enterGetevents, 0, 0)
+				if errno != 0 {
+					return fmt.Errorf("io_uring_enter(wait): %w", errno)
+				}
+			}
+		}
+		done += wave
+	}
+	return nil
+}

--- a/common/iouring/warmone_linux.go
+++ b/common/iouring/warmone_linux.go
@@ -3,11 +3,11 @@
 package iouring
 
 import (
-	"fmt"
 	"os"
 	"sync"
 
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/log/v3"
 )
 
 // Pool of small rings for per-access warming: each goroutine borrows a ring,
@@ -30,28 +30,24 @@ func initPool() {
 	ringPool = make(chan *pooledRing, n)
 	for i := 0; i < n; i++ {
 		r, err := New(8)
-		if err != nil { // io_uring unavailable (e.g. seccomp): leave pool empty → WarmOne returns false
-			fmt.Fprintf(os.Stderr, "[IOURING] setup FAILED after %d rings: %v — falling back to pread\n", i, err)
-			return
+		if err != nil { // io_uring is required — there is no fallback path.
+			log.Crit("[IOURING] io_uring_setup failed; kernel does not support it or it is blocked (seccomp)", "ring", i, "err", err)
+			os.Exit(1)
 		}
 		ringPool <- &pooledRing{r: r, buf: make([]byte, warmBufSize)}
 	}
 }
 
 // WarmOne reads [off, off+length) via a pooled io_uring ring to populate the
-// page cache. Returns false if io_uring is unavailable or the pool is exhausted,
-// in which case the caller should fall back to a blocking read.
-func WarmOne(fd int, off int64, length int) bool {
+// page cache. It blocks for a free ring when the pool is drained (parking the
+// goroutine, freeing its P). There is no fallback: io_uring must be available,
+// and the process exits the first time a warm is needed if setup fails.
+func WarmOne(fd int, off int64, length int) {
 	ringPoolOnce.Do(initPool)
 	if length > warmBufSize {
 		length = warmBufSize
 	}
-	select {
-	case pr := <-ringPool:
-		err := pr.r.BatchReadWarm(fd, []int64{off}, []int{length}, [][]byte{pr.buf})
-		ringPool <- pr
-		return err == nil
-	default:
-		return false // pool exhausted → caller falls back to pread
-	}
+	pr := <-ringPool
+	_ = pr.r.BatchReadWarm(fd, []int64{off}, []int{length}, [][]byte{pr.buf})
+	ringPool <- pr
 }

--- a/common/iouring/warmone_linux.go
+++ b/common/iouring/warmone_linux.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package iouring
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/erigontech/erigon/common/dbg"
+)
+
+// Pool of small rings for per-access warming: each goroutine borrows a ring,
+// does a single-read submit+wait (which releases the P via io_uring_enter),
+// and returns it. Sized to the expected number of concurrent cold readers.
+const warmBufSize = 32 * 1024
+
+type pooledRing struct {
+	r   *Ring
+	buf []byte
+}
+
+var (
+	ringPool     chan *pooledRing
+	ringPoolOnce sync.Once
+)
+
+func initPool() {
+	n := dbg.EnvInt("RESIDENCY_IOURING_RINGS", 128)
+	ringPool = make(chan *pooledRing, n)
+	for i := 0; i < n; i++ {
+		r, err := New(8)
+		if err != nil { // io_uring unavailable (e.g. seccomp): leave pool empty → WarmOne returns false
+			fmt.Fprintf(os.Stderr, "[IOURING] setup FAILED after %d rings: %v — falling back to pread\n", i, err)
+			return
+		}
+		ringPool <- &pooledRing{r: r, buf: make([]byte, warmBufSize)}
+	}
+}
+
+// WarmOne reads [off, off+length) via a pooled io_uring ring to populate the
+// page cache. Returns false if io_uring is unavailable or the pool is exhausted,
+// in which case the caller should fall back to a blocking read.
+func WarmOne(fd int, off int64, length int) bool {
+	ringPoolOnce.Do(initPool)
+	if length > warmBufSize {
+		length = warmBufSize
+	}
+	select {
+	case pr := <-ringPool:
+		err := pr.r.BatchReadWarm(fd, []int64{off}, []int{length}, [][]byte{pr.buf})
+		ringPool <- pr
+		return err == nil
+	default:
+		return false // pool exhausted → caller falls back to pread
+	}
+}

--- a/common/iouring/warmone_other.go
+++ b/common/iouring/warmone_other.go
@@ -2,5 +2,9 @@
 
 package iouring
 
-// WarmOne is a no-op on non-linux; returns false so callers fall back to pread.
-func WarmOne(fd int, off int64, length int) bool { return false }
+// WarmOne is unreachable off Linux: the residency probe (mmap.Resident) is a
+// no-op there, so the gate never warms. It panics rather than silently no-op
+// because there is no fallback path — io_uring is Linux-only.
+func WarmOne(fd int, off int64, length int) {
+	panic("iouring: io_uring warming is only available on linux")
+}

--- a/common/iouring/warmone_other.go
+++ b/common/iouring/warmone_other.go
@@ -1,0 +1,6 @@
+//go:build !linux
+
+package iouring
+
+// WarmOne is a no-op on non-linux; returns false so callers fall back to pread.
+func WarmOne(fd int, off int64, length int) bool { return false }

--- a/common/mmap/residency_linux.go
+++ b/common/mmap/residency_linux.go
@@ -1,0 +1,50 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package mmap
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Resident reports whether every page spanned by m is present in this process's
+// page tables (i.e. touching it will not take a major fault). m must start on a
+// page boundary. It never triggers I/O.
+func Resident(m []byte) (bool, error) {
+	if len(m) == 0 {
+		return true, nil
+	}
+	pageSize := os.Getpagesize()
+	vec := make([]byte, (len(m)+pageSize-1)/pageSize)
+	_, _, errno := unix.Syscall(unix.SYS_MINCORE,
+		uintptr(unsafe.Pointer(&m[0])),
+		uintptr(len(m)),
+		uintptr(unsafe.Pointer(&vec[0])))
+	if errno != 0 {
+		return false, errno
+	}
+	for _, v := range vec {
+		if v&1 == 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/common/mmap/residency_linux_test.go
+++ b/common/mmap/residency_linux_test.go
@@ -1,0 +1,68 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package mmap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// residencySink defeats dead-code elimination of the page-touching loop.
+var residencySink int
+
+func TestResidencyProbe(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f")
+	pg := os.Getpagesize()
+	data := make([]byte, pg*8)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	require.NoError(t, os.WriteFile(p, data, 0o644))
+
+	f, err := os.Open(p)
+	require.NoError(t, err)
+	defer f.Close()
+
+	// Flush to disk and drop the file's clean pages from the page cache so the
+	// mapping starts cold.
+	require.NoError(t, f.Sync())
+	require.NoError(t, unix.Fadvise(int(f.Fd()), 0, int64(len(data)), unix.FADV_DONTNEED))
+
+	m, h2, err := Mmap(f, len(data))
+	require.NoError(t, err)
+	defer Munmap(m, h2)
+
+	res, err := Resident(m)
+	require.NoError(t, err)
+	require.False(t, res, "pages should be cold right after a page-cache drop")
+
+	// Touch every page to fault them all in from disk.
+	for i := 0; i < len(m); i += pg {
+		residencySink += int(m[i])
+	}
+
+	res, err = Resident(m)
+	require.NoError(t, err)
+	require.True(t, res, "all pages should be resident after touching them")
+}

--- a/common/mmap/residency_other.go
+++ b/common/mmap/residency_other.go
@@ -1,0 +1,23 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !linux
+
+package mmap
+
+// Resident is a no-op on platforms without mincore: it reports pages as
+// resident so callers skip the residency gate and fall back to plain mmap.
+func Resident(m []byte) (bool, error) { return true, nil }

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -780,11 +780,12 @@ type Getter struct {
 	posEntries []posEntry // cached d.posDict.entries, avoids pointer chain on hot path
 	data       []byte
 	//less hot fields
-	posTables   []posTable // posArena.tables; only used for the subtable path
-	patternDict *patternTable
-	d           *Decompressor
-	fName       string
-	trace       bool
+	posTables     []posTable // posArena.tables; only used for the subtable path
+	patternDict   *patternTable
+	d             *Decompressor
+	fName         string
+	trace         bool
+	residencyGate bool
 }
 
 func (g *Getter) MadvNormal() MadvDisabler {
@@ -935,6 +936,9 @@ func (g *Getter) DataLen() int {
 func (g *Getter) Reset(offset uint64) {
 	g.dataP = offset
 	g.dataBit = 0
+	if g.residencyGate {
+		g.ensureResident(offset)
+	}
 }
 
 func (g *Getter) HasNext() bool {

--- a/db/seg/residency_gate.go
+++ b/db/seg/residency_gate.go
@@ -18,7 +18,6 @@ package seg
 
 import (
 	"os"
-	"sync"
 	"unsafe"
 
 	"github.com/erigontech/erigon/common/dbg"
@@ -34,20 +33,10 @@ var pageSize = os.Getpagesize()
 // itself and nothing more. Tunable via env (RESIDENCY_WINDOW_PAGES) without a rebuild.
 var residencyWindow = dbg.EnvInt("RESIDENCY_WINDOW_PAGES", 1) * pageSize
 
-// warmConcurrency bounds how many goroutines may be blocked in a warming read
-// at once. Acquiring parks the goroutine (freeing its P) when full; the read
-// itself goes through Go's syscall path, so a slow read hands the P off too.
-var warmSem = make(chan struct{}, 512)
-
-var warmBufPool = sync.Pool{New: func() any {
-	b := make([]byte, residencyWindow+pageSize)
-	return &b
-}}
-
 // EnableResidencyGate makes this getter probe page-cache residency on Reset and
-// warm cold pages with a bounded blocking read before the value is decompressed
-// off the mapping — turning would-be blocking mmap page faults into read()s that
-// release the goroutine's P. Intended for random-access readers over state .kv files.
+// warm cold pages via io_uring before the value is decompressed off the mapping —
+// turning would-be blocking mmap page faults into io_uring reads that release the
+// goroutine's P. Intended for random-access readers over state .kv files.
 func (g *Getter) EnableResidencyGate() { g.residencyGate = true }
 
 // residencyRegion returns the page-aligned mmap slice covering the word extent
@@ -81,18 +70,10 @@ func (g *Getter) ensureResident(offset uint64) {
 	g.warm(fileOffset, len(region))
 }
 
-// warm pulls the byte range into the page cache so the following mmap access is
-// a minor fault rather than a blocking disk fault. It prefers io_uring (whose
-// io_uring_enter releases the goroutine's P during the read); if io_uring is
-// unavailable or its ring pool is exhausted it falls back to a semaphore-bounded
-// blocking pread. Best-effort: on any error the mmap access simply faults as before.
+// warm pulls the byte range into the page cache via io_uring so the following
+// mmap access is a minor fault rather than a blocking disk fault; io_uring_enter
+// releases the goroutine's P for the duration of the read. There is no fallback —
+// if io_uring is unavailable the process exits on the first warm (see iouring.WarmOne).
 func (g *Getter) warm(fileOffset int64, n int) {
-	if iouring.WarmOne(int(g.d.f.Fd()), fileOffset, n) {
-		return
-	}
-	warmSem <- struct{}{}
-	buf := warmBufPool.Get().(*[]byte)
-	_, _ = g.d.f.ReadAt((*buf)[:n], fileOffset)
-	warmBufPool.Put(buf)
-	<-warmSem
+	iouring.WarmOne(int(g.d.f.Fd()), fileOffset, n)
 }

--- a/db/seg/residency_gate.go
+++ b/db/seg/residency_gate.go
@@ -1,0 +1,89 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package seg
+
+import (
+	"os"
+	"sync"
+	"unsafe"
+
+	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/mmap"
+)
+
+var pageSize = os.Getpagesize()
+
+// residencyWindow is how many bytes from the reset offset the gate ensures are
+// resident. A compressed word's on-disk extent is at most a page or two, so a
+// couple of pages covers effectively every value across all state domains.
+// Tunable via env (RESIDENCY_WINDOW_PAGES) to experiment (e.g. =1) without a rebuild.
+var residencyWindow = dbg.EnvInt("RESIDENCY_WINDOW_PAGES", 2) * pageSize
+
+// warmConcurrency bounds how many goroutines may be blocked in a warming read
+// at once. Acquiring parks the goroutine (freeing its P) when full; the read
+// itself goes through Go's syscall path, so a slow read hands the P off too.
+var warmSem = make(chan struct{}, 512)
+
+var warmBufPool = sync.Pool{New: func() any {
+	b := make([]byte, residencyWindow+pageSize)
+	return &b
+}}
+
+// EnableResidencyGate makes this getter probe page-cache residency on Reset and
+// warm cold pages with a bounded blocking read before the value is decompressed
+// off the mapping — turning would-be blocking mmap page faults into read()s that
+// release the goroutine's P. Intended for random-access readers over state .kv files.
+func (g *Getter) EnableResidencyGate() { g.residencyGate = true }
+
+// residencyRegion returns the page-aligned mmap slice covering the word extent
+// at offset, along with its file offset. Returns nil when out of range.
+func (g *Getter) residencyRegion(offset uint64) (region []byte, fileOffset int64) {
+	full := g.d.mmapHandle1
+	if len(full) == 0 || len(g.data) == 0 {
+		return nil, 0
+	}
+	base := int(uintptr(unsafe.Pointer(&g.data[0])) - uintptr(unsafe.Pointer(&full[0])))
+	absStart := base + int(offset)
+	if absStart < 0 || absStart >= len(full) {
+		return nil, 0
+	}
+	aligned := absStart &^ (pageSize - 1)
+	end := min(absStart+residencyWindow, len(full))
+	return full[aligned:end], int64(aligned)
+}
+
+func (g *Getter) ensureResident(offset uint64) {
+	region, fileOffset := g.residencyRegion(offset)
+	if region == nil {
+		return
+	}
+	if resident, err := mmap.Resident(region); err != nil || resident {
+		return
+	}
+	g.warm(fileOffset, len(region))
+}
+
+// warm reads the byte range into a scratch buffer to pull it into the page
+// cache, so the following mmap access is a minor fault rather than a blocking
+// disk fault. Best-effort: on any error the mmap access simply faults as before.
+func (g *Getter) warm(fileOffset int64, n int) {
+	warmSem <- struct{}{}
+	buf := warmBufPool.Get().(*[]byte)
+	_, _ = g.d.f.ReadAt((*buf)[:n], fileOffset)
+	warmBufPool.Put(buf)
+	<-warmSem
+}

--- a/db/seg/residency_gate.go
+++ b/db/seg/residency_gate.go
@@ -67,6 +67,9 @@ func (g *Getter) residencyRegion(offset uint64) (region []byte, fileOffset int64
 }
 
 func (g *Getter) ensureResident(offset uint64) {
+	if residencyWindow <= 0 { // RESIDENCY_WINDOW_PAGES=0 disables the gate
+		return
+	}
 	region, fileOffset := g.residencyRegion(offset)
 	if region == nil {
 		return

--- a/db/seg/residency_gate.go
+++ b/db/seg/residency_gate.go
@@ -22,16 +22,17 @@ import (
 	"unsafe"
 
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/iouring"
 	"github.com/erigontech/erigon/common/mmap"
 )
 
 var pageSize = os.Getpagesize()
 
 // residencyWindow is how many bytes from the reset offset the gate ensures are
-// resident. A compressed word's on-disk extent is at most a page or two, so a
-// couple of pages covers effectively every value across all state domains.
-// Tunable via env (RESIDENCY_WINDOW_PAGES) to experiment (e.g. =1) without a rebuild.
-var residencyWindow = dbg.EnvInt("RESIDENCY_WINDOW_PAGES", 2) * pageSize
+// resident. State reads are scattered, so warming beyond the page holding the
+// read is pure read-amplification; the default of one page covers the read
+// itself and nothing more. Tunable via env (RESIDENCY_WINDOW_PAGES) without a rebuild.
+var residencyWindow = dbg.EnvInt("RESIDENCY_WINDOW_PAGES", 1) * pageSize
 
 // warmConcurrency bounds how many goroutines may be blocked in a warming read
 // at once. Acquiring parks the goroutine (freeing its P) when full; the read
@@ -62,7 +63,7 @@ func (g *Getter) residencyRegion(offset uint64) (region []byte, fileOffset int64
 		return nil, 0
 	}
 	aligned := absStart &^ (pageSize - 1)
-	end := min(absStart+residencyWindow, len(full))
+	end := min(aligned+residencyWindow, len(full))
 	return full[aligned:end], int64(aligned)
 }
 
@@ -80,10 +81,15 @@ func (g *Getter) ensureResident(offset uint64) {
 	g.warm(fileOffset, len(region))
 }
 
-// warm reads the byte range into a scratch buffer to pull it into the page
-// cache, so the following mmap access is a minor fault rather than a blocking
-// disk fault. Best-effort: on any error the mmap access simply faults as before.
+// warm pulls the byte range into the page cache so the following mmap access is
+// a minor fault rather than a blocking disk fault. It prefers io_uring (whose
+// io_uring_enter releases the goroutine's P during the read); if io_uring is
+// unavailable or its ring pool is exhausted it falls back to a semaphore-bounded
+// blocking pread. Best-effort: on any error the mmap access simply faults as before.
 func (g *Getter) warm(fileOffset int64, n int) {
+	if iouring.WarmOne(int(g.d.f.Fd()), fileOffset, n) {
+		return
+	}
 	warmSem <- struct{}{}
 	buf := warmBufPool.Get().(*[]byte)
 	_, _ = g.d.f.ReadAt((*buf)[:n], fileOffset)

--- a/db/seg/residency_gate_test.go
+++ b/db/seg/residency_gate_test.go
@@ -1,0 +1,111 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package seg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/mmap"
+)
+
+// regionAround returns the page-aligned mmap slice covering [offset, offset+window)
+// within the getter's data, mirroring what the residency gate probes.
+func regionAround(g *Getter, offset uint64, window int) []byte {
+	full := g.d.mmapHandle1
+	base := int(uintptr(unsafe.Pointer(&g.data[0])) - uintptr(unsafe.Pointer(&full[0])))
+	absStart := base + int(offset)
+	pg := os.Getpagesize()
+	aligned := absStart &^ (pg - 1)
+	end := min(absStart+window, len(full))
+	return full[aligned:end]
+}
+
+func TestResidencyGateWarmsOnReset(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "test.kv")
+	cfg := DefaultCfg
+	cfg.MinPatternScore = 1
+	c, err := NewCompressor(t.Context(), "t", file, tmp, cfg, log.LvlDebug, log.New())
+	require.NoError(t, err)
+	const n = 40000
+	for i := 0; i < n; i++ {
+		require.NoError(t, c.AddWord(fmt.Appendf(nil, "residency-word-%d-padding-aaaaaaaaaaaaaaaaaaaa", i)))
+	}
+	require.NoError(t, c.Compress())
+	c.Close()
+
+	d, err := NewDecompressor(file)
+	require.NoError(t, err)
+	defer d.Close()
+
+	// Collect (offset, word) pairs; iterating warms the whole file.
+	type ent struct {
+		off uint64
+		w   []byte
+	}
+	var ents []ent
+	gi := d.MakeGetter()
+	for gi.HasNext() {
+		off := gi.dataP
+		w, _ := gi.Next(nil)
+		ents = append(ents, ent{off, append([]byte(nil), w...)})
+	}
+	require.Greater(t, len(ents), n/2)
+	pick := ents[len(ents)*3/4]
+
+	// Probe just the word's start page; the gate warms at least this,
+	// independent of the configured window size.
+	window := os.Getpagesize()
+	evict := func() {
+		require.NoError(t, unix.Madvise(d.mmapHandle1, unix.MADV_DONTNEED))
+		require.NoError(t, d.f.Sync())
+		require.NoError(t, unix.Fadvise(int(d.f.Fd()), 0, int64(len(d.mmapHandle1)), unix.FADV_DONTNEED))
+	}
+	isResident := func(g *Getter) bool {
+		r, err := mmap.Resident(regionAround(g, pick.off, window))
+		require.NoError(t, err)
+		return r
+	}
+
+	// Ungated getter: Reset must not warm anything.
+	evict()
+	gu := d.MakeGetter()
+	require.False(t, isResident(gu), "region must be cold right after eviction")
+	gu.Reset(pick.off)
+	require.False(t, isResident(gu), "ungated Reset must not warm the page")
+
+	// Gated getter: Reset warms the word's pages before the mmap touch.
+	evict()
+	gg := d.MakeGetter()
+	gg.EnableResidencyGate()
+	require.False(t, isResident(gg), "region must be cold right after eviction")
+	gg.Reset(pick.off)
+	require.True(t, isResident(gg), "gated Reset should warm the word's pages")
+
+	w, _ := gg.Next(nil)
+	require.Equal(t, pick.w, w, "gated read must still return the correct word")
+}

--- a/db/seg/residency_overhead_test.go
+++ b/db/seg/residency_overhead_test.go
@@ -1,0 +1,164 @@
+//go:build linux
+
+package seg
+
+import (
+	"os"
+	"testing"
+
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/erigontech/erigon/common/iouring"
+	"github.com/erigontech/erigon/common/mmap"
+)
+
+// These benchmarks isolate the cost the residency gate adds on top of a plain
+// mmap access, separately for the warm path (page already resident: the gate
+// pays a mincore probe and returns) and the cold path (page not resident: the
+// gate pays mincore + an io_uring read, turning the following mmap access from a
+// major fault into a minor one). Compare Warm{Mincore,Touch} for the per-read
+// tax paid on every read, and Cold{Gate,MmapFault} for whether the gate's cold
+// path is cheaper or more expensive than just letting the mapping major-fault.
+
+var byteSink byte
+
+const resBenchPages = 8192 // 32MB working file; cold benches re-evict per iteration
+
+func setupResidencyBench(tb testing.TB) (fd int, m []byte, ps int) {
+	ps = os.Getpagesize()
+	f, err := os.CreateTemp(tb.TempDir(), "resbench")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { f.Close() })
+	size := resBenchPages * ps
+	chunk := make([]byte, ps)
+	for i := range chunk {
+		chunk[i] = byte(i*31 + 7)
+	}
+	for p := 0; p < resBenchPages; p++ {
+		if _, err := f.WriteAt(chunk, int64(p*ps)); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		tb.Fatal(err)
+	}
+	fd = int(f.Fd())
+	m, err = unix.Mmap(fd, 0, size, unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { unix.Munmap(m) })
+	// MADV_RANDOM so a major fault pulls exactly one page (no readahead), matching
+	// the single-page io_uring warm — otherwise the fault path gets free readahead
+	// the gate doesn't, which would flatter it.
+	_ = unix.Madvise(m, unix.MADV_RANDOM)
+	return fd, m, ps
+}
+
+func evictPage(fd int, m []byte, off, ps int) {
+	_ = unix.Madvise(m[off:off+ps], unix.MADV_DONTNEED) // drop the PTE
+	_, _, _ = unix.Syscall6(unix.SYS_FADVISE64, uintptr(fd), uintptr(off), uintptr(ps), unix.FADV_DONTNEED, 0, 0)
+}
+
+// warm path: page resident, gate pays a mincore probe and returns.
+func BenchmarkResidencyWarmMincore(b *testing.B) {
+	_, m, ps := setupResidencyBench(b)
+	byteSink = m[0] // make page 0 resident
+	region := m[0:ps]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := mmap.Resident(region); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// warm path, mincore with a reused vec (no per-call heap alloc) to separate the
+// bare syscall cost from the allocation in mmap.Resident.
+func BenchmarkResidencyWarmMincoreNoAlloc(b *testing.B) {
+	_, m, ps := setupResidencyBench(b)
+	byteSink = m[0]
+	vec := make([]byte, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, errno := unix.Syscall(unix.SYS_MINCORE,
+			uintptr(unsafe.Pointer(&m[0])), uintptr(ps), uintptr(unsafe.Pointer(&vec[0])))
+		if errno != 0 {
+			b.Fatal(errno)
+		}
+	}
+	_ = ps
+}
+
+// warm path baseline: no gate, just read the resident byte.
+func BenchmarkResidencyWarmTouch(b *testing.B) {
+	_, m, _ := setupResidencyBench(b)
+	byteSink = m[0]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		byteSink = m[0]
+	}
+}
+
+// cold path baseline: no gate, mmap major fault does the disk read.
+func BenchmarkResidencyColdMmapFault(b *testing.B) {
+	fd, m, ps := setupResidencyBench(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		off := (i % resBenchPages) * ps
+		b.StopTimer()
+		evictPage(fd, m, off, ps)
+		b.StartTimer()
+		byteSink = m[off]
+	}
+}
+
+// always-io_uring, warm page: no mincore probe, io_uring reads already-cached
+// data then the mmap access is resident. This is the per-read tax the
+// no-probe design pays on the common (warm) case.
+func BenchmarkResidencyWarmGateNoProbe(b *testing.B) {
+	fd, m, ps := setupResidencyBench(b)
+	byteSink = m[0]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		iouring.WarmOne(fd, 0, ps)
+		byteSink = m[0]
+	}
+}
+
+// always-io_uring, cold page: no mincore probe, io_uring does the disk read then
+// the mmap access is a minor fault.
+func BenchmarkResidencyColdGateNoProbe(b *testing.B) {
+	fd, m, ps := setupResidencyBench(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		off := (i % resBenchPages) * ps
+		b.StopTimer()
+		evictPage(fd, m, off, ps)
+		b.StartTimer()
+		iouring.WarmOne(fd, int64(off), ps)
+		byteSink = m[off]
+	}
+}
+
+// cold path with gate: mincore (reports not resident) + io_uring warm, then the
+// mmap access is a minor fault.
+func BenchmarkResidencyColdGate(b *testing.B) {
+	fd, m, ps := setupResidencyBench(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		off := (i % resBenchPages) * ps
+		b.StopTimer()
+		evictPage(fd, m, off, ps)
+		b.StartTimer()
+		region := m[off : off+ps]
+		if resident, err := mmap.Resident(region); err == nil && !resident {
+			iouring.WarmOne(fd, int64(off), ps)
+		}
+		byteSink = m[off]
+	}
+}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1566,7 +1566,9 @@ func (d *Domain) dataReader(f *seg.Decompressor) *seg.Reader {
 	if !strings.Contains(f.FileName(), ".kv") {
 		panic("assert: miss-use " + f.FileName())
 	}
-	return seg.NewReader(f.MakeGetter(), d.Compression)
+	g := f.MakeGetter()
+	g.EnableResidencyGate()
+	return seg.NewReader(g, d.Compression)
 }
 func (d *Domain) dataWriter(f *seg.Compressor, forceNoCompress bool) *seg.Writer {
 	if !strings.Contains(f.FileName(), ".kv") {


### PR DESCRIPTION
**WIP / draft.** v1 of turning blocking mmap page faults on state `.kv` snapshots into P-releasing reads.

## Why
A blocking mmap page fault freezes the Go **P**, not just the thread: the fault bypasses `entersyscall`, so the runtime can't hand the P off (unlike a real syscall), and it stays frozen for the whole disk wait. Snapshot `.kv` reads — unlike the MDBX path, which is bounded by `db.read.concurrency` — are bounded by nothing, and many are **major** (disk) faults even at chain tip, since a block touches a near-random scatter over state ≫ RAM. That caps parallel-exec throughput.

## What
Gate random-access `.kv` value reads at `Getter.Reset`:
1. cheap `mincore` residency probe — page-cache resident? which is exactly the major-fault boundary;
2. on a cold page, warm the word's extent with a bounded blocking `ReadAt` before the mmap touch.

The warm read goes through Go's syscall path, so the **P is released** while the kernel does the disk wait (blocked-thread count capped by a semaphore). A buffered read shares page-cache pages with the mapping, so the following mmap touch is a cheap **minor** fault.

| aspect | choice |
|---|---|
| scope | accounts / storage / code / commitment `.kv` only; `.seg` untouched |
| probe | `mincore` (no data copy, no I/O) |
| miss fetch | blocking `ReadAt` + semaphore (512); io_uring is the drop-in v2 |
| window | `RESIDENCY_WINDOW_PAGES` env, default 2 |

## Deliberately out of scope (v1)
- **MDBX** faults — untouched (already bounded by `db.read.concurrency`); a MDBX-read-heavy workload won't move.
- **Minor fault** after warm — not eliminated; killing it needs decompress-from-buffer, which trades the zero-copy mmap slice on the 3 uncompressed-value domains. Minor faults don't block on disk, so not worth it.
- **io_uring** — deferred; the warm seam is a drop-in (queue-depth-per-thread win).
- Benign race: eviction between probe and touch falls back to a real fault.

## Next
- [ ] measure major-fault rate + concurrent-in-flight faults; A/B parallel-exec throughput
- [ ] try `RESIDENCY_WINDOW_PAGES=1`
- [ ] io_uring warm path
- [ ] wire warm concurrency to a CLI flag (e.g. `db.snapshot.read.concurrency`)

https://claude.ai/code/session_01XrsKn5aAZ9czD6mJmyiDJa
