### PR TITLE
execution/state: detect WriteSets dropped without ReleaseAndReset

### DIFF
--- a/execution/stagedsync/calc_state.go
+++ b/execution/stagedsync/calc_state.go
@@ -320,7 +320,7 @@ func (cs *calcState) LoadFromBAL(bal types.BlockAccessList, emptyRemoval bool, i
 // remainder — the BAL carries every change's tx index, so no re-execution is
 // needed. maxTxIndex == math.MaxUint32 is the whole block (== LoadFromBAL).
 func (cs *calcState) LoadFromBALUpTo(bal types.BlockAccessList, maxTxIndex uint32, emptyRemoval bool, isAura bool, eip8246 bool) {
-	writes := &state.WriteSet{}
+	writes := state.NewWriteSet()
 	for _, ac := range bal {
 		addr := ac.Address
 		if bc, ok := finalChangeUpTo(ac.BalanceChanges, maxTxIndex); ok {

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1985,7 +1985,7 @@ func (result *execResult) calcFees(
 	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
 		(coinbaseEmptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
 
-	addWrites := &state.WriteSet{}
+	addWrites := state.NewWriteSet()
 	if emitCoinbase {
 		result.CollectorWrites = result.CollectorWrites.SetAccountBalanceOrDelete(
 			result.Coinbase, coinbaseAcc, newCoinbaseBalance,
@@ -3286,7 +3286,7 @@ func MergeVersionedWrites(prev, next *state.WriteSet) *state.WriteSet {
 var codePathRecoveryHashMismatch = metrics.GetOrCreateCounter("exec3_codepath_recovery_hash_mismatch")
 
 func normalizeWriteSet(writes *state.WriteSet, vm *state.VersionMap, txIndex int, incarnation int, stateReader state.StateReader, domainStorageKeys func(addr accounts.Address) []accounts.StorageKey, emptyRemoval bool, isAura bool, eip8246 bool) *state.WriteSet {
-	filtered := &state.WriteSet{}
+	filtered := state.NewWriteSet()
 	if writes == nil {
 		return filtered
 	}

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2865,7 +2865,7 @@ func (sdb *IntraBlockState) ResetVersionedReads() {
 // creation marker); Nonce/Code/CodeHash/CodeSize/Address are dropped.
 func (sdb *IntraBlockState) VersionedWrites(checkDirty bool) *WriteSet {
 	src := &sdb.versionedWrites
-	out := &WriteSet{}
+	out := NewWriteSet()
 
 	addrs := make(map[accounts.Address]struct{})
 	for h := range src.AllHeaders() {

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -1630,7 +1630,7 @@ func (sdb *IntraBlockState) getStateObject(addr accounts.Address, recordRead boo
 			destructed, _, _, err := refreshSelfDestruct(sdb, addr)
 
 			if destructed || err != nil {
-				so := stateObjectPool.Get().(*stateObject)
+				so := getStateObject()
 				so.db = sdb
 				so.address = addr
 				so.selfdestructed = destructed
@@ -1670,7 +1670,7 @@ func (sdb *IntraBlockState) getStateObject(addr accounts.Address, recordRead boo
 				}
 			}
 			if !localResurrected {
-				so := stateObjectPool.Get().(*stateObject)
+				so := getStateObject()
 				so.db = sdb
 				so.address = addr
 				so.selfdestructed = true

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -578,7 +578,7 @@ type versionedWriteCollector struct {
 // NewVersionedWriteCollector creates a versionedWriteCollector that collects
 // StateWriter calls into a VersionedWrites slice and maintains rs.accounts.
 func NewVersionedWriteCollector(rs *StateV3Buffered) *versionedWriteCollector {
-	return &versionedWriteCollector{rs: rs, writes: &WriteSet{}}
+	return &versionedWriteCollector{rs: rs, writes: NewWriteSet()}
 }
 
 // Writes returns the collected write set for domain apply.
@@ -710,13 +710,13 @@ type LightCollector struct {
 }
 
 func NewLightCollector() *LightCollector {
-	return &LightCollector{writes: &WriteSet{}}
+	return &LightCollector{writes: NewWriteSet()}
 }
 
 // TakeWrites returns the accumulated writes and resets the collector.
 func (c *LightCollector) TakeWrites() *WriteSet {
 	writes := c.writes
-	c.writes = &WriteSet{}
+	c.writes = NewWriteSet()
 	return writes
 }
 

--- a/execution/state/state_object.go
+++ b/execution/state/state_object.go
@@ -25,8 +25,10 @@ import (
 	"io"
 	"maps"
 	"math/big"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/holiman/uint256"
@@ -34,6 +36,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/types/accounts"
@@ -47,6 +50,35 @@ var stateObjectPool = sync.Pool{
 			dirtyStorage:       make(Storage),
 		}
 	},
+}
+
+var (
+	leakedStateObjects  atomic.Int64
+	reportedLeakOrigins sync.Map
+)
+
+// getStateObject takes an object from the pool, arming a leak check under
+// ERIGON_ASSERT. A pool miss shows up in a heap profile, but the profile names
+// the Get site rather than the caller that failed to return the object; the
+// finalizer reports the latter.
+func getStateObject() *stateObject {
+	so := stateObjectPool.Get().(*stateObject)
+	if dbg.AssertEnabled {
+		so.allocStack = dbg.Stack()
+		runtime.SetFinalizer(so, reportLeakedStateObject)
+	}
+	return so
+}
+
+// reportLeakedStateObject runs when a stateObject is collected without having
+// been released, i.e. its IntraBlockState was dropped without Release or Reset.
+// Origins are deduplicated so a leaking call site logs once, not once per object.
+func reportLeakedStateObject(so *stateObject) {
+	total := leakedStateObjects.Add(1)
+	if _, seen := reportedLeakOrigins.LoadOrStore(so.allocStack, struct{}{}); seen {
+		return
+	}
+	log.Warn("[assert] stateObject never returned to pool", "leaked", total, "origin", so.allocStack)
 }
 
 type Storage map[accounts.StorageKey]uint256.Int
@@ -95,11 +127,13 @@ type stateObject struct {
 	deleted         bool // true if account was deleted during the lifetime of this object
 	newlyCreated    bool // true if this object was created in the current transaction
 	createdContract bool // true if this object represents a newly created contract
+
+	allocStack string // ERIGON_ASSERT only: origin of the Get, for leak reporting
 }
 
 // newObject creates a state object from the pool.
 func newObject(db *IntraBlockState, address accounts.Address, data, original *accounts.Account) *stateObject {
-	so := stateObjectPool.Get().(*stateObject)
+	so := getStateObject()
 	so.db = db
 	so.address = address
 	so.data.Copy(data)
@@ -130,6 +164,10 @@ func (so *stateObject) release() {
 	so.deleted = false
 	so.newlyCreated = false
 	so.createdContract = false
+	if dbg.AssertEnabled {
+		runtime.SetFinalizer(so, nil)
+		so.allocStack = ""
+	}
 	stateObjectPool.Put(so)
 }
 

--- a/execution/state/state_object.go
+++ b/execution/state/state_object.go
@@ -57,14 +57,24 @@ var (
 	reportedLeakOrigins sync.Map
 )
 
+const leakStackDepth = 24
+
 // getStateObject takes an object from the pool, arming a leak check under
 // ERIGON_ASSERT. A pool miss shows up in a heap profile, but the profile names
 // the Get site rather than the caller that failed to return the object; the
 // finalizer reports the latter.
+//
+// Only raw PCs are captured here, into a buffer that survives pool cycles, so
+// arming costs no allocation; symbolisation happens once per reported leak.
+// Formatting the stack eagerly would dominate the heap profile of the very run
+// being diagnosed.
 func getStateObject() *stateObject {
 	so := stateObjectPool.Get().(*stateObject)
 	if dbg.AssertEnabled {
-		so.allocStack = dbg.Stack()
+		if so.allocPCs == nil {
+			so.allocPCs = make([]uintptr, leakStackDepth)
+		}
+		so.allocPCs = so.allocPCs[:runtime.Callers(2, so.allocPCs[:leakStackDepth])]
 		runtime.SetFinalizer(so, reportLeakedStateObject)
 	}
 	return so
@@ -75,10 +85,27 @@ func getStateObject() *stateObject {
 // Origins are deduplicated so a leaking call site logs once, not once per object.
 func reportLeakedStateObject(so *stateObject) {
 	total := leakedStateObjects.Add(1)
-	if _, seen := reportedLeakOrigins.LoadOrStore(so.allocStack, struct{}{}); seen {
+	origin := formatLeakOrigin(so.allocPCs)
+	if _, seen := reportedLeakOrigins.LoadOrStore(origin, struct{}{}); seen {
 		return
 	}
-	log.Warn("[assert] stateObject never returned to pool", "leaked", total, "origin", so.allocStack)
+	log.Warn("[assert] stateObject never returned to pool", "leaked", total, "origin", origin)
+}
+
+func formatLeakOrigin(pcs []uintptr) string {
+	if len(pcs) == 0 {
+		return "<no stack>"
+	}
+	var b strings.Builder
+	frames := runtime.CallersFrames(pcs)
+	for {
+		frame, more := frames.Next()
+		fmt.Fprintf(&b, "%s:%d ", frame.Function, frame.Line)
+		if !more {
+			break
+		}
+	}
+	return b.String()
 }
 
 type Storage map[accounts.StorageKey]uint256.Int
@@ -128,7 +155,7 @@ type stateObject struct {
 	newlyCreated    bool // true if this object was created in the current transaction
 	createdContract bool // true if this object represents a newly created contract
 
-	allocStack string // ERIGON_ASSERT only: origin of the Get, for leak reporting
+	allocPCs []uintptr // ERIGON_ASSERT only: Get-site PCs, reused across pool cycles
 }
 
 // newObject creates a state object from the pool.
@@ -166,7 +193,6 @@ func (so *stateObject) release() {
 	so.createdContract = false
 	if dbg.AssertEnabled {
 		runtime.SetFinalizer(so, nil)
-		so.allocStack = ""
 	}
 	stateObjectPool.Put(so)
 }

--- a/execution/state/state_object_leak_test.go
+++ b/execution/state/state_object_leak_test.go
@@ -140,3 +140,14 @@ func TestEmptyWriteSetIsNotReported(t *testing.T) {
 		t.Fatalf("empty WriteSet was reported as leaked: %d -> %d", base, got)
 	}
 }
+
+// A WriteSet embedded as a value field is an interior pointer; SetFinalizer on
+// one is a fatal error, so ReleaseAndReset must disarm only what it armed.
+func TestEmbeddedWriteSetReleaseDoesNotPanic(t *testing.T) {
+	enableAssert(t)
+
+	type holder struct{ ws WriteSet }
+	h := &holder{}
+	h.ws.SetBalance(accounts.NilAddress, &VersionedWrite[uint256.Int]{})
+	h.ws.ReleaseAndReset()
+}

--- a/execution/state/state_object_leak_test.go
+++ b/execution/state/state_object_leak_test.go
@@ -21,7 +21,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
+
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
 func enableAssert(t *testing.T) {
@@ -72,5 +75,68 @@ func TestReleasedStateObjectIsNotReported(t *testing.T) {
 	}
 	if got := leakedStateObjects.Load(); got != base {
 		t.Fatalf("released stateObject was reported as leaked: %d -> %d", base, got)
+	}
+}
+
+func waitForWriteSetLeaks(base int64) int64 {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		if got := leakedWriteSets.Load(); got > base {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return leakedWriteSets.Load()
+}
+
+func TestDroppedWriteSetIsReported(t *testing.T) {
+	enableAssert(t)
+
+	base := leakedWriteSets.Load()
+	func() {
+		ws := NewWriteSet()
+		ws.SetBalance(accounts.NilAddress, &VersionedWrite[uint256.Int]{})
+	}() // dropped without ReleaseAndReset, holding a pooled map
+
+	if got := waitForWriteSetLeaks(base); got <= base {
+		t.Fatalf("dropped WriteSet was not reported: counter stayed at %d", base)
+	}
+}
+
+func TestReleasedWriteSetIsNotReported(t *testing.T) {
+	enableAssert(t)
+
+	base := leakedWriteSets.Load()
+	func() {
+		ws := NewWriteSet()
+		ws.SetBalance(accounts.NilAddress, &VersionedWrite[uint256.Int]{})
+		ws.ReleaseAndReset()
+	}()
+
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := leakedWriteSets.Load(); got != base {
+		t.Fatalf("released WriteSet was reported as leaked: %d -> %d", base, got)
+	}
+}
+
+// An empty WriteSet strands nothing, so dropping one must stay silent -
+// otherwise the common &WriteSet{} that never checks out a map would drown
+// the real reports.
+func TestEmptyWriteSetIsNotReported(t *testing.T) {
+	enableAssert(t)
+
+	base := leakedWriteSets.Load()
+	func() { _ = NewWriteSet() }()
+
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := leakedWriteSets.Load(); got != base {
+		t.Fatalf("empty WriteSet was reported as leaked: %d -> %d", base, got)
 	}
 }

--- a/execution/state/state_object_leak_test.go
+++ b/execution/state/state_object_leak_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon/common/dbg"
+)
+
+func enableAssert(t *testing.T) {
+	t.Helper()
+	prev := dbg.AssertEnabled
+	dbg.AssertEnabled = true
+	t.Cleanup(func() { dbg.AssertEnabled = prev })
+}
+
+// waitForLeakReports drives GC until the leak counter moves past want-1, since
+// finalizers run asynchronously after collection.
+func waitForLeakReports(base int64) int64 {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		if got := leakedStateObjects.Load(); got > base {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return leakedStateObjects.Load()
+}
+
+func TestLeakedStateObjectIsReported(t *testing.T) {
+	enableAssert(t)
+
+	base := leakedStateObjects.Load()
+	func() { _ = getStateObject() }() // dropped without release
+
+	if got := waitForLeakReports(base); got <= base {
+		t.Fatalf("leaked stateObject was not reported: counter stayed at %d", base)
+	}
+}
+
+func TestReleasedStateObjectIsNotReported(t *testing.T) {
+	enableAssert(t)
+
+	base := leakedStateObjects.Load()
+	func() {
+		so := getStateObject()
+		so.db = nil
+		so.release()
+	}()
+
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := leakedStateObjects.Load(); got != base {
+		t.Fatalf("released stateObject was reported as leaked: %d -> %d", base, got)
+	}
+}

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1211,7 +1211,10 @@ func (s *WriteSet) ReleaseAndReset() {
 		wsPutStorageInner(inner)
 	}
 	wsPutStorageOuter(s.storage)
-	if dbg.AssertEnabled {
+	// Only disarm what NewWriteSet armed. Embedded WriteSet fields (e.g.
+	// IntraBlockState.versionedWrites) are interior pointers, and SetFinalizer
+	// on one is a fatal error, not an error return.
+	if s.allocPCs != nil {
 		runtime.SetFinalizer(s, nil)
 	}
 	*s = WriteSet{}

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -7,13 +7,16 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"runtime"
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/heimdalr/dag"
 	"github.com/holiman/uint256"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/protocol/params"
@@ -615,6 +618,46 @@ type WriteSet struct {
 	codeHash       map[accounts.Address]*VersionedWrite[accounts.CodeHash]
 	codeSize       map[accounts.Address]*VersionedWrite[int]
 	storage        map[accounts.Address]map[accounts.StorageKey]*VersionedWrite[uint256.Int]
+
+	allocPCs []uintptr // ERIGON_ASSERT only: construction-site PCs, for leak reporting
+}
+
+var (
+	leakedWriteSets       atomic.Int64
+	reportedWSLeakOrigins sync.Map
+)
+
+// newWriteSet builds a WriteSet, arming a leak check under ERIGON_ASSERT.
+// The per-path maps are checked out of pools lazily, so a WriteSet dropped
+// without ReleaseAndReset strands every map it acquired.
+func NewWriteSet() *WriteSet {
+	s := &WriteSet{}
+	if dbg.AssertEnabled {
+		s.allocPCs = make([]uintptr, leakStackDepth)
+		s.allocPCs = s.allocPCs[:runtime.Callers(2, s.allocPCs)]
+		runtime.SetFinalizer(s, reportLeakedWriteSet)
+	}
+	return s
+}
+
+// holdsPooledMaps reports whether any per-path map was ever checked out. Length
+// is the wrong test: a map emptied by Del* still owns its pooled container.
+func (s *WriteSet) holdsPooledMaps() bool {
+	return s.address != nil || s.balance != nil || s.nonce != nil ||
+		s.incarnation != nil || s.selfDestruct != nil || s.createContract != nil ||
+		s.code != nil || s.codeHash != nil || s.codeSize != nil || s.storage != nil
+}
+
+func reportLeakedWriteSet(s *WriteSet) {
+	if !s.holdsPooledMaps() {
+		return // never touched a pool; dropping it strands nothing
+	}
+	total := leakedWriteSets.Add(1)
+	origin := formatLeakOrigin(s.allocPCs)
+	if _, seen := reportedWSLeakOrigins.LoadOrStore(origin, struct{}{}); seen {
+		return
+	}
+	log.Warn("[assert] WriteSet dropped without ReleaseAndReset", "leaked", total, "origin", origin)
 }
 
 // vwMapPool[T] pools the per-path map[Address]*VersionedWrite[T] containers
@@ -755,7 +798,7 @@ func (s *WriteSet) Filter(keep func(WriteHeader) bool) *WriteSet {
 	if s == nil {
 		return nil
 	}
-	out := &WriteSet{}
+	out := NewWriteSet()
 	for a, vw := range s.address {
 		if keep(vw.WriteHeader) {
 			out.SetAddress(a, vw)
@@ -1168,6 +1211,9 @@ func (s *WriteSet) ReleaseAndReset() {
 		wsPutStorageInner(inner)
 	}
 	wsPutStorageOuter(s.storage)
+	if dbg.AssertEnabled {
+		runtime.SetFinalizer(s, nil)
+	}
 	*s = WriteSet{}
 }
 
@@ -1870,7 +1916,7 @@ func (prev *WriteSet) Merge(next *WriteSet) *WriteSet {
 	if next.IsEmpty() {
 		return prev
 	}
-	out := &WriteSet{}
+	out := NewWriteSet()
 	out.copyFrom(prev)
 	out.copyFrom(next)
 	return out
@@ -1947,7 +1993,7 @@ func (writes *WriteSet) StripBalanceWrite(addr accounts.Address, readSet ReadSet
 // this address are stripped and a SelfDestructPath entry is emitted instead.
 func (writes *WriteSet) SetAccountBalanceOrDelete(addr accounts.Address, acc *accounts.Account, val uint256.Int, reason tracing.BalanceChangeReason, emptyRemoval bool) *WriteSet {
 	if writes == nil {
-		writes = &WriteSet{}
+		writes = NewWriteSet()
 	}
 	if acc == nil {
 		a := accounts.NewAccount()


### PR DESCRIPTION
Extends the pool-leak detector (#22575) to `WriteSet`, and with it identifies why the versioned-write pools miss so heavily.

### The finding

By **object count**, the write-set pools dominate pool misses on a chiado archive node — and `stateObject`, the pool this line of work started on, is noise:

| pool `Get` | objects | share of pool misses |
|---|---|---|
| `wsGetStorageInner` | 13.1M | 20.7% |
| `vwMapPool[[4]uint64]` | 10.2M | 16.1% |
| `wsGetStorageOuter` | 8.9M | 14.0% |
| `vwMapPool[uint64]` | 8.6M | 13.5% |
| `getCellStorage` | 5.1M | 8.1% |
| `getCellBalance` | 3.2M | 5.1% |
| `commitment.getDeferredUpdate` | 3.2M | 5.0% |
| … | | |
| `getStateObject` | 4.9k | **0.008%** |

`wsGetStorageInner` alone misses ~2,700× more often than `stateObject`.

### Root cause

`ReleaseAndReset` has exactly two call sites, both on `sdb.versionedWrites` — the `IntraBlockState`'s own set. It is **never** called on any WriteSet the parallel executor produces. The per-path maps are checked out of pools lazily, so each dropped WriteSet strands every map it acquired.

With the detector armed, 11 distinct origins appear within a minute of execution:

| producer | dropped at |
|---|---|
| `IntraBlockState.VersionedWrites:2868` | `finalizeSystemTx:1885`, `nextResult:3065`, `TxTask.VersionedWrites:457` |
| `NewVersionedWriteCollector:581` | `nextResult:3071`, `nextResult:2763` |
| `WriteSet.Merge:1922` | `MergeVersionedWrites:3253` (×2) |
| `NewLightCollector:713` | `resetWorkers:964` |
| `LightCollector.TakeWrites:719` | `Worker.RunTxTaskNoLock:569` |
| `normalizeWriteSet:3289` | `nextResult:2833` |
| `calcFees:1988` | `nextResult:2655` |

The pooling machinery — pools, `ReleaseAndReset`, per-path put helpers — was built but never wired into the consumer side.

### Scope: detection only

This PR does **not** fix the 11 sites. Those WriteSets escape to consumers that outlive the producing call (`blockIO`, the version map, `TxOut`), so each needs an ownership decision, and releasing one early would recycle maps a live reader still holds — the same hazard class as the `stateObject` work in #22573/#22574, at much greater width. That belongs in its own change, informed by this output.

### Design notes

- Finalizers cannot be attached to maps, so the check lives on the owning `*WriteSet`.
- Reporting is gated on `holdsPooledMaps()` rather than `IsEmpty()`: a map emptied by `Del*` still owns its pooled container, while a WriteSet that never checked one out strands nothing and must stay silent. Without this the common `&WriteSet{}` that stays empty would drown the real reports.
- `ReleaseAndReset` disarms only what `NewWriteSet` armed, keyed on `allocPCs`. `IntraBlockState.versionedWrites` is a *value* field, so `&sdb.versionedWrites` is an interior pointer, and `SetFinalizer` rejects those with a **fatal error** rather than an error return. The first version of this patch killed the node on the first `TxTask.Reset`; there is now a regression test using an embedded WriteSet, which the heap-allocated-only tests had missed.
- Capture is allocation-free (raw PCs into a reused buffer, symbolised only on report), per #22575 — eager stack formatting reached 48% of node heap and made the assert build misreport its own instrumentation as the leak.
