### PR TITLE
stagedsync: `minimal` node downloaded all files

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -605,6 +605,13 @@ type TemporalRwTx interface {
 	Unwind(ctx context.Context, txNumUnwindTo uint64, changeset *[DomainLen][]DomainEntryDiff) error
 }
 
+// CanReopenUnderlyingFilesTx is implemented by temporal txs (and wrappers over
+// them) that pin aggregator/block-files views at begin-time and can refresh
+// those views to pick up files opened later in the same tx.
+type CanReopenUnderlyingFilesTx interface {
+	ForceReopenUnderlyingFilesTx()
+}
+
 type TemporalPutDel interface {
 	// DomainPut
 	// Optimizations:

--- a/db/kv/membatchwithdb/memory_mutation.go
+++ b/db/kv/membatchwithdb/memory_mutation.go
@@ -607,6 +607,14 @@ func (m *MemoryMutation) BlockFilesRoTx() *blocksnapshots.View {
 	return nil
 }
 
+func (m *MemoryMutation) ForceReopenUnderlyingFilesTx() {
+	p, ok := m.db.(kv.CanReopenUnderlyingFilesTx)
+	if !ok {
+		panic(fmt.Sprintf("snapshots stage requires a tx that can ForceReopenUnderlyingFilesTx, got %T", m.db))
+	}
+	p.ForceReopenUnderlyingFilesTx()
+}
+
 func (m *MemoryMutation) Count(bucket string) (uint64, error) {
 	panic("not implemented")
 }

--- a/db/snapshotsync/freezeblocks/block_reader_test.go
+++ b/db/snapshotsync/freezeblocks/block_reader_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/recsplit"
@@ -559,4 +560,46 @@ func TestCanonicalHashCache_SnapshotPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ok2)
 	assert.Equal(t, header.Hash(), hash2)
+}
+
+// TestTxBlockView_StaleUntilReopen reproduces the minimal-mode history-download
+// regression: a temporal tx pins its block-files view at begin-time, so body
+// segments opened afterwards stay invisible to reads through that tx until the
+// tx reopens its underlying-files view. When they stayed invisible, the
+// snapshots stage's download filter walked an empty body view, couldn't compute
+// the history prune cutoff, and downloaded every history file.
+func TestTxBlockView_StaleUntilReopen(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+	db := temporaltest.NewTestDB(t, dirs)
+	logger := log.New()
+
+	snapshots := db.(HasBlockFiles).DebugBlockFiles()
+	blockReader := NewBlockReader(snapshots, nil)
+
+	// Begin the tx BEFORE any block segments exist: it pins an empty view.
+	rwTx, err := db.BeginRw(t.Context())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+
+	bodiesInTxView := func() int {
+		view, release := blockReader.view(rwTx)
+		defer release()
+		return len(view.Bodies())
+	}
+	require.Equal(t, 0, bodiesInTxView())
+
+	// Create and open header/body/tx segments after the tx began.
+	ver := version.V1_0
+	createTestSegmentFile(t, 1, 1000, snaptype2.Enums.Headers, dirs.Snap, ver, logger)
+	createTestSegmentFile(t, 1, 1000, snaptype2.Enums.Bodies, dirs.Snap, ver, logger)
+	createTestSegmentFile(t, 1, 1000, snaptype2.Enums.Transactions, dirs.Snap, ver, logger)
+	require.NoError(t, snapshots.OpenFolder())
+	require.Equal(t, uint64(999), snapshots.SegmentsMax())
+
+	// Regression: the tx still sees its stale, empty view.
+	require.Equal(t, 0, bodiesInTxView())
+
+	// Fix: reopening the tx's underlying-files view exposes the bodies.
+	rwTx.(kv.CanReopenUnderlyingFilesTx).ForceReopenUnderlyingFilesTx()
+	require.Positive(t, bodiesInTxView())
 }

--- a/db/snapshotsync/snapshotsync.go
+++ b/db/snapshotsync/snapshotsync.go
@@ -436,6 +436,9 @@ func SyncSnapshots(
 			if err != nil {
 				return fmt.Errorf("error opening segments after to block filter deletion: %w", err)
 			}
+			// RetireFilesAbove + OpenSegments changed the on-disk file set; refresh the
+			// tx's pinned view so getMinimumBlocksToDownload below reads the new set.
+			tx.(kv.CanReopenUnderlyingFilesTx).ForceReopenUnderlyingFilesTx()
 		}
 
 		txNumsReader := blockReader.TxnumReader()

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -108,6 +108,18 @@ func StageSnapshotsCfg(db kv.TemporalRwDB,
 	return cfg
 }
 
+// mustReopenUnderlyingFilesTx refreshes the tx's pinned block-files/aggregator
+// view so files opened earlier in this stage are visible to reads made through
+// this tx. Panics rather than silently skipping: a tx that can't reopen would
+// reintroduce stale-view bugs (e.g. minimal-mode history pruning downloading all files).
+func mustReopenUnderlyingFilesTx(tx kv.RwTx) {
+	reopener, ok := tx.(kv.CanReopenUnderlyingFilesTx)
+	if !ok {
+		panic(fmt.Sprintf("snapshots stage requires a tx that can ForceReopenUnderlyingFilesTx, got %T", tx))
+	}
+	reopener.ForceReopenUnderlyingFilesTx()
+}
+
 func SpawnStageSnapshots(s *StageState, ctx context.Context, tx kv.RwTx, cfg SnapshotsCfg, logger log.Logger) (err error) {
 	if err := DownloadAndIndexSnapshotsIfNeed(s, ctx, tx, cfg, logger); err != nil {
 		return err
@@ -216,6 +228,8 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		return err
 	}
 
+	mustReopenUnderlyingFilesTx(tx)
+
 	if err := snapshotsync.SyncSnapshots(
 		ctx,
 		s.LogPrefix(),
@@ -285,9 +299,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		return err
 	}
 
-	if temporal, ok := tx.(*temporal.RwTx); ok {
-		temporal.ForceReopenUnderlyingFilesTx() // otherwise next stages will not see just-indexed-files
-	}
+	mustReopenUnderlyingFilesTx(tx) // otherwise next stages will not see just-indexed-files
 
 	// It's ok to notify before tx.Commit(), because RPCDaemon does read list of files by gRPC (not by reading from db)
 	if cfg.notifier.Events != nil {
@@ -306,9 +318,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		return fmt.Errorf("FillDBFromSnapshots: %w", err)
 	}
 
-	if temporal, ok := tx.(*temporal.RwTx); ok {
-		temporal.ForceReopenUnderlyingFilesTx() // otherwise next stages will not see just-indexed-files
-	}
+	mustReopenUnderlyingFilesTx(tx) // otherwise next stages will not see just-indexed-files
 
 	// In E3, the post-execution state is in domain files. After FillDBFromSnapshots,
 	// snapshot domain state may be ahead of the Execution stage progress (which is 0


### PR DESCRIPTION
fix for: `--prune.mode=minimal` downloaded all files



## Test

`TestTxBlockView_StaleUntilReopen` pins the invariant: a tx that opened body segments after begin-time sees an empty view until it reopens its underlying-files view.
