### PR TITLE
tests: bump EEST stable fixtures to v20.0.1

### DIFF
--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -11,9 +11,9 @@
     "branch": "devnets/glamsterdam/6"
   },
   "eest_stable": {
-    "url": "https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.0/fixtures.tar.gz",
-    "sha256": "b183702a5b447b465873865357ced9eb342315922e52e31b714e2de115dd0bb4",
-    "size": 399656884
+    "url": "https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.1/fixtures.tar.gz",
+    "sha256": "3586193db06d4d5745d5e90b3c3008c2255a4e19ccd8f11a3ce887aec8c0b17c",
+    "size": 423237039
   },
   "eest_zkevm": {
     "url": "https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.5.0/fixtures_zkevm.tar.gz",


### PR DESCRIPTION
## Summary

- update `eest_stable` fixtures from v20.0.0 to v20.0.1
- refresh the pinned archive SHA-256 checksum and size

## Impact

The stable EEST test fixture downloader will use the v20.0.1 release archive.

## Validation

- `make lint`
- `make erigon integration`
- tests not run (configuration-only fixture metadata update)