### PR TITLE
cl/beacon: handle empty Fulu builder response

### DIFF
--- a/cl/beacon/builder/client_test.go
+++ b/cl/beacon/builder/client_test.go
@@ -334,6 +334,61 @@ func TestSubmitBlindedBlocks(t *testing.T) {
 	})
 }
 
+func TestSubmitBlindedBlocksFulu(t *testing.T) {
+	ctx := context.Background()
+	expectPath := mockUrl.JoinPath("/eth/v2/builder/blinded_blocks").String()
+	block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+
+	t.Run("empty accepted response", func(t *testing.T) {
+		mockHttpClient := &http.Client{
+			Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+				require.Equal(t, expectPath, req.URL.String())
+				require.Equal(t, http.MethodPost, req.Method)
+				require.Equal(t, clparams.FuluVersion.String(), req.Header.Get("Eth-Consensus-Version"))
+				return &http.Response{
+					StatusCode: http.StatusAccepted,
+					Body:       io.NopCloser(bytes.NewReader(nil)),
+					Request:    req.Clone(context.Background()),
+				}, nil
+			}),
+		}
+		builderClient := &builderClient{
+			httpClient:   mockHttpClient,
+			url:          mockUrl,
+			beaconConfig: mockBeaconConfig,
+		}
+
+		payload, bundle, requests, err := builderClient.SubmitBlindedBlocks(ctx, block)
+		require.NoError(t, err)
+		require.Nil(t, payload)
+		require.Nil(t, bundle)
+		require.Nil(t, requests)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		mockHttpClient := &http.Client{
+			Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(bytes.NewBufferString("builder error")),
+					Request:    req.Clone(context.Background()),
+				}, nil
+			}),
+		}
+		builderClient := &builderClient{
+			httpClient:   mockHttpClient,
+			url:          mockUrl,
+			beaconConfig: mockBeaconConfig,
+		}
+
+		payload, bundle, requests, err := builderClient.SubmitBlindedBlocks(ctx, block)
+		require.Error(t, err)
+		require.Nil(t, payload)
+		require.Nil(t, bundle)
+		require.Nil(t, requests)
+	})
+}
+
 func newBytes48FromString(s string) common.Bytes48 {
 	bytes := common.Hex2Bytes(s)
 	var b common.Bytes48

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -1518,17 +1518,25 @@ func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request
 	if version >= clparams.GloasVersion {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, cltypes.ErrGloasCannotBlind)
 	}
+	defer r.Body.Close()
+	contentType, err := requestContentType(r)
+	if err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusUnsupportedMediaType, err)
+	}
+	if contentType != "application/json" && contentType != "application/octet-stream" {
+		return nil, beaconhttp.NewEndpointError(http.StatusUnsupportedMediaType, fmt.Errorf("unsupported content type: %s", contentType))
+	}
+	isJSON := contentType == "application/json"
 
 	// todo: broadcast_validation
 
 	signedBlindedBlock := cltypes.NewSignedBlindedBeaconBlock(a.beaconChainCfg, version)
 	signedBlindedBlock.Block.SetVersion(version)
 	b, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
