### PR TITLE
cl/merkle_tree: stack-allocate HashTreeRoot leaf buffer

### DIFF
--- a/cl/merkle_tree/merkle_root.go
+++ b/cl/merkle_tree/merkle_root.go
@@ -31,12 +31,23 @@ import (
 	"github.com/erigontech/erigon/common/ssz"
 )
 
+// maxStackLeaves covers every SSZ schema we hash, so the leaf buffer stays off the
+// heap; anything larger falls back to make. The array is zeroed on every call, so
+// it is sized to the schemas we actually see rather than generously.
+const maxStackLeaves = 32
+
 // HashTreeRoot returns the hash for a given schema of objects.
 // IMPORTANT: DATA TYPE MUST IMPLEMENT HASHABLE
 // SUPPORTED PRIMITIVES: uint64, *uint64 and []byte
 func HashTreeRoot(schema ...any) ([32]byte, error) {
-	// Calculate the total number of leaves needed based on the schema length
-	leaves := make([]byte, NextPowerOfTwo(uint64(len(schema)*length.Hash)))
+	var stack [maxStackLeaves * length.Hash]byte // stack-allocation for most of cases
+	size := NextPowerOfTwo(uint64(len(schema) * length.Hash))
+	var leaves []byte
+	if size <= uint64(len(stack)) {
+		leaves = stack[:size]
+	} else {
+		leaves = make([]byte, size)
+	}
 	pos := 0
 
 	// Iterate over each element in the schema
@@ -70,7 +81,7 @@ func HashTreeRoot(schema ...any) ([32]byte, error) {
 			copy(leaves[pos:], root[:])
 		default:
 			// If the element does not match any supported types, panic with an error message
-			panic(fmt.Sprintf("Can't create TreeRoot: unsported type %T at index %d", i, obj))
+			panic(fmt.Sprintf("Can't create TreeRoot: unsported type %T at index %d", obj, i))
 		}
 
 		// Move the position pointer to the next leaf

--- a/cl/merkle_tree/merkle_root.go
+++ b/cl/merkle_tree/merkle_root.go
@@ -40,6 +40,9 @@ const maxStackLeaves = 32
 // IMPORTANT: DATA TYPE MUST IMPLEMENT HASHABLE
 // SUPPORTED PRIMITIVES: uint64, *uint64 and []byte
 func HashTreeRoot(schema ...any) ([32]byte, error) {
+	if len(schema) == 0 {
+		return [32]byte{}, errors.New("empty schema")
+	}
 	var stack [maxStackLeaves * length.Hash]byte // stack-allocation for most of cases
 	size := NextPowerOfTwo(uint64(len(schema) * length.Hash))
 	var leaves []byte
@@ -81,7 +84,7 @@ func HashTreeRoot(schema ...any) ([32]byte, error) {
 			copy(leaves[pos:], root[:])
 		default:
 			// If the element does not match any supported types, panic with an error message
-			panic(fmt.Sprintf("Can't create TreeRoot: unsported type %T at index %d", obj, i))
+			panic(fmt.Sprintf("Can't create TreeRoot: unsupported type %T at index %d", obj, i))
 		}
 
 		// Move the position pointer to the next leaf

--- a/cl/merkle_tree/merkle_root_test.go
+++ b/cl/merkle_tree/merkle_root_test.go
@@ -39,6 +39,11 @@ func TestHashTreeRoot(t *testing.T) {
 	require.Equal(t, common.Hash(root), common.HexToHash("0x9f684cf34c4ac8eb9056051f93498c552b59de6b0977c453ee099be68e58d90c"))
 }
 
+func TestHashTreeRootEmptySchema(t *testing.T) {
+	_, err := merkle_tree.HashTreeRoot()
+	require.Error(t, err)
+}
+
 func TestHashTreeRootTxs(t *testing.T) {
 	txs := [][]byte{
 		{1, 2, 3},


### PR DESCRIPTION
`HashTreeRoot` sized its leaf buffer with a non-constant `make`, so every call heap-allocated it — 512 B/op, and 71% of the bytes allocated in a hashing benchmark. The buffer never outlives the call, so it goes on the stack, with a heap fallback for oversized schemas.

### Why 32

Sized from the schema-length distribution measured on **mainnet** (590k calls), not a source scan. A scan can't see call frequency, and misses `Eth1Block`/`Eth1Header`, which build their schema per fork (14 base, +1 Capella, +2 Deneb = **17 leaves**):

```
leaves     2:20.5%  3:14.2%  4:29.3%  5:21.9%  13:7.1%  17:7.1%
coverage   8(256B):85.8%   16(512B):92.9%   32(1024B):100%
```

benchstat, 12 runs, on that distribution:

| maxStackLeaves | sec/op | B/op | allocs/op |
|---|---|---|---|
| _current_ | 276.6n ± 1% | 468 | 2 |
| 8 | 234.3n ± 1% | 103 | 0 |
| 16 | 244.9n ± 6% | 69 | 0 |
| **32** | **234.3n ± 1%** | **0** | **0** |

32 is fastest-or-tied with the tightest variance and alone in never falling back — skipping the 1 KB allocation on the 17-leaf path pays for zeroing a larger array. Frame is `$1328-56`, well inside Go's 128 KB stack-var limit.

Also: return an error for an empty schema (previously panicked), and fix swapped arguments in the unsupported-type panic, which passed the index to `%T` and the value to `%d`.

### Not in scope

`merkleHasher` takes a package-global mutex for all merkleization, so `HashTreeRoot` at 16 threads is *slower* than at 1 (745 vs 554 ns/op). Removing it measured ~16× but needs a `sync.Pool` — `gohashtree.Hash`'s params are `leaks to {heap}` (assembly), so any buffer handed to it is forced off the stack. Separate PR.
