### PR TITLE
agents, codex: add shared agent configuration

### DIFF
--- a/.agents/skills/autoresearch
+++ b/.agents/skills/autoresearch
@@ -1,0 +1,1 @@
+../../.claude/skills/autoresearch

--- a/.agents/skills/bal-devnet-ab-test
+++ b/.agents/skills/bal-devnet-ab-test
@@ -1,0 +1,1 @@
+../../.claude/skills/bal-devnet-ab-test

--- a/.agents/skills/benchmarkoor
+++ b/.agents/skills/benchmarkoor
@@ -1,0 +1,1 @@
+../../.claude/skills/benchmarkoor

--- a/.agents/skills/erigon-build
+++ b/.agents/skills/erigon-build
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-build

--- a/.agents/skills/erigon-cherry-pick
+++ b/.agents/skills/erigon-cherry-pick
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-cherry-pick

--- a/.agents/skills/erigon-ci
+++ b/.agents/skills/erigon-ci
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-ci

--- a/.agents/skills/erigon-datadir
+++ b/.agents/skills/erigon-datadir
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-datadir

--- a/.agents/skills/erigon-ephemeral
+++ b/.agents/skills/erigon-ephemeral
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-ephemeral

--- a/.agents/skills/erigon-exec-from-0
+++ b/.agents/skills/erigon-exec-from-0
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-exec-from-0

--- a/.agents/skills/erigon-implement-eip
+++ b/.agents/skills/erigon-implement-eip
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-implement-eip

--- a/.agents/skills/erigon-mdbx-compact
+++ b/.agents/skills/erigon-mdbx-compact
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-mdbx-compact

--- a/.agents/skills/erigon-network-ports
+++ b/.agents/skills/erigon-network-ports
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-network-ports

--- a/.agents/skills/erigon-seg-integrity
+++ b/.agents/skills/erigon-seg-integrity
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-seg-integrity

--- a/.agents/skills/erigon-seg-rebase
+++ b/.agents/skills/erigon-seg-rebase
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-seg-rebase

--- a/.agents/skills/erigon-seg-retire
+++ b/.agents/skills/erigon-seg-retire
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-seg-retire

--- a/.agents/skills/erigon-test-all
+++ b/.agents/skills/erigon-test-all
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-test-all

--- a/.agents/skills/erigon-test-hive
+++ b/.agents/skills/erigon-test-hive
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-test-hive

--- a/.agents/skills/erigon-test-race
+++ b/.agents/skills/erigon-test-race
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-test-race

--- a/.agents/skills/erigon-test-rpc
+++ b/.agents/skills/erigon-test-rpc
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-test-rpc

--- a/.agents/skills/erigon-test-unit
+++ b/.agents/skills/erigon-test-unit
@@ -1,0 +1,1 @@
+../../.claude/skills/erigon-test-unit

--- a/.agents/skills/erigondb-sync-integration-test-plan
+++ b/.agents/skills/erigondb-sync-integration-test-plan
@@ -1,0 +1,1 @@
+../../.claude/skills/erigondb-sync-integration-test-plan

--- a/.agents/skills/github-pr-cleanup
+++ b/.agents/skills/github-pr-cleanup
@@ -1,0 +1,1 @@
+../../.claude/skills/github-pr-cleanup

--- a/.agents/skills/hive-test
+++ b/.agents/skills/hive-test
@@ -1,0 +1,1 @@
+../../.claude/skills/hive-test

--- a/.agents/skills/kurtosis-test
+++ b/.agents/skills/kurtosis-test
@@ -1,0 +1,1 @@
+../../.claude/skills/kurtosis-test

--- a/.agents/skills/launch-devnet
+++ b/.agents/skills/launch-devnet
@@ -1,0 +1,1 @@
+../../.claude/skills/launch-devnet

--- a/.agents/skills/panda-install
+++ b/.agents/skills/panda-install
@@ -1,0 +1,1 @@
+../../.claude/skills/panda-install

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/comment-policy.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/comment-policy.py
+++ b/.codex/hooks/comment-policy.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Advisory PostToolUse hook: flag comment-policy violations in Go edits.
+
+Never blocks. On a Write/Edit to a *.go file it scans the ADDED text's comment
+lines for the narration the project keeps having to strip (scope/limitation,
+incident/reproduction, task references) and, if any are found, returns
+additionalContext so the model can self-correct in a follow-up edit.
+
+See .claude/rules/comments.md for the policy this enforces.
+"""
+import json
+import re
+import sys
+
+# (label, regex) — case-insensitive. Targeted at the recurring offenders, kept
+# conservative to avoid false-positive noise on legitimate why-comments.
+PATTERNS = [
+    ("scope/limitation narration (→ PR body)",
+     re.compile(r"forward[- ](only|prevention)|safety[- ]?net|cannot repair|snapshot unwind|\bNOTE:\s", re.I)),
+    ("incident/reproduction narration (→ PR body)",
+     re.compile(r"\bmainnet\b|\bblock[s]?\s+\d{6,9}\b|\b2[0-9]{7}\b|\bcalled\b.*\bblocks? later\b", re.I)),
+    ("task/PR/issue reference (→ commit msg / PR; keep only genuine workaround links)",
+     re.compile(r"#\d{3,6}\b|\bPR\s*#?\d{3,6}\b|as requested|in review")),
+]
+
+
+def added_comment_lines(tool_name, tool_input):
+    if tool_name == "Write":
+        text = tool_input.get("content", "")
+    elif tool_name in ("Edit", "MultiEdit"):
+        # new_string for Edit; concatenate edits for MultiEdit
+        if "new_string" in tool_input:
+            text = tool_input.get("new_string", "")
+        else:
+            text = "\n".join(e.get("new_string", "") for e in tool_input.get("edits", []))
+    else:
+        return []
+    out = []
+    for ln in text.splitlines():
+        s = ln.strip()
+        if s.startswith("//") or s.startswith("/*") or s.startswith("*"):
+            out.append(s)
+    return out
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # never interfere
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {}) or {}
+    path = tool_input.get("file_path", "")
+    if not path.endswith(".go"):
+        sys.exit(0)
+
+    comments = added_comment_lines(tool_name, tool_input)
+    if not comments:
+        sys.exit(0)
+
+    flagged = []
+    for line in comments:
+        for label, rx in PATTERNS:
+            if rx.search(line):
+                flagged.append((label, line))
+                break
+
+    if not flagged:
+        sys.exit(0)
+
+    msg = ["Comment-policy check (.claude/rules/comments.md) — review these added comment lines; "
+           "scope/incident/task narration belongs in the commit message or PR body, not the code:"]
+    for label, line in flagged[:12]:
+        snippet = line if len(line) <= 100 else line[:97] + "..."
+        msg.append(f"  - [{label}] {snippet}")
+    msg.append("If a flagged line is a genuine why-comment (e.g. a workaround issue link), keep it.")
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": "\n".join(msg),
+        }
+    }))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- expose the existing Claude skills to Codex through repository-local skill symlinks
- keep .claude/skills as the single source of truth for all 26 shared skills
- add the imported Codex comment-policy hook with a checkout-independent git-root path

## Validation

- make lint
- make erigon integration
- verified every skill symlink resolves to a SKILL.md file
- validated hooks.json and exercised the hook from a repository subdirectory