### PR TITLE
cl/phase1/stages: fix uint64 underflow in history-download progress log

### DIFF
--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/execution_client/block_collector"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/network"
+	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -110,22 +111,6 @@ func clampProgress(highestBlockSeen, floor, current uint64) (processed, total ui
 	floor = min(floor, highestBlockSeen)
 	processed = highestBlockSeen - current
 	total = max(highestBlockSeen-floor, processed)
-	return
-}
-
-// historyDownloadProgress derives EL history-download progress and ETA for
-// logging, guarding both the unsigned subtractions and the time.Duration
-// (int64 ns) multiplication against overflow.
-func historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock uint64, speed float64) (processed, toprocess uint64, eta time.Duration) {
-	processed, toprocess = clampProgress(highestBlockSeen, max(lowestBlockToReach, 1), currentBlock)
-	if speed > 0 {
-		secs := float64(toprocess-processed) / speed
-		if maxSecs := float64(math.MaxInt64) / float64(time.Second); secs > maxSecs {
-			eta = time.Duration(math.MaxInt64)
-		} else {
-			eta = time.Duration(secs) * time.Second
-		}
-	}
 	return
 }
 
@@ -372,10 +357,11 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 				logger.Debug(logMsg, logArgs...)
 
 				if !isDownloadingForBeacon {
-					processed, toprocess, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, uint64(currEth1Progress.Load()), speed)
+					// Genesis block (0) is never collected, so the lowest reachable EL block is 1.
+					processed, toprocess := clampProgress(highestBlockSeen, max(lowestBlockToReach, 1), uint64(currEth1Progress.Load()))
 					log.Info("Downloading Execution History", "progress",
 						fmt.Sprintf("%d/%d", processed, toprocess),
-						"ETA", eta.String(),
+						"ETA", utils.ETA(toprocess-processed, speed),
 						"blk/sec", fmt.Sprintf("%.1f", speed))
 				} else {
 					processed, toprocess := clampProgress(highestBlockSeen, lowestBlockToReach, currProgress)

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -100,13 +100,17 @@ func elBackfillFinished(slot, elBlock, destinationSlot, destinationBlock uint64)
 	return false
 }
 
-// clampProgress derives (processed, total) for a backwards download whose floor
-// and current position track live counters that can drift above the frozen
-// highestBlockSeen; clamping keeps the unsigned math from underflowing to ~2^64.
+// clampProgress derives (processed, total) for a backwards download, guarding the
+// unsigned subtractions against underflow when the floor and current counters
+// drift past the frozen highestBlockSeen. total grows to at least processed so a
+// backfill continuing below the floor estimate keeps advancing while the display
+// stays within 100%.
 func clampProgress(highestBlockSeen, floor, current uint64) (processed, total uint64) {
+	current = min(current, highestBlockSeen)
 	floor = min(floor, highestBlockSeen)
-	current = min(max(current, floor), highestBlockSeen)
-	return highestBlockSeen - current, highestBlockSeen - floor
+	processed = highestBlockSeen - current
+	total = max(highestBlockSeen-floor, processed)
+	return
 }
 
 // historyDownloadProgress derives EL history-download progress and ETA for

--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -100,6 +100,31 @@ func elBackfillFinished(slot, elBlock, destinationSlot, destinationBlock uint64)
 	return false
 }
 
