### PR TITLE
docs(installation): add Ethereum on ARM install method

### DIFF
--- a/docs/site/docs/get-started/installation/index.mdx
+++ b/docs/site/docs/get-started/installation/index.mdx
@@ -13,6 +13,7 @@ export const sectionForMethod = {
   'install-source':   'linuxmacos',
   'install-native':   'windows',
   'install-wsl':      'windows',
+  'install-arm':      'ethereum-on-arm',
 };
 
 export const go = (id, e) => {
@@ -79,6 +80,7 @@ To install Erigon, begin by choosing an installation method suited to your opera
   <li><a href="#install-prebuilt" onClick={e => { e.preventDefault(); go('install-prebuilt'); }}><strong>Pre-built Binaries</strong></a> — Fastest way to get started. Download and run a pre-compiled binary for your architecture.</li>
   <li><a href="#install-docker" onClick={e => { e.preventDefault(); go('install-docker'); }}><strong>Docker</strong></a> — Run Erigon in an isolated container. Recommended for most users.</li>
   <li><a href="#install-source" onClick={e => { e.preventDefault(); go('install-source'); }}><strong>Build from Source</strong></a> — Full control over the build. Requires Go, C++ compiler, and CLI experience.</li>
+  <li><a href="#install-arm" onClick={e => { e.preventDefault(); go('install-arm'); }}><strong>Ethereum on ARM</strong></a> — Community image and APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5).</li>
 </ul>
 </TabItem>
 <TabItem value="macos" label="macOS">
@@ -550,6 +552,28 @@ The choice of data location directly impacts how you must configure the RPC Daem
 Be aware that the default WSL2 environment uses its own internal IP address, which is distinct from the IP address of your Windows host machine.
 
 If you need to connect to Erigon from an external network (e.g., opening a port on your home router for peering on port `30303`), you must account for this separate WSL2 IP address when configuring NAT on your router. Alternatively consider [Mirrored mode networking](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking).
