### PR TITLE
[3.5] rpc: cherry-pick makes queryLimit configurabile via --rpc.logs.querylimit (#22418, #22014)

### DIFF
--- a/cmd/evm/zkevmrunner.go
+++ b/cmd/evm/zkevmrunner.go
@@ -250,7 +250,7 @@ func runWitnessTest(test *testutil.WitnessBlockTest) error {
 		return fmt.Errorf("commit commitment history flag: %w", err)
 	}
 
-	baseApi := jsonrpc.NewBaseApi(nil, m.StateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+	baseApi := jsonrpc.NewBaseApi(nil, m.StateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 	debugApi := jsonrpc.NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false)
 	canonicalMode := "canonical"
 

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -183,6 +183,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 	rootCmd.PersistentFlags().IntVar(&cfg.RpcFiltersConfig.RpcSubscriptionFiltersMaxTopics, "rpc.subscription.filters.maxtopics", rpchelper.DefaultFiltersConfig.RpcSubscriptionFiltersMaxTopics, "Maximum number of topics per subscription to filter logs by.")
 	rootCmd.PersistentFlags().IntVar(&cfg.BlockRangeLimit, utils.RpcBlockRangeLimit.Name, utils.RpcBlockRangeLimit.Value, utils.RpcBlockRangeLimit.Usage)
 	rootCmd.PersistentFlags().IntVar(&cfg.GetLogsMaxResults, utils.RpcGetLogsMaxResults.Name, utils.RpcGetLogsMaxResults.Value, utils.RpcGetLogsMaxResults.Usage)
+	rootCmd.PersistentFlags().IntVar(&cfg.LogQueryLimit, utils.RpcLogQueryLimit.Name, utils.RpcLogQueryLimit.Value, utils.RpcLogQueryLimit.Usage)
 	rootCmd.PersistentFlags().IntVar(&cfg.BatchLimit, utils.RpcBatchLimit.Name, utils.RpcBatchLimit.Value, utils.RpcBatchLimit.Usage)
 	rootCmd.PersistentFlags().IntVar(&cfg.ReturnDataLimit, utils.RpcReturnDataLimit.Name, utils.RpcReturnDataLimit.Value, utils.RpcReturnDataLimit.Usage)
 	rootCmd.PersistentFlags().BoolVar(&cfg.AllowUnprotectedTxs, utils.AllowUnprotectedTxs.Name, utils.AllowUnprotectedTxs.Value, utils.AllowUnprotectedTxs.Usage)
@@ -736,6 +737,7 @@ func startRegularRpcServer(ctx context.Context, cfg *httpcfg.HttpCfg, rpcAPI []r
 		"ws", cfg.WebsocketEnabled,
 		"rpc.blockrange.limit", cfg.BlockRangeLimit,
 		"rpc.logs.maxresults", cfg.GetLogsMaxResults,
+		"rpc.logs.querylimit", cfg.LogQueryLimit,
 	}
 
 	if cfg.SocketServerEnabled {

--- a/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
+++ b/cmd/rpcdaemon/cli/httpcfg/http_cfg.go
@@ -62,6 +62,7 @@ type HttpCfg struct {
 	Gascap                            uint64
 	BlockRangeLimit                   int
 	GetLogsMaxResults                 int
+	LogQueryLimit                     int
 	Feecap                            float64
 	MaxTraces                         uint64
 	WebsocketPort                     int

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -440,6 +440,11 @@ var (
 		Usage: "Maximum number of logs returned by eth_getLogs, erigon_getLogs, erigon_getLatestLogs (0 = unlimited)",
 		Value: 20_000,
 	}
+	RpcLogQueryLimit = cli.IntFlag{
+		Name:  "rpc.logs.querylimit",
+		Usage: "Maximum number of alternative addresses or topics allowed per search position in eth_getLogs filter criteria (<=0 = unlimited)",
+		Value: 1_000,
+	}
 	RpcTraceCompatFlag = cli.BoolFlag{
 		Name:  "trace.compat",
 		Usage: "Bug for bug compatibility with OE for trace_ routines",

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -150,7 +150,7 @@ func (e *EngineServer) Start(
 			return nil
 		})
 	}
-	base := jsonrpc.NewBaseApi(filters, stateCache, blockReader, httpConfig.WithDatadir, httpConfig.EvmCallTimeout, engineReader, httpConfig.Dirs, nil, httpConfig.BlockRangeLimit, httpConfig.GetLogsMaxResults)
+	base := jsonrpc.NewBaseApi(filters, stateCache, blockReader, httpConfig.WithDatadir, httpConfig.EvmCallTimeout, engineReader, httpConfig.Dirs, nil, httpConfig.BlockRangeLimit, httpConfig.GetLogsMaxResults, httpConfig.LogQueryLimit)
 	ethImpl := jsonrpc.NewEthAPI(base, db, eth, e.txpool, mining, jsonrpc.NewEthApiConfig(httpConfig), e.logger)
 
 	apiList := []rpc.API{

--- a/execution/engineapi/engine_server_test.go
+++ b/execution/engineapi/engine_server_test.go
@@ -66,7 +66,7 @@ func oneBlockStep(mockSentry *execmoduletester.ExecModuleTester, require *requir
 
 func newBaseApiForTest(m *execmoduletester.ExecModuleTester) *jsonrpc.BaseAPI {
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	return jsonrpc.NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+	return jsonrpc.NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 }
 
 func newEthApiForTest(base *jsonrpc.BaseAPI, db kv.TemporalRoDB, txPool txpoolproto.TxpoolClient) *jsonrpc.APIImpl {

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -99,6 +99,7 @@ var DefaultFlags = []cli.Flag{
 	&utils.RpcGasCapFlag,
 	&utils.RpcBlockRangeLimit,
 	&utils.RpcGetLogsMaxResults,
+	&utils.RpcLogQueryLimit,
 	&utils.RpcBatchLimit,
 	&utils.RpcReturnDataLimit,
 	&utils.AllowUnprotectedTxs,

--- a/node/cli/flags.go
+++ b/node/cli/flags.go
@@ -470,6 +470,7 @@ func setEmbeddedRpcDaemon(ctx *cli.Context, cfg *nodecfg.Config, logger log.Logg
 		Gascap:              ctx.Uint64(utils.RpcGasCapFlag.Name),
 		BlockRangeLimit:     ctx.Int(utils.RpcBlockRangeLimit.Name),
 		GetLogsMaxResults:   ctx.Int(utils.RpcGetLogsMaxResults.Name),
+		LogQueryLimit:       ctx.Int(utils.RpcLogQueryLimit.Name),
 		Feecap:              ctx.Float64(utils.RPCGlobalTxFeeCapFlag.Name),
 		MaxTraces:           ctx.Uint64(utils.TraceMaxtracesFlag.Name),
 		TraceCompatibility:  ctx.Bool(utils.RpcTraceCompatFlag.Name),

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -764,6 +764,7 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		backend.polygonBridge,
 		httpRpcCfg.BlockRangeLimit,
 		httpRpcCfg.GetLogsMaxResults,
+		httpRpcCfg.LogQueryLimit,
 	)
 	ethApiConfig := &jsonrpc.EthApiConfig{
 		GasCap:                      httpRpcCfg.Gascap,

--- a/rpc/gasprice/bench_test.go
+++ b/rpc/gasprice/bench_test.go
@@ -95,7 +95,7 @@ func BenchmarkSuggestTipCap(b *testing.B) {
 	defer m.Close()
 
 	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, false,
-		rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+		rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 
 	cases := []struct {
 		name        string
@@ -159,7 +159,7 @@ func BenchmarkFeeHistory(b *testing.B) {
 	defer m.Close()
 
 	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, false,
-		rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+		rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 
 	gasCache := jsonrpc.NewGasPriceCache()
 

--- a/rpc/gasprice/feehistory_test.go
+++ b/rpc/gasprice/feehistory_test.go
@@ -80,7 +80,7 @@ func TestFeeHistory(t *testing.T) {
 			m := newTestBackend(t) //, big.NewInt(16), c.pending)
 			defer m.Close()
 
-			baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+			baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 			tx, err := m.DB.BeginTemporalRo(m.Ctx)
 			require.NoError(t, err)
 			defer tx.Rollback()

--- a/rpc/gasprice/gasprice_test.go
+++ b/rpc/gasprice/gasprice_test.go
@@ -88,7 +88,7 @@ func TestSuggestPrice(t *testing.T) {
 	}
 
 	m := newTestBackend(t) //, big.NewInt(16), c.pending)
-	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 
 	tx, err := m.DB.BeginTemporalRo(m.Ctx)
 	require.NoError(t, err)
@@ -368,7 +368,7 @@ func TestSuggestTipCap_SparseBlocks(t *testing.T) {
 		Default:    uint256.NewInt(common.GWei),
 	}
 	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, false,
-		rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+		rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 
 	dbTx, txErr := m.DB.BeginTemporalRo(m.Ctx)
 	require.NoError(t, txErr)
@@ -406,7 +406,7 @@ func TestSuggestTipCap_AllEmptyBlocks(t *testing.T) {
 		Default:    uint256.NewInt(common.GWei),
 	}
 	baseApi := jsonrpc.NewBaseApi(nil, kvcache.NewSimple(), m.BlockReader, false,
-		rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+		rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 
 	dbTx, txErr := m.DB.BeginTemporalRo(m.Ctx)
 	require.NoError(t, txErr)

--- a/rpc/jsonrpc/daemon.go
+++ b/rpc/jsonrpc/daemon.go
@@ -49,7 +49,7 @@ func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.Tx
 	logger log.Logger, bridgeReader bridgeReader, spanProducersReader spanProducersReader,
 	testingEntry *rpc.API,
 ) (list []rpc.API) {
-	base := NewBaseApi(filters, stateCache, blockReader, cfg.WithDatadir, cfg.EvmCallTimeout, engine, cfg.Dirs, bridgeReader, cfg.BlockRangeLimit, cfg.GetLogsMaxResults)
+	base := NewBaseApi(filters, stateCache, blockReader, cfg.WithDatadir, cfg.EvmCallTimeout, engine, cfg.Dirs, bridgeReader, cfg.BlockRangeLimit, cfg.GetLogsMaxResults, cfg.LogQueryLimit)
 	ethImpl := NewEthAPI(base, db, eth, txPool, mining, NewEthApiConfig(cfg), logger)
 	erigonImpl := NewErigonAPI(base, db, eth)
 	txpoolImpl := NewTxPoolAPI(base, db, txPool)

--- a/rpc/jsonrpc/debug_api_test.go
+++ b/rpc/jsonrpc/debug_api_test.go
@@ -89,7 +89,7 @@ func TestTraceBlockByNumber(t *testing.T) {
 	}
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 	ethApi := newEthApiForTest(baseApi, m.DB, nil, nil)
 	api := NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false)
 	for _, tt := range debugTraceTransactionTests {

--- a/rpc/jsonrpc/erigon_receipts_test.go
+++ b/rpc/jsonrpc/erigon_receipts_test.go
@@ -19,6 +19,7 @@ package jsonrpc
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -228,7 +229,7 @@ func TestGetBlockReceiptsByBlockHash(t *testing.T) {
 // requested block range exceeds rangeLimit.
 func TestGetLogs_RangeLimitExceeded(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 5, 0), m.DB, nil, nil)
+	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 5, 0, 0), m.DB, nil, nil)
 	_, err := ethApi.GetLogs(context.Background(), filters.FilterCriteria{
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(10),
@@ -245,7 +246,7 @@ func TestGetLogs_RangeLimitExceeded(t *testing.T) {
 // range is within rangeLimit.
 func TestGetLogs_RangeLimitOk(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 11, 0), m.DB, nil, nil)
+	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 11, 0, 0), m.DB, nil, nil)
 	logs, err := ethApi.GetLogs(context.Background(), filters.FilterCriteria{
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(10),
@@ -258,7 +259,7 @@ func TestGetLogs_RangeLimitOk(t *testing.T) {
 // unlimited (0).
 func TestGetLogs_MaxResultsOk(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 0, 0), m.DB, nil, nil)
+	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 0, 0, 0), m.DB, nil, nil)
 	logs, err := ethApi.GetLogs(context.Background(), filters.FilterCriteria{
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(10),
@@ -271,7 +272,7 @@ func TestGetLogs_MaxResultsOk(t *testing.T) {
 // when the matching log count exceeds maxResults.
 func TestGetLogs_MaxResultsExceeded(t *testing.T) {
 	m, _, contractAddr, _ := chainWithDeployedContract(t)
-	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 0, 1), m.DB, nil, nil)
+	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 0, 1, 0), m.DB, nil, nil)
 	_, err := ethApi.GetLogs(context.Background(), filters.FilterCriteria{
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(rpc.LatestBlockNumber.Int64()),
@@ -285,11 +286,70 @@ func TestGetLogs_MaxResultsExceeded(t *testing.T) {
 	assert.Equal(t, errExceedLogResults+": 1", rpcErr.Error())
 }
 
+// TestGetLogs_LogQueryLimitExceeded verifies that eth_getLogs returns invalid params
+// when the filter has more addresses, or more alternatives in one topic position,
+// than logQueryLimit.
+func TestGetLogs_LogQueryLimitExceeded(t *testing.T) {
+	cases := []struct {
+		name string
+		crit filters.FilterCriteria
+	}{
+		{"addresses", filters.FilterCriteria{Addresses: make(common.Addresses, 3)}},
+		{"topics", filters.FilterCriteria{Topics: [][]common.Hash{make([]common.Hash, 3)}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _, _ := rpcdaemontest.CreateTestExecModule(t)
+			ethApi := newEthApiForTest(newBaseApiWithLimits(m, 0, 0, 2), m.DB, nil, nil)
+			tc.crit.FromBlock, tc.crit.ToBlock = big.NewInt(0), big.NewInt(10)
+			_, err := ethApi.GetLogs(context.Background(), tc.crit)
+			require.Error(t, err)
+
+			var rpcErr rpc.Error
+			require.ErrorAs(t, err, &rpcErr)
+			assert.Equal(t, rpc.ErrCodeInvalidParams, rpcErr.ErrorCode())
+			assert.Equal(t, fmt.Sprintf(errExceedLogQueryLimit, 2), rpcErr.Error())
+		})
+	}
+}
+
+// TestGetLogs_LogQueryLimitAtLimit verifies that filters with exactly
+// logQueryLimit addresses or topic alternatives are accepted.
+func TestGetLogs_LogQueryLimitAtLimit(t *testing.T) {
+	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
+	ethApi := newEthApiForTest(newBaseApiWithLimits(m, 0, 0, 2), m.DB, nil, nil)
+	_, err := ethApi.GetLogs(context.Background(), filters.FilterCriteria{
+		FromBlock: big.NewInt(0),
+		ToBlock:   big.NewInt(10),
+		Addresses: make(common.Addresses, 2),
+		Topics:    [][]common.Hash{make([]common.Hash, 2)},
+	})
+	require.NoError(t, err)
+}
+
+// TestGetLogs_LogQueryLimitUnlimited verifies that logQueryLimit<=0 disables the
+// addresses/topics cap.
+func TestGetLogs_LogQueryLimitUnlimited(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+			m, _, _ := rpcdaemontest.CreateTestExecModule(t)
+			ethApi := newEthApiForTest(newBaseApiWithLimits(m, 0, 0, limit), m.DB, nil, nil)
+			_, err := ethApi.GetLogs(context.Background(), filters.FilterCriteria{
+				FromBlock: big.NewInt(0),
+				ToBlock:   big.NewInt(10),
+				Addresses: make(common.Addresses, 1500),
+				Topics:    [][]common.Hash{make([]common.Hash, 1500)},
+			})
+			require.NoError(t, err)
+		})
+	}
+}
+
 // TestGetLatestLogs_LogCountExceedsMaxResults verifies that erigon_getLatestLogs
 // returns an error when the requested logCount exceeds getLogsMaxResults.
 func TestGetLatestLogs_LogCountExceedsMaxResults(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewErigonAPI(newBaseApiWithLimits(m, 0, 5), m.DB, nil)
+	api := NewErigonAPI(newBaseApiWithLimits(m, 0, 5, 0), m.DB, nil)
 	_, err := api.GetLatestLogs(context.Background(), filters.FilterCriteria{}, filters.LogFilterOptions{
 		LogCount: 10,
 	})
@@ -301,7 +361,7 @@ func TestGetLatestLogs_LogCountExceedsMaxResults(t *testing.T) {
 // returns an error when the requested blockCount exceeds rangeLimit.
 func TestGetLatestLogs_BlockCountExceedsRangeLimit(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewErigonAPI(newBaseApiWithLimits(m, 5, 0), m.DB, nil)
+	api := NewErigonAPI(newBaseApiWithLimits(m, 5, 0, 0), m.DB, nil)
 	_, err := api.GetLatestLogs(context.Background(), filters.FilterCriteria{}, filters.LogFilterOptions{
 		BlockCount: 10,
 	})
@@ -314,7 +374,7 @@ func TestGetLatestLogs_BlockCountExceedsRangeLimit(t *testing.T) {
 // no logCount/blockCount is specified.
 func TestGetLatestLogs_ExplicitRangeExceedsLimit(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewErigonAPI(newBaseApiWithLimits(m, 5, 0), m.DB, nil)
+	api := NewErigonAPI(newBaseApiWithLimits(m, 5, 0, 0), m.DB, nil)
 	_, err := api.GetLatestLogs(context.Background(), filters.FilterCriteria{
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(10),
@@ -329,7 +389,7 @@ func TestGetLatestLogs_ExplicitRangeExceedsLimit(t *testing.T) {
 func TestGetLatestLogs_ExplicitRangeWithLogCount_NoRangeCheck(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
 	// rangeLimit=5, but logCount is set so the range check should be skipped.
-	api := NewErigonAPI(newBaseApiWithLimits(m, 5, 0), m.DB, nil)
+	api := NewErigonAPI(newBaseApiWithLimits(m, 5, 0, 0), m.DB, nil)
 	_, err := api.GetLatestLogs(context.Background(), filters.FilterCriteria{
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(10),
@@ -345,7 +405,7 @@ func TestGetLatestLogs_ExplicitRangeWithLogCount_NoRangeCheck(t *testing.T) {
 func TestGetLatestLogs_ExplicitRangeWithBlockCount_NoRangeCheck(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
 	// rangeLimit=5, blockCount=3 (≤5 so ok), explicit range 0-10 is skipped.
-	api := NewErigonAPI(newBaseApiWithLimits(m, 5, 0), m.DB, nil)
+	api := NewErigonAPI(newBaseApiWithLimits(m, 5, 0, 0), m.DB, nil)
 	_, err := api.GetLatestLogs(context.Background(), filters.FilterCriteria{
 		FromBlock: big.NewInt(0),
 		ToBlock:   big.NewInt(10),

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -156,12 +156,13 @@ type BaseAPI struct {
 	evmCallTimeout      time.Duration
 	blockRangeLimit     int
 	getLogsMaxResults   int
+	logQueryLimit       int
 	dirs                datadir.Dirs
 	receiptsGenerator   *receipts.Generator
 	borReceiptGenerator *receipts.BorGenerator
 }
 
-func NewBaseApi(f *rpchelper.Filters, stateCache kvcache.Cache, blockReader services.FullBlockReader, singleNodeMode bool, evmCallTimeout time.Duration, engine rules.EngineReader, dirs datadir.Dirs, bridgeReader bridgeReader, rangeLimit int, getLogsMaxResults int) *BaseAPI {
+func NewBaseApi(f *rpchelper.Filters, stateCache kvcache.Cache, blockReader services.FullBlockReader, singleNodeMode bool, evmCallTimeout time.Duration, engine rules.EngineReader, dirs datadir.Dirs, bridgeReader bridgeReader, rangeLimit int, getLogsMaxResults int, logQueryLimit int) *BaseAPI {
 	var (
 		blocksLRUSize = 128 // ~32Mb
 	)
@@ -189,6 +190,7 @@ func NewBaseApi(f *rpchelper.Filters, stateCache kvcache.Cache, blockReader serv
 		bridgeReader:        bridgeReader,
 		blockRangeLimit:     rangeLimit,
 		getLogsMaxResults:   getLogsMaxResults,
+		logQueryLimit:       logQueryLimit,
 	}
 }
 

--- a/rpc/jsonrpc/eth_api_test.go
+++ b/rpc/jsonrpc/eth_api_test.go
@@ -43,11 +43,11 @@ import (
 )
 
 func newBaseApiForTest(m *execmoduletester.ExecModuleTester) *BaseAPI {
-	return NewBaseApi(nil, m.StateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+	return NewBaseApi(nil, m.StateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 }
 
-func newBaseApiWithLimits(m *execmoduletester.ExecModuleTester, rangeLimit, maxResults int) *BaseAPI {
-	return NewBaseApi(nil, m.StateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, rangeLimit, maxResults)
+func newBaseApiWithLimits(m *execmoduletester.ExecModuleTester, rangeLimit, maxResults, logQueryLimit int) *BaseAPI {
+	return NewBaseApi(nil, m.StateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, rangeLimit, maxResults, logQueryLimit)
 }
 
 func newEthApiForTest(base *BaseAPI, db kv.TemporalRoDB, txPool txpoolproto.TxpoolClient, mining txpoolproto.MiningClient) *APIImpl {
@@ -89,7 +89,7 @@ func TestGetBalanceChangesInBlock(t *testing.T) {
 func TestGetTransactionReceipt(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	api := newEthApiForTest(NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0), m.DB, nil, nil)
+	api := newEthApiForTest(NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0), m.DB, nil, nil)
 	// Call GetTransactionReceipt for transaction which is not in the database
 	if _, err := api.GetTransactionReceipt(context.Background(), common.Hash{}); err != nil {
 		t.Errorf("calling GetTransactionReceipt with empty hash: %v", err)

--- a/rpc/jsonrpc/eth_callMany_test.go
+++ b/rpc/jsonrpc/eth_callMany_test.go
@@ -99,7 +99,7 @@ func TestCallMany(t *testing.T) {
 
 	db := contractBackend.DB()
 	engine := contractBackend.Engine()
-	api := newEthApiForTest(NewBaseApi(nil, stateCache, contractBackend.BlockReader(), false, rpccfg.DefaultEvmCallTimeout, engine, datadir.New(t.TempDir()), nil, 0, 0), db, nil, nil)
+	api := newEthApiForTest(NewBaseApi(nil, stateCache, contractBackend.BlockReader(), false, rpccfg.DefaultEvmCallTimeout, engine, datadir.New(t.TempDir()), nil, 0, 0, 0), db, nil, nil)
 
 	callArgAddr1 := ethapi.CallArgs{From: &address, To: &tokenAddr, Nonce: &nonce,
 		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(1e9)),

--- a/rpc/jsonrpc/eth_filters_test.go
+++ b/rpc/jsonrpc/eth_filters_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 func newBaseApiWithFiltersForTest(f *rpchelper.Filters, stateCache *kvcache.Coherent, m *execmoduletester.ExecModuleTester) *BaseAPI {
-	return NewBaseApi(f, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+	return NewBaseApi(f, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 }
 
 func TestNewFilters(t *testing.T) {

--- a/rpc/jsonrpc/eth_mining_test.go
+++ b/rpc/jsonrpc/eth_mining_test.go
@@ -45,7 +45,7 @@ func TestPendingBlock(t *testing.T) {
 	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, nil, mining, func() {}, m.Log, nil)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	engine := ethash.NewFaker()
-	api := newEthApiForTest(NewBaseApi(ff, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, engine, m.Dirs, nil, 0, 0), nil, nil, nil)
+	api := newEthApiForTest(NewBaseApi(ff, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, engine, m.Dirs, nil, 0, 0, 0), nil, nil, nil)
 	expect := uint64(12345)
 	b, err := rlp.EncodeToBytes(types.NewBlockWithHeader(&types.Header{Number: *uint256.NewInt(expect)}))
 	require.NoError(t, err)

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -47,8 +47,8 @@ var (
 	errExceedBlockRange                = "query block range exceeds server limit, narrow your filter"
 	errBlockRangeIntoFuture            = "block range extends beyond current head block"
 	errBlockHashWithRange              = "can't specify fromBlock/toBlock with blockHash"
-	errExceedMaxTopics                 = "exceed max topics"
-	errExceedLogQueryLimit             = "exceed max addresses or topics per search position"
+	errExceedMaxTopics                 = fmt.Sprintf("query exceeds the maximum of %d topics", maxTopics)
+	errExceedLogQueryLimit             = fmt.Sprintf("query exceeds the maximum of %d addresses or topics per search position", logQueryLimit)
 	errExceedLogResults                = "query returns too many logs, narrow your filter"
 	errRequestedBlockCountExceedsLimit = "requested blockCount exceeds server limit"
 	errRequestedLogCountExceedsLimit   = "requested logCount exceeds server limit"

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -56,8 +56,7 @@ var (
 
 const (
 	// The maximum number of topic criteria allowed, vm.LOG4 - vm.LOG0
-	maxTopics     = 4
-	logQueryLimit = 1000
+	maxTopics = 4
 )
 
 // getReceipts - checking in-mem cache, or else fallback to db, or else fallback to re-exec of block to re-gen receipts
@@ -86,6 +85,23 @@ func (api *BaseAPI) getCachedReceipts(ctx context.Context, hash common.Hash) (ty
 	return api.receiptsGenerator.GetCachedReceipts(ctx, hash)
 }
 
+// exceedsLogQueryLimit reports whether the filter has more addresses, or more
+// alternatives in one topic position, than limit allows (<=0 = unlimited).
+func exceedsLogQueryLimit(crit filters.FilterCriteria, limit int) bool {
+	if limit <= 0 {
+		return false
+	}
+	if len(crit.Addresses) > limit {
+		return true
+	}
+	for _, topics := range crit.Topics {
+		if len(topics) > limit {
+			return true
+		}
+	}
+	return false
+}
+
 // GetLogs implements eth_getLogs. Returns an array of logs matching a given filter object.
 func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (types.RPCLogs, error) {
 	var begin, end uint64
@@ -101,13 +117,8 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) (t
 		return nil, &rpc.CustomError{Message: errExceedMaxTopics, Code: rpc.ErrCodeInvalidParams}
 	}
 
-	if len(crit.Addresses) > logQueryLimit {
-		return nil, &rpc.CustomError{Message: errExceedLogQueryLimit, Code: rpc.ErrCodeInvalidParams}
-	}
-	for _, topics := range crit.Topics {
-		if len(topics) > logQueryLimit {
-			return nil, &rpc.CustomError{Message: errExceedLogQueryLimit, Code: rpc.ErrCodeInvalidParams}
-		}
+	if exceedsLogQueryLimit(crit, api.logQueryLimit) {
+		return nil, &rpc.CustomError{Message: fmt.Sprintf(errExceedLogQueryLimit, api.logQueryLimit), Code: rpc.ErrCodeInvalidParams}
 	}
 
 	if crit.BlockHash != nil {

--- a/rpc/jsonrpc/eth_receipts.go
+++ b/rpc/jsonrpc/eth_receipts.go
@@ -48,7 +48,7 @@ var (
 	errBlockRangeIntoFuture            = "block range extends beyond current head block"
 	errBlockHashWithRange              = "can't specify fromBlock/toBlock with blockHash"
 	errExceedMaxTopics                 = fmt.Sprintf("query exceeds the maximum of %d topics", maxTopics)
-	errExceedLogQueryLimit             = fmt.Sprintf("query exceeds the maximum of %d addresses or topics per search position", logQueryLimit)
+	errExceedLogQueryLimit             = "query exceeds the maximum of %d addresses or topics per search position"
 	errExceedLogResults                = "query returns too many logs, narrow your filter"
 	errRequestedBlockCountExceedsLimit = "requested blockCount exceeds server limit"
 	errRequestedLogCountExceedsLimit   = "requested logCount exceeds server limit"

--- a/rpc/jsonrpc/gen_traces_test.go
+++ b/rpc/jsonrpc/gen_traces_test.go
@@ -46,7 +46,7 @@ Testing tracing RPC API by generating patters of contracts invoking one another 
 func TestGeneratedDebugApi(t *testing.T) {
 	m := rpcdaemontest.CreateTestExecModuleForTraces(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 	api := NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false)
 	var buf bytes.Buffer
 	stream := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -133,7 +133,7 @@ func TestGeneratedDebugApi(t *testing.T) {
 func TestGeneratedTraceApi(t *testing.T) {
 	m := rpcdaemontest.CreateTestExecModuleForTraces(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
-	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 	api := NewTraceAPI(baseApi, m.DB, &httpcfg.HttpCfg{})
 	traces, err := api.Block(context.Background(), rpc.BlockNumber(1), new(bool), nil)
 	if err != nil {

--- a/rpc/jsonrpc/otterscan_transaction_by_sender_and_nonce_test.go
+++ b/rpc/jsonrpc/otterscan_transaction_by_sender_and_nonce_test.go
@@ -31,7 +31,7 @@ func TestGetTransactionBySenderAndNonce(t *testing.T) {
 		t.Skip("slow test")
 	}
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewOtterscanAPI(NewBaseApi(nil, nil, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0), m.DB, 25)
+	api := NewOtterscanAPI(NewBaseApi(nil, nil, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0), m.DB, 25)
 
 	addr := common.HexToAddress("0x537e697c7ab75a26f9ecf0ce810e3154dfcaaf44")
 	expectCreator := common.HexToAddress("0x71562b71999873db5b286df957af199ec94617f7")

--- a/rpc/jsonrpc/parity_api_test.go
+++ b/rpc/jsonrpc/parity_api_test.go
@@ -37,7 +37,7 @@ var latestBlock = rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 func TestParityAPIImpl_ListStorageKeys_NoOffset(t *testing.T) {
 	assert := assert.New(t)
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	baseApi := NewBaseApi(nil, nil, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0)
+	baseApi := NewBaseApi(nil, nil, m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0)
 	api := NewParityAPIImpl(baseApi, m.DB)
 	answers := []string{
 		"0000000000000000000000000000000000000000000000000000000000000000",

--- a/rpc/jsonrpc/txpool_api_test.go
+++ b/rpc/jsonrpc/txpool_api_test.go
@@ -49,7 +49,7 @@ func TestTxPoolContent(t *testing.T) {
 	ctx, conn := rpcdaemontest.CreateTestGrpcConn(t, m)
 	txPool := txpoolproto.NewTxpoolClient(conn)
 	ff := rpchelper.New(ctx, rpchelper.DefaultFiltersConfig, nil, txPool, txpoolproto.NewMiningClient(conn), func() {}, m.Log, nil)
-	api := NewTxPoolAPI(NewBaseApi(ff, kvcache.New(kvcache.DefaultCoherentConfig), m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0), m.DB, txPool)
+	api := NewTxPoolAPI(NewBaseApi(ff, kvcache.New(kvcache.DefaultCoherentConfig), m.BlockReader, false, rpccfg.DefaultEvmCallTimeout, m.Engine, m.Dirs, nil, 0, 0, 0), m.DB, txPool)
 
 	expectValue := uint64(1234)
 	txn, err := types.SignTx(types.NewTransaction(0, common.Address{1}, uint256.NewInt(expectValue), params.TxGas, uint256.NewInt(10*common.GWei), nil), *types.LatestSignerForChainID(m.ChainConfig.ChainID), m.Key)


### PR DESCRIPTION
Replace the hardcoded 1000 addresses/topics-per-search-position limit in eth_getLogs with a new --rpc.logs.querylimit flag default 1000, matching current behaviour; 0 = unlimited

Adding this one parameter required touching ~20 NewBaseApi call sites because the constructor takes every config value positionally. A follow-up PR will refactor NewBaseApi to take a config struct (mirroring the existing EthApiConfig pattern), so future parameters no longer require touching so many files