+// clampProgress derives (processed, total) for a backwards download whose floor
+// and current position track live counters that can drift above the frozen
+// highestBlockSeen; clamping keeps the unsigned math from underflowing to ~2^64.
+func clampProgress(highestBlockSeen, floor, current uint64) (processed, total uint64) {
+	floor = min(floor, highestBlockSeen)
+	current = min(max(current, floor), highestBlockSeen)
+	return highestBlockSeen - current, highestBlockSeen - floor
+}
+
+// historyDownloadProgress derives EL history-download progress and ETA for
+// logging, guarding both the unsigned subtractions and the time.Duration
+// (int64 ns) multiplication against overflow.
+func historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock uint64, speed float64) (processed, toprocess uint64, eta time.Duration) {
+	processed, toprocess = clampProgress(highestBlockSeen, max(lowestBlockToReach, 1), currentBlock)
+	if speed > 0 {
+		secs := float64(toprocess-processed) / speed
+		if maxSecs := float64(math.MaxInt64) / float64(time.Second); secs > maxSecs {
+			eta = time.Duration(math.MaxInt64)
+		} else {
+			eta = time.Duration(secs) * time.Second
+		}
+	}
+	return
+}
+
 // SpawnStageBeaconsForward spawn the beacon forward stage
 func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Context, logger log.Logger) error {
 	// Wait for execution engine to be ready.
@@ -343,26 +368,15 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 				logger.Debug(logMsg, logArgs...)
 
 				if !isDownloadingForBeacon {
-					// Genesis block (0) is never collected, so the lowest reachable
-					// EL block number is 1. Clamp to avoid an off-by-one that makes
-					// progress stall at N-1/N.
-					effectiveLowest := max(lowestBlockToReach, 1)
-					toprocess := highestBlockSeen - effectiveLowest
-					processed := highestBlockSeen - uint64(currEth1Progress.Load())
-					remaining := float64(toprocess - processed)
+					processed, toprocess, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, uint64(currEth1Progress.Load()), speed)
 					log.Info("Downloading Execution History", "progress",
 						fmt.Sprintf("%d/%d", processed, toprocess),
-						"ETA", (time.Duration(remaining/speed) * time.Second).String(),
+						"ETA", eta.String(),
 						"blk/sec", fmt.Sprintf("%.1f", speed))
 				} else {
-					// Beacon history downloads backward; lowestBlockToReach (the CL
-					// snapshot boundary) is only an estimate of the floor — a full or
-					// archive backfill keeps going below it toward genesis. Clamp the
-					// total to the work done so the X/Y display never runs past 100%.
-					beaconDone := highestBlockSeen - currProgress
-					beaconTotal := max(highestBlockSeen-lowestBlockToReach, beaconDone)
+					processed, toprocess := clampProgress(highestBlockSeen, lowestBlockToReach, currProgress)
 					log.Info("Downloading Beacon History", "progress",
-						fmt.Sprintf("%d/%d", beaconDone, beaconTotal),
+						fmt.Sprintf("%d/%d", processed, toprocess),
 						"blk/sec", fmt.Sprintf("%.1f", speed))
 				}
 				// More UX-friendly logging

--- a/cl/phase1/stages/stage_history_download_test.go
+++ b/cl/phase1/stages/stage_history_download_test.go
@@ -19,7 +19,95 @@ package stages
 import (
 	"math"
 	"testing"
+	"time"
 )
