### PR TITLE
consensus: propagate state errors from balance updates

### DIFF
--- a/execution/protocol/rules/aura/aura.go
+++ b/execution/protocol/rules/aura/aura.go
@@ -726,7 +726,9 @@ func (c *AuRa) applyRewards(header *types.Header, state *state.IntraBlockState, 
 		return err
 	}
 	for _, r := range rewards {
-		state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceIncreaseRewardMineBlock)
+		if err := state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceIncreaseRewardMineBlock); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -225,7 +225,13 @@ func (st *TxnExecutor) buyGas(gasBailout bool) error {
 				return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From())
 			}
 			if st.evm.ChainRules().IsCancun && st.msg.BlobGas() > 0 {
-				maxBlobFee, overflow := u256.MulOverflow(*st.msg.MaxFeePerBlobGas(), u256.U64(st.msg.BlobGas()))
+				// Call-style messages may leave this unset; types.NewMessage
+				// stores zero for a nil argument, so treat nil the same way.
+				var maxFeePerBlobGas uint256.Int
+				if f := st.msg.MaxFeePerBlobGas(); f != nil {
+					maxFeePerBlobGas = *f
+				}
+				maxBlobFee, overflow := u256.MulOverflow(maxFeePerBlobGas, u256.U64(st.msg.BlobGas()))
 				if overflow {
 					return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From())
 				}

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -224,7 +224,7 @@ func (st *TxnExecutor) buyGas(gasBailout bool) error {
 			if overflow {
 				return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From())
 			}
