### PR TITLE
hive-test: add skill frontmatter

### DIFF
--- a/.claude/skills/hive-test/SKILL.md
+++ b/.claude/skills/hive-test/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hive-test
+description: Run Ethereum Hive integration tests against a local Erigon build, including engine, RPC compatibility, standard EEST, BAL/Amsterdam EEST, and RLP suites. Use when setting up an ephemeral Hive environment, selecting or running Hive suites, interpreting Hive failures, or cleaning up Hive test resources.
+---
+
 # Skill: hive-test
 
 Run Ethereum Hive integration tests against a local Erigon build. Works from a clean


### PR DESCRIPTION
## Summary

- Add the required YAML frontmatter to the `hive-test` skill.
- Define the skill name and trigger-focused description so skill discovery no longer reports missing frontmatter.

## Root cause

The skill metadata existed only as Markdown body content, while skill discovery expects YAML frontmatter delimited by `---` at the start of `SKILL.md`.

## Impact

The `hive-test` skill can be discovered without the missing-frontmatter warning. Its workflow instructions are unchanged.

## Validation

- Parsed the YAML frontmatter and verified the name matches the skill directory.
- `git diff --check`
- Repository lint/build skipped because this is a Markdown metadata-only change.