### PR TITLE
.github: scope GitHub App tokens to least privilege (zizmor github-app)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -625,6 +625,7 @@ jobs:
         client-id: ${{ vars.RELEASE_BOT_APP_ID }}
         private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
         repositories: "erigon"
+        permission-contents: write
 
     - name: Download linux/arm64 artifact
       uses: actions/download-artifact@v8
@@ -791,6 +792,7 @@ jobs:
           client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           repositories: "erigon"
+          permission-contents: write
 
       - name: Checkout git repository ${{ env.APP_REPO }} reference ${{ inputs.checkout_ref }}
         # Token must persist: the next step deletes the release tag with it.

--- a/.github/workflows/update-disk-sizes.yml
+++ b/.github/workflows/update-disk-sizes.yml
@@ -110,6 +110,8 @@ jobs:
           client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           repositories: "erigon"
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout base branch
         uses: actions/checkout@v7

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,14 +16,6 @@ rules:
       - test-kurtosis-assertoor.yml
       - test-kurtosis-gloas.yml
 
-  # create-github-app-token steps scope `repositories:` but not per-permission
-  # scopes, so the app token inherits blanket installation permissions.
-  # Scoping these down is a release-pipeline change; tracked in #21132.
-  github-app:
-    ignore:
-      - release.yml
-      - update-disk-sizes.yml
-
   # Workflows missing explicit permissions: blocks — needs a cleanup pass
   # to add least-privilege permissions to each workflow; tracked in #21132.
   excessive-permissions:


### PR DESCRIPTION
Part of #21132 (zizmor security-linter cleanup).

## What
The three `create-github-app-token` steps set only `repositories: "erigon"`, so each minted token inherited **every** permission the App installation grants (zizmor `github-app`: "app token inherits blanket installation permissions"). This adds explicit `permission-*` inputs scoping each token to exactly what its job uses:

| Step | Uses the token to… | Scope |
|------|--------------------|-------|
| `release.yml` publish-release | push the release tag + `gh release create` | `contents: write` |
| `release.yml` In-case-of-failure (rollback) | `git push -d` the tag | `contents: write` |
| `update-disk-sizes.yml` | commit + push the docs branch, `gh pr create` | `contents: write`, `pull-requests: write` |

Also removes the now-resolved `github-app` block from `.github/zizmor.yml` so the audit enforces scoping going forward.

## Verification
- `zizmor 1.26.1 --config .github/zizmor.yml .github/workflows/` → `github-app` **0 findings**, gate **exit 0**.
- `actionlint` on both workflows → no new findings.

## Remaining #21132 suppressions after this
`cache-poisoning` (4, mostly intentional caching), `excessive-permissions` (66), `secrets-inherit` (24) — plus the deliberate `unpinned-uses` and `concurrency-limits` policy exceptions.