### PR TITLE
unwind: overlay-prune still has systemTx after unwind

### DIFF
--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -1004,6 +1004,7 @@ func ReadHeaderByHash(db kv.Getter, hash common.Hash) (*types.Header, error) {
 	return ReadHeader(db, hash, *number), nil
 }
 
+// DeleteNewerEpochs drops [blockNum, ∞)
 func DeleteNewerEpochs(tx kv.RwTx, number uint64) error {
 	if err := tx.ForEach(kv.PendingEpoch, hexutil.EncodeTs(number), func(k, v []byte) error {
 		return tx.Delete(kv.PendingEpoch, k)

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -645,6 +645,7 @@ func (sd *SharedDomains) GetDiffset(tx kv.RwTx, blockHash common.Hash, blockNumb
 	return d, ok, err
 }
 
+// Unwind drops [txNumUnwindTo, ∞)
 func (sd *SharedDomains) Unwind(txNumUnwindTo uint64, changeset *[kv.DomainLen][]kv.DomainEntryDiff) {
 	sd.mem.Unwind(txNumUnwindTo, changeset)
 	// Tx/epoch-aware unwind of the commitment BranchCache: every cached branch

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -252,6 +252,56 @@ func TestSharedDomain_UnwindDoesNotRestoreOverlayForNewKey(t *testing.T) {
 		unwindTarget, writeTxNum, v)
 }
 
+// Unwind(t) prunes overlay writes in [t, ∞) and keeps [0, t); t is the resume
+// block's begin-system txNum, so the boundary write itself must not survive.
+func TestSharedDomain_UnwindPrunesBoundaryTxNum(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDb(t, uint64(100))
+	ctx := t.Context()
+
+	rwTx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+
+	domains, err := execctx.NewSharedDomains(ctx, rwTx, log.New())
+	require.NoError(t, err)
+	defer domains.Close()
+
+	addr := common.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7")
+	keptSlot := common.HexToHash("0x01")
+	keptKey := composite(addr[:], keptSlot[:])
+	keptVal := []byte{0x0a}
+	boundarySlot := common.HexToHash("0x02")
+	boundaryKey := composite(addr[:], boundarySlot[:])
+	boundaryVal := []byte{0x0b}
+	const boundaryTxNum uint64 = 100
+
+	committedCs := &changeset.StateChangeSet{}
+	domains.SetChangesetAccumulator(committedCs)
+	domains.SetTxNum(boundaryTxNum - 1)
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, rwTx, keptKey, keptVal, boundaryTxNum-1, nil))
+
+	unwoundCs := &changeset.StateChangeSet{}
+	domains.SetChangesetAccumulator(unwoundCs)
+	domains.SetTxNum(boundaryTxNum)
+	require.NoError(t, domains.DomainPut(kv.StorageDomain, rwTx, boundaryKey, boundaryVal, boundaryTxNum, nil))
+
+	var diffSet [kv.DomainLen][]kv.DomainEntryDiff
+	for idx, d := range unwoundCs.Diffs {
+		diffSet[idx] = d.GetDiffSet()
+	}
+	domains.Unwind(boundaryTxNum, &diffSet)
+
+	v, _, err := domains.GetLatest(kv.StorageDomain, rwTx, boundaryKey)
+	require.NoError(t, err)
+	require.Empty(t, v, "write at exactly the boundary txNum %d must be pruned", boundaryTxNum)
+
+	v, _, err = domains.GetLatest(kv.StorageDomain, rwTx, keptKey)
+	require.NoError(t, err)
+	require.Equal(t, keptVal, v, "write below the boundary txNum must survive")
+}
+
 // TestNewSharedDomains_StateAheadOfBlocks verifies that when the persisted
 // commitment state is ahead of the TxNums index (catch-up scenario),
 // NewSharedDomains returns ErrBehindCommitment but the SharedDomains itself

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -548,27 +548,20 @@ func (sd *TemporalMemBatch) GetDiffset(tx kv.RwTx, blockHash common.Hash, blockN
 	return changeset.ReadDiffSet(tx, blockNumber, blockHash)
 }
 
+// Unwind drops [unwindToTxNum, ∞)
 func (sd *TemporalMemBatch) Unwind(unwindToTxNum uint64, changeset *[kv.DomainLen][]kv.DomainEntryDiff) {
 	sd.latestStateLock.Lock()
 	defer sd.latestStateLock.Unlock()
 
 	sd.unwindToTxNum = unwindToTxNum
 
-	// Drop overlay entries stamped with txNum > unwindToTxNum. Without this,
-	// getLatest returns entries written inside the unwound range because it
-	// picks dataWithTxNums[len-1] without consulting sd.unwindToTxNum — the
-	// unwindChangeset fallback below is only reachable on an overlay miss.
-	// Observed as post-Fusaka gas-used mismatches after forkchoice-driven
-	// unwinds (an SSTORE on a slot first-written inside the unwound range
-	// charges SSTORE_RESET instead of SSTORE_SET — a 17100 gas shortfall
-	// per slot). Keys whose slice empties out are removed so the
-	// unwindChangeset fallback can supply the pre-unwind answer.
 	pruneSlice := func(entries []dataWithTxNum) []dataWithTxNum {
 		kept := entries[:0]
 		for _, e := range entries {
-			if e.txNum <= unwindToTxNum {
-				kept = append(kept, e)
+			if e.txNum >= unwindToTxNum { // drop [unwindToTxNum, ∞)
+				continue
 			}
+			kept = append(kept, e)
 		}
 		return kept
 	}

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -178,18 +178,15 @@ func findExecutedDiffsetAtHeight(ctx context.Context, rwTx kv.TemporalRwTx, br d
 }
 
 func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwTx kv.TemporalRwTx, ctx context.Context, cfg ExecuteBlockCfg, accumulator *shards.Accumulator, logger log.Logger) (err error) {
+	dropStateFromBlockNum := u.UnwindPoint + 1
 	br := cfg.blockReader
-	txNumsReader := br.TxnumReader()
-
-	// unwind all txs of u.UnwindPoint block. 1 txn in begin/end of block - system txs
-	txNum, err := txNumsReader.Min(ctx, rwTx, u.UnwindPoint+1)
-	if err != nil {
-		return err
-	}
 
 	t := time.Now()
+	defer mxState3Unwind.ObserveDuration(t)
+
 	var changeSet *[kv.DomainLen][]kv.DomainEntryDiff
-	for currentBlock := u.CurrentBlockNumber; currentBlock > u.UnwindPoint; currentBlock-- {
+	// collect and merge diffsets of blocks [dropStateFromBlockNum, u.CurrentBlockNumber]
+	for currentBlock := u.CurrentBlockNumber; currentBlock >= dropStateFromBlockNum; currentBlock-- {
 		currentKeys, executedHash, found, err := findExecutedDiffsetAtHeight(ctx, rwTx, br, doms, currentBlock)
 		if err != nil {
 			return err
@@ -214,15 +211,15 @@ func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwT
 			}
 		}
 	}
-	// Get the hash of the last executed block (the tip we're unwinding from).
-	lastExecHash, _, err := br.CanonicalHash(ctx, rwTx, u.CurrentBlockNumber)
+
+	dropFromTxNum, err := unwindDomsToBlock(ctx, rwTx, br, doms, u.UnwindPoint, changeSet)
 	if err != nil {
-		lastExecHash = common.Hash{}
+		return err
 	}
-	if err := unwindExec3State(ctx, doms, rwTx, u.UnwindPoint, txNum, accumulator, changeSet, lastExecHash, logger); err != nil {
-		return fmt.Errorf("unwindExec3State(%d->%d): %w, took %s", s.BlockNumber, u.UnwindPoint, err, time.Since(t))
+	if err := stateChangesStreamAtUnwind(ctx, rwTx, u.UnwindPoint, dropFromTxNum, accumulator, changeSet, logger); err != nil {
+		return fmt.Errorf("stateChangesStreamAtUnwind(%d->%d): %w, took %s", s.BlockNumber, u.UnwindPoint, err, time.Since(t))
 	}
-	if err := rawdb.DeleteNewerEpochs(rwTx, u.UnwindPoint+1); err != nil {
+	if err := rawdb.DeleteNewerEpochs(rwTx, dropStateFromBlockNum); err != nil {
 		return fmt.Errorf("delete newer epochs: %w", err)
 	}
 	return nil
@@ -230,13 +227,12 @@ func unwindExec3(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwT
 
 var mxState3Unwind = metrics.GetOrCreateSummary("state3_unwind")
 
-func unwindExec3State(ctx context.Context,
-	sd *execctx.SharedDomains, tx kv.TemporalRwTx,
+// stateChangesStreamAtUnwind sending state changes to `accumulator`
+func stateChangesStreamAtUnwind(ctx context.Context,
+	tx kv.TemporalRwTx,
 	blockUnwindTo, txUnwindTo uint64,
 	accumulator *shards.Accumulator,
-	changeset *[kv.DomainLen][]kv.DomainEntryDiff, lastExecutedBlockHash common.Hash, logger log.Logger) error {
-	st := time.Now()
-	defer mxState3Unwind.ObserveDuration(st)
+	changeset *[kv.DomainLen][]kv.DomainEntryDiff, logger log.Logger) error {
 	var currentInc uint64
 
 	//TODO: why we don't call accumulator.ChangeCode???
@@ -339,8 +335,6 @@ func unwindExec3State(ctx context.Context,
 
 	}
 
-	sd.Unwind(txUnwindTo, changeset)
-	sd.SetTxNum(txUnwindTo)
 	return nil
 }
 
@@ -390,33 +384,29 @@ func SpawnExecuteBlocksStage(s *StageState, u Unwinder, doms *execctx.SharedDoma
 	return nil
 }
 
+// unwindDomsToBlock drops in-mem state of blocks (unwindToBlock, ∞) and
+// returns the boundary txNum it pruned from.
+func unwindDomsToBlock(ctx context.Context, rwTx kv.TemporalRwTx, br dbservices.FullBlockReader, doms *execctx.SharedDomains, unwindToBlock uint64, changeset *[kv.DomainLen][]kv.DomainEntryDiff) (uint64, error) {
+	dropStateFromBlockNum := unwindToBlock + 1
+	txNum, err := br.TxnumReader().Min(ctx, rwTx, dropStateFromBlockNum)
+	if err != nil {
+		return 0, err
+	}
+	doms.Unwind(txNum, changeset) // drops [txNum, ∞)
+	doms.SetTxNum(txNum)
+	return txNum, nil
+}
+
 func UnwindExecutionStage(u *UnwindState, s *StageState, doms *execctx.SharedDomains, rwTx kv.TemporalRwTx, ctx context.Context, cfg ExecuteBlockCfg, logger log.Logger) (err error) {
-	//fmt.Printf("unwind: %d -> %d\n", u.CurrentBlockNumber, u.UnwindPoint)
 	if u.UnwindPoint >= s.BlockNumber {
-		// MDBX has nothing above u.UnwindPoint to roll back here, but the in-RAM
-		// overlay (reused across the unwind→retry loop) can still hold uncommitted
-		// writes for blocks above it — e.g. a block that failed its post-execution
-		// gas check before its step was flushed. Prune them so re-execution doesn't
-		// read a stale value; the committed prune in unwindExec3 is skipped here.
-		//
-		// Prune from s.BlockNumber+1, not u.UnwindPoint+1: this early return skips
-		// u.Done, so committed progress stays at s.BlockNumber and re-execution
-		// resumes there — the whole (s.BlockNumber, u.UnwindPoint] range re-executes
-		// and its stale overlay writes must be pruned too, or an SSTORE_SET is
-		// mischarged as SSTORE_RESET (gas undercharge).
-		txNum, err := cfg.blockReader.TxnumReader().Min(ctx, rwTx, s.BlockNumber+1)
-		if err != nil {
-			return err
-		}
-		// NB: do NOT ResetPendingUpdates here. Unlike the disk-unwind path below
-		// (which discards then rebuilds commitment state via unwindExec3 +
-		// SeekCommitment), this early return only rewinds the in-RAM overlay and
-		// returns — the overlay and its deferred commitment updates are reused by
-		// the in-loop re-execution, so discarding them strands the commitment
-		// context and stalls the next block.
-		doms.Unwind(txNum, nil)
-		doms.SetTxNum(txNum)
-		return nil
+		// Disk holds nothing above s.BlockNumber, but the in-RAM overlay may.
+
+		// Do not `u.Done()` here — disk state doesn't reach u.UnwindPoint - so re-execution resumes at s.BlockNumber+1
+		// Do not `ResetPendingUpdates()` here. Unlike the disk-unwind path below (which discards then
+		// rebuilds commitment state via unwindExec3 + SeekCommitment), this early return only rewinds the in-RAM overlay
+
+		_, err = unwindDomsToBlock(ctx, rwTx, cfg.blockReader, doms, s.BlockNumber, nil)
+		return err
 	}
 
 	logger.Info(fmt.Sprintf("[%s] Unwind Execution", u.LogPrefix()), "from", s.BlockNumber, "to", u.UnwindPoint)
@@ -472,7 +462,6 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, doms *execctx.SharedDom
 	if _, _, err = doms.SeekCommitment(ctx, rwTx); err != nil {
 		return fmt.Errorf("unwind: SeekCommitment after disk unwind: %w", err)
 	}
-	//dumpPlainStateDebug(tx, nil)
 	return nil
 }
 

--- a/execution/stagedsync/stage_execute_unwind_test.go
+++ b/execution/stagedsync/stage_execute_unwind_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
 	"github.com/erigontech/erigon/db/rawdb"
@@ -80,11 +81,19 @@ func TestUnwindExecutionStage_PrunesUncommittedOverlayWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, (committedBlock+1)*perBlock, pruneFloorTxNum, "sanity: prune floor == first txNum of committedBlock+1")
 
+	// sysKey is written by the first re-executed block's begin-system tx — at
+	// exactly the boundary txNum. It re-executes, so it must be pruned too.
+	sysAddr := common.HexToAddress("0x00000000000000000000000000000000000000cc")
+	sysSlot := common.Hash{31: 0x03}
+	sysKey := dbutils.GenerateStoragePlainKey(sysAddr, sysSlot)
+	sysVal := []byte{0xd0, 0x0d}
+	sysTxNum := pruneFloorTxNum
+
 	// staleKey mirrors ca5daf64 slot0: first-written by failedBlock's tx19 at a
 	// txNum strictly above the unwind boundary — must be pruned on unwind.
 	staleAddr := common.HexToAddress("0xca5daf6473971693b760cc65d726f72c6849d615")
 	staleSlot := common.Hash{} // slot 0
-	staleKey := append(append([]byte{}, staleAddr[:]...), staleSlot[:]...)
+	staleKey := dbutils.GenerateStoragePlainKey(staleAddr, staleSlot)
 	staleValHash := common.HexToHash("0xd7549f2a387fa81a1d5a77adc7bd3f782ac0780c460689d88e22aee6916a3a34")
 	staleVal := staleValHash[:]
 	const staleTxNum = failedBlock*perBlock + 5 // inside failedBlock, above the boundary
@@ -95,19 +104,22 @@ func TestUnwindExecutionStage_PrunesUncommittedOverlayWrite(t *testing.T) {
 	// pruned, even though it's at/below the unwind point.
 	reexecAddr := common.HexToAddress("0x00000000000000000000000000000000000000aa")
 	reexecSlot := common.Hash{31: 0x01}
-	reexecKey := append(append([]byte{}, reexecAddr[:]...), reexecSlot[:]...)
+	reexecKey := dbutils.GenerateStoragePlainKey(reexecAddr, reexecSlot)
 	reexecVal := []byte{0xbe, 0xef}
 	const reexecTxNum = unwindPoint * perBlock // inside the unwind-target block (block 7 > committed 5)
 
-	// keepKey is written at/below committed progress — committed state, must survive.
+	// keepKey is written at exactly the last committed txNum — committed state,
+	// must survive (the prune boundary is one past it).
 	keepAddr := common.HexToAddress("0x00000000000000000000000000000000000000bb")
 	keepSlot := common.Hash{31: 0x02}
-	keepKey := append(append([]byte{}, keepAddr[:]...), keepSlot[:]...)
+	keepKey := dbutils.GenerateStoragePlainKey(keepAddr, keepSlot)
 	keepVal := []byte{0xca, 0xfe}
-	const keepTxNum = committedBlock*perBlock + 3 // inside the committed block
+	const keepTxNum = committedBlock*perBlock + perBlock - 1 // committed block's end-system txNum
 
 	doms.SetTxNum(keepTxNum)
 	require.NoError(t, doms.DomainPut(kv.StorageDomain, tx, keepKey, keepVal, keepTxNum, nil))
+	doms.SetTxNum(sysTxNum)
+	require.NoError(t, doms.DomainPut(kv.StorageDomain, tx, sysKey, sysVal, sysTxNum, nil))
 	doms.SetTxNum(reexecTxNum)
 	require.NoError(t, doms.DomainPut(kv.StorageDomain, tx, reexecKey, reexecVal, reexecTxNum, nil))
 	doms.SetTxNum(staleTxNum)
@@ -135,6 +147,14 @@ func TestUnwindExecutionStage_PrunesUncommittedOverlayWrite(t *testing.T) {
 	require.Empty(t, got,
 		"after Unwind, the overlay must not return failedBlock(%d) tx write %x (got %x)",
 		failedBlock, staleVal, got)
+
+	// The write at exactly the boundary txNum re-executes too — must be pruned.
+	got, _, err = doms.GetLatest(kv.StorageDomain, tx, sysKey)
+	require.NoError(t, err)
+	require.Empty(t, got,
+		"after Unwind, the overlay must not return the write at the boundary txNum %d (got %x): "+
+			"the first re-executed block's system tx is inside the re-executed range",
+		sysTxNum, got)
 
 	// A write in (committedBlock, unwindPoint] re-executes too, so it must also
 	// be pruned — the prune floor is s.BlockNumber+1, not u.UnwindPoint+1.


### PR DESCRIPTION
Closes #21863.

Only biz-logic change is: `if e.txNum >= unwindToTxNum {` (was `>`) 
Everything else: reduce biz-logic duplication. Variable names clarification. 
