### PR TITLE
[r3.5] cl/phase1/stages: guard forward-sync progress log against under/overflow

### DIFF
--- a/cl/phase1/stages/forward_sync.go
+++ b/cl/phase1/stages/forward_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -265,6 +266,37 @@ func processDownloadedBlockBatches(ctx context.Context, logger log.Logger, cfg *
 	return
 }
 
+// boundedDuration converts a number of seconds into a time.Duration, guarding
+// against the int64 nanosecond overflow that would otherwise wrap to garbage.
+func boundedDuration(seconds float64) time.Duration {
+	if seconds <= 0 {
+		return 0
+	}
+	if maxSeconds := float64(math.MaxInt64) / float64(time.Second); seconds > maxSeconds {
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// forwardSyncProgress derives the forward-sync distance and ETA for logging.
+// currentSlot can overshoot chainTipSlot and dip below prevProgress on reorgs,
+// so the differences are clamped to keep the unsigned math from underflowing.
+func forwardSyncProgress(chainTipSlot, currentSlot, prevProgress, secondsPerSlot uint64, secsPerLog int) (distFromChainTip, estimatedTimeRemaining time.Duration) {
+	var slotsRemaining uint64
+	if chainTipSlot > currentSlot {
+		slotsRemaining = chainTipSlot - currentSlot
+	}
+	distFromChainTip = boundedDuration(float64(slotsRemaining) * float64(secondsPerSlot))
+
+	estimatedTimeRemaining = 999 * time.Hour
+	if currentSlot > prevProgress && secsPerLog > 0 {
+		if rate := float64(currentSlot-prevProgress) / float64(secsPerLog); rate > 0 {
+			estimatedTimeRemaining = boundedDuration(float64(slotsRemaining) / rate)
+		}
+	}
+	return
+}
+
 // forwardSync (MAIN ROUTINE FOR ForwardSync) performs the forward synchronization of beacon blocks.
 func forwardSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) error {
 	var (
@@ -370,18 +402,10 @@ func forwardSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) er
 			return ctx.Err()
 		case <-logTicker.C:
 			// Log progress at regular intervals
-			progressMade := chainTipSlot - currentSlot.Load()
-			distFromChainTip := time.Duration(progressMade*cfg.beaconCfg.SecondsPerSlot) * time.Second
-			timeProgress := currentSlot.Load() - prevProgress
-			estimatedTimeRemaining := 999 * time.Hour
-			if timeProgress > 0 {
-				estimatedTimeRemaining = time.Duration(float64(progressMade)/(float64(currentSlot.Load()-prevProgress)/float64(secsPerLog))) * time.Second
-			}
-			if distFromChainTip < 0 || estimatedTimeRemaining < 0 {
-				continue
-			}
-			prevProgress = currentSlot.Load()
-			logger.Info("[Caplin] Forward Sync", "progress", currentSlot.Load(), "distance-from-chain-tip", distFromChainTip, "estimated-time-remaining", estimatedTimeRemaining)
+			cur := currentSlot.Load()
+			distFromChainTip, estimatedTimeRemaining := forwardSyncProgress(chainTipSlot, cur, prevProgress, cfg.beaconCfg.SecondsPerSlot, secsPerLog)
+			prevProgress = cur
+			logger.Info("[Caplin] Forward Sync", "progress", cur, "distance-from-chain-tip", distFromChainTip, "estimated-time-remaining", estimatedTimeRemaining)
 		default:
 		}
 	}

--- a/cl/phase1/stages/forward_sync_test.go
+++ b/cl/phase1/stages/forward_sync_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package stages
+
+import (
+	"testing"
+	"time"
+)
+
+// currentSlot can overshoot the captured chainTipSlot; the distance/ETA math
+// must not underflow into a ~2^64 slot count and overflow time.Duration.
+func TestForwardSyncProgress_CurrentSlotPastChainTip(t *testing.T) {
+	dist, eta := forwardSyncProgress(1_000_000, 1_000_050, 999_900, 12, 30)
+	if dist != 0 {
+		t.Fatalf("distFromChainTip = %s, want 0 when current slot is past the tip", dist)
+	}
+	if eta < 0 {
+		t.Fatalf("ETA must not be negative, got %s", eta)
+	}
+}
+
+// A reorg can drop currentSlot below prevProgress; the rate denominator must not
+// underflow and drive the ETA to a garbage value.
+func TestForwardSyncProgress_ReorgBelowPrevProgress(t *testing.T) {
+	dist, eta := forwardSyncProgress(1_000_000, 900_000, 950_000, 12, 30)
+	if dist < 0 {
+		t.Fatalf("distFromChainTip must not be negative, got %s", dist)
+	}
+	if want := 999 * time.Hour; eta != want {
+		t.Fatalf("ETA = %s, want %s (default when no forward progress)", eta, want)
+	}
+}
+
+// Normal case: distance is slots-remaining × seconds-per-slot, ETA scales with rate.
+func TestForwardSyncProgress_Normal(t *testing.T) {
+	dist, eta := forwardSyncProgress(1_000_000, 900_000, 899_700, 12, 30)
+	if want := 100_000 * 12 * time.Second; dist != want {
+		t.Fatalf("distFromChainTip = %s, want %s", dist, want)
+	}
+	// rate = (900000-899700)/30 = 10 slots/s; eta = 100000/10 = 10000s.
+	if want := 10_000 * time.Second; eta != want {
+		t.Fatalf("ETA = %s, want %s", eta, want)
+	}
+}
+
+func TestBoundedDuration(t *testing.T) {
+	if got := boundedDuration(-5); got != 0 {
+		t.Fatalf("boundedDuration(negative) = %s, want 0", got)
+	}
+	if got := boundedDuration(0); got != 0 {
+		t.Fatalf("boundedDuration(0) = %s, want 0", got)
+	}
+	if got := boundedDuration(42); got != 42*time.Second {
+		t.Fatalf("boundedDuration(42) = %s, want 42s", got)
+	}
+	// Absurdly large second count must saturate, not wrap negative.
+	if got := boundedDuration(1e18); got != time.Duration(1<<63-1) {
+		t.Fatalf("boundedDuration(1e18) = %s, want max duration", got)
+	}
+}


### PR DESCRIPTION
Cherry-pick of #22464 to release/3.5.

Follow-up to #22462 (issue #22455): the "[Caplin] Forward Sync" progress log shares the same unguarded-subtraction / time.Duration-overflow pattern. `chainTipSlot - currentSlot` underflows when the current slot overshoots the captured tip, `currentSlot - prevProgress` underflows on a reorg, and both feed a `time.Duration` multiply that overflows int64 ns; the old `< 0` guard only caught a wrap to negative. Routed through a clamped, bounded helper.

Clean cherry-pick (forward_sync.go is identical on main and release/3.5).