### PR TITLE
docs(hardware): make disk sizes static (forward-port #22596 to main)

### DIFF
--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -43,6 +43,36 @@ jobs:
           python3 docs/site/scripts/generate-llms.py --check
           python3 -m unittest discover docs/site/scripts -v
 
+      - name: Verify disk-size markers are in sync
+        if: steps.guard.outputs.present == 'true'
+        run: python3 docs/site/scripts/render-disk-sizes.py --check
+
+      - name: Guard against dynamic disk-size references in docs pages
+        if: steps.guard.outputs.present == 'true'
+        run: |
+          # Disk sizes must be static text (markers), never a runtime import.
+          # A runtime import in a versioned snapshot silently tracks the live
+          # file; in the current page it hides a `?? '—'` fallback. Fail closed.
+          # Check grep's exit code explicitly: 0=match (fail), 1=no match (ok),
+          # 2+=error (fail) — an `if grep` alone would swallow errors as "no match".
+          set +e
+          matches=$(grep -rn --include='*.md' --include='*.mdx' \
+               -e 'diskSizes' -e "src/data/disk-sizes.json" \
+               docs/site/docs docs/site/versioned_docs)
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "$matches"
+            echo "::error::Found a dynamic disk-sizes reference in a docs page. \
+          Disk sizes must be static (see docs/site/scripts/render-disk-sizes.py \
+          and the README 'Disk size data flow' section)."
+            exit 1
+          elif [ "$rc" -ne 1 ]; then
+            echo "::error::grep failed (exit $rc) while scanning for disk-size references"
+            exit 1
+          fi
+          echo "OK: no dynamic disk-size references in docs pages"
+
       - uses: actions/setup-node@v7
         if: steps.guard.outputs.present == 'true'
         with:

--- a/.github/workflows/update-disk-sizes.yml
+++ b/.github/workflows/update-disk-sizes.yml
@@ -169,17 +169,21 @@ jobs:
             ./artifacts \
             docs/site/src/data/disk-sizes.json \
             "$PRUNE_MODE"
+          # Project the updated JSON onto the static markers in the
+          # hardware-requirements page (see README "Disk size data flow").
+          python3 docs/site/scripts/render-disk-sizes.py
 
       - name: Check for changes
         id: diff
         run: |
           set -euo pipefail
-          if git diff --quiet docs/site/src/data/disk-sizes.json; then
+          TARGETS="docs/site/src/data/disk-sizes.json docs/site/docs/get-started/hardware-requirements.mdx"
+          if git diff --quiet -- $TARGETS; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No changes to disk-sizes.json"
+            echo "No changes to disk sizes"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            git diff docs/site/src/data/disk-sizes.json
+            git diff -- $TARGETS
           fi
 
       - name: Configure git
@@ -198,7 +202,7 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="docs/auto/disk-sizes-${BASE_BRANCH//\//-}"
-          git add docs/site/src/data/disk-sizes.json
+          git add docs/site/src/data/disk-sizes.json docs/site/docs/get-started/hardware-requirements.mdx
           git commit -m "chore(docs): auto-update measured disk sizes [$(date +%Y-%m-%d)]"
           git push origin "$BRANCH"
 

--- a/.github/workflows/update-disk-sizes.yml
+++ b/.github/workflows/update-disk-sizes.yml
@@ -229,7 +229,7 @@ jobs:
           Opened automatically by the **Docs - Update disk sizes** CI workflow after a successful sync-from-scratch run.
 
           ### What changed
-          `docs/site/src/data/disk-sizes.json` — `full` and/or `minimal` mode disk usage updated from the latest CI measurement. The hardware requirements page consumes this file directly, so merging this PR is all that's needed.
+          `docs/site/src/data/disk-sizes.json` — `full` and/or `minimal` mode disk usage updated from the latest CI measurement. `docs/site/docs/get-started/hardware-requirements.mdx` is regenerated from it (static values between MDX markers), so both files are included and merging this PR is all that's needed.
 
           ### What this does NOT update
           - **Archive** mode: requires manual measurement from always-on snapshot machines.

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -1,6 +1,6 @@
 # Erigon Documentation Site
 
-Built with [Docusaurus 3](https://docusaurus.io/). Deployed automatically to [docs.erigon.tech](https://docs.erigon.tech) via GitHub Actions on push to `release/3.4`.
+Built with [Docusaurus 3](https://docusaurus.io/). Deployed automatically to [docs.erigon.tech](https://docs.erigon.tech) via GitHub Actions on push to `release/3.5`.
 
 ## Local Development
 
@@ -16,4 +16,44 @@ npm run typecheck # TypeScript check without emit
 
 ## Deployment
 
-Deployment is handled automatically by `.github/workflows/docs-deploy.yml` on every push to `release/3.4`. Do not use manual `yarn deploy` — it is not configured for this site.
+Deployment is handled automatically by `.github/workflows/docs-deploy.yml` on every push to `release/3.5`. Do not use manual `yarn deploy` — it is not configured for this site.
+
+## Disk size data flow
+
+The "Current Disk Usage" figures on the hardware-requirements page are **static
+text** held between MDX-comment markers, e.g.:
+
+```mdx
+| Archive | {/* ds:mainnet:archive */}1.77 TB{/* ds:end */} | 4 TB | ... |
+_... measured as of {/* ds-date:mainnet */}2025-09-01{/* ds:end */}; ..._
+```
+
+- `src/data/disk-sizes.json` is the machine-readable source of record. CI
+  (`.github/workflows/update-disk-sizes.yml`) writes `full`/`minimal` rows from
+  sync-from-scratch artifacts via `scripts/update-disk-sizes.py`; `archive` rows
+  are entered manually.
+- `scripts/render-disk-sizes.py` projects that JSON onto the page's markers. CI
+  runs it after updating the JSON and commits the page; `--check` (run in
+  `docs-site-build.yml`) fails the build if the two ever drift.
+
+**Why static and not a runtime `import diskSizes from '@site/...'`?** A runtime
+import is shared across all doc versions, so a `docusaurus docs:version` snapshot
+would silently keep showing the *current* version's numbers instead of the ones
+measured for that release. Static markers make each version snapshot correct by
+construction, and remove a silent `?? '—'` fallback. `docs-site-build.yml` guards
+this: it fails if any page under `docs/` or `versioned_docs/` references
+`diskSizes` or imports `disk-sizes.json`.
+
+## Cutting a new docs version
+
+When a new Erigon minor release ships (e.g. cutting `v3.5` because trunk moves to
+`v3.6`), snapshot the current docs into a frozen version:
+
+```bash
+# from docs/site/
+npm run docusaurus docs:version v3.5   # creates versioned_docs/version-v3.5/
+npm run build                          # verify
+```
+
+No extra step is needed for disk sizes: because the current page is already
+static (see above), the snapshot freezes the correct values automatically.

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -16,7 +16,7 @@ npm run typecheck # TypeScript check without emit
 
 ## Deployment
 
-Deployment is handled automatically by `.github/workflows/docs-deploy.yml` on every push to `release/3.5`. Do not use manual `yarn deploy` — it is not configured for this site.
+Deployment is handled automatically by the `docs-deploy.yml` workflow, which lives on the `release/3.5` branch (the deploy source) and runs on every push there. It is intentionally not present on `main`. Do not use manual `yarn deploy` — it is not configured for this site.
 
 ## Disk size data flow
 

--- a/docs/site/docs/get-started/hardware-requirements.mdx
+++ b/docs/site/docs/get-started/hardware-requirements.mdx
@@ -6,7 +6,6 @@ sidebar_position: 2
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import diskSizes from '@site/src/data/disk-sizes.json';
 
 # Hardware Requirements
 
@@ -31,17 +30,21 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 <TabItem value="ethereum-mainnet" label="Ethereum mainnet">
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
-| Archive | {diskSizes?.networks?.['mainnet']?.['archive']?.display ?? '—'} | 4 TB | 32 GB | 64 GB |
-| Full (Default) | {diskSizes?.networks?.['mainnet']?.['full']?.display ?? '—'} | 2 TB | 16 GB | 32 GB |
-| Minimal | {diskSizes?.networks?.['mainnet']?.['minimal']?.display ?? '—'} | 1 TB | 16 GB | 64 GB |
+| Archive | {/* ds:mainnet:archive */}1.77 TB{/* ds:end */} | 4 TB | 32 GB | 64 GB |
+| Full (Default) | {/* ds:mainnet:full */}920 GB{/* ds:end */} | 2 TB | 16 GB | 32 GB |
+| Minimal | {/* ds:mainnet:minimal */}350 GB{/* ds:end */} | 1 TB | 16 GB | 64 GB |
+
+_Current Disk Usage measured as of {/* ds-date:mainnet */}2025-09-01{/* ds:end */}; usage grows over time as the chain grows._
 
 </TabItem>
 <TabItem value="gnosis-chain" label="Gnosis Chain">
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | {diskSizes?.networks?.['gnosis']?.['archive']?.display ?? '—'} | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | {diskSizes?.networks?.['gnosis']?.['full']?.display ?? '—'}    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | {diskSizes?.networks?.['gnosis']?.['minimal']?.display ?? '—'} | 500 GB                      | 8 GB               | 16 GB                 |
+| Archive        | {/* ds:gnosis:archive */}539 GB{/* ds:end */} | 1 TB                        | 16 GB              | 32 GB                 |
+| Full (Default) | {/* ds:gnosis:full */}462 GB{/* ds:end */}    | 1 TB                        | 8 GB               | 16 GB                 |
+| Minimal        | {/* ds:gnosis:minimal */}128 GB{/* ds:end */} | 500 GB                      | 8 GB               | 16 GB                 |
+
+_Current Disk Usage measured as of {/* ds-date:gnosis */}2025-09-01{/* ds:end */}; usage grows over time as the chain grows._
 </TabItem>
 <TabItem value="polygon" label="Polygon">
 :::warning

--- a/docs/site/scripts/render-disk-sizes.py
+++ b/docs/site/scripts/render-disk-sizes.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Render disk-size values from disk-sizes.json into the hardware-requirements page.
+
+Design (see README "Disk size data flow"): the hardware-requirements page holds
+STATIC values between MDX-comment markers instead of importing disk-sizes.json at
+runtime. Static content means `docusaurus docs:version` snapshots freeze correctly
+with no per-version step, and there is no silent `?? '—'` fallback in production.
+
+`src/data/disk-sizes.json` is the machine-readable source of record
+(`update-disk-sizes.py` writes it from CI sync artifacts; archive rows are manual).
+This script projects that JSON onto the page's markers:
+
+    | Archive | {/* ds:mainnet:archive */}1.77 TB{/* ds:end */} | 4 TB | ... |
+    _... measured as of {/* ds-date:mainnet */}2025-09-01{/* ds:end */}; ..._
+
+Run it after editing the JSON; run with --check in CI to fail if they drift.
+
+The renderer is deliberately fail-closed: a marker that does not match the exact
+grammar (spacing typo, wrapped across a newline, nested, unpaired) is a hard
+error rather than a silent skip — otherwise `--check` could stay green while a
+cell quietly went stale, defeating the whole point of the static-marker scheme.
+
+Usage:
+    python3 render-disk-sizes.py            # rewrite the page in place
+    python3 render-disk-sizes.py --check    # exit 1 if the page is out of sync
+"""
+import argparse
+import json
+import re
+from datetime import date
+from pathlib import Path
+
+# Exact, single-line marker grammar. `val` cannot span newlines so a wrapped
+# marker fails the completeness check below instead of being silently skipped.
+VALUE_RE = re.compile(
+    r"\{/\* ds:(?P<net>[a-z0-9]+):(?P<mode>[a-z]+) \*/\}(?P<val>[^\n\r]*?)\{/\* ds:end \*/\}"
+)
+DATE_RE = re.compile(
+    r"\{/\* ds-date:(?P<net>[a-z0-9]+) \*/\}(?P<val>[^\n\r]*?)\{/\* ds:end \*/\}"
+)
+# Any MDX comment, used to find *all* disk-size marker tokens (even malformed
+# ones) so unpaired/typo'd markers can be detected rather than ignored.
+COMMENT_RE = re.compile(r"\{/\*(?P<body>.*?)\*/\}", re.DOTALL)
+
+
+def _is_ds_token(body: str) -> bool:
+    b = body.strip()
+    return b.startswith("ds:") or b.startswith("ds-date:")
+
+
+def _validate_display(net: str, mode: str, display) -> str:
+    if not isinstance(display, str) or not display.strip():
+        raise SystemExit(
+            f"Error: networks.{net}.{mode}.display must be a non-empty string"
+        )
+    if any(c in display for c in "{}\n\r"):
+        raise SystemExit(
+            f"Error: networks.{net}.{mode}.display contains disallowed "
+            f"characters (no braces or newlines): {display!r}"
+        )
+    return display
+
+
+def _validate_date(net: str, mode: str, value) -> str:
+    if not isinstance(value, str):
+        raise SystemExit(f"Error: networks.{net}.{mode}.measured_at must be a string")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        raise SystemExit(
+            f"Error: networks.{net}.{mode}.measured_at is not valid "
+            f"YYYY-MM-DD: {value!r}"
+        )
+    if value != parsed.isoformat():
+        raise SystemExit(
+            f"Error: networks.{net}.{mode}.measured_at must be zero-padded "
+            f"YYYY-MM-DD: {value!r}"
+        )
+    return value
+
+
+def render_text(text: str, data: dict) -> str:
+    """Return `text` with every disk-size marker set from `data`.
+
+    Fail-closed: raises SystemExit on missing data, malformed/unpaired markers,
+    or unsafe values, so a broken page can never silently pass `--check`."""
+    networks = data.get("networks")
+    if not isinstance(networks, dict) or not networks:
+        raise SystemExit("Error: disk-sizes.json has no non-empty 'networks' object")
+
+    value_spans = list(VALUE_RE.finditer(text))
+    date_spans = list(DATE_RE.finditer(text))
+
+    # Completeness guard: every disk-size marker comment must belong to a
+    # well-formed value/date pair. Each pair uses exactly two comment tokens
+    # (opener + `ds:end` closer), so any surplus token means a malformed or
+    # unpaired marker (spacing typo, newline-wrapped, nested, dangling closer).
+    ds_tokens = [m for m in COMMENT_RE.finditer(text) if _is_ds_token(m.group("body"))]
+    if not value_spans:
+        raise SystemExit("Error: no disk-size value markers found in the page")
+    expected_tokens = 2 * (len(value_spans) + len(date_spans))
+    if len(ds_tokens) != expected_tokens:
+        raise SystemExit(
+            "Error: malformed or unpaired disk-size marker(s) in the page — "
+            f"found {len(ds_tokens)} marker comment(s) but only "
+            f"{len(value_spans) + len(date_spans)} well-formed pair(s). Check for "
+            "spacing typos, markers wrapped across a newline, or a stray "
+            "{/* ds:end */}."
+        )
+    for m in value_spans + date_spans:
+        if "{/*" in m.group("val"):
+            raise SystemExit("Error: a nested disk-size marker was detected")
+
+    def value_repl(m: re.Match) -> str:
+        net, mode = m.group("net"), m.group("mode")
+        try:
+            display = networks[net][mode]["display"]
+        except (KeyError, TypeError):
+            raise SystemExit(
+                f"Error: disk-sizes.json has no display value for "
+                f"networks.{net}.{mode} (referenced by a marker in the page)"
+            )
+        display = _validate_display(net, mode, display)
+        return "{/* ds:" + net + ":" + mode + " */}" + display + "{/* ds:end */}"
+
+    def date_repl(m: re.Match) -> str:
+        net = m.group("net")
+        modes = networks.get(net)
+        if not isinstance(modes, dict) or not modes:
+            raise SystemExit(
+                f"Error: disk-sizes.json has no network '{net}' "
+                f"(referenced by a date marker in the page)"
+            )
+        dates = [
+            _validate_date(net, mode, v["measured_at"])
+            for mode, v in modes.items()
+            if isinstance(v, dict) and v.get("measured_at")
+        ]
+        if not dates:
+            raise SystemExit(f"Error: no measured_at for any '{net}' mode")
+        # Use the OLDEST date: the caption covers every mode in the table, so
+        # "measured as of <oldest>" is honest — max() would overstate freshness.
+        return "{/* ds-date:" + net + " */}" + min(dates) + "{/* ds:end */}"
+
+    text = VALUE_RE.sub(value_repl, text)
+    text = DATE_RE.sub(date_repl, text)
+    return text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if the page is out of sync with disk-sizes.json (no writes)",
+    )
+    args = parser.parse_args()
+
+    site_root = Path(__file__).resolve().parent.parent  # docs/site
+    json_path = site_root / "src" / "data" / "disk-sizes.json"
+    page_path = site_root / "docs" / "get-started" / "hardware-requirements.mdx"
+
+    if not json_path.exists():
+        raise SystemExit(f"Error: {json_path} not found")
+    if not page_path.exists():
+        raise SystemExit(f"Error: {page_path} not found")
+
+    try:
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"Error: malformed {json_path}: {e}") from None
+    original = page_path.read_text(encoding="utf-8")
+    rendered = render_text(original, data)
+
+    if args.check:
+        if rendered != original:
+            raise SystemExit(
+                "Error: hardware-requirements.mdx is out of sync with "
+                "disk-sizes.json.\nRun: python3 docs/site/scripts/render-disk-sizes.py"
+            )
+        print("OK: hardware-requirements.mdx matches disk-sizes.json")
+        return
+
+    if rendered != original:
+        page_path.write_text(rendered, encoding="utf-8")
+        print(f"Updated {page_path}")
+    else:
+        print("No changes — page already matches disk-sizes.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/site/scripts/test_render_disk_sizes.py
+++ b/docs/site/scripts/test_render_disk_sizes.py
@@ -1,0 +1,138 @@
+"""Unit tests for render-disk-sizes.py.
+
+Run from repo root:
+  python3 -m unittest discover docs/site/scripts -v
+  python3 docs/site/scripts/test_render_disk_sizes.py    # direct invocation also works
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).parent
+_spec = importlib.util.spec_from_file_location("render_disk_sizes", _HERE / "render-disk-sizes.py")
+r = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(r)
+
+
+DATA = {
+    "networks": {
+        "mainnet": {
+            "archive": {"display": "2.03 TB", "measured_at": "2026-06-02"},
+            "full": {"display": "1.2 TB", "measured_at": "2026-06-02"},
+            "minimal": {"display": "360 GB", "measured_at": "2026-05-01"},
+        },
+        "gnosis": {
+            "archive": {"display": "605 GB", "measured_at": "2026-06-02"},
+        },
+    }
+}
+
+PAGE = (
+    "| Archive | {/* ds:mainnet:archive */}1.77 TB{/* ds:end */} | 4 TB |\n"
+    "| Full | {/* ds:mainnet:full */}920 GB{/* ds:end */} | 2 TB |\n"
+    "| Minimal | {/* ds:mainnet:minimal */}350 GB{/* ds:end */} | 1 TB |\n"
+    "\n_measured as of {/* ds-date:mainnet */}2025-09-01{/* ds:end */}._\n"
+    "| Archive | {/* ds:gnosis:archive */}539 GB{/* ds:end */} | 1 TB |\n"
+)
+
+
+class RenderTextTests(unittest.TestCase):
+    def test_updates_values(self):
+        out = r.render_text(PAGE, DATA)
+        self.assertIn("{/* ds:mainnet:archive */}2.03 TB{/* ds:end */}", out)
+        self.assertIn("{/* ds:mainnet:full */}1.2 TB{/* ds:end */}", out)
+        self.assertIn("{/* ds:mainnet:minimal */}360 GB{/* ds:end */}", out)
+        self.assertIn("{/* ds:gnosis:archive */}605 GB{/* ds:end */}", out)
+
+    def test_date_uses_oldest_measured_at(self):
+        out = r.render_text(PAGE, DATA)
+        # min of 2026-06-02 / 2026-06-02 / 2026-05-01 = 2026-05-01 (honest "as of")
+        self.assertIn("{/* ds-date:mainnet */}2026-05-01{/* ds:end */}", out)
+
+    def test_preserves_surrounding_table_text(self):
+        out = r.render_text(PAGE, DATA)
+        self.assertIn("| Archive |", out)
+        self.assertIn("| 4 TB |", out)
+        self.assertEqual(out.count("{/* ds:end */}"), PAGE.count("{/* ds:end */}"))
+
+    def test_idempotent(self):
+        once = r.render_text(PAGE, DATA)
+        twice = r.render_text(once, DATA)
+        self.assertEqual(once, twice)
+
+    # --- fail-closed: missing data ---
+
+    def test_missing_value_fails_closed(self):
+        page = "| X | {/* ds:mainnet:nope */}?{/* ds:end */} |\n"
+        with self.assertRaises(SystemExit):
+            r.render_text(page, DATA)
+
+    def test_no_value_markers_fails_closed(self):
+        page = "_as of {/* ds-date:mainnet */}?{/* ds:end */}._\n"
+        with self.assertRaises(SystemExit):
+            r.render_text(page, DATA)
+
+    def test_empty_networks_fails_closed(self):
+        with self.assertRaises(SystemExit):
+            r.render_text(PAGE, {"networks": {}})
+
+    # --- fail-closed: malformed markers (the silent-stale hazard) ---
+
+    def test_spacing_typo_marker_fails_closed(self):
+        # missing spaces around ds: — must NOT be silently skipped
+        page = "| X | {/*ds:mainnet:archive*/}1.77 TB{/*ds:end*/} |\n"
+        with self.assertRaises(SystemExit):
+            r.render_text(page, DATA)
+
+    def test_newline_wrapped_marker_fails_closed(self):
+        page = "| X | {/* ds:mainnet:archive */}\n1.77 TB\n{/* ds:end */} |\n"
+        with self.assertRaises(SystemExit):
+            r.render_text(page, DATA)
+
+    def test_dangling_closer_fails_closed(self):
+        page = (
+            "| A | {/* ds:mainnet:archive */}1.77 TB{/* ds:end */} |\n"
+            "| stray {/* ds:end */} |\n"
+        )
+        with self.assertRaises(SystemExit):
+            r.render_text(page, DATA)
+
+    def test_nested_marker_fails_closed(self):
+        page = (
+            "{/* ds:mainnet:archive */}{/* ds:mainnet:full */}x{/* ds:end */}\n"
+        )
+        with self.assertRaises(SystemExit):
+            r.render_text(page, DATA)
+
+    # --- fail-closed: bad data values ---
+
+    def test_non_iso_date_fails_closed(self):
+        data = {"networks": {"mainnet": {
+            "archive": {"display": "2.03 TB", "measured_at": "2026-6-2"},
+        }}}
+        page = "{/* ds:mainnet:archive */}x{/* ds:end */} {/* ds-date:mainnet */}y{/* ds:end */}\n"
+        with self.assertRaises(SystemExit):
+            r.render_text(page, data)
+
+    def test_display_with_braces_fails_closed(self):
+        data = {"networks": {"mainnet": {"archive": {"display": "1 {x} TB"}}}}
+        page = "{/* ds:mainnet:archive */}x{/* ds:end */}\n"
+        with self.assertRaises(SystemExit):
+            r.render_text(page, data)
+
+    def test_empty_display_fails_closed(self):
+        data = {"networks": {"mainnet": {"archive": {"display": ""}}}}
+        page = "{/* ds:mainnet:archive */}x{/* ds:end */}\n"
+        with self.assertRaises(SystemExit):
+            r.render_text(page, data)
+
+    def test_non_dict_mode_with_date_marker_fails_cleanly(self):
+        data = {"networks": {"mainnet": {"archive": "1.77 TB"}}}
+        page = "{/* ds:mainnet:archive */}x{/* ds:end */} {/* ds-date:mainnet */}y{/* ds:end */}\n"
+        with self.assertRaises(SystemExit):
+            r.render_text(page, data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -69,15 +69,19 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
-| Archive | — | 4 TB | 32 GB | 64 GB |
-| Full (Default) | — | 2 TB | 16 GB | 32 GB |
-| Minimal | — | 1 TB | 16 GB | 64 GB |
+| Archive | 1.77 TB | 4 TB | 32 GB | 64 GB |
+| Full (Default) | 920 GB | 2 TB | 16 GB | 32 GB |
+| Minimal | 350 GB | 1 TB | 16 GB | 64 GB |
+
+_Current Disk Usage measured as of 2025-09-01; usage grows over time as the chain grows._
 
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | — | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | —    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | — | 500 GB                      | 8 GB               | 16 GB                 |
+| Archive        | 539 GB | 1 TB                        | 16 GB              | 32 GB                 |
+| Full (Default) | 462 GB    | 1 TB                        | 8 GB               | 16 GB                 |
+| Minimal        | 128 GB | 500 GB                      | 8 GB               | 16 GB                 |
+
+_Current Disk Usage measured as of 2025-09-01; usage grows over time as the chain grows._
 
 :::warning
 The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases). Disk usage figures below are from September 2025 and are no longer automatically updated.

--- a/docs/site/versioned_docs/version-v3.4/get-started/hardware-requirements.mdx
+++ b/docs/site/versioned_docs/version-v3.4/get-started/hardware-requirements.mdx
@@ -6,7 +6,6 @@ sidebar_position: 2
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import diskSizes from '@site/src/data/disk-sizes.json';
 
 # Hardware Requirements
 
@@ -31,17 +30,21 @@ The amount of disk space recommended and RAM you need depends on the [prune mode
 <TabItem value="ethereum-mainnet" label="Ethereum mainnet">
 | Prune Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
-| Archive | {diskSizes?.networks?.['mainnet']?.['archive']?.display ?? '—'} | 4 TB | 32 GB | 64 GB |
-| Full (Default) | {diskSizes?.networks?.['mainnet']?.['full']?.display ?? '—'} | 2 TB | 16 GB | 32 GB |
-| Minimal | {diskSizes?.networks?.['mainnet']?.['minimal']?.display ?? '—'} | 1 TB | 16 GB | 64 GB |
+| Archive | 2.03 TB | 4 TB | 32 GB | 64 GB |
+| Full (Default) | 1.2 TB | 2 TB | 16 GB | 32 GB |
+| Minimal | 360 GB | 1 TB | 16 GB | 64 GB |
+
+_Current Disk Usage measured as of 2026-06-02 (Erigon 3.4); usage grows over time as the chain grows._
 
 </TabItem>
 <TabItem value="gnosis-chain" label="Gnosis Chain">
 | **Prune Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | {diskSizes?.networks?.['gnosis']?.['archive']?.display ?? '—'} | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | {diskSizes?.networks?.['gnosis']?.['full']?.display ?? '—'}    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | {diskSizes?.networks?.['gnosis']?.['minimal']?.display ?? '—'} | 500 GB                      | 8 GB               | 16 GB                 |
+| Archive        | 605 GB | 1 TB                        | 16 GB              | 32 GB                 |
+| Full (Default) | 645 GB    | 1 TB                        | 8 GB               | 16 GB                 |
+| Minimal        | 186 GB | 500 GB                      | 8 GB               | 16 GB                 |
+
+_Current Disk Usage measured as of 2026-06-02 (Erigon 3.4); usage grows over time as the chain grows._
 </TabItem>
 <TabItem value="polygon" label="Polygon">
 :::warning

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69,15 +69,19 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
-| Archive | — | 4 TB | 32 GB | 64 GB |
-| Full (Default) | — | 2 TB | 16 GB | 32 GB |
-| Minimal | — | 1 TB | 16 GB | 64 GB |
+| Archive | 1.77 TB | 4 TB | 32 GB | 64 GB |
+| Full (Default) | 920 GB | 2 TB | 16 GB | 32 GB |
+| Minimal | 350 GB | 1 TB | 16 GB | 64 GB |
+
+_Current Disk Usage measured as of 2025-09-01; usage grows over time as the chain grows._
 
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | — | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | —    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | — | 500 GB                      | 8 GB               | 16 GB                 |
+| Archive        | 539 GB | 1 TB                        | 16 GB              | 32 GB                 |
+| Full (Default) | 462 GB    | 1 TB                        | 8 GB               | 16 GB                 |
+| Minimal        | 128 GB | 500 GB                      | 8 GB               | 16 GB                 |
+
+_Current Disk Usage measured as of 2025-09-01; usage grows over time as the chain grows._
 
 :::warning
 The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases). Disk usage figures below are from September 2025 and are no longer automatically updated.


### PR DESCRIPTION
Forward-port of #22596 (merged to `release/3.5`) to `main`.

## What & why

The hardware-requirements "Current Disk Usage" numbers were pulled at runtime from one shared `disk-sizes.json`. Every docs version imported the **same** file, so the `/v3.4/` page showed the **current** numbers instead of 3.4's — and a missing value silently rendered `—`.

This makes the numbers **static text**, so each docs version keeps its own correct values.

## How it works now

- Values live in the page between markers: `{/* ds:mainnet:full */}920 GB{/* ds:end */}`.
- `scripts/render-disk-sizes.py` fills those markers from `disk-sizes.json`. CI runs it with `--check` and **fails the build** if the page and JSON disagree, or if any page still imports the JSON.
- Because the page is static, `docusaurus docs:version` freezes the right numbers automatically — no extra step at release time.

## Changes

- Current + **v3.4** hardware pages: static values + "measured as of" date; runtime import removed.
- New `render-disk-sizes.py` + tests (fail-closed on typo'd/unpaired markers, bad dates, unsafe values).
- CI (`docs-site-build.yml`): render `--check` + guard against dynamic references. (Keeps main's `checkout@v7` / `persist-credentials` / `timeout-minutes`.)
- `update-disk-sizes.yml`: **only** adds the render step + commit-both. Main's app-token infra (#22547), trigger cleanup (#22556), and `base_branch=release/3.5` are preserved. This is also where the main-side workflow change from the #22596 discussion lands.
- README: documents the data flow + version-cut runbook.
- `llms-full.txt`: regenerated (real values instead of `—`).

## Verification

`render --check`, guard, **78 script tests**, `generate-llms.py --check`, typecheck, and build all pass. Ported content is byte-identical to merged #22596; adversarially reviewed for merge correctness (main-only workflow features confirmed preserved).

## Note

`update-disk-sizes` dispatched against a base branch that lacks `render-disk-sizes.py` (e.g. retired `release/3.4`) now fails at the render step — fail-loud and expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)