### PR TITLE
db/state/statecfg: bump accounts history .v/.ef to v2.1/v3.1

### DIFF
--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -32,7 +32,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -100,6 +99,15 @@ func testDbAndDomainOfStep(t *testing.T, domainCfg statecfg.DomainCfg, aggStep u
 	t.Cleanup(d.Close)
 	d.DisableFsync()
 	return db, d
+}
+
+// requireFileNameMatches asserts the file name shape - base, step range and
+// extension - without pinning the schema version, which bumps independently.
+func requireFileNameMatches(t *testing.T, path, mask string) {
+	t.Helper()
+	matched, err := filepath.Match(mask, filepath.Base(path))
+	require.NoError(t, err)
+	require.Truef(t, matched, "%s does not match %s", path, mask)
 }
 
 func TestDomain_CollationBuild(t *testing.T) {
@@ -215,10 +223,9 @@ func testCollationBuild(t *testing.T, compressDomainVals bool) {
 		c, err := d.collate(ctx, 0, 0, 16, tx)
 
 		require.NoError(t, err)
-		require.True(t, strings.HasSuffix(c.valuesPath, "v2.0-accounts.0-1.kv"))
+		requireFileNameMatches(t, c.valuesPath, d.kvFileNameMask(0, 1))
 		require.Equal(t, 2, c.valuesCount)
-		require.True(t, strings.HasSuffix(c.historyPath, "v2.0"+
-			"-accounts.0-1.v"))
+		requireFileNameMatches(t, c.historyPath, d.History.vFileNameMask(0, 1))
 
 		require.Equal(t, seg.WordsAmount2PagesAmount(3, d.CompressorCfg.ValuesOnCompressedPage), 1) // 16 valus per page
 		require.Equal(t, 3, c.historyComp.Count())                                                  // no compression on collate
@@ -1511,9 +1518,9 @@ func TestDomain_CollationBuildInMem(t *testing.T) {
 	c, err := d.collate(ctx, 0, 0, maxTx, tx)
 
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(c.valuesPath, "v2.0-accounts.0-1.kv"))
+	requireFileNameMatches(t, c.valuesPath, d.kvFileNameMask(0, 1))
 	require.Equal(t, 3, c.valuesCount)
-	require.True(t, strings.HasSuffix(c.historyPath, "v2.0-accounts.0-1.v"))
+	requireFileNameMatches(t, c.historyPath, d.History.vFileNameMask(0, 1))
 
 	require.Equal(t, seg.WordsAmount2PagesAmount(int(3*maxTx), d.CompressorCfg.ValuesOnCompressedPage), 469) // because 646 values at one page
 	require.Equal(t, int(3*maxTx), c.historyComp.Count())                                                    // no compression on collate

--- a/db/state/statecfg/version_schema_gen.go
+++ b/db/state/statecfg/version_schema_gen.go
@@ -8,9 +8,9 @@ func InitSchemasGen() {
 	Schema.AccountsDomain.FileVersion.AccessorBT = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.AccountsDomain.FileVersion.DataKV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.AccountsDomain.FileVersion.AccessorKVEI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
-	Schema.AccountsDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
+	Schema.AccountsDomain.Hist.FileVersion.DataV = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.AccountsDomain.Hist.FileVersion.AccessorVI = version.Versions{version.Version{1, 2}, version.Version{1, 0}}
-	Schema.AccountsDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 0}, version.Version{1, 0}}
+	Schema.AccountsDomain.Hist.IiCfg.FileVersion.DataEF = version.Versions{version.Version{3, 1}, version.Version{1, 0}}
 	Schema.AccountsDomain.Hist.IiCfg.FileVersion.AccessorEFI = version.Versions{version.Version{2, 1}, version.Version{1, 0}}
 	Schema.BodiesBlock.FileVersion.AccessorIdx = version.Versions{version.Version{2, 0}, version.Version{1, 0}}
 	Schema.BodiesBlock.FileVersion.DataSeg = version.Versions{version.Version{1, 1}, version.Version{1, 0}}

--- a/db/state/statecfg/versions.yaml
+++ b/db/state/statecfg/versions.yaml
@@ -11,14 +11,14 @@ accounts:
             min: v1.0
     hist:
         v:
-            current: v2.0
+            current: v2.1
             min: v1.0
         vi:
             current: v1.2
             min: v1.0
     ii:
         ef:
-            current: v3.0
+            current: v3.1
             min: v1.0
         efi:
             current: v2.1


### PR DESCRIPTION
Follow-up to #22437 (absent-key delete dedup in `DomainDel`).

That fix stops recording redundant empty→empty rows in **accounts history**, so the contents of the accounts history data files change. This bumps their minor versions so regenerated / redistributed files are distinguished from the pre-fix contents:

| file | before | after |
|---|---|---|
| accounts `hist.v` | v2.0 | **v2.1** |
| accounts `ii.ef` | v3.0 | **v3.1** |

- Both move together — a mismatched `.v`/`.ef` pair (one bumped, one not) would be internally inconsistent (the `.ef` would list a txNum the `.v` no longer has).
- **Accounts only**: the full-domain duplicate sweep showed **0** consecutive-equal rows in storage/code/commitment (their delete paths never produce empty→empty in practice), so their versions are unchanged. 
- I decided to not update for other domains so that "release check of change hashes" is doable. If we find hash changed because of this change, we can also retroactively change the version for those domains.
- Accessors (`.vi`/`.efi`) are not bumped — only the underlying data content changes, matching the precedent in #21974.

Generated via `make versions-gen` from `versions.yaml` (not hand-edited).

## Coordination
This must land together with (or immediately alongside) #22437 — the version reflects the fix's output. Merging this without the fix would name un-deduped files v2.1; merging the fix without this would name deduped files v2.0 and let nodes mix differing v2.0 contents.