### PR TITLE
execution, cmd, docs: make FcuBackgroundCommit consumers wait out the async commit

### DIFF
--- a/cmd/utils/app/import_cmd.go
+++ b/cmd/utils/app/import_cmd.go
@@ -417,7 +417,9 @@ func InsertChain(ethereum *eth.Ethereum, chain *blockgen.ChainPack, setHead bool
 	}
 
 	// UpdateForkChoice has an async commit so we need to wait to make sure
-	// it is completed before assuming all state changes etc are inserted
+	// it is completed before assuming all state changes etc are inserted.
+	// State-change events are dispatched pre-commit, so waiting on the stream
+	// only ensures the dispatcher fired — not that MDBX is flushed.
 	var lastSeenBlock uint64
 	for len(insertedBlocks) > 0 {
 		req, err := stream.Recv()
@@ -444,6 +446,10 @@ func InsertChain(ethereum *eth.Ethereum, chain *blockgen.ChainPack, setHead bool
 			}
 		}
 	}
+
+	// Wait for the FCU background commit so HeadBlockHash can't land in MDBX
+	// ahead of the header it points to.
+	ethereum.ExecutionModule().WaitIdle(ethereum.SentryCtx())
 
 	return ethereum.ChainDB().Update(ethereum.SentryCtx(), func(tx kv.RwTx) error {
 		rawdb.WriteHeadBlockHash(tx, lvh)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1143,7 +1143,7 @@ var (
 	}
 	FcuBackgroundCommitFlag = cli.BoolFlag{
 		Name:  "fcu.background.commit",
-		Usage: "Enables background flush and commit",
+		Usage: "Return FCU response before MDBX flush+commit lands (commit runs in background; remote rpcdaemon 'latest' stays consistent but can lag for the commit duration)",
 		Value: ethconfig.Defaults.FcuBackgroundCommit,
 	}
 	MCPDisableFlag = cli.BoolFlag{

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -417,7 +417,7 @@ Flags for configuring Fork Choice Update behavior.
   * Default: `1s`
 * `--fcu.background.prune`: Enables background pruning after FCU.
   * Default: `true`
-* `--fcu.background.commit`: Enables background flush and commit after FCU.
+* `--fcu.background.commit`: Returns the FCU response before MDBX flush+commit lands (commit runs in background; remote `rpcdaemon` `latest` stays consistent but can lag for the commit duration).
   * Default: `false`
 
 ### Execution

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2319,7 +2319,7 @@ Flags for configuring Fork Choice Update behavior.
   * Default: `1s`
 * `--fcu.background.prune`: Enables background pruning after FCU.
   * Default: `true`
-* `--fcu.background.commit`: Enables background flush and commit after FCU.
+* `--fcu.background.commit`: Returns the FCU response before MDBX flush+commit lands (commit runs in background; remote `rpcdaemon` `latest` stays consistent but can lag for the commit duration).
   * Default: `false`
 
 ### Execution

--- a/execution/engineapi/engine_block_downloader/block_downloader.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader.go
@@ -271,8 +271,31 @@ func (e *EngineBlockDownloader) downloadBlocks(ctx context.Context, req Backward
 	return nil
 }
 
+// retryBusy re-invokes call while it reports ExecutionStatusBusy (a background
+// FCU commit briefly holds the exec semaphore), polling every 50ms and logging
+// periodically so a stuck commit surfaces instead of hanging silently.
+func (e *EngineBlockDownloader) retryBusy(ctx context.Context, label string, call func() (execmodule.ExecutionStatus, *string, common.Hash, error)) (execmodule.ExecutionStatus, *string, common.Hash, error) {
+	status, validationErr, lastValidHash, err := call()
+	logEvery := time.NewTicker(5 * time.Second)
+	defer logEvery.Stop()
+	for err == nil && status == execmodule.ExecutionStatusBusy {
+		if err := common.Sleep(ctx, 50*time.Millisecond); err != nil {
+			return status, validationErr, lastValidHash, err
+		}
+		select {
+		case <-logEvery.C:
+			e.logger.Debug("[EngineBlockDownloader] execution busy - retrying", "label", label)
+		default:
+		}
+		status, validationErr, lastValidHash, err = call()
+	}
+	return status, validationErr, lastValidHash, err
+}
+
 func (e *EngineBlockDownloader) execDownloadedBatch(ctx context.Context, block *types.Block, requested common.Hash) error {
-	status, validationErr, lastValidHash, err := e.chainRW.ValidateChain(ctx, block.Hash(), block.NumberU64())
+	status, validationErr, lastValidHash, err := e.retryBusy(ctx, "ValidateChain", func() (execmodule.ExecutionStatus, *string, common.Hash, error) {
+		return e.chainRW.ValidateChain(ctx, block.Hash(), block.NumberU64())
+	})
 	if err != nil {
 		return err
 	}
@@ -297,7 +320,9 @@ func (e *EngineBlockDownloader) execDownloadedBatch(ctx context.Context, block *
 			lastValidHash,
 		)
 	}
-	fcuStatus, _, lastValidHash, err := e.chainRW.UpdateForkChoice(ctx, block.Hash(), common.Hash{}, common.Hash{}, 0)
+	fcuStatus, _, lastValidHash, err := e.retryBusy(ctx, "UpdateForkChoice", func() (execmodule.ExecutionStatus, *string, common.Hash, error) {
+		return e.chainRW.UpdateForkChoice(ctx, block.Hash(), common.Hash{}, common.Hash{}, 0)
+	})
 	if err != nil {
 		return err
 	}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2319,7 +2319,7 @@ Flags for configuring Fork Choice Update behavior.
   * Default: `1s`
 * `--fcu.background.prune`: Enables background pruning after FCU.
   * Default: `true`
-* `--fcu.background.commit`: Enables background flush and commit after FCU.
+* `--fcu.background.commit`: Returns the FCU response before MDBX flush+commit lands (commit runs in background; remote `rpcdaemon` `latest` stays consistent but can lag for the commit duration).
   * Default: `false`
 
 ### Execution

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -111,9 +111,13 @@ var Defaults = Config{
 		ProduceE2:  true,
 		ProduceE3:  true,
 	},
-	FcuTimeout:          1 * time.Second,
-	FcuBackgroundPrune:  true,
-	FcuBackgroundCommit: false, // to enable, we need to 1) have rawdb API go via execctx and 2) revive Coherent cache for rpcdaemon
+	FcuTimeout:         1 * time.Second,
+	FcuBackgroundPrune: true,
+	// FcuBackgroundCommit returns the FCU response before the MDBX commit
+	// lands; the commit runs in a background goroutine and successive FCUs are
+	// serialized by the ExecModule semaphore. "Latest" state reads can lag the
+	// announced head by one block for the commit's duration.
+	FcuBackgroundCommit: false,
 	ExperimentalBAL:     false,
 	WarmupKzgCtxOnInit:  true,
 }


### PR DESCRIPTION
Split out of #21293 (`FcuBackgroundCommit` groundwork). Defaults unchanged — the flag stays `false`; the flip is #22269's.

With the flag on, `UpdateForkChoice` returns before the MDBX flush+commit lands (the commit runs in a background goroutine holding the exec semaphore), and state-change notifications alone do not guarantee MDBX contains the head. This PR makes the flag's consumers robust to that:

## Engine: busy-tolerant batch execution

A background FCU commit briefly holds the exec semaphore, so `ValidateChain`/`UpdateForkChoice` can routinely return `Busy`. `execDownloadedBatch` waits it out via `retryBusy`: a ctx-aware 50 ms poll with a periodic debug log so a stuck commit surfaces instead of hanging silently.

## import: wait for the commit

`import_cmd.InsertChain` calls `ExecModule.WaitIdle` after driving forkchoice, so `HeadBlockHash` can't land in MDBX ahead of the header it points to — the state-change stream only confirms the dispatcher fired, not that the commit landed.

## Flag documentation

`--fcu.background.commit` usage now states the actual contract: the FCU response returns before the MDBX flush+commit lands; remote rpcdaemon "latest" stays consistent but can lag for the commit duration. Same wording in `ethconfig` and the docs site (llms files regenerated).

## Safety recap (with the flag enabled)

The bg goroutine releases the exec semaphore only after the commit completes and the overlay is unpublished, so FCU N+1 always reads FCU N's committed state; `engine_newPayload`/`engine_getPayload` serialize behind a pending commit (~commit-duration added latency; a `SYNCING` response in a pipelined burst is spec-valid and self-heals).
