### PR TITLE
execution: improve account lifecycle finalization

### DIFF
--- a/execution/engineapi/engine_api_builder_test.go
+++ b/execution/engineapi/engine_api_builder_test.go
@@ -759,6 +759,85 @@ func TestEngineApiEIP8246PreservedBalanceSurvivesCreate2Recreate(t *testing.T) {
 	})
 }
 
+func TestEngineApiAccountLifecycleFinalizationConsistency(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlDebug)
+	genesis, coinbaseKey, err := engineapitester.DefaultEngineApiTesterGenesis()
+	require.NoError(t, err)
+	genesis.Config.AmsterdamTime = nil
+
+	salt := [32]byte{}
+	factoryAddr := types.CreateAddress(crypto.PubkeyToAddress(coinbaseKey.PublicKey), 0)
+	coinbase := create2Addr(factoryAddr, salt, common.FromHex(contracts.SelfDestructInConstructorBin))
+	genesis.Coinbase = coinbase
+
+	senderKeys := make([]*ecdsa.PrivateKey, 3)
+	funds := new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil)
+	for i := range senderKeys {
+		senderKeys[i], err = crypto.GenerateKey()
+		require.NoError(t, err)
+		genesis.Alloc[crypto.PubkeyToAddress(senderKeys[i].PublicKey)] = types.GenesisAccount{Balance: funds}
+	}
+
+	eat, err := engineapitester.InitialiseEngineApiTester(ctx, engineapitester.EngineApiTesterInitArgs{
+		Logger: logger, DataDir: t.TempDir(), Genesis: genesis, CoinbaseKey: coinbaseKey,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		chainID := eat.ChainId()
+		deployAuth, err := bind.NewKeyedTransactorWithChainID(coinbaseKey, chainID)
+		require.NoError(t, err)
+		deployAuth.GasLimit = params.MaxTxnGasLimit
+		deployedFactoryAddr, _, factory, err := contracts.DeploySelfDestructFactory(deployAuth, eat.ContractBackend)
+		require.NoError(t, err)
+		require.Equal(t, factoryAddr, deployedFactoryAddr)
+		_, err = eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+
+		disperseAuth, err := bind.NewKeyedTransactorWithChainID(coinbaseKey, chainID)
+		require.NoError(t, err)
+		disperseAuth.GasLimit = params.MaxTxnGasLimit
+		_, _, disperse, err := contracts.DeployDisperse(disperseAuth, eat.ContractBackend)
+		require.NoError(t, err)
+		_, err = eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+
+		destroyAuth, err := bind.NewKeyedTransactorWithChainID(senderKeys[0], chainID)
+		require.NoError(t, err)
+		destroyAuth.GasLimit = 1_000_000
+		destroyAuth.GasPrice = big.NewInt(5_000_000_000)
+		destroyTx, err := factory.Deploy(destroyAuth, salt)
+		require.NoError(t, err)
+
+		fundAuth, err := bind.NewKeyedTransactorWithChainID(senderKeys[1], chainID)
+		require.NoError(t, err)
+		fundAuth.GasLimit = 1_000_000
+		fundAuth.GasPrice = big.NewInt(4_000_000_000)
+		fundAuth.Value = big.NewInt(7)
+		fundTx, err := disperse.DisperseEther(fundAuth, []common.Address{coinbase}, []*big.Int{big.NewInt(7)})
+		require.NoError(t, err)
+
+		recreateAuth, err := bind.NewKeyedTransactorWithChainID(senderKeys[2], chainID)
+		require.NoError(t, err)
+		recreateAuth.GasLimit = 1_000_000
+		recreateAuth.GasPrice = big.NewInt(3_000_000_000)
+		recreateTx, err := factory.Deploy(recreateAuth, salt)
+		require.NoError(t, err)
+
+		payload, err := eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+		gotHashes := make([]common.Hash, len(payload.ExecutionPayload.Transactions))
+		for i, encoded := range payload.ExecutionPayload.Transactions {
+			txn, err := types.DecodeTransaction(encoded)
+			require.NoError(t, err)
+			gotHashes[i] = txn.Hash()
+		}
+		require.Equal(t, []common.Hash{destroyTx.Hash(), fundTx.Hash(), recreateTx.Hash()}, gotHashes)
+	})
+}
+
 // creditWei is the fixed amount dispersed to each proxy while it is still empty
 // (0.000256 ETH, the constant seen on glamsterdam-devnet-5).
 var creditWei = uint256.NewInt(256_000_000_000_000)