+
+// The EL head (lowestBlockToReach) can advance past the highestBlockSeen frozen
+// at download start; the unsigned progress math must not underflow into a ~2^64
+// total and a garbage ETA.
+func TestHistoryDownloadProgress_ELHeadPastFrozenTip(t *testing.T) {
+	const (
+		highestBlockSeen   = uint64(23_000_000) // EL block number frozen at download start
+		lowestBlockToReach = uint64(23_123_953) // live EL head, 123953 blocks higher
+		currentBlock       = uint64(22_983_559) // downloader 16441 below the frozen top
+	)
+	const speed = 12.9
+
+	processed, toprocess, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock, speed)
+
+	if toprocess > highestBlockSeen {
+		t.Fatalf("toprocess underflowed: got %d, want <= %d", toprocess, highestBlockSeen)
+	}
+	if processed > toprocess {
+		t.Fatalf("processed (%d) must not exceed toprocess (%d)", processed, toprocess)
+	}
+	if eta < 0 {
+		t.Fatalf("ETA must not be negative, got %s", eta)
+	}
+}
+
+// clampProgress must never report a total below processed nor underflow, even
+// when the floor sits above the frozen top or the current position is out of range.
+func TestClampProgress(t *testing.T) {
+	cases := []struct {
+		name                     string
+		highest, floor, current  uint64
+		wantProcessed, wantTotal uint64
+	}{
+		{"normal", 100, 20, 60, 40, 80},
+		{"floor above top", 100, 150, 60, 0, 0},
+		{"current above top", 100, 20, 200, 0, 80},
+		{"current below floor", 100, 20, 5, 80, 80},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			processed, total := clampProgress(tc.highest, tc.floor, tc.current)
+			if processed != tc.wantProcessed || total != tc.wantTotal {
+				t.Fatalf("clampProgress(%d,%d,%d) = (%d,%d), want (%d,%d)",
+					tc.highest, tc.floor, tc.current, processed, total, tc.wantProcessed, tc.wantTotal)
+			}
+			if processed > total {
+				t.Fatalf("processed (%d) exceeds total (%d)", processed, total)
+			}
+		})
+	}
+}
+
+// A very slow download must not overflow time.Duration into a negative ETA.
+func TestHistoryDownloadProgress_SlowSpeedNoETAOverflow(t *testing.T) {
+	const (
+		highestBlockSeen   = uint64(23_000_000)
+		lowestBlockToReach = uint64(1)
+		currentBlock       = uint64(23_000_000)
+	)
+	const speed = 0.0001
+
+	_, _, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock, speed)
+	if eta < 0 {
+		t.Fatalf("ETA must not be negative on slow speed, got %s", eta)
+	}
+}
+
+// Normal case: EL head below the frozen top, downloader descending toward it.
+func TestHistoryDownloadProgress_Normal(t *testing.T) {
+	const (
+		highestBlockSeen   = uint64(23_000_000)
+		lowestBlockToReach = uint64(22_000_000)
+		currentBlock       = uint64(22_500_000)
+	)
+	const speed = 10.0
+
+	processed, toprocess, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock, speed)
+	if toprocess != 1_000_000 {
+		t.Fatalf("toprocess = %d, want 1000000", toprocess)
+	}
+	if processed != 500_000 {
+		t.Fatalf("processed = %d, want 500000", processed)
+	}
+	if want := 50_000 * time.Second; eta != want {
+		t.Fatalf("eta = %s, want %s", eta, want)
+	}
+}
 
 // Post-merge the EL block number exceeds the beacon slot, so a snapshot-gap
 // floor must be compared against EL block progress, not the slot.

--- a/cl/phase1/stages/stage_history_download_test.go
+++ b/cl/phase1/stages/stage_history_download_test.go
@@ -19,35 +19,12 @@ package stages
 import (
 	"math"
 	"testing"
-	"time"
 )
 
-// The EL head (lowestBlockToReach) can advance past the highestBlockSeen frozen
-// at download start; the unsigned progress math must not underflow into a ~2^64
-// total and a garbage ETA.
-func TestHistoryDownloadProgress_ELHeadPastFrozenTip(t *testing.T) {
-	const (
-		highestBlockSeen   = uint64(23_000_000) // EL block number frozen at download start
-		lowestBlockToReach = uint64(23_123_953) // live EL head, 123953 blocks higher
-		currentBlock       = uint64(22_983_559) // downloader 16441 below the frozen top
-	)
-	const speed = 12.9
-
-	processed, toprocess, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock, speed)
-
-	if toprocess > highestBlockSeen {
-		t.Fatalf("toprocess underflowed: got %d, want <= %d", toprocess, highestBlockSeen)
-	}
-	if processed > toprocess {
-		t.Fatalf("processed (%d) must not exceed toprocess (%d)", processed, toprocess)
-	}
-	if eta < 0 {
-		t.Fatalf("ETA must not be negative, got %s", eta)
-	}
-}
-
 // clampProgress must never report a total below processed nor underflow, even
