### PR TITLE
[r3.5] cl/phase1/stages: simplify forward-sync progress log, use utils.ETA

### DIFF
--- a/cl/phase1/stages/forward_sync.go
+++ b/cl/phase1/stages/forward_sync.go
@@ -388,8 +388,11 @@ func forwardSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) er
 			cur := currentSlot.Load()
 			slotsRemaining, ratePerSec := forwardSyncProgress(chainTipSlot, cur, prevProgress, secsPerLog)
 			prevProgress = cur
+			// distance-from-chain-tip is the ETA at the chain's own production rate
+			// (one slot per SecondsPerSlot), which also saturates instead of overflowing.
+			chainRatePerSec := 1.0 / float64(cfg.beaconCfg.SecondsPerSlot)
 			logger.Info("[Caplin] Forward Sync", "progress", cur,
-				"distance-from-chain-tip", time.Duration(slotsRemaining*cfg.beaconCfg.SecondsPerSlot)*time.Second,
+				"distance-from-chain-tip", utils.ETA(slotsRemaining, chainRatePerSec),
 				"estimated-time-remaining", utils.ETA(slotsRemaining, ratePerSec))
 		default:
 		}

--- a/cl/phase1/stages/forward_sync.go
+++ b/cl/phase1/stages/forward_sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -20,6 +19,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	network2 "github.com/erigontech/erigon/cl/phase1/network"
+	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/cl/utils/bls"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
@@ -266,33 +266,16 @@ func processDownloadedBlockBatches(ctx context.Context, logger log.Logger, cfg *
 	return
 }
 
-// boundedDuration converts a number of seconds into a time.Duration, guarding
-// against the int64 nanosecond overflow that would otherwise wrap to garbage.
-func boundedDuration(seconds float64) time.Duration {
-	if seconds <= 0 {
-		return 0
-	}
-	if maxSeconds := float64(math.MaxInt64) / float64(time.Second); seconds > maxSeconds {
-		return time.Duration(math.MaxInt64)
-	}
-	return time.Duration(seconds) * time.Second
-}
-
-// forwardSyncProgress derives the forward-sync distance and ETA for logging.
-// currentSlot can overshoot chainTipSlot and dip below prevProgress on reorgs,
-// so the differences are clamped to keep the unsigned math from underflowing.
-func forwardSyncProgress(chainTipSlot, currentSlot, prevProgress, secondsPerSlot uint64, secsPerLog int) (distFromChainTip, estimatedTimeRemaining time.Duration) {
-	var slotsRemaining uint64
+// forwardSyncProgress returns the slots still to sync and the observed sync rate
+// in slots/sec. currentSlot can overshoot chainTipSlot and dip below prevProgress
+// on reorgs, so both differences are clamped to keep the unsigned math from
+// underflowing.
+func forwardSyncProgress(chainTipSlot, currentSlot, prevProgress uint64, secsPerLog int) (slotsRemaining uint64, ratePerSec float64) {
 	if chainTipSlot > currentSlot {
 		slotsRemaining = chainTipSlot - currentSlot
 	}
-	distFromChainTip = boundedDuration(float64(slotsRemaining) * float64(secondsPerSlot))
-
-	estimatedTimeRemaining = 999 * time.Hour
 	if currentSlot > prevProgress && secsPerLog > 0 {
-		if rate := float64(currentSlot-prevProgress) / float64(secsPerLog); rate > 0 {
-			estimatedTimeRemaining = boundedDuration(float64(slotsRemaining) / rate)
-		}
+		ratePerSec = float64(currentSlot-prevProgress) / float64(secsPerLog)
 	}
 	return
 }
@@ -403,9 +386,11 @@ func forwardSync(ctx context.Context, logger log.Logger, cfg *Cfg, args Args) er
 		case <-logTicker.C:
 			// Log progress at regular intervals
 			cur := currentSlot.Load()
-			distFromChainTip, estimatedTimeRemaining := forwardSyncProgress(chainTipSlot, cur, prevProgress, cfg.beaconCfg.SecondsPerSlot, secsPerLog)
+			slotsRemaining, ratePerSec := forwardSyncProgress(chainTipSlot, cur, prevProgress, secsPerLog)
 			prevProgress = cur
-			logger.Info("[Caplin] Forward Sync", "progress", cur, "distance-from-chain-tip", distFromChainTip, "estimated-time-remaining", estimatedTimeRemaining)
+			logger.Info("[Caplin] Forward Sync", "progress", cur,
+				"distance-from-chain-tip", time.Duration(slotsRemaining*cfg.beaconCfg.SecondsPerSlot)*time.Second,
+				"estimated-time-remaining", utils.ETA(slotsRemaining, ratePerSec))
 		default:
 		}
 	}

--- a/cl/phase1/stages/forward_sync_test.go
+++ b/cl/phase1/stages/forward_sync_test.go
@@ -18,57 +18,39 @@ package stages
 
 import (
 	"testing"
-	"time"
 )
 
