### PR TITLE
exec: return system-tx IntraBlockState to the stateObject pool

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1864,6 +1864,7 @@ func (result *execResult) finalizeSystemTx(
 	// TXs completed — cached reads would return pre-block values instead
 	// of the post-block state needed by syscalls (withdrawal/consolidation).
 	ibs := state.New(state.NewVersionedStateReader(txIndex, state.ReadSet{}, vm, stateReader))
+	defer ibs.Release(false)
 	ibs.SetTxContext(blockNum, txIndex)
 	ibs.SetVersion(txIncarnation)
 	// Use the block's versionMap so the IBS's versionedRead (used by


### PR DESCRIPTION
for: https://github.com/erigontech/erigon/issues/22572

`finalizeSystemTx` builds an `IntraBlockState` per system tx and drops it on the floor, so its `stateObject`s are never returned to `stateObjectPool`.

The pool starves, every `Get()` falls through to `New` (fresh struct + three empty maps), and those maps then re-grow from zero on each `originStorage`/`blockOriginStorage` insert instead of reusing the capacity that `release()`'s `clear()` was written to preserve.

On a Gnosis parallel-exec heap profile this path is **3.70GB of the 8.69GB** in `stateObjectPool.New`, plus its share of **10.15GB** of map growth in `stateObject.GetCommittedState` (state_object.go:209/210). Both numbers are the same root cause, not two.

The serial path already does this (`exec3_serial.go:376`), as do `block_exec.go:91`, `historical_trace_worker.go:490`, `create_block.go:185`, `exec.go:140`. The parallel executor was the outlier — its only `Release(` calls are on `pe.in`, a queue.

### Why `Release(false)`

`Release(true)` spawns a goroutine and recycles asynchronously, which would hand `stateObject`s back to the pool while the caller may still be reading them. The synchronous variant runs after the return values are evaluated, so the escaping `ReadSet`/`WriteSet` are already materialised.

### Why recycling is safe here

`finalizeSystemTx` returns `ibs.VersionedReads()` and `ibs.VersionedWrites(false)`, and `release()` zeroes `so.data`/`so.original`/`so.code` — so this is only safe if nothing escaping points into a `stateObject`. Audited every path:

| WriteSet path | value | aliases stateObject? |
|---|---|---|
| Address | `*accounts.Account` | no — `data := newobj.data; &data` (intra_block_state.go:1755) |
| Balance/Nonce/Incarnation/CodeSize/Storage | `uint256.Int`, `uint64`, `int` | value types |
| SelfDestruct/CreateContract | `bool` | value |
| CodeHash | `unique.Handle[common.Hash]` | interned, immutable |
| Code | `Code{Hash, Bytes []byte}` | shares backing array, but `release()` sets `so.code = accounts.Code{}` — drops the reference, never mutates the array |

| ReadSet site | holds | aliases? |
|---|---|---|
| intra_block_state.go:2522 | `NewAccountView(&data)`, `data := *account` (2513) | no — copy |
| read_paths.go:529 | `acc := r.mapAddressVal`, from the versionMap | no |
| read_paths.go:536, 1130 | header only, `Val` nil | no |

`Release()` also only walks `sdb.stateObjects` and `sdb.journal` — it never touches `versionedReads`, `versionedWrites`, or `logs`.

### Scope

First of two sites. Companion: #22574 (block-finalize IBS in `nextResult`, 5.75GB) — independent, also based on `main`, either can merge first.

The third site, `runPostApplyMessageOnMinIBS`, leaks in principle but is unreachable on AuRa/Gnosis (`GetPostApplyMessageFunc()` returns nil), so it never appears in the profile and is left alone.

### Note on validation

Package tests pass, but they are weak evidence for a parallel-executor recycling change — the failure mode is a wrong trie root far downstream, not a unit-test failure. A re-exec run is the check that would actually catch a mistake here; worth doing before merge.
