### PR TITLE
execution/state: reuse Reader/HistoryReader key buffer to drop per-read allocs

### DIFF
--- a/execution/state/history_reader_v3.go
+++ b/execution/state/history_reader_v3.go
@@ -23,6 +23,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/state/execctx"
@@ -61,11 +62,12 @@ type HistoryReaderV3 struct {
 	ttx         kv.TemporalTx
 	sd          *execctx.SharedDomains
 	blockCache  *BlockStateCache
-	composite   []byte
+	addr        common.Address                  // reused account/code lookup key
+	composite   [length.Addr + length.Hash]byte // reused storage lookup key (addr||slot)
 }
 
 func NewHistoryReaderV3(ttx kv.TemporalTx, txNum uint64) *HistoryReaderV3 {
-	return &HistoryReaderV3{composite: make([]byte, 20+32), ttx: ttx, txNum: txNum}
+	return &HistoryReaderV3{ttx: ttx, txNum: txNum}
 }
 
 // NewHistoryReaderV3WithSharedDomains is the in-batch variant used by the
@@ -73,7 +75,7 @@ func NewHistoryReaderV3(ttx kv.TemporalTx, txNum uint64) *HistoryReaderV3 {
 // fall back to ttx.GetAsOf so a tx can see prior-tx writes from the same
 // batch that have not yet been flushed to the history index.
 func NewHistoryReaderV3WithSharedDomains(ttx kv.TemporalTx, sd *execctx.SharedDomains, txNum uint64) *HistoryReaderV3 {
-	return &HistoryReaderV3{composite: make([]byte, 20+32), ttx: ttx, sd: sd, txNum: txNum}
+	return &HistoryReaderV3{ttx: ttx, sd: sd, txNum: txNum}
 }
 
 // NewHistoryReaderV3WithBlockCache is the finalize-time variant used by
@@ -83,7 +85,7 @@ func NewHistoryReaderV3WithSharedDomains(ttx kv.TemporalTx, sd *execctx.SharedDo
 // sees every prior-tx write recorded in the current block, not just the
 // pre-block committed state.
 func NewHistoryReaderV3WithBlockCache(ttx kv.TemporalTx, sd *execctx.SharedDomains, blockCache *BlockStateCache, txNum uint64) *HistoryReaderV3 {
-	return &HistoryReaderV3{composite: make([]byte, 20+32), ttx: ttx, sd: sd, blockCache: blockCache, txNum: txNum}
+	return &HistoryReaderV3{ttx: ttx, sd: sd, blockCache: blockCache, txNum: txNum}
 }
 
 // SetBlockStateCache updates the in-flight block cache tier. Used when the
@@ -190,8 +192,8 @@ func StateHistoryStartTxNum(ttx kv.TemporalTx) uint64 {
 func (hr *HistoryReaderV3) DiscardReadList() {}
 
 func (hr *HistoryReaderV3) ReadAccountData(address accounts.Address) (*accounts.Account, error) {
-	addressValue := address.Value()
-	enc, ok, err := hr.getAsOf(kv.AccountsDomain, addressValue[:])
+	hr.addr = address.Value()
+	enc, ok, err := hr.getAsOf(kv.AccountsDomain, hr.addr[:])
 	if err != nil || !ok || len(enc) == 0 {
 		if hr.trace {
 			fmt.Printf("%sReadAccountData (hist)[%x] => []\n", hr.tracePrefix, address)
@@ -217,8 +219,9 @@ func (hr *HistoryReaderV3) ReadAccountDataForDebug(address accounts.Address) (*a
 func (hr *HistoryReaderV3) ReadAccountStorage(address accounts.Address, key accounts.StorageKey) (uint256.Int, bool, error) {
 	addressValue := address.Value()
 	keyValue := key.Value()
-	hr.composite = append(append(hr.composite[:0], addressValue[:]...), keyValue[:]...)
-	enc, ok, err := hr.getAsOf(kv.StorageDomain, hr.composite)
+	copy(hr.composite[:length.Addr], addressValue[:])
+	copy(hr.composite[length.Addr:], keyValue[:])
+	enc, ok, err := hr.getAsOf(kv.StorageDomain, hr.composite[:])
 	if hr.trace {
 		fmt.Printf("%sReadAccountStorage (hist)[%x] [%x] => [%x]\n", hr.tracePrefix, address, key, enc)
 	}
@@ -230,13 +233,13 @@ func (hr *HistoryReaderV3) ReadAccountStorage(address accounts.Address, key acco
 }
 
 func (hr *HistoryReaderV3) HasStorage(address accounts.Address) (bool, error) {
-	addressValue := address.Value()
-	to, ok := kv.NextSubtree(addressValue[:])
+	hr.addr = address.Value()
+	to, ok := kv.NextSubtree(hr.addr[:])
 	if !ok {
 		to = nil
 	}
 
-	it, err := hr.ttx.RangeAsOf(kv.StorageDomain, addressValue[:], to, hr.txNum, order.Asc, kv.Unlim)
+	it, err := hr.ttx.RangeAsOf(kv.StorageDomain, hr.addr[:], to, hr.txNum, order.Asc, kv.Unlim)
 	if err != nil {
 		return false, err
 	}
@@ -263,8 +266,8 @@ func (hr *HistoryReaderV3) HasStorage(address accounts.Address) (bool, error) {
 func (hr *HistoryReaderV3) ReadAccountCode(address accounts.Address) ([]byte, error) {
 	//  must pass key2=Nil here: because Erigon4 does concatinate key1+key2 under the hood
 	//code, _, err := hr.ttx.GetAsOf(kv.CodeDomain, address.Bytes(), codeHash.Bytes(), hr.txNum)
-	addressValue := address.Value()
-	code, _, err := hr.getAsOf(kv.CodeDomain, addressValue[:])
+	hr.addr = address.Value()
+	code, _, err := hr.getAsOf(kv.CodeDomain, hr.addr[:])
 	if hr.trace {
 		lenc, cs := printCode(code)
 		fmt.Printf("%sReadAccountCode (hist)[%x] => [%d:%s]\n", hr.tracePrefix, address, lenc, cs)
@@ -273,14 +276,14 @@ func (hr *HistoryReaderV3) ReadAccountCode(address accounts.Address) ([]byte, er
 }
 
 func (hr *HistoryReaderV3) ReadAccountCodeSize(address accounts.Address) (int, error) {
-	addressValue := address.Value()
-	enc, _, err := hr.getAsOf(kv.CodeDomain, addressValue[:])
+	hr.addr = address.Value()
+	enc, _, err := hr.getAsOf(kv.CodeDomain, hr.addr[:])
 	return len(enc), err
 }
 
 func (hr *HistoryReaderV3) ReadAccountIncarnation(address accounts.Address) (uint64, error) {
-	addressValue := address.Value()
-	enc, ok, err := hr.getAsOf(kv.AccountsDomain, addressValue[:])
+	hr.addr = address.Value()
+	enc, ok, err := hr.getAsOf(kv.AccountsDomain, hr.addr[:])
 	if err != nil || !ok || len(enc) == 0 {
 		if hr.trace {
 			fmt.Printf("%sReadAccountIncarnation (hist)[%x] => [0]\n", hr.tracePrefix, address)

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
@@ -983,11 +984,18 @@ func (w *Writer) CreateContract(address accounts.Address) error {
 	return nil
 }
 
+// ReaderV3 is not thread-safe.
 type ReaderV3 struct {
 	txNum       uint64
 	trace       bool
 	tracePrefix string
 	getter      kv.TemporalGetter
+
+	// addr and composite are reused key buffers: as non-pointer fields of the
+	// heap-allocated reader, the key slices they back reach the interface getter
+	// with no per-call heap allocation.
+	addr      common.Address                  // reused account/code lookup key
+	composite [length.Addr + length.Hash]byte // reused storage lookup key (addr||slot)
 }
 
 func NewReaderV3(getter kv.TemporalGetter) *ReaderV3 {
@@ -1441,16 +1449,13 @@ func (r *CachedReaderV3) ReadAccountStorage(address accounts.Address, key accoun
 }
 
 func (r *ReaderV3) HasStorage(address accounts.Address) (bool, error) {
-	var value common.Address
-	if !address.IsNil() {
-		value = address.Value()
-	}
+	r.addr = address.Value()
 	// this is an optimization, but also checks the account is checked in the domain
 	// for being deleted on unwind before we try to access the storage
-	if enc, _, err := r.getter.GetLatest(kv.AccountsDomain, value[:]); len(enc) == 0 {
+	if enc, _, err := r.getter.GetLatest(kv.AccountsDomain, r.addr[:]); len(enc) == 0 {
 		return false, err
 	}
-	_, _, hasStorage, err := r.getter.HasPrefix(kv.StorageDomain, value[:])
+	_, _, hasStorage, err := r.getter.HasPrefix(kv.StorageDomain, r.addr[:])
 	return hasStorage, err
 }
 
@@ -1460,11 +1465,8 @@ func (r *ReaderV3) ReadAccountData(address accounts.Address) (*accounts.Account,
 }
 
 func (r *ReaderV3) readAccountData(address accounts.Address) ([]byte, *accounts.Account, error) {
-	var value common.Address
-	if !address.IsNil() {
-		value = address.Value()
-	}
-	enc, _, err := r.getter.GetLatest(kv.AccountsDomain, value[:])
+	r.addr = address.Value()
+	enc, _, err := r.getter.GetLatest(kv.AccountsDomain, r.addr[:])
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1490,18 +1492,11 @@ func (r *ReaderV3) ReadAccountDataForDebug(address accounts.Address) (*accounts.
 }
 
 func (r *ReaderV3) ReadAccountStorage(address accounts.Address, key accounts.StorageKey) (uint256.Int, bool, error) {
-	var composite [20 + 32]byte
-	var addressValue common.Address
-	if !address.IsNil() {
-		addressValue = address.Value()
-	}
-	var keyValue common.Hash
-	if !key.IsNil() {
-		keyValue = key.Value()
-	}
-	copy(composite[0:20], addressValue[0:20])
-	copy(composite[20:], keyValue[:])
-	enc, _, err := r.getter.GetLatest(kv.StorageDomain, composite[:])
+	addressValue := address.Value()
+	keyValue := key.Value()
+	copy(r.composite[:length.Addr], addressValue[:])
+	copy(r.composite[length.Addr:], keyValue[:])
+	enc, _, err := r.getter.GetLatest(kv.StorageDomain, r.composite[:])
 	if err != nil {
 		return uint256.Int{}, false, err
 	}
@@ -1513,21 +1508,26 @@ func (r *ReaderV3) ReadAccountStorage(address accounts.Address, key accounts.Sto
 	}
 
 	if r.trace {
-		if enc == nil {
-			fmt.Printf("%sReadAccountStorage [%x %x] => [empty], txNum: %d, stack: %s\n", r.tracePrefix, address, key, r.txNum, dbg.Stack())
-		} else {
-			fmt.Printf("%sReadAccountStorage [%x %x] => [%x], txNum: %d, stack: %s\n", r.tracePrefix, address, key, &res, r.txNum, dbg.Stack())
-		}
+		r.traceReadAccountStorage(address, key, enc, res)
 	}
 
 	return res, ok, err
 }
 
-func (r *ReaderV3) ReadAccountCode(address accounts.Address) ([]byte, error) {
-	var addressValue common.Address
-	if !address.IsNil() {
-		addressValue = address.Value()
+// traceReadAccountStorage is split out (and takes res by value) so the &res it
+// needs for %x formatting does not force res to the heap on every read.
+//
+//go:noinline
+func (r *ReaderV3) traceReadAccountStorage(address accounts.Address, key accounts.StorageKey, enc []byte, res uint256.Int) {
+	if enc == nil {
+		fmt.Printf("%sReadAccountStorage [%x %x] => [empty], txNum: %d, stack: %s\n", r.tracePrefix, address, key, r.txNum, dbg.Stack())
+	} else {
+		fmt.Printf("%sReadAccountStorage [%x %x] => [%x], txNum: %d, stack: %s\n", r.tracePrefix, address, key, &res, r.txNum, dbg.Stack())
 	}
+}
+
+func (r *ReaderV3) ReadAccountCode(address accounts.Address) ([]byte, error) {
+	r.addr = address.Value()
 	// Pure read: prefer the content-addressed fast path (addr → codeHash →
 	// cached bytes, no per-address CodeDomain read) when the getter offers it.
 	// This is a getter, never a setter — it must not feed a DomainPut prevVal,
@@ -1535,9 +1535,9 @@ func (r *ReaderV3) ReadAccountCode(address accounts.Address) ([]byte, error) {
 	var enc []byte
 	var err error
 	if cg, ok := r.getter.(codeGetter); ok {
-		enc, _, err = cg.GetCode(addressValue[:], r.txNum)
+		enc, _, err = cg.GetCode(r.addr[:], r.txNum)
 	} else {
-		enc, _, err = r.getter.GetLatest(kv.CodeDomain, addressValue[:])
+		enc, _, err = r.getter.GetLatest(kv.CodeDomain, r.addr[:])
 	}
 	if err != nil {
 		return nil, err
@@ -1565,27 +1565,24 @@ type codeSizeGetter interface {
 }
 
 func (r *ReaderV3) ReadAccountCodeSize(address accounts.Address) (int, error) {
-	var addressValue common.Address
-	if !address.IsNil() {
-		addressValue = address.Value()
-	}
+	r.addr = address.Value()
 	if sg, ok := r.getter.(codeSizeGetter); ok {
-		size, _, err := sg.GetCodeSize(addressValue[:], r.txNum)
+		size, _, err := sg.GetCodeSize(r.addr[:], r.txNum)
 		if err != nil {
 			return 0, err
 		}
 		if r.trace {
-			fmt.Printf("%sReadAccountCodeSize (sz) [%x] => [%d], txNum: %d\n", r.tracePrefix, addressValue, size, r.txNum)
+			fmt.Printf("%sReadAccountCodeSize (sz) [%x] => [%d], txNum: %d\n", r.tracePrefix, r.addr, size, r.txNum)
 		}
 		return size, nil
 	}
-	enc, _, err := r.getter.GetLatest(kv.CodeDomain, addressValue[:])
+	enc, _, err := r.getter.GetLatest(kv.CodeDomain, r.addr[:])
 	if err != nil {
 		return 0, err
 	}
 	size := len(enc)
 	if r.trace {
-		fmt.Printf("%sReadAccountCodeSize [%x] => [%d], txNum: %d\n", r.tracePrefix, addressValue, size, r.txNum)
+		fmt.Printf("%sReadAccountCodeSize [%x] => [%d], txNum: %d\n", r.tracePrefix, r.addr, size, r.txNum)
 	}
 	return size, nil
 }

--- a/execution/state/rw_v3_allocs_test.go
+++ b/execution/state/rw_v3_allocs_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+type fixedGetter struct{ val []byte }
+
+func (g fixedGetter) GetLatest(name kv.Domain, k []byte) ([]byte, kv.Step, error) {
+	return g.val, 0, nil
+}
+func (g fixedGetter) HasPrefix(name kv.Domain, prefix []byte) ([]byte, []byte, bool, error) {
+	return nil, nil, false, nil
+}
+func (g fixedGetter) StepsInFiles(entitySet ...kv.Domain) kv.Step { return 0 }
+
+type histMockTx struct {
+	kv.TemporalTx
+	val []byte
+}
+
+func (m histMockTx) GetAsOf(domain kv.Domain, key []byte, ts uint64) ([]byte, bool, error) {
+	return m.val, true, nil
+}
+
+func TestStateReader_ReadMethods_Allocs(t *testing.T) {
+	var acc accounts.Account
+	acc.Nonce = 1
+	accEnc := accounts.SerialiseV3(&acc) // valid encoding so ReadAccountData hits the deserialize path
+
+	r := NewReaderV3(fixedGetter{val: accEnc})
+	addr := accounts.InternAddress(common.Address{0x11})
+	key := accounts.InternKey(common.Hash{0x22})
+	hr := NewHistoryReaderV3(histMockTx{val: accEnc}, 0)
+
+	cache := NewBlockStateCache()
+	cache.PutCommittedStorage(addr, key, make([]byte, 32))
+	cache.PutCommittedAccount(addr, &acc)
+	cr := NewCachedReaderV3(fixedGetter{val: make([]byte, 32)}, cache)
+
+	for _, tc := range []struct {
+		name string
+		want float64
+		fn   func()
+	}{
+		{"ReaderV3.ReadAccountStorage", 0, func() { _, _, _ = r.ReadAccountStorage(addr, key) }},
+		{"ReaderV3.ReadAccountData", 1, func() { _, _ = r.ReadAccountData(addr) }}, // 1: returns *accounts.Account
+		{"ReaderV3.HasStorage", 0, func() { _, _ = r.HasStorage(addr) }},
+		{"ReaderV3.ReadAccountCode", 0, func() { _, _ = r.ReadAccountCode(addr) }},
+		{"ReaderV3.ReadAccountCodeSize", 0, func() { _, _ = r.ReadAccountCodeSize(addr) }},
+		{"ReaderV3.ReadAccountDataForDebug", 1, func() { _, _ = r.ReadAccountDataForDebug(addr) }}, // 1: returns *accounts.Account
+		{"ReaderV3.ReadAccountIncarnation", 0, func() { _, _ = r.ReadAccountIncarnation(addr) }},
+
+		{"HistoryReaderV3.ReadAccountStorage", 0, func() { _, _, _ = hr.ReadAccountStorage(addr, key) }},
+		{"HistoryReaderV3.ReadAccountCode", 0, func() { _, _ = hr.ReadAccountCode(addr) }},
+		{"HistoryReaderV3.ReadAccountCodeSize", 0, func() { _, _ = hr.ReadAccountCodeSize(addr) }},
+		{"HistoryReaderV3.ReadAccountData", 1, func() { _, _ = hr.ReadAccountData(addr) }},                 // 1: returns *accounts.Account
+		{"HistoryReaderV3.ReadAccountDataForDebug", 1, func() { _, _ = hr.ReadAccountDataForDebug(addr) }}, // 1: returns *accounts.Account
+
+		{"CachedReaderV3.ReadAccountStorage (cache hit)", 0, func() { _, _, _ = cr.ReadAccountStorage(addr, key) }},
+		{"CachedReaderV3.ReadAccountData (cache hit)", 1, func() { _, _ = cr.ReadAccountData(addr) }}, // 1: returns *accounts.Account
+		{"CachedReaderV3.ReadAccountCode", 0, func() { _, _ = cr.ReadAccountCode(addr) }},
+		{"CachedReaderV3.ReadAccountCodeSize", 0, func() { _, _ = cr.ReadAccountCodeSize(addr) }},
+		{"CachedReaderV3.HasStorage", 0, func() { _, _ = cr.HasStorage(addr) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			allocs := testing.AllocsPerRun(100, tc.fn)
+			require.Equal(t, tc.want, allocs, "%s: alloc count changed", tc.name)
+		})
+	}
+}


### PR DESCRIPTION
The account/storage lookup key is handed to an **interface** getter, so escape analysis heap-allocates it on every read. But the reader itself is already heap-allocated, so a reused field costs nothing per call:

```go
type ReaderV3 struct {
    getter    kv.TemporalGetter
    composite [length.Addr + length.Hash]byte
}

func (r *ReaderV3) ReadAccountStorage(address accounts.Address, key accounts.StorageKey) (uint256.Int, bool, error) {
    copy(r.composite[:length.Addr], addressValue[:])
    copy(r.composite[length.Addr:], keyValue[:])
    enc, _, err := r.getter.GetLatest(kv.StorageDomain, r.composite[:])
    // r.getter is an `interface`. Escape-analysis say: because it's `interface` then "r.composite[:]" needs to be heap-allocated
    // buuuut. Escape-analysis understand that `ReaderV3` object is heap-allocated - means its non-pointer field is also heap-allocated (together with ReaderV3 object) and here no reason to heap-allocate anything
}
```

Applied to `ReaderV3.{ReadAccountStorage, readAccountData, HasStorage, ReadAccountCode, ReadAccountCodeSize}` and `HistoryReaderV3.{ReadAccountStorage, ReadAccountCode, ReadAccountCodeSize}`. `ReadAccountStorage` additionally moves its trace `Printf(&res)` into a by-value helper so `res` stays on the stack.

`ReadAccountStorage` micro-bench: **2 allocs / 96 B / 28 ns → 0 allocs / 0 B / 9.7 ns**. In a mainnet heap profile these were the two flat-top execution allocators (`ReadAccountStorage` ~14M, `readAccountData` ~8.5M objects).

A `require`-based `AllocsPerRun` test pins 0 allocs for the affected methods (green under `-race`).