### PR TITLE
[r3.5] types: reject legacy transactions in typed envelopes

### DIFF
--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -788,3 +788,13 @@ func TestBodyDecodeRejectsEmptyStringTx(t *testing.T) {
 	err := rlp.DecodeBytes(buf.Bytes(), &b)
 	require.Error(t, err, "must reject an empty-string element in the transactions list")
 }
+
+func TestBodyDecodeRejectsWrappedLegacyTransaction(t *testing.T) {
+	t.Parallel()
+	bodyRLP, err := hex.DecodeString("f868f865b863f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3c0")
+	require.NoError(t, err)
+
+	var body Body
+	err = rlp.DecodeBytes(bodyRLP, &body)
+	require.ErrorIs(t, err, ErrInvalidTxType)
+}

--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -157,6 +157,9 @@ func DecodeRLPTransaction(s *rlp.Stream, blobTxnsAreWrappedWithBlobs bool) (Tran
 		if b, err = s.Bytes(); err != nil {
 			return nil, err
 		}
+		if len(b) > 0 && b[0] >= rlp.SingleByteThreshold {
+			return nil, ErrInvalidTxType
+		}
 		if txn, err = UnmarshalTransactionFromBinary(b, blobTxnsAreWrappedWithBlobs); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Cherry-pick of #22522 to release/3.5.

## r3.5-specific adaptations

Resolved decoder context against the release branch's `s.Bytes()` path.