-			if st.evm.ChainRules().IsCancun {
+			if st.evm.ChainRules().IsCancun && st.msg.BlobGas() > 0 {
 				maxBlobFee, overflow := u256.MulOverflow(*st.msg.MaxFeePerBlobGas(), u256.U64(st.msg.BlobGas()))
 				if overflow {
 					return fmt.Errorf("%w: address %v", ErrInsufficientFunds, st.msg.From())
@@ -242,8 +242,12 @@ func (st *TxnExecutor) buyGas(gasBailout bool) error {
 		if have, want := balance, balanceCheck; have.Cmp(&want) < 0 {
 			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From(), &have, &want)
 		}
-		st.state.SubBalance(st.msg.From(), gasVal, tracing.BalanceDecreaseGasBuy)
-		st.state.SubBalance(st.msg.From(), blobGasVal, tracing.BalanceDecreaseGasBuy)
+		if err := st.state.SubBalance(st.msg.From(), gasVal, tracing.BalanceDecreaseGasBuy); err != nil {
+			return err
+		}
+		if err := st.state.SubBalance(st.msg.From(), blobGasVal, tracing.BalanceDecreaseGasBuy); err != nil {
+			return err
+		}
 	}
 
 	if st.evm.Config().Tracer != nil && st.evm.Config().Tracer.OnGasChange != nil {

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -296,3 +296,25 @@ func TestPreCheckErrorOrdering_GasBeforeFeeCap(t *testing.T) {
 		require.NoError(t, CheckBlockGasInclusion(gp, 50_000, 80_000))
 	})
 }
+
+// nilBlobFeeMsg is a Message whose MaxFeePerBlobGas is nil, as returned by
+// call-style messages (e.g. the simulated backend's callMsg).
+type nilBlobFeeMsg struct{ *types.Message }
+
+func (nilBlobFeeMsg) MaxFeePerBlobGas() *uint256.Int { return nil }
+
+// TestBuyGas_NilMaxFeePerBlobGas verifies buyGas does not dereference a nil
+// MaxFeePerBlobGas for a non-blob transaction on Cancun.
+func TestBuyGas_NilMaxFeePerBlobGas(t *testing.T) {
+	t.Parallel()
+
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	ibs := state.New(state.NewNoopReader())
+	evm := newTestEVM(ibs, chain.TestChainOsakaConfig, 30_000_000)
+	msg := nilBlobFeeMsg{newSimpleTransferMsg(sender, recipient, 100_000, false)}
+	st := NewTxnExecutor(evm, msg, new(GasPool).AddGas(30_000_000))
+
+	require.NotPanics(t, func() { _ = st.buyGas(false) })
+}

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -316,7 +316,9 @@ func TestBuyGas_NilMaxFeePerBlobGas(t *testing.T) {
 	msg := nilBlobFeeMsg{newSimpleTransferMsg(sender, recipient, 100_000, false)}
 	st := NewTxnExecutor(evm, msg, new(GasPool).AddGas(30_000_000))
 
-	require.NotPanics(t, func() { _ = st.buyGas(false) })
+	var err error
+	require.NotPanics(t, func() { err = st.buyGas(false) })
+	require.NoError(t, err)
 }
 
 // TestBuyGas_NilMaxFeePerBlobGasWithBlobs covers the same nil max fee on a
@@ -335,5 +337,7 @@ func TestBuyGas_NilMaxFeePerBlobGasWithBlobs(t *testing.T) {
 	gp := new(GasPool).AddGas(30_000_000).AddBlobGas(params.GasPerBlob)
 	st := NewTxnExecutor(evm, nilBlobFeeMsg{inner}, gp)
 
-	require.NotPanics(t, func() { _ = st.buyGas(false) })
+	var err error
+	require.NotPanics(t, func() { err = st.buyGas(false) })
+	require.NoError(t, err)
 }

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -318,3 +318,22 @@ func TestBuyGas_NilMaxFeePerBlobGas(t *testing.T) {
 
 	require.NotPanics(t, func() { _ = st.buyGas(false) })
 }
+
+// TestBuyGas_NilMaxFeePerBlobGasWithBlobs covers the same nil max fee on a
+// message that does carry blobs, so the blob-fee branch is actually entered.
+func TestBuyGas_NilMaxFeePerBlobGasWithBlobs(t *testing.T) {
+	t.Parallel()
+
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	inner := newSimpleTransferMsg(sender, recipient, 100_000, false)
+	inner.SetBlobVersionedHashes([]common.Hash{{0x01}})
+
+	ibs := state.New(state.NewNoopReader())
+	evm := newTestEVM(ibs, chain.TestChainOsakaConfig, 30_000_000)
+	gp := new(GasPool).AddGas(30_000_000).AddBlobGas(params.GasPerBlob)
+	st := NewTxnExecutor(evm, nilBlobFeeMsg{inner}, gp)
+
+	require.NotPanics(t, func() { _ = st.buyGas(false) })
+}

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -1315,8 +1315,12 @@ func opSelfdestruct(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, er
 		return pc, nil, err
 	}
 
-	ibs.AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
-	ibs.Selfdestruct(self, false)
+	if err := ibs.AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct); err != nil {
+		return pc, nil, err
+	}
+	if _, err := ibs.Selfdestruct(self, false); err != nil {
+		return pc, nil, err
+	}
 	tracer := evm.Config().Tracer
 	if tracer != nil && tracer.OnEnter != nil {
 		tracer.OnEnter(evm.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiaryAddr, false, []byte{}, 0, balance, nil)
@@ -1350,8 +1354,12 @@ func opSelfdestruct6780(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte
 		// beneficiary (a no-op when it is self); a same-tx-created contract is
 		// still cleared at finalization but keeps any residual balance.
 		if self != beneficiaryAddr {
-			ibs.SubBalance(self, balance, tracing.BalanceDecreaseSelfdestruct)
-			ibs.AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
+			if err := ibs.SubBalance(self, balance, tracing.BalanceDecreaseSelfdestruct); err != nil {
+				return pc, nil, err
+			}
+			if err := ibs.AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct); err != nil {
+				return pc, nil, err
+			}
 		}
 		if newContract {
 			_, err = ibs.Selfdestruct(self, true)
@@ -1360,17 +1368,25 @@ func opSelfdestruct6780(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte
 			}
 		}
 	} else if newContract { // Contract is new and will actually be deleted.
-		ibs.SubBalance(self, balance, tracing.BalanceDecreaseSelfdestruct)
+		if err := ibs.SubBalance(self, balance, tracing.BalanceDecreaseSelfdestruct); err != nil {
+			return pc, nil, err
+		}
 		if self != beneficiaryAddr {
-			ibs.AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
+			if err := ibs.AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct); err != nil {
+				return pc, nil, err
+			}
 		}
 		_, err = ibs.Selfdestruct(self, false)
 		if err != nil {
 			return pc, nil, err
 		}
 	} else if self != beneficiaryAddr { // Contract already exists, only do transfer if beneficiary is not self.
-		ibs.SubBalance(self, balance, tracing.BalanceDecreaseSelfdestruct)
-		ibs.AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct)
+		if err := ibs.SubBalance(self, balance, tracing.BalanceDecreaseSelfdestruct); err != nil {
+			return pc, nil, err
+		}
+		if err := ibs.AddBalance(beneficiaryAddr, balance, tracing.BalanceIncreaseSelfdestruct); err != nil {
+			return pc, nil, err
+		}
 	}
 	if rules.IsAmsterdam && !rules.IsEIPDisabled(7708) && !balance.IsZero() && self != beneficiaryAddr { // EIP-7708
 		ibs.AddLog(misc.EthTransferLog(self.Value(), beneficiaryAddr.Value(), balance))

--- a/execution/vm/selfdestruct_err_test.go
+++ b/execution/vm/selfdestruct_err_test.go
@@ -1,0 +1,60 @@
+package vm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm/evmtypes"
+)
+
+// beneficiaryErrReader fails the account read for one address only, standing in
+// for a domain read failure on a cold account.
+type beneficiaryErrReader struct {
+	state.StateReader
+	fail accounts.Address
+	err  error
+}
+
+func (r beneficiaryErrReader) ReadAccountData(addr accounts.Address) (*accounts.Account, error) {
+	if addr == r.fail {
+		return nil, r.err
+	}
+	return r.StateReader.ReadAccountData(addr)
+}
+
+// TestOpSelfdestruct_PropagatesBalanceError verifies that a state failure while
+// crediting the beneficiary aborts the opcode instead of silently dropping the
+// transferred balance.
+func TestOpSelfdestruct_PropagatesBalanceError(t *testing.T) {
+	t.Parallel()
+
+	self := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	beneficiary := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	boom := errors.New("domain read failed")
+	ibs := state.New(beneficiaryErrReader{
+		StateReader: state.NewNoopReader(),
+		fail:        beneficiary,
+		err:         boom,
+	})
+	require.NoError(t, ibs.AddBalance(self, *uint256.NewInt(1000), 0))
+
+	evm := NewEVM(evmtypes.BlockContext{}, evmtypes.TxContext{}, ibs, chain.TestChainOsakaConfig, Config{})
+	scope := &CallContext{Contract: *NewContract(self, self, self, uint256.Int{})}
+	// The interpreter bumps cacheGen before each dispatch; without it the
+	// zero-valued gen collides with cachedAddrGen and peekAddress returns a
+	// stale address instead of reading the stack.
+	scope.cacheGen++
+	benVal := beneficiary.Value()
+	scope.Stack.push(*new(uint256.Int).SetBytes(benVal[:]))
+
+	_, _, err := opSelfdestruct(0, evm, scope)
+	require.ErrorIs(t, err, boom)
+}


