### PR TITLE
docs(hardware): freeze v3.4 disk sizes as static values

### DIFF
--- a/docs/site/versioned_docs/version-v3.4/get-started/hardware-requirements.mdx
+++ b/docs/site/versioned_docs/version-v3.4/get-started/hardware-requirements.mdx
@@ -6,7 +6,6 @@ sidebar_position: 2
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import diskSizes from '@site/src/data/disk-sizes.json';
 
 # Hardware Requirements
 
@@ -31,17 +30,17 @@ The amount of disk space recommended and RAM you need depends on the [prune mode
 <TabItem value="ethereum-mainnet" label="Ethereum mainnet">
 | Prune Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
-| Archive | {diskSizes?.networks?.['mainnet']?.['archive']?.display ?? '—'} | 4 TB | 32 GB | 64 GB |
-| Full (Default) | {diskSizes?.networks?.['mainnet']?.['full']?.display ?? '—'} | 2 TB | 16 GB | 32 GB |
-| Minimal | {diskSizes?.networks?.['mainnet']?.['minimal']?.display ?? '—'} | 1 TB | 16 GB | 64 GB |
+| Archive | 2.03 TB | 4 TB | 32 GB | 64 GB |
+| Full (Default) | 1.2 TB | 2 TB | 16 GB | 32 GB |
+| Minimal | 360 GB | 1 TB | 16 GB | 64 GB |
 
 </TabItem>
 <TabItem value="gnosis-chain" label="Gnosis Chain">
 | **Prune Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | {diskSizes?.networks?.['gnosis']?.['archive']?.display ?? '—'} | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | {diskSizes?.networks?.['gnosis']?.['full']?.display ?? '—'}    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | {diskSizes?.networks?.['gnosis']?.['minimal']?.display ?? '—'} | 500 GB                      | 8 GB               | 16 GB                 |
+| Archive        | 605 GB | 1 TB                        | 16 GB              | 32 GB                 |
+| Full (Default) | 645 GB    | 1 TB                        | 8 GB               | 16 GB                 |
+| Minimal        | 186 GB | 500 GB                      | 8 GB               | 16 GB                 |
 </TabItem>
 <TabItem value="polygon" label="Polygon">
 :::warning


### PR DESCRIPTION
## What

Freezes the **v3.4** versioned hardware-requirements page to static, 3.4-era measured disk sizes, and removes its `disk-sizes.json` import.

## Why

The v3.4 versioned page imported the shared, live `@site/src/data/disk-sizes.json`. Since the site deploys from `release/3.5`, that file holds the current (Sep 2025) values — so `/v3.4/get-started/hardware-requirements` rendered those instead of the values measured for the 3.4 release. Versioned docs are frozen snapshots, so their disk sizes should be static (the Polygon rows on this page are already hardcoded for the same reason).

## Values frozen (measured by syncing a node per prune mode)

| | mainnet | gnosis |
|---|---|---|
| archive | 2.03 TB | 605 GB |
| full (default) | 1.2 TB | 645 GB |
| minimal | 360 GB | 186 GB |

## Scope / follow-ups

- **Only** touches `versioned_docs/version-v3.4/...`. The shared `disk-sizes.json` is untouched.
- The **current (v3.5)** page keeps reading the live JSON and will be updated with freshly-measured 3.5 values in a separate PR (mainnet re-measured: archive 2.03 TB, full ~421 GB, minimal ~380 GB; gnosis pending its sync).
- A durable fix so this doesn't recur at the next version cut (v3.6) is under discussion.

Note: v3.5 full (~421 GB) is genuinely smaller than v3.4 full (1.2 TB) — a real version-over-version reduction, which is why each version keeps its own measured numbers.

## Verification

- `python3 docs/site/scripts/generate-llms.py --check` — OK (4 llms files, 74 pages).
- `npm run build` — production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)