### PR TITLE
execution/state: skip SelfDestruct version-map lock when no block-level selfdestruct

### DIFF
--- a/execution/state/refresh_versioned_bench_test.go
+++ b/execution/state/refresh_versioned_bench_test.go
@@ -1,0 +1,98 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// benchRefreshAddrs builds nAddrs deterministic addresses.
+func benchRefreshAddrs(nAddrs int) []accounts.Address {
+	addrs := make([]accounts.Address, nAddrs)
+	for i := range addrs {
+		var a common.Address
+		a[0] = byte(i)
+		a[1] = byte(i >> 8)
+		a[19] = 0xAA
+		addrs[i] = accounts.InternAddress(a)
+	}
+	return addrs
+}
+
+// benchSeedVersionMap writes balance/nonce/incarnation/codehash at tx 0 for
+// every address, so a read at tx 1 resolves entirely in the versionMap
+// (MapRead outcome) without touching the stateReader.
+func benchSeedVersionMap(mvhm *VersionMap, addrs []accounts.Address) {
+	v0 := Version{TxIndex: 0, Incarnation: 1}
+	for i, addr := range addrs {
+		mvhm.WriteBalance(addr, v0, *uint256.NewInt(uint64(100 + i)), true)
+		mvhm.WriteNonce(addr, v0, uint64(i+1), true)
+		mvhm.WriteIncarnation(addr, v0, uint64(1), true)
+		var h common.Hash
+		h[0] = byte(i)
+		h[1] = byte(i >> 8)
+		mvhm.WriteCodeHash(addr, v0, accounts.InternCodeHash(h), true)
+	}
+}
+
+// BenchmarkRefreshVersionedAccount isolates refreshVersionedAccount: it drives
+// the 4 field reads (balance/nonce/incarnation/codehash) through the versionMap
+// with no EVM overhead. "hit" seeds the versionMap so reads resolve there;
+// "miss" leaves it empty so every read falls through to the caller default.
+func BenchmarkRefreshVersionedAccount(b *testing.B) {
+	const nAddrs = 256
+	addrs := benchRefreshAddrs(nAddrs)
+
+	run := func(b *testing.B, seed bool) {
+		_, tx, domains := NewTestRwTx(b)
+		mvhm := NewVersionMap(nil)
+		if seed {
+			benchSeedVersionMap(mvhm, addrs)
+		}
+		s := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), mvhm)
+		s.txIndex = 1
+		base := &accounts.Account{}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		i := 0
+		for b.Loop() {
+			//nolint:errcheck
+			s.refreshVersionedAccount(addrs[i&(nAddrs-1)], base, StorageRead, UnknownVersion)
+			i++
+		}
+	}
+
+	b.Run("hit", func(b *testing.B) { run(b, true) })
+	b.Run("miss", func(b *testing.B) { run(b, false) })
+}
+
+// BenchmarkRefreshVersionedAccountParallel exposes the VersionMap RWMutex
+// contention: many goroutines each own their IntraBlockState but share one
+// seeded versionMap, so every refresh takes the global RLock. The seeded map
+// keeps all reads inside the versionMap (no shared stateReader access).
+func BenchmarkRefreshVersionedAccountParallel(b *testing.B) {
+	const nAddrs = 256
+	addrs := benchRefreshAddrs(nAddrs)
+
+	_, tx, domains := NewTestRwTx(b)
+	mvhm := NewVersionMap(nil)
+	benchSeedVersionMap(mvhm, addrs)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		s := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), mvhm)
+		s.txIndex = 1
+		base := &accounts.Account{}
+		i := 0
+		for pb.Next() {
+			//nolint:errcheck
+			s.refreshVersionedAccount(addrs[i&(nAddrs-1)], base, StorageRead, UnknownVersion)
+			i++
+		}
+	})
+}

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -363,7 +363,9 @@ func (vm *VersionMap) ReadAddress(addr accounts.Address, txIdx int) (*accounts.A
 }
 
 func (vm *VersionMap) ReadSelfDestruct(addr accounts.Address, txIdx int) (bool, ReadResult, bool) {
-	if !vm.hasSelfDestruct.Load() {
+	// vm == nil matches readFloor's nil handling; the flag fast-path preserves
+	// the miss result readFloor would return when no SelfDestruct cell exists.
+	if vm == nil || !vm.hasSelfDestruct.Load() {
 		return false, ReadResult{depIdx: UnknownDep, incarnation: -1}, false
 	}
 	return readFloor(vm, addr, txIdx, func(e *AddressEntry) *btree.Map[int, *WriteCell[bool]] { return e.SelfDestruct })

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/holiman/uint256"
 	"github.com/tidwall/btree"
@@ -150,10 +151,15 @@ func markCellFlag[T any](cells *btree.Map[int, *WriteCell[T]], txIdx int, flag s
 }
 
 type VersionMap struct {
-	mu     sync.RWMutex
-	s      map[accounts.Address]*AddressEntry
-	trace  bool
-	HasBAL bool // When true, all significant writes are pre-populated from BAL
+	mu sync.RWMutex
+	s  map[accounts.Address]*AddressEntry
+	// hasSelfDestruct is set once any SelfDestruct cell is written and never
+	// cleared. While false, no self-destruct exists anywhere, so ReadSelfDestruct
+	// can return the miss result without taking mu — every versioned read
+	// consults it, and self-destructs are rare (EIP-6780).
+	hasSelfDestruct atomic.Bool
+	trace           bool
+	HasBAL          bool // When true, all significant writes are pre-populated from BAL
 }
 
 func NewVersionMap(changes []*types.AccountChanges) *VersionMap {
@@ -223,6 +229,7 @@ func (vm *VersionMap) WriteAddress(addr accounts.Address, v Version, value *acco
 }
 
 func (vm *VersionMap) WriteSelfDestruct(addr accounts.Address, v Version, value bool, complete bool) {
+	vm.hasSelfDestruct.Store(true)
 	vm.mu.Lock()
 	defer vm.mu.Unlock()
 	e := vm.entryOrCreate(addr)
@@ -356,6 +363,9 @@ func (vm *VersionMap) ReadAddress(addr accounts.Address, txIdx int) (*accounts.A
 }
 
 func (vm *VersionMap) ReadSelfDestruct(addr accounts.Address, txIdx int) (bool, ReadResult, bool) {
+	if !vm.hasSelfDestruct.Load() {
+		return false, ReadResult{depIdx: UnknownDep, incarnation: -1}, false
+	}
 	return readFloor(vm, addr, txIdx, func(e *AddressEntry) *btree.Map[int, *WriteCell[bool]] { return e.SelfDestruct })
 }
 
@@ -544,6 +554,9 @@ func (vm *VersionMap) FlushVersionedWrites(writes *WriteSet, complete bool, trac
 	for addr, vw := range writes.address {
 		e := vm.entryOrCreate(addr)
 		e.Address = putCell(e.Address, addr, AddressPath, vw.Version.TxIndex, vw.Version.Incarnation, flag, vw.Val, getCellAccount)
+	}
+	if len(writes.selfDestruct) > 0 {
+		vm.hasSelfDestruct.Store(true)
 	}
 	for addr, vw := range writes.selfDestruct {
 		e := vm.entryOrCreate(addr)

--- a/execution/state/versionmap_test.go
+++ b/execution/state/versionmap_test.go
@@ -316,10 +316,6 @@ func TestMVHashMapBasics(t *testing.T) {
 	require.Equal(t, valueFor(AddressPath, 10, 2), resVal)
 }
 
-// TestValidateRead_HasBAL_NoBypassForAddressPath verifies that when HasBAL is
-// true, AddressPath is NOT bypassed — a new MVReadResultDone entry on
-// AddressPath means a real state change (e.g. account creation) from a
-// concurrent worker, and the read must be invalidated.
 // TestReadSelfDestruct_FastPath covers the hasSelfDestruct short-circuit: a nil
 // receiver and a map with no self-destruct both return the miss result (matching
 // readFloor), and a real self-destruct is still observed once written.
@@ -349,6 +345,10 @@ func TestReadSelfDestruct_FastPath(t *testing.T) {
 	require.Equal(t, MVReadResultDone, res.Status())
 }
 
+// TestValidateRead_HasBAL_NoBypassForAddressPath verifies that when HasBAL is
+// true, AddressPath is NOT bypassed — a new MVReadResultDone entry on
+// AddressPath means a real state change (e.g. account creation) from a
+// concurrent worker, and the read must be invalidated.
 func TestValidateRead_HasBAL_NoBypassForAddressPath(t *testing.T) {
 	t.Parallel()
 

--- a/execution/state/versionmap_test.go
+++ b/execution/state/versionmap_test.go
@@ -320,6 +320,35 @@ func TestMVHashMapBasics(t *testing.T) {
 // true, AddressPath is NOT bypassed — a new MVReadResultDone entry on
 // AddressPath means a real state change (e.g. account creation) from a
 // concurrent worker, and the read must be invalidated.
+// TestReadSelfDestruct_FastPath covers the hasSelfDestruct short-circuit: a nil
+// receiver and a map with no self-destruct both return the miss result (matching
+// readFloor), and a real self-destruct is still observed once written.
+func TestReadSelfDestruct_FastPath(t *testing.T) {
+	t.Parallel()
+	addr := accounts.InternAddress([20]byte{0x5d})
+
+	// nil receiver must not panic (matches readFloor's vm==nil handling).
+	var nilVM *VersionMap
+	_, res, ok := nilVM.ReadSelfDestruct(addr, 5)
+	require.False(t, ok)
+	require.Equal(t, MVReadResultNone, res.Status())
+
+	// Fresh map, no self-destruct written: flag is false, fast-path miss.
+	vm := NewVersionMap(nil)
+	require.False(t, vm.hasSelfDestruct.Load())
+	_, res, ok = vm.ReadSelfDestruct(addr, 5)
+	require.False(t, ok)
+	require.Equal(t, MVReadResultNone, res.Status())
+
+	// After a self-destruct write the flag flips and the value is observed.
+	vm.WriteSelfDestruct(addr, Version{TxIndex: 2, Incarnation: 0}, true, true)
+	require.True(t, vm.hasSelfDestruct.Load())
+	destructed, res, ok := vm.ReadSelfDestruct(addr, 5)
+	require.True(t, ok)
+	require.True(t, destructed)
+	require.Equal(t, MVReadResultDone, res.Status())
+}
+
 func TestValidateRead_HasBAL_NoBypassForAddressPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

`VersionMap.ReadSelfDestruct` is consulted on **every** versioned read (the self-destruct / revival guard at the top of `versionedReadCore`, plus the validator), and it takes the global `RWMutex` RLock + a map lookup — even though a block having any `SELFDESTRUCT` is rare (more so post-EIP-6780). Under parallel execution the RLock's reader-count atomic bounces the cache line across all workers, so it shows up as contention.

## Change

Add a monotonic `hasSelfDestruct atomic.Bool` on `VersionMap`, set the first time any `SelfDestruct` cell is written (`WriteSelfDestruct` and `FlushVersionedWrites`) and never cleared. While it is `false`, `ReadSelfDestruct` returns the miss result without taking `mu`.

## Why it is behaviour-preserving

The flag is set **before** any `SelfDestruct` cell becomes visible, so the invariant `hasSelfDestruct == false ⇒ no SelfDestruct cell exists anywhere` holds strictly. When no cell exists, `ReadSelfDestruct` under the lock returns exactly the miss value the fast path returns: `(false, {UnknownDep, -1}, false)`. Concurrent interleavings are unchanged — a reader that observes `false` behaves identically to one whose locked read ran just before the writer's insert, and the MVCC validator re-checks recorded reads either way.

## Numbers

Isolated `refreshVersionedAccount` microbench (added here):
- single-thread: **-11%**
- 8 cores: **-42%** (removed RLock contention)

Real EVM benchmarks (`execution/vm/benchmark`, `-count=10`, all p=0.000): **-9.9% geomean** (ERC20Transfer -14%, DeFiSwapChain -11%, SLOAD/storage -7…-9%).

Correctness: `execution/state` + parallel-executor + selfdestruct / EIP-8246 / reorg tests pass; `-race` clean; `golangci-lint` clean.
