### PR TITLE
execution/protocol/rules: drop redundant per-tx gas-mismatch dump

### DIFF
--- a/execution/protocol/rules/block_post_validation_test.go
+++ b/execution/protocol/rules/block_post_validation_test.go
@@ -17,7 +17,6 @@
 package rules
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -28,31 +27,6 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/types"
 )
-
-type msgCaptureHandler struct{ msgs *[]string }
-
-func (h msgCaptureHandler) Log(r *log.Record) error {
-	*h.msgs = append(*h.msgs, r.Msg)
-	return nil
-}
-
-func (h msgCaptureHandler) Enabled(context.Context, log.Lvl) bool { return true }
-
-func captureLogger(msgs *[]string) log.Logger {
-	l := log.New()
-	l.SetHandler(msgCaptureHandler{msgs: msgs})
-	return l
-}
-
-func countMsg(msgs []string, want string) int {
-	n := 0
-	for _, m := range msgs {
-		if m == want {
-			n++
-		}
-	}
-	return n
-}
 
 // TestBlockPostValidation_PreByzantiumBloomMismatch covers the regression
 // where a pre-Byzantium block with an invalid logs bloom was silently
@@ -174,34 +148,5 @@ func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid bloom") {
 		t.Fatalf("expected \"invalid bloom\" error, got: %v", err)
-	}
-}
-
-// TestBlockPostValidation_GasMismatchNoPerTxSpam pins that a gas-used mismatch
-// is reported as a single summary line plus the error, with no per-transaction
-// dump — the detailed receipt breakdown is left to the caller's
-// LOG_HASH_MISMATCH_REASON path.
-func TestBlockPostValidation_GasMismatchNoPerTxSpam(t *testing.T) {
-	t.Parallel()
-
-	cfg := &chain.Config{ChainID: uint256.NewInt(1)}
-	receipts := types.Receipts{
-		{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000, CumulativeGasUsed: 21_000},
-		{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000, CumulativeGasUsed: 42_000},
-		{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000, CumulativeGasUsed: 63_000},
-	}
-	header := &types.Header{Number: *uint256.NewInt(1), GasUsed: 100_000}
-	const execGas = 63_000 // != header.GasUsed, triggers the mismatch branch
-
-	var msgs []string
-	err := DefaultBlockPostValidation(cfg, header, execGas, 0, false, false, receipts, nil, captureLogger(&msgs))
-	if err == nil {
-		t.Fatal("expected gas-used mismatch error, got nil")
-	}
-	if got := countMsg(msgs, "gas used mismatch"); got != 1 {
-		t.Fatalf("expected exactly one summary line, got %d", got)
-	}
-	if got := countMsg(msgs, "  tx gas detail"); got != 0 {
-		t.Fatalf("gas mismatch must not emit a per-tx dump, got %d line(s)", got)
 	}
 }

--- a/execution/protocol/rules/block_post_validation_test.go
+++ b/execution/protocol/rules/block_post_validation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/types"
@@ -178,8 +179,8 @@ func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
 }
 
 // TestBlockPostValidation_GasMismatchDetailGated pins that a gas-used mismatch
