### PR TITLE
.github: drop unnecessary secrets: inherit from no-secret workflow calls

### DIFF
--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -30,35 +30,28 @@ on:
 jobs:
   tests:
     uses: ./.github/workflows/test-all-erigon.yml
-    secrets: inherit
 
   race-tests:
     uses: ./.github/workflows/test-all-erigon-race.yml
-    secrets: inherit
 
   caplin:
     uses: ./.github/workflows/test-integration-caplin.yml
-    secrets: inherit
 
   lint:
     uses: ./.github/workflows/lint.yml
-    secrets: inherit
 
   bench:
     uses: ./.github/workflows/test-bench.yml
     with:
       cache-warming-only: true
-    secrets: inherit
 
   eest-spec:
     uses: ./.github/workflows/test-eest-spec.yml
     with:
       cache-warming-only: true
-    secrets: inherit
 
   repro:
     uses: ./.github/workflows/reproducible-build.yml
-    secrets: inherit
 
   sonar:
     uses: ./.github/workflows/sonar.yml

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -77,25 +77,21 @@ jobs:
     if: needs.changes.outputs.code != 'false'
     needs: [changes]
     uses: ./.github/workflows/lint.yml
-    secrets: inherit
 
   tests:
     if: needs.changes.outputs.code != 'false'
     needs: [changes]
     uses: ./.github/workflows/test-all-erigon.yml
-    secrets: inherit
 
   race-tests:
     if: needs.changes.outputs.code != 'false'
     needs: [changes]
     uses: ./.github/workflows/test-all-erigon-race.yml
-    secrets: inherit
 
   eest-spec-tests:
     if: needs.changes.outputs.code != 'false'
     needs: [changes]
     uses: ./.github/workflows/test-eest-spec.yml
-    secrets: inherit
 
   hive:
     if: needs.changes.outputs.code != 'false'
@@ -112,7 +108,6 @@ jobs:
     if: needs.changes.outputs.code != 'false'
     needs: [changes]
     uses: ./.github/workflows/test-integration-caplin.yml
-    secrets: inherit
 
   docs-site:
     if: needs.changes.outputs.docs_site == 'true'
@@ -123,13 +118,11 @@ jobs:
   large-files:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/check-large-files.yml
-    secrets: inherit
 
   bench:
     if: needs.changes.outputs.code != 'false'
     needs: [changes]
     uses: ./.github/workflows/test-bench.yml
-    secrets: inherit
 
   kurtosis:
     if: needs.changes.outputs.code != 'false'
@@ -141,7 +134,6 @@ jobs:
     if: needs.changes.outputs.code != 'false'
     needs: [changes]
     uses: ./.github/workflows/reproducible-build.yml
-    secrets: inherit
 
   sonar:
     # SONAR_TOKEN is a repo secret unavailable to fork PRs and Dependabot PRs

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -21,10 +21,18 @@ rules:
   excessive-permissions:
     disable: true
 
-  # secrets: inherit is intentional in ci-gate.yml and cache-warming.yml;
-  # tracked in #21132.
+  # The remaining `secrets: inherit` calls target same-repo reusable workflows
+  # that genuinely consume secrets — sonar (SONAR_TOKEN) and the DockerHub-pull
+  # hive/kurtosis suites (DOCKERHUB_PULL_*). Those callees read the secrets
+  # directly without declaring workflow_call secrets, so inherit is how they
+  # receive them. Tracked in #21132.
   secrets-inherit:
-    disable: true
+    ignore:
+      - cache-warming.yml
+      - cache-warming-kurtosis-cl-images.yml
+      - cache-warming-kurtosis-gloas-images.yml
+      - ci-gate.yml
+      - sonar-branch-scan.yml
 
   # This workflow must build and publish an image for every triggering commit;
   # a concurrency group would cancel intermediate queued runs and skip images.


### PR DESCRIPTION
Part of #21132 (zizmor security-linter cleanup).

## What
`ci-gate.yml` and `cache-warming.yml` called many reusable workflows with `secrets: inherit`. Auditing each callee's actual secret usage showed most reference **no secrets at all**, so `inherit` was handing them every repo secret for nothing.

- **Removed `secrets: inherit` from 15 calls** to no-secret callees: `test-all-erigon`, `test-all-erigon-race`, `test-integration-caplin`, `lint`, `test-bench`, `test-eest-spec`, `reproducible-build`, `check-large-files`. A workflow that references no `secrets.*` cannot use a secret, so this is pure hardening — **no functional change** (verified each callee greps clean for `secrets.*`).
- **Kept** `inherit` only where the callee genuinely consumes secrets: `sonar` (`SONAR_TOKEN`) and the DockerHub-pull `test-hive` / `test-hive-eest` / `test-kurtosis-assertoor` / `test-kurtosis-gloas` suites (`DOCKERHUB_PULL_*`). These callees read those secrets directly without declaring `workflow_call` secrets, so `inherit` is how they receive them today.
- **Converted** the global `secrets-inherit: disable` to a **per-file `ignore`** of the 5 callers that retain `inherit`, with an accurate justification — so the audit is now **enforced for every other workflow**.

## Verification
- Repo-wide (all audits except `unpinned-uses` policy): `secrets-inherit` **24 → 9**, all 9 in the 5 ignored callers.
- `zizmor --config .github/zizmor.yml` → **0 findings**, no unmatched/stale ignores.
- `actionlint` on both edited callers → clean; job blocks unchanged apart from the removed line.

## Remaining #21132
`excessive-permissions` (66/42) — the last cleanup category — plus the deliberate `unpinned-uses` and `concurrency-limits` exceptions. A fully-scoped follow-up could later declare the DockerHub/Sonar secrets in those 5 reusable workflows and pass them explicitly to drop the last ignore, but that touches the merge gate and is deferred.