### PR TITLE
db/state: stop domain collation tests from pinning the accounts file version

### DIFF
--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -32,7 +32,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -100,6 +99,15 @@ func testDbAndDomainOfStep(t *testing.T, domainCfg statecfg.DomainCfg, aggStep u
 	t.Cleanup(d.Close)
 	d.DisableFsync()
 	return db, d
+}
+
+// requireFileNameMatches asserts the file name shape - base, step range and
+// extension - without pinning the schema version, which bumps independently.
+func requireFileNameMatches(t *testing.T, path, mask string) {
+	t.Helper()
+	matched, err := filepath.Match(mask, filepath.Base(path))
+	require.NoError(t, err)
+	require.Truef(t, matched, "%s does not match %s", path, mask)
 }
 
 func TestDomain_CollationBuild(t *testing.T) {
@@ -215,10 +223,9 @@ func testCollationBuild(t *testing.T, compressDomainVals bool) {
 		c, err := d.collate(ctx, 0, 0, 16, tx)
 
 		require.NoError(t, err)
-		require.True(t, strings.HasSuffix(c.valuesPath, "v2.0-accounts.0-1.kv"))
+		requireFileNameMatches(t, c.valuesPath, d.kvFileNameMask(0, 1))
 		require.Equal(t, 2, c.valuesCount)
-		require.True(t, strings.HasSuffix(c.historyPath, "v2.0"+
-			"-accounts.0-1.v"))
+		requireFileNameMatches(t, c.historyPath, d.History.vFileNameMask(0, 1))
 
 		require.Equal(t, seg.WordsAmount2PagesAmount(3, d.CompressorCfg.ValuesOnCompressedPage), 1) // 16 valus per page
 		require.Equal(t, 3, c.historyComp.Count())                                                  // no compression on collate
@@ -1511,9 +1518,9 @@ func TestDomain_CollationBuildInMem(t *testing.T) {
 	c, err := d.collate(ctx, 0, 0, maxTx, tx)
 
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(c.valuesPath, "v2.0-accounts.0-1.kv"))
+	requireFileNameMatches(t, c.valuesPath, d.kvFileNameMask(0, 1))
 	require.Equal(t, 3, c.valuesCount)
-	require.True(t, strings.HasSuffix(c.historyPath, "v2.0-accounts.0-1.v"))
+	requireFileNameMatches(t, c.historyPath, d.History.vFileNameMask(0, 1))
 
 	require.Equal(t, seg.WordsAmount2PagesAmount(int(3*maxTx), d.CompressorCfg.ValuesOnCompressedPage), 469) // because 646 values at one page
 	require.Equal(t, int(3*maxTx), c.historyComp.Count())                                                    // no compression on collate


### PR DESCRIPTION
`TestDomain_CollationBuild` and `TestDomain_CollationBuildInMem` assert the collated file names with a literal version prefix:

```go
require.True(t, strings.HasSuffix(c.valuesPath, "v2.0-accounts.0-1.kv"))
require.True(t, strings.HasSuffix(c.historyPath, "v2.0-accounts.0-1.v"))
```

So any accounts schema version bump fails them even though nothing is wrong — the file name is correct, only the version prefix moved. This is what turns #22600 (accounts hist `.v` → v2.1) red on `tests / tests-mac-linux`, at `domain_test.go:220` and `domain_test.go:1516`.

Match the existing `kvFileNameMask` / `vFileNameMask` globs (`*-accounts.0-1.kv`) instead. The assertion keeps what the test is about — base name, step range, extension — and drops what it should not own: the version, which `versions.yaml` already pins. `history_test.go:233` already derives its expected name from the schema rather than hardcoding it.

Verified by simulating the bump from #22600 locally: both tests fail at the same two lines as CI before this change and pass after, and the full `db/state` package is green with the bump reverted.