### PR TITLE
db/downloader: shorten the Downloader sync log line

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -1508,8 +1508,8 @@ func (d *Downloader) logSyncStats(startTime time.Time, stats AggStats, target st
 	}
 
 	addCtx(
-		"time-left", calculateTime(remainingBytes, stats.CompletionRate),
-		"time-elapsed", time.Since(startTime).Truncate(time.Second).String(),
+		"eta", calculateTime(remainingBytes, stats.CompletionRate),
+		"elapsed", time.Since(startTime).Truncate(time.Second).String(),
 	)
 
 	d.logStatsInner(log.LvlInfo, stats, fmt.Sprintf("Syncing %v", target), logCtx, true)
@@ -1540,7 +1540,7 @@ func (d *Downloader) logStatsInner(
 		}
 	}
 	addCtx(
-		"file-metadata", fmt.Sprintf("%d/%d", stats.MetadataReady, stats.NumTorrents),
+		"metadata", fmt.Sprintf("%d/%d", stats.MetadataReady, stats.NumTorrents),
 		"files", fmt.Sprintf(
 			"%d/%d",
 			// For now it's 1:1 files:torrents.
@@ -1550,7 +1550,7 @@ func (d *Downloader) logStatsInner(
 		"data", func() string {
 			if haveAllMetadata {
 				return fmt.Sprintf(
-					"%.2f%% - %s/%s",
+					"%.2f%%,%s/%s",
 					percentDone,
 					common.ByteCount(bytesDone),
 					common.ByteCount(stats.BytesTotal),

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -219,7 +219,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 	if err := snapshotsync.SyncSnapshots(
 		ctx,
 		s.LogPrefix(),
-		"remaining snapshots",
+		"snapshots",
 		false, /*headerChain=*/
 		cfg.blobs,
 		cfg.caplinState,


### PR DESCRIPTION
The sync progress line is emitted every 1-15s during snapshot download and had grown to ~270 characters, wrapping on normal terminals.

This shortens the *representation* only — the field set is untouched. Every field still appears on every line at every value, so `peer-download=0B/s` and `metadata=2251/2251` keep showing: a zero or an `n/n` stays distinguishable from a field that was dropped, and columns stay eyeball-able as the lines scroll past.

### 1. Message

`remaining` only distinguished this phase from the `header-chain` sync that runs before it, which the sequence already conveys. It also left the two `SyncSnapshots` targets inconsistent with each other (`header-chain` vs `remaining snapshots`).

- before: `[Downloader] Syncing remaining snapshots` (40)
- after: `[Downloader] Syncing snapshots` (30)

### 2. Renames

| before | after |
|---|---|
| `time-left` | `eta` |
| `time-elapsed` | `elapsed` |
| `file-metadata` | `metadata` |

### 3. `data` quoting

logfmt quotes any value containing a space (`format.go` treats `c <= ' '` as needing quotes), so the spaces around the dash were paying for themselves twice:

- before: `data="97.96% - 1.9TB/1.9TB"`
- after: `data=97.96%,1.9TB/1.9TB`

### Result

Before (271):
```
[Downloader] Syncing remaining snapshots time-left=1m44s time-elapsed=15s file-metadata=2251/2251 files=2146/2251 data="97.96% - 1.9TB/1.9TB" hashing-rate=389.0MB/s webseed-download=389.4MB/s peer-download=0B/s peers=3 conns=5 upload=9.6MB/s alloc=3.2GB sys=3.2GB
```

After (241):
```
[Downloader] Syncing snapshots eta=1m44s elapsed=15s metadata=2251/2251 files=2146/2251 data=97.96%,1.9TB/1.9TB hashing-rate=389.0MB/s webseed-download=389.4MB/s peer-download=0B/s peers=3 conns=5 upload=9.6MB/s alloc=3.2GB sys=3.2GB
```

Verified by rendering both through the real `log/v3` logfmt formatter rather than by eye.

`logStatsInner` is shared with the Debug-level `Idle` line, which picks up the `metadata` and `data` changes too. `eta`/`elapsed` live in `logSyncStats` and only affect the Syncing line.

### Possible follow-up

The largest remaining chunk is the rate fields, 80 chars between them: `hashing-rate`→`hash`, `webseed-download`→`webseed`, `peer-download`→`peer`, `upload`→`up` would cut ~30 more and land the line near ~210. Left out pending a call on how far to go.