### PR TITLE
execution/commitment: stop heap-allocating leaf hash header buffers

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -142,6 +142,8 @@ type HexPatriciaHashed struct {
 	hashAuxBuffer [128]byte     // buffer to compute cell hash or write hash-related things
 	cellHashBuf   common.Hash   // shared scratch buffer for hashKey calls (avoids per-cell allocation)
 	leafHashBuf   [33]byte      // shared scratch for leaf hash prefixing (avoids per-leaf escape)
+	leafRlpBuf    [80]byte      // shared scratch for a leaf's RLP list prefix + compact key: `9 + 1 + 65 = 75`
+	rlpPrefixBuf  [8]byte       // shared scratch for RlpSerializable length prefixes
 	auxBuffer     *bytes.Buffer // auxiliary buffer used during branch updates encoding
 	branchEncoder *BranchEncoder
 
@@ -721,9 +723,7 @@ func (cell *cell) accountForHashing(buffer []byte, storageRootHash common.Hash) 
 func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key []byte, compact0 byte, ni int, val rlp.RlpSerializable, singleton bool) ([]byte, error) {
 	// Compute the total length of binary representation
 	var kp, kl int
-	var keyPrefix [1]byte
 	if compactLen > 1 {
-		keyPrefix[0] = 0x80 + byte(compactLen)
 		kp = 1
 		kl = compactLen
 	} else {
@@ -731,8 +731,23 @@ func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key [
 	}
 
 	totalLen := kp + kl + val.DoubleRLPLen()
-	var lenPrefix [4]byte
-	pl := rlp.EncodeListPrefixToBuf(totalLen, lenPrefix[:])
+	// The header (list prefix, key prefix, compact key) is assembled into one scratch
+	// buffer: passing per-write stack arrays to the io.Writer interface heap-allocates them.
+	header := hph.leafRlpBuf[:]
+	pl := rlp.EncodeListPrefixToBuf(totalLen, header)
+	n := pl
+	if kp > 0 {
+		header[n] = 0x80 + byte(compactLen)
+		n++
+	}
+	header[n] = compact0
+	n++
+	for i := 1; i < compactLen; i++ {
+		header[n] = key[ni]*16 + key[ni+1]
+		n++
+		ni += 2
+	}
+
 	canEmbed := !singleton && totalLen+pl < length.Hash
 	var writer io.Writer
 	if canEmbed {
@@ -743,25 +758,10 @@ func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key [
 		hph.keccak.Reset()
 		writer = hph.witness.leafWriter(hph.keccak)
 	}
-	if _, err := writer.Write(lenPrefix[:pl]); err != nil {
+	if _, err := writer.Write(header[:n]); err != nil {
 		return nil, err
 	}
-	if _, err := writer.Write(keyPrefix[:kp]); err != nil {
-		return nil, err
-	}
-	b := [1]byte{compact0}
-	if _, err := writer.Write(b[:]); err != nil {
-		return nil, err
-	}
-	for i := 1; i < compactLen; i++ {
-		b[0] = key[ni]*16 + key[ni+1]
-		if _, err := writer.Write(b[:]); err != nil {
-			return nil, err
-		}
-		ni += 2
-	}
-	var prefixBuf [8]byte
-	if err := val.ToDoubleRLP(writer, prefixBuf[:]); err != nil {
+	if err := val.ToDoubleRLP(writer, hph.rlpPrefixBuf[:]); err != nil {
 		return nil, err
 	}
 	if canEmbed {

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -139,12 +139,12 @@ type HexPatriciaHashed struct {
 	rootPresent   bool
 	traceW        io.Writer // nil = disabled, non-nil = write trace output
 	ctx           PatriciaContext
-	hashAuxBuffer [128]byte     // buffer to compute cell hash or write hash-related things
-	cellHashBuf   common.Hash   // shared scratch buffer for hashKey calls (avoids per-cell allocation)
-	leafHashBuf   [33]byte      // shared scratch for leaf hash prefixing (avoids per-leaf escape)
-	leafRlpBuf    [80]byte      // shared scratch for a leaf's RLP list prefix + compact key: `9 + 1 + 65 = 75`
-	rlpPrefixBuf  [8]byte       // shared scratch for RlpSerializable length prefixes
-	auxBuffer     *bytes.Buffer // auxiliary buffer used during branch updates encoding
+	hashAuxBuffer [128]byte           // buffer to compute cell hash or write hash-related things
+	cellHashBuf   common.Hash         // shared scratch buffer for hashKey calls (avoids per-cell allocation)
+	leafHashBuf   [33]byte            // shared scratch for leaf hash prefixing (avoids per-leaf escape)
+	leafRlpBuf    [maxLeafRlpLen]byte // shared scratch for a leaf's RLP list prefix + compact key
+	rlpPrefixBuf  [8]byte             // shared scratch for RlpSerializable length prefixes
+	auxBuffer     *bytes.Buffer       // auxiliary buffer used during branch updates encoding
 	branchEncoder *BranchEncoder
 
 	mounted    bool  // true if this trie is mounted to some root trie
@@ -321,6 +321,12 @@ const (
 	cellLoadAccount = loadFlags(1)
 	cellLoadStorage = loadFlags(2)
 )
+
+// maxLeafRlpLen bounds a leaf's assembled RLP header: list prefix (tag plus up to
+// 8 length bytes), key prefix byte, then the compact key. Derived from the nibble
+// array rather than from the shorter keys today's depth arithmetic yields, so a
+// caller slicing deeper cannot overflow the buffer.
+const maxLeafRlpLen = 9 + 1 + (len(cell{}.hashedExtension)/2 + 1)
 
 func (f loadFlags) String() string {
 	var b strings.Builder

--- a/execution/commitment/leaf_hash_test.go
+++ b/execution/commitment/leaf_hash_test.go
@@ -124,44 +124,103 @@ func TestCompleteLeafHashMatchesPerByteHeader(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			compactLen, compact0, ni := compactKeyParams(tc.key, tc.account)
-			kp := 0
-			kl := 1
-			if compactLen > 1 {
-				kp, kl = 1, compactLen
-			}
-			totalLen := kp + kl + val.DoubleRLPLen()
-
 			ref := NewHexPatriciaHashed(length.Addr, nil, TrieConfig{})
 			defer ref.Release()
-			singleton := tc.singleton || tc.account
-			canEmbed := !singleton && totalLen+rlp.ListPrefixLen(totalLen) < length.Hash
-
-			var writer io.Writer
-			if canEmbed {
-				ref.auxBuffer.Reset()
-				writer = ref.auxBuffer
-			} else {
-				ref.keccak.Reset()
-				writer = ref.keccak
-			}
-			require.NoError(t, writeLeafHeaderPerByte(writer, totalLen, compactLen, tc.key, compact0, ni))
-			var prefixBuf [8]byte
-			require.NoError(t, val.ToDoubleRLP(writer, prefixBuf[:]))
-
-			var want []byte
-			if canEmbed {
-				want = ref.auxBuffer.Bytes()
-			} else {
-				var hashBuf [33]byte
-				hashBuf[0] = 0x80 + length.Hash
-				_, err := ref.keccak.Read(hashBuf[1:])
-				require.NoError(t, err)
-				want = hashBuf[:]
-			}
+			want, err := referenceLeafHash(ref, tc.key, val, tc.account, tc.singleton || tc.account)
+			require.NoError(t, err)
 			require.Equal(t, want, got)
 		})
 	}
+}
+
+// The table above pins named shapes; this sweeps every key length the nibble
+// arrays permit, so an undersized leafRlpBuf cannot pass by staying below the
+// longest key the buffer is sized for.
+func TestCompleteLeafHashAllKeyLengths(t *testing.T) {
+	t.Parallel()
+
+	storageVal := make([]byte, 32)
+	for i := range storageVal {
+		storageVal[i] = byte(0xa0 + i)
+	}
+	accountVal := make([]byte, 110)
+	for i := range accountVal {
+		accountVal[i] = byte(i)
+	}
+
+	for keyLen := 1; keyLen <= len(cell{}.hashedExtension); keyLen++ {
+		for _, terminated := range []bool{false, true} {
+			for _, account := range []bool{false, true} {
+				key := make([]byte, keyLen)
+				for i := range key {
+					key[i] = byte(i % 16)
+				}
+				if terminated {
+					key[keyLen-1] = terminatorHexByte
+				}
+
+				hph := NewHexPatriciaHashed(length.Addr, nil, TrieConfig{})
+				var got []byte
+				var err error
+				var val rlp.RlpSerializable
+				if account {
+					val = rlp.RlpEncodedBytes(accountVal)
+					got, err = hph.accountLeafHashWithKey(nil, key, val)
+				} else {
+					storage := rlp.RlpSerializableBytes(storageVal)
+					val = storage
+					got, err = hph.leafHashWithKeyVal(nil, key, storage, true)
+				}
+				require.NoError(t, err, "keyLen=%d terminated=%v account=%v", keyLen, terminated, account)
+
+				ref := NewHexPatriciaHashed(length.Addr, nil, TrieConfig{})
+				want, err := referenceLeafHash(ref, key, val, account, true)
+				require.NoError(t, err)
+				require.Equal(t, want, got, "keyLen=%d terminated=%v account=%v", keyLen, terminated, account)
+
+				ref.Release()
+				hph.Release()
+			}
+		}
+	}
+}
+
+// referenceLeafHash reproduces completeLeafHash as it behaved before the header was
+// assembled in one buffer. It writes through the same witness wrapper production uses,
+// so enabling witness tracing cannot make the reference and the real path diverge.
+func referenceLeafHash(ref *HexPatriciaHashed, key []byte, val rlp.RlpSerializable, account, singleton bool) ([]byte, error) {
+	compactLen, compact0, ni := compactKeyParams(key, account)
+	kp, kl := 0, 1
+	if compactLen > 1 {
+		kp, kl = 1, compactLen
+	}
+	totalLen := kp + kl + val.DoubleRLPLen()
+	canEmbed := !singleton && totalLen+rlp.ListPrefixLen(totalLen) < length.Hash
+
+	var writer io.Writer
+	if canEmbed {
+		ref.auxBuffer.Reset()
+		writer = ref.auxBuffer
+	} else {
+		ref.keccak.Reset()
+		writer = ref.witness.leafWriter(ref.keccak)
+	}
+	if err := writeLeafHeaderPerByte(writer, totalLen, compactLen, key, compact0, ni); err != nil {
+		return nil, err
+	}
+	var prefixBuf [8]byte
+	if err := val.ToDoubleRLP(writer, prefixBuf[:]); err != nil {
+		return nil, err
+	}
+	if canEmbed {
+		return ref.auxBuffer.Bytes(), nil
+	}
+	hashBuf := make([]byte, 33)
+	hashBuf[0] = 0x80 + length.Hash
+	if _, err := ref.keccak.Read(hashBuf[1:]); err != nil {
+		return nil, err
+	}
+	return hashBuf, nil
 }
 
 // compactKeyParams mirrors the compact-encoding decisions leafHashWithKeyVal and

--- a/execution/commitment/leaf_hash_test.go
+++ b/execution/commitment/leaf_hash_test.go
@@ -102,8 +102,9 @@ func TestCompleteLeafHashMatchesPerByteHeader(t *testing.T) {
 				val = rlp.RlpEncodedBytes(accountVal)
 				got, err = hph.accountLeafHashWithKey(nil, tc.key, val)
 			} else {
-				val = rlp.RlpSerializableBytes(storageVal)
-				got, err = hph.leafHashWithKeyVal(nil, tc.key, rlp.RlpSerializableBytes(storageVal), tc.singleton)
+				storage := rlp.RlpSerializableBytes(storageVal)
+				val = storage
+				got, err = hph.leafHashWithKeyVal(nil, tc.key, storage, tc.singleton)
 			}
 			require.NoError(t, err)
 

--- a/execution/commitment/leaf_hash_test.go
+++ b/execution/commitment/leaf_hash_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package commitment
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/length"
+	"github.com/erigontech/erigon/execution/commitment/nibbles"
+	"github.com/erigontech/erigon/execution/rlp"
+)
+
+// writeLeafHeaderPerByte reproduces the header byte stream completeLeafHash emitted
+// before it assembled the header in one buffer: list prefix, key prefix, then the
+// compact key one byte per Write.
+func writeLeafHeaderPerByte(w io.Writer, totalLen, compactLen int, key []byte, compact0 byte, ni int) error {
+	var lenPrefix [4]byte
+	pl := rlp.EncodeListPrefixToBuf(totalLen, lenPrefix[:])
+	if _, err := w.Write(lenPrefix[:pl]); err != nil {
+		return err
+	}
+	if compactLen > 1 {
+		keyPrefix := [1]byte{0x80 + byte(compactLen)}
+		if _, err := w.Write(keyPrefix[:]); err != nil {
+			return err
+		}
+	}
+	b := [1]byte{compact0}
+	if _, err := w.Write(b[:]); err != nil {
+		return err
+	}
+	for i := 1; i < compactLen; i++ {
+		b[0] = key[ni]*16 + key[ni+1]
+		if _, err := w.Write(b[:]); err != nil {
+			return err
+		}
+		ni += 2
+	}
+	return nil
+}
+
+// Storage and account leaves at depth 0 produce the longest key completeLeafHash
+// ever compacts, which is where its single fixed header buffer would overflow or
+// truncate first.
+func TestCompleteLeafHashMatchesPerByteHeader(t *testing.T) {
+	t.Parallel()
+
+	maxKey := make([]byte, 65)
+	for i := range maxKey {
+		maxKey[i] = byte(i % 16)
+	}
+	maxKey[64] = terminatorHexByte
+
+	shortKey := []byte{0x1, 0x2, terminatorHexByte}
+
+	storageVal := make([]byte, 32)
+	for i := range storageVal {
+		storageVal[i] = byte(0xa0 + i)
+	}
+	accountVal := make([]byte, 70)
+	for i := range accountVal {
+		accountVal[i] = byte(i)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		key       []byte
+		singleton bool
+		account   bool
+	}{
+		{"storage max-length key, singleton", maxKey, true, false},
+		{"storage max-length key, embeddable", maxKey, false, false},
+		{"storage short key", shortKey, false, false},
+		{"account max-length key", maxKey, true, true},
+		{"account short key", shortKey, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hph := NewHexPatriciaHashed(length.Addr, nil, TrieConfig{})
+			defer hph.Release()
+
+			var got []byte
+			var err error
+			var val rlp.RlpSerializable
+			if tc.account {
+				val = rlp.RlpEncodedBytes(accountVal)
+				got, err = hph.accountLeafHashWithKey(nil, tc.key, val)
+			} else {
+				val = rlp.RlpSerializableBytes(storageVal)
+				got, err = hph.leafHashWithKeyVal(nil, tc.key, rlp.RlpSerializableBytes(storageVal), tc.singleton)
+			}
+			require.NoError(t, err)
+
+			compactLen, compact0, ni := compactKeyParams(tc.key, tc.account)
+			kp := 0
+			kl := 1
+			if compactLen > 1 {
+				kp, kl = 1, compactLen
+			}
+			totalLen := kp + kl + val.DoubleRLPLen()
+
+			ref := NewHexPatriciaHashed(length.Addr, nil, TrieConfig{})
+			defer ref.Release()
+			singleton := tc.singleton || tc.account
+			canEmbed := !singleton && totalLen+rlp.ListPrefixLen(totalLen) < length.Hash
+
+			var writer io.Writer
+			if canEmbed {
+				ref.auxBuffer.Reset()
+				writer = ref.auxBuffer
+			} else {
+				ref.keccak.Reset()
+				writer = ref.keccak
+			}
+			require.NoError(t, writeLeafHeaderPerByte(writer, totalLen, compactLen, tc.key, compact0, ni))
+			var prefixBuf [8]byte
+			require.NoError(t, val.ToDoubleRLP(writer, prefixBuf[:]))
+
+			var want []byte
+			if canEmbed {
+				want = ref.auxBuffer.Bytes()
+			} else {
+				var hashBuf [33]byte
+				hashBuf[0] = 0x80 + length.Hash
+				_, err := ref.keccak.Read(hashBuf[1:])
+				require.NoError(t, err)
+				want = hashBuf[:]
+			}
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+// compactKeyParams mirrors the compact-encoding decisions leafHashWithKeyVal and
+// accountLeafHashWithKey make before delegating to completeLeafHash.
+func compactKeyParams(key []byte, account bool) (compactLen int, compact0 byte, ni int) {
+	if account {
+		if nibbles.HasTerm(key) {
+			compactLen = (len(key)-1)/2 + 1
+			if len(key)&1 == 0 {
+				return compactLen, 48 + key[0], 1
+			}
+			return compactLen, 32, 0
+		}
+		compactLen = len(key)/2 + 1
+		if len(key)&1 == 1 {
+			return compactLen, terminatorHexByte + key[0], 1
+		}
+		return compactLen, 0, 0
+	}
+	compactLen = (len(key)-1)/2 + 1
+	if len(key)&1 == 0 {
+		return compactLen, 0x30 + key[0], 1
+	}
+	return compactLen, 0x20, 0
+}

--- a/execution/commitment/leaf_hash_test.go
+++ b/execution/commitment/leaf_hash_test.go
@@ -68,6 +68,10 @@ func TestCompleteLeafHashMatchesPerByteHeader(t *testing.T) {
 	}
 	maxKey[64] = terminatorHexByte
 
+	// Storage keys reach an even length by starting deeper, never by dropping the
+	// terminator, which the call sites always append.
+	evenKey := maxKey[1:]
+
 	// accountLeafHashWithKey takes its longer compactLen (len/2+1 rather than
 	// (len-1)/2+1) when the key carries no terminator, so that is the branch the
 	// header buffer must be sized for.
@@ -96,7 +100,7 @@ func TestCompleteLeafHashMatchesPerByteHeader(t *testing.T) {
 	}{
 		{"storage max-length key, singleton", maxKey, true, false},
 		{"storage max-length key, embeddable", maxKey, false, false},
-		{"storage even-length key", noTermEvenKey, false, false},
+		{"storage even-length key", evenKey, false, false},
 		{"storage short key", shortKey, false, false},
 		{"account max-length key", maxKey, true, true},
 		{"account max-length key, no terminator", noTermOddKey, true, true},

--- a/execution/commitment/leaf_hash_test.go
+++ b/execution/commitment/leaf_hash_test.go
@@ -68,6 +68,15 @@ func TestCompleteLeafHashMatchesPerByteHeader(t *testing.T) {
 	}
 	maxKey[64] = terminatorHexByte
 
+	// accountLeafHashWithKey takes its longer compactLen (len/2+1 rather than
+	// (len-1)/2+1) when the key carries no terminator, so that is the branch the
+	// header buffer must be sized for.
+	noTermOddKey := make([]byte, 65)
+	for i := range noTermOddKey {
+		noTermOddKey[i] = byte(i % 16)
+	}
+	noTermEvenKey := maxKey[:64]
+
 	shortKey := []byte{0x1, 0x2, terminatorHexByte}
 
 	storageVal := make([]byte, 32)
@@ -87,8 +96,11 @@ func TestCompleteLeafHashMatchesPerByteHeader(t *testing.T) {
 	}{
 		{"storage max-length key, singleton", maxKey, true, false},
 		{"storage max-length key, embeddable", maxKey, false, false},
+		{"storage even-length key", noTermEvenKey, false, false},
 		{"storage short key", shortKey, false, false},
 		{"account max-length key", maxKey, true, true},
+		{"account max-length key, no terminator", noTermOddKey, true, true},
+		{"account even-length key, no terminator", noTermEvenKey, true, true},
 		{"account short key", shortKey, true, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
`completeLeafHash` built its RLP header out of four small stack arrays — `lenPrefix [4]byte`, `keyPrefix [1]byte`, `b [1]byte`, `prefixBuf [8]byte`. Every one of them is passed to an `io.Writer` **interface**, so escape analysis moves all four to the heap:

```
hex_patricia_hashed.go:724 moved to heap: keyPrefix
hex_patricia_hashed.go:734 moved to heap: lenPrefix
hex_patricia_hashed.go:752 moved to heap: b
hex_patricia_hashed.go:763 moved to heap: prefixBuf
```

Four allocations per leaf hash, on the hottest path in the fold.

In a mainnet heap profile these four sites are **1.21B `alloc_objects`**. They sit under a chain that is 11.8% of every object the process allocates:

```
dfsSubtreeDeep                    21.9B objects (11.8% of total)
└─ followAndUpdate                17.8B
   └─ fold                        12.6B
      └─ foldBranch               10.5B
         └─ hashRow                2.9B
            └─ computeCellHash     2.6B
               └─ completeLeafHash   <- here
```

## Change

Assemble the list prefix, key prefix and compact key into one scratch buffer on `HexPatriciaHashed` (following the existing `leafHashBuf`) and emit it with a single `Write`.

That removes the four allocations, and also collapses up to 36 interface `Write` calls per leaf into one — which is why the time win is larger than the allocation win alone would buy.

The byte stream is unchanged, so trie roots are identical.

## Numbers

benchstat, median of 6:

| benchmark | allocs/op | sec/op |
|---|---|---|
| `HexPatriciaHashedFold` | 1783 → **1286** (−27.9%) | 226.7µs → 195.4µs (−13.8%) |
| `_HexPatriciaHashed_Process` | 99 → **79** (−20.2%) | 15.38µs → 14.32µs (−6.9%) |

All `p=0.002`. `B/op` moves much less (−4.1% / −0.4%) — these are tiny objects, so the win is allocation count and GC pressure, not heap footprint.

One caveat worth stating plainly: these are microbenchmarks. Whole-program, the four sites were 0.65% of allocated objects; the 20–28% figures are what the commitment path sees in isolation.

An earlier revision of this PR reported −8.3% on Fold and flagged it as possibly noise. It was — that run had ±9% variance. The current numbers are ±1%.

## On the buffer size

`leafRlpBuf` is `[maxLeafRlpLen]byte`, derived rather than asserted:

```go
const maxLeafRlpLen = 9 + 1 + (len(cell{}.hashedExtension)/2 + 1)
```

= 75 at compile time: RLP list prefix (tag + up to 8 length bytes) + key prefix byte + compact key for the longest key the nibble array can hold.

The reachable maximum today is 36, not 75 — current call sites slice `[:65-depth]` and `[:64-hashedKeyOffset+1]`, capping `compactLen` at 33. Sizing to the type-permitted bound is deliberate: the replaced per-byte write loop had no length ceiling at all, so a future caller slicing deeper (or a negative `depth`) would panic instead of being absorbed. That is the one new failure mode this change introduces, and it is cheap to size away.

(Copilot flagged an earlier `[80]byte` literal here — it was 75 rounded up for no articulable reason. The constant also cannot go stale if `hashedExtension` is resized.)

## Test

`TestCompleteLeafHashMatchesPerByteHeader` pins the output byte-for-byte against a reference that reproduces the old per-write sequence, at both the maximum key length and short keys.

I did not trust it for passing on the first run. Two mutations confirm it discriminates:

- corrupting the key prefix → all 5 subtests fail
- dropping the last key byte **only when `compactLen > 32`** → exactly the 3 max-length subtests fail, short-key ones stay green

That second one is the point: the pre-existing suite caught it via a single incidental test (`TestWitnessNodesForKeys_AbsentSlotStopsAtBlindedChild`), whose failure gives no hint that the leaf header is at fault.

Per CLAUDE.md this is a pure refactor with no behavior change, so no Red→Green cycle — existing commitment tests are the safety net, and the new test exists to pin the boundary the fixed buffer introduces.

## Follow-ups (not in this PR)

- `execution/commitment/trie/hashbuilder.go:149` has a near-identical `completeLeafHash` carrying the same four escaping arrays. Same fix applies; different type, different package, colder path.
- `hashRow:1760`'s `b := [...]byte{0x80}` escapes the same way (335M objects) — a one-line package-level var.
- `rlp.encodePrefixToBuf` truncates silently on a short destination: `putint` copies `min(len(b), size)` but returns the untruncated size, so `to[0]` can claim more length bytes than were written. Unreachable at leaf-hash sizes and this PR moves further from it, but it offers no bounds check to other callers.

