### PR TITLE
execution/vm: move CallContext.Contract ahead of the pointer-free Stack

### DIFF
--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -76,8 +76,11 @@ type CallContext struct {
 	cachedKey     accounts.StorageKey
 	cachedAddr    accounts.Address
 
-	Stack    Stack
+	// Contract carries pointers, so it must precede the pointer-free Stack:
+	// the GC scans a struct only up to its last pointer word (PtrBytes), and
+	// Stack.data is 32 KB it can skip entirely.
 	Contract Contract
+	Stack    Stack
 }
 
 // peekStorageKey returns the top-of-stack value as an interned StorageKey.


### PR DESCRIPTION
## What

Moves the `Contract` field ahead of `Stack` in `CallContext`. No fields added or removed; struct size is unchanged (33,040 bytes).

## Why

The Go GC scans a struct only up to its last pointer-bearing word — the runtime records this as the type's `PtrBytes`, and the mark phase walks the pointer bitmap over exactly that prefix. `Stack` embeds a 1024-entry `[1024]uint256.Int` (32 KiB, no pointers); `Contract` holds several pointers (`Code`, `analysis`, interned handles). With `Contract` sitting *after* `Stack`, `PtrBytes` covered the whole struct — **32,968 bytes** — so every live `CallContext` forced the GC to walk bitmap across the entire 32 KiB stack array to reach a handful of pointers behind it.

Moving `Contract` in front of `Stack` drops `PtrBytes` to **192 bytes**; the GC skips the stack array entirely. `CallContext` is pooled (`contextPool`) and instantiated per EVM call frame, so this is live on the hot execution path.

## Measurement

A/B on a fixed 40,000-block mainnet replay (blocks 25,503,855–25,543,854, parallel exec, archive datadir, cold page cache before each run, `STOP_AFTER_BLOCK` for an exact window). Baseline and patched runs interleaved and paired within each session, since absolute GC cost drifts across sessions.

GC mark CPU (assist + dedicated), 8 valid paired runs:

| pair | baseline | patched | Δ |
|---|---|---|---|
| 1 | 132.0 s | 129.3 s | −2.7 s |
| 2 | 133.1 s | 129.9 s | −3.2 s |
| 3 | 130.7 s | 126.4 s | −4.2 s |
| 4 | 135.6 s | 132.8 s | −2.8 s |
| 5 | 144.5 s | 145.2 s | +0.6 s |
| 6 | 135.6 s | 135.0 s | −0.6 s |
| 7 | 139.1 s | 136.1 s | −3.0 s |
| 8 | 141.6 s | 137.2 s | −4.4 s |

Mean **−2.5 s per ~68-min window (≈ −2% of mark CPU)**, paired t-test t≈−4.2, p≈0.004. Two pairs land near zero, so the effect is small and not visible in a single run.

**No end-to-end throughput change is claimed.** GC mark work is only ~0.5–0.6% of total process CPU on this workload, so a 2% reduction of that slice is far below the run-to-run noise in MGas/s (±3%).

Guardrails: `go test ./execution/vm/...` green; interpreter microbenchmarks (`BenchmarkCall`, `BenchmarkEVM_CREATE_500`, `BenchmarkSimpleLoop/*`, 10 reps, benchstat) statistically flat — `gas` and the cache-generation scalars are untouched near the front of the struct, so the L1 locality note on those fields still holds.

## Testing

Pure field-layout change, no behavior change (verified during development with a scratch `PtrBytes` assertion, 32,968 → 192, not committed since it would pin Go-internal type-descriptor layout). Per the TDD-exemption convention for mechanical/layout changes, no new test is added.
