### PR TITLE
[r3.6] db/version: app version 3.6.0

### DIFF
--- a/db/version/app.go
+++ b/db/version/app.go
@@ -33,7 +33,7 @@ const (
 	Major                    = 3             // Major version component of the current release
 	Minor                    = 6             // Minor version component of the current release
 	Micro                    = 0             // Patch version component of the current release
-	Modifier                 = "dev"         // Modifier component of the current release
+	Modifier                 = ""            // Modifier component of the current release
 	DefaultSnapshotGitBranch = "release/3.6" // Branch of erigontech/erigon-snapshot to use in OtterSync.
 	VersionKeyCreated        = "ErigonVersionCreated"
 	VersionKeyFinished       = "ErigonVersionFinished"


### PR DESCRIPTION
Drops the `dev` modifier on `release/3.6`, same as #22043 did for 3.5.0.