### PR TITLE
[r3.5] cl/phase1/stages: use utils.ETA for history-download progress log

### DIFF
--- a/cl/phase1/stages/stage_history_download.go
+++ b/cl/phase1/stages/stage_history_download.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/execution_client/block_collector"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/network"
+	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -106,22 +107,6 @@ func clampProgress(highestBlockSeen, floor, current uint64) (processed, total ui
 	floor = min(floor, highestBlockSeen)
 	processed = highestBlockSeen - current
 	total = max(highestBlockSeen-floor, processed)
-	return
-}
-
-// historyDownloadProgress derives EL history-download progress and ETA for
-// logging, guarding both the unsigned subtractions and the time.Duration
-// (int64 ns) multiplication against overflow.
-func historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock uint64, speed float64) (processed, toprocess uint64, eta time.Duration) {
-	processed, toprocess = clampProgress(highestBlockSeen, max(lowestBlockToReach, 1), currentBlock)
-	if speed > 0 {
-		secs := float64(toprocess-processed) / speed
-		if maxSecs := float64(math.MaxInt64) / float64(time.Second); secs > maxSecs {
-			eta = time.Duration(math.MaxInt64)
-		} else {
-			eta = time.Duration(secs) * time.Second
-		}
-	}
 	return
 }
 
@@ -368,10 +353,11 @@ func SpawnStageHistoryDownload(cfg StageHistoryReconstructionCfg, ctx context.Co
 				logger.Debug(logMsg, logArgs...)
 
 				if !isDownloadingForBeacon {
-					processed, toprocess, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, uint64(currEth1Progress.Load()), speed)
+					// Genesis block (0) is never collected, so the lowest reachable EL block is 1.
+					processed, toprocess := clampProgress(highestBlockSeen, max(lowestBlockToReach, 1), uint64(currEth1Progress.Load()))
 					log.Info("Downloading Execution History", "progress",
 						fmt.Sprintf("%d/%d", processed, toprocess),
-						"ETA", eta.String(),
+						"ETA", utils.ETA(toprocess-processed, speed),
 						"blk/sec", fmt.Sprintf("%.1f", speed))
 				} else {
 					processed, toprocess := clampProgress(highestBlockSeen, lowestBlockToReach, currProgress)

--- a/cl/phase1/stages/stage_history_download_test.go
+++ b/cl/phase1/stages/stage_history_download_test.go
@@ -19,35 +19,12 @@ package stages
 import (
 	"math"
 	"testing"
-	"time"
 )
 
-// The EL head (lowestBlockToReach) can advance past the highestBlockSeen frozen
-// at download start; the unsigned progress math must not underflow into a ~2^64
-// total and a garbage ETA.
-func TestHistoryDownloadProgress_ELHeadPastFrozenTip(t *testing.T) {
-	const (
-		highestBlockSeen   = uint64(23_000_000) // EL block number frozen at download start
-		lowestBlockToReach = uint64(23_123_953) // live EL head, 123953 blocks higher
-		currentBlock       = uint64(22_983_559) // downloader 16441 below the frozen top
-	)
-	const speed = 12.9
-
-	processed, toprocess, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock, speed)
-
-	if toprocess > highestBlockSeen {
-		t.Fatalf("toprocess underflowed: got %d, want <= %d", toprocess, highestBlockSeen)
-	}
-	if processed > toprocess {
-		t.Fatalf("processed (%d) must not exceed toprocess (%d)", processed, toprocess)
-	}
-	if eta < 0 {
-		t.Fatalf("ETA must not be negative, got %s", eta)
-	}
-}
-
 // clampProgress must never report a total below processed nor underflow, even
