### PR TITLE
execution/rlp: decode string fields through ViewBytes

### DIFF
--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -264,7 +264,7 @@ func decodeBool(s *Stream, val reflect.Value) error {
 }
 
 func decodeString(s *Stream, val reflect.Value) error {
-	b, err := s.Bytes()
+	b, err := s.ViewBytes() // SetString copies, so the view never outlives the stream
 	if err != nil {
 		return wrapStreamError(err, val.Type())
 	}

--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -264,7 +264,7 @@ func decodeBool(s *Stream, val reflect.Value) error {
 }
 
 func decodeString(s *Stream, val reflect.Value) error {
-	b, err := s.ViewBytes() // SetString copies, so the view never outlives the stream
+	b, err := s.ViewBytes() // the string(b) conversion below copies, so the view never outlives the stream
 	if err != nil {
 		return wrapStreamError(err, val.Type())
 	}

--- a/execution/rlp/streambench_test.go
+++ b/execution/rlp/streambench_test.go
@@ -101,3 +101,37 @@ func BenchmarkDecodeBytes_Tiny(b *testing.B) {
 		_ = dst
 	}
 }
+
+type benchCap struct {
+	Name    string
+	Version uint
+}
+
+type benchHandshake struct {
+	Version    uint64
+	Name       string
+	Caps       []benchCap
+	ListenPort uint64
+	ID         []byte
+}
+
+func BenchmarkDecodeStringFields(b *testing.B) {
+	encoded, err := EncodeToBytes(&benchHandshake{
+		Version:    5,
+		Name:       "erigon/v3.6.0-dev/linux-amd64/go1.25.0",
+		Caps:       []benchCap{{"eth", 68}, {"eth", 69}, {"snap", 1}, {"wit", 0}},
+		ListenPort: 30303,
+		ID:         bytes.Repeat([]byte{0xab}, 64),
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var dst benchHandshake
+		if err := DecodeBytes(encoded, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/execution/rlp/streambench_test.go
+++ b/execution/rlp/streambench_test.go
@@ -133,5 +133,6 @@ func BenchmarkDecodeStringFields(b *testing.B) {
 		if err := DecodeBytes(encoded, &dst); err != nil {
 			b.Fatal(err)
 		}
+		_ = dst
 	}
 }


### PR DESCRIPTION
Follow-up to #22587, which found this while profiling ENR decode.

`decodeString` copies the payload twice:

```go
b, err := s.Bytes()      // alloc 1: copy out of the stream
val.SetString(string(b)) // alloc 2: copy again into the string
```

`ViewBytes` returns a view into the input on a slice-backed stream — which is what every `rlp.DecodeBytes` call builds — so `SetString`'s copy becomes the only one. It falls back to `Bytes` for any other reader, and `SetString` copies unconditionally, so the view never outlives the stream.

`decodeByteSlice` and `decodeInterface` deliberately keep using `Bytes`: `SetBytes` and `Set(reflect.ValueOf(b))` both retain the slice, so they need an owned buffer.

## Scope

One allocation per string field decoded. Worth being clear that this is a small win in practice: Erigon's hot RLP structs (blocks, transactions, receipts) use `[]byte` and integers, and the only RLP-decoded `string` fields in the tree are the devp2p handshake — `protoHandshake.Name` and `Cap.Name` — which is once per peer connection. The benchmark models exactly that struct.

It is free and carries no aliasing risk, so it is worth taking as a cleanup rather than as a hot-path optimization.

## Numbers

`BenchmarkDecodeStringFields` (new; devp2p handshake shape, 5 string fields), benchstat over 8 runs:

| | before | after | |
|---|---|---|---|
| sec/op | 640.8n | 586.5n | -8.47% |
| B/op | 564 | 504 | -10.64% |
| allocs/op | 17 | 12 | -29.41% |