### PR TITLE
db/state/execctx: fix stale trunk-preload pins in the branch cache

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -983,21 +983,7 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 				return v, uint64(step), len(v) > 0, nil
 			}
 			factory := func() (commitment.BatchBranchResolver, func(), error) {
-				resolve := func(keys [][]byte) ([][]byte, error) {
-					d := ttx.Debug()
-					vals := make([][]byte, len(keys))
-					for i, k := range keys {
-						v, found, _, _, err := d.GetLatestFromFiles(kv.CommitmentDomain, k, 0)
-						if err != nil {
-							return nil, err
-						}
-						if found {
-							vals[i] = common.Copy(v)
-						}
-					}
-					return vals, nil
-				}
-				return resolve, nil, nil
+				return pinBranchResolver(ttx), nil, nil
 			}
 			provider := func(contractHash []byte) map[string][]byte {
 				m := map[string][]byte{}

--- a/db/state/execctx/pin_branch_resolver.go
+++ b/db/state/execctx/pin_branch_resolver.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execctx
+
+import (
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/commitment"
+)
+
+// pinBranchResolver resolves trunk-preload branch reads for the adaptive pin
+// controller. Resolved values are pinned into the branch cache as the current
+// branch state, so the read must be the authoritative latest (DB then files) —
+// a files-only read pins stale data whenever the newest value is still in the DB.
+// The TemporalGetter parameter enforces that: files-only reads are not reachable.
+func pinBranchResolver(ttx kv.TemporalGetter) commitment.BatchBranchResolver {
+	return func(keys [][]byte) ([][]byte, error) {
+		vals := make([][]byte, len(keys))
+		for i, k := range keys {
+			v, _, err := ttx.GetLatest(kv.CommitmentDomain, k)
+			if err != nil {
+				return nil, err
+			}
+			if len(v) > 0 {
+				vals[i] = common.Copy(v)
+			}
+		}
+		return vals, nil
+	}
+}

--- a/db/state/execctx/pin_branch_resolver.go
+++ b/db/state/execctx/pin_branch_resolver.go
@@ -27,6 +27,9 @@ import (
 // branch state, so the read must be the authoritative latest (DB then files) —
 // a files-only read pins stale data whenever the newest value is still in the DB.
 // The TemporalGetter parameter enforces that: files-only reads are not reachable.
+// Empty values (deletion tombstones) resolve to nil like absent keys: the branch
+// cache never stores tombstones, and unpinned prefixes fall through to the
+// authoritative read anyway.
 func pinBranchResolver(ttx kv.TemporalGetter) commitment.BatchBranchResolver {
 	return func(keys [][]byte) ([][]byte, error) {
 		vals := make([][]byte, len(keys))

--- a/db/state/execctx/pin_branch_resolver_test.go
+++ b/db/state/execctx/pin_branch_resolver_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execctx
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/kv"
+)
+
+type fakeTemporalGetter struct {
+	vals map[string][]byte
+	err  error
+}
+
+func (f *fakeTemporalGetter) GetLatest(_ kv.Domain, k []byte) ([]byte, kv.Step, error) {
+	return f.vals[string(k)], 0, f.err
+}
+
+func (f *fakeTemporalGetter) HasPrefix(kv.Domain, []byte) ([]byte, []byte, bool, error) {
+	return nil, nil, false, nil
+}
+
+func (f *fakeTemporalGetter) StepsInFiles(...kv.Domain) kv.Step { return 0 }
+
+// TestPinBranchResolver_ReturnsAuthoritativeLatest pins the trunk-preload resolver
+// contract: its output is pinned into the branch cache as the latest branch value,
+// so it must come from the authoritative GetLatest — a files-only read here pinned
+// stale data whenever the newest value was still in the DB.
+func TestPinBranchResolver_ReturnsAuthoritativeLatest(t *testing.T) {
+	t.Parallel()
+	latest := []byte("branch-latest")
+	getter := &fakeTemporalGetter{vals: map[string][]byte{"\x0a\x0b": latest}}
+	resolve := pinBranchResolver(getter)
+	vals, err := resolve([][]byte{[]byte{0x0a, 0x0b}, []byte{0x0c}})
+	require.NoError(t, err)
+	require.Len(t, vals, 2)
+	require.Equal(t, latest, vals[0])
+	require.Nil(t, vals[1], "absent keys must resolve to nil so the preload skips pinning them")
+	latest[0] = 'X'
+	require.Equal(t, []byte("branch-latest"), vals[0], "resolved values must be copies, detached from the getter's buffer")
+}
+
+func TestPinBranchResolver_PropagatesReadErrors(t *testing.T) {
+	t.Parallel()
+	readErr := errors.New("read failed")
+	getter := &fakeTemporalGetter{vals: map[string][]byte{"\x0a": []byte("v")}, err: readErr}
+	resolve := pinBranchResolver(getter)
+	_, err := resolve([][]byte{[]byte{0x0a}})
+	require.ErrorIs(t, err, readErr)
+}

--- a/db/state/execctx/pin_branch_resolver_test.go
+++ b/db/state/execctx/pin_branch_resolver_test.go
@@ -47,13 +47,14 @@ func (f *fakeTemporalGetter) StepsInFiles(...kv.Domain) kv.Step { return 0 }
 func TestPinBranchResolver_ReturnsAuthoritativeLatest(t *testing.T) {
 	t.Parallel()
 	latest := []byte("branch-latest")
-	getter := &fakeTemporalGetter{vals: map[string][]byte{"\x0a\x0b": latest}}
+	getter := &fakeTemporalGetter{vals: map[string][]byte{"\x0a\x0b": latest, "\x0d": {}}}
 	resolve := pinBranchResolver(getter)
-	vals, err := resolve([][]byte{[]byte{0x0a, 0x0b}, []byte{0x0c}})
+	vals, err := resolve([][]byte{[]byte{0x0a, 0x0b}, []byte{0x0c}, []byte{0x0d}})
 	require.NoError(t, err)
-	require.Len(t, vals, 2)
+	require.Len(t, vals, 3)
 	require.Equal(t, latest, vals[0])
 	require.Nil(t, vals[1], "absent keys must resolve to nil so the preload skips pinning them")
+	require.Nil(t, vals[2], "deletion tombstones (empty values) must also resolve to nil — the cache never stores tombstones")
 	latest[0] = 'X'
 	require.Equal(t, []byte("branch-latest"), vals[0], "resolved values must be copies, detached from the getter's buffer")
 }

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -241,10 +241,9 @@ func (s *EngineServer) validatePayloadAttributesPostFCU(version clparams.StateVe
 	if version >= clparams.GloasVersion && payloadAttributes.SlotNumber == nil {
 		return &engine_helpers.InvalidPayloadAttributesErr // SlotNumber required for Glamsterdam (EIP-7843)
 	}
-	// TargetGasLimit is not in bal-devnet-7 spec, only in glamsterdam-devnet-4+
-	//if version >= clparams.GloasVersion && payloadAttributes.TargetGasLimit == nil {
-	//	return &engine_helpers.InvalidPayloadAttributesErr // TargetGasLimit required for V4 attrs
-	//}
+	if version >= clparams.GloasVersion && payloadAttributes.TargetGasLimit == nil {
+		return &engine_helpers.InvalidPayloadAttributesErr // TargetGasLimit required for V4 attrs
+	}
 	if version < clparams.GloasVersion && payloadAttributes.SlotNumber != nil {
 		return &engine_helpers.InvalidPayloadAttributesErr // pre-V4 attrs MUST NOT carry slotNumber
 	}

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -241,9 +241,10 @@ func (s *EngineServer) validatePayloadAttributesPostFCU(version clparams.StateVe
 	if version >= clparams.GloasVersion && payloadAttributes.SlotNumber == nil {
 		return &engine_helpers.InvalidPayloadAttributesErr // SlotNumber required for Glamsterdam (EIP-7843)
 	}
-	if version >= clparams.GloasVersion && payloadAttributes.TargetGasLimit == nil {
-		return &engine_helpers.InvalidPayloadAttributesErr // TargetGasLimit required for V4 attrs
-	}
+	// TargetGasLimit is not in bal-devnet-7 spec, only in glamsterdam-devnet-4+
+	//if version >= clparams.GloasVersion && payloadAttributes.TargetGasLimit == nil {
+	//	return &engine_helpers.InvalidPayloadAttributesErr // TargetGasLimit required for V4 attrs
+	//}
 	if version < clparams.GloasVersion && payloadAttributes.SlotNumber != nil {
 		return &engine_helpers.InvalidPayloadAttributesErr // pre-V4 attrs MUST NOT carry slotNumber
 	}


### PR DESCRIPTION
## Why

Re-executing a `--keep-blocks` tail (step-rebased datadir) failed with `Wrong trie root` at block ~24.36M, non-deterministic root hash. Bisected across 8 controlled runs: not the commitment convert, not exec parallelism, not merge, not prune — the corrupter is the parallel trunk-preload of the adaptive pin controller.

The preload classifies keys against the `dbBranches` map, which comes from a **budget-bounded** scan of `TblCommitmentVals` — so "absent from the map" does not mean "not in the DB". Keys beyond the scan budget whose newest value still sat in the DB were resolved via `GetLatestFromFiles` (files-only) and pinned as the current branch state (`pinTxNum=now`, `step=0`). The branch cache serves pins ahead of the DB, so folds read the stale branch → wrong root. The window opens whenever a commitment file becomes visible mid-execution (guaranteed in a `--keep-blocks` re-exec, where the background builder catches the exec frontier; why bg-off and serial-preload runs never hit it).

Instrumented pre-fix run: **4,207** `file-resolved ≠ authoritative-latest` warnings on the promoted contract, seconds before the wrong root.

## What

- `pinBranchResolver` (extracted from the inline factory in `SharedDomains.Commit`) resolves via the authoritative `ttx.GetLatest` (DB→files) instead of `Debug().GetLatestFromFiles`.
- Parameter narrowed to `kv.TemporalGetter` — no files-only API is reachable, so the bug class cannot be reintroduced without widening the type.
- Unit tests: authoritative-value contract, nil-for-absent (preload skips pinning), copy semantics, error propagation.

## Before / after (same pipeline: fresh datadir copy → rebase to step 3125 → `--keep-blocks` re-exec of the 53k-block tail, pins active)

| | before | after |
|---|---|---|
| default env | wrong trie root @ 24,355,616/617 (~10 min in) | executes to tip 24,402,727, zero errors (8h23m) |
| poison detections (instrumented) | 4,207 before failure | n/a (unrepresentable) |
| pin activity | active | active (796 pin events, 259 preloads) |

## Testing

- `TestPinBranchResolver_*` (red on the old behavior via a real DB+files fixture during development, kept as fake-based contract tests)
- `db/state/execctx` under `-race`: clean; `make lint`: 0 issues
- Full real-world validation as in the table above
