### PR TITLE
db/kv/temporal: stop retaining iterators on the tx

### DIFF
--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -257,12 +257,11 @@ func (db *DB) OnFilesChange(onChange, onDel kv.OnFilesChange) {
 }
 
 type tx struct {
-	db               *DB
-	aggtx            *state.AggregatorRoTx
-	blocktx          *blocksnapshots.View
-	resourcesToClose []kv.Closer
-	ctx              context.Context
-	mu               sync.RWMutex
+	db      *DB
+	aggtx   *state.AggregatorRoTx
+	blocktx *blocksnapshots.View
+	ctx     context.Context
+	mu      sync.RWMutex
 }
 
 type Tx struct {
@@ -300,13 +299,13 @@ func (tx *tx) Retire(ctx context.Context, cutoffs kv.RetireCutoffs) (int, error)
 }
 
 func (tx *tx) Rollback() {
-	tx.autoClose()
+	tx.closeFilesView()
 }
 func (tx *Tx) Rollback() {
 	if tx == nil {
 		return
 	}
-	tx.autoClose()
+	tx.closeFilesView()
 	if tx.Tx == nil { // invariant: it's safe to call Commit/Rollback multiple times
 		return
 	}
@@ -414,7 +413,7 @@ func (tx *RwTx) Rollback() {
 	if tx == nil {
 		return
 	}
-	tx.autoClose()
+	tx.closeFilesView()
 	if tx.RwTx == nil { // invariant: it's safe to call Commit/Rollback multiple times
 		return
 	}
@@ -435,11 +434,10 @@ func (rwtx *RwTx) AsyncClone(asyncTx kv.RwTx) *asyncClone {
 		RwTx{
 			RwTx: asyncTx,
 			tx: tx{
-				db:               rwtx.db,
-				aggtx:            rwtx.aggtx,
-				blocktx:          rwtx.blocktx,
-				resourcesToClose: nil,
-				ctx:              rwtx.ctx,
+				db:      rwtx.db,
+				aggtx:   rwtx.aggtx,
+				blocktx: rwtx.blocktx,
+				ctx:     rwtx.ctx,
 			}}}
 }
 
@@ -453,21 +451,18 @@ func (tx *asyncClone) Commit() error {
 func (tx *asyncClone) Rollback() {
 }
 
-func (tx *tx) autoClose() {
-	for _, closer := range tx.resourcesToClose {
-		closer.Close()
-	}
+func (tx *tx) closeFilesView() {
 	tx.aggtx.Close()
-	if tx.blocktx != nil {
-		tx.blocktx.Close()
-	}
+	tx.aggtx = nil
+	tx.blocktx.Close()
+	tx.blocktx = nil
 }
 
 func (tx *RwTx) Commit() error {
 	if tx == nil {
 		return nil
 	}
-	tx.autoClose()
+	tx.closeFilesView()
 	if tx.RwTx == nil { // invariant: it's safe to call Commit/Rollback multiple times
 		return nil
 	}
@@ -481,7 +476,6 @@ func (tx *tx) rangeAsOf(name kv.Domain, rtx kv.Tx, fromKey, toKey []byte, asOfTs
 	if err != nil {
 		return nil, err
 	}
-	tx.resourcesToClose = append(tx.resourcesToClose, it)
 	return it, nil
 }
 
@@ -573,7 +567,6 @@ func (tx *tx) indexRange(name kv.InvertedIdx, dbTx kv.Tx, k []byte, fromTs, toTs
 	if err != nil {
 		return nil, err
 	}
-	tx.resourcesToClose = append(tx.resourcesToClose, timestamps)
 	return timestamps, nil
 }
 
@@ -590,7 +583,6 @@ func (tx *tx) historyRange(name kv.Domain, dbTx kv.Tx, fromTs, toTs int, asc ord
 	if err != nil {
 		return nil, err
 	}
-	tx.resourcesToClose = append(tx.resourcesToClose, it)
 	return it, nil
 }
 
@@ -607,7 +599,6 @@ func (tx *tx) historyKeyTxNumRange(name kv.Domain, dbTx kv.Tx, fromTs, toTs int,
 	if err != nil {
 		return nil, err
 	}
-	tx.resourcesToClose = append(tx.resourcesToClose, it)
 	return it, nil
 }
 

--- a/db/kv/temporal/kv_temporal_resources_test.go
+++ b/db/kv/temporal/kv_temporal_resources_test.go
@@ -1,0 +1,56 @@
+package temporal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbcfg"
+	"github.com/erigontech/erigon/db/kv/memdb"
+	"github.com/erigontech/erigon/db/kv/order"
+	"github.com/erigontech/erigon/db/state"
+)
+
+// Iterators are no longer registered for tx-lifetime cleanup, so the layers
+// underneath have to do it: abandoning many of them must still leave the tx
+// able to roll back cleanly, without mdbx objecting to open cursors at abort.
+func TestTemporalTx_AbandonedIteratorsRollbackCleanly(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mdbxDb := memdb.NewTestDB(t, dbcfg.ChainDB)
+	dirs := datadir.New(t.TempDir())
+	agg := state.NewTest(dirs).StepSize(1).MustOpen(ctx, mdbxDb)
+	defer agg.Close()
+
+	temporalDb, err := New(mdbxDb, agg, nil)
+	require.NoError(t, err)
+	defer temporalDb.Close()
+
+	ttx, err := temporalDb.BeginTemporalRo(ctx)
+	require.NoError(t, err)
+	t.Cleanup(ttx.Rollback)
+
+	addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	to, _ := kv.NextSubtree(addr[:])
+	for range 100 {
+		_, err := ttx.RangeAsOf(kv.StorageDomain, addr[:], to, 0, order.Asc, kv.Unlim)
+		require.NoError(t, err)
+		_, err = ttx.HistoryRange(kv.StorageDomain, 0, -1, order.Asc, kv.Unlim)
+		require.NoError(t, err)
+		_, err = ttx.IndexRange(kv.StorageHistoryIdx, addr[:], 0, -1, order.Asc, kv.Unlim)
+		require.NoError(t, err)
+	}
+
+	require.NotPanics(t, ttx.Rollback)
+	// Re-entrant by design, and the second pass must not touch a released view.
+	require.NotPanics(t, ttx.Rollback)
+
+	// The db is still usable, so nothing was left pinned by the abandoned iterators.
+	ttx2, err := temporalDb.BeginTemporalRo(ctx)
+	require.NoError(t, err)
+	defer ttx2.Rollback()
+}


### PR DESCRIPTION
here: https://github.com/erigontech/erigon/issues/22580

Iterators returned by `rangeAsOf`, `indexRange`, `historyRange` and `historyKeyTxNumRange` were appended to an append-only list on the tx, and `Close` never removed them. A caller that closes each iterator in a loop still kept every one of them — plus the file readers, merge buffers and union nodes they reference — alive until the tx ended.

## Fix

Drop `autoClose` ferature from `temporal.DB`. We still have it in `kv_mdbx.go` - because leaking resources allocated in C - is more painful (not visible on pprof)
