### PR TITLE
db/version/app: bump to 3.7.0-dev

### DIFF
--- a/db/version/app.go
+++ b/db/version/app.go
@@ -31,7 +31,7 @@ var (
 // see https://calver.org
 const (
 	Major                    = 3             // Major version component of the current release
-	Minor                    = 6             // Minor version component of the current release
+	Minor                    = 7             // Minor version component of the current release
 	Micro                    = 0             // Patch version component of the current release
 	Modifier                 = "dev"         // Modifier component of the current release
 	DefaultSnapshotGitBranch = "release/3.6" // Branch of erigontech/erigon-snapshot to use in OtterSync.


### PR DESCRIPTION
Bump `main` to 3.7.0-dev now that `release/3.6` is cut (3.6.0 flip: #22652). Same as #21682 did after the 3.5 cut.