### PR TITLE
consensus: propagate state errors from rewards and withdrawals

### DIFF
--- a/execution/protocol/rules/merge/merge.go
+++ b/execution/protocol/rules/merge/merge.go
@@ -177,7 +177,7 @@ func (s *Merge) Finalize(config *chain.Config, header *types.Header, state *stat
 			err = state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceChangeUnspecified)
 		}
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("applying reward kind %d to %x: %w", r.Kind, r.Beneficiary, err)
 		}
 	}
 
@@ -190,7 +190,7 @@ func (s *Merge) Finalize(config *chain.Config, header *types.Header, state *stat
 			for _, w := range withdrawals {
 				amountInWei := new(uint256.Int).Mul(uint256.NewInt(w.Amount), uint256.NewInt(common.GWei))
 				if err := state.AddBalance(accounts.InternAddress(w.Address), *amountInWei, tracing.BalanceIncreaseWithdrawal); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("crediting withdrawal %d to %x: %w", w.Index, w.Address, err)
 				}
 			}
 		}

--- a/execution/protocol/rules/merge/merge.go
+++ b/execution/protocol/rules/merge/merge.go
@@ -167,13 +167,17 @@ func (s *Merge) Finalize(config *chain.Config, header *types.Header, state *stat
 		return nil, err
 	}
 	for _, r := range rewards {
+		var err error
 		switch r.Kind {
 		case rules.RewardAuthor:
-			state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceIncreaseRewardMineBlock)
+			err = state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceIncreaseRewardMineBlock)
 		case rules.RewardUncle:
-			state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceIncreaseRewardMineUncle)
+			err = state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceIncreaseRewardMineUncle)
 		default:
