### PR TITLE
exec: reuse IntraBlockState map capacity across Reset

### DIFF
--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -354,7 +354,7 @@ func (sdb *IntraBlockState) Reset() {
 	clear(sdb.stateObjects)
 	clear(sdb.stateObjectsDirty)
 	for i := range sdb.logs {
-		clear(sdb.logs[i]) // free p¬ointers
+		clear(sdb.logs[i]) // free pointers
 		sdb.logs[i] = sdb.logs[i][:0]
 	}
 	clear(sdb.balanceInc)

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2397,7 +2397,7 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 		}
 	}
 	// Reset transient storage at the beginning of transaction execution
-	sdb.transientStorage = newTransientStorage()
+	clear(sdb.transientStorage)
 	sdb.addressAccess = make(map[accounts.Address]*accessOptions)
 	sdb.recordAccess = true
 

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -347,24 +347,24 @@ func (sdb *IntraBlockState) HasStorage(addr accounts.Address) (bool, error) {
 // Reset clears out all ephemeral state objects from the state db, but keeps
 // the underlying state trie to avoid reloading data for the next operations.
 func (sdb *IntraBlockState) Reset() {
-	sdb.nilAccounts = map[accounts.Address]struct{}{}
+	clear(sdb.nilAccounts)
 	for _, so := range sdb.stateObjects {
 		so.release()
 	}
-	sdb.stateObjects = map[accounts.Address]*stateObject{}
-	sdb.stateObjectsDirty = map[accounts.Address]struct{}{}
+	clear(sdb.stateObjects)
+	clear(sdb.stateObjectsDirty)
 	for i := range sdb.logs {
 		clear(sdb.logs[i]) // free p¬ointers
 		sdb.logs[i] = sdb.logs[i][:0]
 	}
-	sdb.balanceInc = map[accounts.Address]*BalanceIncrease{}
+	clear(sdb.balanceInc)
 	sdb.journal.Reset()
 	sdb.revisions = sdb.revisions.put()
 	sdb.refund = uint64(0)
 	sdb.txIndex = 0
 	sdb.logSize = 0
 	sdb.accessList.Reset()
-	sdb.transientStorage = newTransientStorage()
+	clear(sdb.transientStorage)
 	sdb.versionMap = nil
 	// Read side rebinds to a fresh empty set: VersionedReads() at end of
 	// tx hands the per-path maps to result.TxIn, so rebinding leaves the

--- a/execution/state/reset_bench_test.go
+++ b/execution/state/reset_bench_test.go
@@ -26,8 +26,10 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// BenchmarkIntraBlockStateReset measures the per-tx Reset the executor runs
-// between transactions, at a few realistic touched-account counts.
+// BenchmarkIntraBlockStateReset measures the touch-then-Reset cycle the executor
+// runs per tx, at a few realistic touched-account counts. The touch phase stays
+// inside the timer on purpose: reusing a map's buckets saves the regrow cost on
+// the next fill, which timing Reset alone would hide.
 func BenchmarkIntraBlockStateReset(b *testing.B) {
 	for _, n := range []int{8, 64, 512} {
 		b.Run(fmt.Sprintf("accounts=%d", n), func(b *testing.B) {

--- a/execution/state/reset_bench_test.go
+++ b/execution/state/reset_bench_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// BenchmarkIntraBlockStateReset measures the per-tx Reset the executor runs
+// between transactions, at a few realistic touched-account counts.
+func BenchmarkIntraBlockStateReset(b *testing.B) {
+	for _, n := range []int{8, 64, 512} {
+		b.Run(fmt.Sprintf("accounts=%d", n), func(b *testing.B) {
+			addrs := make([]accounts.Address, n)
+			for i := range addrs {
+				addrs[i] = accounts.InternAddress(common.BytesToAddress([]byte{byte(i), byte(i >> 8), 0x5a}))
+			}
+			ibs := New(nil)
+			b.ReportAllocs()
+			for b.Loop() {
+				for _, a := range addrs {
+					ibs.nilAccounts[a] = struct{}{}
+					ibs.stateObjectsDirty[a] = struct{}{}
+					ibs.balanceInc[a] = &BalanceIncrease{}
+					ibs.transientStorage.Set(a, accounts.NilKey, *uint256.NewInt(1))
+				}
+				ibs.Reset()
+			}
+		})
+	}
+}

--- a/execution/state/reset_bench_test.go
+++ b/execution/state/reset_bench_test.go
@@ -36,13 +36,17 @@ func BenchmarkIntraBlockStateReset(b *testing.B) {
 				addrs[i] = accounts.InternAddress(common.BytesToAddress([]byte{byte(i), byte(i >> 8), 0x5a}))
 			}
 			ibs := New(nil)
+			var one uint256.Int
+			one.SetUint64(1)
+
 			b.ReportAllocs()
+			b.ResetTimer()
 			for b.Loop() {
 				for _, a := range addrs {
 					ibs.nilAccounts[a] = struct{}{}
 					ibs.stateObjectsDirty[a] = struct{}{}
-					ibs.balanceInc[a] = &BalanceIncrease{}
-					ibs.transientStorage.Set(a, accounts.NilKey, *uint256.NewInt(1))
+					ibs.balanceInc[a] = nil
+					ibs.transientStorage.Set(a, accounts.NilKey, one)
 				}
 				ibs.Reset()
 			}


### PR DESCRIPTION
`Reset` rebound five maps to fresh ones on every tx, discarding their bucket capacity.

## Benchmark: `BenchmarkIntraBlockStateReset`

`benchstat`, `-count=8`, quiet dev box (AMD EPYC 4344P, linux/amd64). Same benchmark file run against `main` and this branch.

```
goos: linux
goarch: amd64
pkg: github.com/erigontech/erigon/execution/state
cpu: AMD EPYC 4344P 8-Core Processor

                                     │ main        │ clear()                      │
                                     │ sec/op      │ sec/op        vs base        │
IntraBlockStateReset/accounts=8-16      1059.5n ± 1%   924.9n ± 2%  -12.70% (p=0.000 n=8)
IntraBlockStateReset/accounts=64-16     15.056µ ± 1%   7.692µ ± 0%  -48.91% (p=0.000 n=8)
IntraBlockStateReset/accounts=512-16    118.29µ ± 0%   62.41µ ± 1%  -47.24% (p=0.000 n=8)
geomean                                  12.36µ        7.629µ       -38.26%

                                     │ B/op        │ B/op          vs base        │
IntraBlockStateReset/accounts=8-16     4.297Ki ± 0%  3.500Ki ± 0%   -18.55% (p=0.000 n=8)
IntraBlockStateReset/accounts=64-16    46.20Ki ± 0%  28.00Ki ± 0%   -39.40% (p=0.000 n=8)
IntraBlockStateReset/accounts=512-16   370.6Ki ± 0%  224.0Ki ± 0%   -39.55% (p=0.000 n=8)
geomean                                41.90Ki       28.00Ki        -33.18%

                                     │ allocs/op   │ allocs/op     vs base        │
IntraBlockStateReset/accounts=8-16       33.00 ± 0%    24.00 ± 0%   -27.27% (p=0.000 n=8)
IntraBlockStateReset/accounts=64-16      237.0 ± 0%    192.0 ± 0%   -18.99% (p=0.000 n=8)
IntraBlockStateReset/accounts=512-16    1.605k ± 0%   1.536k ± 0%    -4.30% (p=0.000 n=8)
geomean                                  232.4         192.0        -17.39%
```

The gain exceeds the removed allocations because a reused map keeps its buckets: `clear()` on a warm map beats allocating and re-growing one.


The benchmark is included in this PR (`execution/state/reset_bench_test.go`):

```
go test ./execution/state/ -run='^$' -bench=BenchmarkIntraBlockStateReset -benchmem -count=8
```

### Why no existing benchmark covers this

Neither suite can see the change:

- `execution/vm/benchmark` — builds one IBS in `benchConfig` and reuses it across all iterations; `prepareAndCall` never calls `Reset`.
- `execution/stagedsync` `BenchmarkLessConflicts` / `MoreConflicts` / `RandomTx` / `AlternatingTx` — synthetic tasks with simulated IO times, `runParallel` called once outside any `b.N` loop, reporting a custom `speedup` metric. Every line reports `0 B/op, 0 allocs/op`.

## On a real node

`alloc_objects` from a chiado archive node, before:

```
Total: 1009663269
  6182512  7861877 (flat, cum)  0.78% of Total   IntraBlockState.Reset
  1452781                        350: sdb.nilAccounts       = map[...]{}
  1638475                        354: sdb.stateObjects      = map[...]{}
  1649398                        355: sdb.stateObjectsDirty = map[...]{}
  1441858                        360: sdb.balanceInc        = map[...]{}
        .  1638475               367: sdb.transientStorage  = newTransientStorage()
```

After: all five lines allocate nothing.

## Why these five are safe to reuse

All are IBS-private — only indexed access, and nothing hands the map itself outward. The journal holds individual `*BalanceIncrease` values, not the map. `ExtractAndClearDirty` returns a `maps.Clone`, not the live map.

`sdb.versionedReads` is deliberately left rebinding: its per-path maps are handed to `result.TxIn` at tx end, so clearing would corrupt data already passed on. The existing comment at that line records this; the same reasoning is what rules it out here.

