### PR TITLE
cmd/evm: fix fork configuration link

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -214,7 +214,7 @@ exitcode:3 OK
 
 The chain configuration to be used for a transition is specified via the
 `--state.fork` CLI flag. A list of possible values and configurations can be
-found in [`execution/testutil/forks.go`](../../execution/testutil/forks.go).
+found in [`execution/tests/testforks/forks.go`](../../execution/tests/testforks/forks.go).
 
 #### Examples
 ##### Basic usage


### PR DESCRIPTION
## Summary

Update the EVM tool documentation to point to the current location of the supported fork configurations.

## Root cause

The link was previously corrected in #16958, but #17119 later moved `execution/testutil/forks.go` to `execution/tests/testforks/forks.go` without updating the README. As a result, the documentation currently points to a
non-existent file.

## Validation

- `lychee --offline --no-progress cmd/evm/README.md`
- `git diff --check`

Go builds and tests were not run because this is a Markdown-only link update.