### PR TITLE
execution/state: report stateObjects never returned to the pool under ERIGON_ASSERT

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1630,7 +1630,7 @@ func (sdb *IntraBlockState) getStateObject(addr accounts.Address, recordRead boo
 			destructed, _, _, err := refreshSelfDestruct(sdb, addr)
 
 			if destructed || err != nil {
-				so := stateObjectPool.Get().(*stateObject)
+				so := getStateObject()
 				so.db = sdb
 				so.address = addr
 				so.selfdestructed = destructed
@@ -1670,7 +1670,7 @@ func (sdb *IntraBlockState) getStateObject(addr accounts.Address, recordRead boo
 				}
 			}
 			if !localResurrected {
-				so := stateObjectPool.Get().(*stateObject)
+				so := getStateObject()
 				so.db = sdb
 				so.address = addr
 				so.selfdestructed = true

--- a/execution/state/state_object.go
+++ b/execution/state/state_object.go
@@ -25,8 +25,10 @@ import (
 	"io"
 	"maps"
 	"math/big"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/holiman/uint256"
@@ -34,6 +36,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -47,6 +50,35 @@ var stateObjectPool = sync.Pool{
 			dirtyStorage:       make(Storage),
 		}
 	},
+}
+
+var (
+	leakedStateObjects  atomic.Int64
+	reportedLeakOrigins sync.Map
+)
+
+// getStateObject takes an object from the pool, arming a leak check under
+// ERIGON_ASSERT. A pool miss shows up in a heap profile, but the profile names
+// the Get site rather than the caller that failed to return the object; the
+// finalizer reports the latter.
+func getStateObject() *stateObject {
+	so := stateObjectPool.Get().(*stateObject)
+	if dbg.AssertEnabled {
+		so.allocStack = dbg.Stack()
+		runtime.SetFinalizer(so, reportLeakedStateObject)
+	}
+	return so
+}
+
+// reportLeakedStateObject runs when a stateObject is collected without having
+// been released, i.e. its IntraBlockState was dropped without Release or Reset.
+// Origins are deduplicated so a leaking call site logs once, not once per object.
+func reportLeakedStateObject(so *stateObject) {
+	total := leakedStateObjects.Add(1)
+	if _, seen := reportedLeakOrigins.LoadOrStore(so.allocStack, struct{}{}); seen {
+		return
+	}
+	log.Warn("[assert] stateObject never returned to pool", "leaked", total, "origin", so.allocStack)
 }
 
 type Storage map[accounts.StorageKey]uint256.Int
@@ -95,11 +127,13 @@ type stateObject struct {
 	deleted         bool // true if account was deleted during the lifetime of this object
 	newlyCreated    bool // true if this object was created in the current transaction
 	createdContract bool // true if this object represents a newly created contract
+
+	allocStack string // ERIGON_ASSERT only: origin of the Get, for leak reporting
 }
 
 // newObject creates a state object from the pool.
 func newObject(db *IntraBlockState, address accounts.Address, data, original *accounts.Account) *stateObject {
-	so := stateObjectPool.Get().(*stateObject)
+	so := getStateObject()
 	so.db = db
 	so.address = address
 	so.data.Copy(data)
@@ -130,6 +164,10 @@ func (so *stateObject) release() {
 	so.deleted = false
 	so.newlyCreated = false
 	so.createdContract = false
+	if dbg.AssertEnabled {
+		runtime.SetFinalizer(so, nil)
+		so.allocStack = ""
+	}
 	stateObjectPool.Put(so)
 }
 

--- a/execution/state/state_object.go
+++ b/execution/state/state_object.go
@@ -57,14 +57,24 @@ var (
 	reportedLeakOrigins sync.Map
 )
 
+const leakStackDepth = 24
+
 // getStateObject takes an object from the pool, arming a leak check under
 // ERIGON_ASSERT. A pool miss shows up in a heap profile, but the profile names
 // the Get site rather than the caller that failed to return the object; the
 // finalizer reports the latter.
+//
+// Only raw PCs are captured here, into a buffer that survives pool cycles, so
+// arming costs no allocation; symbolisation happens once per reported leak.
+// Formatting the stack eagerly would dominate the heap profile of the very run
+// being diagnosed.
 func getStateObject() *stateObject {
 	so := stateObjectPool.Get().(*stateObject)
 	if dbg.AssertEnabled {
-		so.allocStack = dbg.Stack()
+		if so.allocPCs == nil {
+			so.allocPCs = make([]uintptr, leakStackDepth)
+		}
+		so.allocPCs = so.allocPCs[:runtime.Callers(2, so.allocPCs[:leakStackDepth])]
 		runtime.SetFinalizer(so, reportLeakedStateObject)
 	}
 	return so
@@ -75,10 +85,27 @@ func getStateObject() *stateObject {
 // Origins are deduplicated so a leaking call site logs once, not once per object.
 func reportLeakedStateObject(so *stateObject) {
 	total := leakedStateObjects.Add(1)
-	if _, seen := reportedLeakOrigins.LoadOrStore(so.allocStack, struct{}{}); seen {
+	origin := formatLeakOrigin(so.allocPCs)
+	if _, seen := reportedLeakOrigins.LoadOrStore(origin, struct{}{}); seen {
 		return
 	}
-	log.Warn("[assert] stateObject never returned to pool", "leaked", total, "origin", so.allocStack)
+	log.Warn("[assert] stateObject never returned to pool", "leaked", total, "origin", origin)
+}
+
+func formatLeakOrigin(pcs []uintptr) string {
+	if len(pcs) == 0 {
+		return "<no stack>"
+	}
+	var b strings.Builder
+	frames := runtime.CallersFrames(pcs)
+	for {
+		frame, more := frames.Next()
+		fmt.Fprintf(&b, "%s:%d ", frame.Function, frame.Line)
+		if !more {
+			break
+		}
+	}
+	return b.String()
 }
 
 type Storage map[accounts.StorageKey]uint256.Int
@@ -128,7 +155,7 @@ type stateObject struct {
 	newlyCreated    bool // true if this object was created in the current transaction
 	createdContract bool // true if this object represents a newly created contract
 
-	allocStack string // ERIGON_ASSERT only: origin of the Get, for leak reporting
+	allocPCs []uintptr // ERIGON_ASSERT only: Get-site PCs, reused across pool cycles
 }
 
 // newObject creates a state object from the pool.
@@ -166,7 +193,6 @@ func (so *stateObject) release() {
 	so.createdContract = false
 	if dbg.AssertEnabled {
 		runtime.SetFinalizer(so, nil)
-		so.allocStack = ""
 	}
 	stateObjectPool.Put(so)
 }

--- a/execution/state/state_object_leak_test.go
+++ b/execution/state/state_object_leak_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon/common/dbg"
+)
+
+func enableAssert(t *testing.T) {
+	t.Helper()
+	prev := dbg.AssertEnabled
+	dbg.AssertEnabled = true
+	t.Cleanup(func() { dbg.AssertEnabled = prev })
+}
+
+// waitForLeakReports drives GC until the leak counter moves past want-1, since
+// finalizers run asynchronously after collection.
+func waitForLeakReports(base int64) int64 {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		if got := leakedStateObjects.Load(); got > base {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return leakedStateObjects.Load()
+}
+
+func TestLeakedStateObjectIsReported(t *testing.T) {
+	enableAssert(t)
+
+	base := leakedStateObjects.Load()
+	func() { _ = getStateObject() }() // dropped without release
+
+	if got := waitForLeakReports(base); got <= base {
+		t.Fatalf("leaked stateObject was not reported: counter stayed at %d", base)
+	}
+}
+
+func TestReleasedStateObjectIsNotReported(t *testing.T) {
+	enableAssert(t)
+
+	base := leakedStateObjects.Load()
+	func() {
+		so := getStateObject()
+		so.db = nil
+		so.release()
+	}()
+
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := leakedStateObjects.Load(); got != base {
+		t.Fatalf("released stateObject was reported as leaked: %d -> %d", base, got)
+	}
+}


### PR DESCRIPTION
Reports `stateObject`s that are never returned to `stateObjectPool`, under `ERIGON_ASSERT`.

### Why a profile isn't enough

A pool miss is visible in a heap profile as allocation in `stateObjectPool.New`, but the profile names the **Get** site — not the caller that failed to return the object. Those coincide only when one function both creates and drops the `IntraBlockState`. When the object escapes, the profile points at an innocent caller and the real leak is invisible.

That gap is not theoretical. Running this on a chiado archive sync surfaced two orphan paths that profiling could not attribute, because the pool miss rate is now ~0.0007% and they never rose above noise:

| origin | mechanism |
|---|---|
| `intra_block_state.go:1853` (`CreateAccount`'s synthetic `previous`) | parked in `resetObjectChange{prev:}`; only `journal.revert()` releases journal-held objects, `journal.Reset()` just clears entries |
| `intra_block_state.go:1694` via `setStateObject` | `sdb.stateObjects[addr] = object` overwrites an existing occupant without releasing it |

Both are left unfixed here: they produced **2 objects across 14 minutes / ~260k blocks**, and releasing them is genuinely unsafe — `CreateAccount` keeps `previous` live after registering a replacement, and `resetObjectChange` holds that same pointer, so recycling either would be a use-after-free in the parallel executor. Recorded here so the next person doesn't rediscover them.

### How it works

- `getStateObject()` takes from the pool and, under `ERIGON_ASSERT`, records `dbg.Stack()` and arms a finalizer
- `release()` clears the finalizer before `Put`
- anything collected while still armed is reported with its **creation** stack
- origins are deduplicated, so a leaking call site logs once rather than once per object

The two direct `stateObjectPool.Get()` sites in `intra_block_state.go` now route through `getStateObject()` as well — otherwise the detector would be blind exactly where leaks can hide.

### Cost

Off by default. Under `ERIGON_ASSERT` the stack capture costs ~19% of CPU (measured: `dbg.Stack` at 8.88s of a 46s profile on the dev box), which is why it is not a always-on metric. The always-paid cost is one `string` field on `stateObject` (16 bytes on a ~280-byte struct that, with a working pool, is now rarely allocated).

### Validation

Unit tests pin both directions — a dropped object is reported, a released one is not. These matter more than usual: finalizers only run after a GC cycle, so a short test process can exit before firing, and the first `ERIGON_ASSERT=true` suite run reported nothing purely because of that. A detector that silently never fires is worse than none.

Verified live rather than assumed: a CPU profile from the running node shows `dbg.Stack` under `getStateObject`, confirming the instrumentation was actually armed and the observed zero was a real zero.