-	if r.Header.Get("Content-Type") == "application/json" {
+	if isJSON {
 		signedBlindedBlock.Block.Body.ExecutionPayload = nil
 		if err := json.Unmarshal(b, signedBlindedBlock); err != nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
@@ -1541,7 +1549,7 @@ func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request
 	if err := validateBlindedBlockRequest(signedBlindedBlock, version); err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
-	if r.Header.Get("Content-Type") == "application/json" {
+	if isJSON {
 		signedBlindedBlock.Block.SetVersion(version)
 	}
 	// submit and unblind the signedBlindedBlock

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -1472,13 +1472,16 @@ func (a *ApiHandler) PostEthV2BlindedBlocks(w http.ResponseWriter, r *http.Reque
 }
 
 func validateBlindedBlockRequest(block *cltypes.SignedBlindedBeaconBlock, version clparams.StateVersion) error {
+	if version < clparams.BellatrixVersion {
+		return errors.New("blinded blocks are unsupported before Bellatrix")
+	}
 	if block == nil || block.Block == nil {
 		return errors.New("missing block")
 	}
 	if block.Block.Body == nil {
 		return errors.New("missing block body")
 	}
-	if version.AfterOrEqual(clparams.BellatrixVersion) && block.Block.Body.ExecutionPayload == nil {
+	if block.Block.Body.ExecutionPayload == nil {
 		return errors.New("missing execution payload header")
 	}
 	return nil

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -63,8 +63,6 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
-	"github.com/erigontech/erigon/execution/protocol/params"
-	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
@@ -1473,6 +1471,41 @@ func (a *ApiHandler) PostEthV2BlindedBlocks(w http.ResponseWriter, r *http.Reque
 	return resp, err
 }
 
+func validateBlindedBlockRequest(block *cltypes.SignedBlindedBeaconBlock, version clparams.StateVersion) error {
+	if block == nil || block.Block == nil {
+		return errors.New("missing block")
+	}
+	if block.Block.Body == nil {
+		return errors.New("missing block body")
+	}
+	if version.AfterOrEqual(clparams.BellatrixVersion) && block.Block.Body.ExecutionPayload == nil {
+		return errors.New("missing execution payload header")
+	}
+	return nil
+}
+
+func validateBuilderPayload(blockPayload *cltypes.Eth1Block, executionRequests *cltypes.ExecutionRequests, expectedVersion clparams.StateVersion) error {
+	if blockPayload == nil {
+		return errors.New("builder returned nil execution payload")
+	}
+	if blockPayload.Version() != expectedVersion {
+		return fmt.Errorf("builder execution payload version mismatch: got %s, expected %s", blockPayload.Version(), expectedVersion)
+	}
+	if blockPayload.Extra == nil {
+		return errors.New("builder execution payload missing extra data")
+	}
+	if blockPayload.Transactions == nil {
+		return errors.New("builder execution payload missing transactions")
+	}
+	if expectedVersion.AfterOrEqual(clparams.CapellaVersion) && blockPayload.Withdrawals == nil {
+		return errors.New("builder execution payload missing withdrawals")
+	}
+	if expectedVersion.AfterOrEqual(clparams.ElectraVersion) && executionRequests == nil {
+		return errors.New("builder response missing execution requests")
+	}
+	return nil
+}
+
 func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request, apiVersion int) (*beaconhttp.BeaconResponse, error) {
 	ethVersion := r.Header.Get("Eth-Consensus-Version")
 	version, err := a.parseEthConsensusVersion(ethVersion, apiVersion)
@@ -1501,6 +1534,9 @@ func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request
 			return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 		}
 	}
+	if err := validateBlindedBlockRequest(signedBlindedBlock, version); err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
+	}
 	// submit and unblind the signedBlindedBlock
 	blockPayload, blobsBundle, executionRequests, err := a.builderClient.SubmitBlindedBlocks(r.Context(), signedBlindedBlock)
 	if err != nil {
@@ -1508,21 +1544,11 @@ func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request
 	}
 
 	if signedBlindedBlock.Version().AfterOrEqual(clparams.FuluVersion) {
-		requestsList := cltypes.GetExecutionRequestsList(a.beaconChainCfg, executionRequests)
-		requestsHash := cltypes.ComputeExecutionRequestHash(requestsList)
-		header, err := blockPayload.RlpHeader(&signedBlindedBlock.Block.ParentRoot, requestsHash)
-		if err != nil {
-			return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
-		}
-		rawBlock := types.RawBlock{Header: header, Body: blockPayload.Body()}
-		blockRlpSize := rawBlock.EncodingSize()
-		blockRlpSize += rlp.ListPrefixLen(blockRlpSize)
-		if blockRlpSize > params.MaxRlpBlockSize {
-			return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("block payload rlp size exceeds the limit: %d > %d", blockRlpSize, params.MaxRlpBlockSize))
-		}
-
 		log.Info("Successfully submitted blinded block", "block_num", signedBlindedBlock.Block.Body.ExecutionPayload.BlockNumber, "api_version", apiVersion)
 		return newBeaconResponse(nil), nil
+	}
+	if err := validateBuilderPayload(blockPayload, executionRequests, version); err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}
 
 	signedBlock, err := signedBlindedBlock.Unblind(blockPayload)

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -1526,6 +1526,7 @@ func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
 	if r.Header.Get("Content-Type") == "application/json" {
+		signedBlindedBlock.Block.Body.ExecutionPayload = nil
 		if err := json.Unmarshal(b, signedBlindedBlock); err != nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 		}
