### PR TITLE
docs(hardware): refresh v3.5 measured disk sizes (mainnet + gnosis)

### DIFF
--- a/docs/site/docs/get-started/hardware-requirements.mdx
+++ b/docs/site/docs/get-started/hardware-requirements.mdx
@@ -30,21 +30,21 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 <TabItem value="ethereum-mainnet" label="Ethereum mainnet">
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
-| Archive | {/* ds:mainnet:archive */}1.77 TB{/* ds:end */} | 4 TB | 32 GB | 64 GB |
-| Full (Default) | {/* ds:mainnet:full */}920 GB{/* ds:end */} | 2 TB | 16 GB | 32 GB |
-| Minimal | {/* ds:mainnet:minimal */}350 GB{/* ds:end */} | 1 TB | 16 GB | 64 GB |
+| Archive | {/* ds:mainnet:archive */}2.03 TB{/* ds:end */} | 4 TB | 32 GB | 64 GB |
+| Full (Default) | {/* ds:mainnet:full */}419.04 GB{/* ds:end */} | 2 TB | 16 GB | 32 GB |
+| Minimal | {/* ds:mainnet:minimal */}378.97 GB{/* ds:end */} | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of {/* ds-date:mainnet */}2025-09-01{/* ds:end */}; usage grows over time as the chain grows._
+_Current Disk Usage measured as of {/* ds-date:mainnet */}2026-07-19{/* ds:end */}; usage grows over time as the chain grows._
 
 </TabItem>
 <TabItem value="gnosis-chain" label="Gnosis Chain">
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | {/* ds:gnosis:archive */}539 GB{/* ds:end */} | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | {/* ds:gnosis:full */}462 GB{/* ds:end */}    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | {/* ds:gnosis:minimal */}128 GB{/* ds:end */} | 500 GB                      | 8 GB               | 16 GB                 |
+| Archive        | {/* ds:gnosis:archive */}673.59 GB{/* ds:end */} | 1 TB                        | 16 GB              | 32 GB                 |
+| Full (Default) | {/* ds:gnosis:full */}220.10 GB{/* ds:end */}    | 1 TB                        | 8 GB               | 16 GB                 |
+| Minimal        | {/* ds:gnosis:minimal */}204.45 GB{/* ds:end */} | 500 GB                      | 8 GB               | 16 GB                 |
 
-_Current Disk Usage measured as of {/* ds-date:gnosis */}2025-09-01{/* ds:end */}; usage grows over time as the chain grows._
+_Current Disk Usage measured as of {/* ds-date:gnosis */}2026-07-21{/* ds:end */}; usage grows over time as the chain grows._
 </TabItem>
 <TabItem value="polygon" label="Polygon">
 :::warning

