### PR TITLE
types, snapshotsync: decode body RLP without reflection

### DIFF
--- a/db/snapshotsync/freezeblocks/block_reader.go
+++ b/db/snapshotsync/freezeblocks/block_reader.go
@@ -1116,7 +1116,7 @@ func BodyForTxnFromSnapshot(blockHeight uint64, sn *snapshotsync.VisibleSegment,
 		return nil, buf, nil
 	}
 	b := &types.BodyOnlyTxn{}
-	if err := rlp.DecodeBytesPartial(buf, b); err != nil {
+	if err := b.DecodeRLPBytes(buf); err != nil {
 		return nil, buf, err
 	}
 
@@ -1357,7 +1357,7 @@ func (r *BlockReader) IterateFrozenBodies(tx kv.Getter, f func(blockNum, baseTxN
 		var b types.BodyOnlyTxn
 		for g.HasNext() {
 			buf, _ = g.Next(buf[:0])
-			if err := rlp.DecodeBytesPartial(buf, &b); err != nil {
+			if err := b.DecodeRLPBytes(buf); err != nil {
 				return err
 			}
 			if err := f(blockNum, b.BaseTxnID.U64(), uint64(b.TxCount)); err != nil {

--- a/execution/types/block.go
+++ b/execution/types/block.go
@@ -711,7 +711,7 @@ func (b BaseTxnID) LastSystemTx(txAmount uint32) uint64 { return b.U64() + uint6
 // this structure does rlp decode only for
 // "tx related" data
 //
-// must use `rlp.DecodeBytesPartial` to decode
+// decode from bytes with `DecodeRLPBytes`, not `rlp.DecodeBytes`
 type BodyOnlyTxn struct {
 	BaseTxnID BaseTxnID
 	TxCount   uint32
@@ -723,15 +723,25 @@ func (b *BodyOnlyTxn) DecodeRLP(s *rlp.Stream) error {
 	if err != nil {
 		return err
 	}
-	// decode BaseTxId
-	if err = s.Decode(&b.BaseTxnID); err != nil {
-		return err
+	baseTxnID, err := s.Uint64()
+	if err != nil {
+		return fmt.Errorf("read BaseTxnID: %w", err)
 	}
-	// decode TxCount
-	if err = s.Decode(&b.TxCount); err != nil {
-		return err
+	txCount, err := s.Uint32()
+	if err != nil {
+		return fmt.Errorf("read TxCount: %w", err)
 	}
+	b.BaseTxnID, b.TxCount = BaseTxnID(baseTxnID), txCount
 	return nil
+}
+
+// DecodeRLPBytes reads only the leading txn fields, so rlp.DecodeBytes would reject
+// the unread tail. Going through DecodeRLP directly also skips a reflect dispatch
+// that costs more than the decode itself.
+func (b *BodyOnlyTxn) DecodeRLPBytes(buf []byte) error {
+	s := rlp.NewBytesStream(buf)
+	defer rlp.PutStream(s)
+	return b.DecodeRLP(s)
 }
 
 type BodyForStorage struct {
@@ -981,19 +991,18 @@ func (bfs *BodyForStorage) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 
-	// decode BaseTxId
-	if err = s.Decode(&bfs.BaseTxnID); err != nil {
-		return err
+	baseTxnID, err := s.Uint64()
+	if err != nil {
+		return fmt.Errorf("read BaseTxnID: %w", err)
 	}
-	// decode TxCount
-	if err = s.Decode(&bfs.TxCount); err != nil {
-		return err
+	txCount, err := s.Uint32()
+	if err != nil {
+		return fmt.Errorf("read TxCount: %w", err)
 	}
-	// decode Uncles
+	bfs.BaseTxnID, bfs.TxCount = BaseTxnID(baseTxnID), txCount
 	if err := decodeUncles(&bfs.Uncles, s); err != nil {
 		return err
 	}
-	// decode Withdrawals
 	bfs.Withdrawals = []*Withdrawal{}
 	if err := decodeWithdrawals(&bfs.Withdrawals, s); err != nil {
 		return err

--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"math/big"
 	"reflect"
 	"testing"
@@ -319,6 +320,95 @@ func BenchmarkEncodeBlock(b *testing.B) {
 		if err := rlp.Encode(benchBuffer, block); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func encodedBenchBody(b *testing.B) []byte {
+	b.Helper()
+	var buf bytes.Buffer
+	if err := rlp.Encode(&buf, &BodyForStorage{BaseTxnID: BaseTxnID(1234567), TxCount: 250}); err != nil {
+		b.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// TestBodyOnlyTxnDecodeRLPBytes pins the contract that makes DecodeRLPBytes exist:
+// it reads the leading txn fields of a full BodyForStorage encoding and tolerates
+// the unread tail, which rlp.DecodeBytes rejects.
+func TestBodyOnlyTxnDecodeRLPBytes(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := rlp.Encode(&buf, &BodyForStorage{BaseTxnID: BaseTxnID(1234567), TxCount: 250}); err != nil {
+		t.Fatal(err)
+	}
+	enc := buf.Bytes()
+
+	var b BodyOnlyTxn
+	if err := b.DecodeRLPBytes(enc); err != nil {
+		t.Fatalf("DecodeRLPBytes: %v", err)
+	}
+	if b.BaseTxnID != BaseTxnID(1234567) || b.TxCount != 250 {
+		t.Fatalf("unexpected decode result: %+v", b)
+	}
+
+	// Tolerating the unread tail - the uncles list here, and withdrawals whenever
+	// they are present - is the whole reason this entrypoint exists: swapping it for
+	// rlp.DecodeBytes would start rejecting every body.
+	if err := rlp.DecodeBytes(enc, &BodyOnlyTxn{}); !errors.Is(err, rlp.ErrMoreThanOneValue) {
+		t.Fatalf("rlp.DecodeBytes must reject the unread tail, got %v", err)
+	}
+}
+
+func TestBodyOnlyTxnDecodeRLPBytesErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{"empty", nil},
+		{"not a list", []byte{0x80}},
+		{"truncated list", []byte{0xC3, 0x82}},
+		{"non-canonical BaseTxnID", []byte{0xC3, 0x82, 0x00, 0x02}},
+		{"BaseTxnID only", []byte{0xC1, 0x01}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var b BodyOnlyTxn
+			if err := b.DecodeRLPBytes(tt.input); err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
+	}
+}
+
+func BenchmarkBodyOnlyTxnDecodeRLPBytes(b *testing.B) {
+	enc := encodedBenchBody(b)
+
+	var out BodyOnlyTxn
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := out.DecodeRLPBytes(enc); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if out.BaseTxnID != BaseTxnID(1234567) || out.TxCount != 250 {
+		b.Fatalf("unexpected decode result: %+v", out)
+	}
+}
+
+func BenchmarkBodyForStorageDecodeBytes(b *testing.B) {
+	enc := encodedBenchBody(b)
+
+	var out BodyForStorage
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := rlp.DecodeBytes(enc, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if out.BaseTxnID != BaseTxnID(1234567) || out.TxCount != 250 {
+		b.Fatalf("unexpected decode result: %+v", out)
 	}
 }
 


### PR DESCRIPTION
`BodyOnlyTxn` and `BodyForStorage` both start with two integers — `BaseTxnID` and `TxCount` — but read them through `s.Decode`, the reflect-based decoder. A 10s CPU profile of a syncing node attributes **9.7% of samples** (2.27s of 23.41s) to `BodyOnlyTxn.DecodeRLP`, 93% of it inside `rlp.(*Stream).Decode`.

```
BodyOnlyTxn      143 ns/op, 24 B/op, 3 allocs  ->  53 ns/op, 0 B/op, 0 allocs
BodyForStorage   4 allocs -> 2  (time unchanged, see below)
```

## Two layers of reflection

**Inside `DecodeRLP`** — `s.Decode(&b.BaseTxnID)` boxes the pointer into an `any`, does an `atomic.Value` load plus a typecache map lookup hashing a `reflect.Type` (the `aeshashbody` samples in the profile), then runs `errors.As` on every call. `s.Uint64()`/`s.Uint32()` do the same decode directly. For `BodyOnlyTxn` this alone is −42%.

**Reaching `DecodeRLP`** — callers of `BodyOnlyTxn` used `rlp.DecodeBytesPartial(buf, b)`, which reflects *again* purely to dispatch to the `Decoder` interface. The new `BodyOnlyTxn.DecodeRLPBytes` calls `DecodeRLP` directly. This removes the last allocation and a further ~48%.

`BodyOnlyTxn` gains the most because those two integers are the entire decode. `BodyForStorage` goes through the same fix for consistency and drops 2 allocations per body read, but its wall time is unchanged — uncle and withdrawal decoding dominates it (776 B/op). Reported honestly rather than as a headline number.

## Why it's equivalent

`decodeUint` is `s.uint(typ.Bits())` — the same call `Uint64()` makes — so decoded values and error cases are unchanged. `BodyOnlyTxn.DecodeRLP` still deliberately leaves the stream mid-list ("discard rlp.Stream after this..."), which `DecodeBytesPartial` equally permitted, so `DecodeRLPBytes` matches the old semantics exactly.

Adds `BenchmarkBodyOnlyTxnDecodeRLPBytes` and `BenchmarkBodyForStorageDecodeBytes` alongside the existing block encode/decode benchmarks.

The two are deliberately asymmetric, because the call sites are. `BenchmarkBodyOnlyTxnDecodeRLPBytes` calls the new direct path, which is what the snapshot readers now use. `BenchmarkBodyForStorageDecodeBytes` calls `rlp.DecodeBytes`, because that is what `ReadBodyForStorage` and friends actually do and `BodyForStorage` has no direct entrypoint - so it measures the reflect dispatch this PR does *not* remove there, which is why its wall time is unchanged.
