### PR TITLE
[r3.6] db/state: retire OpenFolder-invalidated files instead of closing under readers

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -569,28 +569,47 @@ func (a *Aggregator) openFolder() error {
 		return err
 	}
 
+	standaloneIIs := a.standaloneIIs()
+	retiredByDomain := make([][]*FilesItem, len(a.d))
+	retiredByII := make([][]*FilesItem, len(standaloneIIs))
+
 	eg, ctx := errgroup.WithContext(a.ctx)
-	for _, d := range a.d {
+	for id, d := range a.d {
 		if d.Disable {
 			continue
 		}
 
-		d := d
+		id, d := id, d
 		eg.Go(func() error {
-			return d.openFolder(ctx, scanDirsRes)
+			retired, err := d.openFolder(ctx, scanDirsRes)
+			retiredByDomain[id] = retired
+			return err
 		})
 	}
-	for _, ii := range a.standaloneIIs() {
+	for id, ii := range standaloneIIs {
 		if ii.Disable {
 			continue
 		}
-		ii := ii
-		eg.Go(func() error { return ii.openFolder(ctx, scanDirsRes) })
+		id, ii := id, ii
+		eg.Go(func() error {
+			retired, err := ii.openFolder(ctx, scanDirsRes)
+			retiredByII[id] = retired
+			return err
+		})
 	}
 	if err := eg.Wait(); err != nil {
 		return fmt.Errorf("openFolder: %w", err)
 	}
-	a.recalcVisibleFiles(nil)
+
+	var retired []*FilesItem
+	for _, r := range retiredByDomain {
+		retired = append(retired, r...)
+	}
+	for _, r := range retiredByII {
+		retired = append(retired, r...)
+	}
+	// Retire (not close in place) files gone from disk — see detachFilesNotInList.
+	a.recalcVisibleFiles(retired)
 	return nil
 }
 

--- a/db/state/aggregator_openfolder_reclaim_test.go
+++ b/db/state/aggregator_openfolder_reclaim_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/db/kv"
+)
+
+// A reader that pinned the visible-file generation before Aggregator.OpenFolder
+// runs must keep reading the files it still references, even if OpenFolder finds
+// some of them removed from disk. The buggy path closed those files in place
+// (nil-ing FilesItem.decompressor), crashing the reader that still held them.
+func TestAggregatorOpenFolderKeepsReaderFilesAlive(t *testing.T) {
+	_, agg := testDbAggregatorWithFiles(t, &testAggConfig{stepSize: 16})
+
+	kvPath, ok := newestDomainFile(t, agg.Dirs().SnapDomain, "accounts")
+	require.True(t, ok, "expected at least one accounts .kv file")
+
+	// Reader pins the current generation, which still references kvPath.
+	at := agg.BeginFilesRo()
+	defer at.Close()
+
+	// An external actor removes the newest file from disk (e.g. after an unwind
+	// or merge cleanup), then the folder is reopened while `at` is still live.
+	require.NoError(t, dir.RemoveFile(kvPath))
+	require.NoError(t, agg.OpenFolder())
+
+	require.NotPanics(t, func() {
+		_, _, _, _, err := at.DebugGetLatestFromFiles(kv.AccountsDomain, make([]byte, 20), 0)
+		require.NoError(t, err)
+	})
+}
+
+// newestDomainFile returns the path of the domain .kv file with the greatest end
+// step (the visible tip) for the given domain, matching `<ver>-<name>.<from>-<to>.kv`.
+func newestDomainFile(t *testing.T, dir, name string) (string, bool) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	bestEnd, bestPath := -1, ""
+	for _, e := range entries {
+		fn := e.Name()
+		if !strings.HasSuffix(fn, ".kv") || !strings.Contains(fn, "-"+name+".") {
+			continue
+		}
+		body := strings.TrimSuffix(fn, ".kv")
+		rng := body[strings.LastIndex(body, ".")+1:]
+		_, toStep, ok := strings.Cut(rng, "-")
+		if !ok {
+			continue
+		}
+		end, err := strconv.Atoi(toStep)
+		if err != nil {
+			continue
+		}
+		if end > bestEnd {
+			bestEnd, bestPath = end, filepath.Join(dir, fn)
+		}
+	}
+	return bestPath, bestPath != ""
+}

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -345,6 +345,7 @@ type retireReason int
 const (
 	retireReasonMerged retireReason = iota + 1
 	retireReasonAged
+	retireReasonDeletedFromDisk
 )
 
 func (r retireReason) String() string {
@@ -353,6 +354,8 @@ func (r retireReason) String() string {
 		return "merged"
 	case retireReasonAged:
 		return "aged"
+	case retireReasonDeletedFromDisk:
+		return "deleted-from-disk"
 	default:
 		return "unknown"
 	}
@@ -849,18 +852,41 @@ func fileItemsWithMissedAccessors(dirtyFiles []*FilesItem, aggregationStep uint6
 	return
 }
 
-// closeWhatNotInList closes and removes from dirtyFiles all items whose decompressor file name
-// is not in the provided fNames list.
-func closeWhatNotInList(dirtyFiles *DirtyFiles, fNames []string) {
+// filesNotInList collects (without removing or closing) every dirtyFiles item whose
+// decompressor file is not in fNames. A nil decompressor has no backing file, so it
+// always qualifies.
+func filesNotInList(dirtyFiles *DirtyFiles, fNames []string) []*FilesItem {
 	protectFiles := make(map[string]struct{}, len(fNames))
 	for _, f := range fNames {
 		protectFiles[f] = struct{}{}
 	}
-	dirtyFiles.CloseIf(func(item *FilesItem) bool {
+	var outs []*FilesItem
+	dirtyFiles.Scan(func(item *FilesItem) bool {
 		if item.decompressor == nil {
+			outs = append(outs, item)
 			return true
 		}
-		_, protected := protectFiles[item.decompressor.FileName()]
-		return !protected
+		if _, protected := protectFiles[item.decompressor.FileName()]; !protected {
+			outs = append(outs, item)
+		}
+		return true
 	})
+	return outs
+}
+
+// closeWhatNotInList closes and removes from dirtyFiles all items whose decompressor file name
+// is not in the provided fNames list.
+func closeWhatNotInList(dirtyFiles *DirtyFiles, fNames []string) {
+	dirtyFiles.CloseItems(filesNotInList(dirtyFiles, fNames))
+}
+
+// detachFilesNotInList removes from dirtyFiles — but does not close — every item
+// whose decompressor file is absent from fNames, returning them for the caller to
+// attach to the outgoing visible generation. It must not close in place: a reader
+// may still hold the same FilesItem, so physical close waits until that reader's
+// generation drains (via recalcVisibleFiles/reclaimRetiredLocked).
+func detachFilesNotInList(dirtyFiles *DirtyFiles, fNames []string, filenameBase string, logger log.Logger) []*FilesItem {
+	outs := filesNotInList(dirtyFiles, fNames)
+	retire(dirtyFiles, outs, filenameBase, retireReasonDeletedFromDisk, logger)
+	return outs
 }

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -323,18 +323,19 @@ func (dt *DomainRoTx) NewWriter() *DomainBufferedWriter { return dt.newWriter(dt
 // It's ok if some files was open earlier.
 // If some file already open: noop.
 // If some file already open but not in provided list: close and remove from `files` field.
-func (d *Domain) OpenList(ctx context.Context, scanResult ScanDirsResult) error {
-	if err := d.History.openList(ctx, scanResult.iiFiles, scanResult.historyFiles, scanResult.accessorFiles); err != nil {
-		return err
+func (d *Domain) OpenList(ctx context.Context, scanResult ScanDirsResult) ([]*FilesItem, error) {
+	retired, err := d.History.openList(ctx, scanResult.iiFiles, scanResult.historyFiles, scanResult.accessorFiles)
+	if err != nil {
+		return retired, err
 	}
 
-	d.closeWhatNotInList(scanResult.domainFiles)
+	retired = append(retired, d.retireFilesNotInList(scanResult.domainFiles)...)
 	d.scanDirtyFiles(scanResult.domainFiles)
 	if err := d.openDirtyFiles(ctx, scanResult.domainFiles); err != nil {
-		return fmt.Errorf("Domain(%s).openList: %w", d.FilenameBase, err)
+		return retired, fmt.Errorf("Domain(%s).openList: %w", d.FilenameBase, err)
 	}
 	d.protectFromHistoryFilesAheadOfDomainFiles()
-	return nil
+	return retired, nil
 }
 
 // protectFromHistoryFilesAheadOfDomainFiles - in some corner-cases app may see more .ef/.v files than .kv:
@@ -344,9 +345,9 @@ func (d *Domain) protectFromHistoryFilesAheadOfDomainFiles() {
 	d.closeFilesAfterStep(kv.Step(d.dirtyFilesEndTxNumMinimax() / d.stepSize))
 }
 
-func (d *Domain) openFolder(ctx context.Context, r *ScanDirsResult) error {
+func (d *Domain) openFolder(ctx context.Context, r *ScanDirsResult) ([]*FilesItem, error) {
 	if d.Disable {
-		return nil
+		return nil, nil
 	}
 	return d.OpenList(ctx, *r)
 }
@@ -381,6 +382,10 @@ func (d *Domain) scanDirtyFiles(fileNames []string) (garbageFiles []*FilesItem) 
 
 func (d *Domain) closeWhatNotInList(fNames []string) {
 	closeWhatNotInList(d.dirtyFiles, fNames)
+}
+
+func (d *Domain) retireFilesNotInList(fNames []string) []*FilesItem {
+	return detachFilesNotInList(d.dirtyFiles, fNames, d.FilenameBase, d.logger)
 }
 
 // calcVisibleFiles is pure — it does not mutate d, d.History, or d.History.InvertedIndex.

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -155,7 +155,7 @@ func TestDomain_OpenFolder(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(d.dirs)
 	require.NoError(t, err)
-	err = d.openFolder(t.Context(), scanDirsRes)
+	_, err = d.openFolder(t.Context(), scanDirsRes)
 	require.NoError(t, err)
 	d.Close()
 }
@@ -861,7 +861,8 @@ func TestDomain_ScanFiles(t *testing.T) {
 	d.closeWhatNotInList([]string{})
 	scanDirsRes, err := scanDirs(d.dirs)
 	require.NoError(t, err)
-	require.NoError(t, d.openFolder(t.Context(), scanDirsRes))
+	_, err = d.openFolder(t.Context(), scanDirsRes)
+	require.NoError(t, err)
 
 	// Check the history
 	checkHistory(t, db, d, txs)
@@ -1373,7 +1374,7 @@ func TestDomain_OpenFilesWithDeletions(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(dom.dirs)
 	require.NoError(t, err)
-	err = dom.openFolder(t.Context(), scanDirsRes)
+	_, err = dom.openFolder(t.Context(), scanDirsRes)
 
 	require.NoError(t, err)
 

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -125,20 +125,21 @@ func (h *History) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
 // It's ok if some files was open earlier.
 // If some file already open: noop.
 // If some file already open but not in provided list: close and remove from `files` field.
-func (h *History) openList(ctx context.Context, idxFiles, histNames, accessorFiles []string) error {
-	if err := h.InvertedIndex.openList(ctx, idxFiles, accessorFiles); err != nil {
-		return err
+func (h *History) openList(ctx context.Context, idxFiles, histNames, accessorFiles []string) ([]*FilesItem, error) {
+	retired, err := h.InvertedIndex.openList(ctx, idxFiles, accessorFiles)
+	if err != nil {
+		return retired, err
 	}
 
-	h.closeWhatNotInList(histNames)
+	retired = append(retired, h.retireFilesNotInList(histNames)...)
 	h.scanDirtyFiles(histNames)
 	if err := h.openDirtyFiles(ctx, histNames, accessorFiles); err != nil {
-		return fmt.Errorf("History(%s).openList: %w", h.FilenameBase, err)
+		return retired, fmt.Errorf("History(%s).openList: %w", h.FilenameBase, err)
 	}
-	return nil
+	return retired, nil
 }
 
-func (h *History) openFolder(ctx context.Context, scanDirsRes *ScanDirsResult) error {
+func (h *History) openFolder(ctx context.Context, scanDirsRes *ScanDirsResult) ([]*FilesItem, error) {
 	return h.openList(ctx, scanDirsRes.iiFiles, scanDirsRes.historyFiles, scanDirsRes.accessorFiles)
 }
 
@@ -158,6 +159,10 @@ func (h *History) scanDirtyFiles(fileNames []string) {
 
 func (h *History) closeWhatNotInList(fNames []string) {
 	closeWhatNotInList(h.dirtyFiles, fNames)
+}
+
+func (h *History) retireFilesNotInList(fNames []string) []*FilesItem {
+	return detachFilesNotInList(h.dirtyFiles, fNames, h.FilenameBase, h.logger)
 }
 
 func (h *History) Tables() []string { return append(h.InvertedIndex.Tables(), h.ValuesTable) }
@@ -358,8 +363,13 @@ func (h *History) Scan(ctx context.Context, toTxNum uint64) error {
 		return err
 	}
 
-	if err := h.openFolder(ctx, scanResult); err != nil {
+	retired, err := h.openFolder(ctx, scanResult)
+	if err != nil {
 		return err
+	}
+	// Standalone reload: no visible generation to attach to and no concurrent readers, so close in place.
+	for _, item := range retired {
+		item.closeFiles()
 	}
 
 	//h.reCalcVisibleFiles(toTxNum) // TODO: what need here?

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -1328,7 +1328,8 @@ func TestHistoryScanFiles(t *testing.T) {
 		// Recreate domain and re-scan the files
 		scanDirsRes, err := scanDirs(h.dirs)
 		require.NoError(err)
-		require.NoError(h.openFolder(t.Context(), scanDirsRes))
+		_, err = h.openFolder(t.Context(), scanDirsRes)
+		require.NoError(err)
 		// Check the history
 		checkHistoryHistory(t, h, txs)
 	}
@@ -1905,7 +1906,7 @@ func TestHistory_OpenFolder(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(h.dirs)
 	require.NoError(t, err)
-	err = h.openFolder(t.Context(), scanDirsRes)
+	_, err = h.openFolder(t.Context(), scanDirsRes)
 	require.NoError(t, err)
 	h.Close()
 }

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -187,18 +187,18 @@ func filesFromDir(dir string) ([]string, error) {
 	return filtered, nil
 }
 
-func (ii *InvertedIndex) openList(ctx context.Context, fNames, accessorFiles []string) error {
-	ii.closeWhatNotInList(fNames)
+func (ii *InvertedIndex) openList(ctx context.Context, fNames, accessorFiles []string) ([]*FilesItem, error) {
+	retired := ii.retireFilesNotInList(fNames)
 	ii.scanDirtyFiles(fNames)
 	if err := ii.openDirtyFiles(ctx, fNames, accessorFiles); err != nil {
-		return fmt.Errorf("InvertedIndex(%s).openDirtyFiles: %w", ii.FilenameBase, err)
+		return retired, fmt.Errorf("InvertedIndex(%s).openDirtyFiles: %w", ii.FilenameBase, err)
 	}
-	return nil
+	return retired, nil
 }
 
-func (ii *InvertedIndex) openFolder(ctx context.Context, r *ScanDirsResult) error {
+func (ii *InvertedIndex) openFolder(ctx context.Context, r *ScanDirsResult) ([]*FilesItem, error) {
 	if ii.Disable {
-		return nil
+		return nil, nil
 	}
 	return ii.openList(ctx, r.iiFiles, r.accessorFiles)
 }
@@ -292,6 +292,10 @@ func (ii *InvertedIndex) BuildMissedAccessors(ctx context.Context, g *errgroup.G
 
 func (ii *InvertedIndex) closeWhatNotInList(fNames []string) {
 	closeWhatNotInList(ii.dirtyFiles, fNames)
+}
+
+func (ii *InvertedIndex) retireFilesNotInList(fNames []string) []*FilesItem {
+	return detachFilesNotInList(ii.dirtyFiles, fNames, ii.FilenameBase, ii.logger)
 }
 
 func (ii *InvertedIndex) Tables() []string { return []string{ii.KeysTable, ii.ValuesTable} }

--- a/db/state/inverted_index_test.go
+++ b/db/state/inverted_index_test.go
@@ -934,7 +934,7 @@ func TestInvIndexScanFiles(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(ii.dirs)
 	require.NoError(err)
-	err = ii.openFolder(t.Context(), scanDirsRes)
+	_, err = ii.openFolder(t.Context(), scanDirsRes)
 	require.NoError(err)
 
 	mergeInverted(t, db, ii, txs)
@@ -1059,7 +1059,7 @@ func TestInvIndex_OpenFolder(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(ii.dirs)
 	require.NoError(t, err)
-	err = ii.openFolder(t.Context(), scanDirsRes)
+	_, err = ii.openFolder(t.Context(), scanDirsRes)
 	require.NoError(t, err)
 	ii.Close()
 }


### PR DESCRIPTION
Fixes #22646.

## Problem

`Aggregator.OpenFolder` invalidated files that had vanished from disk **in place**: `closeWhatNotInList → DirtyFiles.CloseIf → FilesItem.closeFiles()` does `i.decompressor.Close(); i.decompressor = nil`. A concurrent read-only tx that had captured the same `*FilesItem` in `DomainRoTx.files` (via `dv.files`, each `visibleFile.src`) then panics the moment it dereferences the now-nil decompressor — typically at `Decompressor.FileName()` on the `dataReader` path.

This is reachable whenever `OpenFolder` runs at runtime while active RO readers exist (snapshot reopen during sync, rpcdaemon new-snapshot events, unwind machinery, …). The most visible victim is the txpool: it opens temporal RO txs in a goroutine that runs in parallel with execution to resolve sender nonce/balance, with no lock coordinating against execution triggering `OpenFolder`.

The generation-refcount reclamation from #21397 (`aggregatorVisible.retired` + `reclaimRetiredLocked`) already solves this for the merge/prune path (`cleanAfterMerge → recalcVisibleFiles(retired)`), but `closeWhatNotInList` was never rewired onto it.

## Fix

Route `OpenFolder`-invalidated files through that same reclamation instead of closing them in place:

- `detachFilesNotInList` (dirty_files.go) uses the existing `retire()` primitive to remove items from `dirtyFiles` **without closing**, and returns the invalidated `[]*FilesItem`.
- `retireFilesNotInList` on Domain/History/InvertedIndex; `openList`/`openFolder` now return `([]*FilesItem, error)` and thread the slice up.
- `Aggregator.openFolder` collects the per-entity slices (lock-free, distinct-index writes across the errgroup) and passes them to `recalcVisibleFiles(retired)` — identical to `cleanAfterMergeLocked`. `reclaimRetiredLocked` closes+removes them only once the last reader pinning that generation drains, so a reader never observes a nil decompressor.

Deliberately left closing in place (analyzed as safe or out of scope): the `Close()` teardown paths, `SnapshotRepo` (separate refcount+`canDelete` scheme), `openDirtyFiles`'s `CloseItems` (nil-decompressor items, never reader-visible), and `closeFilesAfterStep`/`protectFromHistoryFilesAheadOfDomainFiles` (only touches files with `StartStep ≥ minimax`, which are never in a visible set — and routing it through the retire path would wrongly delete valid on-disk history files). `History.Scan` (standalone integration debug tool, no visible-generation machinery, no concurrent readers) closes its returned items in place.

The repro (`aggregator_openfolder_reclaim_test.go`) is deterministic and needs no `-race`, because this is a lifetime bug, not a data race: a single goroutine pins the generation, removes a file from disk, runs `OpenFolder`, then reads again — panic before the fix, clean after.