### PR TITLE
all: enable reflecttypefor, slicesbackward, and slicescontains under modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,7 +90,7 @@ linters:
         underef:
           skipRecvDeref: true
     modernize:
-      disable: # each disabled backlog has an existing backlog; enable it once its findings are cleared
+      disable: # each disabled analyzer has an existing backlog; enable it once its findings are cleared
         - slicessort
         - stditerators
         - stringsbuilder

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,7 +91,6 @@ linters:
           skipRecvDeref: true
     modernize:
       disable: # each disabled backlog has an existing backlog; enable it once its findings are cleared
-        - slicescontains
         - slicessort
         - stditerators
         - stringsbuilder

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,8 +90,7 @@ linters:
         underef:
           skipRecvDeref: true
     modernize:
-      disable: # each disabled analyzer has an existing backlog; enable it once its findings are cleared
-        - reflecttypefor
+      disable: # each disabled backlog has an existing backlog; enable it once its findings are cleared
         - slicesbackward
         - slicescontains
         - slicessort

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,7 +91,6 @@ linters:
           skipRecvDeref: true
     modernize:
       disable: # each disabled backlog has an existing backlog; enable it once its findings are cleared
-        - slicesbackward
         - slicescontains
         - slicessort
         - stditerators

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	mathrand "math/rand"
 	"os"
+	"slices"
 	"sort"
 	"time"
 
