### PR TITLE
[wip] execution/commitment: keep the account nav path across a storage propagate fold

### DIFF
--- a/db/state/aggregator_visible_from_test.go
+++ b/db/state/aggregator_visible_from_test.go
@@ -48,8 +48,9 @@ func TestFilesPin_PinsSourceGeneration(t *testing.T) {
 	genV1 := src.visible
 	require.Same(t, agg.visible.Load(), genV1, "src pins the current generation")
 
-	// Publish a newer generation while src stays open.
-	gen([]testFileRange{{0, 1}, {1, 2}})
+	// Publish a newer generation while src stays open — only add the {1,2} step;
+	// rewriting {0,1} would rename over the file src holds open, which Windows denies.
+	gen([]testFileRange{{1, 2}})
 	genV2 := agg.visible.Load()
 	require.NotSame(t, genV1, genV2, "OpenFolder must publish a newer visible generation")
 

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -496,10 +496,7 @@ func (cell *cell) fillFromLowerCell(lowCell *cell, lowDepth int16, preExtension 
 	}
 	if lowCell.hashLen > 0 {
 		if (lowCell.accountAddrLen == 0 && lowDepth < 64) || (lowCell.storageAddrLen == 0 && lowDepth > 64) {
-			// Extension is related to either accounts branch node, or storage branch node, we prepend it by preExtension | nibble.
-			// The same nibbles are the unfold navigation path, so hashedExtension must stay in sync
-			// (like foldBranch does), or the cell demands an on-disk branch record that a propagate
-			// fold never writes.
+			// Extension is related to either accounts branch node, or storage branch node, we prepend it by preExtension | nibble
 			if len(preExtension) > 0 {
 				copy(cell.extension[:], preExtension)
 			}
@@ -508,8 +505,16 @@ func (cell *cell) fillFromLowerCell(lowCell *cell, lowDepth int16, preExtension 
 				copy(cell.extension[1+len(preExtension):], lowCell.extension[:lowCell.extLen])
 			}
 			cell.extLen = lowCell.extLen + 1 + int16(len(preExtension))
-			copy(cell.hashedExtension[:], cell.extension[:cell.extLen])
-			cell.hashedExtLen = cell.extLen
+			if cell.accountAddrLen == 0 && cell.storageAddrLen == 0 {
+				// Only a cell without a plain key navigates by its extension, and then these
+				// nibbles are also its unfold path, so hashedExtension must stay in sync (like
+				// foldBranch does) or the cell demands an on-disk branch record that a propagate
+				// fold never writes. A cell holding a plain key navigates by the keccak-derived
+				// path instead, and a storage fold's extension is in the wrong nibble space to
+				// overwrite it with.
+				copy(cell.hashedExtension[:], cell.extension[:cell.extLen])
+				cell.hashedExtLen = cell.extLen
+			}
 		} else {
 			// Extension is related to a storage branch node, so we copy it upwards as is
 			cell.extLen = lowCell.extLen

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -506,12 +506,6 @@ func (cell *cell) fillFromLowerCell(lowCell *cell, lowDepth int16, preExtension 
 			}
 			cell.extLen = lowCell.extLen + 1 + int16(len(preExtension))
 			if cell.accountAddrLen == 0 && cell.storageAddrLen == 0 {
-				// Only a cell without a plain key navigates by its extension, and then these
-				// nibbles are also its unfold path, so hashedExtension must stay in sync (like
-				// foldBranch does) or the cell demands an on-disk branch record that a propagate
-				// fold never writes. A cell holding a plain key navigates by the keccak-derived
-				// path instead, and a storage fold's extension is in the wrong nibble space to
-				// overwrite it with.
 				copy(cell.hashedExtension[:], cell.extension[:cell.extLen])
 				cell.hashedExtLen = cell.extLen
 			}

--- a/execution/commitment/storage_fold_navpath_regression_test.go
+++ b/execution/commitment/storage_fold_navpath_regression_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/length"
 )
 
 // A storage row that propagates into an account cell must not overwrite that cell's
@@ -33,20 +35,20 @@ func TestFillFromLowerCell_StorageFoldKeepsAccountNavPath(t *testing.T) {
 	t.Parallel()
 
 	// Account cell holding a storage root, carrying the keccak-derived path it navigates by.
-	accountCell := &cell{accountAddrLen: 20, hashLen: 32}
+	accountCell := &cell{accountAddrLen: length.Addr, hashLen: 32}
 	navPath := []byte{0x3, 0xc, 0x1, 0x9, 0xe}
 	copy(accountCell.hashedExtension[:], navPath)
 	accountCell.hashedExtLen = int16(len(navPath))
 
 	// Storage branch one row below the account leaf (depth 65 > 64, no storage plain key).
-	storageBranch := &cell{storageAddrLen: 0, hashLen: 32, extLen: 0}
+	storageBranch := &cell{hashLen: 32}
 
 	accountCell.fillFromLowerCell(storageBranch, 65, nil, 0x7)
 
 	require.Equalf(t, navPath, accountCell.hashedExtension[:accountCell.hashedExtLen],
 		"account cell must keep its account navigation path across a storage propagate fold; "+
 			"got hashedExtLen=%d", accountCell.hashedExtLen)
-	require.EqualValues(t, 20, accountCell.accountAddrLen, "fold must not drop the account plain key")
+	require.EqualValues(t, length.Addr, accountCell.accountAddrLen, "fold must not drop the account plain key")
 	require.EqualValues(t, 1, accountCell.extLen, "storage extension still travels up in extension space")
 }
 
@@ -63,8 +65,25 @@ func TestFillFromLowerCell_AccountBranchSyncsNavPath(t *testing.T) {
 
 	branchCell.fillFromLowerCell(lowBranch, 3, []byte{0x1}, 0x2)
 
-	require.EqualValues(t, branchCell.extLen, branchCell.hashedExtLen,
-		"a branch cell navigates by its extension, so hashedExtension must stay in sync")
-	require.Equal(t, branchCell.extension[:branchCell.extLen],
-		branchCell.hashedExtension[:branchCell.hashedExtLen])
+	// preExtension | nibble | lowCell.extension
+	want := []byte{0x1, 0x2, 0xa, 0xb}
+	require.Equal(t, want, branchCell.extension[:branchCell.extLen])
+	require.Equalf(t, want, branchCell.hashedExtension[:branchCell.hashedExtLen],
+		"a branch cell navigates by its extension, so hashedExtension must stay in sync; got hashedExtLen=%d",
+		branchCell.hashedExtLen)
+}
+
+// A storage-internal branch carries no plain key, so it navigates by its extension and
+// must sync like an account-space branch: the skip is keyed on the plain key, not on depth.
+func TestFillFromLowerCell_StorageBranchSyncsNavPath(t *testing.T) {
+	t.Parallel()
+
+	branchCell := &cell{hashLen: 32}
+	lowBranch := &cell{hashLen: 32, extLen: 1}
+	lowBranch.extension[0] = 0xd
+
+	branchCell.fillFromLowerCell(lowBranch, 70, nil, 0x5)
+
+	require.Equal(t, []byte{0x5, 0xd}, branchCell.hashedExtension[:branchCell.hashedExtLen],
+		"a keyless cell deep in storage still navigates by its extension")
 }

--- a/execution/commitment/storage_fold_navpath_regression_test.go
+++ b/execution/commitment/storage_fold_navpath_regression_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A storage row that propagates into an account cell must not overwrite that cell's
+// hashedExtension: the account cell navigates by its keccak-derived account path, while
+// the prepended extension is in storage nibble space. Writing the storage extension over
+// it sends the next unfold to a prefix that owns no branch record ("empty branch data read
+// during unfold" on the mount path).
+//
+// Only a cell carrying no plain key navigates by its extension, so only that cell may sync.
+func TestFillFromLowerCell_StorageFoldKeepsAccountNavPath(t *testing.T) {
+	t.Parallel()
+
+	// Account cell holding a storage root, carrying the keccak-derived path it navigates by.
+	accountCell := &cell{accountAddrLen: 20, hashLen: 32}
+	navPath := []byte{0x3, 0xc, 0x1, 0x9, 0xe}
+	copy(accountCell.hashedExtension[:], navPath)
+	accountCell.hashedExtLen = int16(len(navPath))
+
+	// Storage branch one row below the account leaf (depth 65 > 64, no storage plain key).
+	storageBranch := &cell{storageAddrLen: 0, hashLen: 32, extLen: 0}
+
+	accountCell.fillFromLowerCell(storageBranch, 65, nil, 0x7)
+
+	require.Equalf(t, navPath, accountCell.hashedExtension[:accountCell.hashedExtLen],
+		"account cell must keep its account navigation path across a storage propagate fold; "+
+			"got hashedExtLen=%d", accountCell.hashedExtLen)
+	require.EqualValues(t, 20, accountCell.accountAddrLen, "fold must not drop the account plain key")
+	require.EqualValues(t, 1, accountCell.extLen, "storage extension still travels up in extension space")
+}
+
+// The mirror case: an account-space branch cell (no plain key) navigates by its extension, so a
+// propagate fold must keep hashedExtension in sync or a restored extension-topped root demands a
+// root branch record that a propagate fold never writes.
+func TestFillFromLowerCell_AccountBranchSyncsNavPath(t *testing.T) {
+	t.Parallel()
+
+	branchCell := &cell{hashLen: 32}
+	lowBranch := &cell{hashLen: 32, extLen: 2}
+	lowBranch.extension[0] = 0xa
+	lowBranch.extension[1] = 0xb
+
+	branchCell.fillFromLowerCell(lowBranch, 3, []byte{0x1}, 0x2)
+
+	require.EqualValues(t, branchCell.extLen, branchCell.hashedExtLen,
+		"a branch cell navigates by its extension, so hashedExtension must stay in sync")
+	require.Equal(t, branchCell.extension[:branchCell.extLen],
+		branchCell.hashedExtension[:branchCell.hashedExtLen])
+}

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -95,17 +95,17 @@ type StreamingCommitter struct {
 
 	deepLocalFolds atomic.Uint64
 
+	// rootValid gates root promotion: cleared each Process and set only on the
+	// folded path, so the no-touch path leaves the template's prior root untouched.
+	// rootSeeded marks the same snapshot as a base seed: a trie whose root row
+	// collapsed to one child has no root branch record on disk, so the carried
+	// root cell is the only way a fresh base can see the existing state.
 	rootCell    cell
 	rootChecked bool
 	rootTouched bool
 	rootPresent bool
-	// rootValid gates root promotion: cleared each Process and set only on the
-	// folded path, so the no-touch path leaves the template's prior root untouched.
-	rootValid bool
-	// rootSeeded marks the same snapshot as a base seed: a trie whose root row
-	// collapsed to one child has no root branch record on disk, so the carried
-	// root cell is the only way a fresh base can see the existing state.
-	rootSeeded bool
+	rootValid   bool
+	rootSeeded  bool
 
 	traceW io.Writer
 }

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -95,17 +95,17 @@ type StreamingCommitter struct {
 
 	deepLocalFolds atomic.Uint64
 
-	// rootValid gates root promotion: cleared each Process and set only on the
-	// folded path, so the no-touch path leaves the template's prior root untouched.
-	// rootSeeded marks the same snapshot as a base seed: a trie whose root row
-	// collapsed to one child has no root branch record on disk, so the carried
-	// root cell is the only way a fresh base can see the existing state.
 	rootCell    cell
 	rootChecked bool
 	rootTouched bool
 	rootPresent bool
-	rootValid   bool
-	rootSeeded  bool
+	// rootValid gates root promotion: cleared each Process and set only on the
+	// folded path, so the no-touch path leaves the template's prior root untouched.
+	rootValid bool
+	// rootSeeded marks the same snapshot as a base seed: a trie whose root row
+	// collapsed to one child has no root branch record on disk, so the carried
+	// root cell is the only way a fresh base can see the existing state.
+	rootSeeded bool
 
 	traceW io.Writer
 }

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -319,7 +319,10 @@ func (sc *StreamingCommitter) SeedRootFrom(tmpl *HexPatriciaHashed) {
 		sc.releaseBase()
 	}
 	// Splits folded against the previous seed's base are stale; drop their cells and
-	// deferred updates so Process re-folds them against the reseeded base.
+	// deferred updates so Process re-folds them against the reseeded base. Read-lock
+	// trieMu: TouchKey inserts into sc.splits under its write lock, and iterating a
+	// map against a concurrent insert is a fatal runtime error.
+	sc.trieMu.RLock()
 	for _, s := range sc.splits {
 		s.mu.Lock()
 		s.folded = false
@@ -330,6 +333,7 @@ func (sc *StreamingCommitter) SeedRootFrom(tmpl *HexPatriciaHashed) {
 		s.deferred = nil
 		s.mu.Unlock()
 	}
+	sc.trieMu.RUnlock()
 }
 
 // PromoteRootInto copies the most recently folded root cell and flags into tmpl,

--- a/polygon/sync/event_channel_test.go
+++ b/polygon/sync/event_channel_test.go
@@ -64,6 +64,14 @@ func TestEventChannel(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			ch := NewEventChannel[string](2)
+
+			// Fill past capacity before Run starts consuming: a consumer that takes
+			// event1 off the queue first leaves the queue below capacity, so event1 is
+			// never evicted and arrives instead of event2.
+			ch.PushEvent("event1")
+			ch.PushEvent("event2")
+			ch.PushEvent("event3")
+
 			eg := errgroup.Group{}
 			eg.Go(func() error {
 				return ch.Run(ctx)
@@ -72,10 +80,6 @@ func TestEventChannel(t *testing.T) {
 				err := eg.Wait()
 				require.ErrorIs(t, err, context.Canceled)
 			})
-
-			ch.PushEvent("event1")
-			ch.PushEvent("event2")
-			ch.PushEvent("event3")
 
 			events := ch.Events()
 			require.Equal(t, "event2", <-events)


### PR DESCRIPTION
Same fix as #22495, stacked on #22141 instead of `main`.

#22141's base predates the #22362 revert, so it already carries #22257 — only the fix itself is needed here (~87 lines vs #22495's ~600).

## The bug

`fillFromLowerCell` synced `hashedExtension` on every prepended extension. When a storage row (`lowDepth > 64`) propagates into an account leaf the cell is still the account cell, so the sync overwrote its keccak-derived **account** nav path with **storage** nibbles. The next unfold followed the bogus path to a prefix owning no branch record — `mount[f] build: unfold: empty branch data read during unfold` at mainnet block 5227811, #22362's stated root cause.

**Fix:** sync only when the cell has no plain key — only such a cell navigates by its extension. Red-first tests pin both halves.

## Also here

A port of main's #22354 fix for `TestFilesPin_PinsSourceGeneration` (Windows `Access is denied` on rename-over-open-file). #22141's base predates it. **That commit belongs to #22141** and should be dropped if it rebases onto main.

## Why #22141 needs one of these

#22141 turns on `ERIGON_COMMITMENT_PARALLEL` in CI. Its ubuntu leg is green only because its base predates the revert. Rebased onto main it inherits the revert and goes red with wrong trie roots across 11 tests.

**[wip]: not verified against mainnet block 5227811.**

cc @awskii