--- a/execution/engineapi/engine_api_builder_test.go
+++ b/execution/engineapi/engine_api_builder_test.go
@@ -838,6 +838,101 @@ func TestEngineApiAccountLifecycleFinalizationConsistency(t *testing.T) {
 	})
 }
 
+// TestEngineApiAccountLifecycleFinalizationConsistencyEIP8246 is the Amsterdam
+// counterpart of TestEngineApiAccountLifecycleFinalizationConsistency. Under
+// EIP-8246 a self-destructed account that still holds a balance is preserved
+// (balance-only) rather than deleted, so the tip credited to a same-block
+// created+self-destructed coinbase must survive — the builder and the parallel
+// validator must still agree on the assembled block.
+func TestEngineApiAccountLifecycleFinalizationConsistencyEIP8246(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlDebug)
+	genesis, coinbaseKey, err := engineapitester.DefaultEngineApiTesterGenesis()
+	require.NoError(t, err)
+	require.NotNil(t, genesis.Config.AmsterdamTime, "genesis must keep Amsterdam enabled to exercise the EIP-8246 path")
+
+	salt := [32]byte{}
+	factoryAddr := types.CreateAddress(crypto.PubkeyToAddress(coinbaseKey.PublicKey), 0)
+	coinbase := create2Addr(factoryAddr, salt, common.FromHex(contracts.SelfDestructInConstructorBin))
+	genesis.Coinbase = coinbase
+
+	senderKeys := make([]*ecdsa.PrivateKey, 3)
+	funds := new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil)
+	for i := range senderKeys {
+		senderKeys[i], err = crypto.GenerateKey()
+		require.NoError(t, err)
+		genesis.Alloc[crypto.PubkeyToAddress(senderKeys[i].PublicKey)] = types.GenesisAccount{Balance: funds}
+	}
+
+	eat, err := engineapitester.InitialiseEngineApiTester(ctx, engineapitester.EngineApiTesterInitArgs{
+		Logger: logger, DataDir: t.TempDir(), Genesis: genesis, CoinbaseKey: coinbaseKey,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		chainID := eat.ChainId()
+		deployAuth, err := bind.NewKeyedTransactorWithChainID(coinbaseKey, chainID)
+		require.NoError(t, err)
+		deployAuth.GasLimit = params.MaxTxnGasLimit
+		deployedFactoryAddr, _, factory, err := contracts.DeploySelfDestructFactory(deployAuth, eat.ContractBackend)
+		require.NoError(t, err)
+		require.Equal(t, factoryAddr, deployedFactoryAddr)
+		_, err = eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+
+		disperseAuth, err := bind.NewKeyedTransactorWithChainID(coinbaseKey, chainID)
+		require.NoError(t, err)
+		disperseAuth.GasLimit = params.MaxTxnGasLimit
+		_, _, disperse, err := contracts.DeployDisperse(disperseAuth, eat.ContractBackend)
+		require.NoError(t, err)
+		_, err = eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+
+		destroyAuth, err := bind.NewKeyedTransactorWithChainID(senderKeys[0], chainID)
+		require.NoError(t, err)
+		destroyAuth.GasLimit = 1_000_000
+		destroyAuth.GasPrice = big.NewInt(5_000_000_000)
+		destroyTx, err := factory.Deploy(destroyAuth, salt)
+		require.NoError(t, err)
+
+		fundAuth, err := bind.NewKeyedTransactorWithChainID(senderKeys[1], chainID)
+		require.NoError(t, err)
+		fundAuth.GasLimit = 1_000_000
+		fundAuth.GasPrice = big.NewInt(4_000_000_000)
+		fundAuth.Value = big.NewInt(7)
+		fundTx, err := disperse.DisperseEther(fundAuth, []common.Address{coinbase}, []*big.Int{big.NewInt(7)})
+		require.NoError(t, err)
+
+		recreateAuth, err := bind.NewKeyedTransactorWithChainID(senderKeys[2], chainID)
+		require.NoError(t, err)
+		recreateAuth.GasLimit = 1_000_000
+		recreateAuth.GasPrice = big.NewInt(3_000_000_000)
+		recreateTx, err := factory.Deploy(recreateAuth, salt)
+		require.NoError(t, err)
+
+		payload, err := eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+		gotHashes := make([]common.Hash, len(payload.ExecutionPayload.Transactions))
+		for i, encoded := range payload.ExecutionPayload.Transactions {
+			txn, err := types.DecodeTransaction(encoded)
+			require.NoError(t, err)
+			gotHashes[i] = txn.Hash()
+		}
+		require.Equal(t, []common.Hash{destroyTx.Hash(), fundTx.Hash(), recreateTx.Hash()}, gotHashes)
+
+		// EIP-8246: the created+self-destructed+recreated coinbase is preserved as
+		// a balance-only account (empty code, non-zero accrued tips + funding), so
+		// the delayed tip is credited rather than burned.
+		code, err := eat.RpcApiClient.GetCode(coinbase, rpc.LatestBlock)
+		require.NoError(t, err)
+		require.Empty(t, code, "EIP-8246: self-destructed coinbase is balance-only")
+		balance, err := eat.RpcApiClient.GetBalance(coinbase, rpc.LatestBlock)
+		require.NoError(t, err)
+		require.Positive(t, balance.Sign(), "EIP-8246: coinbase tip must be preserved, not burned")
+	})
+}
+
 // creditWei is the fixed amount dispersed to each proxy while it is still empty
 // (0.000256 ETH, the constant seen on glamsterdam-devnet-5).
 var creditWei = uint256.NewInt(256_000_000_000_000)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1931,6 +1931,7 @@ func (result *execResult) calcFees(
 	}
 	coinbaseEmptyCodeHash := coinbaseAcc == nil || coinbaseAcc.IsEmptyCodeHash()
 	coinbaseSelfdestructed := false