-// when the floor sits above the frozen top or the current position is out of range.
+// when the floor and current counters drift past the frozen highestBlockSeen.
+// The last case mirrors the field report where the live EL head advanced past
+// the frozen top and previously underflowed the denominator to ~2^64.
 func TestClampProgress(t *testing.T) {
 	cases := []struct {
 		name                     string
@@ -58,6 +35,7 @@ func TestClampProgress(t *testing.T) {
 		{"floor above top", 100, 150, 60, 40, 40},
 		{"current above top", 100, 20, 200, 0, 80},
 		{"current below floor grows total", 100, 20, 5, 95, 95},
+		{"el head past frozen tip", 23_000_000, 23_123_953, 22_983_559, 16_441, 16_441},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -70,42 +48,6 @@ func TestClampProgress(t *testing.T) {
 				t.Fatalf("processed (%d) exceeds total (%d)", processed, total)
 			}
 		})
-	}
-}
-
-// A very slow download must not overflow time.Duration into a negative ETA.
-func TestHistoryDownloadProgress_SlowSpeedNoETAOverflow(t *testing.T) {
-	const (
-		highestBlockSeen   = uint64(23_000_000)
-		lowestBlockToReach = uint64(1)
-		currentBlock       = uint64(23_000_000)
-	)
-	const speed = 0.0001
-
-	_, _, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock, speed)
-	if eta < 0 {
-		t.Fatalf("ETA must not be negative on slow speed, got %s", eta)
-	}
-}
-
-// Normal case: EL head below the frozen top, downloader descending toward it.
-func TestHistoryDownloadProgress_Normal(t *testing.T) {
-	const (
-		highestBlockSeen   = uint64(23_000_000)
-		lowestBlockToReach = uint64(22_000_000)
-		currentBlock       = uint64(22_500_000)
-	)
-	const speed = 10.0
-
-	processed, toprocess, eta := historyDownloadProgress(highestBlockSeen, lowestBlockToReach, currentBlock, speed)
-	if toprocess != 1_000_000 {
-		t.Fatalf("toprocess = %d, want 1000000", toprocess)
-	}
-	if processed != 500_000 {
-		t.Fatalf("processed = %d, want 500000", processed)
-	}
-	if want := 50_000 * time.Second; eta != want {
-		t.Fatalf("eta = %s, want %s", eta, want)
 	}
 }
 

--- a/cl/utils/math.go
+++ b/cl/utils/math.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"math"
+	"time"
 
 	"github.com/thomaso-mirodin/intmath/u64"
 )
@@ -56,4 +57,18 @@ func IntegerSquareRoot(n uint64) uint64 {
 	}
 
 	return uint64(math.Sqrt(float64(n)))
+}
+
+// ETA estimates the time to process `remaining` items at `ratePerSec` items per
+// second, truncated to whole seconds. Returns "n/a" for a non-positive rate and
+// clamps to the max representable duration when the rate is extremely slow.
+func ETA(remaining uint64, ratePerSec float64) string {
+	if ratePerSec <= 0 {
+		return "n/a"
+	}
+	nanos := float64(remaining) / ratePerSec * float64(time.Second)
+	if nanos >= float64(math.MaxInt64) {
+		return time.Duration(math.MaxInt64).Truncate(time.Second).String()
+	}
+	return time.Duration(nanos).Truncate(time.Second).String()
 }

--- a/cl/utils/math_test.go
+++ b/cl/utils/math_test.go
@@ -17,7 +17,9 @@
 package utils_test
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	"github.com/erigontech/erigon/cl/utils"
 )
@@ -107,6 +109,30 @@ func TestIntegerSquareRoot(t *testing.T) {
 		sqrt := utils.IntegerSquareRoot(tc.n)
 		if sqrt != tc.expectedSqrt {
 			t.Errorf("IntegerSquareRoot returned incorrect result for %d. Expected: %d, Got: %d", tc.n, tc.expectedSqrt, sqrt)
+		}
+	}
+}
+
+func TestETA(t *testing.T) {
+	maxDuration := time.Duration(math.MaxInt64).Truncate(time.Second).String()
+	testCases := []struct {
+		remaining  uint64
+		ratePerSec float64
+		expected   string
+	}{
+		{100, 0, "n/a"},
+		{100, -5, "n/a"},
+		{0, 10, "0s"},
+		{100, 10, "10s"},
+		{105, 10, "10s"}, // truncated to whole seconds
+		{math.MaxUint64, 1e-9, maxDuration},
+		{math.MaxUint64, math.SmallestNonzeroFloat64, maxDuration},
+	}
+
+	for _, tc := range testCases {
+		got := utils.ETA(tc.remaining, tc.ratePerSec)
+		if got != tc.expected {
+			t.Errorf("ETA(%d, %g) = %q, want %q", tc.remaining, tc.ratePerSec, got, tc.expected)
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to the already-merged #22462, applying the review rework that landed on `main` in #22461.

`#22462` fixed the `uint64` underflow (issue #22455) but kept a custom `historyDownloadProgress` helper with a hand-rolled `time.Duration` overflow guard. In review of #22461, @AskAlexSharov asked to use the shared `utils.ETA` instead. This brings release/3.5 in line with `main`.

## Changes

- **cl/utils**: backport the overflow-safe `utils.ETA(remaining, ratePerSec)` helper + test from #22388 (not present on release/3.5), so it can be shared here.
- **cl/phase1/stages**: drop `historyDownloadProgress` and use `utils.ETA` for the Execution History ETA. `clampProgress` keeps both progress figures underflow-safe via its `min()` clamps, so the `toprocess-processed` value feeding `utils.ETA` can never wrap.

## r3.5-specific adaptations

- `utils.ETA` had to be backported (only the tiny helper + its test from #22388, not the unrelated archive-download log changes in that PR).

Behaviour is otherwise identical to #22461. Package tests + `make lint` pass.