### PR TITLE
ci: drop broken 'QA - Sync from scratch' trigger from update-disk-sizes

### DIFF
--- a/.github/workflows/update-disk-sizes.yml
+++ b/.github/workflows/update-disk-sizes.yml
@@ -9,7 +9,6 @@ on:
   # zizmor: ignore[dangerous-triggers] no checkout of triggering run's head; BASE_BRANCH is pinned to release/3.5 for workflow_run events
   workflow_run:
     workflows:
-      - "QA - Sync from scratch"
       - "QA - Sync from scratch (minimal node)"
       - "QA - Sync from scratch (full node)"
     types:


### PR DESCRIPTION
## Problem
`update-disk-sizes` fires on `workflow_run` completion of three workflows and picks its prune mode from the **triggering workflow's name**: `*minimal*` → minimal, `*full node*` → full, else `::error::` + exit 1.

The plain **`QA - Sync from scratch`** matches neither keyword, so every time it completes it fires `update-disk-sizes`, which dies immediately at the "Determine prune mode" step. It also has no "Measure disk usage" step and uploads no `disk-usage-*` artifact (only the minimal/full workflows do), so there is nothing to process even if a mode were guessed.

`update-disk-sizes` has 0 successful runs recently — this trigger is one of the reasons.

## Fix
Remove the `QA - Sync from scratch` entry from the `workflow_run` triggers. The two dedicated producers (`… (minimal node)`, `… (full node)`) name themselves correctly **and** emit the disk-usage artifacts, so they fully cover the use case. This does **not** change the `QA - Sync from scratch` workflow itself — it just stops it kicking off a guaranteed-failing `update-disk-sizes` run.

## Note on the App token
The separate token failure that appeared after #22547 (`create-github-app-token` → "permissions requested are not granted to this installation") is now resolved out-of-band: the `RELEASE_BOT_APP` installation was granted **contents: write** + **pull-requests: write**, so the least-privilege scoping added in #22547 mints the scoped token successfully. No code change needed here for that.

## Verification
- `zizmor 1.26.1 --config .github/zizmor.yml` → **exit 0, `github-app` 0 findings** (both `release.yml` and `update-disk-sizes.yml` pass the audit *scoped*, no suppression).
- `actionlint` on the workflow → clean.

Supersedes #22553.