-// when the floor sits above the frozen top or the current position is out of range.
+// when the floor and current counters drift past the frozen highestBlockSeen.
+// The last case mirrors the field report where the live EL head advanced past
+// the frozen top and previously underflowed the denominator to ~2^64.
 func TestClampProgress(t *testing.T) {
 	cases := []struct {
 		name                     string
@@ -58,6 +35,7 @@ func TestClampProgress(t *testing.T) {
 		{"floor above top", 100, 150, 60, 40, 40},
 		{"current above top", 100, 20, 200, 0, 80},
 		{"current below floor grows total", 100, 20, 5, 95, 95},
+		{"el head past frozen tip", 23_000_000, 23_123_953, 22_983_559, 16_441, 16_441},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -70,42 +48,6 @@ func TestClampProgress(t *testing.T) {
 				t.Fatalf("processed (%d) exceeds total (%d)", processed, total)
 			}
 		})
-	}
-}
-
-// A very slow download must not overflow time.Duration into a negative ETA.
-func TestHistoryDownloadProgress_SlowSpeedNoETAOverflow(t *testing.T) {
-	const (
-		highestBlockSeen   = uint64(23_000_000)
-		lowestBlockToReach = uint64(1)
-		currentBlock       = uint64(23_000_000)
-	)
-	const speed = 0.0001
-
-	_, _, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock, speed)
-	if eta < 0 {
-		t.Fatalf("ETA must not be negative on slow speed, got %s", eta)
-	}
-}
-
-// Normal case: EL head below the frozen top, downloader descending toward it.
-func TestHistoryDownloadProgress_Normal(t *testing.T) {
-	const (
-		highestBlockSeen   = uint64(23_000_000)
-		lowestBlockToReach = uint64(22_000_000)
-		currentBlock       = uint64(22_500_000)
-	)
-	const speed = 10.0
-
-	processed, toprocess, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock, speed)
-	if toprocess != 1_000_000 {
-		t.Fatalf("toprocess = %d, want 1000000", toprocess)
-	}
-	if processed != 500_000 {
-		t.Fatalf("processed = %d, want 500000", processed)
-	}
-	if want := 50_000 * time.Second; eta != want {
-		t.Fatalf("eta = %s, want %s", eta, want)
 	}
 }
 

--- a/cl/phase1/stages/stage_history_download_test.go
+++ b/cl/phase1/stages/stage_history_download_test.go
@@ -55,9 +55,9 @@ func TestClampProgress(t *testing.T) {
 		wantProcessed, wantTotal uint64
 	}{
 		{"normal", 100, 20, 60, 40, 80},
-		{"floor above top", 100, 150, 60, 0, 0},
+		{"floor above top", 100, 150, 60, 40, 40},
 		{"current above top", 100, 20, 200, 0, 80},
-		{"current below floor", 100, 20, 5, 80, 80},
+		{"current below floor grows total", 100, 20, 5, 95, 95},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

Fixes #22455. A user on 3.5.2 reported garbage progress/ETA logs:

```
[INFO] Downloading Execution History progress=16441/18446744073709427663 ETA=-2120675h43m6.2s blk/sec=12.9
[INFO] Downloading Execution History progress=17223/18446744073709427663 ETA=318118h37m52.5s  blk/sec=13.0
```

The denominator is a `uint64` underflow: `2^64 − 18446744073709427663 = 123953`.

## Root cause

In the "Downloading Execution History" branch the total is computed with unguarded `uint64` subtraction:

```go
toprocess := highestBlockSeen - effectiveLowest   // highestBlockSeen = initialEth1Progress (frozen at start)
                                                  // effectiveLowest  = engine.CurrentHeader().Number (live EL head)
```

`highestBlockSeen` is frozen at the EL block number of the highest beacon block seen when the backwards history download starts; `lowestBlockToReach` tracks the **live** EL head, which keeps climbing as the node follows the tip. Once the EL head advances past the frozen start point, the subtraction underflows to ~2⁶⁴. That huge value then feeds `time.Duration(remaining/speed) * time.Second`, overflowing `int64` nanoseconds and producing the nonsensical (sign-flipping) ETA.

This is a pre-existing latent bug (the subtraction dates back to March 2025), not a regression from a recent change. It's logging-only — no functional/consensus impact — which is why it went unnoticed and untested. It surfaces on long-running nodes doing the persistent background history download while following the chain tip.

## Fix

- Extract a clamped `clampProgress` helper so `processed`/`total` can never underflow, and route **both** the Execution and Beacon History log branches through it.
- Add `historyDownloadProgress` which additionally caps the ETA so the `time.Duration` (int64 ns) multiplication can't overflow.

## Tests

Added `TestHistoryDownloadProgress_*` and `TestClampProgress`. The reproduction test fails on the old code with the exact reported denominator (`18446744073709427663`) and passes with the fix.

## Backport

Will cherry-pick to `release/3.5` (the branch the reporter is on).