### PR TITLE
cmd/utils: fix TestCommitmentPlainValuesFromCtx flag-state leak under -count

### DIFF
--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -308,8 +308,9 @@ func TestNewP2PConfig_DiscoveryDefaults(t *testing.T) {
 func TestCommitmentPlainValuesFromCtx(t *testing.T) {
 	parse := func(args ...string) *bool {
 		var got *bool
+		flag := cli.BoolFlag{Name: CommitmentPlainValuesFlag.Name}
 		app := &cli.Command{
-			Flags: []cli.Flag{&CommitmentPlainValuesFlag},
+			Flags: []cli.Flag{&flag},
 			Action: func(ctx context.Context, cmd *cli.Command) error {
 				got = CommitmentPlainValuesFromCtx(cmd)
 				return nil


### PR DESCRIPTION
`go test -shuffle=on -race -count=2 ./...` surfaced an order/count-dependent failure in `TestCommitmentPlainValuesFromCtx`:

```
--- FAIL: TestCommitmentPlainValuesFromCtx (0.00s)
    flags_test.go:322: Expected nil, but got: (*bool)(0x...)
        Messages: unset => nil
```

## Root cause

The test registered the package-global `CommitmentPlainValuesFlag` into a fresh `cli.Command` on every `parse()` call. urfave/cli v3 flags retain their `hasBeenSet` state across `Command.Run`, so on the second in-process iteration (`-count=2`, or a `-shuffle` reordering that re-runs the function) the opening `parse()` — which asserts "unset ⇒ nil" — observed leftover state from an earlier `parse()` and returned a non-nil `*bool`.

## Fix

Use a fresh `cli.BoolFlag` (same name) per `parse()` so each `Run` starts pristine and the exported global is never mutated. `CommitmentPlainValuesFromCtx` resolves `IsSet`/`Bool` from the `*cli.Command` by name, so a same-named local flag is equivalent.

Verified with `go test -shuffle=on -count=5 -run TestCommitmentPlainValuesFromCtx ./cmd/utils/` and the original failing seed (`-shuffle=1784356754748987655 -count=2 ./cmd/utils/`).
