### PR TITLE
types: reject legacy transactions in typed envelopes

### DIFF
--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -878,3 +878,13 @@ func TestBodyDecodeRejectsEmptyStringTx(t *testing.T) {
 	err := rlp.DecodeBytes(buf.Bytes(), &b)
 	require.Error(t, err, "must reject an empty-string element in the transactions list")
 }
+
+func TestBodyDecodeRejectsWrappedLegacyTransaction(t *testing.T) {
+	t.Parallel()
+	bodyRLP, err := hex.DecodeString("f868f865b863f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3c0")
+	require.NoError(t, err)
+
+	var body Body
+	err = rlp.DecodeBytes(bodyRLP, &body)
+	require.ErrorIs(t, err, ErrInvalidTxType)
+}

--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -177,6 +177,9 @@ func DecodeRLPTransaction(s *rlp.Stream, blobTxnsAreWrappedWithBlobs bool) (Tran
 		if b, err = s.ViewBytes(); err != nil {
 			return nil, err
 		}
+		if len(b) > 0 && b[0] >= rlp.SingleByteThreshold {
+			return nil, ErrInvalidTxType
+		}
 		if txn, err = UnmarshalTransactionFromBinary(b, blobTxnsAreWrappedWithBlobs); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Follow-up to chfast's #22514, found while reviewing its adjacent empty-string transaction-envelope case.

Reject RLP byte-string transaction envelopes whose first payload byte cannot be an EIP-2718 transaction type.

Legacy transactions remain accepted in their canonical block-body form as RLP lists. The regression test uses the same malformed block-body bytes used for the cross-client comparison.

## Root cause

`DecodeRLPTransaction` correctly classified an RLP string as a typed-transaction envelope, but then passed its contents to the general-purpose `UnmarshalTransactionFromBinary`.

That function also accepts canonical legacy transaction bytes. When the envelope contents began with a legacy RLP-list prefix (`>= 0x80`), it recursively called `DecodeTransaction`, so an RLP string wrapping a legacy transaction was accepted. Additional string wrappers repeatedly re-entered the same path.

EIP-2718 defines a transaction as either:

- `TransactionType || TransactionPayload`, where the type byte is in the `[0x00, 0x7f]` range; or
- a legacy transaction encoded directly as `rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])`.

The eth wire specification likewise encodes legacy transactions as RLP lists and typed transactions as RLP byte arrays.

## Shared reproduction

All clients were checked with this block-body RLP:

```
f868f865b863f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3c0
```

The single transaction element is an RLP byte string containing an otherwise valid signed legacy transaction.

| Client | Revision | Result |
|---|---|---|
| Erigon | `cc8fe456da` (main before this patch) | accepted; decoded 1 transaction |
| Geth | `06b23b4293` | rejected: `transaction type not supported` |
| Nethermind | `b5a64c0215` | rejected by `TxDecoder`: envelope byte `0xf8` is an unknown typed transaction ID |
| Reth | `4ed6acaffd` | rejected: `unexpected tx type` |

The Geth and Reth results were executed through their native block-body decoders with the exact fixture above. Nethermind's current decoder was cross-referenced at the equivalent body/transaction decode path: byte-string contents are dispatched by their first byte as a typed ID, and `0xf8` has no registered decoder.

Specifications:

- https://eips.ethereum.org/EIPS/eip-2718
- https://github.com/ethereum/devp2p/blob/master/caps/eth.md#transaction-encoding-and-validity

## Impact

Erigon disagreed with other clients on malformed block-body validity. Recursively nested wrappers also caused repeated transaction-decoder re-entry. On current main, a local Apple M1 benchmark scaled from approximately 1 µs at depth 1 to 136 µs at depth 1000 for a 3 KB body; the zero-copy envelope path keeps allocations mostly flat, but CPU and stack depth still grow with attacker-controlled nesting.

The new check rejects the first invalid envelope before recursion. It adds one length/type comparison to the typed transaction path and does not affect canonical legacy decoding.

## Validation

The regression was added before the production change and failed because Erigon returned no error. It passes after the guard was added.

- `go test ./execution/types -count=1`
- `make lint`
- `make erigon integration`
