### PR TITLE
exec: return block-finalize IntraBlockState to the stateObject pool

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3017,6 +3017,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			pe.RUnlock()
 
 			ibs := state.New(reader)
+			defer ibs.Release(false)
 			ibs.SetVersion(finalVersion.Incarnation)
 			localVersionMap := state.NewVersionMap(nil)
 			ibs.SetVersionMap(localVersionMap)


### PR DESCRIPTION
for: https://github.com/erigontech/erigon/issues/22572


Second of two sites. Companion to #22573 — independent, based on `main`, either can merge first.

`nextResult` builds an `IntraBlockState` per block for `engine.Finalize` (withdrawals, EIP-7002/7251 system calls) and drops it, so its `stateObject`s never return to `stateObjectPool`. The pool starves, every `Get()` falls through to `New`, and the fresh maps re-grow from zero instead of reusing the capacity `release()`'s `clear()` preserves.

On a Gnosis parallel-exec heap profile: **5.75GB of the 17.94GB** allocated by `state.New`, plus its share of the **33.56GB** in `stateObjectPool.New`.

The parallel executor has exactly three `state.New` sites:

| IBS | function | status |
|---|---|---|
| system-tx finalize | `finalizeSystemTx` | #22573 |
| block finalize | `nextResult` | **this PR** |
| post-apply-message | `runPostApplyMessageOnMinIBS` | leaks, but unreachable on AuRa/Gnosis (`GetPostApplyMessageFunc()` returns nil), so it never appears in the profile |

Every other IBS in the codebase already releases — `exec3_serial.go:376`, `exec3.go:461`, `block_exec.go:91`, `historical_trace_worker.go:490`, `create_block.go:185`, `exec.go:140`. The parallel executor was the outlier.

### Why recycling is safe

`release()` zeroes `so.data`/`so.original`/`so.code`, and `updateAccount` hands raw interior pointers to the writer (`stateWriter.UpdateAccountData(addr, &so.original, &so.data)`, intra_block_state.go:2054) — so this is only safe if nothing escaping retains them. This IBS has five escape paths; all copy:

| escape | disposition |
|---|---|
| `ibs.MakeWriteSet(…, collector)` | `versionedWriteCollector.UpdateAccountData` copies the account **explicitly for this reason** — rw_v3.go:588: *"Copy to prevent aliasing with pooled stateObjects. After tx finalization the stateObject is returned to the pool and its Account may be overwritten."* |
| `ibs.VersionedReads()` → `blockIO.RecordReads` | account path copies (`data := *account`, intra_block_state.go:2513) |
| `ibs.VersionedWrites(true)` → `RecordWrites`, `FlushVersionedWrites` | value types / interned handles; account path copies at 1755 |
| `ibs.AccessedAddresses()` → `blockIO.RecordAccesses` | `maps.Copy` into a fresh map (2496) |
| `syscallIBS.GetRawLogs(…)` → `lastResult.Logs` | `slices.Clone` (457); `Release()` never touches `sdb.logs` |

`UpdateAccountCode` does retain `stateObject.code.Bytes` (rw_v3.go:639, 648) — safe, because `release()` sets `so.code = accounts.Code{}`, dropping the slice header without mutating the backing array.

`Release()` itself only walks `sdb.stateObjects` and `sdb.journal`; it never touches `versionedReads`, `versionedWrites`, or `logs`.

### Why `Release(false)` and why `defer` is safe here

`Release(true)` spawns a goroutine and recycles asynchronously, handing objects back to the pool while the caller may still read them. The synchronous variant runs after all uses.

The site sits inside `if be.blockNum > 0 { … }`, not a loop, so the deferred release runs once per `nextResult` call rather than accumulating.

### Note on validation

Package tests pass, but that is weak evidence for a parallel-executor recycling change — the failure mode is a wrong trie root far downstream, not a unit-test failure. A re-exec run is the check that would actually catch a mistake here; worth doing before merge, and it covers both PRs at once.