+
+</details>
+
+### Ethereum on ARM
+
+<details id="install-arm">
+
+<summary>Ethereum on ARM</summary>
+
+[Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/) is a community project that provides a custom Linux image for ARM single-board computers (such as Raspberry Pi, Rock 5B, and Orange Pi 5) with an APT repository preconfigured to install and update Ethereum clients — including Erigon — as native system packages.
+
+Once the image is installed, Erigon can be installed and kept up to date with your system's package manager:
+
+```sh
+sudo apt update && sudo apt install erigon
+```
+
+For the full image, supported boards, and setup instructions, see the [Ethereum on ARM documentation](https://ethereum-on-arm-documentation.readthedocs.io/) and the [project on GitHub](https://github.com/diglos/ethereum-on-arm).
+
+:::info
+Ethereum on ARM is maintained independently by the community and is not an official Erigon distribution channel. The Erigon version available through its APT repository may lag behind the latest [GitHub release](https://github.com/erigontech/erigon/releases).
+:::
 
 </details>
 

--- a/docs/site/docs/get-started/installation/index.mdx
+++ b/docs/site/docs/get-started/installation/index.mdx
@@ -559,7 +559,7 @@ If you need to connect to Erigon from an external network (e.g., opening a port 
 
 <details id="install-arm">
 
-<summary>Ethereum on ARM</summary>
+<summary>Install with APT on ARM boards</summary>
 
 [Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/) is a community project that provides a custom Linux image for ARM single-board computers (such as Raspberry Pi, Rock 5B, and Orange Pi 5) with an APT repository preconfigured to install and update Ethereum clients — including Erigon — as native system packages.
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -231,6 +231,7 @@ URL: https://docs.erigon.tech/get-started/installation
   'install-source':   'linuxmacos',
   'install-native':   'windows',
   'install-wsl':      'windows',
+  'install-arm':      'ethereum-on-arm',
 };
 
   if (e) e.preventDefault();
@@ -292,6 +293,7 @@ To install Erigon, begin by choosing an installation method suited to your opera
 Pre-built Binaries — Fastest way to get started. Download and run a pre-compiled binary for your architecture.
 Docker — Run Erigon in an isolated container. Recommended for most users.
 Build from Source — Full control over the build. Requires Go, C++ compiler, and CLI experience.
+Ethereum on ARM — Community image and APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5).
 
 Docker — Run Erigon in an isolated container. The recommended method on macOS.
 Build from Source — Compile directly on your Mac. Requires Go, Clang/GCC, and CLI experience.
@@ -721,6 +723,24 @@ The choice of data location directly impacts how you must configure the RPC Daem
 Be aware that the default WSL2 environment uses its own internal IP address, which is distinct from the IP address of your Windows host machine.
 
 If you need to connect to Erigon from an external network (e.g., opening a port on your home router for peering on port `30303`), you must account for this separate WSL2 IP address when configuring NAT on your router. Alternatively consider [Mirrored mode networking](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking).
+
+### Ethereum on ARM
+
+Ethereum on ARM
+
+[Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/) is a community project that provides a custom Linux image for ARM single-board computers (such as Raspberry Pi, Rock 5B, and Orange Pi 5) with an APT repository preconfigured to install and update Ethereum clients — including Erigon — as native system packages.
+
+Once the image is installed, Erigon can be installed and kept up to date with your system's package manager:
+
+```sh
+sudo apt update && sudo apt install erigon
+```
+
+For the full image, supported boards, and setup instructions, see the [Ethereum on ARM documentation](https://ethereum-on-arm-documentation.readthedocs.io/) and the [project on GitHub](https://github.com/diglos/ethereum-on-arm).
+
+:::info
+Ethereum on ARM is maintained independently by the community and is not an official Erigon distribution channel. The Erigon version available through its APT repository may lag behind the latest [GitHub release](https://github.com/erigontech/erigon/releases).
+:::
 
 Once you have Erigon installed, you can see [Basic Usage](/fundamentals/basic-usage) to configure your node and confirm it is syncing.
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -726,7 +726,7 @@ If you need to connect to Erigon from an external network (e.g., opening a port 
 
 ### Ethereum on ARM
 
-Ethereum on ARM
+Install with APT on ARM boards
 
 [Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/) is a community project that provides a custom Linux image for ARM single-board computers (such as Raspberry Pi, Rock 5B, and Orange Pi 5) with an APT repository preconfigured to install and update Ethereum clients — including Erigon — as native system packages.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -231,6 +231,7 @@ URL: https://docs.erigon.tech/get-started/installation
   'install-source':   'linuxmacos',
   'install-native':   'windows',
   'install-wsl':      'windows',
+  'install-arm':      'ethereum-on-arm',
 };
 
   if (e) e.preventDefault();
@@ -292,6 +293,7 @@ To install Erigon, begin by choosing an installation method suited to your opera
 Pre-built Binaries — Fastest way to get started. Download and run a pre-compiled binary for your architecture.
 Docker — Run Erigon in an isolated container. Recommended for most users.
 Build from Source — Full control over the build. Requires Go, C++ compiler, and CLI experience.
+Ethereum on ARM — Community image and APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5).
 
 Docker — Run Erigon in an isolated container. The recommended method on macOS.
 Build from Source — Compile directly on your Mac. Requires Go, Clang/GCC, and CLI experience.
@@ -721,6 +723,24 @@ The choice of data location directly impacts how you must configure the RPC Daem
 Be aware that the default WSL2 environment uses its own internal IP address, which is distinct from the IP address of your Windows host machine.
 
 If you need to connect to Erigon from an external network (e.g., opening a port on your home router for peering on port `30303`), you must account for this separate WSL2 IP address when configuring NAT on your router. Alternatively consider [Mirrored mode networking](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking).
+
+### Ethereum on ARM
+
+Ethereum on ARM
+
+[Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/) is a community project that provides a custom Linux image for ARM single-board computers (such as Raspberry Pi, Rock 5B, and Orange Pi 5) with an APT repository preconfigured to install and update Ethereum clients — including Erigon — as native system packages.
+
+Once the image is installed, Erigon can be installed and kept up to date with your system's package manager:
+
+```sh
+sudo apt update && sudo apt install erigon
+```
+
+For the full image, supported boards, and setup instructions, see the [Ethereum on ARM documentation](https://ethereum-on-arm-documentation.readthedocs.io/) and the [project on GitHub](https://github.com/diglos/ethereum-on-arm).
+
+:::info
+Ethereum on ARM is maintained independently by the community and is not an official Erigon distribution channel. The Erigon version available through its APT repository may lag behind the latest [GitHub release](https://github.com/erigontech/erigon/releases).
+:::
 
 Once you have Erigon installed, you can see [Basic Usage](/fundamentals/basic-usage) to configure your node and confirm it is syncing.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -726,7 +726,7 @@ If you need to connect to Erigon from an external network (e.g., opening a port 
 
 ### Ethereum on ARM
 
-Ethereum on ARM
+Install with APT on ARM boards
 
 [Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/) is a community project that provides a custom Linux image for ARM single-board computers (such as Raspberry Pi, Rock 5B, and Orange Pi 5) with an APT repository preconfigured to install and update Ethereum clients — including Erigon — as native system packages.
 


### PR DESCRIPTION
## What

Adds a community **Ethereum on ARM** installation option to the get-started installation page.

[Ethereum on ARM](https://ethereum-on-arm-documentation.readthedocs.io/) ships a custom Linux image + APT repository for ARM single-board computers (Raspberry Pi, Rock 5B, Orange Pi 5) that installs and updates Erigon as a native system package:

```sh
sudo apt update && sudo apt install erigon
```

## Changes

- New collapsible `<details id="install-arm">` section at the end of `docs/get-started/installation/index.mdx`, with links to the Ethereum on ARM documentation and GitHub project.
- An `:::info` note clarifying it is community-maintained (not an official Erigon distribution channel) and may lag the latest GitHub release.
- Added **Ethereum on ARM** to the **Linux** tab of the top method-selection table and registered it in the `sectionForMethod` scroll map so the top link opens and scrolls to the section like the other methods.
- Regenerated `llms-full.txt` artifacts to match (`generate-llms.py --check` passes).

## Verification

- `npm run build` — production build succeeds.
- `python3 docs/site/scripts/generate-llms.py --check` — OK, 4 llms files match (74 pages).

## Related

Forward-port of #22515 (targets `release/3.5`) to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)