### PR TITLE
rpc: apply BaseFeePerGas block override on pre-London blocks

### DIFF
--- a/rpc/ethapi/block_overrides.go
+++ b/rpc/ethapi/block_overrides.go
@@ -98,13 +98,11 @@ func (overrides *BlockOverrides) Override(context *evmtypes.BlockContext) error 
 	return nil
 }
 
-// OverrideBaseFee returns baseFee with BaseFeePerGas applied if set. When the
-// caller passes a nil baseFee (a pre-London block), it stays nil rather than
-// having a base fee introduced. It exists separately from Override because
-// some callers need the overridden base fee before a BlockContext exists to
-// call Override on.
+// OverrideBaseFee returns baseFee with BaseFeePerGas applied if set, applying it
+// even when baseFee is nil (pre-London block). It exists separately from Override
+// because some callers need the overridden base fee before a BlockContext exists.
 func (overrides *BlockOverrides) OverrideBaseFee(baseFee *uint256.Int) (*uint256.Int, error) {
-	if overrides == nil || overrides.BaseFeePerGas == nil || baseFee == nil {
+	if overrides == nil || overrides.BaseFeePerGas == nil {
 		return baseFee, nil
 	}
 	overridden := new(uint256.Int)

--- a/rpc/ethapi/block_overrides_test.go
+++ b/rpc/ethapi/block_overrides_test.go
@@ -150,6 +150,47 @@ func TestOverride_GasLimitAndMaxGasLimit(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// OverrideBaseFee — message base fee (debug_traceCall / trace_callMany)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestOverrideBaseFee_NilReceiver(t *testing.T) {
+	var o *BlockOverrides
+	baseFee := uint256.NewInt(7)
+	got, err := o.OverrideBaseFee(baseFee)
+	require.NoError(t, err)
+	assert.Same(t, baseFee, got, "nil receiver must return the input unchanged")
+}
+
+func TestOverrideBaseFee_NoOverride(t *testing.T) {
+	baseFee := uint256.NewInt(7)
+	got, err := (&BlockOverrides{}).OverrideBaseFee(baseFee)
+	require.NoError(t, err)
+	assert.Same(t, baseFee, got, "no BaseFeePerGas must return the input unchanged")
+}
+
+func TestOverrideBaseFee_AppliesOverride(t *testing.T) {
+	o := BlockOverrides{BaseFeePerGas: bigHex(500)}
+	got, err := o.OverrideBaseFee(uint256.NewInt(7))
+	require.NoError(t, err)
+	assert.Equal(t, uint256.NewInt(500), got)
+}
+
+func TestOverrideBaseFee_AppliesOverrideOnPreLondonBlock(t *testing.T) {
+	o := BlockOverrides{BaseFeePerGas: bigHex(500)}
+	got, err := o.OverrideBaseFee(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint256.NewInt(500), got, "explicit BaseFeePerGas must apply even when the target block has no base fee")
+}
+
+func TestOverrideBaseFee_Overflow(t *testing.T) {
+	tooBig := new(big.Int).Lsh(big.NewInt(1), 256)
+	o := BlockOverrides{BaseFeePerGas: (*hexutil.Big)(tooBig)}
+	_, err := o.OverrideBaseFee(uint256.NewInt(1))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BaseFeePerGas")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // OverrideHeader — block header copy (eth_simulateV1 block assembly)
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`(*BlockOverrides).OverrideBaseFee` short-circuited to `nil` whenever the target block had no base fee:

```go
if overrides == nil || overrides.BaseFeePerGas == nil || baseFee == nil {
    return baseFee, nil
}
```

As a result, an explicit `BlockOverrides.BaseFeePerGas` supplied to **`debug_traceCall`** and **`trace_callMany`** was silently ignored on **pre-London** blocks (`header.BaseFee == nil`) when computing the message's effective gas price — even though the same override *was* applied to the block context via `Override`. The two diverged within the same call.

This is inconsistent with the sibling paths:

| Method | Applies `BaseFeePerGas` override to the message gas price on pre-London? |
|---|---|
| `eth_call` / `eth_estimateGas` (via `OverrideHeader`) | ✅ |
| `trace_call` (via the overridden block context) | ✅ |
| `debug_traceCall` (via `OverrideBaseFee`) | ❌ before this PR |
| `trace_callMany` (via `OverrideBaseFee`) | ❌ before this PR |

It is also inconsistent with go-ethereum, whose `BlockOverrides.Apply` / `MakeHeader` apply `BaseFeePerGas` unconditionally (no `baseFee == nil` guard), and whose `debug_traceCall` derives the message base fee from the overridden block context.

## Fix

Drop the `baseFee == nil` condition from the guard so an explicit `BaseFeePerGas` is honored unconditionally, matching `Override`, `OverrideHeader`, and geth. `OverrideBaseFee` was the only one of the four override methods carrying this extra special-case; removing it de-special-cases the code rather than adding a bandaid.

## Tests

`OverrideBaseFee` previously had no unit tests. Adds five (nil receiver, no override, applies override, applies override on a pre-London block, overflow). The pre-London case is the red→green test for this fix.

Followed TDD (Red -> Green): the pre-London test failed before the guard change and passes after.
