### PR TITLE
[r3.5] ChangeLog: add v3.5.2 release notes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,7 +18,7 @@ Aligns Erigon with the `eth_simulateV1` error code specification ([NethermindEth
 
 ---
 
-# Erigon v3.5.2 — Tidal Tails — TBD
+# Erigon v3.5.2 — Tidal Tails — 2026-07-13
 
 v3.5.2 is a bugfix release recommended for all users, and especially for anyone running 3.5.1 — it fixes a sync-halting trie-root regression introduced there (#22399). It is a drop-in upgrade from 3.5.1 — no re-sync required.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,7 +31,7 @@ v3.5.2 is a bugfix release recommended for all users, and especially for anyone 
 
 ---
 
-# Erigon v3.5.1 — Tidal Tails — TBD
+# Erigon v3.5.1 — Tidal Tails — 2026-07-10
 
 v3.5.1 is a bugfix release recommended for all users. It is a drop-in upgrade from 3.5.0 — no re-sync required.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,19 @@ Aligns Erigon with the `eth_simulateV1` error code specification ([NethermindEth
 
 ---
 
+# Erigon v3.5.2 — Tidal Tails — TBD
+
+v3.5.2 is a bugfix release recommended for all users, and especially for anyone running 3.5.1 — it fixes a sync-halting trie-root regression introduced there (#22399). It is a drop-in upgrade from 3.5.1 — no re-sync required.
+
+**Bugfixes**
+
+- db/state: clear the StateCache on `SharedDomains` unwind below the reorg window (#22402) by @Sahil-4555 — after the v3.5.1 changeset-isolation backport, a block that failed execution within the reorg window did a disk-noop overlay unwind that left dirty, uncommitted writes in the state cache; on the next run execution read those stale values instead of the database, producing a deterministic trie-root mismatch that halted sync. Closes #22399.
+- rpc, node: fix the nil-pointer panic in the gzip batch flush race (#22383) by @lupin012 — a gzipped JSON-RPC batch with two or more streamable methods invoked the shared gzip-streaming flush hook concurrently from per-call goroutines; `gzipResponseWriter.Flush` is not concurrency-safe, so the calls raced on the underlying gzip writer and could dereference a nil flate compressor, crashing the node. Closes #22334.
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.5.1...v3.5.2
+
+---
+
 # Erigon v3.5.1 — Tidal Tails — TBD
 
 v3.5.1 is a bugfix release recommended for all users. It is a drop-in upgrade from 3.5.0 — no re-sync required.


### PR DESCRIPTION
Adds the **v3.5.2** release notes to `ChangeLog.md`, following the v3.5.1 point-release format (codename **Tidal Tails**, kept from 3.5.0).

Scope: the two user-facing **Bugfixes** merged to `release/3.5` since the `v3.5.1` tag, covering both issues in [milestone 3.5.2](https://github.com/erigontech/erigon/milestone/79). Each entry cites the `[r3.5]` PR that landed on the branch and credits the original fix author, matching the existing point-release style.

- #22399 (**Sync fails after upgrade to 3.5.1**) — `db/state`: clear the StateCache on `SharedDomains` unwind below the reorg window (#22402) by @Sahil-4555. A regression from the v3.5.1 changeset-isolation backport; the headline reason for this release.
- #22334 (nil-pointer panic in `gzipResponseWriter.Flush` on gzipped batch RPC) — `rpc, node`: fix the gzip batch flush race (#22383, cherry-pick of #22338) by @lupin012.

The only other commit on the branch since `v3.5.1` is the app-version bump to 3.5.2 (#22431), which is not a user-facing changelog entry.

