### PR TITLE
.github: fix manifest cache-poisoning + tighten cache-poisoning ignores

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version: ${{ steps.goversion.outputs.version }}
+          cache: false
       - run: make downloader
       - run: echo $ModModified
       - run: ./build/bin/downloader manifest-verify --chain mainnet     --webseed 'https://erigon34-v1-snapshots-mainnet.erigon.network'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,16 +5,16 @@ rules:
   unpinned-uses:
     disable: true
 
-  # Cache-poisoning (artipacked) findings in these workflows are intentional;
-  # tracked in issue #21132.
+  # These self-hosted QA workflows cache a clone of the pinned external
+  # erigontech/rpc-tests repo (cache key includes RPC_VERSION). The restored
+  # content is fixed and re-fetchable test code, not build output feeding a
+  # publish or deploy step, so a poisoned cache has no privileged sink here.
+  # Tracked in #21132.
   cache-poisoning:
     ignore:
-      - manifest.yml
       - qa-rpc-integration-tests-gnosis.yml
       - qa-rpc-integration-tests.yml
       - qa-sync-from-scratch.yml
-      - test-kurtosis-assertoor.yml
-      - test-kurtosis-gloas.yml
 
   # Workflows missing explicit permissions: blocks — needs a cleanup pass
   # to add least-privilege permissions to each workflow; tracked in #21132.


### PR DESCRIPTION
Part of #21132 (zizmor security-linter cleanup).

## What
**Fix** the one cache-poisoning finding that's cheap to resolve, and **tighten** the ignore list for the rest.

- **manifest.yml** — set `cache: false` on `setup-go`. This workflow publishes nothing and runs only on `go.mod` changes (which invalidate the Go module cache anyway), so the build cache buys almost nothing here — disabling it removes the finding at no practical cost.
- **`.github/zizmor.yml`** — reduce the `cache-poisoning` ignore from 6 entries to the 3 that still trigger:
  - drop **manifest.yml** (now fixed),
  - drop **test-kurtosis-assertoor.yml** / **test-kurtosis-gloas.yml** (stale — they no longer trigger the audit),
  - keep the 3 self-hosted QA workflows (`qa-rpc-integration-tests`, `-gnosis`, `qa-sync-from-scratch`) with a sharper justification: their `actions/cache` restores a clone of the **pinned external `rpc-tests` repo** (key includes `RPC_VERSION`) — fixed, re-fetchable test code, **not** build output feeding a publish/deploy step, so a poisoned cache has no privileged sink.

## Verification
- Repo-wide (all audits except the `unpinned-uses` policy): cache-poisoning **4 → 3** (manifest resolved); the 3 remaining are exactly the ignored QA files.
- `zizmor --config .github/zizmor.yml` → **0 findings**, no unmatched/stale ignore warnings.
- `actionlint` on manifest.yml → clean.

## Remaining #21132
`excessive-permissions` (66/42) and `secrets-inherit` (24/5), plus the deliberate `unpinned-uses` and `concurrency-limits` exceptions.