### PR TITLE
cmd/integration: attach StateCache in stage_exec offline re-execution

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -768,10 +768,6 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 	tx.Rollback()
 	tx = nil
 
-	// Offline re-execution should use the same read-cache tier as the live node,
-	// which attaches a StateCache in execmodule; without this, stage_exec bypasses
-	// it entirely. One process-lifetime cache is shared across the per-batch
-	// SharedDomains so it accumulates cross-batch. Self-gates on --exec.state-cache.
 	var execStateCache *cache.StateCache
 	if dbg.UseStateCache {
 		execStateCache = cache.NewDefaultStateCache()

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -58,6 +58,7 @@ import (
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/db/state/stats"
 	"github.com/erigontech/erigon/execution/builder/buildercfg"
+	"github.com/erigontech/erigon/execution/cache"
 	chain2 "github.com/erigontech/erigon/execution/chain"
 	chainspec "github.com/erigontech/erigon/execution/chain/spec"
 	"github.com/erigontech/erigon/execution/exec"
@@ -767,6 +768,15 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 	tx.Rollback()
 	tx = nil
 
+	// Offline re-execution should use the same read-cache tier as the live node,
+	// which attaches a StateCache in execmodule; without this, stage_exec bypasses
+	// it entirely. One process-lifetime cache is shared across the per-batch
+	// SharedDomains so it accumulates cross-batch. Self-gates on --exec.state-cache.
+	var execStateCache *cache.StateCache
+	if dbg.UseStateCache {
+		execStateCache = cache.NewDefaultStateCache()
+	}
+
 	collateAndPrune := func() error {
 		return agg.CollateAndPrune(ctx, db, func(tx kv.TemporalRwTx) error {
 			pruneStage, err := sync.PruneStageState(stages.Execution, s.BlockNumber, tx, s.CurrentSyncCycle.IsInitialCycle)
@@ -779,7 +789,7 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 
 	if chainTipMode {
 		for bn := execProgress; bn < block; bn++ {
-			if _, err := execBlocksBatch(ctx, db, sync, cfg, bn, false, logger); err != nil {
+			if _, err := execBlocksBatch(ctx, db, sync, cfg, bn, false, execStateCache, logger); err != nil {
 				return err
 			}
 			if err := collateAndPrune(); err != nil {
@@ -799,7 +809,7 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 	agg.LockWorkersEditing()
 
 	for {
-		execProgress, err = execBlocksBatch(ctx, db, sync, cfg, block, true, logger)
+		execProgress, err = execBlocksBatch(ctx, db, sync, cfg, block, true, execStateCache, logger)
 		if err != nil {
 			return err
 		}
@@ -820,7 +830,7 @@ func stageExec(db kv.TemporalRwDB, ctx context.Context, logger log.Logger) error
 // SharedDomains per call avoids reusing a committed (spent) one. Pruning and
 // file-building are the caller's job (agg.CollateAndPrune). Returns the Execution
 // stage progress after the batch.
-func execBlocksBatch(ctx context.Context, db kv.TemporalRwDB, st *stagedsync.Sync, cfg stagedsync.ExecuteBlockCfg, toBlock uint64, initialCycle bool, logger log.Logger) (uint64, error) {
+func execBlocksBatch(ctx context.Context, db kv.TemporalRwDB, st *stagedsync.Sync, cfg stagedsync.ExecuteBlockCfg, toBlock uint64, initialCycle bool, stateCache *cache.StateCache, logger log.Logger) (uint64, error) {
 	tx, err := db.BeginTemporalRw(ctx)
 	if err != nil {
 		return 0, err
@@ -833,6 +843,7 @@ func execBlocksBatch(ctx context.Context, db kv.TemporalRwDB, st *stagedsync.Syn
 	}
 	defer doms.Close()
 	doms.SetInMemHistoryReads(false)
+	doms.SetStateCache(stateCache)
 
 	s, err := st.StageState(stages.Execution, tx, initialCycle, false)
 	if err != nil {


### PR DESCRIPTION
## Problem

`integration stage_exec` runs offline re-execution but never attaches a `cache.StateCache` to its per-batch `SharedDomains`. The live node attaches one in `execmodule` (`exec_module.go`, `forkchoice.go`, `set_head.go`), so offline exec **diverges from a real node**: accounts/storage/code reads that a node serves from the StateCache instead fall through to DB/files. This affects both perf-comparison fidelity and any read-path measurement done via `stage_exec`.

(The commitment **branch** cache is unaffected — it's aggregator-scoped and auto-wired via `AggTx().BranchCache()`, so it already works in `stage_exec`. Only the app-level StateCache was missing.)

## Fix

Create one **process-lifetime** `cache.NewDefaultStateCache()` in `stageExec` and share it across the per-batch `SharedDomains` (so it accumulates cross-batch, mirroring the node). It's threaded into `execBlocksBatch` and attached via `SetStateCache`.

- Gated on `dbg.UseStateCache`, and `SetStateCache` already no-ops on `nil` / when disabled, so `--exec.state-cache=false` (or `USE_STATE_CACHE=false`) fully disables it — **no behavior change in that case**.
- A single long-lived cache is required for cross-batch hits; a per-batch cache would never warm up (mem covers within-batch).