### PR TITLE
unify behaviour of "steps in frozen domain files" across integration commands and erigon

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -308,16 +308,21 @@ func (a *Aggregator) applyReferencesInCommitmentBranches(refs bool) {
 	}
 }
 
-// SetDomainStepsInFrozenFile sets the domain merge cap from a flag spec: empty or
-// "Inf" means unbounded, otherwise a positive integer step count.
+// SetDomainStepsInFrozenFile sets the domain merge cap from a flag spec: empty means
+// no override (the domain uses the erigondb.toml cap), "Inf" means unbounded, otherwise
+// a positive integer step count.
 func (a *Aggregator) SetDomainStepsInFrozenFile(spec string) error {
-	v := config3.UnboundedDomainMerge
-	if spec != "" && !strings.EqualFold(spec, "inf") {
-		parsed, err := strconv.ParseUint(spec, 10, 64)
-		if err != nil || parsed == 0 {
-			return fmt.Errorf("invalid domain steps-in-frozen-file %q: must be a positive integer or \"Inf\"", spec)
+	var v uint64 // 0 = no override
+	if spec != "" {
+		if strings.EqualFold(spec, "inf") {
+			v = config3.UnboundedDomainMerge
+		} else {
+			parsed, err := strconv.ParseUint(spec, 10, 64)
+			if err != nil || parsed == 0 {
+				return fmt.Errorf("invalid domain steps-in-frozen-file %q: must be a positive integer or \"Inf\"", spec)
+			}
+			v = parsed
 		}
-		v = parsed
 	}
 	a.SetErigondbDomainStepsInFrozenFile(v)
 	return nil

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/erigontech/erigon/common/background"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/datastruct/btindex"
 	"github.com/erigontech/erigon/db/etl"
@@ -45,6 +46,33 @@ import (
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
+
+func TestSetDomainStepsInFrozenFile(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		spec    string
+		want    uint64
+		wantErr bool
+	}{
+		{spec: "", want: 0}, // unset must mean "no override" (use erigondb.toml), matching the node's nil-pointer path
+		{spec: "Inf", want: config3.UnboundedDomainMerge},
+		{spec: "inf", want: config3.UnboundedDomainMerge},
+		{spec: "5", want: 5},
+		{spec: "0", wantErr: true},
+		{spec: "bad", wantErr: true},
+	} {
+		t.Run(tc.spec, func(t *testing.T) {
+			a := &Aggregator{}
+			err := a.SetDomainStepsInFrozenFile(tc.spec)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, a.erigondbDomainStepsInFrozenFile)
+		})
+	}
+}
 
 // takes first 100k keys from file
 func pivotKeysFromKV(dataPath string) ([][]byte, error) {


### PR DESCRIPTION
`--erigondb.domain.steps-in-frozen-file` encoded "unset" differently in the two CLI frameworks, and those defaults mapped to **opposite** domain-merge semantics:

| Path | "unset" representation | domain merge cap when unset |
|---|---|---|
| erigon node (urfave, `*uint64`) | `nil` → override skipped → aggregator keeps default `0` (`case 0: no override`) | **uses `erigondb.toml` `steps_in_frozen_file`** |
| integration `stage_exec` / `stage_custom_trace` and `erigon seg retire` (cobra/urfave `string`) | `""` → `SetDomainStepsInFrozenFile("")` → `UnboundedDomainMerge` | **unbounded** |

The flag's shared `Usage` string documents the node's behavior — *"Default: unset, meaning the domain uses the same cap as determined by erigondb.toml"* — so the string-path callers silently contradicted their own help text.

The root cause is entirely in `SetDomainStepsInFrozenFile`: it mapped `""` to `UnboundedDomainMerge`. This maps `""` to `0` (no override → use `erigondb.toml`), so every caller now agrees with the node and the documented default. `"Inf"` still means unbounded; a positive integer still sets an explicit cap. The direct `SetErigondbDomainStepsInFrozenFile(UnboundedDomainMerge)` caller in `commitment.go` is unaffected.

Callers unified by this fix (all route through `SetDomainStepsInFrozenFile`):
- integration `stage_exec` (`cmd/integration/commands/stages.go`)
- integration `stage_custom_trace` (`cmd/integration/commands/stages.go`)
- `erigon seg retire` (`cmd/utils/app/snapshots_cmd.go`)

Added `TestSetDomainStepsInFrozenFile`, written before the fix (red on the `""` case: `UnboundedDomainMerge` vs expected `0`), green after.