@@ -728,8 +729,8 @@ type BeaconChainConfig struct {
 // GetBlobParameters returns the blob parameters at a given epoch
 func (b *BeaconChainConfig) GetBlobParameters(epoch uint64) BlobParameters {
 	// Iterate through schedule in desc order
-	for i := len(b.BlobSchedule) - 1; i >= 0; i-- {
-		entry := b.BlobSchedule[i]
+	for _, entry := range slices.Backward(b.BlobSchedule) {
+
 		if epoch >= entry.Epoch {
 			return entry
 		}

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -730,7 +730,6 @@ type BeaconChainConfig struct {
 func (b *BeaconChainConfig) GetBlobParameters(epoch uint64) BlobParameters {
 	// Iterate through schedule in desc order
 	for _, entry := range slices.Backward(b.BlobSchedule) {
-
 		if epoch >= entry.Epoch {
 			return entry
 		}

--- a/cl/cltypes/solid/bitlist.go
+++ b/cl/cltypes/solid/bitlist.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math/bits"
+	"slices"
 
 	"github.com/erigontech/erigon/cl/merkle_tree"
 	"github.com/erigontech/erigon/common/clonable"
@@ -222,9 +223,9 @@ func (u *BitList) Bits() int {
 	// The most significant bit is present in the last byte in the array.
 	var last byte
 	var byteLen int
-	for i := len(u.u) - 1; i >= 0; i-- {
-		if u.u[i] != 0 {
-			last = u.u[i]
+	for i, v := range slices.Backward(u.u) {
+		if v != 0 {
+			last = v
 			byteLen = i + 1
 			break
 		}

--- a/cl/cltypes/solid/bitlist.go
+++ b/cl/cltypes/solid/bitlist.go
@@ -223,9 +223,9 @@ func (u *BitList) Bits() int {
 	// The most significant bit is present in the last byte in the array.
 	var last byte
 	var byteLen int
-	for i, v := range slices.Backward(u.u) {
-		if v != 0 {
-			last = v
+	for i, b := range slices.Backward(u.u) {
+		if b != 0 {
+			last = b
 			byteLen = i + 1
 			break
 		}

--- a/cl/merkle_tree/list.go
+++ b/cl/merkle_tree/list.go
@@ -18,6 +18,7 @@ package merkle_tree
 
 import (
 	"math/bits"
+	"slices"
 
 	"github.com/prysmaticlabs/gohashtree"
 
@@ -97,8 +98,8 @@ func parseBitlist(dst, buf []byte) ([]byte, uint64) {
 	dst[len(dst)-1] &^= uint8(1 << msb)
 
 	newLen := len(dst)
-	for i := len(dst) - 1; i >= 0; i-- {
-		if dst[i] != 0x00 {
+	for i, d := range slices.Backward(dst) {
+		if d != 0x00 {
 			break
 		}
 		newLen = i

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -19,6 +19,7 @@ package fork_graph
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -530,8 +531,8 @@ func (f *forkGraphDisk) getState(blockRoot common.Hash, alwaysCopy bool, addChai
 	}
 
 	// Traverse the blocks from top to bottom.
-	for i := len(blocksInTheWay) - 1; i >= 0; i-- {
-		if err := transition.TransitionState(copyReferencedState, blocksInTheWay[i], nil, false); err != nil {
+	for _, b := range slices.Backward(blocksInTheWay) {
+		if err := transition.TransitionState(copyReferencedState, b, nil, false); err != nil {
 			if addChainSegment {
 				f.currentStateMu.Lock()
 				f.currentState = nil

--- a/cl/phase1/forkchoice/gloas_weight_tree.go
+++ b/cl/phase1/forkchoice/gloas_weight_tree.go
@@ -360,7 +360,6 @@ func (t *gloasWeightTree) recompute(root common.Hash) {
 			t.weightSeen[item.root] = struct{}{}
 			t.weightStack = append(t.weightStack, gloasWeightStackItem{root: item.root, visited: true})
 			for _, child := range slices.Backward(node.children) {
-
 				if _, ok := t.weightSeen[child]; ok {
 					continue
 				}

--- a/cl/phase1/forkchoice/gloas_weight_tree.go
+++ b/cl/phase1/forkchoice/gloas_weight_tree.go
@@ -17,6 +17,8 @@
 package forkchoice
 
 import (
+	"slices"
+
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/common"
@@ -357,8 +359,8 @@ func (t *gloasWeightTree) recompute(root common.Hash) {
 			}
 			t.weightSeen[item.root] = struct{}{}
 			t.weightStack = append(t.weightStack, gloasWeightStackItem{root: item.root, visited: true})
-			for i := len(node.children) - 1; i >= 0; i-- {
-				child := node.children[i]
+			for _, child := range slices.Backward(node.children) {
+
 				if _, ok := t.weightSeen[child]; ok {
 					continue
 				}

--- a/cl/phase1/network/backward_beacon_downloader.go
+++ b/cl/phase1/network/backward_beacon_downloader.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -297,12 +298,11 @@ func (b *BackwardBeaconDownloader) processResponses(ctx context.Context, respons
 	// when a retry causes the same batch to be re-fetched.
 	advanced := false
 	matched := false
-	for i := len(responses) - 1; i >= 0; i-- {
+	for _, block := range slices.Backward(responses) {
 		if b.finished.Load() {
 			return nil
 		}
 
-		block := responses[i]
 		blockRoot, err := block.Block.HashSSZ()
 		if err != nil {
 			log.Debug("Could not compute block root", "err", err)

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
 	"time"
 
@@ -582,8 +583,8 @@ func verifyUnverifiedGloasPayloads(ctx context.Context, cfg *Cfg) {
 	}
 
 	swept := 0
-	for i := len(blocks) - 1; i >= 0; i-- {
-		item := blocks[i]
+	for _, item := range slices.Backward(blocks) {
+
 		if cfg.forkChoice.IsPayloadVerified(item.root) {
 			continue
 		}

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -584,7 +584,6 @@ func verifyUnverifiedGloasPayloads(ctx context.Context, cfg *Cfg) {
 
 	swept := 0
 	for _, item := range slices.Backward(blocks) {
-
 		if cfg.forkChoice.IsPayloadVerified(item.root) {
 			continue
 		}

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -151,8 +152,8 @@ func updateCanonicalChainInTheDatabase(ctx context.Context, tx kv.RwTx, headSlot
 	}
 
 	// Mark the new canonical chain segments in reverse order
-	for i := len(reconnectionRoots) - 1; i >= 0; i-- {
-		if err := beacon_indicies.MarkRootCanonical(ctx, tx, reconnectionRoots[i].slot, reconnectionRoots[i].root); err != nil {
+	for _, reconnectionRoot := range slices.Backward(reconnectionRoots) {
+		if err := beacon_indicies.MarkRootCanonical(ctx, tx, reconnectionRoot.slot, reconnectionRoot.root); err != nil {
 			return fmt.Errorf("failed to mark root canonical: %w", err)
 		}
 	}

--- a/cmd/rpctest/rpctest/utils.go
+++ b/cmd/rpctest/rpctest/utils.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/valyala/fastjson"
@@ -38,8 +39,8 @@ import (
 func openWriters(recordFileName, errorFileName string) (rec, errs *bufio.Writer, cleanup func(), err error) {
 	var closers []func()
 	cleanup = func() {
-		for i := len(closers) - 1; i >= 0; i-- {
-			closers[i]()
+		for _, closer := range slices.Backward(closers) {
+			closer()
 		}
 	}
 	if errorFileName != "" {

--- a/common/event/feed_test.go
+++ b/common/event/feed_test.go
@@ -32,7 +32,7 @@ func TestFeedPanics(t *testing.T) {
 	{
 		var f Feed
 		f.Send(2)
-		want := feedTypeError{op: "Send", got: reflect.TypeOf(uint64(0)), want: reflect.TypeOf(0)}
+		want := feedTypeError{op: "Send", got: reflect.TypeFor[uint64](), want: reflect.TypeFor[int]()}
 		if err := checkPanic(want, func() { f.Send(uint64(2)) }); err != nil {
 			t.Error(err)
 		}
@@ -41,7 +41,7 @@ func TestFeedPanics(t *testing.T) {
 		var f Feed
 		ch := make(chan int)
 		f.Subscribe(ch)
-		want := feedTypeError{op: "Send", got: reflect.TypeOf(uint64(0)), want: reflect.TypeOf(0)}
+		want := feedTypeError{op: "Send", got: reflect.TypeFor[uint64](), want: reflect.TypeFor[int]()}
 		if err := checkPanic(want, func() { f.Send(uint64(2)) }); err != nil {
 			t.Error(err)
 		}
@@ -49,7 +49,7 @@ func TestFeedPanics(t *testing.T) {
 	{
 		var f Feed
 		f.Send(2)
-		want := feedTypeError{op: "Subscribe", got: reflect.TypeOf(make(chan uint64)), want: reflect.TypeOf(make(chan<- int))}
+		want := feedTypeError{op: "Subscribe", got: reflect.TypeFor[chan uint64](), want: reflect.TypeFor[chan<- int]()}
 		if err := checkPanic(want, func() { f.Subscribe(make(chan uint64)) }); err != nil {
 			t.Error(err)
 		}

--- a/db/seg/sais/sais_16.go
+++ b/db/seg/sais/sais_16.go
@@ -8,7 +8,6 @@
 // Copyright 2019 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-
 package sais
 
 import "slices"

--- a/db/seg/sais/sais_16.go
+++ b/db/seg/sais/sais_16.go
@@ -11,6 +11,8 @@
 
 package sais
 
+import "slices"
+
 func sais_16_32(text []uint16, textMax int, sa, tmp []int32) {
 	if len(sa) != len(text) || len(tmp) < textMax {
 		panic("sais: misuse of sais_16_32")
@@ -93,8 +95,8 @@ func placeLMS_16_32(text []uint16, sa, freq, bucket []int32) int {
 	lastB := int32(-1)
 
 	c0, c1, isTypeS := uint16(0), uint16(0), false
-	for i := len(text) - 1; i >= 0; i-- {
-		c0, c1 = text[i], c0
+	for i, t := range slices.Backward(text) {
+		c0, c1 = t, c0
 		if c0 < c1 {
 			isTypeS = true
 		} else if c0 > c1 && isTypeS {
@@ -195,8 +197,8 @@ func length_16_32(text []uint16, sa []int32, numLMS int) {
 	end := 0
 
 	c0, c1, isTypeS := uint16(0), uint16(0), false
-	for i := len(text) - 1; i >= 0; i-- {
-		c0, c1 = text[i], c0
+	for i, t := range slices.Backward(text) {
+		c0, c1 = t, c0
 		if c0 < c1 {
 			isTypeS = true
 		} else if c0 > c1 && isTypeS {
@@ -253,8 +255,8 @@ func unmap_16_32(text []uint16, sa []int32, numLMS int) {
 	j := len(unmap)
 
 	c0, c1, isTypeS := uint16(0), uint16(0), false
-	for i := len(text) - 1; i >= 0; i-- {
-		c0, c1 = text[i], c0
+	for i, t := range slices.Backward(text) {
+		c0, c1 = t, c0
 		if c0 < c1 {
 			isTypeS = true
 		} else if c0 > c1 && isTypeS {

--- a/db/seg/sais/sais_inner.go
+++ b/db/seg/sais/sais_inner.go
@@ -8,6 +8,8 @@
 
 package sais
 
+import "slices"
+
 func sais_32(text []int32, textMax int, sa, tmp []int32) {
 	if len(sa) != len(text) || len(tmp) < textMax {
 		panic("sais: misuse of sais_32")
@@ -91,8 +93,8 @@ func placeLMS_32(text []int32, sa, freq, bucket []int32) int {
 	lastB := int32(-1)
 
 	c0, c1, isTypeS := int32(0), int32(0), false
-	for i := len(text) - 1; i >= 0; i-- {
-		c0, c1 = text[i], c0
+	for i, t := range slices.Backward(text) {
+		c0, c1 = t, c0
 		if c0 < c1 {
 			isTypeS = true
 		} else if c0 > c1 && isTypeS {
@@ -193,8 +195,8 @@ func length_32(text []int32, sa []int32, numLMS int) {
 	end := 0
 
 	c0, c1, isTypeS := int32(0), int32(0), false
-	for i := len(text) - 1; i >= 0; i-- {
-		c0, c1 = text[i], c0
+	for i, t := range slices.Backward(text) {
+		c0, c1 = t, c0
 		if c0 < c1 {
 			isTypeS = true
 		} else if c0 > c1 && isTypeS {
@@ -251,8 +253,8 @@ func unmap_32(text []int32, sa []int32, numLMS int) {
 	j := len(unmap)
 
 	c0, c1, isTypeS := int32(0), int32(0), false
-	for i := len(text) - 1; i >= 0; i-- {
-		c0, c1 = text[i], c0
+	for i, t := range slices.Backward(text) {
+		c0, c1 = t, c0
 		if c0 < c1 {
 			isTypeS = true
 		} else if c0 > c1 && isTypeS {

--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -649,8 +650,8 @@ func (r *BlockReader) HeaderByHash(ctx context.Context, tx kv.Getter, hash commo
 	defer release()
 
 	buf := make([]byte, 128)
-	for i := len(segments) - 1; i >= 0; i-- {
-		h, err = r.headerFromSnapshotByHash(hash, segments[i], buf)
+	for _, segment := range slices.Backward(segments) {
+		h, err = r.headerFromSnapshotByHash(hash, segment, buf)
 		if err != nil {
 			return nil, err
 		}
@@ -1217,8 +1218,7 @@ func (r *BlockReader) txnByID(txnID uint64, sn *snapshotsync.VisibleSegment, buf
 }
 
 func (r *BlockReader) txnByHash(txnHash common.Hash, segments []*snapshotsync.VisibleSegment, buf []byte) (types.Transaction, uint64, uint64, bool, error) {
-	for i := len(segments) - 1; i >= 0; i-- {
-		sn := segments[i]
+	for _, sn := range slices.Backward(segments) {
 
 		idxTxnHash := sn.Src().Index(snaptype2.Indexes.TxnHash)
 		idxTxnHash2BlockNum := sn.Src().Index(snaptype2.Indexes.TxnHash2BlockNum)

--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -1216,10 +1216,8 @@ func (r *BlockReader) txnByID(txnID uint64, sn *snapshotsync.VisibleSegment, buf
 	txn.SetSender(accounts.InternAddress(*(*common.Address)(sender))) // see: https://tip.golang.org/ref/spec#Conversions_from_slice_to_array_pointer
 	return
 }
-
 func (r *BlockReader) txnByHash(txnHash common.Hash, segments []*snapshotsync.VisibleSegment, buf []byte) (types.Transaction, uint64, uint64, bool, error) {
 	for _, sn := range slices.Backward(segments) {
-
 		idxTxnHash := sn.Src().Index(snaptype2.Indexes.TxnHash)
 		idxTxnHash2BlockNum := sn.Src().Index(snaptype2.Indexes.TxnHash2BlockNum)
 

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -784,10 +785,10 @@ func (files visibleFiles) LatestMergedRange(stepSize uint64) MergeRange {
 	if len(files) == 0 {
 		return MergeRange{}
 	}
-	for i := len(files) - 1; i >= 0; i-- {
-		shardSize := (files[i].endTxNum - files[i].startTxNum) / stepSize
+	for _, file := range slices.Backward(files) {
+		shardSize := (file.endTxNum - file.startTxNum) / stepSize
 		if shardSize > 2 {
-			return MergeRange{from: files[i].startTxNum, to: files[i].endTxNum}
+			return MergeRange{from: file.startTxNum, to: file.endTxNum}
 		}
 	}
 	return MergeRange{}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1431,26 +1431,26 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 
 	// Walk newest→oldest; skip files starting strictly after maxTxNum so a key's
 	// last write in an older .kv is still found (walkback bounded by maxTxNum).
-	for i := len(dt.files) - 1; i >= 0; i-- {
-		if maxTxNum != math.MaxUint64 && dt.files[i].startTxNum > maxTxNum {
+	for i, v0 := range slices.Backward(dt.files) {
+		if maxTxNum != math.MaxUint64 && v0.startTxNum > maxTxNum {
 			continue
 		}
 		// fmt.Printf("getLatestFromFiles: lim=%d %d %d %d %d\n", maxTxNum, dt.files[i].startTxNum, dt.files[i].endTxNum, dt.files[i].startTxNum/dt.stepSize, dt.files[i].endTxNum/dt.stepSize)
 		if useExistenceFilter {
-			if dt.files[i].src.existence != nil {
-				if !dt.files[i].src.existence.ContainsHash(hi) {
+			if v0.src.existence != nil {
+				if !v0.src.existence.ContainsHash(hi) {
 					if traceGetLatest == dt.name {
-						fmt.Printf("GetLatest(%s, %x) -> existence index %s -> false\n", dt.d.FilenameBase, k, dt.files[i].src.existence.FileName)
+						fmt.Printf("GetLatest(%s, %x) -> existence index %s -> false\n", dt.d.FilenameBase, k, v0.src.existence.FileName)
 					}
 					continue
 				} else {
 					if traceGetLatest == dt.name {
-						fmt.Printf("GetLatest(%s, %x) -> existence index %s -> true\n", dt.d.FilenameBase, k, dt.files[i].src.existence.FileName)
+						fmt.Printf("GetLatest(%s, %x) -> existence index %s -> true\n", dt.d.FilenameBase, k, v0.src.existence.FileName)
 					}
 				}
 			} else {
 				if traceGetLatest == dt.name {
-					fmt.Printf("GetLatest(%s, %x) -> existence index is nil %s\n", dt.name.String(), k, dt.files[i].src.decompressor.FileName())
+					fmt.Printf("GetLatest(%s, %x) -> existence index is nil %s\n", dt.name.String(), k, v0.src.decompressor.FileName())
 				}
 			}
 		}
@@ -1461,18 +1461,18 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 		}
 		if !found {
 			if traceGetLatest == dt.name {
-				fmt.Printf("GetLatest(%s, %x) -> not found in file %s\n", dt.name.String(), k, dt.files[i].src.decompressor.FileName())
+				fmt.Printf("GetLatest(%s, %x) -> not found in file %s\n", dt.name.String(), k, v0.src.decompressor.FileName())
 			}
 			continue
 		}
 		if traceGetLatest == dt.name {
-			fmt.Printf("GetLatest(%s, %x) -> found in file %s\n", dt.name.String(), k, dt.files[i].src.decompressor.FileName())
+			fmt.Printf("GetLatest(%s, %x) -> found in file %s\n", dt.name.String(), k, v0.src.decompressor.FileName())
 		}
 
 		if dt.getFromFileCache != nil && useCache {
 			dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: uint8(i), v: v})
 		}
-		return v, true, dt.files[i].startTxNum, dt.files[i].endTxNum, nil
+		return v, true, v0.startTxNum, v0.endTxNum, nil
 	}
 	if traceGetLatest == dt.name {
 		fmt.Printf("GetLatest(%s, %x) -> not found in %d files\n", dt.name.String(), k, len(dt.files))

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1431,26 +1431,26 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 
 	// Walk newest→oldest; skip files starting strictly after maxTxNum so a key's
 	// last write in an older .kv is still found (walkback bounded by maxTxNum).
-	for i, v0 := range slices.Backward(dt.files) {
-		if maxTxNum != math.MaxUint64 && v0.startTxNum > maxTxNum {
+	for i, f := range slices.Backward(dt.files) {
+		if maxTxNum != math.MaxUint64 && f.startTxNum > maxTxNum {
 			continue
 		}
 		// fmt.Printf("getLatestFromFiles: lim=%d %d %d %d %d\n", maxTxNum, dt.files[i].startTxNum, dt.files[i].endTxNum, dt.files[i].startTxNum/dt.stepSize, dt.files[i].endTxNum/dt.stepSize)
 		if useExistenceFilter {
-			if v0.src.existence != nil {
-				if !v0.src.existence.ContainsHash(hi) {
+			if f.src.existence != nil {
+				if !f.src.existence.ContainsHash(hi) {
 					if traceGetLatest == dt.name {
-						fmt.Printf("GetLatest(%s, %x) -> existence index %s -> false\n", dt.d.FilenameBase, k, v0.src.existence.FileName)
+						fmt.Printf("GetLatest(%s, %x) -> existence index %s -> false\n", dt.d.FilenameBase, k, f.src.existence.FileName)
 					}
 					continue
 				} else {
 					if traceGetLatest == dt.name {
-						fmt.Printf("GetLatest(%s, %x) -> existence index %s -> true\n", dt.d.FilenameBase, k, v0.src.existence.FileName)
+						fmt.Printf("GetLatest(%s, %x) -> existence index %s -> true\n", dt.d.FilenameBase, k, f.src.existence.FileName)
 					}
 				}
 			} else {
 				if traceGetLatest == dt.name {
-					fmt.Printf("GetLatest(%s, %x) -> existence index is nil %s\n", dt.name.String(), k, v0.src.decompressor.FileName())
+					fmt.Printf("GetLatest(%s, %x) -> existence index is nil %s\n", dt.name.String(), k, f.src.decompressor.FileName())
 				}
 			}
 		}
@@ -1461,18 +1461,18 @@ func (dt *DomainRoTx) getLatestFromFiles(k []byte, maxTxNum uint64) (v []byte, f
 		}
 		if !found {
 			if traceGetLatest == dt.name {
-				fmt.Printf("GetLatest(%s, %x) -> not found in file %s\n", dt.name.String(), k, v0.src.decompressor.FileName())
+				fmt.Printf("GetLatest(%s, %x) -> not found in file %s\n", dt.name.String(), k, f.src.decompressor.FileName())
 			}
 			continue
 		}
 		if traceGetLatest == dt.name {
-			fmt.Printf("GetLatest(%s, %x) -> found in file %s\n", dt.name.String(), k, v0.src.decompressor.FileName())
+			fmt.Printf("GetLatest(%s, %x) -> found in file %s\n", dt.name.String(), k, f.src.decompressor.FileName())
 		}
 
 		if dt.getFromFileCache != nil && useCache {
 			dt.getFromFileCache.Add(hi, domainGetFromFileCacheItem{lvl: uint8(i), v: v})
 		}
-		return v, true, v0.startTxNum, v0.endTxNum, nil
+		return v, true, f.startTxNum, f.endTxNum, nil
 	}
 	if traceGetLatest == dt.name {
 		fmt.Printf("GetLatest(%s, %x) -> not found in %d files\n", dt.name.String(), k, len(dt.files))

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -29,6 +29,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -2945,9 +2946,9 @@ func TestDomainContext_findShortenedKey(t *testing.T) {
 		v, found, st, en, err := domainRoTx.getLatestFromFiles([]byte(key), 0)
 		require.True(t, found)
 		require.NoError(t, err)
-		for i := len(updates) - 1; i >= 0; i-- {
-			if st <= updates[i].txNum && updates[i].txNum < en {
-				require.Equal(t, updates[i].value, v)
+		for _, update := range slices.Backward(updates) {
+			if st <= update.txNum && update.txNum < en {
+				require.Equal(t, update.value, v)
 				break
 			}
 		}

--- a/db/state/integrity.go
+++ b/db/state/integrity.go
@@ -80,13 +80,13 @@ func (at *AggregatorRoTx) IntegrityInvertedIndexAllValuesAreInRange(ctx context.
 
 func (dt *DomainRoTx) IntegrityDomainFilesWithKey(k []byte) (res []string, err error) {
 	hi, lo := dt.ht.iit.hashKey(k)
-	for i, v := range slices.Backward(dt.files) {
+	for i, f := range slices.Backward(dt.files) {
 		_, ok, _, err := dt.getLatestFromFile(i, k, hi, lo)
 		if err != nil {
 			return res, err
 		}
 		if ok {
-			res = append(res, v.src.decompressor.FileName())
+			res = append(res, f.src.decompressor.FileName())
 		}
 	}
 	return res, nil

--- a/db/state/integrity.go
+++ b/db/state/integrity.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -79,13 +80,13 @@ func (at *AggregatorRoTx) IntegrityInvertedIndexAllValuesAreInRange(ctx context.
 
 func (dt *DomainRoTx) IntegrityDomainFilesWithKey(k []byte) (res []string, err error) {
 	hi, lo := dt.ht.iit.hashKey(k)
-	for i := len(dt.files) - 1; i >= 0; i-- {
+	for i, v := range slices.Backward(dt.files) {
 		_, ok, _, err := dt.getLatestFromFile(i, k, hi, lo)
 		if err != nil {
 			return res, err
 		}
 		if ok {
-			res = append(res, dt.files[i].src.decompressor.FileName())
+			res = append(res, v.src.decompressor.FileName())
 		}
 	}
 	return res, nil

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -671,18 +671,18 @@ func (iit *InvertedIndexRoTx) iterateRangeOnFiles(key []byte, startTxNum, endTxN
 		ii:          iit,
 	}
 	if asc {
-		for _, v := range slices.Backward(iit.files) {
+		for _, f := range slices.Backward(iit.files) {
 			// [from,to) && from < to
-			if endTxNum >= 0 && int(v.startTxNum) >= endTxNum {
+			if endTxNum >= 0 && int(f.startTxNum) >= endTxNum {
 				continue
 			}
-			if startTxNum >= 0 && v.endTxNum <= uint64(startTxNum) {
+			if startTxNum >= 0 && f.endTxNum <= uint64(startTxNum) {
 				break
 			}
-			if v.src.index.KeyCount() == 0 {
+			if f.src.index.KeyCount() == 0 {
 				continue
 			}
-			it.stack = append(it.stack, v)
+			it.stack = append(it.stack, f)
 			it.stack[len(it.stack)-1].getter = it.stack[len(it.stack)-1].src.decompressor.MakeGetter()
 			it.stack[len(it.stack)-1].reader = it.stack[len(it.stack)-1].src.index.Reader()
 			it.hasNext = true

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -670,18 +671,18 @@ func (iit *InvertedIndexRoTx) iterateRangeOnFiles(key []byte, startTxNum, endTxN
 		ii:          iit,
 	}
 	if asc {
-		for i := len(iit.files) - 1; i >= 0; i-- {
+		for _, v := range slices.Backward(iit.files) {
 			// [from,to) && from < to
-			if endTxNum >= 0 && int(iit.files[i].startTxNum) >= endTxNum {
+			if endTxNum >= 0 && int(v.startTxNum) >= endTxNum {
 				continue
 			}
-			if startTxNum >= 0 && iit.files[i].endTxNum <= uint64(startTxNum) {
+			if startTxNum >= 0 && v.endTxNum <= uint64(startTxNum) {
 				break
 			}
-			if iit.files[i].src.index.KeyCount() == 0 {
+			if v.src.index.KeyCount() == 0 {
 				continue
 			}
-			it.stack = append(it.stack, iit.files[i])
+			it.stack = append(it.stack, v)
 			it.stack[len(it.stack)-1].getter = it.stack[len(it.stack)-1].src.decompressor.MakeGetter()
 			it.stack[len(it.stack)-1].reader = it.stack[len(it.stack)-1].src.index.Reader()
 			it.hasNext = true

--- a/db/state/snap_repo.go
+++ b/db/state/snap_repo.go
@@ -222,9 +222,10 @@ func (f *SnapshotRepo) CloseFilesAfterRootNum(after RootNum) {
 }
 
 func (f *SnapshotRepo) CloseVisibleFilesAfterRootNum(after RootNum) {
-	var i int
-	for _, v := range slices.Backward(f.current) {
-		if v.endTxNum <= uint64(after) {
+	i := -1
+	for idx, item := range slices.Backward(f.current) {
+		if item.endTxNum <= uint64(after) {
+			i = idx
 			break
 		}
 	}
@@ -480,9 +481,9 @@ func getFreezingRange(rootFrom, rootTo RootNum, cfg *SnapshotConfig) (freezeFrom
 	if from%mergeLimit == 0 {
 		maxJump = mergeLimit
 	} else {
-		for _, v := range slices.Backward(cfg.MergeStages) {
-			if from%v == 0 {
-				maxJump = v
+		for _, stage := range slices.Backward(cfg.MergeStages) {
+			if from%stage == 0 {
+				maxJump = stage
 				break
 			}
 		}
@@ -499,9 +500,9 @@ func getFreezingRange(rootFrom, rootTo RootNum, cfg *SnapshotConfig) (freezeFrom
 	case jump >= cfg.MergeStages[0]:
 		// else find if a merge step can be used
 		// assuming merge step multiple of each other
-		for _, v := range slices.Backward(cfg.MergeStages) {
-			if jump >= v {
-				_freezeTo = _freezeFrom + v
+		for _, stage := range slices.Backward(cfg.MergeStages) {
+			if jump >= stage {
+				_freezeTo = _freezeFrom + stage
 				break
 			}
 		}

--- a/db/state/snap_repo.go
+++ b/db/state/snap_repo.go
@@ -3,6 +3,7 @@ package state
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datastruct/btindex"
@@ -222,8 +223,8 @@ func (f *SnapshotRepo) CloseFilesAfterRootNum(after RootNum) {
 
 func (f *SnapshotRepo) CloseVisibleFilesAfterRootNum(after RootNum) {
 	var i int
-	for i = len(f.current) - 1; i >= 0; i-- {
-		if f.current[i].endTxNum <= uint64(after) {
+	for _, v := range slices.Backward(f.current) {
+		if v.endTxNum <= uint64(after) {
 			break
 		}
 	}
@@ -479,9 +480,9 @@ func getFreezingRange(rootFrom, rootTo RootNum, cfg *SnapshotConfig) (freezeFrom
 	if from%mergeLimit == 0 {
 		maxJump = mergeLimit
 	} else {
-		for i := len(cfg.MergeStages) - 1; i >= 0; i-- {
-			if from%cfg.MergeStages[i] == 0 {
-				maxJump = cfg.MergeStages[i]
+		for _, v := range slices.Backward(cfg.MergeStages) {
+			if from%v == 0 {
+				maxJump = v
 				break
 			}
 		}
@@ -498,9 +499,9 @@ func getFreezingRange(rootFrom, rootTo RootNum, cfg *SnapshotConfig) (freezeFrom
 	case jump >= cfg.MergeStages[0]:
 		// else find if a merge step can be used
 		// assuming merge step multiple of each other
-		for i := len(cfg.MergeStages) - 1; i >= 0; i-- {
-			if jump >= cfg.MergeStages[i] {
-				_freezeTo = _freezeFrom + cfg.MergeStages[i]
+		for _, v := range slices.Backward(cfg.MergeStages) {
+			if jump >= v {
+				_freezeTo = _freezeFrom + v
 				break
 			}
 		}

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -882,11 +882,11 @@ func (sd *TemporalMemBatch) flushWriters(ctx context.Context, tx kv.RwTx) error 
 		aggTx.d[di].closeValsCursor() //TODO: why?
 		w.Close()
 	}
-	for _, v := range slices.Backward(sd.pastIIWriters) {
-		if err := v.Flush(ctx, tx); err != nil {
+	for _, writer := range slices.Backward(sd.pastIIWriters) {
+		if err := writer.Flush(ctx, tx); err != nil {
 			return err
 		}
-		v.close()
+		writer.close()
 	}
 	for _, w := range sd.iiWriters {
 		if w == nil {

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -864,11 +865,11 @@ func (sd *TemporalMemBatch) flushDiffSet(_ context.Context, tx kv.RwTx) error {
 func (sd *TemporalMemBatch) flushWriters(ctx context.Context, tx kv.RwTx) error {
 	aggTx := AggTx(tx)
 	for _, ws := range sd.pastDomainWriters {
-		for i := len(ws) - 1; i >= 0; i-- {
-			if err := ws[i].Flush(ctx, tx); err != nil {
+		for _, w := range slices.Backward(ws) {
+			if err := w.Flush(ctx, tx); err != nil {
 				return err
 			}
-			ws[i].Close()
+			w.Close()
 		}
 	}
 	for di, w := range sd.domainWriters {
@@ -881,11 +882,11 @@ func (sd *TemporalMemBatch) flushWriters(ctx context.Context, tx kv.RwTx) error 
 		aggTx.d[di].closeValsCursor() //TODO: why?
 		w.Close()
 	}
-	for i := len(sd.pastIIWriters) - 1; i >= 0; i-- {
-		if err := sd.pastIIWriters[i].Flush(ctx, tx); err != nil {
+	for _, v := range slices.Backward(sd.pastIIWriters) {
+		if err := v.Flush(ctx, tx); err != nil {
 			return err
 		}
-		sd.pastIIWriters[i].close()
+		v.close()
 	}
 	for _, w := range sd.iiWriters {
 		if w == nil {

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"math/bits"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -3097,8 +3098,8 @@ func HexTrieStateToString(enc []byte) (string, error) {
 	printAfterMap := func(sb *strings.Builder, name string, list []uint16, depths []int16, existedBefore []bool) {
 		fmt.Fprintf(sb, "\t::%s::\n\n", name)
 		lastNonZero := 0
-		for i := len(list) - 1; i >= 0; i-- {
-			if list[i] != 0 {
+		for i, l := range slices.Backward(list) {
+			if l != 0 {
 				lastNonZero = i
 				break
 			}

--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"net"
 	"path"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -179,8 +180,8 @@ type cleanupHandle struct {
 func (h *cleanupHandle) close() error {
 	h.once.Do(func() {
 		var errs []error
-		for i := len(h.cleanups) - 1; i >= 0; i-- {
-			err := h.cleanups[i]()
+		for _, v := range slices.Backward(h.cleanups) {
+			err := v()
 			if err != nil {
 				errs = append(errs, err)
 			}

--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -180,8 +180,8 @@ type cleanupHandle struct {
 func (h *cleanupHandle) close() error {
 	h.once.Do(func() {
 		var errs []error
-		for _, v := range slices.Backward(h.cleanups) {
-			err := v()
+		for _, cleanup := range slices.Backward(h.cleanups) {
+			err := cleanup()
 			if err != nil {
 				errs = append(errs, err)
 			}

--- a/execution/execmodule/getters.go
+++ b/execution/execmodule/getters.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/holiman/uint256"
 
@@ -226,8 +227,8 @@ func (e *ExecModule) GetBodiesByRange(ctx context.Context, start, count uint64) 
 	}
 	// Remove trailing nil values as per spec
 	// See point 4 in https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#specification-4
-	for i := len(bodies) - 1; i >= 0; i-- {
-		if bodies[i] == nil {
+	for i, bodie := range slices.Backward(bodies) {
+		if bodie == nil {
 			bodies = bodies[:i]
 		} else {
 			break
@@ -336,8 +337,8 @@ func (e *ExecModule) GetPayloadBodiesByRange(ctx context.Context, start, count u
 		})
 	}
 	// Remove trailing nil values
-	for i := len(bodies) - 1; i >= 0; i-- {
-		if bodies[i] == nil {
+	for i, bodie := range slices.Backward(bodies) {
+		if bodie == nil {
 			bodies = bodies[:i]
 		} else {
 			break

--- a/execution/execmodule/getters.go
+++ b/execution/execmodule/getters.go
@@ -227,8 +227,8 @@ func (e *ExecModule) GetBodiesByRange(ctx context.Context, start, count uint64) 
 	}
 	// Remove trailing nil values as per spec
 	// See point 4 in https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#specification-4
-	for i, bodie := range slices.Backward(bodies) {
-		if bodie == nil {
+	for i, body := range slices.Backward(bodies) {
+		if body == nil {
 			bodies = bodies[:i]
 		} else {
 			break
@@ -337,8 +337,8 @@ func (e *ExecModule) GetPayloadBodiesByRange(ctx context.Context, start, count u
 		})
 	}
 	// Remove trailing nil values
-	for i, bodie := range slices.Backward(bodies) {
-		if bodie == nil {
+	for i, body := range slices.Backward(bodies) {
+		if body == nil {
 			bodies = bodies[:i]
 		} else {
 			break

--- a/execution/p2p/bbd.go
+++ b/execution/p2p/bbd.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -348,8 +349,8 @@ func (bbd *BackwardBlockDownloader) downloadHeaderChainBackwards(
 
 		// collect the headers batch into the etl and check for a connecting point
 		headers := resp.Data
-		for i := len(headers) - 1; i >= 0; i-- {
-			header := headers[i]
+		for _, header := range slices.Backward(headers) {
+
 			headerNum := header.Number.Uint64()
 			if headerNum == 0 {
 				break

--- a/execution/p2p/bbd.go
+++ b/execution/p2p/bbd.go
@@ -350,7 +350,6 @@ func (bbd *BackwardBlockDownloader) downloadHeaderChainBackwards(
 		// collect the headers batch into the etl and check for a connecting point
 		headers := resp.Data
 		for _, header := range slices.Backward(headers) {
-
 			headerNum := header.Number.Uint64()
 			if headerNum == 0 {
 				break

--- a/execution/protocol/rules/aura/validators.go
+++ b/execution/protocol/rules/aura/validators.go
@@ -270,9 +270,9 @@ func (s *Multi) correctSet(blockHash common.Hash) (ValidatorSet, bool) {
 func (s *Multi) correctSetByNumber(parentNumber uint64) (uint64, ValidatorSet) {
 	// get correct set by block number, along with block number at which
 	// this set was activated.
-	for _, v := range slices.Backward(s.sorted) {
-		if v.num <= parentNumber+1 {
-			return v.num, v.set
+	for _, entry := range slices.Backward(s.sorted) {
+		if entry.num <= parentNumber+1 {
+			return entry.num, entry.set
 		}
 	}
 	panic("constructor validation ensures that there is at least one validator set for block 0; block 0 is less than any uint; qed")

--- a/execution/protocol/rules/aura/validators.go
+++ b/execution/protocol/rules/aura/validators.go
@@ -270,9 +270,9 @@ func (s *Multi) correctSet(blockHash common.Hash) (ValidatorSet, bool) {
 func (s *Multi) correctSetByNumber(parentNumber uint64) (uint64, ValidatorSet) {
 	// get correct set by block number, along with block number at which
 	// this set was activated.
-	for i := len(s.sorted) - 1; i >= 0; i-- {
-		if s.sorted[i].num <= parentNumber+1 {
-			return s.sorted[i].num, s.sorted[i].set
+	for _, v := range slices.Backward(s.sorted) {
+		if v.num <= parentNumber+1 {
+			return v.num, v.set
 		}
 	}
 	panic("constructor validation ensures that there is at least one validator set for block 0; block 0 is less than any uint; qed")
@@ -669,8 +669,8 @@ func (s *ValidatorSafeContract) extractFromEvent(header *types.Header, receipts 
 	// iterate in reverse because only the _last_ change in a given
 	// block actually has any effect.
 	// the contract should only increment the nonce once.
-	for j := len(receipts) - 1; j >= 0; j-- {
-		logs := receipts[j].Logs
+	for _, receipt := range slices.Backward(receipts) {
+		logs := receipt.Logs
 		/*
 			TODO: skipped next bloom check (is it required?)
 					expectedBloom := expected_bloom(&self, header: &Header) -> Bloom {

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -135,8 +135,8 @@ func (e *decodeError) Error() string {
 	ctx := ""
 	if len(e.ctx) > 0 {
 		ctx = ", decoding into "
-		for _, v := range slices.Backward(e.ctx) {
-			ctx += v
+		for _, c := range slices.Backward(e.ctx) {
+			ctx += c
 		}
 	}
 	return fmt.Sprintf("rlp: %s for %v%s", e.msg, e.typ, ctx)

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 
@@ -134,8 +135,8 @@ func (e *decodeError) Error() string {
 	ctx := ""
 	if len(e.ctx) > 0 {
 		ctx = ", decoding into "
-		for i := len(e.ctx) - 1; i >= 0; i-- {
-			ctx += e.ctx[i]
+		for _, v := range slices.Backward(e.ctx) {
+			ctx += v
 		}
 	}
 	return fmt.Sprintf("rlp: %s for %v%s", e.msg, e.typ, ctx)

--- a/execution/stagedsync/calc_state.go
+++ b/execution/stagedsync/calc_state.go
@@ -3,6 +3,7 @@ package stagedsync
 import (
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/holiman/uint256"
 
@@ -293,9 +294,9 @@ type hasTxIndex interface{ GetIndex() uint32 }
 // a reverse scan stops at the first in-range element. maxTxIndex == MaxUint32
 // selects the block-end value (the whole block).
 func finalChangeUpTo[T hasTxIndex](changes []T, maxTxIndex uint32) (T, bool) {
-	for i := len(changes) - 1; i >= 0; i-- {
-		if changes[i].GetIndex() <= maxTxIndex {
-			return changes[i], true
+	for _, change := range slices.Backward(changes) {
+		if change.GetIndex() <= maxTxIndex {
+			return change, true
 		}
 	}
 	var zero T

--- a/execution/tracing/tracers/logger/logger.go
+++ b/execution/tracing/tracers/logger/logger.go
@@ -347,8 +347,8 @@ func WriteTrace(writer io.Writer, logs []StructLog) {
 
 		if len(log.Stack) > 0 {
 			fmt.Fprintln(writer, "Stack:")
-			for i, v := range slices.Backward(log.Stack) {
-				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, math.PaddedBigBytes(v, 32))
+			for i, val := range slices.Backward(log.Stack) {
+				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, math.PaddedBigBytes(val, 32))
 			}
 		}
 		if len(log.Memory) > 0 {

--- a/execution/tracing/tracers/logger/logger.go
+++ b/execution/tracing/tracers/logger/logger.go
@@ -25,6 +25,7 @@ import (
 	"maps"
 	"math/big"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/holiman/uint256"
@@ -346,8 +347,8 @@ func WriteTrace(writer io.Writer, logs []StructLog) {
 
 		if len(log.Stack) > 0 {
 			fmt.Fprintln(writer, "Stack:")
-			for i := len(log.Stack) - 1; i >= 0; i-- {
-				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, math.PaddedBigBytes(log.Stack[i], 32))
+			for i, v := range slices.Backward(log.Stack) {
+				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, math.PaddedBigBytes(v, 32))
 			}
 		}
 		if len(log.Memory) > 0 {

--- a/node/app/component/component.go
+++ b/node/app/component/component.go
@@ -682,7 +682,7 @@ func (c *component) Name() string {
 		if c.provider != nil {
 			return fmt.Sprintf("%T(%p)", c, c)
 		}
-		return reflect.TypeOf(c).String()
+		return reflect.TypeFor[*component]().String()
 	}
 
 	return c.id.String()

--- a/node/app/event/eventbus_test.go
+++ b/node/app/event/eventbus_test.go
@@ -71,7 +71,7 @@ func TestHasCallback(t *testing.T) {
 
 	assert.Nil(t, err, "Subscribe failed")
 
-	if bus.HasCallback(reflect.TypeOf("String")) {
+	if bus.HasCallback(reflect.TypeFor[string]()) {
 		t.Fail()
 	}
 	if !bus.HasCallback() {

--- a/node/app/options.go
+++ b/node/app/options.go
@@ -43,7 +43,7 @@ func WithOption[T any](applicator func(t *T) bool) Option {
 
 func ApplyOptions[T any](t *T, options []Option) (remaining []Option) {
 	for _, opt := range options {
-		if opt.Target() == reflect.TypeOf(t).Elem() {
+		if opt.Target() == reflect.TypeFor[T]() {
 			if opt.Apply(t) {
 				continue
 			}

--- a/node/app/options.go
+++ b/node/app/options.go
@@ -34,9 +34,12 @@ func (o Option) Target() reflect.Type {
 }
 
 func WithOption[T any](applicator func(t *T) bool) Option {
-	var t T
+	target := reflect.TypeFor[T]()
+	if target == reflect.TypeFor[any]() {
+		target = nil
+	}
 	return Option{
-		target:     reflect.TypeOf(t),
+		target:     target,
 		applicator: func(t any) bool { return applicator(t.(*T)) },
 	}
 }

--- a/node/app/util/await.go
+++ b/node/app/util/await.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"sync"
 )
 
@@ -181,14 +182,7 @@ WAIT:
 		mux.pending = nil
 		var active []reflect.SelectCase
 		for _, a := range mux.active {
-			var remove bool
-			for _, r := range mux.pendingRemove {
-				if a.Chan == r {
-					remove = true
-					break
-				}
-			}
-
+			remove := slices.Contains(mux.pendingRemove, a.Chan)
 			if !remove {
 				active = append(active, a)
 			} else {

--- a/node/node.go
+++ b/node/node.go
@@ -212,9 +212,9 @@ func (n *Node) stopServices(running []Lifecycle) error {
 
 	// Stop running lifecycles in reverse order.
 	failure := &StopError{Services: make(map[reflect.Type]error)}
-	for i := len(running) - 1; i >= 0; i-- {
-		if err := running[i].Stop(); err != nil {
-			failure.Services[reflect.TypeOf(running[i])] = err
+	for _, r := range slices.Backward(running) {
+		if err := r.Stop(); err != nil {
+			failure.Services[reflect.TypeOf(r)] = err
 		}
 	}
 

--- a/polygon/bridge/snapshot_store.go
+++ b/polygon/bridge/snapshot_store.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/erigontech/erigon/common"
@@ -89,11 +90,11 @@ func (s *SnapshotStore) LastFrozenEventBlockNum() uint64 {
 	}
 	// find the last segment which has a built non-empty index
 	var lastSegment *snapshotsync.VisibleSegment
-	for i := len(segments) - 1; i >= 0; i-- {
-		if segments[i].Src().Index() != nil {
-			gg := segments[i].Src().MakeGetter()
+	for _, segment := range slices.Backward(segments) {
+		if segment.Src().Index() != nil {
+			gg := segment.Src().MakeGetter()
 			if gg.HasNext() {
-				lastSegment = segments[i]
+				lastSegment = segment
 				break
 			}
 		}
@@ -164,11 +165,11 @@ func (s *SnapshotStore) LastFrozenEventId() uint64 {
 	}
 	// find the last segment which has a built non-empty index
 	var lastSegment *snapshotsync.VisibleSegment
-	for i := len(segments) - 1; i >= 0; i-- {
-		if segments[i].Src().Index() != nil {
-			gg := segments[i].Src().MakeGetter()
+	for _, segment := range slices.Backward(segments) {
+		if segment.Src().Index() != nil {
+			gg := segment.Src().MakeGetter()
 			if gg.HasNext() {
-				lastSegment = segments[i]
+				lastSegment = segment
 				break
 			}
 		}
@@ -233,8 +234,8 @@ func (s *SnapshotStore) BlockEventIdsRange(ctx context.Context, blockHash common
 	defer tx.Close()
 	segments := tx.Segments
 
-	for i := len(segments) - 1; i >= 0; i-- {
-		sn := segments[i]
+	for _, sn := range slices.Backward(segments) {
+
 		if sn.From() > blockNum {
 			continue
 		}
@@ -290,15 +291,15 @@ func (s *SnapshotStore) events(ctx context.Context, start, end, blockNumber uint
 	var buf []byte
 	var result [][]byte
 
-	for i := len(segments) - 1; i >= 0; i-- {
-		if segments[i].From() > blockNumber {
+	for _, segment := range slices.Backward(segments) {
+		if segment.From() > blockNumber {
 			continue
 		}
-		if segments[i].To() <= blockNumber {
+		if segment.To() <= blockNumber {
 			break
 		}
 
-		gg0 := segments[i].Src().MakeGetter()
+		gg0 := segment.Src().MakeGetter()
 
 		if !gg0.HasNext() {
 			continue
@@ -331,8 +332,8 @@ func (s *SnapshotStore) events(ctx context.Context, start, end, blockNumber uint
 }
 
 func (s *SnapshotStore) borBlockByEventHash(txnHash common.Hash, segments []*snapshotsync.VisibleSegment, buf []byte) (blockNum uint64, ok bool, err error) {
-	for i := len(segments) - 1; i >= 0; i-- {
-		sn := segments[i]
+	for _, sn := range slices.Backward(segments) {
+
 		idxBorTxnHash := sn.Src().Index()
 
 		if idxBorTxnHash == nil {

--- a/polygon/bridge/snapshot_store.go
+++ b/polygon/bridge/snapshot_store.go
@@ -235,7 +235,6 @@ func (s *SnapshotStore) BlockEventIdsRange(ctx context.Context, blockHash common
 	segments := tx.Segments
 
 	for _, sn := range slices.Backward(segments) {
-
 		if sn.From() > blockNum {
 			continue
 		}
@@ -333,7 +332,6 @@ func (s *SnapshotStore) events(ctx context.Context, start, end, blockNumber uint
 
 func (s *SnapshotStore) borBlockByEventHash(txnHash common.Hash, segments []*snapshotsync.VisibleSegment, buf []byte) (blockNum uint64, ok bool, err error) {
 	for _, sn := range slices.Backward(segments) {
-
 		idxBorTxnHash := sn.Src().Index()
 
 		if idxBorTxnHash == nil {

--- a/polygon/heimdall/snapshot_store.go
+++ b/polygon/heimdall/snapshot_store.go
@@ -140,8 +140,8 @@ func (s *SpanSnapshotStore) snapshotsReverseForEach(f func(span Span) (stop bool
 	defer tx.Close()
 	segments := tx.Segments
 	// walk the segment files backwards
-	for i := len(segments) - 1; i >= 0; i-- {
-		sn := segments[i]
+	for _, sn := range slices.Backward(segments) {
+
 		idx := sn.Src().Index()
 		if idx == nil || idx.KeyCount() == 0 {
 			continue
@@ -196,11 +196,11 @@ func (s *SpanSnapshotStore) LastFrozenEntityId() (uint64, bool, error) {
 	}
 	// find the last segment which has a built non-empty index
 	var lastSegment *snapshotsync.VisibleSegment
-	for i := len(segments) - 1; i >= 0; i-- {
-		if segments[i].Src().Index() != nil {
-			gg := segments[i].Src().MakeGetter()
+	for _, segment := range slices.Backward(segments) {
+		if segment.Src().Index() != nil {
+			gg := segment.Src().MakeGetter()
 			if gg.HasNext() {
-				lastSegment = segments[i]
+				lastSegment = segment
 				break
 			}
 		}
@@ -238,8 +238,8 @@ func (s *SpanSnapshotStore) Entity(ctx context.Context, id uint64) (*Span, bool,
 	defer tx.Close()
 	segments := tx.Segments
 
-	for i := len(segments) - 1; i >= 0; i-- {
-		sn := segments[i]
+	for _, sn := range slices.Backward(segments) {
+
 		idx := sn.Src().Index()
 
 		if idx == nil || idx.KeyCount() == 0 {
@@ -351,8 +351,8 @@ func (s *CheckpointSnapshotStore) Entity(ctx context.Context, id uint64) (*Check
 	defer tx.Close()
 	segments := tx.Segments
 
-	for i := len(segments) - 1; i >= 0; i-- {
-		sn := segments[i]
+	for _, sn := range slices.Backward(segments) {
+
 		index := sn.Src().Index()
 
 		if index == nil || index.KeyCount() == 0 || id < index.BaseDataID() {
@@ -389,11 +389,11 @@ func (s *CheckpointSnapshotStore) LastFrozenEntityId() (uint64, bool, error) {
 	}
 	// find the last segment which has a built non-empty index
 	var lastSegment *snapshotsync.VisibleSegment
-	for i := len(segments) - 1; i >= 0; i-- {
-		if segments[i].Src().Index() != nil {
-			gg := segments[i].Src().MakeGetter()
+	for _, segment := range slices.Backward(segments) {
+		if segment.Src().Index() != nil {
+			gg := segment.Src().MakeGetter()
 			if gg.HasNext() {
-				lastSegment = segments[i]
+				lastSegment = segment
 				break
 			}
 		}
@@ -561,8 +561,8 @@ func snapshotStoreRangeFromBlockNum[T Entity](
 	var snapshotEntities []T
 
 OUTER:
-	for i := len(segments) - 1; i >= 0; i-- {
-		sn := segments[i]
+	for _, sn := range slices.Backward(segments) {
+
 		idx := sn.Src().Index()
 		if idx == nil || idx.KeyCount() == 0 {
 			continue

--- a/polygon/heimdall/snapshot_store.go
+++ b/polygon/heimdall/snapshot_store.go
@@ -141,7 +141,6 @@ func (s *SpanSnapshotStore) snapshotsReverseForEach(f func(span Span) (stop bool
 	segments := tx.Segments
 	// walk the segment files backwards
 	for _, sn := range slices.Backward(segments) {
-
 		idx := sn.Src().Index()
 		if idx == nil || idx.KeyCount() == 0 {
 			continue
@@ -239,7 +238,6 @@ func (s *SpanSnapshotStore) Entity(ctx context.Context, id uint64) (*Span, bool,
 	segments := tx.Segments
 
 	for _, sn := range slices.Backward(segments) {
-
 		idx := sn.Src().Index()
 
 		if idx == nil || idx.KeyCount() == 0 {
@@ -352,7 +350,6 @@ func (s *CheckpointSnapshotStore) Entity(ctx context.Context, id uint64) (*Check
 	segments := tx.Segments
 
 	for _, sn := range slices.Backward(segments) {
-
 		index := sn.Src().Index()
 
 		if index == nil || index.KeyCount() == 0 || id < index.BaseDataID() {
@@ -562,7 +559,6 @@ func snapshotStoreRangeFromBlockNum[T Entity](
 
 OUTER:
 	for _, sn := range slices.Backward(segments) {
-
 		idx := sn.Src().Index()
 		if idx == nil || idx.KeyCount() == 0 {
 			continue

--- a/rpc/jsonrpc/erigon_receipts_test.go
+++ b/rpc/jsonrpc/erigon_receipts_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"slices"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -83,10 +84,10 @@ func TestErigonGetLatestLogs(t *testing.T) {
 	expectedLogs, _ := api.GetLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())})
 
 	expectedErigonLogs := make(types.ErigonLogs, 0)
-	for i := len(expectedLogs) - 1; i >= 0; i-- {
+	for _, expectedLog := range slices.Backward(expectedLogs) {
 		expectedErigonLogs = append(expectedErigonLogs, &types.ErigonLog{
-			Log:       expectedLogs[i].Log,
-			Timestamp: expectedLogs[i].Timestamp,
+			Log:       expectedLog.Log,
+			Timestamp: expectedLog.Timestamp,
 		})
 	}
 	actual, err := api.GetLatestLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())}, filters.LogFilterOptions{
@@ -123,10 +124,10 @@ func TestErigonGetLatestLogsIgnoreTopics(t *testing.T) {
 	expectedLogs, _ := api.GetLogs(m.Ctx, filters.FilterCriteria{FromBlock: big.NewInt(0), ToBlock: big.NewInt(rpc.LatestBlockNumber.Int64())})
 
 	expectedErigonLogs := make([]*types.ErigonLog, 0)
-	for i := len(expectedLogs) - 1; i >= 0; i-- {
+	for _, expectedLog := range slices.Backward(expectedLogs) {
 		expectedErigonLogs = append(expectedErigonLogs, &types.ErigonLog{
-			Log:       expectedLogs[i].Log,
-			Timestamp: expectedLogs[i].Timestamp,
+			Log:       expectedLog.Log,
+			Timestamp: expectedLog.Timestamp,
 		})
 	}
 

--- a/rpc/mcp/metrics/gather_test.go
+++ b/rpc/mcp/metrics/gather_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -72,13 +73,7 @@ func TestListMetricNames(t *testing.T) {
 	}
 
 	// Check if our test metric is in the list
-	found := false
-	for _, name := range names {
-		if name == "test_mcp_counter" {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(names, "test_mcp_counter")
 
 	if !found {
 		t.Error("test_mcp_counter not found in metric names")


### PR DESCRIPTION
This PR enables the `reflecttypefor`, `slicesbackward`, and `slicescontains` modernisation checkers in the `modernize` linter section of `.golangci.yml`, and modernises their usage across the entire codebase.

In particular, the following modernisations were introduced:

* **Reflect Type For (`reflecttypefor`)**: Modernized type discovery calls to use Go 1.22's clean generic function `reflect.TypeFor[T]()` instead of traditional `reflect.TypeOf((*T)(nil)).Elem()` or value-based type discovery.
* **Slices Backward (`slicesbackward`)**: Replaced traditional reverse slice iteration loops (e.g. `for i := len(s) - 1; i >= 0; i--`) with Go 1.22's native `for i, v := range slices.Backward(s)` iterator function.
* **Slices Contains (`slicescontains`)**: Modernized manual search loops checking slice membership to use Go 1.21/1.22's native `slices.Contains(slice, element)` utility.

part of #22199