--- a/docs/site/src/data/disk-sizes.json
+++ b/docs/site/src/data/disk-sizes.json
@@ -1,43 +1,43 @@
 {
-  "ci_last_updated": "2025-09-01",
+  "ci_last_updated": "2026-07-21",
   "networks": {
     "mainnet": {
       "archive": {
-        "bytes": null,
-        "display": "1.77 TB",
-        "measured_at": "2025-09-01",
+        "bytes": 2032210546379,
+        "display": "2.03 TB",
+        "measured_at": "2026-07-19",
         "source": "manual"
       },
       "full": {
-        "bytes": null,
-        "display": "920 GB",
-        "measured_at": "2025-09-01",
+        "bytes": 419040837312,
+        "display": "419.04 GB",
+        "measured_at": "2026-07-19",
         "source": "manual"
       },
       "minimal": {
-        "bytes": null,
-        "display": "350 GB",
-        "measured_at": "2025-09-01",
+        "bytes": 378972109206,
+        "display": "378.97 GB",
+        "measured_at": "2026-07-19",
         "source": "manual"
       }
     },
     "gnosis": {
       "archive": {
-        "bytes": null,
-        "display": "539 GB",
-        "measured_at": "2025-09-01",
+        "bytes": 673591206484,
+        "display": "673.59 GB",
+        "measured_at": "2026-07-21",
         "source": "manual"
       },
       "full": {
-        "bytes": null,
-        "display": "462 GB",
-        "measured_at": "2025-09-01",
+        "bytes": 220098790979,
+        "display": "220.10 GB",
+        "measured_at": "2026-07-21",
         "source": "manual"
       },
       "minimal": {
-        "bytes": null,
-        "display": "128 GB",
-        "measured_at": "2025-09-01",
+        "bytes": 204449318751,
+        "display": "204.45 GB",
+        "measured_at": "2026-07-21",
         "source": "manual"
       }
     }

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -69,19 +69,19 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
-| Archive | 1.77 TB | 4 TB | 32 GB | 64 GB |
-| Full (Default) | 920 GB | 2 TB | 16 GB | 32 GB |
-| Minimal | 350 GB | 1 TB | 16 GB | 64 GB |
+| Archive | 2.03 TB | 4 TB | 32 GB | 64 GB |
+| Full (Default) | 419.04 GB | 2 TB | 16 GB | 32 GB |
+| Minimal | 378.97 GB | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of 2025-09-01; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
 
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | 539 GB | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | 462 GB    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | 128 GB | 500 GB                      | 8 GB               | 16 GB                 |
+| Archive        | 673.59 GB | 1 TB                        | 16 GB              | 32 GB                 |
+| Full (Default) | 220.10 GB    | 1 TB                        | 8 GB               | 16 GB                 |
+| Minimal        | 204.45 GB | 500 GB                      | 8 GB               | 16 GB                 |
 
-_Current Disk Usage measured as of 2025-09-01; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
 
 :::warning
 The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases). Disk usage figures below are from September 2025 and are no longer automatically updated.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69,19 +69,19 @@ The amount of disk space recommended and RAM you need depends on the [pruning mo
 
 | Pruning Mode | Current Disk Usage | Disk Size (Recommended) | RAM (Required) | RAM (Recommended) |
 | --- | --- | --- | --- | --- |
-| Archive | 1.77 TB | 4 TB | 32 GB | 64 GB |
-| Full (Default) | 920 GB | 2 TB | 16 GB | 32 GB |
-| Minimal | 350 GB | 1 TB | 16 GB | 64 GB |
+| Archive | 2.03 TB | 4 TB | 32 GB | 64 GB |
+| Full (Default) | 419.04 GB | 2 TB | 16 GB | 32 GB |
+| Minimal | 378.97 GB | 1 TB | 16 GB | 64 GB |
 
-_Current Disk Usage measured as of 2025-09-01; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-07-19; usage grows over time as the chain grows._
 
 | **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
 | -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | 539 GB | 1 TB                        | 16 GB              | 32 GB                 |
-| Full (Default) | 462 GB    | 1 TB                        | 8 GB               | 16 GB                 |
-| Minimal        | 128 GB | 500 GB                      | 8 GB               | 16 GB                 |
+| Archive        | 673.59 GB | 1 TB                        | 16 GB              | 32 GB                 |
+| Full (Default) | 220.10 GB    | 1 TB                        | 8 GB               | 16 GB                 |
+| Minimal        | 204.45 GB | 500 GB                      | 8 GB               | 16 GB                 |
 
-_Current Disk Usage measured as of 2025-09-01; usage grows over time as the chain grows._
+_Current Disk Usage measured as of 2026-07-21; usage grows over time as the chain grows._
 
 :::warning
 The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases). Disk usage figures below are from September 2025 and are no longer automatically updated.


### PR DESCRIPTION
## What

Refreshes the "Current Disk Usage" figures on the Hardware Requirements page with fresh **v3.5.2**, default-config measurements. Previous values were manual estimates from **2025-09**.

| Network | Archive | Full | Minimal |
|---------|---------|------|---------|
| **mainnet** | 2.03 TB | 419.04 GB | 378.97 GB |
| **gnosis** | 673.59 GB | 220.10 GB | 204.45 GB |

## How measured

- `du -sb` on fully-synced nodes running **v3.5.2** with default config (only `--prune.mode` set — no `--persist.receipts` override), so receipts follow the default: kept for full/minimal; archive carries the full receipt domain as part of its history.
- mainnet measured 2026-07-19, gnosis 2026-07-21 (dates recorded per-network in `disk-sizes.json`).
- `disk-sizes.json` updated (source of record); `hardware-requirements.mdx` regenerated from it via `scripts/render-disk-sizes.py` (static markers); `render --check` and the llms `--check` both pass.

## Notes

- `source` is `manual` for all rows this cycle (hand-measured). CI (`update-disk-sizes.yml`) will resume writing `full`/`minimal` as `ci` on the next sync-from-scratch run.
- Full < Archive is expected in v3.5 (E3 pruning) — same shape on both chains.