-// currentSlot can overshoot the captured chainTipSlot; the distance/ETA math
-// must not underflow into a ~2^64 slot count and overflow time.Duration.
+// currentSlot can overshoot the captured chainTipSlot; slotsRemaining must clamp
+// to 0 rather than underflow into a ~2^64 slot count.
 func TestForwardSyncProgress_CurrentSlotPastChainTip(t *testing.T) {
-	dist, eta := forwardSyncProgress(1_000_000, 1_000_050, 999_900, 12, 30)
-	if dist != 0 {
-		t.Fatalf("distFromChainTip = %s, want 0 when current slot is past the tip", dist)
+	slotsRemaining, ratePerSec := forwardSyncProgress(1_000_000, 1_000_050, 999_900, 30)
+	if slotsRemaining != 0 {
+		t.Fatalf("slotsRemaining = %d, want 0 when current slot is past the tip", slotsRemaining)
 	}
-	if eta < 0 {
-		t.Fatalf("ETA must not be negative, got %s", eta)
+	if ratePerSec < 0 {
+		t.Fatalf("ratePerSec must not be negative, got %g", ratePerSec)
 	}
 }
 
-// A reorg can drop currentSlot below prevProgress; the rate denominator must not
-// underflow and drive the ETA to a garbage value.
+// A reorg can drop currentSlot below prevProgress; the rate must clamp to 0
+// rather than underflow the slots-processed denominator.
 func TestForwardSyncProgress_ReorgBelowPrevProgress(t *testing.T) {
-	dist, eta := forwardSyncProgress(1_000_000, 900_000, 950_000, 12, 30)
-	if dist < 0 {
-		t.Fatalf("distFromChainTip must not be negative, got %s", dist)
+	slotsRemaining, ratePerSec := forwardSyncProgress(1_000_000, 900_000, 950_000, 30)
+	if slotsRemaining != 100_000 {
+		t.Fatalf("slotsRemaining = %d, want 100000", slotsRemaining)
 	}
-	if want := 999 * time.Hour; eta != want {
-		t.Fatalf("ETA = %s, want %s (default when no forward progress)", eta, want)
+	if ratePerSec != 0 {
+		t.Fatalf("ratePerSec = %g, want 0 when current slot is below prev progress", ratePerSec)
 	}
 }
 
-// Normal case: distance is slots-remaining × seconds-per-slot, ETA scales with rate.
+// Normal case: slotsRemaining is the tip gap, rate is slots processed per second.
 func TestForwardSyncProgress_Normal(t *testing.T) {
-	dist, eta := forwardSyncProgress(1_000_000, 900_000, 899_700, 12, 30)
-	if want := 100_000 * 12 * time.Second; dist != want {
-		t.Fatalf("distFromChainTip = %s, want %s", dist, want)
+	slotsRemaining, ratePerSec := forwardSyncProgress(1_000_000, 900_000, 899_700, 30)
+	if slotsRemaining != 100_000 {
+		t.Fatalf("slotsRemaining = %d, want 100000", slotsRemaining)
 	}
-	// rate = (900000-899700)/30 = 10 slots/s; eta = 100000/10 = 10000s.
-	if want := 10_000 * time.Second; eta != want {
-		t.Fatalf("ETA = %s, want %s", eta, want)
-	}
-}
-
-func TestBoundedDuration(t *testing.T) {
-	if got := boundedDuration(-5); got != 0 {
-		t.Fatalf("boundedDuration(negative) = %s, want 0", got)
-	}
-	if got := boundedDuration(0); got != 0 {
-		t.Fatalf("boundedDuration(0) = %s, want 0", got)
-	}
-	if got := boundedDuration(42); got != 42*time.Second {
-		t.Fatalf("boundedDuration(42) = %s, want 42s", got)
-	}
-	// Absurdly large second count must saturate, not wrap negative.
-	if got := boundedDuration(1e18); got != time.Duration(1<<63-1) {
-		t.Fatalf("boundedDuration(1e18) = %s, want max duration", got)
+	if ratePerSec != 10 { // (900000-899700)/30
+		t.Fatalf("ratePerSec = %g, want 10", ratePerSec)
 	}
 }


### PR DESCRIPTION
Follow-up to the already-merged #22465, applying the review rework that landed on `main` in #22464.

`#22465` fixed the forward-sync progress-log under/overflow but did so with a bespoke `boundedDuration`/`float64` helper. In review of #22464, @AskAlexSharov asked to use idiomatic conversion / the shared `utils.ETA`, and Copilot flagged that the distance conversion could still overflow. This brings release/3.5 in line with `main`.

## Changes

- Drop `boundedDuration`; `forwardSyncProgress` now just clamps the two slot differences (overshoot past the tip, reorg below the previous sample) with plain `if` checks and returns the remaining slots + slots/sec rate.
- Both `distance-from-chain-tip` and `estimated-time-remaining` go through `utils.ETA`, which saturates instead of overflowing `time.Duration`. The distance is the ETA at the chain's own production rate (one slot per `SecondsPerSlot`).

`utils.ETA` is already present on release/3.5 (backported in #22493).

Package tests + `make lint` pass.