### PR TITLE
rlp: use Stream.Addr for address decodes; stop escaping Authorization

### DIFF
--- a/execution/types/access_list_tx.go
+++ b/execution/types/access_list_tx.go
@@ -278,7 +278,7 @@ func decodeAccessList(al *AccessList, s *rlp.Stream) error {
 		// decode tuple
 		*al = append(*al, AccessTuple{StorageKeys: []common.Hash{}})
 		tuple := &(*al)[len(*al)-1]
-		if err = s.ReadBytes(tuple.Address[:]); err != nil {
+		if tuple.Address, err = s.Addr(); err != nil {
 			return fmt.Errorf("read Address: %w", err)
 		}
 		if _, err = s.List(); err != nil {

--- a/execution/types/authorization.go
+++ b/execution/types/authorization.go
@@ -116,21 +116,14 @@ func authorizationsSize(authorizations []Authorization) (totalSize int) {
 	return
 }
 
-func decodeAuthorizations(auths *[]Authorization, s *rlp.Stream) (retErr error) {
-	n0 := len(*auths)
-	defer func() {
-		if retErr != nil {
-			*auths = (*auths)[:n0]
-		}
-	}()
+func decodeAuthorizations(auths *[]Authorization, s *rlp.Stream) error {
 	_, err := s.List()
 	if err != nil {
 		return fmt.Errorf("open authorizations: %w", err)
 	}
 	i := 0
 	for _, err = s.List(); err == nil; _, err = s.List() {
-		*auths = append(*auths, Authorization{})
-		auth := &(*auths)[len(*auths)-1]
+		auth := Authorization{}
 
 		if err = s.ReadUint256(&auth.ChainID); err != nil {
 			return err
@@ -166,6 +159,7 @@ func decodeAuthorizations(auths *[]Authorization, s *rlp.Stream) (retErr error) 
 			return err
 		}
 
+		*auths = append(*auths, auth)
 		// end of authorization
 		if err = s.ListEnd(); err != nil {
 			return fmt.Errorf("close Authorization: %w", err)

--- a/execution/types/authorization.go
+++ b/execution/types/authorization.go
@@ -116,7 +116,13 @@ func authorizationsSize(authorizations []Authorization) (totalSize int) {
 	return
 }
 
-func decodeAuthorizations(auths *[]Authorization, s *rlp.Stream) error {
+func decodeAuthorizations(auths *[]Authorization, s *rlp.Stream) (retErr error) {
+	n0 := len(*auths)
+	defer func() {
+		if retErr != nil {
+			*auths = (*auths)[:n0]
+		}
+	}()
 	_, err := s.List()
 	if err != nil {
 		return fmt.Errorf("open authorizations: %w", err)
@@ -132,7 +138,7 @@ func decodeAuthorizations(auths *[]Authorization, s *rlp.Stream) error {
 
 		// address
 		if auth.Address, err = s.Addr(); err != nil {
-			return err
+			return fmt.Errorf("read Address: %w", err)
 		}
 
 		// nonce

--- a/execution/types/authorization.go
+++ b/execution/types/authorization.go
@@ -123,14 +123,15 @@ func decodeAuthorizations(auths *[]Authorization, s *rlp.Stream) error {
 	}
 	i := 0
 	for _, err = s.List(); err == nil; _, err = s.List() {
-		auth := Authorization{}
+		*auths = append(*auths, Authorization{})
+		auth := &(*auths)[len(*auths)-1]
 
 		if err = s.ReadUint256(&auth.ChainID); err != nil {
 			return err
 		}
 
 		// address
-		if err = s.ReadBytes(auth.Address[:]); err != nil {
+		if auth.Address, err = s.Addr(); err != nil {
 			return err
 		}
 
@@ -159,7 +160,6 @@ func decodeAuthorizations(auths *[]Authorization, s *rlp.Stream) error {
 			return err
 		}
 
-		*auths = append(*auths, auth)
 		// end of authorization
 		if err = s.ListEnd(); err != nil {
 			return fmt.Errorf("close Authorization: %w", err)

--- a/execution/types/blob_tx.go
+++ b/execution/types/blob_tx.go
@@ -369,17 +369,11 @@ func (stx *BlobTx) DecodeRLP(s *rlp.Stream) error {
 	if stx.GasLimit, err = s.Uint64(); err != nil {
 		return err
 	}
-	stx.To = &common.Address{}
-	if kind, size, err := s.Kind(); err != nil {
-		return err
-	} else if kind == rlp.Byte {
-		return fmt.Errorf("wrong size for To: 1")
-	} else if size != 20 {
-		return fmt.Errorf("wrong size for To: %d", size)
+	to, err := s.Addr()
+	if err != nil {
+		return fmt.Errorf("read To: %w", err)
 	}
-	if err = s.ReadBytes(stx.To[:]); err != nil {
-		return err
-	}
+	stx.To = &to
 	if err = s.ReadUint256(&stx.Value); err != nil {
 		return err
 	}

--- a/execution/types/block_access_list.go
+++ b/execution/types/block_access_list.go
@@ -141,8 +141,8 @@ func (ac *AccountChanges) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("account changes payload exceeds maximum size (%d bytes)", size)
 	}
 
-	var address common.Address
-	if err := s.ReadBytes(address[:]); err != nil {
+	address, err := s.Addr()
+	if err != nil {
 		return fmt.Errorf("read Address: %w", err)
 	}
 	ac.Address = accounts.InternAddress(address)

--- a/execution/types/rlp_address.go
+++ b/execution/types/rlp_address.go
@@ -17,7 +17,6 @@
 package types
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/erigontech/erigon/common"
@@ -37,24 +36,21 @@ func EncodeOptionalAddress(addr *common.Address, w io.Writer, buffer []byte) err
 	return err
 }
 
-// DecodeOptionalAddress decodes an optional 20-byte address from the RLP stream.
+// DecodeOptionalAddress decodes an optional 20-byte address from the RLP
+// stream; an empty string decodes as nil (contract creation).
 func DecodeOptionalAddress(dst **common.Address, s *rlp.Stream) error {
 	kind, size, err := s.Kind()
 	if err != nil {
 		return err
 	}
-	switch {
-	case kind == rlp.String && size == 0:
+	if kind == rlp.String && size == 0 {
 		*dst = nil
 		return s.ReadBytes(nil)
-	case kind == rlp.String && size == 20:
-		*dst = &common.Address{}
-		return s.ReadBytes((*dst)[:])
-	case kind == rlp.List:
-		return fmt.Errorf("expected string for address, got list")
-	case kind == rlp.Byte:
-		return fmt.Errorf("wrong size for address: 1")
-	default:
-		return fmt.Errorf("wrong size for address: %d", size)
 	}
+	a, err := s.Addr()
+	if err != nil {
+		return err
+	}
+	*dst = &a
+	return nil
 }

--- a/execution/types/rlp_address.go
+++ b/execution/types/rlp_address.go
@@ -37,7 +37,7 @@ func EncodeOptionalAddress(addr *common.Address, w io.Writer, buffer []byte) err
 }
 
 // DecodeOptionalAddress decodes an optional 20-byte address from the RLP
-// stream; an empty string decodes as nil (contract creation).
+// stream; an empty string decodes as nil.
 func DecodeOptionalAddress(dst **common.Address, s *rlp.Stream) error {
 	kind, size, err := s.Kind()
 	if err != nil {

--- a/execution/types/set_code_tx.go
+++ b/execution/types/set_code_tx.go
@@ -254,17 +254,11 @@ func (tx *SetCodeTransaction) DecodeRLP(s *rlp.Stream) error {
 	if tx.GasLimit, err = s.Uint64(); err != nil {
 		return err
 	}
-	tx.To = &common.Address{}
-	if kind, size, err := s.Kind(); err != nil {
-		return err
-	} else if kind == rlp.Byte {
-		return fmt.Errorf("wrong size for To: 1")
-	} else if size != 20 {
-		return fmt.Errorf("wrong size for To: %d", size)
+	to, err := s.Addr()
+	if err != nil {
+		return fmt.Errorf("read To: %w", err)
 	}
-	if err = s.ReadBytes(tx.To[:]); err != nil {
-		return err
-	}
+	tx.To = &to
 	if err = s.ReadUint256(&tx.Value); err != nil {
 		return err
 	}


### PR DESCRIPTION
Stacked on #22584.

- BAL `AccountChanges`, blob/set-code `To`, and `DecodeOptionalAddress` decode via `Stream.Addr` (one canonical size check; BAL loses an escaping local, blob/set-code drop hand-rolled Kind/size checks)
- `decodeAuthorizations` keeps the decode-into-local, append-on-success shape: with `Stream.Addr` the local no longer escapes, so there is no per-authorization allocation and the slice only ever holds fully-decoded entries

Allocs/op (fixed fixtures): SetCodeTx 12→7 (5 auths), AccountChanges 8→7; blob/access-list unchanged.
Speed (median of 3): SetCodeTx decode 838→728 ns (−13%).
