### PR TITLE
ci: disable background FCU pruning and timeout in Hive EEST

### DIFF
--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -39,6 +39,7 @@ jobs:
             sim-limit: ".*/.*fork_(Paris|Shanghai)"
             shard: paris+shanghai
             fixtures-tarball: eest_stable
+            erigon-extra-flags: "--fcu.background.prune=false"
             max-failures: 0
             exec_mode: serial
           - sim: consume-enginex
@@ -46,6 +47,7 @@ jobs:
             sim-limit: ".*/.*fork_(Paris|Shanghai)"
             shard: paris+shanghai
             fixtures-tarball: eest_stable
+            erigon-extra-flags: "--fcu.background.prune=false"
             max-failures: 0
             exec_mode: parallel
           - sim: consume-enginex
@@ -53,6 +55,7 @@ jobs:
             sim-limit: ".*/.*fork_Cancun"
             shard: cancun
             fixtures-tarball: eest_stable
+            erigon-extra-flags: "--fcu.background.prune=false"
             max-failures: 0
             exec_mode: serial
           - sim: consume-enginex
@@ -60,6 +63,7 @@ jobs:
             sim-limit: ".*/.*fork_Cancun"
             shard: cancun
             fixtures-tarball: eest_stable
+            erigon-extra-flags: "--fcu.background.prune=false"
             max-failures: 0
             exec_mode: parallel
           - sim: consume-enginex
@@ -67,6 +71,7 @@ jobs:
             sim-limit: ".*/.*fork_Prague"
             shard: prague
             fixtures-tarball: eest_stable
+            erigon-extra-flags: "--fcu.background.prune=false"
             max-failures: 0
             exec_mode: serial
           - sim: consume-enginex
@@ -74,6 +79,7 @@ jobs:
             sim-limit: ".*/.*fork_Prague"
             shard: prague
             fixtures-tarball: eest_stable
+            erigon-extra-flags: "--fcu.background.prune=false"
             max-failures: 0
             exec_mode: parallel
           - sim: consume-enginex
@@ -81,6 +87,7 @@ jobs:
             sim-limit: ".*/.*fork_(Osaka|BPO)"
             shard: osaka
             fixtures-tarball: eest_stable
+            erigon-extra-flags: "--fcu.background.prune=false"
             max-failures: 0
             exec_mode: serial
           - sim: consume-enginex
@@ -88,6 +95,7 @@ jobs:
             sim-limit: ".*/.*fork_(Osaka|BPO)"
             shard: osaka
             fixtures-tarball: eest_stable
+            erigon-extra-flags: "--fcu.background.prune=false"
             max-failures: 0
             exec_mode: parallel
           - sim: consume-rlp

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -39,7 +39,7 @@ jobs:
             sim-limit: ".*/.*fork_(Paris|Shanghai)"
             shard: paris+shanghai
             fixtures-tarball: eest_stable
-            erigon-extra-flags: "--fcu.background.prune=false"
+            erigon-extra-flags: "--fcu.background.prune=false --fcu.timeout=0"
             max-failures: 0
             exec_mode: serial
           - sim: consume-enginex
@@ -47,7 +47,7 @@ jobs:
             sim-limit: ".*/.*fork_(Paris|Shanghai)"
             shard: paris+shanghai
             fixtures-tarball: eest_stable
-            erigon-extra-flags: "--fcu.background.prune=false"
+            erigon-extra-flags: "--fcu.background.prune=false --fcu.timeout=0"
             max-failures: 0
             exec_mode: parallel
           - sim: consume-enginex
@@ -55,7 +55,7 @@ jobs:
             sim-limit: ".*/.*fork_Cancun"
             shard: cancun
             fixtures-tarball: eest_stable
-            erigon-extra-flags: "--fcu.background.prune=false"
+            erigon-extra-flags: "--fcu.background.prune=false --fcu.timeout=0"
             max-failures: 0
             exec_mode: serial
           - sim: consume-enginex
@@ -63,7 +63,7 @@ jobs:
             sim-limit: ".*/.*fork_Cancun"
             shard: cancun
             fixtures-tarball: eest_stable
-            erigon-extra-flags: "--fcu.background.prune=false"
+            erigon-extra-flags: "--fcu.background.prune=false --fcu.timeout=0"
             max-failures: 0
             exec_mode: parallel
           - sim: consume-enginex
@@ -71,7 +71,7 @@ jobs:
             sim-limit: ".*/.*fork_Prague"
             shard: prague
             fixtures-tarball: eest_stable
-            erigon-extra-flags: "--fcu.background.prune=false"
+            erigon-extra-flags: "--fcu.background.prune=false --fcu.timeout=0"
             max-failures: 0
             exec_mode: serial
           - sim: consume-enginex
@@ -79,7 +79,7 @@ jobs:
             sim-limit: ".*/.*fork_Prague"
             shard: prague
             fixtures-tarball: eest_stable
-            erigon-extra-flags: "--fcu.background.prune=false"
+            erigon-extra-flags: "--fcu.background.prune=false --fcu.timeout=0"
             max-failures: 0
             exec_mode: parallel
           - sim: consume-enginex
@@ -87,7 +87,7 @@ jobs:
             sim-limit: ".*/.*fork_(Osaka|BPO)"
             shard: osaka
             fixtures-tarball: eest_stable
-            erigon-extra-flags: "--fcu.background.prune=false"
+            erigon-extra-flags: "--fcu.background.prune=false --fcu.timeout=0"
             max-failures: 0
             exec_mode: serial
           - sim: consume-enginex
@@ -95,7 +95,7 @@ jobs:
             sim-limit: ".*/.*fork_(Osaka|BPO)"
             shard: osaka
             fixtures-tarball: eest_stable
-            erigon-extra-flags: "--fcu.background.prune=false"
+            erigon-extra-flags: "--fcu.background.prune=false --fcu.timeout=0"
             max-failures: 0
             exec_mode: parallel
           - sim: consume-rlp


### PR DESCRIPTION
## Summary

- Start Erigon with `--fcu.background.prune=false --fcu.timeout=0` for every GitHub-hosted Hive EEST `consume-enginex` shard.
- Leave the self-hosted RLP and Glamsterdam jobs unchanged.

## Root cause

Two runner-sensitive FCU timing paths produced transient `SYNCING` responses in otherwise valid EEST cases:

- In [run 29814512890](https://github.com/erigontech/erigon/actions/runs/29814512890/job/88582648490), background pruning from the preceding FCU held the execution semaphore beyond the Engine API's 500 ms readiness window, so the following `engine_newPayloadV4` returned `SYNCING`.
- In [run 29822021736](https://github.com/erigontech/erigon/actions/runs/29822021736/job/88606624422), final FCU flush/commit work exceeded the default one-second FCU timeout under runner I/O pressure. The FCU continued asynchronously, but the request returned `SYNCING` before it completed.

These fixture tests submit known payloads and expect the final FCU result. Disabling background pruning prevents semaphore overlap between calls, while disabling the internal FCU timeout makes Hive wait for the actual result instead of converting a slow FCU into a transient `SYNCING` response. Hive's request, test, and job deadlines still bound genuine hangs.

## Testing

- `actionlint -shellcheck= .github/workflows/test-hive-eest.yml`
- `make lint` (two clean runs)
- `make erigon integration`

TDD is not applicable because this is a workflow-only configuration change.