+	coinbaseCreatedContract := false
 	if bw, ok := result.TxOut.GetBalance(result.Coinbase); ok {
 		newCoinbaseBalance = bw.Val
 	}
@@ -1943,6 +1944,9 @@ func (result *execResult) calcFees(
 	if sw, ok := result.TxOut.GetSelfDestruct(result.Coinbase); ok {
 		coinbaseSelfdestructed = sw.Val
 	}
+	if cw, ok := result.TxOut.GetCreateContract(result.Coinbase); ok {
+		coinbaseCreatedContract = cw.Val
+	}
 	if hasBurnt {
 		if bw, ok := result.TxOut.GetBalance(burntAddr); ok {
 			newBurntBalance = bw.Val
@@ -1953,7 +1957,7 @@ func (result *execResult) calcFees(
 	// DeleteAccount also emits SelfDestructPath=true for EIP-161 empty-removal of
 	// a touched EOA coinbase, where the delayed tip must still be credited (it
 	// re-creates the account) to match serial.
-	coinbaseWasContract := !coinbaseEmptyCodeHash || coinbaseHasCodeHashWrite
+	coinbaseWasContract := !coinbaseEmptyCodeHash || coinbaseHasCodeHashWrite || coinbaseCreatedContract
 	if !(coinbaseSelfdestructed && coinbaseWasContract) {
 		newCoinbaseBalance.Add(&newCoinbaseBalance, &result.ExecutionResult.FeeTipped)
 	}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1953,12 +1953,13 @@ func (result *execResult) calcFees(
 		}
 	}
 	oldCoinbaseBalance := newCoinbaseBalance
-	// Burn the tip only for an actual SELFDESTRUCT of a contract coinbase.
+	// Before EIP-8246, burn the tip only for an actual SELFDESTRUCT of a contract coinbase.
 	// DeleteAccount also emits SelfDestructPath=true for EIP-161 empty-removal of
 	// a touched EOA coinbase, where the delayed tip must still be credited (it
 	// re-creates the account) to match serial.
 	coinbaseWasContract := !coinbaseEmptyCodeHash || coinbaseHasCodeHashWrite || coinbaseCreatedContract
-	if !(coinbaseSelfdestructed && coinbaseWasContract) {
+	burnCoinbaseTip := !chainRules.IsAmsterdam && coinbaseSelfdestructed && coinbaseWasContract
+	if !burnCoinbaseTip {
 		newCoinbaseBalance.Add(&newCoinbaseBalance, &result.ExecutionResult.FeeTipped)
 	}
 	oldBurntBalance := newBurntBalance

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -3046,6 +3046,9 @@ func (sdb *IntraBlockState) ApplyVersionedWrites(writes *WriteSet) error {
 				sdb.recordWriteSelfDestruct(addr, false)
 			}
 		case CreateContractPath:
+			if sw, ok := writes.GetSelfDestruct(addr); ok && sw.Val {
+				continue
+			}
 			// Contract creation: set createdContract flag on the stateObject.
 			so, err := sdb.GetOrNewStateObject(addr)
 			if err != nil {

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2832,9 +2832,9 @@ func (sdb *IntraBlockState) ResetVersionedReads() {
 // VersionedWrites returns a frozen typed snapshot of this tx's writes. With
 // checkDirty, a non-dirty address's writes are dropped (and deleted from the
 // version map). Under self-destruct only SelfDestruct/Balance/Incarnation/
-// Storage are kept (the BAL needs residual balance, resurrection needs the
-// prior incarnation, and the calculator needs per-slot deletes); Nonce/Code/
-// CodeHash/CodeSize/Address/CreateContract are dropped.
+// Storage/CreateContract are kept (the BAL needs residual balance,
+// resurrection needs the prior incarnation, and fee finalization needs the
+// creation marker); Nonce/Code/CodeHash/CodeSize/Address are dropped.
 func (sdb *IntraBlockState) VersionedWrites(checkDirty bool) *WriteSet {
 	src := &sdb.versionedWrites
 	out := &WriteSet{}
@@ -2868,6 +2868,9 @@ func (sdb *IntraBlockState) VersionedWrites(checkDirty bool) *WriteSet {
 				out.SetStorage(addr, k, cloneVW(vw))
 			}
 		}
+		if vw, ok := src.createContract[addr]; ok {
+			out.SetCreateContract(addr, cloneVW(vw))
+		}
 		if !sd {
 			if vw, ok := src.address[addr]; ok {
 				out.SetAddress(addr, cloneVW(vw))
@@ -2883,9 +2886,6 @@ func (sdb *IntraBlockState) VersionedWrites(checkDirty bool) *WriteSet {
 			}
 			if vw, ok := src.codeSize[addr]; ok {
 				out.SetCodeSize(addr, cloneVW(vw))
-			}
-			if vw, ok := src.createContract[addr]; ok {
-				out.SetCreateContract(addr, cloneVW(vw))
 			}
 		}
 	}

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -1044,6 +1044,32 @@ func TestApplyVersionedWrites_NewAccountNoBalanceRead(t *testing.T) {
 		"newly-created account (not in DB) should NOT generate a BalancePath read")
 }
 
+func TestApplyVersionedWrites_SelfDestructDominatesCreateContract(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xF600"))
+	vm := NewVersionMap(nil)
+	ibs := New(NewVersionedStateReader(0, ReadSet{}, vm, &minimalStateReader{}))
+	ibs.SetTxContext(1, 0)
+	ibs.SetVersionMap(vm)
+
+	writes := &WriteSet{}
+	writes.SetSelfDestruct(addr, &VersionedWrite[bool]{
+		WriteHeader: WriteHeader{Address: addr, Path: SelfDestructPath},
+		Val:         true,
+	})
+	writes.SetCreateContract(addr, &VersionedWrite[bool]{
+		WriteHeader: WriteHeader{Address: addr, Path: CreateContractPath},
+		Val:         true,
+	})
+
+	require.NoError(t, ibs.ApplyVersionedWrites(writes))
+	stateObject := ibs.stateObjects[addr]
+	require.NotNil(t, stateObject)
+	require.True(t, stateObject.selfdestructed)
+	require.False(t, stateObject.createdContract)
+}
+
 // recordTouch records an address-level ephemeral access for txIndex via the
 // access map (accesses feed the BAL through RecordAccesses).
 func recordTouch(io *VersionedIO, txIndex int, addr accounts.Address, revertable bool) {

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -572,18 +572,17 @@ func TestVersionedIO_RemovedDependencyFallsThroughToStorage(t *testing.T) {
 			"the underlying storage value, not abort or return the stale MapRead")
 }
 
-// TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths verifies
-// that IntraBlockState.VersionedWrites retains SelfDestructPath, BalancePath
-// (including non-zero residual balances — EIP-7708 case 2), and IncarnationPath
-// after selfdestruct, and drops NoncePath/CodePath which selfdestruct resets.
-func TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths(t *testing.T) {
+// TestIBSVersionedWrites_SelfdestructRetainsMetadataDropsResetPaths verifies
+// that IntraBlockState.VersionedWrites retains deletion metadata and drops
+// account fields reset by selfdestruct.
+func TestIBSVersionedWrites_SelfdestructRetainsMetadataDropsResetPaths(t *testing.T) {
 	t.Parallel()
 
 	addr := accounts.InternAddress(common.HexToAddress("0xdead"))
 	ibs := NewWithVersionMap(&minimalStateReader{}, NewVersionMap(nil))
 	ibs.SetTxContext(1, 0)
 
-	// Establish nonce and code before selfdestruct — these should be dropped.
+	require.NoError(t, ibs.CreateAccount(addr, true))
 	require.NoError(t, ibs.SetNonce(addr, 5, tracing.NonceChangeUnspecified))
 	require.NoError(t, ibs.SetCode(addr, []byte{0x60, 0x00}, tracing.CodeChangeUnspecified))
 	require.NoError(t, ibs.SetBalance(addr, *uint256.NewInt(0), tracing.BalanceChangeUnspecified))
@@ -611,6 +610,7 @@ func TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths(t *testing
 	require.True(t, pathSet[SelfDestructPath], "SelfDestructPath must be retained")
 	require.True(t, pathSet[IncarnationPath], "IncarnationPath must be retained")
 	require.True(t, pathSet[BalancePath], "BalancePath (non-zero residual) must be retained")
+	require.True(t, pathSet[CreateContractPath], "CreateContractPath must be retained")
 
 	// Dropped paths — selfdestruct resets nonce and code, so they must not appear.
 	require.False(t, pathSet[NoncePath], "NoncePath must be dropped after selfdestruct")


### PR DESCRIPTION
## Summary

- preserve lifecycle metadata through finalization
- improve consistency of deferred account updates
- add regression coverage for parallel execution

## Testing

- go test ./execution/state ./execution/stagedsync -count=1
- go test ./execution/engineapi -count=1
- make lint
- make erigon integration