### PR TITLE
ci: update hive version to latest commit with pre-staged fixtures support

### DIFF
--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,4 +1,6 @@
 {
   "hive_ref": "086c7556b09aa200d578cbf39e3e3cf26c8ac3eb",
+  "hive_eest_repository": "ethereum/hive",
+  "hive_eest_ref": "3184ac37d3dfbb9b8b0348ae70ea98bb61fa6f13",
   "execution_apis_ref": "f74de4b86e3b011384808c294c3d71f2854729a2"
 }

--- a/.github/workflows/hive-versions.json
+++ b/.github/workflows/hive-versions.json
@@ -1,6 +1,4 @@
 {
-  "hive_ref": "086c7556b09aa200d578cbf39e3e3cf26c8ac3eb",
-  "hive_eest_repository": "ethereum/hive",
-  "hive_eest_ref": "3184ac37d3dfbb9b8b0348ae70ea98bb61fa6f13",
+  "hive_ref": "3184ac37d3dfbb9b8b0348ae70ea98bb61fa6f13",
   "execution_apis_ref": "f74de4b86e3b011384808c294c3d71f2854729a2"
 }

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -126,17 +126,14 @@ jobs:
           path: erigon-full
           persist-credentials: false
 
-      - name: Read pinned Hive EEST checkout
+      - name: Read pinned Hive ref
         id: hive-version
-        run: |
-          versions=erigon-full/.github/workflows/hive-versions.json
-          echo "repository=$(jq -r .hive_eest_repository "$versions")" >> "$GITHUB_OUTPUT"
-          echo "ref=$(jq -r .hive_eest_ref "$versions")" >> "$GITHUB_OUTPUT"
+        run: echo "ref=$(jq -r .hive_ref erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
         uses: actions/checkout@v7
         with:
-          repository: ${{ steps.hive-version.outputs.repository }}
+          repository: ethereum/hive
           ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
           persist-credentials: false

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -126,14 +126,17 @@ jobs:
           path: erigon-full
           persist-credentials: false
 
-      - name: Read pinned Hive ref
+      - name: Read pinned Hive EEST checkout
         id: hive-version
-        run: echo "ref=$(jq -r .hive_ref erigon-full/.github/workflows/hive-versions.json)" >> "$GITHUB_OUTPUT"
+        run: |
+          versions=erigon-full/.github/workflows/hive-versions.json
+          echo "repository=$(jq -r .hive_eest_repository "$versions")" >> "$GITHUB_OUTPUT"
+          echo "ref=$(jq -r .hive_eest_ref "$versions")" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Hive
         uses: actions/checkout@v7
         with:
-          repository: ethereum/hive
+          repository: ${{ steps.hive-version.outputs.repository }}
           ref: ${{ steps.hive-version.outputs.ref }}
           path: hive
           persist-credentials: false
@@ -225,8 +228,8 @@ jobs:
       # them every run. Restore the base-branch cache warmed by
       # cache-warming-eest-fixtures.yml (restore-only — never saved here); on a
       # miss, fetch via the hardened tools/test-fixtures.sh. Then stage the
-      # tarball into the sim build context, where the (local-fixtures) eels
-      # Dockerfile extracts it for `consume --input /fixtures`.
+      # tarball into the sim build context, where the eels image keeps it
+      # compressed until startup and runs `consume --input /fixtures`.
       - name: Restore EEST fixtures cache
         id: eest-cache
         uses: actions/cache/restore@v6
@@ -257,7 +260,6 @@ jobs:
           if [ -n "$branch" ]; then
             branch_arg="--sim.buildarg branch=$branch"
           fi
-          fixtures_url=$(jq -r --arg t '${{ matrix.fixtures-tarball }}' '.[$t].url' erigon-full/test-fixtures.json)
           cd hive
           docker ps
           run_suite() {
@@ -268,7 +270,7 @@ jobs:
             # image-build/registry/clone failure); a completed run is judged on its first result.
             local attempt=1 max_attempts=3
             while true; do
-              ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures="$fixtures_url" ${branch_arg} ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || true
+              ./hive -docker.output -docker.auth --sim ethereum/eels/"${1}" --sim.limit="${2}" --sim.parallelism=12 --client erigon --docker.nocache=true --sim.limit.exact=false --sim.buildarg fixtures=/fixtures ${branch_arg} ${{ matrix.extra-hive-flags }} 2>&1 | tee output.log || true
               status_line=$(tail -2 output.log | head -1 | sed -r "s/\x1B\[[0-9;]*[a-zA-Z]//g")
               suites=$(echo "$status_line" | sed -n 's/.*suites=\([0-9]*\).*/\1/p')
               if [ -z "$suites" ]; then


### PR DESCRIPTION
https://github.com/ethereum/hive/pull/1577 got merged in upstream Hive so we can now switch back to passing our GitHub cached fixtures directly to EELS