### PR TITLE
p2p: decode disconnect reason leniently and bound payload read

### DIFF
--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -184,31 +183,33 @@ func readProtocolHandshake(rw MsgReader) (*protoHandshake, error) {
 	return &hs, nil
 }
 
+// maxDisconnectPayloadSize bounds how much of a disconnect message is read. A
+// well-formed reason is a few bytes; the cap stops a peer from forcing a large
+// allocation with an oversized final message.
+const maxDisconnectPayloadSize = 100
+
 func DisconnectMessagePayloadDecode(reader io.Reader) (DiscReason, error) {
-	var buffer bytes.Buffer
-	_, err := buffer.ReadFrom(reader)
+	data, err := io.ReadAll(io.LimitReader(reader, maxDisconnectPayloadSize))
 	if err != nil {
 		return DiscRequested, err
 	}
-	data := buffer.Bytes()
 	if len(data) == 0 {
 		return DiscRequested, nil
 	}
 
+	// Peers encode the reason as a single-element list [reason] or, against the
+	// spec, as a bare integer, and some send it non-canonically. None of this is
+	// actionable on a closing connection, so decode leniently and fall back to
+	// DiscRequested rather than surfacing an error.
 	var reasonList struct{ Reason DiscReason }
-	err = rlp.DecodeBytes(data, &reasonList)
-
-	// en empty list
-	if (err != nil) && strings.Contains(err.Error(), "rlp: too few elements") {
-		return DiscRequested, nil
+	if rlp.DecodeBytes(data, &reasonList) == nil {
+		return reasonList.Reason, nil
 	}
-
-	// not a list, try to decode as a plain integer
-	if (err != nil) && strings.Contains(err.Error(), "rlp: expected input list") {
-		err = rlp.DecodeBytes(data, &reasonList.Reason)
+	var reason DiscReason
+	if rlp.DecodeBytes(data, &reason) == nil {
+		return reason, nil
 	}
-
-	return reasonList.Reason, err
+	return DiscRequested, nil
 }
 
 func DisconnectMessagePayloadEncode(writer io.Writer, reason DiscReason) error {

--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -199,4 +199,32 @@ func TestDisconnectMessagePayloadDecode(t *testing.T) {
 	if reason != DiscRequested {
 		t.Fail()
 	}
+
+	// non-canonical integer (leading zero bytes): a peer encodes reason 0 as the
+	// bare byte 0x00 instead of the canonical empty string. Strict RLP rejects it.
+	reason, err = DisconnectMessagePayloadDecode(bytes.NewBuffer([]byte{0x00}))
+	if err != nil {
+		t.Error(err)
+	}
+	if reason != DiscRequested {
+		t.Fail()
+	}
+
+	// non-canonical size: reason wrapped in a length-prefixed single byte.
+	reason, err = DisconnectMessagePayloadDecode(bytes.NewBuffer([]byte{0x81, 0x00}))
+	if err != nil {
+		t.Error(err)
+	}
+	if reason != DiscRequested {
+		t.Fail()
+	}
+
+	// oversized/garbage payload must not error or allocate unbounded memory.
+	reason, err = DisconnectMessagePayloadDecode(bytes.NewBuffer(make([]byte, 1<<20)))
+	if err != nil {
+		t.Error(err)
+	}
+	if reason != DiscRequested {
+		t.Fail()
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #12765.

A peer that sends a disconnect reason encoded non-canonically — e.g. reason `0` as the bare byte `0x00` instead of the canonical empty string — made `DisconnectMessagePayloadDecode` return an error that was logged at debug:

```
Peer.handle: failed to rlp.Decode msg.Payload err="rlp: non-canonical integer (leading zero bytes) for p2p.DiscReason"
```

The disconnect reason is purely informational on a connection that is already closing (a misbehaving/lenient peer, not erigon). go-ethereum's `decodeDisconnectMessage` already handles this by decoding leniently and never surfacing an error. Erigon's custom `DisconnectMessagePayloadDecode` did not handle the non-canonical case, so it kept emitting benign debug noise.

## Changes

- Decode the reason leniently: try the spec form `[reason]`, then a bare integer, and fall back to `DiscRequested` with no error rather than propagating an RLP error. All previously handled cases (plain int, single-element list, empty list, empty payload) are preserved.
- Bound the payload read to 100 bytes. The previous `buffer.ReadFrom` was unbounded; on the post-handshake disconnect path `msg.Payload` is capped only by the rlpx frame limit (`maxUint24`, ~16MB), so a peer could force a large allocation with an oversized final message. This matches go-ethereum's 100-byte cap for the same decode.

## Test plan

- Extended `TestDisconnectMessagePayloadDecode` with the exact reported case (`0x00`), a non-canonical-size case (`0x81 0x00`), and an oversized (1MiB) garbage payload — all now decode without error to `DiscRequested`. Confirmed the new cases fail before the fix (reproducing the reported error) and pass after.
- `go test ./p2p/`, `go vet ./p2p/`, `make lint`, `make erigon integration` all green.

Follows TDD (red → green): the failing test reproduced the reported `non-canonical integer` error before the fix landed.