### PR TITLE
params: use final EIP-8282 builder contract addresses (v7.0.0)

### DIFF
--- a/execution/protocol/params/protocol.go
+++ b/execution/protocol/params/protocol.go
@@ -291,11 +291,11 @@ var (
 
 // EIP-8282 - The Builder Deposit Addresses
 // Nick's-method derived address from the builder deposit contract deployment transaction.
-var BuilderDepositAddress = accounts.InternAddress(common.HexToAddress("0x00006AE84ed173D4394de5E28F9ED56b28008282"))
+var BuilderDepositAddress = accounts.InternAddress(common.HexToAddress("0x0000BFF46984E3725691FA540A8C7589300D8282"))
 
 // EIP-8282 - The Builder Exit Addresses
 // Nick's-method derived address from the builder exit contract deployment transaction.
-var BuilderExitAddress = accounts.InternAddress(common.HexToAddress("0x000014574A74c805590AFF9499fc7A690f008282"))
+var BuilderExitAddress = accounts.InternAddress(common.HexToAddress("0x000064D678505AD48F8CCB093BC65613800E8282"))
 
 // See EIP-7840: Add blob schedule to EL config files
 type BlobConfig struct {


### PR DESCRIPTION
The glamsterdam-devnet-7 genesis deploys the EIP-8282 builder deposit and exit predeploys at the addresses re-mined for the v7.0.0 spec release (ethereum/EIPs#11899):

  deposit  0x0000BFF46984E3725691FA540A8C7589300D8282
  exit     0x000064D678505AD48F8CCB093BC65613800E8282

Erigon still pointed at the earlier draft addresses, so the builder-deposit system call at the Gloas fork hit a codeless account and block production failed:

  cannot finalize block execution: [EIP-8282] Syscall failure:
      Empty Code at BuilderDepositAddress=00006ae84ed173d4394de5e28f9ed56b28008282

An all-erigon network therefore halted at slot 7 and never crossed GLOAS_FORK_EPOCH. Verified against a 3-node erigon + lighthouse Kurtosis network on glamsterdam-devnet-7: before the change the chain never produced a block; after it the fork is crossed and the chain finalizes epoch 2 by slot 33 with all three nodes byte-identical and zero syscall failures.