### PR TITLE
ci: grant workflows:write to release App tokens for tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -626,6 +626,7 @@ jobs:
         private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
         repositories: "erigon"
         permission-contents: write
+        permission-workflows: write
 
     - name: Download linux/arm64 artifact
       uses: actions/download-artifact@v8
@@ -793,6 +794,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           repositories: "erigon"
           permission-contents: write
+          permission-workflows: write
 
       - name: Checkout git repository ${{ env.APP_REPO }} reference ${{ inputs.checkout_ref }}
         # Token must persist: the next step deletes the release tag with it.


### PR DESCRIPTION
## Problem
The `v3.5.9999` release run failed at **Create and push git tag**:

```
! [remote rejected] v3.5.9999 -> v3.5.9999 (Unable to determine if workflow can be created or updated due to timeout; `workflows` scope may be required.)
```

Pushing a tag to a repo that contains `.github/workflows/` files trips GitHub's App push-protection: the token must hold **`workflows: write`**, or GitHub verifies the push touches no workflow files (it timed out and demanded the scope). #22547 scoped the release App tokens to `contents: write` **only**, dropping the `workflows` access the unscoped token previously inherited — so the tag push began failing.

Everything else in the run succeeded (build, tests, docker, debian); only the tag push failed, and rollback correctly found no tag to remove.

## Fix
Add `permission-workflows: write` to both `create-github-app-token` steps (publish-release and the rollback job — its `git push -d` hits the same check). The `RELEASE_BOT_APP` installation is granted `workflows: write`, so the scoped token can request it. Tokens stay least-privilege: `contents` + `workflows` only (no `pull-requests`, which release doesn't use).

## Verification
- `zizmor 1.26.1 --config .github/zizmor.yml` → exit 0, `github-app` 0 findings (still scoped, no suppression).
- `actionlint` → clean.

Follow-up to #22547.