### PR TITLE
cl/block_collector, execution/types: decode only the header in Flush

### DIFF
--- a/cl/phase1/execution_client/block_collector/encode_block_bench_test.go
+++ b/cl/phase1/execution_client/block_collector/encode_block_bench_test.go
@@ -20,6 +20,8 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/common"
@@ -37,6 +39,40 @@ func benchPayload(txCount, txSize int) *cltypes.Eth1Block {
 	}
 	body := &types.RawBody{Transactions: txs, Withdrawals: []*types.Withdrawal{}}
 	return cltypes.NewEth1BlockFromHeaderAndBody(makeTestHeader(12345, common.Hash{}, nil), body, &clparams.MainnetBeaconConfig)
+}
+
+func BenchmarkDecodeBlock(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		txCount int
+		txSize  int
+	}{
+		{"empty", 0, 0},
+		{"100KB", 200, 500},
+		{"1MB", 500, 2048},
+	} {
+		txs := make([]types.Transaction, tc.txCount)
+		for i := range txs {
+			txs[i] = signedTestTx(b, uint64(i), make([]byte, tc.txSize)...)
+		}
+		bb := makeBeaconBlock(b, 1, 'a', common.Hash{}, txs...)
+
+		c := &PersistentBlockCollector{beaconChainCfg: &clparams.MainnetBeaconConfig}
+		c.mu.Lock()
+		encoded, err := c.encodeBlock(bb.Body.ExecutionPayload, bb.ParentRoot, nil)
+		require.NoError(b, err)
+		encoded = common.Copy(encoded)
+		c.mu.Unlock()
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, _, err := c.decodeBlock(encoded); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }
 
 func BenchmarkEncodeBlock(b *testing.B) {

--- a/cl/phase1/execution_client/block_collector/encode_block_bench_test.go
+++ b/cl/phase1/execution_client/block_collector/encode_block_bench_test.go
@@ -58,11 +58,13 @@ func BenchmarkDecodeBlock(b *testing.B) {
 		bb := makeBeaconBlock(b, 1, 'a', common.Hash{}, txs...)
 
 		c := &PersistentBlockCollector{beaconChainCfg: &clparams.MainnetBeaconConfig}
-		c.mu.Lock()
-		encoded, err := c.encodeBlock(bb.Body.ExecutionPayload, bb.ParentRoot, nil)
-		require.NoError(b, err)
-		encoded = common.Copy(encoded)
-		c.mu.Unlock()
+		encoded := func() []byte {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			encoded, err := c.encodeBlock(bb.Body.ExecutionPayload, bb.ParentRoot, nil)
+			require.NoError(b, err)
+			return common.Copy(encoded)
+		}()
 
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()

--- a/cl/phase1/execution_client/block_collector/encode_block_test.go
+++ b/cl/phase1/execution_client/block_collector/encode_block_test.go
@@ -29,12 +29,12 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-func signedTestTx(t *testing.T, nonce uint64) types.Transaction {
+func signedTestTx(t testing.TB, nonce uint64, data ...byte) types.Transaction {
 	t.Helper()
 	key, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	require.NoError(t, err)
 	to := common.HexToAddress("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")
-	txn, err := types.SignTx(types.NewTransaction(nonce, to, uint256.NewInt(1000), 21000, uint256.NewInt(1), nil), *types.LatestSignerForChainID(uint256.NewInt(1)), key)
+	txn, err := types.SignTx(types.NewTransaction(nonce, to, uint256.NewInt(1000), 21000, uint256.NewInt(1), data), *types.LatestSignerForChainID(uint256.NewInt(1)), key)
 	require.NoError(t, err)
 	return txn
 }
@@ -69,9 +69,12 @@ func TestEncodeDecodeBlockRoundTrip(t *testing.T) {
 		require.Equal(t, payload.BlockHash, decoded.Hash())
 		require.Equal(t, payload.BlockNumber, decoded.NumberU64())
 		require.Equal(t, payload.ParentHash, decoded.ParentHash())
-		require.Len(t, decoded.Transactions(), len(tc.txs))
+		// decodeBlock leaves transactions undecoded, so check the raw body bytes.
+		decodedTxs, err := types.DecodeTransactions(decoded.RawBody().Transactions)
+		require.NoError(t, err)
+		require.Len(t, decodedTxs, len(tc.txs))
 		for i, txn := range tc.txs {
-			require.Equal(t, txn.Hash(), decoded.Transactions()[i].Hash())
+			require.Equal(t, txn.Hash(), decodedTxs[i].Hash())
 		}
 	}
 }

--- a/cl/phase1/execution_client/block_collector/persistent_block_collector.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector.go
@@ -458,10 +458,6 @@ func (p *PersistentBlockCollector) decodeBlock(v []byte) (*types.Block, []byte, 
 	}
 
 	body := executionPayload.Body()
-	txs, err := types.DecodeTransactions(body.Transactions)
-	if err != nil {
-		return nil, nil, err
-	}
 
 	// Skip genesis block
 	if executionPayload.BlockNumber == 0 {
@@ -480,7 +476,7 @@ func (p *PersistentBlockCollector) decodeBlock(v []byte) (*types.Block, []byte, 
 		bal = executionPayload.BlockAccessList.Bytes()
 	}
 
-	return types.NewBlockFromStorageWithBinaryTxs(executionPayload.BlockHash, header, txs, body.Transactions, nil, body.Withdrawals), bal, nil
+	return types.NewBlockFromBinaryTxs(executionPayload.BlockHash, header, body.Transactions, nil, body.Withdrawals), bal, nil
 }
 
 func (p *PersistentBlockCollector) insertBatch(ctx context.Context, blocksBatch []*types.Block, balByHash map[common.Hash][]byte, inserted *uint64, lastInserted **types.Block) error {

--- a/cl/phase1/execution_client/block_collector/persistent_block_collector_test.go
+++ b/cl/phase1/execution_client/block_collector/persistent_block_collector_test.go
@@ -60,7 +60,7 @@ func makeTestHeader(number uint64, parent common.Hash, extra []byte) *types.Head
 // makeBeaconBlock builds a Deneb BeaconBlock whose ExecutionPayload carries the
 // given block number chained onto parent. forkTag seeds header.Extra so two blocks
 // at the same number produce distinct SSZ roots — mimicking competing beacon variants.
-func makeBeaconBlock(t *testing.T, number uint64, forkTag byte, parent common.Hash, txs ...types.Transaction) *cltypes.BeaconBlock {
+func makeBeaconBlock(t testing.TB, number uint64, forkTag byte, parent common.Hash, txs ...types.Transaction) *cltypes.BeaconBlock {
 	t.Helper()
 	block := types.NewBlock(makeTestHeader(number, parent, []byte{forkTag}), txs, nil, nil, []*types.Withdrawal{})
 
@@ -311,6 +311,39 @@ func TestFlushDropsRowsBelowFrozen(t *testing.T) {
 
 	require.Equal(t, []uint64{3}, h.insertedNumbers())
 	require.Equal(t, 0, countRowsAtOrAbove(t, h.collector.db, 0))
+}
+
+// makeBeaconBlockWithRawTxs is makeBeaconBlock for transaction payloads that are
+// not decodable as transactions. The header's TxHash is derived from the raw
+// bytes, exactly as RlpHeader derives it on the way back out.
+func makeBeaconBlockWithRawTxs(t *testing.T, number uint64, parent common.Hash, txs [][]byte) *cltypes.BeaconBlock {
+	t.Helper()
+	body := &types.RawBody{Transactions: txs, Withdrawals: []*types.Withdrawal{}}
+	header := types.NewBlock(makeTestHeader(number, parent, nil), nil, nil, nil, body.Withdrawals).Header()
+	header.TxHash = types.DeriveSha(types.BinaryTransactions(txs))
+
+	bb := cltypes.NewBeaconBlock(&clparams.MainnetBeaconConfig, clparams.DenebVersion)
+	bb.Body.ExecutionPayload = cltypes.NewEth1BlockFromHeaderAndBody(header, body, &clparams.MainnetBeaconConfig)
+	return bb
+}
+
+// TestFlushKeepsOpaqueTransactionBytes pins that Flush hands the stored
+// transaction bytes to the engine verbatim. The payload's own block hash already
+// commits to them, so bytes the collector cannot interpret as transactions must
+// still reach the engine rather than being dropped as an undecodable block —
+// which would make the following block look like a chain gap.
+func TestFlushKeepsOpaqueTransactionBytes(t *testing.T) {
+	h := newFlushTestHarness(t, 0)
+
+	// RLP lists with too few fields to be legacy transactions. The leading byte
+	// is >= 0x80, so RawBody() passes them through without re-wrapping.
+	opaqueTxs := [][]byte{{0xc1, 0x01}, {0xc2, 0x02, 0x03}}
+	require.NoError(t, h.collector.AddBlock(makeBeaconBlockWithRawTxs(t, 1, common.Hash{}, opaqueTxs)))
+
+	require.NoError(t, h.collector.Flush(t.Context()))
+
+	require.Equal(t, []uint64{1}, h.insertedNumbers())
+	require.Equal(t, opaqueTxs, h.inserted[0].RawBody().Transactions)
 }
 
 // plantMarker writes a sentinel file into the collector's persistDir; it

--- a/execution/types/block.go
+++ b/execution/types/block.go
@@ -1160,9 +1160,9 @@ func NewBlockFromStorageWithBinaryTxs(hash common.Hash, header *Header, txs []Tr
 	return b
 }
 
-// NewBlockFromBinaryTxs creates a Block whose transactions were never decoded.
-// Transactions() and Body() are empty on such a block; it is only usable by
-// consumers that go through Header() and RawBody().
+// NewBlockFromBinaryTxs creates a Block whose transactions were never decoded:
+// Transactions() is nil and Body() carries no transactions. Only consumers that
+// go through Header() and RawBody() may use such a block.
 func NewBlockFromBinaryTxs(hash common.Hash, header *Header, binaryTxs BinaryTransactions, uncles []*Header, withdrawals []*Withdrawal) *Block {
 	header.hash.Store(&hash)
 	return &Block{header: header, binaryTransactions: binaryTxs, uncles: uncles, withdrawals: withdrawals}

--- a/execution/types/block.go
+++ b/execution/types/block.go
@@ -1417,10 +1417,12 @@ func rlpFromBinaryTxn(binaryTxn []byte) []byte {
 // will probably be removed in favour of RawBlock. Also it panics
 func (b *Block) RawBody() *RawBody {
 	br := &RawBody{Uncles: b.uncles, Withdrawals: b.withdrawals}
-	// The cached binary encodings are authoritative when present: re-wrapping them
-	// into their rlp.EncodeToBytes form is cheaper than a per-tx struct re-encode,
-	// and a block built by NewBlockFromBinaryTxs has no decoded transactions at all.
-	if b.binaryTransactions != nil {
+	// Re-wrapping the cached encodings into their rlp.EncodeToBytes form is cheaper
+	// than a per-tx struct re-encode, and a NewBlockFromBinaryTxs block has no
+	// decoded transactions to fall back on.
+	binaryTxsCoverBlock := b.binaryTransactions != nil &&
+		(b.transactions == nil || len(b.binaryTransactions) == len(b.transactions))
+	if binaryTxsCoverBlock {
 		br.Transactions = make([][]byte, len(b.binaryTransactions))
 		for i, binaryTxn := range b.binaryTransactions {
 			br.Transactions[i] = rlpFromBinaryTxn(binaryTxn)

--- a/execution/types/block.go
+++ b/execution/types/block.go
@@ -1160,6 +1160,14 @@ func NewBlockFromStorageWithBinaryTxs(hash common.Hash, header *Header, txs []Tr
 	return b
 }
 
+// NewBlockFromBinaryTxs creates a Block whose transactions were never decoded.
+// Transactions() and Body() are empty on such a block; it is only usable by
+// consumers that go through Header() and RawBody().
+func NewBlockFromBinaryTxs(hash common.Hash, header *Header, binaryTxs BinaryTransactions, uncles []*Header, withdrawals []*Withdrawal) *Block {
+	header.hash.Store(&hash)
+	return &Block{header: header, binaryTransactions: binaryTxs, uncles: uncles, withdrawals: withdrawals}
+}
+
 // NewBlockWithHeader creates a block with the given header data. The
 // header data is copied, changes to header and to the field values
 // will not affect the block.
@@ -1408,15 +1416,18 @@ func rlpFromBinaryTxn(binaryTxn []byte) []byte {
 // RawBody creates a RawBody based on the block. It is not very efficient, so
 // will probably be removed in favour of RawBlock. Also it panics
 func (b *Block) RawBody() *RawBody {
-	br := &RawBody{Transactions: make([][]byte, len(b.transactions)), Uncles: b.uncles, Withdrawals: b.withdrawals}
-	// Re-wrap the cached binary encodings into their rlp.EncodeToBytes form —
-	// cheaper than a full per-tx struct re-encode.
-	if len(b.binaryTransactions) == len(b.transactions) {
+	br := &RawBody{Uncles: b.uncles, Withdrawals: b.withdrawals}
+	// The cached binary encodings are authoritative when present: re-wrapping them
+	// into their rlp.EncodeToBytes form is cheaper than a per-tx struct re-encode,
+	// and a block built by NewBlockFromBinaryTxs has no decoded transactions at all.
+	if b.binaryTransactions != nil {
+		br.Transactions = make([][]byte, len(b.binaryTransactions))
 		for i, binaryTxn := range b.binaryTransactions {
 			br.Transactions[i] = rlpFromBinaryTxn(binaryTxn)
 		}
 		return br
 	}
+	br.Transactions = make([][]byte, len(b.transactions))
 	for i, txn := range b.transactions {
 		var err error
 		br.Transactions[i], err = rlp.EncodeToBytes(txn)

--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -890,6 +890,11 @@ func TestBlockRawBodyFromBinaryTxsOnly(t *testing.T) {
 	reference := NewBlockFromStorage(common.Hash{}, &Header{}, txns, nil, nil)
 
 	require.Equal(t, reference.RawBody().Transactions, binaryOnly.RawBody().Transactions)
+
+	// A cache that does not cover every decoded transaction is not usable: the
+	// decoded transactions win rather than the raw body losing transactions.
+	partial := &Block{header: &Header{}, transactions: txns, binaryTransactions: binaryTxs[:1]}
+	require.Equal(t, reference.RawBody().Transactions, partial.RawBody().Transactions)
 }
 
 // TestBodyDecodeRejectsEmptyStringTx pins that an empty-string element

--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -864,6 +864,34 @@ func TestBlockRawBodyFromBinaryTxsMatchesEncoded(t *testing.T) {
 	}
 }
 
+// A Block built from binary tx bytes alone — without ever RLP-decoding them —
+// must produce the same RawBody() as one that carries the decoded transactions.
+func TestBlockRawBodyFromBinaryTxsOnly(t *testing.T) {
+	t.Parallel()
+	tr := NewTRand()
+
+	binaryTxs := make(BinaryTransactions, 4)
+	txns := make([]Transaction, len(binaryTxs))
+	for i := range binaryTxs {
+		for attempt := 0; txns[i] == nil && attempt < 1000; attempt++ {
+			var buf bytes.Buffer
+			if tr.RandTransaction(DynamicFeeTxType).MarshalBinary(&buf) != nil {
+				continue
+			}
+			binaryTxn := common.Copy(buf.Bytes())
+			if decoded, err := DecodeTransaction(binaryTxn); err == nil {
+				binaryTxs[i], txns[i] = binaryTxn, decoded
+			}
+		}
+		require.NotNil(t, txns[i], "could not generate a decodable transaction")
+	}
+
+	binaryOnly := NewBlockFromBinaryTxs(common.Hash{}, &Header{}, binaryTxs, nil, nil)
+	reference := NewBlockFromStorage(common.Hash{}, &Header{}, txns, nil, nil)
+
+	require.Equal(t, reference.RawBody().Transactions, binaryOnly.RawBody().Transactions)
+}
+
 // TestBodyDecodeRejectsEmptyStringTx pins that an empty-string element
 // (0x80) in the transactions list is rejected, not dropped as if it were
 // the list terminator.


### PR DESCRIPTION
`PersistentBlockCollector.Flush` decoded the full body of every stored block, when only the header is actually needed.

`decodeBlock` ran `types.DecodeTransactions` over each payload's transactions, but nothing downstream reads the decoded structs:

- `Eth1Block.RlpHeader` derives `TxHash` with `DeriveSha(BinaryTransactions(...))` — from the raw bytes.
- `engine.InsertBlocks` reaches the execution module via `ChainReaderWriterEth1.blocksToRaw`, i.e. `Block.Header()` + `Block.RawBody()`, and `RawBody()` serves the cached binary encodings.

So the typed transactions were built, held live in `blocksBatch` (up to 1000 blocks at a time), and dropped unread.

## Change

- `types.NewBlockFromBinaryTxs` — a `Block` carrying only the binary transaction encodings. `Transactions()`/`Body()` are empty on it; only `Header()`/`RawBody()` consumers may use it.
- `Block.RawBody()` treats `binaryTransactions` as authoritative whenever present, instead of gating on a length match with the decoded slice.
- `decodeBlock` uses it and drops the RLP decode.

`ExecutionClientDirect.NewPayload` deliberately keeps its decode — it needs the decode error to answer `PayloadStatusInvalidated`.

## Behaviour note

A stored block whose transaction bytes fail to RLP-decode is no longer skipped with a `Failed to decode block` warning. That skip was not a useful guard: the payload's own block hash commits to those bytes, execution rejects them later if they are malformed, and dropping a block mid-chain made the *next* one look like a gap. `TestFlushKeepsOpaqueTransactionBytes` pins the new behaviour.

## Benchmark

`BenchmarkDecodeBlock` (new), Apple M4 Max, 5 runs:

| case | ns/op | B/op | allocs/op |
| --- | --- | --- | --- |
| 100KB before | 233,987 | 296,715 | 861 |
| 100KB after | 157,234 | 141,063 | 260 |
| 1MB before | 1,293,077 | 2,276,326 | 2,066 |
| 1MB after | 1,121,513 | 1,119,242 | 563 |

−33% / −13% wall clock, ~−52% bytes and ~−70% allocations. The remaining time is dominated by snappy decompression and the payload SSZ decode.