### PR DESCRIPTION
`IntraBlockState.AddBalance`/`SubBalance` return an `error` (they load the account through `GetOrNewStateObject`), but several callers discard it. Where they do, a state-read failure silently skips the balance update and execution continues against wrong state instead of aborting.

Erigon is the outlier among clients here — it is the only one of the three that returns a per-call error from this path and therefore the only one that can drop it:

| client | balance deduction | error handling |
|---|---|---|
| **geth** | [`buyGas`](https://github.com/ethereum/go-ethereum/blob/bb6401ee5f91cb5138aed19177603891a6f5ea60/core/state_transition.go#L437) → [bare `SubBalance`](https://github.com/ethereum/go-ethereum/blob/bb6401ee5f91cb5138aed19177603891a6f5ea60/core/state_transition.go#L490) | [`SubBalance` returns the previous balance, not an error](https://github.com/ethereum/go-ethereum/blob/bb6401ee5f91cb5138aed19177603891a6f5ea60/core/state/statedb.go#L461); DB failures latch in `dbErr` via [`setError`](https://github.com/ethereum/go-ethereum/blob/bb6401ee5f91cb5138aed19177603891a6f5ea60/core/state/statedb.go#L243) and abort at `Commit` |
| **reth** (revm) | [`validate_against_state_and_deduct_caller`](https://github.com/bluealloy/revm/blob/5199506d7290889a6943a916f96a8cd161299bf8/crates/handler/src/pre_execution.rs#L168-L188) | returns `Result<(), ERROR>` with `ERROR: From<<CTX::Db as Database>::Error>`; the account load on [L177](https://github.com/bluealloy/revm/blob/5199506d7290889a6943a916f96a8cd161299bf8/crates/handler/src/pre_execution.rs#L177) propagates DB errors with `?` |
| **spec** | [`process_transaction`](https://github.com/ethereum/execution-specs/blob/2119b382cebe57d9953eb6252e927e130b1ca51c/src/ethereum/forks/prague/fork.py#L827) → [L891-894](https://github.com/ethereum/execution-specs/blob/2119b382cebe57d9953eb6252e927e130b1ca51c/src/ethereum/forks/prague/fork.py#L891-L894) | state access is infallible in the Python model, so there is no error to drop |

## Fixes

- **`protocol.buyGas`** — both `SubBalance` calls. Reachable under parallel execution, where `getStateObject` re-validates a cached object against the `versionMap` and can fail even though `GetBalance` succeeded moments earlier. In serial execution `GetBalance` immediately before populates the object cache, so the path is defensive there.
- **`vm.opSelfdestruct` / `opSelfdestruct6780`** — `Add`/`SubBalance` and one unchecked `Selfdestruct`. Both functions already propagate errors from `GetBalance` and `IsNewContract`, so this was drift rather than intent.

  **Caveat on what this achieves inside the EVM.** An error returned from an opcode does *not* abort block processing: `Execute` treats it as a VM error (`vmerr // vm errors do not affect consensus and are therefore not assigned to err`), and `handleFrameRevert` burns the frame's remaining gas for any non-`REVERT` error. So a state failure here surfaces as a chain-committed *failed transaction* rather than a halt. It is still an improvement — state is reverted to the frame snapshot instead of left partially applied — and it matches what the pre-existing `GetBalance` check three lines above already does. Classifying state failures as fatal, distinct from VM exceptions, is a separate and much larger change.
- **`aura.applyRewards`** — `AddBalance`, in a function that already returns `error`.

## Also: nil deref in the blob-fee branch

`buyGas` dereferenced `*st.msg.MaxFeePerBlobGas()` for every Cancun transaction, guarded only by `IsCancun`. That panics for a `Message` implementation returning nil — `callMsg` in the simulated backend does. Now guarded with `BlobGas() > 0`, matching the identical call 100 lines below in the same file, and matching geth and the spec, which only run blob math when the transaction carries blobs. The arithmetic is unchanged: `BlobGas() == 0` made the term zero anyway.

`TestBuyGas_NilMaxFeePerBlobGas` and `TestBuyGas_NilMaxFeePerBlobGasWithBlobs` panic without the fix; `TestOpSelfdestruct_PropagatesBalanceError` fails with `errStopToken` when the `AddBalance` error is discarded.

## Not covered here

The same class of unchecked `Add`/`SubBalance` exists at 8 more sites, including consensus-relevant ones — `merge.go:172-188` (block rewards and **withdrawals**), `ethash/rules.go:531-534` (mining rewards), and `txn_executor.go:691,863` (burnt fees and the **gas refund**). Left out deliberately to keep this reviewable; happy to fold them in or file a follow-up.