@@ -1536,6 +1537,9 @@ func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request
 	}
 	if err := validateBlindedBlockRequest(signedBlindedBlock, version); err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
+	}
+	if r.Header.Get("Content-Type") == "application/json" {
+		signedBlindedBlock.Block.SetVersion(version)
 	}
 	// submit and unblind the signedBlindedBlock
 	blockPayload, blobsBundle, executionRequests, err := a.builderClient.SubmitBlindedBlocks(r.Context(), signedBlindedBlock)

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -90,6 +90,32 @@ func TestPublishBlindedBlocksRejectsGloas(t *testing.T) {
 	require.Contains(t, err.Error(), cltypes.ErrGloasCannotBlind.Error())
 }
 
+func TestPublishBlindedBlocksRejectsPreBellatrix(t *testing.T) {
+	for _, version := range []clparams.StateVersion{clparams.Phase0Version, clparams.AltairVersion} {
+		t.Run(version.String(), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			h := &ApiHandler{
+				beaconChainCfg: &clparams.MainnetBeaconConfig,
+				builderClient:  builder_mock.NewMockBuilderClient(ctrl),
+			}
+			block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, version)
+			body, err := json.Marshal(block)
+			require.NoError(t, err)
+			req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Eth-Consensus-Version", version.String())
+
+			_, err = h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+			require.ErrorContains(t, err, "blinded blocks are unsupported before Bellatrix")
+		})
+	}
+
+	require.NoError(t, validateBlindedBlockRequest(
+		cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.BellatrixVersion),
+		clparams.BellatrixVersion,
+	))
+}
+
 func TestPublishBlindedBlocksAcceptsEmptyFuluBuilderResponse(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	builderClient := builder_mock.NewMockBuilderClient(ctrl)

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"math/big"
 	"net/http"
@@ -28,9 +29,12 @@ import (
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	builder_mock "github.com/erigontech/erigon/cl/beacon/builder/mock_services"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
@@ -84,6 +88,172 @@ func TestPublishBlindedBlocksRejectsGloas(t *testing.T) {
 	_, err := h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), cltypes.ErrGloasCannotBlind.Error())
+}
+
+func TestPublishBlindedBlocksAcceptsEmptyFuluBuilderResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	builderClient := builder_mock.NewMockBuilderClient(ctrl)
+	builderClient.EXPECT().SubmitBlindedBlocks(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil)
+	h := &ApiHandler{
+		beaconChainCfg: &clparams.MainnetBeaconConfig,
+		builderClient:  builderClient,
+	}
+	block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	body, err := json.Marshal(block)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Eth-Consensus-Version", clparams.FuluVersion.String())
+
+	resp, err := h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestPublishBlindedBlocksRejectsMissingPreFuluPayload(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	builderClient := builder_mock.NewMockBuilderClient(ctrl)
+	builderClient.EXPECT().SubmitBlindedBlocks(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil)
+	h := &ApiHandler{
+		beaconChainCfg: &clparams.MainnetBeaconConfig,
+		builderClient:  builderClient,
+	}
+	block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.ElectraVersion)
+	body, err := json.Marshal(block)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Eth-Consensus-Version", clparams.ElectraVersion.String())
+
+	_, err = h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+	require.ErrorContains(t, err, "builder returned nil execution payload")
+}
+
+func TestPublishBlindedBlocksRejectsMalformedRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*cltypes.SignedBlindedBeaconBlock)
+		wantErr string
+	}{
+		{
+			name: "missing block",
+			mutate: func(block *cltypes.SignedBlindedBeaconBlock) {
+				block.Block = nil
+			},
+			wantErr: "missing block",
+		},
+		{
+			name: "missing body",
+			mutate: func(block *cltypes.SignedBlindedBeaconBlock) {
+				block.Block.Body = nil
+			},
+			wantErr: "missing block body",
+		},
+		{
+			name: "missing execution payload header",
+			mutate: func(block *cltypes.SignedBlindedBeaconBlock) {
+				block.Block.Body.ExecutionPayload = nil
+			},
+			wantErr: "missing execution payload header",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			builderClient := builder_mock.NewMockBuilderClient(ctrl)
+			h := &ApiHandler{
+				beaconChainCfg: &clparams.MainnetBeaconConfig,
+				builderClient:  builderClient,
+			}
+			block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+			tc.mutate(block)
+			body, err := json.Marshal(block)
+			require.NoError(t, err)
+			if tc.name == "missing execution payload header" {
+				body = bytes.Replace(body, []byte(`"body":{`), []byte(`"body":{"execution_payload_header":null,`), 1)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Eth-Consensus-Version", clparams.FuluVersion.String())
+
+			_, err = h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestValidateBuilderPayload(t *testing.T) {
+	validPayload := func(version clparams.StateVersion) *cltypes.Eth1Block {
+		payload := cltypes.NewEth1Block(version, &clparams.MainnetBeaconConfig)
+		payload.Extra = solid.NewExtraData()
+		payload.Transactions = &solid.TransactionsSSZ{}
+		if version.AfterOrEqual(clparams.CapellaVersion) {
+			payload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(clparams.MainnetBeaconConfig.MaxWithdrawalsPerPayload), 44)
+		}
+		return payload
+	}
+	validBellatrix := validPayload(clparams.BellatrixVersion)
+	require.NoError(t, validateBuilderPayload(validBellatrix, nil, clparams.BellatrixVersion))
+
+	for _, tc := range []struct {
+		name    string
+		payload *cltypes.Eth1Block
+		version clparams.StateVersion
+		wantErr string
+	}{
+		{name: "missing payload", version: clparams.BellatrixVersion, wantErr: "nil execution payload"},
+		{
+			name: "missing extra data",
+			payload: func() *cltypes.Eth1Block {
+				payload := validPayload(clparams.BellatrixVersion)
+				payload.Extra = nil
+				return payload
+			}(),
+			version: clparams.BellatrixVersion,
+			wantErr: "missing extra data",
+		},
+		{
+			name: "missing transactions",
+			payload: func() *cltypes.Eth1Block {
+				payload := validPayload(clparams.BellatrixVersion)
+				payload.Transactions = nil
+				return payload
+			}(),
+			version: clparams.BellatrixVersion,
+			wantErr: "missing transactions",
+		},
+		{
+			name: "missing withdrawals",
+			payload: func() *cltypes.Eth1Block {
+				payload := validPayload(clparams.CapellaVersion)
+				payload.Withdrawals = nil
+				return payload
+			}(),
+			version: clparams.CapellaVersion,
+			wantErr: "missing withdrawals",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.ErrorContains(t, validateBuilderPayload(tc.payload, nil, tc.version), tc.wantErr)
+		})
+	}
+}
+
+func TestValidateBuilderPayloadRejectsOlderResponseVersion(t *testing.T) {
+	payload := cltypes.NewEth1Block(clparams.BellatrixVersion, &clparams.MainnetBeaconConfig)
+	payload.Extra = solid.NewExtraData()
+	payload.Transactions = &solid.TransactionsSSZ{}
+
+	require.ErrorContains(t, validateBuilderPayload(payload, nil, clparams.ElectraVersion), "version mismatch")
+}
+
+func TestValidateBuilderPayloadRejectsMissingElectraExecutionRequests(t *testing.T) {
+	payload := cltypes.NewEth1Block(clparams.ElectraVersion, &clparams.MainnetBeaconConfig)
+	payload.Extra = solid.NewExtraData()
+	payload.Transactions = &solid.TransactionsSSZ{}
+	payload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(clparams.MainnetBeaconConfig.MaxWithdrawalsPerPayload), 44)
+
+	require.ErrorContains(t, validateBuilderPayload(payload, nil, clparams.ElectraVersion), "missing execution requests")
+	require.NoError(t, validateBuilderPayload(payload, cltypes.NewExecutionRequestsWithVersion(&clparams.MainnetBeaconConfig, clparams.ElectraVersion), clparams.ElectraVersion))
 }
 
 func TestBlockBuilderWindowLateStartKeepsPublicationMargin(t *testing.T) {

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -93,7 +93,12 @@ func TestPublishBlindedBlocksRejectsGloas(t *testing.T) {
 func TestPublishBlindedBlocksAcceptsEmptyFuluBuilderResponse(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	builderClient := builder_mock.NewMockBuilderClient(ctrl)
-	builderClient.EXPECT().SubmitBlindedBlocks(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil)
+	builderClient.EXPECT().SubmitBlindedBlocks(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, block *cltypes.SignedBlindedBeaconBlock) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *cltypes.ExecutionRequests, error) {
+			require.Equal(t, cltypes.NewEth1Header(clparams.FuluVersion).EncodingSizeSSZ(), block.Block.Body.ExecutionPayload.EncodingSizeSSZ())
+			return nil, nil, nil, nil
+		},
+	)
 	h := &ApiHandler{
 		beaconChainCfg: &clparams.MainnetBeaconConfig,
 		builderClient:  builderClient,
@@ -131,9 +136,10 @@ func TestPublishBlindedBlocksRejectsMissingPreFuluPayload(t *testing.T) {
 
 func TestPublishBlindedBlocksRejectsMalformedRequest(t *testing.T) {
 	for _, tc := range []struct {
-		name    string
-		mutate  func(*cltypes.SignedBlindedBeaconBlock)
-		wantErr string
+		name       string
+		mutate     func(*cltypes.SignedBlindedBeaconBlock)
+		mutateJSON func(*testing.T, []byte) []byte
+		wantErr    string
 	}{
 		{
 			name: "missing block",
@@ -150,7 +156,24 @@ func TestPublishBlindedBlocksRejectsMalformedRequest(t *testing.T) {
 			wantErr: "missing block body",
 		},
 		{
-			name: "missing execution payload header",
+			name: "null execution payload header",
+			mutate: func(block *cltypes.SignedBlindedBeaconBlock) {
+				block.Block.Body.ExecutionPayload = nil
+			},
+			mutateJSON: func(t *testing.T, body []byte) []byte {
+				var request map[string]any
+				require.NoError(t, json.Unmarshal(body, &request))
+				message := request["message"].(map[string]any)
+				blockBody := message["body"].(map[string]any)
+				blockBody["execution_payload_header"] = nil
+				encoded, err := json.Marshal(request)
+				require.NoError(t, err)
+				return encoded
+			},
+			wantErr: "missing execution payload header",
+		},
+		{
+			name: "omitted execution payload header",
 			mutate: func(block *cltypes.SignedBlindedBeaconBlock) {
 				block.Block.Body.ExecutionPayload = nil
 			},
@@ -168,8 +191,8 @@ func TestPublishBlindedBlocksRejectsMalformedRequest(t *testing.T) {
 			tc.mutate(block)
 			body, err := json.Marshal(block)
 			require.NoError(t, err)
-			if tc.name == "missing execution payload header" {
-				body = bytes.Replace(body, []byte(`"body":{`), []byte(`"body":{"execution_payload_header":null,`), 1)
+			if tc.mutateJSON != nil {
+				body = tc.mutateJSON(t, body)
 			}
 			req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
 	builder_mock "github.com/erigontech/erigon/cl/beacon/builder/mock_services"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -116,6 +117,19 @@ func TestPublishBlindedBlocksRejectsPreBellatrix(t *testing.T) {
 	))
 }
 
+func TestPublishBlindedBlocksRejectsUnsupportedContentType(t *testing.T) {
+	h := &ApiHandler{beaconChainCfg: &clparams.MainnetBeaconConfig}
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", nil)
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Eth-Consensus-Version", clparams.FuluVersion.String())
+
+	_, err := h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+	endpointErr, ok := err.(*beaconhttp.EndpointError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnsupportedMediaType, endpointErr.Code)
+	require.ErrorContains(t, err, "unsupported content type")
+}
+
 func TestPublishBlindedBlocksAcceptsEmptyFuluBuilderResponse(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	builderClient := builder_mock.NewMockBuilderClient(ctrl)
@@ -133,7 +147,7 @@ func TestPublishBlindedBlocksAcceptsEmptyFuluBuilderResponse(t *testing.T) {
 	body, err := json.Marshal(block)
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Eth-Consensus-Version", clparams.FuluVersion.String())
 
 	resp, err := h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)


### PR DESCRIPTION
Cherry-pick of #22606 to main.

## Summary

- Handle the empty `202 Accepted` response returned by the Fulu Builder API v2 endpoint
- Reject malformed blinded block requests (null/omitted execution payload headers, pre-Bellatrix submissions)
- Accept parameterized JSON media types and reject unsupported content types with `415`
- Reject nil, partial, or fork-mismatched pre-Fulu builder responses before unblinding
- Add handler and builder-client regression coverage

Fixes #22598