### PR TITLE
agg: reduce size of `InvertedIndexRoTx` object

### DIFF
--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -477,8 +477,6 @@ type InvertedIndexRoTx struct {
 	salt              *uint32
 	stepSize          uint64
 	stepsInFrozenFile uint64
-
-	reUsableSeq multiencseq.SequenceReader // re-usable instance, to reduce allocations
 }
 
 // hashKey - change of salt will require re-gen of indices
@@ -522,6 +520,8 @@ func (iit *InvertedIndexRoTx) seekInFiles(key []byte, txNum uint64) (found bool,
 		return false, 0, nil
 	}
 
+	var seq multiencseq.SequenceReader
+
 	hi, lo := iit.hashKey(key)
 	if iit.seekInFilesCache == nil {
 		iit.seekInFilesCache = iit.visible.newSeekInFilesCache()
@@ -558,8 +558,8 @@ func (iit *InvertedIndexRoTx) seekInFiles(key []byte, txNum uint64) (found bool,
 		}
 		encodedSeq, _ := g.Next(nil)
 
-		iit.reUsableSeq.Reset(iit.files[i].startTxNum, encodedSeq)
-		equalOrHigherTxNum, _, found = iit.reUsableSeq.Seek(txNum)
+		seq.Reset(iit.files[i].startTxNum, encodedSeq)
+		equalOrHigherTxNum, _, found = seq.Seek(txNum)
 		if !found {
 			continue
 		}

--- a/db/state/inverted_index_bench_test.go
+++ b/db/state/inverted_index_bench_test.go
@@ -1,0 +1,50 @@
+package state
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/erigontech/erigon/common/background"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+)
+
+// BenchmarkInvertedIndexSeekInFiles measures the per-seek cost of the file-scan path.
+// Run with II_LRU_ENABLED=false to bypass the seek cache, otherwise the cache short-circuits
+// before the sequence decoding this is meant to measure.
+func BenchmarkInvertedIndexSeekInFiles(b *testing.B) {
+	logger := log.New()
+	db, ii, txs := filledInvIndexOfSize(b, 1000, 16, 31, logger)
+	ctx := b.Context()
+
+	tx, err := db.BeginRw(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tx.Rollback()
+	for step := kv.Step(0); step < kv.Step(txs/ii.stepSize)-1; step++ {
+		if err := ii.collateBuildIntegrate(ctx, step, tx, background.NewProgressSet()); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	iit := ii.beginForTests()
+	defer iit.Close()
+	if len(iit.files) == 0 {
+		b.Fatal("no visible files: benchmark would not reach the seek path")
+	}
+
+	keys := make([][8]byte, 31)
+	for i := range keys {
+		binary.BigEndian.PutUint64(keys[i][:], uint64(i+1))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		k := keys[i%len(keys)]
+		if _, _, err := iit.seekInFiles(k[:], uint64(i%900)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
`multiencseq.SequenceReader` this reader is already optimized for on-stack allocation - means we don't need reusable object for this reader (in long-term plan to have it for all readers)

`InvertedIndexRoTx 344 → 128 B, arena 5952 → 3792 B` 