### PR TITLE
execution, rpc: release IntraBlockState in unit tests

### DIFF
--- a/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
+++ b/execution/execmodule/execmoduletester/from0_genesis_internal_test.go
@@ -117,6 +117,7 @@ func runFromZeroGenesisAllocPreservedAfterResetReExec(t *testing.T) {
 			defer doms.Close()
 			r := state.NewReaderV3(doms.AsGetter(rTx))
 			st := state.New(r)
+			defer st.Release(false)
 			b, err := st.GetBalance(dormantAddr)
 			if err != nil {
 				return err

--- a/execution/protocol/misc/eip8282_test.go
+++ b/execution/protocol/misc/eip8282_test.go
@@ -86,6 +86,7 @@ func TestDequeueBuilderDepositRequests_EmptyCodeReturnsError(t *testing.T) {
 	db := testutil.TemporalDB(t)
 	tx, domains := testutil.TemporalTxSD(t, db)
 	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer statedb.Release(false)
 
 	// Contract exists with zero-length code.
 	statedb.CreateAccount(params.BuilderDepositAddress, true)
@@ -104,6 +105,7 @@ func TestDequeueBuilderExitRequests_EmptyCodeReturnsError(t *testing.T) {
 	db := testutil.TemporalDB(t)
 	tx, domains := testutil.TemporalTxSD(t, db)
 	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer statedb.Release(false)
 
 	// Contract exists with zero-length code.
 	statedb.CreateAccount(params.BuilderExitAddress, true)

--- a/execution/protocol/rules/aura/aura_test.go
+++ b/execution/protocol/rules/aura/aura_test.go
@@ -189,6 +189,7 @@ func TestEmptySystemAccountCreation(t *testing.T) {
 	reader := state.NewBufferedReader(rs, state.NewReaderV3(rs.Domains().AsGetter(tx)))
 	writer := state.NewVersionedWriteCollector(rs)
 	ibs := state.New(reader)
+	defer ibs.Release(false)
 	err = protocol.InitializeBlockExecution(engine, chainRdr, header, config, ibs, writer, logger, nil)
 	require.NoError(err)
 	account, err := reader.ReadAccountData(params.SystemAddress)

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -77,6 +77,7 @@ func TestEIP7825_GasPoolPreservedOnReject(t *testing.T) {
 
 	t.Run("rejected tx preserves gas pool", func(t *testing.T) {
 		ibs := state.New(state.NewNoopReader())
+		defer ibs.Release(false)
 		evm := newTestEVM(ibs, cfg, blockGasLimit)
 		msg := newSimpleTransferMsg(sender, recipient, params.MaxTxnGasLimit+1, true)
 		gp := new(GasPool).AddGas(blockGasLimit)
@@ -91,6 +92,7 @@ func TestEIP7825_GasPoolPreservedOnReject(t *testing.T) {
 
 	t.Run("valid tx debits gas pool normally", func(t *testing.T) {
 		ibs := state.New(state.NewNoopReader())
+		defer ibs.Release(false)
 		evm := newTestEVM(ibs, cfg, blockGasLimit)
 		msg := newSimpleTransferMsg(sender, recipient, params.MaxTxnGasLimit, true)
 		gp := new(GasPool).AddGas(blockGasLimit)
@@ -108,6 +110,7 @@ func TestEIP7825_GasPoolPreservedOnReject(t *testing.T) {
 		// Simulate the original bug scenario: a rejected tx should not prevent
 		// a subsequent valid tx from succeeding due to pool exhaustion.
 		ibs := state.New(state.NewNoopReader())
+		defer ibs.Release(false)
 		gp := new(GasPool).AddGas(blockGasLimit)
 
 		// First: a tx that exceeds the cap — must be rejected without touching pool.
@@ -151,6 +154,7 @@ func TestEIP8037_GasPoolTracksRegularAndStateIndependently(t *testing.T) {
 	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
 
 	ibs := state.New(state.NewNoopReader())
+	defer ibs.Release(false)
 	gp := NewGasPool(blockGasLimit, 0)
 	blockCtx := evmtypes.BlockContext{
 		CanTransfer: CanTransfer,
@@ -239,6 +243,7 @@ func TestPreCheckErrorOrdering_GasBeforeFeeCap(t *testing.T) {
 
 	t.Run("tx-gas > block-gas-limit AND fee-cap < baseFee returns ErrGasLimitReached", func(t *testing.T) {
 		ibs := state.New(state.NewNoopReader())
+		defer ibs.Release(false)
 		blockCtx := evmtypes.BlockContext{
 			CanTransfer: CanTransfer,
 			Transfer:    misc.Transfer,

--- a/execution/stagedsync/exec3_2cache_test.go
+++ b/execution/stagedsync/exec3_2cache_test.go
@@ -114,6 +114,7 @@ func TestCrossBlockTimingRace(t *testing.T) {
 	baseReader := state.NewReaderV3(domains.AsGetter(tx))
 	bufferedRdr := state.NewBufferedReader(rs, baseReader)
 	ibsN1 := state.New(bufferedRdr)
+	defer ibsN1.Release(false)
 
 	// Must read block N's value from rs.accounts, not stale domains.
 	gotBal, err := ibsN1.GetBalance(addr)
@@ -129,6 +130,7 @@ func TestCrossBlockTimingRace(t *testing.T) {
 	// Sanity check: a plain domain reader (no buffering) still sees zero —
 	// the timing hole is real without rs.accounts.
 	ibsRaw := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer ibsRaw.Release(false)
 	rawBal, err := ibsRaw.GetBalance(addr)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), rawBal.Uint64(),
@@ -137,6 +139,7 @@ func TestCrossBlockTimingRace(t *testing.T) {
 	// Simulate ApplyStateWrites completing (domain apply catches up).
 	w := state.NewWriter(domains.AsPutDel(tx), nil, 5)
 	ibsApply := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer ibsApply.Release(false)
 	ibsApply.SetTxContext(1, 0)
 	err = ibsApply.SetBalance(addr, *uint256.NewInt(500), tracing.BalanceChangeUnspecified)
 	require.NoError(t, err)
@@ -147,6 +150,7 @@ func TestCrossBlockTimingRace(t *testing.T) {
 
 	// After domain apply, plain reader must see the correct value.
 	ibsRawAfter := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer ibsRawAfter.Release(false)
 	rawBalAfter, err := ibsRawAfter.GetBalance(addr)
 	require.NoError(t, err)
 	require.Equal(t, uint64(500), rawBalAfter.Uint64(),

--- a/execution/state/access_list_test.go
+++ b/execution/state/access_list_test.go
@@ -92,6 +92,7 @@ func TestAccessList(t *testing.T) {
 	require.NoError(t, err)
 
 	state := New(NewReaderV3(domains.AsGetter(tx)))
+	defer state.Release(false)
 
 	state.accessList.Reset()
 

--- a/execution/state/database_test.go
+++ b/execution/state/database_test.go
@@ -130,6 +130,7 @@ func TestCreate2Revive(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -151,6 +152,7 @@ func TestCreate2Revive(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -169,6 +171,7 @@ func TestCreate2Revive(t *testing.T) {
 	var check2 uint256.Int
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -191,6 +194,7 @@ func TestCreate2Revive(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
 		} else if exist {
@@ -206,6 +210,7 @@ func TestCreate2Revive(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -350,6 +355,7 @@ func TestCreate2Polymorth(t *testing.T) {
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -371,6 +377,7 @@ func TestCreate2Polymorth(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -387,6 +394,7 @@ func TestCreate2Polymorth(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -418,6 +426,7 @@ func TestCreate2Polymorth(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
 		} else if exist {
@@ -433,6 +442,7 @@ func TestCreate2Polymorth(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -464,6 +474,7 @@ func TestCreate2Polymorth(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(create2address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -585,6 +596,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -607,6 +619,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 	var correctValueX uint256.Int
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -628,6 +641,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if exist {
@@ -642,6 +656,7 @@ func TestReorgOverSelfDestruct(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -741,6 +756,7 @@ func TestReorgOverStateChange(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -765,6 +781,7 @@ func TestReorgOverStateChange(t *testing.T) {
 	var correctValueX uint256.Int
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -790,6 +807,7 @@ func TestReorgOverStateChange(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -883,6 +901,7 @@ func TestCreateOnExistingStorage(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -904,6 +923,7 @@ func TestCreateOnExistingStorage(t *testing.T) {
 	var check0 uint256.Int
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -942,6 +962,7 @@ func TestReproduceCrash(t *testing.T) {
 	tsr := state.NewReaderV3(sd.AsGetter(tx))
 
 	intraBlockState := state.New(tsr)
+	defer intraBlockState.Release(false)
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, tsw); err != nil {
@@ -1033,6 +1054,7 @@ func TestEip2200Gas(t *testing.T) {
 	var balanceBefore uint256.Int
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -1055,6 +1077,7 @@ func TestEip2200Gas(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -1133,6 +1156,7 @@ func TestWrongIncarnation(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -1167,6 +1191,7 @@ func TestWrongIncarnation(t *testing.T) {
 		}
 
 		st := state.New(stateReader)
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -1293,6 +1318,7 @@ func TestWrongIncarnation2(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(address); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -1314,6 +1340,7 @@ func TestWrongIncarnation2(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(contractAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -1367,6 +1394,7 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 
 	r, tsw := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
 	intraBlockState := state.New(r)
+	defer intraBlockState.Release(false)
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 
@@ -1414,6 +1442,7 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 	r, w := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
 
 	intraBlockState := state.New(r)
+	defer intraBlockState.Release(false)
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 
@@ -1451,6 +1480,7 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 	r, w := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
 
 	intraBlockState := state.New(r)
+	defer intraBlockState.Release(false)
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 
@@ -1630,6 +1660,7 @@ func TestRecreateAndRewind(t *testing.T) {
 	var check0 uint256.Int
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(phoenixAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -1651,6 +1682,7 @@ func TestRecreateAndRewind(t *testing.T) {
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(phoenixAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {
@@ -1672,6 +1704,7 @@ func TestRecreateAndRewind(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		if exist, err := st.Exist(accounts.InternAddress(phoenixAddress)); err != nil {
 			t.Error(err)
 		} else if !exist {

--- a/execution/state/eip8246_selfdestruct_test.go
+++ b/execution/state/eip8246_selfdestruct_test.go
@@ -30,6 +30,7 @@ func TestEIP8246_PreservedSD_ReadsAsEmptyCodeAccountInLaterTx(t *testing.T) {
 	vm := NewVersionMap(nil)
 	reader := newAccountStateReader()
 	tx0 := New(reader)
+	defer tx0.Release(false)
 	tx0.SetTxContext(0, 0)
 	tx0.SetVersion(0)
 	tx0.SetVersionMap(vm)
@@ -42,6 +43,7 @@ func TestEIP8246_PreservedSD_ReadsAsEmptyCodeAccountInLaterTx(t *testing.T) {
 	require.NoError(t, tx0.MakeWriteSet(&chain.Rules{IsAmsterdam: true}, NewNoopWriter()))
 	vm.FlushVersionedWrites(tx0.VersionedWrites(false), true, "")
 	tx1 := New(reader)
+	defer tx1.Release(false)
 	tx1.SetTxContext(0, 1)
 	tx1.SetVersion(0)
 	tx1.SetVersionMap(vm)
@@ -72,6 +74,7 @@ func TestEIP8246_FinalizeTx_PreservedBalanceCarriesToLaterTxCreate(t *testing.T)
 
 	rules := &chain.Rules{IsAmsterdam: true}
 	ibs := New(reader)
+	defer ibs.Release(false)
 
 	ibs.SetTxContext(1, 0)
 	_, err := ibs.Selfdestruct(addr, true /* preserveBalance */)
@@ -104,6 +107,7 @@ func TestEIP8246_VersionedAccount_LaterBalanceWriteDoesNotSkipReconstruction(t *
 	vm.WriteBalance(addr, Version{TxIndex: 1}, *uint256.NewInt(2), true)
 
 	ibs := New(reader)
+	defer ibs.Release(false)
 	ibs.SetTxContext(0, 2)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -133,6 +137,7 @@ func TestEIP8246_CreateAfterPreservedSD_IncarnationAndBalanceAcrossModes(t *test
 		reader := newAccountStateReader()
 		vm := NewVersionMap(nil)
 		tx0 := New(reader)
+		defer tx0.Release(false)
 		tx0.SetTxContext(0, 0)
 		tx0.SetVersion(0)
 		tx0.SetVersionMap(vm)
@@ -144,6 +149,7 @@ func TestEIP8246_CreateAfterPreservedSD_IncarnationAndBalanceAcrossModes(t *test
 		require.NoError(t, tx0.MakeWriteSet(rules, NewNoopWriter()))
 		vm.FlushVersionedWrites(tx0.VersionedWrites(false), true, "")
 		tx1 := New(reader)
+		defer tx1.Release(false)
 		tx1.SetTxContext(0, 1)
 		tx1.SetVersion(0)
 		tx1.SetVersionMap(vm)
@@ -163,6 +169,7 @@ func TestEIP8246_CreateAfterPreservedSD_IncarnationAndBalanceAcrossModes(t *test
 		t.Parallel()
 		reader := newAccountStateReader()
 		ibs := New(reader)
+		defer ibs.Release(false)
 		ibs.eip8246 = true
 		ibs.SetTxContext(1, 0)
 		require.NoError(t, ibs.CreateAccount(addr, true))
@@ -200,6 +207,7 @@ func TestEIP8246_PreservedAccount_OverlaysLaterFieldWrites(t *testing.T) {
 	vm.WriteNonce(addr, laterVer, 7, true)
 	vm.WriteCodeHash(addr, laterVer, laterCodeHash, true)
 	ibs := New(reader)
+	defer ibs.Release(false)
 	ibs.SetTxContext(0, 2)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)

--- a/execution/state/genesiswrite/genesis_test.go
+++ b/execution/state/genesiswrite/genesis_test.go
@@ -171,6 +171,7 @@ func TestAllocConstructor(t *testing.T) {
 	reader, err := rpchelper.CreateHistoryStateReader(ctx, tx, 1, 0, rawdbv3.TxNums)
 	require.NoError(err)
 	state := state.New(reader)
+	defer state.Release(false)
 	balance, err := state.GetBalance(address)
 	require.NoError(err)
 	assert.Equal(funds, balance.ToBig())

--- a/execution/state/ibs_2cache_test.go
+++ b/execution/state/ibs_2cache_test.go
@@ -67,6 +67,7 @@ func TestVersionedWritesMatchStateObjects(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 
 	addr1 := accounts.InternAddress(common.HexToAddress("0x1111"))
@@ -156,6 +157,7 @@ func TestSnapshotRandomWithVersionMap(t *testing.T) {
 	key := accounts.InternKey(common.HexToHash("0x0001"))
 
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 
 	// Pre-snapshot state
@@ -235,6 +237,7 @@ func TestCommittedStateWithVersionMap(t *testing.T) {
 
 	// — tx0 (txIndex 0) — writes val1, flushes to versionMap —
 	ibs0 := NewWithVersionMap(reader, mvhm)
+	defer ibs0.Release(false)
 	ibs0.SetTxContext(1, 0)
 
 	err := ibs0.SetState(addr, key, val1)
@@ -246,6 +249,7 @@ func TestCommittedStateWithVersionMap(t *testing.T) {
 
 	// — tx1 (txIndex 1) — reads committed state before modifying —
 	ibs1 := NewWithVersionMap(reader, mvhm)
+	defer ibs1.Release(false)
 	ibs1.SetTxContext(1, 1)
 
 	// Before tx1 writes anything, committed state must be val1.
@@ -287,6 +291,7 @@ func TestCrossBlockStateReadConsistency(t *testing.T) {
 	// — Block N: write state then commit to domains via Writer —
 	{
 		ibsN := New(NewReaderV3(domains.AsGetter(tx)))
+		defer ibsN.Release(false)
 		ibsN.SetTxContext(1, 0)
 
 		err := ibsN.SetBalance(addr, *wantBalance, tracing.BalanceChangeUnspecified)
@@ -303,6 +308,7 @@ func TestCrossBlockStateReadConsistency(t *testing.T) {
 
 	// — Block N+1: fresh IBS reads state that block N wrote to domains —
 	ibsN1 := New(NewReaderV3(domains.AsGetter(tx)))
+	defer ibsN1.Release(false)
 
 	gotBal, err := ibsN1.GetBalance(addr)
 	require.NoError(t, err)
@@ -338,6 +344,7 @@ func TestDomainApplyFromVersionedWrites(t *testing.T) {
 
 	// — Step 1: produce VersionedWrites via a tx —
 	ibsTx := NewWithVersionMap(reader, mvhm)
+	defer ibsTx.Release(false)
 	ibsTx.SetTxContext(1, 0)
 
 	err := ibsTx.SetBalance(addr, wantBalance, tracing.BalanceChangeUnspecified)
@@ -352,6 +359,7 @@ func TestDomainApplyFromVersionedWrites(t *testing.T) {
 
 	// — Step 2: apply VersionedWrites through existing round-trip path —
 	ibsApply := New(reader)
+	defer ibsApply.Release(false)
 	err = ibsApply.ApplyVersionedWrites(writes)
 	require.NoError(t, err)
 
@@ -361,6 +369,7 @@ func TestDomainApplyFromVersionedWrites(t *testing.T) {
 
 	// — Step 3: read back from domains, assert correct state —
 	ibsRead := New(NewReaderV3(domains.AsGetter(tx)))
+	defer ibsRead.Release(false)
 
 	gotBal, err := ibsRead.GetBalance(addr)
 	require.NoError(t, err)

--- a/execution/state/intra_block_state_logger_test.go
+++ b/execution/state/intra_block_state_logger_test.go
@@ -110,6 +110,7 @@ func TestStateLogger(t *testing.T) {
 			defer mockCtl.Finish()
 			mt := mockTracer{}
 			state := New(NewReaderV3(tx))
+			defer state.Release(false)
 			state.SetHooks(mt.Hooks())
 
 			tt.run(state)

--- a/execution/state/intra_block_state_test.go
+++ b/execution/state/intra_block_state_test.go
@@ -264,13 +264,14 @@ func (test *snapshotTest) run(t *testing.T) bool {
 	// that is equivalent to fresh state with all actions up the snapshot applied.
 	for sindex--; sindex >= 0; sindex-- {
 		checkstate := New(NewReaderV3(tx))
-		defer checkstate.Release(false)
 		for _, action := range test.actions[:test.snapshots[sindex]] {
 			action.fn(action, checkstate)
 		}
 		state.RevertToSnapshot(snapshotRevs[sindex], nil)
 		state.PopSnapshot(snapshotRevs[sindex])
-		if err := test.checkEqual(state, checkstate); err != nil {
+		err := test.checkEqual(state, checkstate)
+		checkstate.Release(false)
+		if err != nil {
 			test.err = fmt.Errorf("state mismatch after revert to snapshot %d\n%w", sindex, err)
 			return false
 		}

--- a/execution/state/intra_block_state_test.go
+++ b/execution/state/intra_block_state_test.go
@@ -252,6 +252,7 @@ func (test *snapshotTest) run(t *testing.T) bool {
 		snapshotRevs = make([]int, len(test.snapshots))
 		sindex       = 0
 	)
+	defer state.Release(false)
 	for i, action := range test.actions {
 		if len(test.snapshots) > sindex && i == test.snapshots[sindex] {
 			snapshotRevs[sindex] = state.PushSnapshot()
@@ -263,6 +264,7 @@ func (test *snapshotTest) run(t *testing.T) bool {
 	// that is equivalent to fresh state with all actions up the snapshot applied.
 	for sindex--; sindex >= 0; sindex-- {
 		checkstate := New(NewReaderV3(tx))
+		defer checkstate.Release(false)
 		for _, action := range test.actions[:test.snapshots[sindex]] {
 			action.fn(action, checkstate)
 		}
@@ -401,6 +403,7 @@ func (test *snapshotTest) checkEqual(state, checkstate *IntraBlockState) error {
 func TestTransientStorage(t *testing.T) {
 	t.Parallel()
 	state := New(nil)
+	defer state.Release(false)
 
 	key := accounts.InternKey(common.Hash{0x01})
 	value := uint256.NewInt(2)
@@ -432,12 +435,14 @@ func TestVersionMapReadWriteDelete(t *testing.T) {
 	reader := NewReaderV3(domains.AsGetter(tx))
 
 	s := NewWithVersionMap(reader, mvhm)
+	defer s.Release(false)
 
 	states := []*IntraBlockState{s}
 
 	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
+		defer sCopy.Release(false)
 		sCopy.txIndex = i
 		states = append(states, sCopy)
 	}
@@ -506,12 +511,14 @@ func TestVersionMapRevert(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	s := NewWithVersionMap(reader, mvhm)
+	defer s.Release(false)
 
 	states := []*IntraBlockState{s}
 
 	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
+		defer sCopy.Release(false)
 		sCopy.txIndex = i
 		states = append(states, sCopy)
 	}
@@ -568,11 +575,13 @@ func TestVersionMapMarkEstimate(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	s := NewWithVersionMap(reader, mvhm)
+	defer s.Release(false)
 	states := []*IntraBlockState{s}
 
 	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
+		defer sCopy.Release(false)
 		sCopy.txIndex = i
 		states = append(states, sCopy)
 	}
@@ -640,12 +649,14 @@ func TestVersionMapOverwrite(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	s := NewWithVersionMap(reader, mvhm)
+	defer s.Release(false)
 
 	states := []*IntraBlockState{s}
 
 	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
+		defer sCopy.Release(false)
 		sCopy.txIndex = i
 		states = append(states, sCopy)
 	}
@@ -729,12 +740,14 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	s := NewWithVersionMap(reader, mvhm)
+	defer s.Release(false)
 
 	states := []*IntraBlockState{s}
 
 	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
+		defer sCopy.Release(false)
 		sCopy.txIndex = i
 		states = append(states, sCopy)
 	}
@@ -869,15 +882,19 @@ func TestApplyVersionedWrites(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	s := NewWithVersionMap(reader, mvhm)
+	defer s.Release(false)
 
 	sClean := New(reader)
+	defer sClean.Release(false)
 	sSingleProcess := New(reader)
+	defer sSingleProcess.Release(false)
 
 	states := []*IntraBlockState{s}
 
 	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
+		defer sCopy.Release(false)
 		sCopy.txIndex = i
 		states = append(states, sCopy)
 	}
@@ -964,6 +981,7 @@ func TestMakeWriteSetClearsCodeDomainOnEmptyOverride(t *testing.T) {
 	code := []byte{0x60, 0x00, 0x60, 0x00, 0xf3}
 
 	deploy := New(NewReaderV3(domains.AsGetter(tx)))
+	defer deploy.Release(false)
 	require.NoError(t, deploy.CreateAccount(addr, true))
 	require.NoError(t, deploy.SetNonce(addr, 1, tracing.NonceChangeUnspecified))
 	require.NoError(t, deploy.SetCode(addr, code, tracing.CodeChangeUnspecified))
@@ -974,6 +992,7 @@ func TestMakeWriteSetClearsCodeDomainOnEmptyOverride(t *testing.T) {
 	require.Equal(t, code, got)
 
 	clear := New(NewReaderV3(domains.AsGetter(tx)))
+	defer clear.Release(false)
 	require.NoError(t, clear.SetCode(addr, []byte{}, tracing.CodeChangeUnspecified))
 	require.NoError(t, clear.MakeWriteSet(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 1)))
 

--- a/execution/state/parallel_fixes_test.go
+++ b/execution/state/parallel_fixes_test.go
@@ -136,6 +136,7 @@ func TestVersionedWriteVersion(t *testing.T) {
 // TX executions on the same worker.
 func TestAccessListResetInIBSReset(t *testing.T) {
 	ibs := New(nil)
+	defer ibs.Release(false)
 
 	// Add an address to the access list
 	testAddr := accounts.InternAddress([20]byte{0x42})
@@ -157,6 +158,7 @@ func TestAccessListResetInIBSReset(t *testing.T) {
 // its own block's access list as phantom entries.
 func TestAddressAccessResetInIBSReset(t *testing.T) {
 	ibs := New(nil)
+	defer ibs.Release(false)
 	sender := accounts.InternAddress([20]byte{0x01})
 	coinbase := accounts.InternAddress([20]byte{0x02})
 	leaked := accounts.InternAddress([20]byte{0x42})
@@ -173,6 +175,7 @@ func TestAddressAccessResetInIBSReset(t *testing.T) {
 // transient storage (EIP-1153).
 func TestTransientStorageResetInIBSReset(t *testing.T) {
 	ibs := New(nil)
+	defer ibs.Release(false)
 
 	testAddr := accounts.InternAddress([20]byte{0x42})
 	testKey := accounts.InternKey([32]byte{0x01})
@@ -446,6 +449,7 @@ func TestSelfDestructKeepsDirtyStorageReadableSameTx(t *testing.T) {
 	vm := NewVersionMap(nil)
 
 	ibs := New(&emptyReader{})
+	defer ibs.Release(false)
 	ibs.SetVersionMap(vm)
 	ibs.SetTxContext(100, 0)
 	ibs.SetVersion(0)

--- a/execution/state/setcode_parallel_test.go
+++ b/execution/state/setcode_parallel_test.go
@@ -83,6 +83,7 @@ func TestSetCodeParallel_RevertToOriginalBug(t *testing.T) {
 	// TX 88: clear the code (write EmptyCodeHash + nil code)
 	// -----------------------------------------------------------
 	ibs88 := NewWithVersionMap(reader, vm)
+	defer ibs88.Release(false)
 	ibs88.SetTxContext(100, 88)
 	ibs88.SetVersion(0)
 
@@ -103,6 +104,7 @@ func TestSetCodeParallel_RevertToOriginalBug(t *testing.T) {
 	// TX 90: re-set the same delegation code (hash A)
 	// -----------------------------------------------------------
 	ibs90 := NewWithVersionMap(reader, vm)
+	defer ibs90.Release(false)
 	ibs90.SetTxContext(100, 90)
 	ibs90.SetVersion(0)
 
@@ -143,6 +145,7 @@ func TestGetDelegatedDesignation_TracksSplitCodePublish(t *testing.T) {
 	priorVersion := Version{TxIndex: 0, Incarnation: 0}
 	vm.WriteCodeHash(authority, priorVersion, delegation.Hash, true)
 	ibs := NewWithVersionMap(reader, vm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 1)
 	ibs.SetVersion(0)
 	hash, err := ibs.GetCodeHash(authority)

--- a/execution/state/state_test.go
+++ b/execution/state/state_test.go
@@ -82,6 +82,7 @@ func TestFinalizeTxDoesNotSkipStorageRevertToBlockOrigin(t *testing.T) {
 	domains.SetTxNum(txNum)
 	w := NewWriter(domains.AsPutDel(tx), nil, txNum)
 	setup := New(NewReaderV3(domains.AsGetter(tx)))
+	defer setup.Release(false)
 	setup.CreateAccount(addr, true)
 	setup.SetState(addr, key, valA)
 	err = setup.FinalizeTx(&chain.Rules{}, w)
@@ -91,6 +92,7 @@ func TestFinalizeTxDoesNotSkipStorageRevertToBlockOrigin(t *testing.T) {
 
 	// IBS for the next block — reads block-start state (slot=A) from domains.
 	ibs := New(NewReaderV3(domains.AsGetter(tx)))
+	defer ibs.Release(false)
 
 	// Tx1: A → B.
 	ibs.SetState(addr, key, valB)
@@ -124,6 +126,7 @@ func TestNull(t *testing.T) {
 	r := NewReaderV3(domains.AsGetter(tx))
 	w := NewWriter(domains.AsPutDel(tx), nil, txNum)
 	state := New(r)
+	defer state.Release(false)
 
 	address := accounts.InternAddress(common.HexToAddress("0x823140710bf13990e4500136726d8b55"))
 	state.CreateAccount(address, true)
@@ -157,6 +160,7 @@ func TestTouchDelete(t *testing.T) {
 	r := NewReaderV3(domains.AsGetter(tx))
 	w := NewWriter(domains.AsPutDel(tx), nil, txNum)
 	state := New(r)
+	defer state.Release(false)
 
 	state.GetOrNewStateObject(accounts.ZeroAddress)
 
@@ -190,6 +194,7 @@ func TestSnapshot(t *testing.T) {
 
 	r := NewReaderV3(domains.AsGetter(tx))
 	state := New(r)
+	defer state.Release(false)
 
 	stateobjaddr := toAddr([]byte("aa"))
 	storageaddr := accounts.ZeroKey
@@ -234,6 +239,7 @@ func TestSnapshotEmpty(t *testing.T) {
 
 	r := NewReaderV3(domains.AsGetter(tx))
 	state := New(r)
+	defer state.Release(false)
 
 	snapshot := state.PushSnapshot()
 	state.RevertToSnapshot(snapshot, nil)
@@ -253,6 +259,7 @@ func TestSnapshot2(t *testing.T) {
 	w := NewWriter(domains.AsPutDel(tx), nil, txNum)
 
 	state := New(NewReaderV3(domains.AsGetter(tx)))
+	defer state.Release(false)
 
 	stateobjaddr0 := toAddr([]byte("so0"))
 	stateobjaddr1 := toAddr([]byte("so1"))
@@ -327,6 +334,7 @@ func TestCodeResolve(t *testing.T) {
 	w := NewWriter(domains.AsPutDel(tx), nil, txNum)
 
 	state := New(NewReaderV3(domains.AsGetter(tx)))
+	defer state.Release(false)
 
 	stateobjaddr0 := toAddr([]byte("so0"))
 	stateobjaddr1 := toAddr([]byte("so1"))
@@ -354,6 +362,7 @@ func TestCodeResolve(t *testing.T) {
 	require.NoError(t, err)
 
 	state1 := New(NewReaderV3(domains.AsGetter(tx)))
+	defer state1.Release(false)
 	state1.SetVersionMap(&VersionMap{})
 	state1.Prepare(&chain.Rules{}, accounts.ZeroAddress, accounts.ZeroAddress, accounts.ZeroAddress, nil, nil, nil)
 
@@ -447,6 +456,7 @@ func TestDump(t *testing.T) {
 	require.NoError(t, err)
 
 	st := New(NewReaderV3(domains.AsGetter(tx)))
+	defer st.Release(false)
 
 	// generate a few entries
 	obj1, err := st.GetOrNewStateObject(toAddr([]byte{0x01}))

--- a/execution/state/versioned_read_bench_test.go
+++ b/execution/state/versioned_read_bench_test.go
@@ -27,6 +27,7 @@ func BenchmarkVersionedReadGetters(b *testing.B) {
 
 	// tx 1 reads → hits MapRead path inside versionedRead
 	s := NewWithVersionMap(reader, mvhm)
+	defer s.Release(false)
 	s.txIndex = 1
 
 	b.Run("GetNonce", func(b *testing.B) {

--- a/execution/state/versioned_read_paths_test.go
+++ b/execution/state/versioned_read_paths_test.go
@@ -26,6 +26,7 @@ func TestVersionedRead_A1_LegacyWithStorage(t *testing.T) {
 
 	// IBS without versionMap → legacy/serial path
 	ibs := New(&emptyReader{})
+	defer ibs.Release(false)
 	bal, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
 	// emptyReader returns nil account → zero balance, no error
@@ -40,6 +41,7 @@ func TestVersionedRead_A2_LegacyGetCodeReturnsEmpty(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xa2})
 
 	ibs := New(&emptyReader{})
+	defer ibs.Release(false)
 	code, err := ibs.GetCode(addr)
 	require.NoError(t, err)
 	assert.Empty(t, code, "empty reader => empty code")
@@ -58,6 +60,7 @@ func TestVersionedRead_B_DeletedStateObjectReturnsDefault(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 
 	addr := accounts.InternAddress(common.HexToAddress("0xdead"))
@@ -86,6 +89,7 @@ func TestVersionedRead_C5_DestructedCommittedReturnsZero(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xc5})
@@ -110,6 +114,7 @@ func TestVersionedRead_C6_DestructedRecordsDepAndReturnsZero(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xc6})
@@ -133,6 +138,7 @@ func TestVersionedRead_C4_CodePathBypassesSelfDestruct(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xc4})
@@ -156,6 +162,7 @@ func TestVersionedRead_C1_RevivalViaBalance(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 10)
 
 	addr := accounts.InternAddress([20]byte{0xc1})
@@ -189,6 +196,7 @@ func TestVersionedRead_C7_RefreshReturnsZeroPastSelfDestruct(t *testing.T) {
 	}
 	mvhm := NewVersionMap(nil)
 	ibs := NewWithVersionMap(r, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xc7})
@@ -222,6 +230,7 @@ func TestVersionedRead_D2_WriteSetHit(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 
 	addr := accounts.InternAddress([20]byte{0xd2})
@@ -246,6 +255,7 @@ func TestVersionedRead_E1_MapHitThenReadSetSameVersion(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xe1})
@@ -271,6 +281,7 @@ func TestVersionedRead_E3a_CodePathTrumpedBySelfDestruct(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 10)
 
 	addr := accounts.InternAddress([20]byte{0xe3})
@@ -296,6 +307,7 @@ func TestVersionedRead_G1_ReadSetReadOnSecondCall(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0x91})
@@ -326,6 +338,7 @@ func TestVersionedRead_G6_StorageZeroOnIncarnationWritten(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0x96})
@@ -350,6 +363,7 @@ func TestVersionedRead_G7_BalanceViaResolvedAddressPath(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0x97})
@@ -368,6 +382,7 @@ func TestVersionedRead_G8_StorageFallbackEmptyReader(t *testing.T) {
 	t.Parallel()
 	mvhm := NewVersionMap(nil)
 	ibs := NewWithVersionMap(&emptyReader{}, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0x98})
@@ -408,6 +423,7 @@ func TestVersionedRead_G4_RefreshRecordsTypedDefaultInReadSet(t *testing.T) {
 	}
 	mvhm := NewVersionMap(nil)
 	ibs := NewWithVersionMap(r, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xa4})
@@ -474,6 +490,7 @@ func TestVersionedRead_C2_RevivalViaNonce(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 10)
 
 	addr := accounts.InternAddress([20]byte{0xc2})
@@ -492,6 +509,7 @@ func TestVersionedRead_C3_RevivalViaCodeHash(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 10)
 
 	addr := accounts.InternAddress([20]byte{0xc3})
@@ -513,6 +531,7 @@ func TestVersionedRead_E2_MapReadDifferentVersionPanics(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 10)
 
 	addr := accounts.InternAddress([20]byte{0xe2})
@@ -546,6 +565,7 @@ func TestVersionedRead_F_MVReadResultDependencyPanics(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xf0})
@@ -572,6 +592,7 @@ func TestVersionedRead_D1_WriteSetHitWithStaleReadSetPanics(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xd1})

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -491,6 +491,7 @@ func TestCreateAccount_FundedThenCreated_SyntheticReadKeepsPreTxBalance(t *testi
 	t.Parallel()
 
 	ibs := New(&minimalStateReader{})
+	defer ibs.Release(false)
 	ibs.SetVersionMap(NewVersionMap(nil))
 	ibs.SetTxContext(1, 0)
 	ibs.SetVersion(0)
@@ -520,6 +521,7 @@ func TestCreateAccount_InternalBalanceReadPromotedOnCreate_NoSpuriousBalanceChan
 	reader.accounts[addr].Balance = *uint256.NewInt(7)
 
 	ibs := New(reader)
+	defer ibs.Release(false)
 	ibs.SetVersionMap(NewVersionMap(nil))
 	ibs.SetTxContext(0, 0)
 	ibs.SetVersion(0)
@@ -663,6 +665,7 @@ func TestVersionedIO_RemovedDependencyFallsThroughToStorage(t *testing.T) {
 	acct := accounts.NewAccount()
 	sr := &fallthroughStateReader{acct: &acct, storageKey: key, storageVal: storageVal}
 	ibs := NewWithVersionMap(sr, NewVersionMap(nil))
+	defer ibs.Release(false)
 	ibs.SetTxContext(2, 0)
 
 	ibs.versionedReads = ReadSet{}
@@ -686,6 +689,7 @@ func TestIBSVersionedWrites_SelfdestructRetainsMetadataDropsResetPaths(t *testin
 
 	addr := accounts.InternAddress(common.HexToAddress("0xdead"))
 	ibs := NewWithVersionMap(&minimalStateReader{}, NewVersionMap(nil))
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 
 	require.NoError(t, ibs.CreateAccount(addr, true))
@@ -1032,6 +1036,7 @@ func TestApplyVersionedWrites_BalanceWriteGeneratesBalanceRead(t *testing.T) {
 	reader := newAccountStateReader(addr)
 	vm := NewVersionMap(nil)
 	ibs := New(NewVersionedStateReader(0, ReadSet{}, vm, reader))
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -1056,6 +1061,7 @@ func TestApplyVersionedWrites_StorageWriteGeneratesBalanceRead(t *testing.T) {
 	reader := newAccountStateReader(addr)
 	vm := NewVersionMap(nil)
 	ibs := New(NewVersionedStateReader(0, ReadSet{}, vm, reader))
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -1081,6 +1087,7 @@ func TestApplyVersionedWrites_NonceWriteGeneratesBalanceRead(t *testing.T) {
 	reader := newAccountStateReader(addr)
 	vm := NewVersionMap(nil)
 	ibs := New(NewVersionedStateReader(0, ReadSet{}, vm, reader))
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -1107,6 +1114,7 @@ func TestApplyVersionedWrites_MultipleAccountsAllGetBalanceReads(t *testing.T) {
 	reader := newAccountStateReader(addrA, addrB, addrC)
 	vm := NewVersionMap(nil)
 	ibs := New(NewVersionedStateReader(0, ReadSet{}, vm, reader))
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -1136,6 +1144,7 @@ func TestApplyVersionedWrites_NewAccountNoBalanceRead(t *testing.T) {
 	vm := NewVersionMap(nil)
 	// Use minimalStateReader — returns nil for all accounts.
 	ibs := New(NewVersionedStateReader(0, ReadSet{}, vm, &minimalStateReader{}))
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -1156,6 +1165,7 @@ func TestApplyVersionedWrites_SelfDestructDominatesCreateContract(t *testing.T) 
 	addr := accounts.InternAddress(common.HexToAddress("0xF600"))
 	vm := NewVersionMap(nil)
 	ibs := New(NewVersionedStateReader(0, ReadSet{}, vm, &minimalStateReader{}))
+	defer ibs.Release(false)
 	ibs.SetTxContext(1, 0)
 	ibs.SetVersionMap(vm)
 
@@ -1207,6 +1217,7 @@ func TestAccountRead_BalancePathPromotion_DoesNotInvalidate(t *testing.T) {
 		postWithdrawalBalance, true)
 
 	ibs := New(NewVersionedStateReader(1, ReadSet{}, vm, reader))
+	defer ibs.Release(false)
 	ibs.SetTxContext(0, 1)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -1258,6 +1269,7 @@ func TestCreateAccount_SyntheticIncarnationStamp_DoesNotInvalidate(t *testing.T)
 		postWithdrawalBalance, true)
 
 	ibs := New(NewVersionedStateReader(1, ReadSet{}, vm, reader))
+	defer ibs.Release(false)
 	ibs.SetTxContext(0, 1)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -1310,6 +1322,7 @@ func TestGetVersionedAccount_PriorTxSelfDestruct_ReturnsNil(t *testing.T) {
 	// the SD case. Only getVersionedAccount's versionMap check should convert
 	// that to nil.
 	ibs := New(reader)
+	defer ibs.Release(false)
 	ibs.SetTxContext(0, 4)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -1355,6 +1368,7 @@ func TestGetVersionedAccount_SameTxMetamorphicRecreate_ReturnsAccount(t *testing
 	// same-TxIdx Balance/Nonce/CodeHash; the AddressPath >= destructTxIndex
 	// branch is what surfaces the re-created account.
 	ibs := New(NewVersionedStateReader(4, ReadSet{}, vm, reader))
+	defer ibs.Release(false)
 	ibs.SetTxContext(0, 4)
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
@@ -1387,6 +1401,7 @@ func TestVersionedRead_EIP8246_PriorTxSelfDestructReadsAsPreserved(t *testing.T)
 		reader := newAccountStateReader()
 		vm := NewVersionMap(nil)
 		tx3 := New(reader)
+		defer tx3.Release(false)
 		tx3.SetTxContext(0, 3)
 		tx3.SetVersion(0)
 		tx3.SetVersionMap(vm)
@@ -1408,6 +1423,7 @@ func TestVersionedRead_EIP8246_PriorTxSelfDestructReadsAsPreserved(t *testing.T)
 	}
 
 	ibs := newIBS(true)
+	defer ibs.Release(false)
 	bal, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
 	require.Equal(t, preserved, bal, "EIP-8246: SD'd account keeps its balance for a concurrent reader")
@@ -1422,6 +1438,7 @@ func TestVersionedRead_EIP8246_PriorTxSelfDestructReadsAsPreserved(t *testing.T)
 	require.Equal(t, accounts.EmptyCodeHash, ch, "EIP-8246: SD removes code, so the codehash reads as empty (not the pre-SD hash, not nil)")
 
 	pre := newIBS(false)
+	defer pre.Release(false)
 	preBal, err := pre.GetBalance(addr)
 	require.NoError(t, err)
 	require.True(t, preBal.IsZero(), "pre-EIP-8246: SD burns the balance for a concurrent reader")

--- a/execution/state/versionmap_test.go
+++ b/execution/state/versionmap_test.go
@@ -677,6 +677,7 @@ func TestVersionedWritePoolReuse_NoStaleFields(t *testing.T) {
 	_, tx, domains := NewTestRwTx(t)
 	vm := NewVersionMap(nil)
 	ibs := NewWithVersionMap(NewReaderV3(domains.AsGetter(tx)), vm)
+	defer ibs.Release(false)
 	ibs.SetTxContext(0, 3)
 
 	// Seed the pool so the recorder's getVWBalance hands back a poisoned cell.

--- a/execution/state/vio_exec_alloc_bench_test.go
+++ b/execution/state/vio_exec_alloc_bench_test.go
@@ -105,6 +105,7 @@ func BenchmarkVersionedExecReads(b *testing.B) {
 
 	reader := NewReaderV3(domains.AsGetter(tx))
 	ibs := NewWithVersionMap(reader, mvhm)
+	defer ibs.Release(false)
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/execution/tests/blockchain_test.go
+++ b/execution/tests/blockchain_test.go
@@ -1123,24 +1123,28 @@ func TestDoubleAccountRemoval(t *testing.T) {
 	defer tx.Rollback()
 
 	st := state.New(m.NewStateReader(tx))
+	defer st.Release(false)
 	require.NoError(t, err)
 	exist, err := st.Exist(accounts.InternAddress(theAddr))
 	require.NoError(t, err)
 	assert.False(t, exist, "Contract should've been removed")
 
 	st = state.New(m.NewHistoryStateReader(1, tx))
+	defer st.Release(false)
 	require.NoError(t, err)
 	exist, err = st.Exist(accounts.InternAddress(theAddr))
 	require.NoError(t, err)
 	assert.False(t, exist, "Contract should not exist at block #0")
 
 	st = state.New(m.NewHistoryStateReader(2, tx))
+	defer st.Release(false)
 	require.NoError(t, err)
 	exist, err = st.Exist(accounts.InternAddress(theAddr))
 	require.NoError(t, err)
 	assert.True(t, exist, "Contract should exist at block #1")
 
 	st = state.New(m.NewHistoryStateReader(3, tx))
+	defer st.Release(false)
 	require.NoError(t, err)
 	exist, err = st.Exist(accounts.InternAddress(theAddr))
 	require.NoError(t, err)
@@ -1542,6 +1546,7 @@ func TestDeleteRecreateSlots(t *testing.T) {
 	defer tx.Rollback()
 
 	statedb := state.New(m.NewHistoryStateReader(2, tx))
+	defer statedb.Release(false)
 
 	// If all is correct, then slot 1 and 2 are zero
 	key1 := accounts.InternKey(common.HexToHash("01"))
@@ -1666,6 +1671,7 @@ func TestCVE2020_26265(t *testing.T) {
 	err = m.DB.ViewTemporal(m.Ctx, func(tx kv.TemporalTx) error {
 		reader := m.NewHistoryStateReader(2, tx)
 		statedb := state.New(reader)
+		defer statedb.Release(false)
 
 		got, err := statedb.GetBalance(aa)
 		if err != nil {
@@ -1739,6 +1745,7 @@ func TestDeleteRecreateAccount(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(m.Ctx, func(tx kv.TemporalTx) error {
 		statedb := state.New(m.NewHistoryStateReader(2, tx))
+		defer statedb.Release(false)
 
 		// If all is correct, then both slots are zero
 		key1 := accounts.InternKey(common.HexToHash("01"))
@@ -1924,6 +1931,7 @@ func TestDeleteRecreateSlotsAcrossManyBlocks(t *testing.T) {
 		err = m.DB.ViewTemporal(m.Ctx, func(tx kv.TemporalTx) error {
 
 			statedb := state.New(m.NewStateReader(tx))
+			defer statedb.Release(false)
 			// If all is correct, then slot 1 and 2 are zero
 			key1 := accounts.InternKey(common.HexToHash("01"))
 			got, err := statedb.GetState(aa, key1)
@@ -2068,6 +2076,7 @@ func TestInitThenFailCreateContract(t *testing.T) {
 
 		// Import the canonical chain
 		statedb := state.New(m.NewHistoryStateReader(2, tx))
+		defer statedb.Release(false)
 		got, err := statedb.GetBalance(aa)
 		if err != nil {
 			return err
@@ -2082,6 +2091,7 @@ func TestInitThenFailCreateContract(t *testing.T) {
 				t.Fatalf("block %d: failed to insert into chain: %v", block.NumberU64(), err)
 			}
 			statedb = state.New(m.NewHistoryStateReader(1, tx))
+			defer statedb.Release(false)
 			got, err := statedb.GetBalance(aa)
 			if err != nil {
 				return err
@@ -2307,6 +2317,7 @@ func TestEIP1559Transition(t *testing.T) {
 
 	err = m.DB.ViewTemporal(m.Ctx, func(tx kv.TemporalTx) error {
 		statedb := state.New(m.NewHistoryStateReader(block.NumberU64()+1, tx))
+		defer statedb.Release(false)
 
 		// 3: Ensure that miner received only the tx's tip.
 		actual, err := statedb.GetBalance(accounts.InternAddress(block.Coinbase()))
@@ -2355,6 +2366,7 @@ func TestEIP1559Transition(t *testing.T) {
 	block = chain.Blocks[0]
 	err = m.DB.ViewTemporal(m.Ctx, func(tx kv.TemporalTx) error {
 		statedb := state.New(m.NewHistoryStateReader(block.NumberU64()+1, tx))
+		defer statedb.Release(false)
 		baseFee := block.BaseFee()
 		tip := block.Transactions()[0].GetEffectiveGasTip(baseFee)
 		effectiveTip := tip.Uint64()

--- a/execution/tests/blockgen/chain_makers_test.go
+++ b/execution/tests/blockgen/chain_makers_test.go
@@ -112,6 +112,7 @@ func TestGenerateChain(t *testing.T) {
 	defer tx.Rollback()
 
 	st := state.New(m.NewStateReader(tx))
+	defer st.Release(false)
 
 	if m.Current(tx).NumberU64() != 5 {
 		t.Errorf("wrong block number: %d", m.Current(tx).Number())

--- a/execution/tests/statedb_chain_test.go
+++ b/execution/tests/statedb_chain_test.go
@@ -106,6 +106,7 @@ func TestSelfDestructReceive(t *testing.T) {
 
 	if err := m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(address)
 		if err != nil {
 			return err
@@ -140,6 +141,7 @@ func TestSelfDestructReceive(t *testing.T) {
 		// and that means that the state of the accounts written in the first block was correct.
 		// This test checks that the storage root of the account is properly set to the root of the empty tree
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(address)
 		if err != nil {
 			t.Error(err)

--- a/execution/tests/statedb_insert_chain_transaction_test.go
+++ b/execution/tests/statedb_insert_chain_transaction_test.go
@@ -96,6 +96,7 @@ func TestInsertIncorrectStateRootDifferentAccounts(t *testing.T) {
 	defer tx.Rollback()
 
 	st := state.New(m.NewStateReader(tx))
+	defer st.Release(false)
 	exist, err := st.Exist(accounts.InternAddress(to))
 	if err != nil {
 		t.Error(err)
@@ -183,6 +184,7 @@ func TestInsertIncorrectStateRootSameAccount(t *testing.T) {
 	defer tx.Rollback()
 
 	st := state.New(m.NewStateReader(tx))
+	defer st.Release(false)
 	exist, err := st.Exist(accounts.InternAddress(to))
 	if err != nil {
 		t.Error(err)
@@ -257,6 +259,7 @@ func TestInsertIncorrectStateRootSameAccountSameAmount(t *testing.T) {
 	defer tx.Rollback()
 
 	st := state.New(m.NewStateReader(tx))
+	defer st.Release(false)
 	exist, err := st.Exist(accounts.InternAddress(to))
 	if err != nil {
 		t.Error(err)
@@ -331,6 +334,7 @@ func TestInsertIncorrectStateRootAllFundsRoot(t *testing.T) {
 	defer tx.Rollback()
 
 	st := state.New(m.NewStateReader(tx))
+	defer st.Release(false)
 	exist, err := st.Exist(accounts.InternAddress(to))
 	if err != nil {
 		t.Error(err)
@@ -405,6 +409,7 @@ func TestInsertIncorrectStateRootAllFunds(t *testing.T) {
 	defer tx.Rollback()
 
 	st := state.New(m.NewStateReader(tx))
+	defer st.Release(false)
 	exist, err := st.Exist(accounts.InternAddress(to))
 	if err != nil {
 		t.Error(err)
@@ -458,6 +463,7 @@ func TestAccountDeployIncorrectRoot(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(accounts.InternAddress(from))
 		if err != nil {
 			return err
@@ -488,6 +494,7 @@ func TestAccountDeployIncorrectRoot(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(accounts.InternAddress(from))
 		if err != nil {
 			return err
@@ -514,6 +521,7 @@ func TestAccountDeployIncorrectRoot(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(accounts.InternAddress(from))
 		if err != nil {
 			return err
@@ -568,6 +576,7 @@ func TestAccountCreateIncorrectRoot(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(accounts.InternAddress(from))
 		if err != nil {
 			return err
@@ -594,6 +603,7 @@ func TestAccountCreateIncorrectRoot(t *testing.T) {
 	}
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(accounts.InternAddress(from))
 		if err != nil {
 			return err
@@ -668,6 +678,7 @@ func TestAccountUpdateIncorrectRoot(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(accounts.InternAddress(from))
 		if err != nil {
 			return err
@@ -695,6 +706,7 @@ func TestAccountUpdateIncorrectRoot(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(accounts.InternAddress(from))
 		if err != nil {
 			return err
@@ -776,6 +788,7 @@ func TestAccountDeleteIncorrectRoot(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(accounts.InternAddress(from))
 		if err != nil {
 			return err
@@ -802,6 +815,7 @@ func TestAccountDeleteIncorrectRoot(t *testing.T) {
 
 	err = m.DB.ViewTemporal(context.Background(), func(tx kv.TemporalTx) error {
 		st := state.New(m.NewStateReader(tx))
+		defer st.Release(false)
 		exist, err := st.Exist(accounts.InternAddress(from))
 		if err != nil {
 			return err

--- a/execution/tracing/tracers/logger/logger_test.go
+++ b/execution/tracing/tracers/logger/logger_test.go
@@ -58,6 +58,7 @@ func (d *dummyContractRef) Balance() *big.Int          { return new(big.Int) }
 func TestStoreCapture(t *testing.T) {
 	//c := vm.NewJumpDestCache(128)
 	ibs := state.New(state.NewNoopReader())
+	defer ibs.Release(false)
 	ibs.AddRefund(1337)
 
 	var (

--- a/execution/vm/gas_table_test.go
+++ b/execution/vm/gas_table_test.go
@@ -126,6 +126,7 @@ func TestEIP2200(t *testing.T) {
 
 			r, w := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
 			s := state.New(r)
+			defer s.Release(false)
 
 			address := accounts.InternAddress(common.BytesToAddress([]byte("contract")))
 			s.CreateAccount(address, true)
@@ -227,6 +228,7 @@ func TestEIP8038SStore(t *testing.T) {
 			require.NoError(t, err)
 			r, w := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
 			s := state.New(r)
+			defer s.Release(false)
 			address := accounts.InternAddress(common.BytesToAddress([]byte("contract")))
 			s.CreateAccount(address, true)
 			s.SetCode(address, hexutil.MustDecode(tt.input), tracing.CodeChangeUnspecified)
@@ -297,6 +299,7 @@ func TestCallNewAccountSpillBefore63of64(t *testing.T) {
 			require.NoError(t, err)
 			r, w := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
 			s := state.New(r)
+			defer s.Release(false)
 			caller := accounts.InternAddress(common.BytesToAddress([]byte("contract")))
 			s.CreateAccount(caller, true)
 			s.SetCode(caller, hexutil.MustDecode(callerCode), tracing.CodeChangeUnspecified)
@@ -353,6 +356,7 @@ func TestCreateGas(t *testing.T) {
 		stateWriter := rpchelper.NewLatestStateWriter(tx, domains, (*freezeblocks.BlockReader)(nil), 0)
 
 		s := state.New(stateReader)
+		defer s.Release(false)
 		s.CreateAccount(address, true)
 		s.SetCode(address, hexutil.MustDecode(tt.code), tracing.CodeChangeUnspecified)
 
@@ -398,6 +402,7 @@ func TestSystemCallZeroValueSkipsTransferChecks(t *testing.T) {
 
 	r, w := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
 	s := state.New(r)
+	defer s.Release(false)
 
 	address := accounts.InternAddress(common.BytesToAddress([]byte("callee")))
 

--- a/execution/vm/instructions_test.go
+++ b/execution/vm/instructions_test.go
@@ -582,6 +582,7 @@ func TestOpTstore(t *testing.T) {
 		callContext = &CallContext{Contract: *NewContract(caller, caller, to, uint256.Int{})}
 		value       = common.Hex2Bytes("abcdef00000000000000abba000000000deaf000000c0de00100000000133700")
 	)
+	defer state.Release(false)
 
 	pc := uint64(0)
 	// push the value to the stack

--- a/execution/vm/runtime/reason_test.go
+++ b/execution/vm/runtime/reason_test.go
@@ -101,6 +101,7 @@ func TestCreateEmitsNonceChangeContractCreator(t *testing.T) {
 	initCode := []byte{byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00, byte(vm.RETURN)}
 
 	cfg := newTestIBS(t, recordingTracer(&nonceEvents, &codeEvents))
+	defer cfg.State.Release(false)
 
 	_, _, _, err := Create(initCode, cfg, 0)
 	require.NoError(t, err)
@@ -136,6 +137,7 @@ func TestCreateEmitsNonceChangeNewContract(t *testing.T) {
 	initCode := []byte{byte(vm.PUSH1), 0x00, byte(vm.PUSH1), 0x00, byte(vm.RETURN)}
 
 	cfg := newTestIBS(t, recordingTracer(&nonceEvents, &codeEvents))
+	defer cfg.State.Release(false)
 
 	_, contractAddr, _, err := Create(initCode, cfg, 0)
 	require.NoError(t, err)
@@ -187,6 +189,7 @@ func TestCreateEmitsCodeChangeContractCreation(t *testing.T) {
 	}
 
 	cfg := newTestIBS(t, recordingTracer(&nonceEvents, &codeEvents))
+	defer cfg.State.Release(false)
 
 	_, contractAddr, _, err := Create(initCode, cfg, 0)
 	require.NoError(t, err)
@@ -235,6 +238,7 @@ func TestCreateReasonOrdering(t *testing.T) {
 	}
 
 	cfg := newTestIBS(t, tracer)
+	defer cfg.State.Release(false)
 
 	_, _, _, err := Create(initCode, cfg, 0)
 	require.NoError(t, err)
@@ -264,6 +268,7 @@ func TestCodeChangeUnspecifiedOnSetup(t *testing.T) {
 	// Simple code: STOP
 	code := []byte{byte(vm.STOP)}
 	cfg := newTestIBS(t, tracer)
+	defer cfg.State.Release(false)
 
 	_, _, err := Execute(code, nil, cfg, t.TempDir())
 	require.NoError(t, err)
@@ -312,6 +317,7 @@ func TestReasonRoundTripThroughIBS(t *testing.T) {
 					},
 				}
 				cfg := newTestIBS(t, tracer)
+				defer cfg.State.Release(false)
 				addr := accounts.InternAddress(common.HexToAddress("0x01"))
 
 				require.NoError(t, cfg.State.SetNonce(addr, 1, reason))
@@ -340,6 +346,7 @@ func TestReasonRoundTripThroughIBS(t *testing.T) {
 					},
 				}
 				cfg := newTestIBS(t, tracer)
+				defer cfg.State.Release(false)
 				addr := accounts.InternAddress(common.HexToAddress("0x02"))
 
 				require.NoError(t, cfg.State.SetCode(addr, []byte{byte(vm.STOP)}, reason))

--- a/execution/vm/runtime/runtime_test.go
+++ b/execution/vm/runtime/runtime_test.go
@@ -114,6 +114,7 @@ func TestCall(t *testing.T) {
 	tx, domains := testutil.TemporalTxSD(t, db)
 
 	state := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer state.Release(false)
 	address := accounts.InternAddress(common.HexToAddress("0xaa"))
 	state.SetCode(address, []byte{
 		byte(vm.PUSH1), 10,
@@ -162,6 +163,7 @@ func BenchmarkCall(b *testing.B) {
 	tx, sd := testutil.TemporalTxSD(b, db)
 	//cfg.w = state.NewWriter(execctx, nil)
 	cfg.State = state.New(state.NewReaderV3(sd.AsGetter(tx)))
+	defer cfg.State.Release(false)
 	//cfg.EVMConfig.JumpDestCache = vm.NewJumpDestCache(128)
 
 	tmpdir := b.TempDir()
@@ -187,6 +189,7 @@ func benchmarkEVM_Create(b *testing.B, code string) {
 		sender   = accounts.InternAddress(common.BytesToAddress([]byte("sender")))
 		receiver = accounts.InternAddress(common.BytesToAddress([]byte("receiver")))
 	)
+	defer statedb.Release(false)
 
 	statedb.CreateAccount(sender, true)
 	statedb.SetCode(receiver, common.FromHex(code), tracing.CodeChangeUnspecified)
@@ -251,6 +254,7 @@ func BenchmarkEVM_RETURN(b *testing.B) {
 	tx, domains := testutil.TemporalTxSD(b, db)
 
 	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer statedb.Release(false)
 	contractAddr := accounts.InternAddress(common.BytesToAddress([]byte("contract")))
 
 	for _, n := range []uint64{1_000, 10_000, 100_000, 1_000_000} {
@@ -435,6 +439,7 @@ func benchmarkNonModifyingCode(gas mdgas.MdGas, code []byte, name string, tracer
 	require.NoError(b, err)
 
 	cfg.State = state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer cfg.State.Release(false)
 	cfg.GasLimit = gas.Regular
 	//
 	// TODO revise
@@ -694,6 +699,7 @@ func BenchmarkEVM_SWAP1(b *testing.B) {
 	db := testutil.TemporalDB(b)
 	tx, domains := testutil.TemporalTxSD(b, db)
 	state := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer state.Release(false)
 	contractAddr := accounts.InternAddress(common.BytesToAddress([]byte("contract")))
 
 	b.Run("10k", func(b *testing.B) {
@@ -720,6 +726,7 @@ func TestCreate2CollisionWithEIP7702Delegation(t *testing.T) {
 	db := testutil.TemporalDB(t)
 	tx, domains := testutil.TemporalTxSD(t, db)
 	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer statedb.Release(false)
 
 	sender := accounts.InternAddress(common.HexToAddress("0x1234"))
 	statedb.CreateAccount(sender, true)
@@ -778,6 +785,7 @@ func TestCreateCollisionWithEIP7702Delegation(t *testing.T) {
 	db := testutil.TemporalDB(t)
 	tx, domains := testutil.TemporalTxSD(t, db)
 	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer statedb.Release(false)
 
 	sender := accounts.InternAddress(common.HexToAddress("0x1234"))
 	statedb.CreateAccount(sender, true)
@@ -910,6 +918,7 @@ func TestSystemCallZeroValueSkipsTransferChecks(t *testing.T) {
 	db := testutil.TemporalDB(t)
 	tx, domains := testutil.TemporalTxSD(t, db)
 	statedb := state.New(state.NewReaderV3(domains.AsGetter(tx)))
+	defer statedb.Release(false)
 
 	systemAddr := params.SystemAddress
 	target := accounts.InternAddress(common.HexToAddress("0xbeef"))

--- a/rpc/ethapi/state_overrides_test.go
+++ b/rpc/ethapi/state_overrides_test.go
@@ -35,10 +35,12 @@ func TestStateOverrides_MovePrecompileDeterministicError(t *testing.T) {
 	want := fmt.Sprintf("account %s is not a precompile", addr1)
 
 	for i := range 500 {
-		ibs := state.New(state.NewNoopReader())
-		defer ibs.Release(false)
-		err := so.Override(ibs, vm.PrecompiledContracts{}, &chain.Rules{})
-		require.EqualError(t, err, want, "iteration %d: error must be deterministic", i)
+		func(i int) {
+			ibs := state.New(state.NewNoopReader())
+			defer ibs.Release(false)
+			err := so.Override(ibs, vm.PrecompiledContracts{}, &chain.Rules{})
+			require.EqualError(t, err, want, "iteration %d: error must be deterministic", i)
+		}(i)
 	}
 }
 

--- a/rpc/ethapi/state_overrides_test.go
+++ b/rpc/ethapi/state_overrides_test.go
@@ -36,6 +36,7 @@ func TestStateOverrides_MovePrecompileDeterministicError(t *testing.T) {
 
 	for i := range 500 {
 		ibs := state.New(state.NewNoopReader())
+		defer ibs.Release(false)
 		err := so.Override(ibs, vm.PrecompiledContracts{}, &chain.Rules{})
 		require.EqualError(t, err, want, "iteration %d: error must be deterministic", i)
 	}
@@ -55,6 +56,7 @@ func TestStateOverrides_MovePrecompileSuccess(t *testing.T) {
 
 	precompiles := vm.PrecompiledContracts{src: stub}
 	ibs := state.New(state.NewNoopReader())
+	defer ibs.Release(false)
 	err := so.Override(ibs, precompiles, &chain.Rules{})
 	require.NoError(t, err)
 

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -841,6 +841,7 @@ func chainWithDeployedContractAndConfig(t *testing.T, cfg *chain.Config) (*execm
 	stateReader, err := rpchelper.CreateHistoryStateReader(ctx, tx, 1, 0, rawdbv3.TxNums)
 	require.NoError(t, err)
 	st := state.New(stateReader)
+	defer st.Release(false)
 	exist, err := st.Exist(accounts.InternAddress(contractAddr))
 	require.NoError(t, err)
 	assert.False(t, exist, "Contract should not exist at block #1")
@@ -848,6 +849,7 @@ func chainWithDeployedContractAndConfig(t *testing.T, cfg *chain.Config) (*execm
 	stateReader, err = rpchelper.CreateHistoryStateReader(ctx, tx, 2, 0, rawdbv3.TxNums)
 	require.NoError(t, err)
 	st = state.New(stateReader)
+	defer st.Release(false)
 	exist, err = st.Exist(accounts.InternAddress(contractAddr))
 	require.NoError(t, err)
 	assert.True(t, exist, "Contract should exist at block #2")
@@ -858,6 +860,7 @@ func chainWithDeployedContractAndConfig(t *testing.T, cfg *chain.Config) (*execm
 	stateReader, err = rpchelper.CreateHistoryStateReader(ctx, tx, 6, 0, rawdbv3.TxNums)
 	require.NoError(t, err)
 	st = state.New(stateReader)
+	defer st.Release(false)
 	createdFillers := 0
 	for _, pk := range fillerPublicKeys {
 		exist, err := st.Exist(accounts.InternAddress(crypto.PubkeyToAddress(*pk)))

--- a/rpc/jsonrpc/trace_filtering_test.go
+++ b/rpc/jsonrpc/trace_filtering_test.go
@@ -112,6 +112,7 @@ func TestCallBlockParallelMatchesSequential(t *testing.T) {
 	noop := state.NewNoopWriter()
 	cachedWriter := state.NewCachedWriter(noop, sc)
 	ibs := state.New(cachedReader)
+	defer ibs.Release(false)
 
 	consensusHeaderReader := consensuschain.NewReader(cfg, tx, api._blockReader, nil)
 	logger := log.New("trace_filtering_test")


### PR DESCRIPTION
`IntraBlockState.Release` returns pooled `stateObject`s and the `journal` to their `sync.Pool`s. All six production callers use it:

- `execution/protocol/block_exec.go`
- `execution/stagedsync/exec3_serial.go`, `exec3.go`
- `execution/exec/historical_trace_worker.go`
- `execution/builder/exec.go`, `create_block.go`

No test did. The recycle path (`stateObject.release()` → `stateObjectPool.Put`, `journal.release()` → `journalPool.Put`) was therefore never exercised by the suite, so a `*stateObject` escaping its owner, or a double-`Put` poisoning a pool, would only ever surface in production.

This adds a release at every test-owned construction site — 201 across 32 files — using the synchronous `Release(false)` so teardown is deterministic.

## Sites deliberately not released

- **Result never bound to a variable**, e.g. `state.New(m.NewStateReader(tx)).Exist(addr)` — nothing to defer on.
- **IBS outlives the constructing function** (built in a helper and returned). For these the release moved to the owning caller instead — e.g. `reason_test.go`'s `newTestIBS` returns the state via `cfg.State`, so each of its 7 callers got `defer cfg.State.Release(false)`.

Benchmarks are included only where the state is built once in setup, outside the timed loop, so the defer runs after timing ends and cannot perturb `b.ReportAllocs` numbers.

## What this does and does not prove

No test failed, so nothing in the tree uses an IBS after releasing it — but that is partial signal. `Release` nils `stateObjects` and `journal`, so a *write* after release panics loudly, while a *read* returns the zero value from the nil map and falls through to the state reader silently. This rules out write-after-release, not read-after-release.

One site is stronger than the rest: in `versionedio_test.go`, the `newIBS` helper releases its first state before returning a second one, so the caller draws from a pool that was just refilled — real release-then-reuse inside a single test. It incidentally pins that `FlushVersionedWrites` deep-copies rather than aliasing into `stateObject` memory: `so.release()` zeroes `so.data`, so an aliasing implementation would fail the preserved-balance assertion.

Mechanical, test-only change with no behaviour change, so no new tests — per the TDD carve-out for mechanical changes in `CLAUDE.md`.

## Verification

- `make lint` — clean
- `go test -count=1` **non-short** for all affected packages (many of the edited tests are `testing.Short()`-gated, so a `-short` run would never execute the new defers)
- `execution/state` additionally under `-count=2 -shuffle=on`, to maximize pool reuse across tests in one process
- benchmarks run with `-bench . -benchtime=1x`, since plain `go test` never executes them