### PR TITLE
execution: isolate block builders from shared branch cache

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -187,7 +187,10 @@ func PickTrieVariant() commitment.TrieVariant {
 }
 
 func NewSharedDomains(ctx context.Context, tx kv.TemporalTx, logger log.Logger, opts ...SharedDomainOption) (*SharedDomains, error) {
-	o := sharedDomainOptions{trieCfg: commitment.DefaultTrieConfig(), useSharedBranchCache: true}
+	o := sharedDomainOptions{
+		trieCfg:              commitment.DefaultTrieConfig(),
+		useSharedBranchCache: true,
+	}
 	o.trieCfg.Variant = PickTrieVariant()
 	for _, opt := range opts {
 		opt(&o)

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -187,7 +187,7 @@ func PickTrieVariant() commitment.TrieVariant {
 }
 
 func NewSharedDomains(ctx context.Context, tx kv.TemporalTx, logger log.Logger, opts ...SharedDomainOption) (*SharedDomains, error) {
-	o := sharedDomainOptions{trieCfg: commitment.DefaultTrieConfig()}
+	o := sharedDomainOptions{trieCfg: commitment.DefaultTrieConfig(), useSharedBranchCache: true}
 	o.trieCfg.Variant = PickTrieVariant()
 	for _, opt := range opts {
 		opt(&o)
@@ -207,7 +207,7 @@ func NewSharedDomains(ctx context.Context, tx kv.TemporalTx, logger log.Logger, 
 	// importing db/state directly — db/state already imports execctx, so
 	// the reverse import would create a cycle.
 	var branchCache *commitment.BranchCache
-	if p, ok := tx.AggTx().(commitment.BranchCacheProvider); ok {
+	if p, ok := tx.AggTx().(commitment.BranchCacheProvider); ok && o.useSharedBranchCache {
 		branchCache = p.BranchCache()
 	}
 	sd.branchCache = branchCache
@@ -218,7 +218,7 @@ func NewSharedDomains(ctx context.Context, tx kv.TemporalTx, logger log.Logger, 
 
 	// The pin controller is aggregator-scoped (co-located with branchCache) so pin
 	// residency ages by block-access recency across all SharedDomains, not per-SD.
-	if p, ok := tx.AggTx().(commitment.AdaptivePinControllerProvider); ok {
+	if p, ok := tx.AggTx().(commitment.AdaptivePinControllerProvider); ok && o.useSharedBranchCache {
 		sd.adaptivePinController = p.AdaptivePinController()
 	}
 
@@ -1203,11 +1203,8 @@ func (sd *SharedDomains) getLatestMetered(domain kv.Domain, tx kv.TemporalTx, k 
 	}
 
 	// branchCache sits between sd.mem/parent.mem and the aggTx files for
-	// CommitmentDomain only. It mirrors MDBX-flushed bytes; writers' fresh
-	// bytes are held in sd.mem above, so a cache hit here is always
-	// equivalent to reading from MDBX. Refreshed per-key by sd.Flush and
-	// evicted by txN watermark on unwind, so a cache hit never coexists
-	// with a newer MDBX state.
+	// CommitmentDomain only. Snapshot-isolated readers must disable it because
+	// concurrent commits can advance the cache beyond their transaction view.
 	if domain == kv.CommitmentDomain && sd.branchCache != nil {
 		if cv, cStepU64, ok := sd.branchCache.Get(k); ok {
 			// Get returns the on-disk step index directly — do NOT divide by

--- a/db/state/execctx/options.go
+++ b/db/state/execctx/options.go
@@ -19,7 +19,8 @@ package execctx
 import "github.com/erigontech/erigon/execution/commitment"
 
 type sharedDomainOptions struct {
-	trieCfg commitment.TrieConfig
+	trieCfg              commitment.TrieConfig
+	useSharedBranchCache bool
 }
 
 // SharedDomainOption configures NewSharedDomains.
@@ -33,6 +34,11 @@ func WithTrieConfig(cfg commitment.TrieConfig) SharedDomainOption {
 // WithoutDeferredBranchUpdates disables deferred branch updates (read-only / one-shot domains).
 func WithoutDeferredBranchUpdates() SharedDomainOption {
 	return func(o *sharedDomainOptions) { o.trieCfg.DeferBranchUpdates = false }
+}
+
+// WithoutSharedBranchCache keeps commitment reads within the transaction snapshot.
+func WithoutSharedBranchCache() SharedDomainOption {
+	return func(o *sharedDomainOptions) { o.useSharedBranchCache = false }
 }
 
 // WithSequentialCommitment forces the sequential HexPatriciaHashed trie regardless

--- a/execution/builder/builder.go
+++ b/execution/builder/builder.go
@@ -145,7 +145,7 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 		}
 	}
 
-	sd, err := execctx.NewSharedDomains(b.ctx, compositeTx, b.logger, execctx.WithoutDeferredBranchUpdates())
+	sd, err := execctx.NewSharedDomains(b.ctx, compositeTx, b.logger, execctx.WithoutDeferredBranchUpdates(), execctx.WithoutSharedBranchCache())
 	if err != nil {
 		return nil, err
 	}

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -600,7 +600,6 @@ func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	m := execmoduletester.New(t, execmoduletester.WithChainConfig(chain.AllProtocolChanges))
-
 	parentChain, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(_ int, gen *blockgen.BlockGen) {
 		tx, txErr := types.SignTx(
 			types.NewTransaction(0, common.Address{1}, uint256.NewInt(10_000), 50_000, uint256.NewInt(m.Genesis.BaseFee().Uint64()), nil),
@@ -613,7 +612,6 @@ func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, m.InsertChain(parentChain))
 	parent := parentChain.TopBlock
-
 	builderTx, err := types.SignTx(
 		types.NewTransaction(1, common.Address{2}, uint256.NewInt(20_000), 50_000, uint256.NewInt(parent.BaseFee().Uint64()), nil),
 		*types.LatestSignerForChainID(m.ChainConfig.ChainID),
@@ -631,7 +629,6 @@ func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
 		gen.AddTx(siblingTx)
 	})
 	require.NoError(t, err)
-
 	provider := &blockingTxnProvider{
 		ready:     make(chan struct{}),
 		release:   make(chan struct{}, 1),
@@ -644,7 +641,6 @@ func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
 		default:
 		}
 	}()
-
 	parentBeaconBlockRoot := randomHash()
 	payloadID, err := assembleBlock(ctx, m.ExecModule, &builder.Parameters{
 		ParentHash:            parent.Hash(),
@@ -656,13 +652,11 @@ func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
 		CustomTxnProvider:     provider,
 	})
 	require.NoError(t, err)
-
 	select {
 	case <-provider.ready:
 	case <-time.After(10 * time.Second):
 		t.Fatal("builder did not reach transaction selection")
 	}
-
 	require.NoError(t, insertValidateAndUfc1By1(ctx, m.ExecModule, siblingChain.Blocks))
 	provider.release <- struct{}{}
 	select {
@@ -670,13 +664,11 @@ func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("builder did not finish transaction selection")
 	}
-
 	built, err := getAssembledBlock(ctx, m.ExecModule, payloadID)
 	require.NoError(t, err)
 	require.Equal(t, parent.Hash(), built.ParentHash())
 	require.Len(t, built.Transactions(), 1)
 	require.Equal(t, builderTx.Hash(), built.Transactions()[0].Hash())
-
 	status, err := insertBlocks(ctx, m.ExecModule, []*types.Block{built})
 	require.NoError(t, err)
 	require.Equal(t, execmodule.ExecutionStatusSuccess, status)

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -56,7 +57,35 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
+	"github.com/erigontech/erigon/txnprovider"
 )
+
+type blockingTxnProvider struct {
+	ready     chan struct{}
+	release   chan struct{}
+	exhausted chan struct{}
+	txns      []types.Transaction
+	readyOnce sync.Once
+	emptyOnce sync.Once
+}
+
+func (p *blockingTxnProvider) ProvideTxns(ctx context.Context, _ ...txnprovider.ProvideOption) ([]types.Transaction, error) {
+	first := false
+	p.readyOnce.Do(func() {
+		first = true
+		close(p.ready)
+	})
+	if first {
+		select {
+		case <-p.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return p.txns, nil
+	}
+	p.emptyOnce.Do(func() { close(p.exhausted) })
+	return nil, nil
+}
 
 func TestValidateChainWithLastTxNumOfBlockAtStepBoundary(t *testing.T) {
 	// See https://github.com/erigontech/erigon/issues/18823
@@ -565,6 +594,95 @@ func TestAssembleBlock(t *testing.T) {
 
 	err = insertValidateAndUfc1By1(ctx, exec, []*types.Block{block})
 	require.NoError(t, err)
+}
+
+func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	m := execmoduletester.New(t, execmoduletester.WithChainConfig(chain.AllProtocolChanges))
+
+	parentChain, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(_ int, gen *blockgen.BlockGen) {
+		tx, txErr := types.SignTx(
+			types.NewTransaction(0, common.Address{1}, uint256.NewInt(10_000), 50_000, uint256.NewInt(m.Genesis.BaseFee().Uint64()), nil),
+			*types.LatestSignerForChainID(m.ChainConfig.ChainID),
+			m.Key,
+		)
+		require.NoError(t, txErr)
+		gen.AddTx(tx)
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(parentChain))
+	parent := parentChain.TopBlock
+
+	builderTx, err := types.SignTx(
+		types.NewTransaction(1, common.Address{2}, uint256.NewInt(20_000), 50_000, uint256.NewInt(parent.BaseFee().Uint64()), nil),
+		*types.LatestSignerForChainID(m.ChainConfig.ChainID),
+		m.Key,
+	)
+	require.NoError(t, err)
+	builderTx.SetSender(accounts.InternAddress(m.Address))
+	siblingTx, err := types.SignTx(
+		types.NewTransaction(1, common.Address{3}, uint256.NewInt(30_000), 50_000, uint256.NewInt(parent.BaseFee().Uint64()), nil),
+		*types.LatestSignerForChainID(m.ChainConfig.ChainID),
+		m.Key,
+	)
+	require.NoError(t, err)
+	siblingChain, err := blockgen.GenerateChain(m.ChainConfig, parent, m.Engine, m.DB, 1, func(_ int, gen *blockgen.BlockGen) {
+		gen.AddTx(siblingTx)
+	})
+	require.NoError(t, err)
+
+	provider := &blockingTxnProvider{
+		ready:     make(chan struct{}),
+		release:   make(chan struct{}, 1),
+		exhausted: make(chan struct{}),
+		txns:      []types.Transaction{builderTx},
+	}
+	defer func() {
+		select {
+		case provider.release <- struct{}{}:
+		default:
+		}
+	}()
+
+	parentBeaconBlockRoot := randomHash()
+	payloadID, err := assembleBlock(ctx, m.ExecModule, &builder.Parameters{
+		ParentHash:            parent.Hash(),
+		Timestamp:             parent.Time() + 1,
+		PrevRandao:            parent.Header().MixDigest,
+		SuggestedFeeRecipient: common.Address{4},
+		Withdrawals:           make([]*types.Withdrawal, 0),
+		ParentBeaconBlockRoot: &parentBeaconBlockRoot,
+		CustomTxnProvider:     provider,
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-provider.ready:
+	case <-time.After(10 * time.Second):
+		t.Fatal("builder did not reach transaction selection")
+	}
+
+	require.NoError(t, insertValidateAndUfc1By1(ctx, m.ExecModule, siblingChain.Blocks))
+	provider.release <- struct{}{}
+	select {
+	case <-provider.exhausted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("builder did not finish transaction selection")
+	}
+
+	built, err := getAssembledBlock(ctx, m.ExecModule, payloadID)
+	require.NoError(t, err)
+	require.Equal(t, parent.Hash(), built.ParentHash())
+	require.Len(t, built.Transactions(), 1)
+	require.Equal(t, builderTx.Hash(), built.Transactions()[0].Hash())
+
+	status, err := insertBlocks(ctx, m.ExecModule, []*types.Block{built})
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, status)
+	validation, err := validateChain(ctx, m.ExecModule, built.Header())
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusSuccess, validation.ValidationStatus)
 }
 
 func TestAssembleBlockWithFreshlyAddedTxns(t *testing.T) {

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -635,12 +635,6 @@ func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
 		exhausted: make(chan struct{}),
 		txns:      []types.Transaction{builderTx},
 	}
-	defer func() {
-		select {
-		case provider.release <- struct{}{}:
-		default:
-		}
-	}()
 	parentBeaconBlockRoot := randomHash()
 	payloadID, err := assembleBlock(ctx, m.ExecModule, &builder.Parameters{
 		ParentHash:            parent.Hash(),
@@ -652,6 +646,13 @@ func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
 		CustomTxnProvider:     provider,
 	})
 	require.NoError(t, err)
+	defer func() {
+		select {
+		case provider.release <- struct{}{}:
+		default:
+		}
+		_, _ = getAssembledBlock(context.Background(), m.ExecModule, payloadID)
+	}()
 	select {
 	case <-provider.ready:
 	case <-time.After(10 * time.Second):


### PR DESCRIPTION
fixes https://github.com/erigontech/erigon/issues/22254
fixes https://github.com/erigontech/erigon/issues/22152
relates to https://github.com/erigontech/erigon/pull/22198 (smaller version of it just for block building)

## Summary

Block builders retain a read-only state snapshot while competing sibling blocks can advance the aggregator-wide commitment `BranchCache`. Mixing those views can seal a state root that clean payload execution rejects.

This change:

- Detaches payload builders from the shared branch cache and its adaptive pin controller.
- Keeps the fix scoped to block production; RPC paths are unchanged.
- Adds a deterministic regression that pauses a build, commits a competing sibling, resumes the build, and validates the resulting payload.

The regression fails before the fix with `wrong trie root` and passes afterward.

## Verification

- Regression passed 50 consecutive runs.
- Race detector passed.
- Affected package tests passed.
- `make lint` passed repeatedly.
- `make erigon integration` passed.
