### PR TITLE
cl/phase1/network/services: restore swapped signature globals in tests

### DIFF
--- a/cl/phase1/network/services/attestation_service_test.go
+++ b/cl/phase1/network/services/attestation_service_test.go
@@ -71,6 +71,7 @@ type attestationTestSuite struct {
 }
 
 func (t *attestationTestSuite) SetupTest() {
+	saveSignatureGlobals(t.T())
 	t.gomockCtrl = gomock.NewController(t.T())
 	t.mockForkChoice = &mock_services.ForkChoiceStorageMock{}
 	_, st, _ := tests.GetBellatrixRandom()

--- a/cl/phase1/network/services/global_mock_test.go
+++ b/cl/phase1/network/services/global_mock_test.go
@@ -17,6 +17,8 @@
 package services
 
 import (
+	"testing"
+
 	"go.uber.org/mock/gomock"
 
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -86,4 +88,18 @@ func (m *mockFuncs) VerifyDataColumnSidecarKZGProofsWithCommitments(sidecar *clt
 	ret := m.ctrl.Call(m, "VerifyDataColumnSidecarKZGProofsWithCommitments", sidecar, kzgCommitments)
 	ret0, _ := ret[0].(bool)
 	return ret0
+}
+
+// saveSignatureGlobals restores the package-level signature-verification func
+// vars when the test finishes, so a test's mock (bound to its own gomock
+// controller) can't leak into a later shuffled test and panic there.
+func saveSignatureGlobals(t testing.TB) {
+	origComputeSigningRoot := computeSigningRoot
+	origBlsVerify := blsVerify
+	origBlsVerifyMultipleSignatures := blsVerifyMultipleSignatures
+	t.Cleanup(func() {
+		computeSigningRoot = origComputeSigningRoot
+		blsVerify = origBlsVerify
+		blsVerifyMultipleSignatures = origBlsVerifyMultipleSignatures
+	})
 }

--- a/cl/phase1/network/services/proposer_slashing_service_test.go
+++ b/cl/phase1/network/services/proposer_slashing_service_test.go
@@ -46,6 +46,7 @@ type proposerSlashingTestSuite struct {
 }
 
 func (t *proposerSlashingTestSuite) SetupTest() {
+	saveSignatureGlobals(t.T())
 	t.gomockCtrl = gomock.NewController(t.T())
 	t.operationsPool = &pool.OperationsPool{
 		ProposerSlashingsPool: pool.NewOperationPool[common.Bytes96, *cltypes.ProposerSlashing](10, "proposerSlashingsPool"),

--- a/cl/phase1/network/services/sync_committee_messages_service_test.go
+++ b/cl/phase1/network/services/sync_committee_messages_service_test.go
@@ -95,6 +95,7 @@ func TestSyncCommitteesSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockFuncs := &mockFuncs{ctrl: ctrl}
+	saveSignatureGlobals(t)
 	blsVerifyMultipleSignatures = mockFuncs.BlsVerifyMultipleSignatures
 
 	state, msg := getObjectsForSyncCommitteesServiceTest(t, ctrl)

--- a/cl/phase1/network/services/sync_contribution_service_test.go
+++ b/cl/phase1/network/services/sync_contribution_service_test.go
@@ -136,6 +136,7 @@ func TestSyncContributionServiceSuccess(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockFuncs := &mockFuncs{ctrl: ctrl}
+	saveSignatureGlobals(t)
 	blsVerifyMultipleSignatures = mockFuncs.BlsVerifyMultipleSignatures
 	s, sd, clock := setupSyncContributionServiceTest(t, ctrl)
 	clock.EXPECT().IsSlotCurrentSlotWithMaximumClockDisparity(gomock.Any()).Return(true).AnyTimes()

--- a/cl/phase1/network/services/voluntary_exit_service_test.go
+++ b/cl/phase1/network/services/voluntary_exit_service_test.go
@@ -49,6 +49,7 @@ type voluntaryExitTestSuite struct {
 }
 
 func (t *voluntaryExitTestSuite) SetupTest() {
+	saveSignatureGlobals(t.T())
 	computeSigningRoot = func(_ ssz.HashableSSZ, domain []byte) ([32]byte, error) {
 		return [32]byte{}, nil
 	}


### PR DESCRIPTION
`go test -shuffle=on -race -count=2 ./...` panicked the `cl/phase1/network/services` package:

```
--- FAIL: TestExecutionPayloadBidServiceDifferentParentHashes
panic: Fail in goroutine after TestProposerSlashing has completed [recovered, repanicked]
    gomock/controller.go:214 (*Controller).Call
    services/global_mock_test.go:33 (*mockFuncs).ComputeSigningRoot
    services/execution_payload_bid_service.go:438 validateBuilderBidSignature
```

## Root cause

The service tests swap package-level function variables (`computeSigningRoot`, `blsVerify`, `blsVerifyMultipleSignatures`) for gomock-backed mocks bound to the *running* test's `gomock.Controller`. Several suites/tests never restored them:

- `TestProposerSlashing` sets `computeSigningRoot = mock` and, on teardown, calls `ctrl.Finish()` but leaves the global pointing at the (now finished) mock.
- Under `-shuffle`/`-count`, whichever test runs next and computes a signing root without setting its own mock (the epbs bid service, proposer-preferences, …) invokes a mock bound to a completed controller → `t.Fatalf` fires on a finished `T` → panic.

The victim varies by shuffle order; the source is always a leaker that doesn't restore. Reproduced locally on the first shuffled run (victim: `TestProposerPreferencesServiceDuplicate`).

## Fix

Add `saveSignatureGlobals(t)` (snapshots the three globals, restores them on `t.Cleanup`) and call it from the setups that were missing restoration: `proposer_slashing`, `voluntary_exit`, `attestation`, `sync_contribution`, `sync_committee_messages`. The `bid`, `data_column`, `bls_to_execution_change` and `proposer_preferences` tests already restore their own swaps and are unchanged.

Verified with `go test -shuffle=on -count=2 ./cl/phase1/network/services/` — 15/15 green after the fix; the unfixed tree panics within one shuffled run.
