### PR TITLE
all: enable modernize linter rules and replace sort.Slice with slices

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,9 +91,6 @@ linters:
           skipRecvDeref: true
     modernize:
       disable: # each disabled analyzer has an existing backlog; enable it once its findings are cleared
-        - slicessort
-        - stditerators
-        - stringsbuilder
         - stringscut
         - stringscutprefix
         - testingcontext

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -26,7 +27,6 @@ import (
 	"math/big"
 	"net/http"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2194,9 +2194,8 @@ func (a *ApiHandler) electraMergedAttestationCandidates(s abstract.BeaconState) 
 				})
 			}
 
-			// Sort in descending order by bit count
-			sort.SliceStable(cands, func(i, j int) bool {
-				return cands[i].count > cands[j].count
+			slices.SortStableFunc(cands, func(a, b candSort) int {
+				return cmp.Compare(b.count, a.count)
 			})
 
 			// Create new slice with sorted attestations
@@ -2398,8 +2397,8 @@ func (a *ApiHandler) findBestAttestationsForBlockProduction(
 			})
 		}
 	}
-	sort.Slice(attestationCandidates, func(i, j int) bool {
-		return attestationCandidates[i].reward > attestationCandidates[j].reward
+	slices.SortFunc(attestationCandidates, func(a, b attestationCandidate) int {
+		return cmp.Compare(b.reward, a.reward)
 	})
 
 	// decide the max attestation length based on the version

--- a/cl/beacon/handler/config.go
+++ b/cl/beacon/handler/config.go
@@ -18,8 +18,9 @@ package handler
 
 import (
 	"bytes"
+	"cmp"
 	"net/http"
-	"sort"
+	"slices"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -59,11 +60,11 @@ func (a *ApiHandler) getForkSchedule(w http.ResponseWriter, r *http.Request) (*b
 		})
 	}
 	// Sort the responses by epoch
-	sort.Slice(response, func(i, j int) bool {
-		if response[i].Epoch == response[j].Epoch {
-			return bytes.Compare(response[i].CurrentVersion[:], response[j].CurrentVersion[:]) < 0
+	slices.SortFunc(response, func(a, b cltypes.Fork) int {
+		if a.Epoch == b.Epoch {
+			return bytes.Compare(a.CurrentVersion[:], b.CurrentVersion[:])
 		}
-		return response[i].Epoch < response[j].Epoch
+		return cmp.Compare(a.Epoch, b.Epoch)
 	})
 	previousVersion := utils.Uint32ToBytes4(uint32(a.beaconChainCfg.GenesisForkVersion))
 	for i := range response {

--- a/cl/beacon/handler/duties_sync.go
+++ b/cl/beacon/handler/duties_sync.go
@@ -17,10 +17,11 @@
 package handler
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
+	"slices"
 	"strconv"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
@@ -136,8 +137,8 @@ func (a *ApiHandler) getSyncDuties(w http.ResponseWriter, r *http.Request) (*bea
 		}
 		duties = append(duties, duty)
 	}
-	sort.Slice(duties, func(i, j int) bool {
-		return duties[i].ValidatorIndex < duties[j].ValidatorIndex
+	slices.SortFunc(duties, func(a, b *syncDutyResponse) int {
+		return cmp.Compare(a.ValidatorIndex, b.ValidatorIndex)
 	})
 
 	return newBeaconResponse(duties).WithOptimistic(a.forkchoiceStore.IsHeadOptimistic()), nil

--- a/cl/beacon/handler/epbs.go
+++ b/cl/beacon/handler/epbs.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -405,27 +406,27 @@ func aggregatePayloadAttestationMessages(
 	}
 
 	slices.SortFunc(candidates, func(a, b candidate) int {
-		less := func(x, y candidate) bool {
-			if x.weight != y.weight {
-				return x.weight > y.weight
-			}
-			left := x.attestation.Data
-			right := y.attestation.Data
-			if left.Slot != right.Slot {
-				return left.Slot < right.Slot
-			}
-			if cmp := bytes.Compare(left.BeaconBlockRoot[:], right.BeaconBlockRoot[:]); cmp != 0 {
-				return cmp < 0
-			}
-			if left.PayloadPresent != right.PayloadPresent {
-				return left.PayloadPresent
-			}
-			return left.BlobDataAvailable && !right.BlobDataAvailable
+		if a.weight != b.weight {
+			return cmp.Compare(b.weight, a.weight)
 		}
-		if less(a, b) {
-			return -1
+		left := a.attestation.Data
+		right := b.attestation.Data
+		if left.Slot != right.Slot {
+			return cmp.Compare(left.Slot, right.Slot)
 		}
-		if less(b, a) {
+		if c := bytes.Compare(left.BeaconBlockRoot[:], right.BeaconBlockRoot[:]); c != 0 {
+			return c
+		}
+		if left.PayloadPresent != right.PayloadPresent {
+			if left.PayloadPresent {
+				return -1
+			}
+			return 1
+		}
+		if left.BlobDataAvailable != right.BlobDataAvailable {
+			if left.BlobDataAvailable {
+				return -1
+			}
 			return 1
 		}
 		return 0

--- a/cl/beacon/handler/epbs.go
+++ b/cl/beacon/handler/epbs.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"sort"
+	"slices"
 	"strconv"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
@@ -404,22 +404,31 @@ func aggregatePayloadAttestationMessages(
 		})
 	}
 
-	sort.Slice(candidates, func(i, j int) bool {
-		if candidates[i].weight != candidates[j].weight {
-			return candidates[i].weight > candidates[j].weight
+	slices.SortFunc(candidates, func(a, b candidate) int {
+		less := func(x, y candidate) bool {
+			if x.weight != y.weight {
+				return x.weight > y.weight
+			}
+			left := x.attestation.Data
+			right := y.attestation.Data
+			if left.Slot != right.Slot {
+				return left.Slot < right.Slot
+			}
+			if cmp := bytes.Compare(left.BeaconBlockRoot[:], right.BeaconBlockRoot[:]); cmp != 0 {
+				return cmp < 0
+			}
+			if left.PayloadPresent != right.PayloadPresent {
+				return left.PayloadPresent
+			}
+			return left.BlobDataAvailable && !right.BlobDataAvailable
 		}
-		left := candidates[i].attestation.Data
-		right := candidates[j].attestation.Data
-		if left.Slot != right.Slot {
-			return left.Slot < right.Slot
+		if less(a, b) {
+			return -1
 		}
-		if cmp := bytes.Compare(left.BeaconBlockRoot[:], right.BeaconBlockRoot[:]); cmp != 0 {
-			return cmp < 0
+		if less(b, a) {
+			return 1
 		}
-		if left.PayloadPresent != right.PayloadPresent {
-			return left.PayloadPresent
-		}
-		return left.BlobDataAvailable && !right.BlobDataAvailable
+		return 0
 	})
 	for i := 0; i < len(candidates) && result.Len() < int(cfg.MaxPayloadAttestations); i++ {
 		result.Append(candidates[i].attestation)

--- a/cl/beacon/handler/liveness.go
+++ b/cl/beacon/handler/liveness.go
@@ -17,10 +17,11 @@
 package handler
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sort"
+	"slices"
 	"strconv"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
@@ -120,8 +121,8 @@ func (a *ApiHandler) liveness(w http.ResponseWriter, r *http.Request) (*beaconht
 	for _, v := range liveSet {
 		resp = append(resp, v)
 	}
-	sort.Slice(resp, func(i, j int) bool {
-		return resp[i].Index < resp[j].Index
+	slices.SortFunc(resp, func(a, b *live) int {
+		return cmp.Compare(a.Index, b.Index)
 	})
 
 	return newBeaconResponse(resp), nil

--- a/cl/beacon/handler/rewards.go
+++ b/cl/beacon/handler/rewards.go
@@ -17,12 +17,13 @@
 package handler
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
+	"slices"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
 	"github.com/erigontech/erigon/cl/clparams"
@@ -239,8 +240,8 @@ func (a *ApiHandler) PostEthV1BeaconRewardsSyncCommittees(w http.ResponseWriter,
 			Reward:         reward,
 		})
 	}
-	sort.Slice(rewards, func(i, j int) bool {
-		return rewards[i].ValidatorIndex < rewards[j].ValidatorIndex
+	slices.SortFunc(rewards, func(a, b syncCommitteeReward) int {
+		return cmp.Compare(a.ValidatorIndex, b.ValidatorIndex)
 	})
 	return newBeaconResponse(rewards).WithFinalized(isFinalized).WithOptimistic(a.forkchoiceStore.IsRootOptimistic(root)), nil
 }

--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -17,6 +17,7 @@
 package clparams
 
 import (
+	"cmp"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -24,7 +25,6 @@ import (
 	mathrand "math/rand"
 	"os"
 	"slices"
-	"sort"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -832,8 +832,8 @@ func (b *BeaconChainConfig) AttestationDueMs(gloas bool) uint64 {
 func (b *BeaconChainConfig) InitializeForkSchedule() {
 	b.ForkVersionSchedule = configForkSchedule(b)
 	// sort blob schedule by epoch in ascending order
-	sort.Slice(b.BlobSchedule, func(i, j int) bool {
-		return b.BlobSchedule[i].Epoch < b.BlobSchedule[j].Epoch
+	slices.SortFunc(b.BlobSchedule, func(a, b BlobParameters) int {
+		return cmp.Compare(a.Epoch, b.Epoch)
 	})
 }
 

--- a/cl/phase1/core/state/cache_accessors.go
+++ b/cl/phase1/core/state/cache_accessors.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -684,9 +684,7 @@ func (b *CachingBeaconState) GetIndexedPayloadAttestation(payloadAttestation *cl
 			indices = append(indices, index)
 		}
 	}
-	sort.SliceStable(indices, func(i, j int) bool {
-		return indices[i] < indices[j]
-	})
+	slices.Sort(indices)
 
 	return &cltypes.IndexedPayloadAttestation{
 		AttestingIndices: solid.NewRawUint64List(len(indices), indices),

--- a/cl/phase1/core/state/upgrade.go
+++ b/cl/phase1/core/state/upgrade.go
@@ -17,8 +17,9 @@
 package state
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -200,14 +201,12 @@ func (b *CachingBeaconState) UpgradeToElectra() error {
 		return true
 	})
 	// sort
-	sort.Slice(validators, func(i, j int) bool {
-		vi, vj := validators[i].validator, validators[j].validator
-		if vi.ActivationEligibilityEpoch() == vj.ActivationEligibilityEpoch() {
-			//  If eligibility epochs are equal, compare indices
-			return validators[i].index < validators[j].index
+	slices.SortFunc(validators, func(a, b tempValidator) int {
+		ae, be := a.validator.ActivationEligibilityEpoch(), b.validator.ActivationEligibilityEpoch()
+		if ae == be {
+			return cmp.Compare(a.index, b.index)
 		}
-		// Otherwise, sort by activationEligibilityEpoch
-		return vi.ActivationEligibilityEpoch() < vj.ActivationEligibilityEpoch()
+		return cmp.Compare(ae, be)
 	})
 
 	for _, v := range validators {

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -17,8 +17,8 @@
 package forkchoice
 
 import (
+	"cmp"
 	"slices"
-	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -734,8 +734,8 @@ func (f *ForkChoiceStore) ForkNodes() []ForkNode {
 			ExecutionBlock: blockHash,
 		})
 	}
-	sort.Slice(forkNodes, func(i, j int) bool {
-		return forkNodes[i].Slot < forkNodes[j].Slot
+	slices.SortFunc(forkNodes, func(a, b ForkNode) int {
+		return cmp.Compare(a.Slot, b.Slot)
 	})
 	return forkNodes
 }

--- a/cl/phase1/forkchoice/get_head.go
+++ b/cl/phase1/forkchoice/get_head.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"math/rand"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -294,10 +294,8 @@ func (f *ForkChoiceStore) getHead(auxilliaryState *state.CachingBeaconState) (co
 			continue
 		}
 		// Sort children by lexigographical order
-		sort.Slice(children, func(i, j int) bool {
-			childA := children[i]
-			childB := children[j]
-			return bytes.Compare(childA[:], childB[:]) < 0
+		slices.SortFunc(children, func(a, b common.Hash) int {
+			return bytes.Compare(a[:], b[:])
 		})
 		// After sorting is done determine best fit.
 		f.headHash = children[0]

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -17,10 +17,11 @@
 package forkchoice
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
@@ -558,8 +559,8 @@ func (f *ForkChoiceStore) isDataAvailable(ctx context.Context, slot uint64, bloc
 	}
 	if !foundOnDisk {
 		// If we didn't find the sidecars on disk, we should write them to disk now
-		sort.Slice(sidecars, func(i, j int) bool {
-			return sidecars[i].Index < sidecars[j].Index
+		slices.SortFunc(sidecars, func(a, b *cltypes.BlobSidecar) int {
+			return cmp.Compare(a.Index, b.Index)
 		})
 		if err := f.blobStorage.WriteBlobSidecars(ctx, blockRoot, sidecars); err != nil {
 			return fmt.Errorf("failed to write blob sidecars: %v", err)

--- a/cl/phase1/forkchoice/weight_store_diff_test.go
+++ b/cl/phase1/forkchoice/weight_store_diff_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	_ "embed"
 	"math"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -255,7 +255,7 @@ func TestGloasWeightTreeDeltaMatchesFullScan(t *testing.T) {
 		roots = append(roots, r)
 	}
 	require.GreaterOrEqual(t, len(roots), 2)
-	sort.Slice(roots, func(i, j int) bool { return bytes.Compare(roots[i][:], roots[j][:]) < 0 })
+	slices.SortFunc(roots, func(a, b common.Hash) int { return bytes.Compare(a[:], b[:]) })
 
 	for n, vi := range voters {
 		target := roots[n%len(roots)]

--- a/cl/phase1/network/beacon_downloader.go
+++ b/cl/phase1/network/beacon_downloader.go
@@ -17,13 +17,14 @@
 package network
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -260,8 +261,8 @@ Process:
 	processBlocks := resp.blocks
 	pid := resp.peerId
 
-	sort.Slice(processBlocks, func(i, j int) bool {
-		return processBlocks[i].Block.Slot < processBlocks[j].Block.Slot
+	slices.SortFunc(processBlocks, func(a, b *cltypes.SignedBeaconBlock) int {
+		return cmp.Compare(a.Block.Slot, b.Block.Slot)
 	})
 
 	// For GLOAS blocks, fetch envelopes only for FULL blocks (whose payload was delivered).
@@ -417,7 +418,7 @@ func (f *ForwardBeaconDownloader) capAtForkBoundary(reqSlot, reqCount uint64) (u
 		}
 		boundaries = append(boundaries, epoch*slotsPerEpoch)
 	}
-	sort.Slice(boundaries, func(i, j int) bool { return boundaries[i] < boundaries[j] })
+	slices.Sort(boundaries)
 
 	endSlot := reqSlot + reqCount
 	for _, boundarySlot := range boundaries {

--- a/cl/phase1/stages/chain_tip_sync.go
+++ b/cl/phase1/stages/chain_tip_sync.go
@@ -1,12 +1,12 @@
 package stages
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"maps"
 	"slices"
-	"sort"
 	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -135,8 +135,8 @@ func fetchBlocksFromReqResp(ctx context.Context, cfg *Cfg, from uint64, count ui
 		return nil, nil
 	}
 
-	sort.Slice(blocks, func(i, j int) bool {
-		return blocks[i].Block.Slot < blocks[j].Block.Slot
+	slices.SortFunc(blocks, func(a, b *cltypes.SignedBeaconBlock) int {
+		return cmp.Compare(a.Block.Slot, b.Block.Slot)
 	})
 
 	// Return the blocks and the peer ID wrapped in a PeeredObject

--- a/cl/phase1/stages/forward_sync.go
+++ b/cl/phase1/stages/forward_sync.go
@@ -1,10 +1,11 @@
 package stages
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -126,8 +127,8 @@ func downloadAndProcessEip4844DA(ctx context.Context, logger log.Logger, cfg *Cf
 // It returns the new highest block processed and an error if any.
 func processDownloadedBlockBatches(ctx context.Context, logger log.Logger, cfg *Cfg, highestBlockProcessed uint64, shouldInsert bool, blocks []*cltypes.SignedBeaconBlock, envelopes map[common.Hash]*cltypes.SignedExecutionPayloadEnvelope) (newHighestBlockProcessed uint64, err error) {
 	// Pre-process the block batch to ensure that the blocks are sorted by slot in ascending order
-	sort.Slice(blocks, func(i, j int) bool {
-		return blocks[i].Block.Slot < blocks[j].Block.Slot
+	slices.SortFunc(blocks, func(a, b *cltypes.SignedBeaconBlock) int {
+		return cmp.Compare(a.Block.Slot, b.Block.Slot)
 	})
 
 	var blockRoot common.Hash

--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -354,21 +354,15 @@ func (s *Sentinel) pruneExcessPeers() {
 	// Sort peers by "removability" (most removable first)
 	// Priority: peers with no critical subnets, then by fewest covered subnets
 	slices.SortFunc(peerInfos, func(a, b peerSubnetInfo) int {
-		less := func(x, y peerSubnetInfo) bool {
-			xCritical := len(x.criticalSubnets) > 0
-			yCritical := len(y.criticalSubnets) > 0
-			if xCritical != yCritical {
-				return !xCritical
+		aCritical := len(a.criticalSubnets) > 0
+		bCritical := len(b.criticalSubnets) > 0
+		if aCritical != bCritical {
+			if !aCritical {
+				return -1
 			}
-			return x.subnetsCount < y.subnetsCount
-		}
-		if less(a, b) {
-			return -1
-		}
-		if less(b, a) {
 			return 1
 		}
-		return 0
+		return cmp.Compare(a.subnetsCount, b.subnetsCount)
 	})
 
 	// Remove peers, but re-check coverage after each removal

--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -17,10 +17,11 @@
 package sentinel
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/OffchainLabs/go-bitfield"
@@ -227,8 +228,8 @@ func (s *Sentinel) proactiveSubnetPeerSearch() {
 			}
 
 			// Sort by wanted count descending (subnets needing most peers first, i.e., 0-peer subnets)
-			sort.Slice(underserved, func(i, j int) bool {
-				return underserved[i].wanted > underserved[j].wanted
+			slices.SortFunc(underserved, func(a, b subnetSearchState) int {
+				return cmp.Compare(b.wanted, a.wanted)
 			})
 
 			// Extract just the subnet indices for logging
@@ -352,18 +353,22 @@ func (s *Sentinel) pruneExcessPeers() {
 
 	// Sort peers by "removability" (most removable first)
 	// Priority: peers with no critical subnets, then by fewest covered subnets
-	sort.Slice(peerInfos, func(i, j int) bool {
-		// Critical peers (covering unique subnets) should never be removed
-		iCritical := len(peerInfos[i].criticalSubnets) > 0
-		jCritical := len(peerInfos[j].criticalSubnets) > 0
-
-		if iCritical != jCritical {
-			return !iCritical // Non-critical peers first (more removable)
+	slices.SortFunc(peerInfos, func(a, b peerSubnetInfo) int {
+		less := func(x, y peerSubnetInfo) bool {
+			xCritical := len(x.criticalSubnets) > 0
+			yCritical := len(y.criticalSubnets) > 0
+			if xCritical != yCritical {
+				return !xCritical
+			}
+			return x.subnetsCount < y.subnetsCount
 		}
-
-		// Among non-critical peers, prefer removing those covering fewer subnets
-		// (they provide less value)
-		return peerInfos[i].subnetsCount < peerInfos[j].subnetsCount
+		if less(a, b) {
+			return -1
+		}
+		if less(b, a) {
+			return 1
+		}
+		return 0
 	})
 
 	// Remove peers, but re-check coverage after each removal

--- a/cl/transition/impl/eth2/statechange/process_registry_updates.go
+++ b/cl/transition/impl/eth2/statechange/process_registry_updates.go
@@ -17,7 +17,8 @@
 package statechange
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"sync"
 
 	"github.com/erigontech/erigon/cl/abstract"
@@ -77,12 +78,11 @@ func ProcessRegistryUpdates(s abstract.BeaconState) error {
 
 	if s.Version() <= clparams.DenebVersion {
 		// order the queue accordingly.
-		sort.Slice(activationQueue, func(i, j int) bool {
-			//  Order by the sequence of activation_eligibility_epoch setting and then index.
-			if activationQueue[i].activationEligibilityEpoch != activationQueue[j].activationEligibilityEpoch {
-				return activationQueue[i].activationEligibilityEpoch < activationQueue[j].activationEligibilityEpoch
+		slices.SortFunc(activationQueue, func(a, b minimizeQueuedValidator) int {
+			if a.activationEligibilityEpoch != b.activationEligibilityEpoch {
+				return cmp.Compare(a.activationEligibilityEpoch, b.activationEligibilityEpoch)
 			}
-			return activationQueue[i].validatorIndex < activationQueue[j].validatorIndex
+			return cmp.Compare(a.validatorIndex, b.validatorIndex)
 		})
 		activationQueueLength := s.GetValidatorActivationChurnLimit()
 		if len(activationQueue) > int(activationQueueLength) {

--- a/cl/utils/eth_clock/ethereum_clock.go
+++ b/cl/utils/eth_clock/ethereum_clock.go
@@ -17,11 +17,11 @@
 package eth_clock
 
 import (
+	"cmp"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"slices"
-	"sort"
 	"time"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -63,11 +63,11 @@ func forkList(schedule map[common.Bytes4]clparams.VersionScheduleEntry) (f []for
 	for version, entry := range schedule {
 		f = append(f, forkNode{epoch: entry.Epoch, version: version, stateVersion: entry.StateVersion})
 	}
-	sort.Slice(f, func(i, j int) bool {
-		if f[i].epoch == f[j].epoch {
-			return f[i].stateVersion < f[j].stateVersion
+	slices.SortFunc(f, func(a, b forkNode) int {
+		if a.epoch == b.epoch {
+			return cmp.Compare(a.stateVersion, b.stateVersion)
 		}
-		return f[i].epoch < f[j].epoch
+		return cmp.Compare(a.epoch, b.epoch)
 	})
 	return
 }

--- a/cmd/evm/enginexrunner.go
+++ b/cmd/evm/enginexrunner.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -25,7 +26,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime/pprof"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -206,7 +207,7 @@ func engineXTestCmd(ctx context.Context, cliCtx *cli.Command) error {
 		results = append(results, r)
 	}
 
-	sort.Slice(results, func(i, j int) bool { return results[i].Name < results[j].Name })
+	slices.SortFunc(results, func(a, b testResult) int { return cmp.Compare(a.Name, b.Name) })
 
 	report(cliCtx, results)
 	if timeIt {
@@ -224,8 +225,8 @@ func printTimings(results []testResult) {
 			timed = append(timed, r)
 		}
 	}
-	sort.Slice(timed, func(i, j int) bool {
-		return timed[i].Stats.Time > timed[j].Stats.Time
+	slices.SortFunc(timed, func(a, b testResult) int {
+		return cmp.Compare(b.Stats.Time, a.Stats.Time)
 	})
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "=== test timings (descending) ===")

--- a/cmd/rlpgen/main.go
+++ b/cmd/rlpgen/main.go
@@ -214,12 +214,11 @@ func findType(scope *types.Scope, typename string) (*types.Named, error) {
 func addEncodeLogic(b1, b2, b3 *bytes.Buffer, named *types.Named) error {
 
 	if _struct, ok := named.Underlying().(*types.Struct); ok {
-		for i := 0; i < _struct.NumFields(); i++ {
-
-			strTyp := matchTypeToString(_struct.Field(i).Type(), "")
+		for field := range _struct.Fields() {
+			strTyp := matchTypeToString(field.Type(), "")
 			// fmt.Println("-+-", strTyp)
 
-			matchStrTypeToFunc(strTyp)(b1, b2, b3, _struct.Field(i).Type(), _struct.Field(i).Name())
+			matchStrTypeToFunc(strTyp)(b1, b2, b3, field.Type(), field.Name())
 		}
 	}
 	// else {
@@ -276,9 +275,9 @@ func handleType(t types.Type, caller types.Type, depth int, ptr bool) {
 		//			return
 
 		// else -> top level call
-		for i := 0; i < e.NumFields(); i++ {
+		for field := range e.Fields() {
 			// this should panic and fail generating everything in case of error
-			handleType(e.Field(i).Type(), e, depth+1, false)
+			handleType(field.Type(), e, depth+1, false)
 		}
 	default:
 		panic("unhandled")

--- a/cmd/utils/app/publishable_check.go
+++ b/cmd/utils/app/publishable_check.go
@@ -1,11 +1,12 @@
 package app
 
 import (
+	"cmp"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/state"
@@ -66,8 +67,11 @@ func CheckFilesForSchema(schema state.SnapNameSchema, params CheckFilesParams) (
 		return 0, false, err
 	}
 
-	sort.Slice(dataFiles, func(i, j int) bool {
-		return (dataFiles[i].From < dataFiles[j].From) || (dataFiles[i].From == dataFiles[j].From && dataFiles[i].To < dataFiles[j].To)
+	slices.SortFunc(dataFiles, func(a, b state.SnapInfo) int {
+		if a.From != b.From {
+			return cmp.Compare(a.From, b.From)
+		}
+		return cmp.Compare(a.To, b.To)
 	})
 
 	if len(dataFiles) == 0 {

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -19,6 +19,7 @@ package app
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1211,14 +1212,14 @@ func DeleteBlockSnapshots(args DeleteBlockSnapshotsArgs) error {
 	}
 
 	// Sort by (From desc, To desc, name asc) for display: newest ranges first.
-	sort.Slice(allFiles, func(i, j int) bool {
-		if allFiles[i].From != allFiles[j].From {
-			return allFiles[i].From > allFiles[j].From
+	slices.SortFunc(allFiles, func(a, b snaptype.FileInfo) int {
+		if a.From != b.From {
+			return cmp.Compare(b.From, a.From)
 		}
-		if allFiles[i].To != allFiles[j].To {
-			return allFiles[i].To > allFiles[j].To
+		if a.To != b.To {
+			return cmp.Compare(b.To, a.To)
 		}
-		return allFiles[i].Name() < allFiles[j].Name()
+		return cmp.Compare(a.Name(), b.Name())
 	})
 
 	fmt.Printf("\nDatadir: %s\n", dirs.DataDir)
@@ -2312,8 +2313,11 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 		return err
 	}
 
-	sort.Slice(accFiles, func(i, j int) bool {
-		return (accFiles[i].From < accFiles[j].From) || (accFiles[i].From == accFiles[j].From && accFiles[i].To < accFiles[j].To)
+	slices.SortFunc(accFiles, func(a, b snaptype.FileInfo) int {
+		if a.From != b.From {
+			return cmp.Compare(a.From, b.From)
+		}
+		return cmp.Compare(a.To, b.To)
 	})
 	if len(accFiles) == 0 {
 		return fmt.Errorf("%w (.kv) in %s", ErrSnapNoAccountFiles, dirs.SnapDomain)
@@ -2422,8 +2426,11 @@ func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentH
 		return err
 	}
 
-	sort.Slice(accFiles, func(i, j int) bool {
-		return (accFiles[i].From < accFiles[j].From) || (accFiles[i].From == accFiles[j].From && accFiles[i].To < accFiles[j].To)
+	slices.SortFunc(accFiles, func(a, b snaptype.FileInfo) int {
+		if a.From != b.From {
+			return cmp.Compare(a.From, b.From)
+		}
+		return cmp.Compare(a.To, b.To)
 	})
 	if len(accFiles) == 0 {
 		return fmt.Errorf("%w (.ef) in %s", ErrSnapNoAccountFiles, dirs.SnapIdx)
@@ -2534,8 +2541,8 @@ func doBlockSnapshotsRangeCheck(snapDir string, suffix string, snapType string) 
 	}); err != nil {
 		return err
 	}
-	sort.Slice(intervals, func(i, j int) bool {
-		return intervals[i].from < intervals[j].from
+	slices.SortFunc(intervals, func(a, b interval) int {
+		return cmp.Compare(a.from, b.from)
 	})
 	if len(intervals) == 0 {
 		return fmt.Errorf("no snapshot files found in %s for type: %s", snapDir, snapType)
@@ -4139,11 +4146,11 @@ func duFormatHuman(w io.Writer, result duResult, verbose bool) {
 	for cat, stat := range result.Categories {
 		entries = append(entries, catEntry{cat, stat})
 	}
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].stat.Bytes != entries[j].stat.Bytes {
-			return entries[i].stat.Bytes > entries[j].stat.Bytes
+	slices.SortFunc(entries, func(a, b catEntry) int {
+		if a.stat.Bytes != b.stat.Bytes {
+			return cmp.Compare(b.stat.Bytes, a.stat.Bytes)
 		}
-		return entries[i].name < entries[j].name
+		return cmp.Compare(a.name, b.name)
 	})
 
 	fmt.Fprintln(w, "── Breakdown ──────────────────────────────────────────────────")
@@ -4167,11 +4174,11 @@ func duFormatHuman(w io.Writer, result duResult, verbose bool) {
 				for sub, stat := range subs {
 					subEntries = append(subEntries, catEntry{sub, stat})
 				}
-				sort.Slice(subEntries, func(i, j int) bool {
-					if subEntries[i].stat.Bytes != subEntries[j].stat.Bytes {
-						return subEntries[i].stat.Bytes > subEntries[j].stat.Bytes
+				slices.SortFunc(subEntries, func(a, b catEntry) int {
+					if a.stat.Bytes != b.stat.Bytes {
+						return cmp.Compare(b.stat.Bytes, a.stat.Bytes)
 					}
-					return subEntries[i].name < subEntries[j].name
+					return cmp.Compare(a.name, b.name)
 				})
 				for j, sub := range subEntries {
 					subPct := float64(0)

--- a/db/downloader/chaintoml.go
+++ b/db/downloader/chaintoml.go
@@ -1,12 +1,13 @@
 package downloader
 
 import (
+	"cmp"
 	"context"
 	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/anacrolix/torrent/metainfo"
@@ -69,8 +70,8 @@ func GenerateChainToml(snapDir string) ([]byte, error) {
 	}
 
 	// Sort by name for deterministic output.
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].name < items[j].name
+	slices.SortFunc(items, func(a, b entry) int {
+		return cmp.Compare(a.name, b.name)
 	})
 
 	// Build TOML output manually for exact control over formatting and determinism.

--- a/db/downloader/chaintoml_v2.go
+++ b/db/downloader/chaintoml_v2.go
@@ -18,8 +18,9 @@ package downloader
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 
 	snapshotinv "github.com/erigontech/erigon/node/components/storage/snapshot"
 	"github.com/pelletier/go-toml/v2"
@@ -119,8 +120,8 @@ func GenerateV2(inv *snapshotinv.Inventory) *ChainTomlV2 {
 		}
 
 		// Sort files by range for deterministic output.
-		sort.Slice(dm.Files, func(i, j int) bool {
-			return dm.Files[i].Range[0] < dm.Files[j].Range[0]
+		slices.SortFunc(dm.Files, func(a, b DomainFileEntry) int {
+			return cmp.Compare(a.Range[0], b.Range[0])
 		})
 
 		// Compute coverage from the published file list (not all local files).

--- a/db/integrity/changed_keys_per_block_test.go
+++ b/db/integrity/changed_keys_per_block_test.go
@@ -17,7 +17,9 @@
 package integrity
 
 import (
+	"bytes"
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 
@@ -208,7 +210,12 @@ func TestChangedKeysPerBlock_ManyKeysOneBlock(t *testing.T) {
 	for i := range pairs {
 		pairs[i] = pair(fmt.Sprintf("key%03d", i), uint64(i%10))
 	}
-	sort.Slice(pairs, func(a, b int) bool { return string(pairs[a].key) < string(pairs[b].key) })
+	slices.SortFunc(pairs, func(a, b struct {
+		key   []byte
+		txNum uint64
+	}) int {
+		return bytes.Compare(a.key, b.key)
+	})
 	idx, err := changedKeysPerBlock(&pairKU64{pairs: pairs}, simpleTxNums(1))
 	require.NoError(t, err)
 	require.Equal(t, 100, idx.NumKeys())

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -18,6 +18,7 @@ package integrity
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/binary"
 	"encoding/hex"
@@ -26,7 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1663,8 +1664,8 @@ func checkStateCorrespondenceReverse(ctx context.Context, file state.VisibleFile
 		prevCommitmentPaths = append(prevCommitmentPaths, pf.Fullpath())
 	}
 	// Sort newest-first so we check the most recent previous file first.
-	sort.Slice(prevCommitmentPaths, func(i, j int) bool {
-		return prevCommitmentPaths[i] > prevCommitmentPaths[j]
+	slices.SortFunc(prevCommitmentPaths, func(a, b string) int {
+		return cmp.Compare(b, a)
 	})
 	accMissing, err := reverseCheckDomainKeys(ctx, accDecomp, kv.AccountsDomain, accCollector, prevCommitmentPaths, fileName, failFast, logger)
 	if err != nil && !errors.Is(err, ErrIntegrity) {
@@ -1816,8 +1817,8 @@ func verifyMissingAgainstPrevFiles(entries []missingEntry, domain kv.Domain, pre
 	}
 
 	// Sort missing entries by key for merge-join.
-	sort.Slice(entries, func(i, j int) bool {
-		return bytes.Compare(entries[i].key, entries[j].key) < 0
+	slices.SortFunc(entries, func(a, b missingEntry) int {
+		return bytes.Compare(a.key, b.key)
 	})
 
 	// Track which entries are confirmed as no-ops.

--- a/db/integrity/integrity_action_type.go
+++ b/db/integrity/integrity_action_type.go
@@ -17,7 +17,8 @@
 package integrity
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 )
 
 type Check string
@@ -157,18 +158,18 @@ func SortChecksByCost(checks []Check) []Check {
 		rank[c] = i
 	}
 	out := append([]Check{}, checks...)
-	sort.SliceStable(out, func(i, j int) bool {
-		ri, oki := rank[out[i]]
-		rj, okj := rank[out[j]]
+	slices.SortStableFunc(out, func(a, b Check) int {
+		ri, oki := rank[a]
+		rj, okj := rank[b]
 		switch {
 		case oki && okj:
-			return ri < rj
+			return cmp.Compare(ri, rj)
 		case oki:
-			return true
+			return -1
 		case okj:
-			return false
+			return 1
 		default:
-			return false
+			return 0
 		}
 	})
 	return out

--- a/db/kv/helpers.go
+++ b/db/kv/helpers.go
@@ -17,11 +17,12 @@
 package kv
 
 import (
+	"cmp"
 	"context"
 	"encoding/binary"
 	"errors"
 	"maps"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -342,8 +343,8 @@ func (d *DomainDiff) GetDiffSet() (keysToValue []DomainEntryDiff) {
 		d.prevValsSlice[i].Value = v
 		i++
 	}
-	sort.Slice(d.prevValsSlice, func(i, j int) bool {
-		return d.prevValsSlice[i].Key < d.prevValsSlice[j].Key
+	slices.SortFunc(d.prevValsSlice, func(a, b DomainEntryDiff) int {
+		return cmp.Compare(a.Key, b.Key)
 	})
 	return d.prevValsSlice
 }

--- a/db/kv/mdbx/split_bucket_test.go
+++ b/db/kv/mdbx/split_bucket_test.go
@@ -19,7 +19,7 @@ package mdbx
 import (
 	"bytes"
 	"encoding/binary"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -66,9 +66,7 @@ func TestSplitBucketByCount(t *testing.T) {
 		require.Greater(t, len(bounds), 2, "must split clustered keys into many ranges, not one")
 		require.Nil(t, bounds[0])
 		require.Nil(t, bounds[len(bounds)-1])
-		require.True(t, sort.SliceIsSorted(bounds[1:len(bounds)-1], func(a, b int) bool {
-			return bytes.Compare(bounds[1+a], bounds[1+b]) < 0
-		}), "interior boundaries must be strictly increasing")
+		require.True(t, slices.IsSortedFunc(bounds[1:len(bounds)-1], bytes.Compare), "interior boundaries must be strictly increasing")
 
 		per, total := n/(len(bounds)-1), 0
 		for i := 0; i+1 < len(bounds); i++ {
@@ -119,9 +117,7 @@ func TestSplitBucketByCountDupSort(t *testing.T) {
 		require.Greater(t, len(bounds), 2, "must split into many ranges")
 		require.Nil(t, bounds[0])
 		require.Nil(t, bounds[len(bounds)-1])
-		require.True(t, sort.SliceIsSorted(bounds[1:len(bounds)-1], func(a, b int) bool {
-			return bytes.Compare(bounds[1+a], bounds[1+b]) < 0
-		}), "interior boundaries must be strictly increasing")
+		require.True(t, slices.IsSortedFunc(bounds[1:len(bounds)-1], bytes.Compare), "interior boundaries must be strictly increasing")
 
 		seen := 0
 		for i := 0; i+1 < len(bounds); i++ {

--- a/db/kv/tables.go
+++ b/db/kv/tables.go
@@ -18,7 +18,7 @@ package kv
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/erigontech/erigon/db/kv/dbcfg"
@@ -637,9 +637,7 @@ func TablesCfgByLabel(label Label) TableCfg {
 	}
 }
 func sortBuckets() {
-	sort.SliceStable(ChaindataTables, func(i, j int) bool {
-		return strings.Compare(ChaindataTables[i], ChaindataTables[j]) < 0
-	})
+	slices.Sort(ChaindataTables)
 }
 
 func init() {

--- a/db/seg/patricia/aho_corasick.go
+++ b/db/seg/patricia/aho_corasick.go
@@ -17,7 +17,7 @@
 package patricia
 
 import (
-	"sort"
+	"slices"
 )
 
 // Match is a single pattern occurrence: its associated value and the [Start, End)
@@ -115,7 +115,7 @@ func (ac *AhoCorasick) Build() {
 		for b := range m {
 			bs = append(bs, b)
 		}
-		sort.Slice(bs, func(i, j int) bool { return bs[i] < bs[j] })
+		slices.Sort(bs)
 		tos := make([]int32, len(bs))
 		for i, b := range bs {
 			tos[i] = m[b]

--- a/db/snapshotsync/caplin_state_overlap_test.go
+++ b/db/snapshotsync/caplin_state_overlap_test.go
@@ -17,9 +17,10 @@
 package snapshotsync
 
 import (
+	"cmp"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -87,8 +88,11 @@ func hasDiskOverlap(t *testing.T, dir, table string) bool {
 		}
 		rs = append(rs, rng{fi.From, fi.To})
 	}
-	sort.Slice(rs, func(i, j int) bool {
-		return rs[i].from < rs[j].from || (rs[i].from == rs[j].from && rs[i].to < rs[j].to)
+	slices.SortFunc(rs, func(a, b rng) int {
+		if a.from != b.from {
+			return cmp.Compare(a.from, b.from)
+		}
+		return cmp.Compare(a.to, b.to)
 	})
 	for i := 1; i < len(rs); i++ {
 		if rs[i].from < rs[i-1].to {

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -17,6 +17,7 @@
 package snapshotsync
 
 import (
+	"cmp"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -25,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -297,7 +299,7 @@ func (s *CaplinStateSnapshots) coveredRangesForType(name string) []Range {
 // starts at slot 0 for the given type, or 0 when coverage is not rooted at genesis.
 func (s *CaplinStateSnapshots) ContiguousCoverageEnd(typeName string) uint64 {
 	ranges := s.coveredRangesForType(typeName)
-	sort.Slice(ranges, func(i, j int) bool { return ranges[i].from < ranges[j].from })
+	slices.SortFunc(ranges, func(a, b Range) int { return cmp.Compare(a.from, b.from) })
 	var end uint64
 	for _, r := range ranges {
 		if r.from > end {

--- a/db/state/archive_test.go
+++ b/db/state/archive_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"bytes"
 	"path/filepath"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -52,7 +52,7 @@ func TestArchiveWriter(t *testing.T) {
 	for k := range td {
 		keys = append(keys, []byte(k))
 	}
-	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
+	slices.SortFunc(keys, bytes.Compare)
 
 	writeLatest := func(tb testing.TB, w *seg.Writer, td map[string][]upd) {
 		tb.Helper()

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -18,6 +18,7 @@ package state
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/binary"
 	"encoding/hex"
@@ -30,7 +31,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -1780,7 +1780,7 @@ func generateUpdates(r *rndGen, totalTx, keyTxsLimit uint64) []upd {
 		updates = append(updates, up)
 		usedTxNums[txNum] = true
 	}
-	sort.Slice(updates, func(i, j int) bool { return updates[i].txNum < updates[j].txNum })
+	slices.SortFunc(updates, func(a, b upd) int { return cmp.Compare(a.txNum, b.txNum) })
 
 	return updates
 }

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"os"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -1860,9 +1859,7 @@ func Test_HistoryIterate_VariousKeysLen(t *testing.T) {
 			//vals = append(vals, fmt.Sprintf("%x", v))
 		}
 
-		sort.Slice(writtenKeys, func(i, j int) bool {
-			return bytes.Compare(writtenKeys[i], writtenKeys[j]) < 0
-		})
+		slices.SortFunc(writtenKeys, bytes.Compare)
 
 		require.Equal(fmt.Sprintf("%#x", writtenKeys[0]), fmt.Sprintf("%#x", keys[0]))
 		require.Len(keys, len(writtenKeys))

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -17,13 +17,13 @@
 package state
 
 import (
+	"cmp"
 	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"maps"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 
@@ -766,8 +766,8 @@ func (sd *TemporalMemBatch) Merge(o kv.TemporalMemBatch) error {
 func (sd *TemporalMemBatch) flushLocked(ctx context.Context, tx kv.RwTx) error {
 	if sd.unwindChangesetRaw != nil {
 		for domain := range sd.unwindChangesetRaw {
-			sort.Slice(sd.unwindChangesetRaw[domain], func(i, j int) bool {
-				return sd.unwindChangesetRaw[domain][i].Key < sd.unwindChangesetRaw[domain][j].Key
+			slices.SortFunc(sd.unwindChangesetRaw[domain], func(a, b kv.DomainEntryDiff) int {
+				return cmp.Compare(a.Key, b.Key)
 			})
 		}
 		if err := tx.(kv.TemporalRwTx).Unwind(ctx, sd.unwindToTxNum, sd.unwindChangesetRaw); err != nil {

--- a/db/test/domain_shared_bench_test.go
+++ b/db/test/domain_shared_bench_test.go
@@ -17,10 +17,11 @@
 package test
 
 import (
+	"cmp"
 	"encoding/binary"
 	randOld "math/rand"
 	"math/rand/v2"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -282,7 +283,7 @@ func generateAccountUpdates(r *rndGen, totalTx, keyTxsLimit uint64) []upd {
 		updates = append(updates, upd{txNum: txNum, value: value})
 		usedTxNums[txNum] = true
 	}
-	sort.Slice(updates, func(i, j int) bool { return updates[i].txNum < updates[j].txNum })
+	slices.SortFunc(updates, func(a, b upd) int { return cmp.Compare(a.txNum, b.txNum) })
 
 	return updates
 }
@@ -301,7 +302,7 @@ func generateArbitraryValueUpdates(r *rndGen, totalTx, keyTxsLimit, maxSize uint
 		updates = append(updates, upd{txNum: txNum, value: value})
 		usedTxNums[txNum] = true
 	}
-	sort.Slice(updates, func(i, j int) bool { return updates[i].txNum < updates[j].txNum })
+	slices.SortFunc(updates, func(a, b upd) int { return cmp.Compare(a.txNum, b.txNum) })
 
 	return updates
 }

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -233,14 +233,20 @@ func FindFilesWithVersionsByPattern(pattern string) (string, Version, bool, erro
 		return "", Version{}, false, nil
 	}
 	if len(matches) > 1 {
-		sort.Slice(matches, func(i, j int) bool {
-			_, fName1 := filepath.Split(matches[i])
+		slices.SortFunc(matches, func(a, b string) int {
+			_, fName1 := filepath.Split(a)
 			version1, _ := ParseVersion(fName1)
 
-			_, fName2 := filepath.Split(matches[j])
+			_, fName2 := filepath.Split(b)
 			version2, _ := ParseVersion(fName2)
 
-			return version1.Less(version2)
+			if version1.Less(version2) {
+				return -1
+			}
+			if version2.Less(version1) {
+				return 1
+			}
+			return 0
 		})
 		_, fName := filepath.Split(matches[len(matches)-1])
 		ver, _ := ParseVersion(fName)

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -240,13 +240,7 @@ func FindFilesWithVersionsByPattern(pattern string) (string, Version, bool, erro
 			_, fName2 := filepath.Split(b)
 			version2, _ := ParseVersion(fName2)
 
-			if version1.Less(version2) {
-				return -1
-			}
-			if version2.Less(version1) {
-				return 1
-			}
-			return 0
+			return version1.Cmp(version2)
 		})
 		_, fName := filepath.Split(matches[len(matches)-1])
 		ver, _ := ParseVersion(fName)

--- a/diagnostics/diaglib/network.go
+++ b/diagnostics/diaglib/network.go
@@ -17,7 +17,7 @@
 package diaglib
 
 import (
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -214,8 +214,14 @@ func (p *PeerStats) getOldestUpdatedPeersWithSize(size int) []PeerUpdTime {
 		timeArray = append(timeArray, PeerUpdTime{k, v})
 	}
 
-	sort.Slice(timeArray, func(i, j int) bool {
-		return timeArray[i].Time.Before(timeArray[j].Time)
+	slices.SortFunc(timeArray, func(a, b PeerUpdTime) int {
+		if a.Time.Before(b.Time) {
+			return -1
+		}
+		if b.Time.Before(a.Time) {
+			return 1
+		}
+		return 0
 	})
 
 	if len(timeArray) < size {

--- a/diagnostics/metrics/set.go
+++ b/diagnostics/metrics/set.go
@@ -17,10 +17,10 @@
 package metrics
 
 import (
+	"cmp"
 	"fmt"
 	"reflect"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -63,15 +63,18 @@ func NewSet() *Set {
 }
 
 func (s *Set) Describe(ch chan<- *prometheus.Desc) {
-	lessFunc := func(i, j int) bool {
-		return s.a[i].name < s.a[j].name
+	cmpA := func(a, b *namedMetric) int {
+		return cmp.Compare(a.name, b.name)
+	}
+	cmpAV := func(a, b *namedMetricVec) int {
+		return cmp.Compare(a.name, b.name)
 	}
 	s.mu.Lock()
-	if !sort.SliceIsSorted(s.a, lessFunc) {
-		sort.Slice(s.a, lessFunc)
+	if !slices.IsSortedFunc(s.a, cmpA) {
+		slices.SortFunc(s.a, cmpA)
 	}
-	if !sort.SliceIsSorted(s.av, lessFunc) {
-		sort.Slice(s.av, lessFunc)
+	if !slices.IsSortedFunc(s.av, cmpAV) {
+		slices.SortFunc(s.av, cmpAV)
 	}
 	sa := append([]*namedMetric(nil), s.a...)
 	sav := append([]*namedMetricVec(nil), s.av...)
@@ -85,15 +88,18 @@ func (s *Set) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (s *Set) Collect(ch chan<- prometheus.Metric) {
-	lessFunc := func(i, j int) bool {
-		return s.a[i].name < s.a[j].name
+	cmpA := func(a, b *namedMetric) int {
+		return cmp.Compare(a.name, b.name)
+	}
+	cmpAV := func(a, b *namedMetricVec) int {
+		return cmp.Compare(a.name, b.name)
 	}
 	s.mu.Lock()
-	if !sort.SliceIsSorted(s.a, lessFunc) {
-		sort.Slice(s.a, lessFunc)
+	if !slices.IsSortedFunc(s.a, cmpA) {
+		slices.SortFunc(s.a, cmpA)
 	}
-	if !sort.SliceIsSorted(s.av, lessFunc) {
-		sort.Slice(s.av, lessFunc)
+	if !slices.IsSortedFunc(s.av, cmpAV) {
+		slices.SortFunc(s.av, cmpAV)
 	}
 	sa := append([]*namedMetric(nil), s.a...)
 	sav := append([]*namedMetricVec(nil), s.av...)

--- a/execution/commitment/commitment_test.go
+++ b/execution/commitment/commitment_test.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 	"math/bits"
 	"math/rand"
-	"sort"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -689,8 +689,8 @@ func TestUpdates_TouchPlainKey(t *testing.T) {
 	for _, v := range uniqUpds {
 		sortedUniqUpds = append(sortedUniqUpds, v)
 	}
-	sort.Slice(sortedUniqUpds, func(i, j int) bool {
-		return bytes.Compare(sortedUniqUpds[i].key, sortedUniqUpds[j].key) < 0
+	slices.SortFunc(sortedUniqUpds, func(a, b tc) int {
+		return bytes.Compare(a.key, b.key)
 	})
 
 	sz := utUpdate.Size()

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -18,6 +18,7 @@ package commitment
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/binary"
 	"encoding/hex"
@@ -27,7 +28,6 @@ import (
 	"math/bits"
 	"runtime"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2619,7 +2619,7 @@ func (hph *HexPatriciaHashed) Process(ctx context.Context, updates *Updates, log
 		for k := range hph.hadToLoadL {
 			ends = append(ends, k)
 		}
-		sort.Slice(ends, func(i, j int) bool { return ends[i] > ends[j] })
+		slices.SortFunc(ends, func(a, b uint64) int { return cmp.Compare(b, a) })
 		var Li int
 		for _, k := range ends {
 			v := hph.hadToLoadL[k]

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -23,7 +23,7 @@ import (
 	"math/bits"
 	"math/rand"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1445,8 +1445,8 @@ func sortUpdatesByHashIncrease(t *testing.T, hph *HexPatriciaHashed, plainKeys [
 		ku[i] = &KeyUpdate{plainKey: string(pk), hashedKey: KeyToHexNibbleHash(pk), update: &updates[i]}
 	}
 
-	sort.Slice(ku, func(i, j int) bool {
-		return bytes.Compare(ku[i].hashedKey, ku[j].hashedKey) < 0
+	slices.SortFunc(ku, func(a, b *KeyUpdate) int {
+		return bytes.Compare(a.hashedKey, b.hashedKey)
 	})
 
 	pks := make([][]byte, len(ku))

--- a/execution/commitment/metrics.go
+++ b/execution/commitment/metrics.go
@@ -1,10 +1,11 @@
 package commitment
 
 import (
+	"cmp"
 	"encoding/csv"
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -327,7 +328,7 @@ func (m *Metrics) CollectFileDepthStats(endTxNumStats map[uint64]skipStat) {
 		ends = append(ends, k)
 	}
 	// sort by file endTxNum
-	sort.Slice(ends, func(i, j int) bool { return ends[i] > ends[j] })
+	slices.SortFunc(ends, func(a, b uint64) int { return cmp.Compare(b, a) })
 	for i := 0; i < 5 && i < len(ends); i++ {
 		// get stats for specific file depth
 		v := endTxNumStats[ends[i]]

--- a/execution/commitment/nibbles/nibbles_v2_test.go
+++ b/execution/commitment/nibbles/nibbles_v2_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"math/rand"
-	"sort"
+	"slices"
 	"testing"
 )
 
@@ -349,11 +349,11 @@ func BenchmarkLocalityV1VsV2(b *testing.B) {
 			v1Idx[i] = i
 			v2Idx[i] = i
 		}
-		sort.Slice(v1Idx, func(i, j int) bool {
-			return bytes.Compare(v1Keys[v1Idx[i]], v1Keys[v1Idx[j]]) < 0
+		slices.SortFunc(v1Idx, func(a, b int) int {
+			return bytes.Compare(v1Keys[a], v1Keys[b])
 		})
-		sort.Slice(v2Idx, func(i, j int) bool {
-			return bytes.Compare(v2Keys[v2Idx[i]], v2Keys[v2Idx[j]]) < 0
+		slices.SortFunc(v2Idx, func(a, b int) int {
+			return bytes.Compare(v2Keys[a], v2Keys[b])
 		})
 
 		var v1Sum, v2Sum int64

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -1,12 +1,13 @@
 package commitment
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
 	"math/bits"
 	"os"
-	"sort"
+	"slices"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -229,7 +230,7 @@ func printMountTiming(tStart, tUnfolded, tWorkers time.Time, buildDur, foldDur *
 			maxSum, maxSumNib = sum, nib
 		}
 	}
-	sort.Slice(stats, func(i, j int) bool { return stats[i].sum > stats[j].sum })
+	slices.SortFunc(stats, func(a, b wstat) int { return cmp.Compare(b.sum, a.sum) })
 	fmt.Printf("\n[CMT_TIMING] baseUnfold=%v workerWall=%v rootFold=%v | criticalWorker=nib %x sum=%v (build=%v fold=%v)\n",
 		tUnfolded.Sub(tStart), tWorkers.Sub(tUnfolded), time.Since(tWorkers), maxSumNib, maxSum, stats[0].build, stats[0].fold)
 	fmt.Printf("[CMT_TIMING] sum(maxBuild=%v maxFold=%v) = ideal critical path if build & fold each split perfectly across nibbles\n", maxBuild, maxFold)

--- a/execution/commitment/preload_parallel.go
+++ b/execution/commitment/preload_parallel.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
@@ -167,7 +167,7 @@ func (p *ContractTrunkPreloadParallel) Run(
 	for !budgetHit && p.nextDepth <= maxStorageTrunkDepth && len(p.frontier) > 0 {
 		depth := p.nextDepth
 		// Ascending key order so the file-batch partition is contiguous-in-file.
-		sort.Slice(p.frontier, func(i, j int) bool { return bytes.Compare(p.frontier[i].key, p.frontier[j].key) < 0 })
+		slices.SortFunc(p.frontier, func(a, b pathKey) int { return bytes.Compare(a.key, b.key) })
 
 		var dbHits []pathKey
 		var dbVals [][]byte

--- a/execution/commitment/preload_parallel_test.go
+++ b/execution/commitment/preload_parallel_test.go
@@ -10,9 +10,10 @@ package commitment
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/binary"
 	"errors"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
@@ -137,11 +138,11 @@ func breadthFirstOrder(tree syntheticTree, exclude map[string]bool) []string {
 		copy(kc, k)
 		pks = append(pks, pk{path: p, key: kc})
 	}
-	sort.Slice(pks, func(i, j int) bool {
-		if len(pks[i].path) != len(pks[j].path) {
-			return len(pks[i].path) < len(pks[j].path)
+	slices.SortFunc(pks, func(a, b pk) int {
+		if len(a.path) != len(b.path) {
+			return cmp.Compare(len(a.path), len(b.path))
 		}
-		return bytes.Compare(pks[i].key, pks[j].key) < 0
+		return bytes.Compare(a.key, b.key)
 	})
 	out := make([]string, len(pks))
 	for i := range pks {

--- a/execution/commitment/prepare_on_touch_test.go
+++ b/execution/commitment/prepare_on_touch_test.go
@@ -1,8 +1,9 @@
 package commitment
 
 import (
+	"bytes"
 	"context"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -117,14 +118,8 @@ func sortedTriples(pk [][]byte, upds []Update) []triple {
 	for i := range pk {
 		ts[i] = triple{hk: KeyToHexNibbleHash(pk[i]), pk: pk[i], upd: &upds[i]}
 	}
-	sort.Slice(ts, func(i, j int) bool {
-		a, b := ts[i].hk, ts[j].hk
-		for k := 0; k < len(a) && k < len(b); k++ {
-			if a[k] != b[k] {
-				return a[k] < b[k]
-			}
-		}
-		return len(a) < len(b)
+	slices.SortFunc(ts, func(a, b triple) int {
+		return bytes.Compare(a.hk, b.hk)
 	})
 	return ts
 }

--- a/execution/commitment/trie_trace.go
+++ b/execution/commitment/trie_trace.go
@@ -17,10 +17,11 @@
 package commitment
 
 import (
+	"cmp"
 	"encoding/hex"
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
@@ -110,8 +111,8 @@ func BuildTrieTrace(rc *RecordingContext, inputKeys map[string]struct{}, trieSta
 	}
 
 	// Sort updates by plain key for deterministic output.
-	sort.Slice(tt.Updates, func(i, j int) bool {
-		return tt.Updates[i].PlainKey < tt.Updates[j].PlainKey
+	slices.SortFunc(tt.Updates, func(a, b TraceKeyUpdate) int {
+		return cmp.Compare(a.PlainKey, b.PlainKey)
 	})
 
 	// Include PutBranch writes if any were recorded.

--- a/execution/commitment/verify.go
+++ b/execution/commitment/verify.go
@@ -17,6 +17,7 @@
 package commitment
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -144,12 +145,12 @@ func VerifyBranchHashes(
 
 	if len(mismatches) > 0 {
 		var sb strings.Builder
-		sb.WriteString(fmt.Sprintf("hash verification failed with %d mismatch(es) at branchKey=%x:", len(mismatches), branchKey))
+		fmt.Fprintf(&sb, "hash verification failed with %d mismatch(es) at branchKey=%x:", len(mismatches), branchKey)
 		for _, m := range mismatches {
 			sb.WriteString("\n  ")
 			sb.WriteString(m)
 		}
-		return fmt.Errorf("%s", sb.String())
+		return errors.New(sb.String())
 	}
 	return nil
 }

--- a/execution/commitment/verify.go
+++ b/execution/commitment/verify.go
@@ -18,6 +18,7 @@ package commitment
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/empty"
@@ -142,11 +143,13 @@ func VerifyBranchHashes(
 	}
 
 	if len(mismatches) > 0 {
-		msg := fmt.Sprintf("hash verification failed with %d mismatch(es) at branchKey=%x:", len(mismatches), branchKey)
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("hash verification failed with %d mismatch(es) at branchKey=%x:", len(mismatches), branchKey))
 		for _, m := range mismatches {
-			msg += "\n  " + m
+			sb.WriteString("\n  ")
+			sb.WriteString(m)
 		}
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf("%s", sb.String())
 	}
 	return nil
 }

--- a/execution/p2p/fetcher_errors.go
+++ b/execution/p2p/fetcher_errors.go
@@ -184,9 +184,9 @@ func lowestHeadersNum(headers []*types.Header) (uint64, bool) {
 		return 0, false
 	}
 
-	slices.SortFunc(headers, func(a, b *types.Header) int {
+	lowest := slices.MinFunc(headers, func(a, b *types.Header) int {
 		return cmp.Compare(a.Number.Uint64(), b.Number.Uint64())
 	})
 
-	return headers[0].Number.Uint64(), true
+	return lowest.Number.Uint64(), true
 }

--- a/execution/p2p/fetcher_errors.go
+++ b/execution/p2p/fetcher_errors.go
@@ -17,9 +17,10 @@
 package p2p
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/types"
@@ -183,8 +184,8 @@ func lowestHeadersNum(headers []*types.Header) (uint64, bool) {
 		return 0, false
 	}
 
-	sort.Slice(headers, func(i, j int) bool {
-		return headers[i].Number.Uint64() < headers[j].Number.Uint64()
+	slices.SortFunc(headers, func(a, b *types.Header) int {
+		return cmp.Compare(a.Number.Uint64(), b.Number.Uint64())
 	})
 
 	return headers[0].Number.Uint64(), true

--- a/execution/p2p/peer_tracker_test.go
+++ b/execution/p2p/peer_tracker_test.go
@@ -17,9 +17,10 @@
 package p2p
 
 import (
+	"cmp"
 	"context"
 	"encoding/binary"
-	"sort"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -378,12 +379,10 @@ func (ptt *peerTrackerTest) run(f func(ctx context.Context, t *testing.T)) {
 // by using PeerIdFromUint64 and so uint64 value is sorted in first 8 bytes. Sorting is needed since
 // ListPeersMayHaveBlockNum returns peer ids from a map and order is non-deterministic.
 func sortPeerIdsAssumingUints(peerIds []*PeerId) {
-	sort.Slice(peerIds, func(i, j int) bool {
-		bytesI := peerIds[i][:8]
-		bytesJ := peerIds[j][:8]
-		numI := binary.BigEndian.Uint64(bytesI)
-		numJ := binary.BigEndian.Uint64(bytesJ)
-		return numI < numJ
+	slices.SortFunc(peerIds, func(a, b *PeerId) int {
+		numA := binary.BigEndian.Uint64((*a)[:8])
+		numB := binary.BigEndian.Uint64((*b)[:8])
+		return cmp.Compare(numA, numB)
 	})
 }
 

--- a/execution/state/triedb_state.go
+++ b/execution/state/triedb_state.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"maps"
-	"sort"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -287,8 +287,8 @@ func (tds *TrieDbState) buildPlainStorageReads() ([][]byte, [][]byte) {
 	}
 
 	// Sort indices based on accountAddresses
-	sort.SliceStable(indices, func(i, j int) bool {
-		return bytes.Compare(storagePlainKeys[indices[i]], storagePlainKeys[indices[j]]) < 0
+	slices.SortStableFunc(indices, func(a, b int) int {
+		return bytes.Compare(storagePlainKeys[a], storagePlainKeys[b])
 	})
 
 	// Apply the sorted order to accountAddresses and accountAddressHashes
@@ -396,8 +396,8 @@ func (tds *TrieDbState) buildAccountAddressReads() ([][]byte, [][]byte) {
 	}
 
 	// Sort indices based on accountAddresses
-	sort.SliceStable(indices, func(i, j int) bool {
-		return bytes.Compare(accountAddresses[indices[i]], accountAddresses[indices[j]]) < 0
+	slices.SortStableFunc(indices, func(a, b int) int {
+		return bytes.Compare(accountAddresses[a], accountAddresses[b])
 	})
 
 	// Apply the sorted order to accountAddresses and accountAddressHashes

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -8,7 +8,6 @@ import (
 	"iter"
 	"maps"
 	"slices"
-	"sort"
 	"strconv"
 	"sync"
 
@@ -1766,15 +1765,17 @@ func (s *WriteSet) TouchUpdates(updates *commitment.Updates) {
 // processing order; WriteSet map iteration is non-deterministic in Go.
 // The sort relies on the AccountPath enum ordering defined in versionmap.go.
 func sortWriteHeaders(headers []WriteHeader) {
-	sort.Slice(headers, func(i, j int) bool {
-		hi, hj := headers[i], headers[j]
-		if c := hi.Address.Cmp(hj.Address); c != 0 {
-			return c < 0
+	slices.SortFunc(headers, func(a, b WriteHeader) int {
+		if c := a.Address.Cmp(b.Address); c != 0 {
+			return c
 		}
-		if hi.Path != hj.Path {
-			return hi.Path < hj.Path
+		if a.Path != b.Path {
+			if a.Path < b.Path {
+				return -1
+			}
+			return 1
 		}
-		return hi.Key.Cmp(hj.Key) < 0
+		return a.Key.Cmp(b.Key)
 	})
 }
 
@@ -2347,8 +2348,8 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 		bal = append(bal, account.changes)
 	}
 
-	sort.Slice(bal, func(i, j int) bool {
-		return bal[i].Address.Cmp(bal[j].Address) < 0
+	slices.SortFunc(bal, func(a, b *types.AccountChanges) int {
+		return a.Address.Cmp(b.Address)
 	})
 
 	return bal

--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -2,11 +2,12 @@ package types
 
 import (
 	"bytes"
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
 	"math"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/holiman/uint256"
@@ -184,8 +185,8 @@ func (ac *AccountChanges) DecodeRLP(s *rlp.Stream) error {
 
 func (ac *AccountChanges) Normalize() {
 	if len(ac.StorageChanges) > 1 {
-		sort.Slice(ac.StorageChanges, func(i, j int) bool {
-			return ac.StorageChanges[i].Slot.Cmp(ac.StorageChanges[j].Slot) < 0
+		slices.SortFunc(ac.StorageChanges, func(a, b *SlotChanges) int {
+			return a.Slot.Cmp(b.Slot)
 		})
 	}
 
@@ -455,20 +456,20 @@ func dedupByEquality[T comparable](items []T) []T {
 }
 
 func sortByIndex[T interface{ GetIndex() uint32 }](changes []T) {
-	sort.Slice(changes, func(i, j int) bool {
-		return changes[i].GetIndex() < changes[j].GetIndex()
+	slices.SortFunc(changes, func(a, b T) int {
+		return cmp.Compare(a.GetIndex(), b.GetIndex())
 	})
 }
 
 func sortByBytes[T interface{ GetBytes() []byte }](items []T) {
-	sort.Slice(items, func(i, j int) bool {
-		return bytes.Compare(items[i].GetBytes(), items[j].GetBytes()) < 0
+	slices.SortFunc(items, func(a, b T) int {
+		return bytes.Compare(a.GetBytes(), b.GetBytes())
 	})
 }
 
 func sortHashes(hashes []accounts.StorageKey) {
-	sort.Slice(hashes, func(i, j int) bool {
-		return hashes[i].Cmp(hashes[j]) < 0
+	slices.SortFunc(hashes, func(a, b accounts.StorageKey) int {
+		return a.Cmp(b)
 	})
 }
 

--- a/node/components/storage/snapshot/ranges.go
+++ b/node/components/storage/snapshot/ranges.go
@@ -16,7 +16,10 @@
 
 package snapshot
 
-import "sort"
+import (
+	"cmp"
+	"slices"
+)
 
 // StepRange represents a half-open interval [From, To) of aggregator steps.
 type StepRange struct {
@@ -56,7 +59,7 @@ func (rs StepRanges) Normalize() StepRanges {
 	if len(rs) <= 1 {
 		return rs
 	}
-	sort.Slice(rs, func(i, j int) bool { return rs[i].From < rs[j].From })
+	slices.SortFunc(rs, func(a, b StepRange) int { return cmp.Compare(a.From, b.From) })
 
 	merged := StepRanges{rs[0]}
 	for _, r := range rs[1:] {

--- a/polygon/bridge/client_http.go
+++ b/polygon/bridge/client_http.go
@@ -17,11 +17,12 @@
 package bridge
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"net/url"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/erigontech/erigon/common/log/v3"
@@ -97,8 +98,8 @@ func (c *HttpClient) FetchStateSyncEvents(ctx context.Context, fromID uint64, to
 			fromID += uint64(StateEventsFetchLimit)
 		}
 
-		sort.SliceStable(eventRecords, func(i, j int) bool {
-			return eventRecords[i].ID < eventRecords[j].ID
+		slices.SortStableFunc(eventRecords, func(a, b *EventRecordWithTime) int {
+			return cmp.Compare(a.ID, b.ID)
 		})
 
 		return eventRecords, nil
@@ -141,8 +142,8 @@ func (c *HttpClient) FetchStateSyncEvents(ctx context.Context, fromID uint64, to
 		fromID += uint64(StateEventsFetchLimit)
 	}
 
-	sort.SliceStable(eventRecords, func(i, j int) bool {
-		return eventRecords[i].ID < eventRecords[j].ID
+	slices.SortStableFunc(eventRecords, func(a, b *EventRecordWithTime) int {
+		return cmp.Compare(a.ID, b.ID)
 	})
 
 	return eventRecords, nil

--- a/rpc/ethapi/state_overrides.go
+++ b/rpc/ethapi/state_overrides.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
-	"sort"
 
 	"github.com/holiman/uint256"
 
@@ -97,9 +96,9 @@ func (so *StateOverrides) Override(ibs *state.IntraBlockState, precompiles vm.Pr
 	for addr := range *so {
 		addrs = append(addrs, addr)
 	}
-	sort.Slice(addrs, func(i, j int) bool {
-		ai, aj := addrs[i].Value(), addrs[j].Value()
-		return bytes.Compare(ai[:], aj[:]) < 0
+	slices.SortFunc(addrs, func(a, b accounts.Address) int {
+		av, bv := a.Value(), b.Value()
+		return bytes.Compare(av[:], bv[:])
 	})
 
 	err := so.override(ibs, addrs)

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -22,12 +22,13 @@ package rpc
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -121,8 +122,8 @@ func runTestScript(t *testing.T, file string, logger log.Logger) {
 			sent = strings.TrimRight(sent, "\r\n")
 			msgs, batch, _ := parseMessage(json.RawMessage(sent))
 			if batch {
-				sort.Slice(msgs, func(i, j int) bool {
-					return string(msgs[i].ID) < string(msgs[j].ID)
+				slices.SortFunc(msgs, func(a, b *jsonrpcMessage) int {
+					return cmp.Compare(string(a.ID), string(b.ID))
 				})
 				b, err := json.Marshal(msgs)
 				if err != nil {
@@ -130,8 +131,8 @@ func runTestScript(t *testing.T, file string, logger log.Logger) {
 				}
 				sent = string(b)
 				msgs, _, _ = parseMessage(json.RawMessage(want))
-				sort.Slice(msgs, func(i, j int) bool {
-					return string(msgs[i].ID) < string(msgs[j].ID)
+				slices.SortFunc(msgs, func(a, b *jsonrpcMessage) int {
+					return cmp.Compare(string(a.ID), string(b.ID))
 				})
 				b, err = json.Marshal(msgs)
 				if err != nil {


### PR DESCRIPTION
This PR enables the `slicessort`, `stditerators`, and `stringsbuilder` modernisation checkers within the `modernise` linter section of `.golangci.yml` and modernises their usage across the entire codebase.

In particular the following modernisations were introduced:

* **Slices Sort (`slicessort`)**: Replaced the legacy slice sorting routines of the primitive/ordered types to use the type-safe, generic `slices.Sort(slice)` functions instead of the old reflection-based `sort.Slice` calls.
* **Standard Iterators (`stditerators`)**: Changed struct fields loop constructs from index-style loops to the native Go 1.23 iterator sequence `Struct.Fields()`.
* **Strings Builder (`stringsbuilder`)**: Replaced suboptimal string concatenation in loops with high-performance `strings.Builder`.
* **Legacy Sort to Slices Modernisation**: Converted all legacy reflection-based `sort.Slice`, `sort.SliceStable` and `sort.SliceIsSorted` invocations project-wide to high-performance, type-safe `slices.SortFunc`, `slices.SortStableFunc` and `slices.IsSortedFunc` generic counterparts.

part of #22199