### PR TITLE
[r3.5] types: reject empty-string element in RLP transaction-list decode

### DIFF
--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -773,3 +773,18 @@ func TestBlockRawBodyFromBinaryTxsMatchesEncoded(t *testing.T) {
 			"txType=%d: cached RawBody tx bytes must equal the rlp.EncodeToBytes form", txType)
 	}
 }
+
+// TestBodyDecodeRejectsEmptyStringTx pins that an empty-string element
+// (0x80) in the transactions list is rejected, not dropped as if it were
+// the list terminator.
+func TestBodyDecodeRejectsEmptyStringTx(t *testing.T) {
+	validTx := append([]byte{0xc9}, bytes.Repeat([]byte{0x80}, 9)...) // legacy tx: list of 9 zero fields
+	raw := RawBody{Transactions: [][]byte{validTx, {0x80}}}
+
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, raw.EncodeRLP(buf))
+
+	var b Body
+	err := rlp.DecodeBytes(buf.Bytes(), &b)
+	require.Error(t, err, "must reject an empty-string element in the transactions list")
+}

--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -157,9 +157,6 @@ func DecodeRLPTransaction(s *rlp.Stream, blobTxnsAreWrappedWithBlobs bool) (Tran
 		if b, err = s.Bytes(); err != nil {
 			return nil, err
 		}
-		if len(b) == 0 {
-			return nil, rlp.EOL
-		}
 		if txn, err = UnmarshalTransactionFromBinary(b, blobTxnsAreWrappedWithBlobs); err != nil {
 			return nil, err
 		}

--- a/execution/types/transaction_test.go
+++ b/execution/types/transaction_test.go
@@ -116,8 +116,8 @@ func TestDecodeEmptyTypedTx(t *testing.T) {
 	t.Parallel()
 	input := []byte{0x80}
 	_, err := DecodeTransaction(input)
-	if !errors.Is(err, rlp.EOL) {
-		t.Fatal("wrong error:", err)
+	if err == nil || errors.Is(err, rlp.EOL) {
+		t.Fatal("expected a decode error, not EOL:", err)
 	}
 }
 


### PR DESCRIPTION
Cherry-pick of #22514 to release/3.5.