### PR TITLE
.github/zizmor: enable overprovisioned-secrets audit

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -29,10 +29,6 @@ rules:
   excessive-permissions:
     disable: true
 
-  # persist-credentials: false not set on most checkouts; tracked in #21132.
-  overprovisioned-secrets:
-    disable: true
-
   # secrets: inherit is intentional in ci-gate.yml and cache-warming.yml;
   # tracked in #21132.
   secrets-inherit:


### PR DESCRIPTION
Part of #21132 (zizmor security-linter cleanup).

## What
Removes the `overprovisioned-secrets: disable: true` block from `.github/zizmor.yml`, turning the audit on.

Two reasons it's safe and overdue:
- **Zero findings.** Running zizmor 1.26.1 with the repo config over the whole workflow tree, `overprovisioned-secrets` produces **0** findings — the audit was disabled defensively, not because anything trips it.
- **Stale comment.** The block's comment described `persist-credentials`, which is actually the `artipacked` category (fixed in #22447 / #22448) — not `overprovisioned-secrets`. Removing the block also removes the misleading note.

## Verification
`zizmor 1.26.1 --config .github/zizmor.yml .github/workflows/` → **exit 0, 0 findings**. CI gate unaffected.

This shrinks the remaining #21132 suppression set to: `cache-poisoning`, `github-app`, `excessive-permissions`, `secrets-inherit` (cleanup pending), plus the deliberate `unpinned-uses` and `concurrency-limits` policy exceptions.