### PR TITLE
rpc: fix panic in debug_traceBlockByHash with prestateTracer due to overflow

### DIFF
--- a/execution/tracing/tracers/native/prestate.go
+++ b/execution/tracing/tracers/native/prestate.go
@@ -189,7 +189,6 @@ func (t *prestateTracer) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scop
 		size := stackData[stackLen-3]
 		init, err := tracers.GetMemoryCopyPadded(scope.MemoryData(), int64(offset.Uint64()), int64(size.Uint64()))
 		if err != nil {
-			t.Stop(fmt.Errorf("failed to copy CREATE2 in prestate tracer input err: %s", err))
 			return
 		}
 		inithash := accounts.InternCodeHash(crypto.Keccak256Hash(init))

--- a/execution/tracing/tracers/util.go
+++ b/execution/tracing/tracers/util.go
@@ -19,6 +19,7 @@ package tracers
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/holiman/uint256"
 )
@@ -32,6 +33,9 @@ const (
 func GetMemoryCopyPadded(m []byte, offset, size int64) ([]byte, error) {
 	if offset < 0 || size < 0 {
 		return nil, errors.New("offset or size must not be negative")
+	}
+	if size > math.MaxInt64-offset {
+		return nil, errors.New("offset and size overflow")
 	}
 	length := int64(len(m))
 	if offset+size < length { // slice fully inside memory

--- a/rpc/jsonrpc/debug_api_test.go
+++ b/rpc/jsonrpc/debug_api_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/holiman/uint256"
+	"github.com/jinzhu/copier"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 
@@ -48,9 +49,13 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/execmodule"
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/tests/blockgen"
 	tracersConfig "github.com/erigontech/erigon/execution/tracing/tracers/config"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/node/direct"
 	"github.com/erigontech/erigon/node/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon/node/privateapi"
@@ -170,6 +175,92 @@ func TestTraceBlockByHash(t *testing.T) {
 			t.Fatalf("incorrect length: %v", err)
 		}
 	}
+}
+
+// TestTraceBlockByHashPrestateTracerCreate2MemoryOverflow verifies that an unexecutable
+// CREATE2 memory range does not panic or abort the prestate trace.
+// Its operands overflow the memory-end calculation, so gas validation fails before account creation.
+// Previously, GetMemoryCopyPadded added the positive int64 CREATE2 offset and size; only their sum
+// wrapped negative and compared less than the empty memory length. That branch passed the still-positive,
+// enormous size to make([]byte, size), causing runtime error: makeslice: len out of range.
+func TestTraceBlockByHashPrestateTracerCreate2MemoryOverflow(t *testing.T) {
+	sender := common.HexToAddress("0x5b20612d8c4d585e69838429135cd507319cae63")
+	coinbase := common.HexToAddress("0xf97e180c050e5ab072211ad2c213eb5aee4df134")
+	rawTx := "0x02f902428501a462808d8210a184773594008504a817c800830f42408080b901e17fed31282eee3bc1bde857e940edef1cfc1089ae426cfad485a4294a48cf57f16a7f0000000000000000000000000000000000000000000000000000000000023207336bf5274d567553ac8781594d06335b92f55b7f000000000000000000000000000000000833533fc9ed23992d2157bd01cc78d86000527f60df1e9d9638c3c798058bd079c61adaca8132637f8592f6a04d179a3432751f6020527f000000000000000000000000000000000e5c168bccdaf1363808a6cc387f33b76040527fc36efc4a0cb56a5139bbf86f8670213223a6102906649e3d78965f6b3118da6a6060527f68aa8400dd534bc72632e36b15b3dfe9e0bb8ae6816e19860eca270c9e38bf786080527f0000000000000000000000000000000006a82cb45b36e3377f5f26fdb5d7ee7960a0527f255a035ab2406f80123e4793c8e796179b059b477e0634d8fe6901bad630c93860c0527f0000000000000000000000000000000017e91b2c49464944c1feefe6db5955c960e0527f5a673098b913a338f1303293a3985174eb47ab41e0227c634e73e21e62e2243f610100527f198b0c6015b2a3240b03153835e3176a1ef4e975442b00c264499c8a442ec43461012052608061010061014060006000600c5af1610100516101205161014051610160514600c001a0203bef105491f41d890b579382216a527d6b009ce3949a97d6ab1889daaa63c3a0131c13da1e75cb2238bb12b5545124d7a326ec22e5500bc20bde9f460c2b5ea2"
+	tx, err := types.DecodeTransaction(common.FromHex(rawTx))
+	require.NoError(t, err)
+	require.Equal(t, common.HexToHash("0x13946ef4324d802e4b496a73d1f9b3789b21557de59d6f025e96435a2dbc9be4"), tx.Hash())
+	var cfg chain.Config
+	require.NoError(t, copier.CopyWithOption(&cfg, chain.AllProtocolChanges, copier.Option{DeepCopy: true}))
+	cfg.ChainName = "trace-create2-overflow"
+	cfg.ChainID = uint256.NewInt(7052886157)
+	gasLimit := uint64(0xb532b80)
+	blobGasUsed := uint64(0)
+	excessBlobGas := uint64(0)
+	parentBeaconBlockRoot := common.HexToHash("0x194bddd170136ba17081d9d3a0791e76b21e73f1e8bc483fe36e8c9adade96ff")
+	gspec := &types.Genesis{
+		Config:                &cfg,
+		Timestamp:             0x6a476e64 - 10,
+		GasLimit:              gasLimit,
+		GasUsed:               gasLimit / 2,
+		Difficulty:            uint256.NewInt(0),
+		BaseFee:               uint256.NewInt(7),
+		BlobGasUsed:           &blobGasUsed,
+		ExcessBlobGas:         &excessBlobGas,
+		ParentBeaconBlockRoot: &parentBeaconBlockRoot,
+		Alloc: types.GenesisAlloc{
+			sender:   {Balance: uint256.MustFromHex("0x28704d335b594c07").ToBig(), Nonce: 4257},
+			coinbase: {Balance: uint256.MustFromHex("0x14a5fa81e10fd353696").ToBig()},
+		},
+	}
+	m := execmoduletester.New(t, execmoduletester.WithGenesisSpec(gspec))
+	generated, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, func(_ int, gen *blockgen.BlockGen) {
+		gen.SetCoinbase(coinbase)
+		gen.AddTx(tx)
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(generated))
+	dbtx, err := m.DB.BeginTemporalRo(m.Ctx)
+	require.NoError(t, err)
+	defer dbtx.Rollback()
+	st := state.New(m.NewStateReader(dbtx))
+	defer st.Release(false)
+	senderBalance, err := st.GetBalance(accounts.InternAddress(sender))
+	require.NoError(t, err)
+	require.Equal(t, uint256.MustFromHex("0x286a802d7b04d897"), &senderBalance)
+	senderNonce, err := st.GetNonce(accounts.InternAddress(sender))
+	require.NoError(t, err)
+	require.Equal(t, uint64(4258), senderNonce)
+	coinbaseBalance, err := st.GetBalance(accounts.InternAddress(coinbase))
+	require.NoError(t, err)
+	require.Equal(t, uint256.MustFromHex("0x14a5fadeb16dd327696"), &coinbaseBalance)
+	tracer := "prestateTracer"
+	var buf bytes.Buffer
+	stream := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	require.NoError(t, api.TraceBlockByHash(m.Ctx, generated.TopBlock.Hash(), &tracersConfig.TraceConfig{Tracer: &tracer}, stream))
+	require.NoError(t, stream.Flush())
+	var traces []struct {
+		TxHash common.Hash `json:"txHash"`
+		Result map[common.Address]struct {
+			Balance *hexutil.Big `json:"balance"`
+			Nonce   uint64       `json:"nonce"`
+		} `json:"result"`
+		Error json.RawMessage `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &traces))
+	require.Len(t, traces, 1)
+	require.Equal(t, tx.Hash(), traces[0].TxHash)
+	require.Empty(t, traces[0].Error)
+	require.Len(t, traces[0].Result, 2)
+	senderPrestate, ok := traces[0].Result[sender]
+	require.True(t, ok)
+	require.Equal(t, uint256.MustFromHex("0x28704d335b594c07").ToBig(), (*big.Int)(senderPrestate.Balance))
+	require.Equal(t, uint64(4257), senderPrestate.Nonce)
+	coinbasePrestate, ok := traces[0].Result[coinbase]
+	require.True(t, ok)
+	require.Equal(t, uint256.MustFromHex("0x14a5fa81e10fd353696").ToBig(), (*big.Int)(coinbasePrestate.Balance))
+	require.Zero(t, coinbasePrestate.Nonce)
 }
 
 func TestTraceTransaction(t *testing.T) {


### PR DESCRIPTION
fixes #22607

## Summary

- Add an rpcdaemon exec-module regression using the real signed transaction and independently verified pre/post state from the affected block. The test reproduces the original `runtime error: makeslice: len out of range` panic before the fix.
- Reject `int64` overflow before calculating the end of a padded memory copy.
- Let `prestateTracer` skip CREATE2 account derivation when the opcode's memory cannot be copied safely. The unexecutable CREATE2 no longer aborts the trace, and the returned prestate matches Reth and Nethermind.

## Root cause

The CREATE2 offset and size were positive `int64` values, but their sum exceeded `math.MaxInt64` and wrapped negative. `GetMemoryCopyPadded` therefore mistook the range for data already present in empty EVM memory, then passed the still-positive, enormous size to `make([]byte, size)`, which panicked.

## Testing

- `go test ./execution/tracing/tracers/... ./rpc/jsonrpc -count=1`
- `make lint` (two consecutive clean runs)
- `make erigon integration`
