### PR TITLE
polygon/sync: fix flaky TestEventChannel/ConsumeEvents

### DIFF
--- a/polygon/sync/event_channel_test.go
+++ b/polygon/sync/event_channel_test.go
@@ -64,6 +64,14 @@ func TestEventChannel(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			ch := NewEventChannel[string](2)
+
+			// Fill past capacity before Run starts consuming: a consumer that takes
+			// event1 off the queue first leaves the queue below capacity, so event1 is
+			// never evicted and arrives instead of event2.
+			ch.PushEvent("event1")
+			ch.PushEvent("event2")
+			ch.PushEvent("event3")
+
 			eg := errgroup.Group{}
 			eg.Go(func() error {
 				return ch.Run(ctx)
@@ -72,10 +80,6 @@ func TestEventChannel(t *testing.T) {
 				err := eg.Wait()
 				require.ErrorIs(t, err, context.Canceled)
 			})
-
-			ch.PushEvent("event1")
-			ch.PushEvent("event2")
-			ch.PushEvent("event3")
 
 			events := ch.Events()
 			require.Equal(t, "event2", <-events)


### PR DESCRIPTION
Seen on CI:

```
--- FAIL: TestEventChannel/ConsumeEvents
    event_channel_test.go:81:
        expected: "event2"
        actual  : "event1"
```

`ConsumeEvents` pushed three events into a capacity-2 channel **while `Run` was already consuming**, then asserted event1 had been evicted.

`waitForEvent` takes an event off the queue and `Run` blocks sending it on the unbuffered `events` channel. So a consumer that drains event1 before the third push leaves the queue below capacity — `PushEvent` only evicts when `queue.Len() == queueCap`, so event1 is never dropped and arrives first. The test conflated "buffer evicts oldest" with "consumer has not started yet".

Push all three before starting `Run`. `PushEvent` evicts synchronously under the queue mutex, so reaching capacity with no consumer makes the drop deterministic. The assertions are unchanged — it still tests exactly that a capacity-2 channel drops the oldest event.

Not a skip: the test still runs everywhere and asserts the same thing.

## Honesty about verification

**This does not reproduce locally** — 400x under `-race` on the original ordering, all green (my box is 16-core and idle; CI is a loaded 4-core runner). The fix is reasoned from the CI failure plus the queue implementation, not from a local repro: `expected event2 / actual event1` is only explicable by early consumption, and the new ordering removes the scheduling dependency entirely rather than narrowing it.

Prior art: #17200 fixed flakiness in these same tests before.