### PR TITLE
cl/spectest: make Test re-runnable under -count (guard global config init)

### DIFF
--- a/cl/spectest/tests_test.go
+++ b/cl/spectest/tests_test.go
@@ -38,7 +38,9 @@ func Test(t *testing.T) {
 	if dbg.EnvBool("ERIGON_SKIP_CL_SPECTEST", false) {
 		t.Skip("ERIGON_SKIP_CL_SPECTEST=true; consensus spec tests are covered by test-integration-caplin")
 	}
-	caplinConfig := clparams.CaplinConfig{}
-	clparams.InitGlobalStaticConfig(&clparams.MainnetBeaconConfig, &caplinConfig)
+	if clparams.GetBeaconConfig() == nil {
+		caplinConfig := clparams.CaplinConfig{}
+		clparams.InitGlobalStaticConfig(&clparams.MainnetBeaconConfig, &caplinConfig)
+	}
 	spectest.RunCases(t, consensus_tests.TestFormats, transition.ValidatingMachine, os.DirFS(mainnetDir))
 }


### PR DESCRIPTION
`go test -shuffle=on -race -count=2 ./...` panicked the `cl/spectest` package on the second in-process iteration:

```
--- FAIL: Test (0.00s)
panic: globalConfig already initialized [recovered, repanicked]
    cl/clparams/global.go:16 InitGlobalStaticConfig
    cl/spectest/tests_test.go:42 Test
```

## Root cause

`clparams.InitGlobalStaticConfig` panics if the process-global beacon/caplin config is already set (a deliberate guard against double-init in production). `cl/spectest.Test` called it unconditionally, so under `-count=2` (or a `-shuffle` re-run) the second execution re-initialized the already-set global and panicked.

## Fix

Only initialize when the global config is unset (`clparams.GetBeaconConfig() == nil`). The mainnet config is identical across iterations, so reusing the one set by the first run is correct, and the production double-init guard is left untouched.

Verified with `go test -shuffle=on -count=5 ./cl/spectest/` (the panic reproduces at `-count=2` before the fix, at the init call — independent of whether the `cl_mainnet` fixtures are present).
