### PR TITLE
kurtosis: update versions for glamsterdam-devnet-6

### DIFF
--- a/.github/workflows/kurtosis/glamsterdam-caplin.io
+++ b/.github/workflows/kurtosis/glamsterdam-caplin.io
@@ -8,7 +8,7 @@ participants:
     el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: lighthouse
-    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-5
+    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-6
     count: 1
 global_log_level: 'debug'
 network_params:
@@ -18,9 +18,9 @@ network_params:
   fulu_fork_epoch: 0
   gloas_fork_epoch: 1
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:5.3.5
+  image: ethpandaops/ethereum-genesis-generator:6.1.2
 additional_services: [assertoor]
 assertoor_params:
-  image: ethpandaops/assertoor:master
+  image: ethpandaops/assertoor:v0.1.3
   run_stability_check: false
   run_block_proposal_check: true

--- a/.github/workflows/kurtosis/glamsterdam.io
+++ b/.github/workflows/kurtosis/glamsterdam.io
@@ -1,6 +1,6 @@
 participants:
   - cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-5
+    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-6
     el_type: erigon
     el_image: test/erigon:current
     el_log_level: "debug"
@@ -29,9 +29,9 @@ spamoor_params:
     - scenario: setcodetx
       config: {throughput: 20, funding_gas_limit: 200000}
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:5.3.5
+  image: ethpandaops/ethereum-genesis-generator:6.1.2
 additional_services: [spamoor, assertoor]
 assertoor_params:
   run_stability_check: false  # re-enable once go-eth2-client supports alpha.8 (#21442)
   run_block_proposal_check: true
-  image: ethpandaops/assertoor:master-0ad56fb  # switch to release tag when available (#21441)
+  image: ethpandaops/assertoor:v0.1.3

--- a/.github/workflows/kurtosis/gloas-caplin-mixed.io
+++ b/.github/workflows/kurtosis/gloas-caplin-mixed.io
@@ -27,9 +27,9 @@ network_params:
   fulu_fork_epoch: 0
   gloas_fork_epoch: 1
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:5.3.5
+  image: ethpandaops/ethereum-genesis-generator:6.1.2
 additional_services: [assertoor]
 assertoor_params:
   run_stability_check: false
   run_block_proposal_check: true
-  image: ethpandaops/assertoor:master
+  image: ethpandaops/assertoor:v0.1.3

--- a/.github/workflows/kurtosis/gloas-three-cl-mixed.io
+++ b/.github/workflows/kurtosis/gloas-three-cl-mixed.io
@@ -37,9 +37,9 @@ network_params:
   fulu_fork_epoch: 0
   gloas_fork_epoch: 1
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:5.3.5
+  image: ethpandaops/ethereum-genesis-generator:6.1.2
 additional_services: [assertoor]
 assertoor_params:
   run_stability_check: false
   run_block_proposal_check: true
-  image: ethpandaops/assertoor:master
+  image: ethpandaops/assertoor:v0.1.3


### PR DESCRIPTION
## Problem

Since #22093 (EIP-8282, 2026-07-10) erigon runs the builder-request syscalls at the gloas
fork, but the kurtosis configs pinned `ethereum-genesis-generator:5.3.5`, whose genesis has
no EIP-8282 builder predeploys. Every block build from the first amsterdam block (block 8,
minimal preset) fails with `[EIP-8282] Syscall failure: Empty Code at BuilderDepositAddress`,
halting the chain ~70s in. `assertoor_glamsterdam_parallel_test` passed only when all three
client pairs happened to propose within the ~7 pre-halt blocks (a proposer lottery), so it
presented as a flake. Fixes #22454.

## Fix (config-only; erigon behaviour is spec-correct)

Bump the four gloas-enabling `.github/workflows/kurtosis/*.io` configs:

- `ethereum-genesis-generator` 5.3.5 → **6.1.2** — last devnet-6 build; predeploys match
  erigon's addresses (`protocol.go`) and bytecode (`eip8282.go`) exactly. 6.1.3+ is
  devnet-7 (revised addresses) — do not bump past 6.1.2 while on devnet-6.
- `assertoor` → **v0.1.3** — first released tag decoding the 5-list ExecutionRequests;
  also resolves #21441.
- `glamsterdam.io` + `glamsterdam-caplin.io` lighthouse devnet-5 → **devnet-6** (devnet-5's
  3-list layout can't handle erigon's post-8282 5-list output).

## Validation

Local kurtosis (`glamsterdam.io`, ethereum-package@6.1.0): chain sails past the block-8
halt to 29+, builder predeploys present on-chain (`eth_getCode` = 1138/794 hex chars),
0 empty-code errors / panics across all 3 erigon nodes, assertoor `block-proposal-check`
green.