### PR TITLE
agents: remove stale autoresearch skill link

### DIFF
--- a/.agents/skills/autoresearch
+++ b/.agents/skills/autoresearch
@@ -1,1 +1,0 @@
-../../.claude/skills/autoresearch


### PR DESCRIPTION
## Summary

- remove the `.agents/skills/autoresearch` symlink
- keep Codex's repository-local skill list aligned with the autoresearch retirement in #22492

## Why

PR #22491 added the shared Codex skill links shortly after #22492 removed the vendored autoresearch references. The merge order left the Codex-facing autoresearch link on `main`, so Codex continued to advertise a skill that was being retired.

This is a repository configuration cleanup with no Erigon runtime impact. TDD is not applicable because the change is a mechanical symlink deletion with no behavior change.

## Validation

- `make lint` (two clean passes)
- `make erigon integration`
- `git diff --check`
- verified every remaining `.agents/skills/*` symlink resolves to a `SKILL.md` file