-			state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceChangeUnspecified)
+			err = state.AddBalance(r.Beneficiary, r.Amount, tracing.BalanceChangeUnspecified)
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -185,7 +189,9 @@ func (s *Merge) Finalize(config *chain.Config, header *types.Header, state *stat
 		} else {
 			for _, w := range withdrawals {
 				amountInWei := new(uint256.Int).Mul(uint256.NewInt(w.Amount), uint256.NewInt(common.GWei))
-				state.AddBalance(accounts.InternAddress(w.Address), *amountInWei, tracing.BalanceIncreaseWithdrawal)
+				if err := state.AddBalance(accounts.InternAddress(w.Address), *amountInWei, tracing.BalanceIncreaseWithdrawal); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}

--- a/execution/protocol/rules/merge/merge_test.go
+++ b/execution/protocol/rules/merge/merge_test.go
@@ -17,10 +17,12 @@
 package merge
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -135,4 +137,48 @@ func TestNullParentBeaconBlockRootDoesNotPanic(t *testing.T) {
 	mergeEngine := New(eth1Engine)
 	err := mergeEngine.Initialize(chainConfig, chainReader, header, &intraBlockState, systemCallCustom, logger, &tracer)
 	assert.NoError(t, err)
+}
+
+// withdrawalErrReader fails the account read for one address, standing in for a
+// domain read failure on a cold withdrawal recipient.
+type withdrawalErrReader struct {
+	state.StateReader
+	fail accounts.Address
+	err  error
+}
+
+func (r withdrawalErrReader) ReadAccountData(addr accounts.Address) (*accounts.Account, error) {
+	if addr == r.fail {
+		return nil, r.err
+	}
+	return r.StateReader.ReadAccountData(addr)
+}
+
+// TestFinalizeWithdrawalStateErrorPropagates verifies a state failure while
+// crediting a withdrawal aborts Finalize instead of silently skipping it.
+func TestFinalizeWithdrawalStateErrorPropagates(t *testing.T) {
+	chainConfig := chainspec.Mainnet.Config
+	header := &types.Header{
+		Difficulty: *ProofOfStakeDifficulty,
+		Time:       *chainConfig.CancunTime + 1,
+	}
+	recipient := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	boom := errors.New("domain read failed")
+	ibs := state.New(withdrawalErrReader{
+		StateReader: state.NewNoopReader(),
+		fail:        accounts.InternAddress(recipient),
+		err:         boom,
+	})
+
+	logger := log.New()
+	var eth1Engine rules.Engine
+	mergeEngine := New(eth1Engine)
+	withdrawals := []*types.Withdrawal{{Index: 7, Address: recipient, Amount: 1_000}}
+	syscall := func(accounts.Address, []byte) ([]byte, error) { return nil, nil }
+
+	_, err := mergeEngine.Finalize(chainConfig, header, ibs, nil, nil, withdrawals,
+		consensuschain.NewReader(chainConfig, nil, nil, logger), syscall, false, logger)
+
+	require.ErrorIs(t, err, boom)
+	require.Contains(t, err.Error(), "withdrawal 7")
 }


### PR DESCRIPTION
`Merge.Finalize` discarded the error from all four `AddBalance` calls — three block-reward kinds and the EIP-4895 withdrawal loop. On a state-read failure the reward or withdrawal is silently skipped and the block is finalized against wrong state instead of aborting.

`Finalize` already returns `error` and already propagates it from `CalculateRewards` and `ExecuteSystemWithdrawals` a few lines away, so this was drift rather than intent.

**Withdrawals are the reachable case.** Unlike the transaction paths, a withdrawal recipient has usually not been read earlier in the block, so `AddBalance` takes the cold path through `GetOrNewStateObject` into the state reader, where a domain read can genuinely fail.

## How other clients handle it

| client | withdrawal / reward application | error handling |
|---|---|---|
| **geth** | [`Beacon.Finalize`](https://github.com/ethereum/go-ethereum/blob/bb6401ee5f91cb5138aed19177603891a6f5ea60/consensus/beacon/consensus.go#L346) → [withdrawal loop L352-356](https://github.com/ethereum/go-ethereum/blob/bb6401ee5f91cb5138aed19177603891a6f5ea60/consensus/beacon/consensus.go#L352-L356) | [`StateDB.AddBalance` returns the previous balance, not an error](https://github.com/ethereum/go-ethereum/blob/bb6401ee5f91cb5138aed19177603891a6f5ea60/core/state/statedb.go#L443); DB failures latch in `dbErr` via [`setError`](https://github.com/ethereum/go-ethereum/blob/bb6401ee5f91cb5138aed19177603891a6f5ea60/core/state/statedb.go#L243) and abort at `Commit`. `Finalize` itself cannot fail |
| **reth** (alloy-evm) | [`apply_post_execution_changes`](https://github.com/alloy-rs/evm/blob/ce6b773ab958548e37fe195b21412a2a1638706e/crates/evm/src/eth/block.rs#L268-L273) collects rewards + withdrawals, then [`increment_balances` L294-298](https://github.com/alloy-rs/evm/blob/ce6b773ab958548e37fe195b21412a2a1638706e/crates/evm/src/eth/block.rs#L294-L298) | `.map_err(|_| BlockValidationError::IncrementBalanceFailed)?` — a **dedicated block-validation error for exactly this failure**. Underlying [`increment_balances` returns `Result<(), Self::Error>`](https://github.com/bluealloy/revm/blob/5199506d7290889a6943a916f96a8cd161299bf8/crates/database/interface/src/lib.rs#L290-L293) |
| **spec** | [`process_withdrawals`](https://github.com/ethereum/execution-specs/blob/2119b382cebe57d9953eb6252e927e130b1ca51c/src/ethereum/forks/prague/fork.py#L977-L996) → `create_ether` | state access is infallible in the Python model, so there is no error to drop |

Erigon is the only one of the three that surfaces a per-call error here, and therefore the only one that can drop it. reth treats the same failure as a block-validation error; geth makes it unrepresentable and catches it at commit time.

## Related

Same class of unchecked `Add`/`SubBalance`, split for reviewability:
- #22592 — `buyGas`, the selfdestruct opcodes, and `aura.applyRewards`
- still open: `ethash/rules.go:531-534` (PoW mining rewards) and `txn_executor.go:691,863` (burnt fees and the gas refund)