-// logs a single summary line by default and only spews the per-transaction
-// breakdown when explicitly opted in.
+// logs a single summary line at the default terse level and only emits the
+// per-transaction breakdown once exec verbosity is raised to debug.
 func TestBlockPostValidation_GasMismatchDetailGated(t *testing.T) {
 	cfg := &chain.Config{ChainID: uint256.NewInt(1)}
 	receipts := types.Receipts{
@@ -190,6 +191,10 @@ func TestBlockPostValidation_GasMismatchDetailGated(t *testing.T) {
 	header := &types.Header{Number: *uint256.NewInt(1), GasUsed: 100_000}
 	const execGas = 63_000 // != header.GasUsed, triggers the mismatch branch
 
+	old := dbg.ExecTerseLoggerLevel
+	defer func() { dbg.ExecTerseLoggerLevel = old }()
+
+	dbg.ExecTerseLoggerLevel = int(log.LvlWarn)
 	var msgs []string
 	err := DefaultBlockPostValidation(cfg, header, execGas, 0, false, false, receipts, nil, captureLogger(&msgs))
 	if err == nil {
@@ -199,16 +204,13 @@ func TestBlockPostValidation_GasMismatchDetailGated(t *testing.T) {
 		t.Fatalf("expected exactly one summary line, got %d", got)
 	}
 	if got := countMsg(msgs, "  tx gas detail"); got != 0 {
-		t.Fatalf("per-tx gas detail must be suppressed by default, got %d line(s)", got)
+		t.Fatalf("per-tx gas detail must be suppressed at the default terse level, got %d line(s)", got)
 	}
 
-	old := dumpGasMismatchDetail
-	dumpGasMismatchDetail = true
-	defer func() { dumpGasMismatchDetail = old }()
-
+	dbg.ExecTerseLoggerLevel = int(log.LvlDebug)
 	var opted []string
 	_ = DefaultBlockPostValidation(cfg, header, execGas, 0, false, false, receipts, nil, captureLogger(&opted))
 	if got := countMsg(opted, "  tx gas detail"); got != len(receipts) {
-		t.Fatalf("opt-in should emit one detail line per receipt: want %d, got %d", len(receipts), got)
+		t.Fatalf("debug terse level should emit one detail line per receipt: want %d, got %d", len(receipts), got)
 	}
 }

--- a/execution/protocol/rules/block_post_validation_test.go
+++ b/execution/protocol/rules/block_post_validation_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/types"
@@ -178,10 +177,13 @@ func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
 	}
 }
 
-// TestBlockPostValidation_GasMismatchDetailGated pins that a gas-used mismatch
-// logs a single summary line at the default terse level and only emits the
-// per-transaction breakdown once exec verbosity is raised to debug.
-func TestBlockPostValidation_GasMismatchDetailGated(t *testing.T) {
+// TestBlockPostValidation_GasMismatchNoPerTxSpam pins that a gas-used mismatch
+// is reported as a single summary line plus the error, with no per-transaction
+// dump — the detailed receipt breakdown is left to the caller's
+// LOG_HASH_MISMATCH_REASON path.
+func TestBlockPostValidation_GasMismatchNoPerTxSpam(t *testing.T) {
+	t.Parallel()
+
 	cfg := &chain.Config{ChainID: uint256.NewInt(1)}
 	receipts := types.Receipts{
 		{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000, CumulativeGasUsed: 21_000},
@@ -191,10 +193,6 @@ func TestBlockPostValidation_GasMismatchDetailGated(t *testing.T) {
 	header := &types.Header{Number: *uint256.NewInt(1), GasUsed: 100_000}
 	const execGas = 63_000 // != header.GasUsed, triggers the mismatch branch
 
-	old := dbg.ExecTerseLoggerLevel
-	defer func() { dbg.ExecTerseLoggerLevel = old }()
-
-	dbg.ExecTerseLoggerLevel = int(log.LvlWarn)
 	var msgs []string
 	err := DefaultBlockPostValidation(cfg, header, execGas, 0, false, false, receipts, nil, captureLogger(&msgs))
 	if err == nil {
@@ -204,13 +202,6 @@ func TestBlockPostValidation_GasMismatchDetailGated(t *testing.T) {
 		t.Fatalf("expected exactly one summary line, got %d", got)
 	}
 	if got := countMsg(msgs, "  tx gas detail"); got != 0 {
-		t.Fatalf("per-tx gas detail must be suppressed at the default terse level, got %d line(s)", got)
-	}
-
-	dbg.ExecTerseLoggerLevel = int(log.LvlDebug)
-	var opted []string
-	_ = DefaultBlockPostValidation(cfg, header, execGas, 0, false, false, receipts, nil, captureLogger(&opted))
-	if got := countMsg(opted, "  tx gas detail"); got != len(receipts) {
-		t.Fatalf("debug terse level should emit one detail line per receipt: want %d, got %d", len(receipts), got)
+		t.Fatalf("gas mismatch must not emit a per-tx dump, got %d line(s)", got)
 	}
 }

--- a/execution/protocol/rules/block_post_validation_test.go
+++ b/execution/protocol/rules/block_post_validation_test.go
@@ -17,6 +17,7 @@
 package rules
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -27,6 +28,31 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/types"
 )
+
+type msgCaptureHandler struct{ msgs *[]string }
+
+func (h msgCaptureHandler) Log(r *log.Record) error {
+	*h.msgs = append(*h.msgs, r.Msg)
+	return nil
+}
+
+func (h msgCaptureHandler) Enabled(context.Context, log.Lvl) bool { return true }
+
+func captureLogger(msgs *[]string) log.Logger {
+	l := log.New()
+	l.SetHandler(msgCaptureHandler{msgs: msgs})
+	return l
+}
+
+func countMsg(msgs []string, want string) int {
+	n := 0
+	for _, m := range msgs {
+		if m == want {
+			n++
+		}
+	}
+	return n
+}
 
 // TestBlockPostValidation_PreByzantiumBloomMismatch covers the regression
 // where a pre-Byzantium block with an invalid logs bloom was silently
@@ -148,5 +174,41 @@ func TestBlockPostValidation_ReceiptBloomReuse(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid bloom") {
 		t.Fatalf("expected \"invalid bloom\" error, got: %v", err)
+	}
+}
+
+// TestBlockPostValidation_GasMismatchDetailGated pins that a gas-used mismatch
+// logs a single summary line by default and only spews the per-transaction
+// breakdown when explicitly opted in.
+func TestBlockPostValidation_GasMismatchDetailGated(t *testing.T) {
+	cfg := &chain.Config{ChainID: uint256.NewInt(1)}
+	receipts := types.Receipts{
+		{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000, CumulativeGasUsed: 21_000},
+		{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000, CumulativeGasUsed: 42_000},
+		{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000, CumulativeGasUsed: 63_000},
+	}
+	header := &types.Header{Number: *uint256.NewInt(1), GasUsed: 100_000}
+	const execGas = 63_000 // != header.GasUsed, triggers the mismatch branch
+
+	var msgs []string
+	err := DefaultBlockPostValidation(cfg, header, execGas, 0, false, false, receipts, nil, captureLogger(&msgs))
+	if err == nil {
+		t.Fatal("expected gas-used mismatch error, got nil")
+	}
+	if got := countMsg(msgs, "gas used mismatch"); got != 1 {
+		t.Fatalf("expected exactly one summary line, got %d", got)
+	}
+	if got := countMsg(msgs, "  tx gas detail"); got != 0 {
+		t.Fatalf("per-tx gas detail must be suppressed by default, got %d line(s)", got)
+	}
+
+	old := dumpGasMismatchDetail
+	dumpGasMismatchDetail = true
+	defer func() { dumpGasMismatchDetail = old }()
+
+	var opted []string
+	_ = DefaultBlockPostValidation(cfg, header, execGas, 0, false, false, receipts, nil, captureLogger(&opted))
+	if got := countMsg(opted, "  tx gas detail"); got != len(receipts) {
+		t.Fatalf("opt-in should emit one detail line per receipt: want %d, got %d", len(receipts), got)
 	}
 }

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -199,6 +199,7 @@ type EngineWriter interface {
 }
 
 var alwaysSkipReceiptCheck = dbg.EnvBool("EXEC_SKIP_RECEIPT_CHECK", false)
+var dumpGasMismatchDetail = dbg.EnvBool("EXEC_DUMP_GAS_MISMATCH_DETAIL", false)
 
 func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
 	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
@@ -206,16 +207,18 @@ func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
 	if gasUsed != header.GasUsed {
 		logger.Warn("gas used mismatch", "block", header.Number.Uint64(), "header", header.GasUsed, "execution", gasUsed,
 			"diff", int64(gasUsed)-int64(header.GasUsed), "txCount", len(txns), "receiptCount", len(receipts))
-		var cumGas uint64
-		for i, r := range receipts {
-			txGas := r.GasUsed
-			cumGas += txGas
-			var txHash string
-			if i < len(txns) {
-				txHash = txns[i].Hash().Hex()[:18]
+		if dumpGasMismatchDetail {
+			var cumGas uint64
+			for i, r := range receipts {
+				txGas := r.GasUsed
+				cumGas += txGas
+				var txHash string
+				if i < len(txns) {
+					txHash = txns[i].Hash().Hex()[:18]
+				}
+				logger.Warn("  tx gas detail", "block", header.Number.Uint64(), "txIdx", i, "txHash", txHash,
+					"gasUsed", txGas, "cumGasUsed", r.CumulativeGasUsed, "computedCumGas", cumGas, "status", r.Status)
 			}
-			logger.Warn("  tx gas detail", "block", header.Number.Uint64(), "txIdx", i, "txHash", txHash,
-				"gasUsed", txGas, "cumGasUsed", r.CumulativeGasUsed, "computedCumGas", cumGas, "status", r.Status)
 		}
 		return fmt.Errorf("gas used by execution: %d, in header: %d, headerNum=%d, %x",
 			gasUsed, header.GasUsed, header.Number.Uint64(), header.Hash())

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -206,19 +206,6 @@ func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
 	if gasUsed != header.GasUsed {
 		logger.Warn("gas used mismatch", "block", header.Number.Uint64(), "header", header.GasUsed, "execution", gasUsed,
 			"diff", int64(gasUsed)-int64(header.GasUsed), "txCount", len(txns), "receiptCount", len(receipts))
-		if log.Lvl(dbg.ExecTerseLoggerLevel) >= log.LvlDebug {
-			var cumGas uint64
-			for i, r := range receipts {
-				txGas := r.GasUsed
-				cumGas += txGas
-				var txHash string
-				if i < len(txns) {
-					txHash = txns[i].Hash().Hex()[:18]
-				}
-				logger.Warn("  tx gas detail", "block", header.Number.Uint64(), "txIdx", i, "txHash", txHash,
-					"gasUsed", txGas, "cumGasUsed", r.CumulativeGasUsed, "computedCumGas", cumGas, "status", r.Status)
-			}
-		}
 		return fmt.Errorf("gas used by execution: %d, in header: %d, headerNum=%d, %x",
 			gasUsed, header.GasUsed, header.Number.Uint64(), header.Hash())
 	}

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -199,7 +199,6 @@ type EngineWriter interface {
 }
 
 var alwaysSkipReceiptCheck = dbg.EnvBool("EXEC_SKIP_RECEIPT_CHECK", false)
-var dumpGasMismatchDetail = dbg.EnvBool("EXEC_DUMP_GAS_MISMATCH_DETAIL", false)
 
 func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
 	gasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool,
@@ -207,7 +206,7 @@ func DefaultBlockPostValidation(chainConfig *chain.Config, header *types.Header,
 	if gasUsed != header.GasUsed {
 		logger.Warn("gas used mismatch", "block", header.Number.Uint64(), "header", header.GasUsed, "execution", gasUsed,
 			"diff", int64(gasUsed)-int64(header.GasUsed), "txCount", len(txns), "receiptCount", len(receipts))
-		if dumpGasMismatchDetail {
+		if log.Lvl(dbg.ExecTerseLoggerLevel) >= log.LvlDebug {
 			var cumGas uint64
 			for i, r := range receipts {
 				txGas := r.GasUsed


### PR DESCRIPTION
## Problem

On a gas-used mismatch, `DefaultBlockPostValidation` logged one `WARN` line **per receipt** (`  tx gas detail`) on top of the summary line. When a node is stuck on a deterministically-invalid block, it re-executes that block on every unwind/re-exec cycle, so the whole dump repeats — a 199-tx block emitted ~200 `WARN` lines every ~84s, indefinitely.

## Fix

That per-receipt detail is **already available on demand** via the existing `LOG_HASH_MISMATCH_REASON` knob: the caller `validateBlockPostExecution` (`block_post_validator.go`) emits it through `ethutils.LogReceipts` — a single JSON line — on *any* post-execution validation error, including this gas mismatch. It's the same knob the builder uses to dump built-block receipts (`execution/builder/finish.go`, "Block built").

So the hand-rolled per-tx loop is redundant. Drop it, keeping only the one-line `gas used mismatch` summary (block, diff, tx/receipt counts). Detailed per-receipt output stays reachable with `LOG_HASH_MISMATCH_REASON=true`, now via one consistent path instead of two.

Net effect on a stuck node: **~200 WARN lines per retry → 1**.

## Testing

Logging-only change (no functional/consensus effect), so no new unit test. `make lint` — 0 issues; `make erigon integration` builds; existing `execution/protocol/rules` tests pass.

## Scope / follow-ups

- This addresses only the **log spam** (the filed UX issue). It does not touch the underlying deterministic gas mismatch that leaves the node stuck on the block — a separate problem in the ghost-state / parallel-exec family (cf. #21515).
- On `release/3.5`/`3.4` the equivalent loop lives in `execution/protocol/block_exec.go` (`BlockPostValidation`), in the same function as a sibling receipt-hash branch that already uses `LOG_HASH_MISMATCH_REASON` + `ethutils.LogReceipts`; the backport replaces the gas-branch loop with that same call. To follow once this merges.

Closes #22376.
