### PR TITLE
stagedsync, cmd/utils/app: use db.BuildMissedAccessors instead of reaching into agg

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1366,7 +1366,7 @@ func doRollbackSnapshotsToBlock(ctx context.Context, blockNum uint64, prompt boo
 	if err != nil {
 		return err
 	}
-	toStep := toTxNum / agg.StepSize()
+	toStep := toTxNum / tx.Debug().StepSize()
 	var toDelete []string
 	for _, dirPath := range []string{dirs.Snap, dirs.SnapIdx, dirs.SnapHistory, dirs.SnapDomain, dirs.SnapAccessors} {
 		filePaths, err := dir2.ListFiles(dirPath)
@@ -2012,7 +2012,6 @@ func doVerifyHistory(ctx context.Context, cliCtx *cli.Command, logger log.Logger
 	}
 
 	verifier := verify.NewHistoryVerifier(blockReader, chainConfig, engine, workers, logger)
-	stepSize := agg.StepSize()
 
 	// Iterate domain files to find history ranges to verify.
 	// We use AccountsDomain files as the canonical list of step ranges,
@@ -2022,6 +2021,7 @@ func doVerifyHistory(ctx context.Context, cliCtx *cli.Command, logger log.Logger
 		return err
 	}
 	defer tx.Rollback()
+	stepSize := tx.Debug().StepSize()
 	aggTx := state.AggTx(tx)
 	files := aggTx.Files(kv.AccountsDomain)
 
@@ -2709,7 +2709,7 @@ func doBlkTxNum(ctx context.Context, cliCtx *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		stepSize := agg.StepSize()
+		stepSize := tx.Debug().StepSize()
 		minStep := min / stepSize
 		maxStep := max / stepSize
 		logger.Info("out", "block", blkNumber, "min_txnum", min, "max_txnum", max, "min_step", minStep, "max_step", maxStep)

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3504,14 +3504,15 @@ func doRetireCommand(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs
 
 	logger.Info("Pruning has ended", "deleted blocks", allDeletedBlocks)
 
-	db, err = temporal.New(db, agg, res.BlockSnaps)
+	temporalDb, err := temporal.New(db, agg, res.BlockSnaps)
 	if err != nil {
 		return err
 	}
+	db = temporalDb
 
 	logger.Info("Work on state history snapshots")
 	indexWorkers := estimate.IndexSnapshot.Workers()
-	if err = agg.BuildMissedAccessors(ctx, indexWorkers); err != nil {
+	if err = temporalDb.BuildMissedAccessors(ctx, indexWorkers); err != nil {
 		return err
 	}
 

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -1610,7 +1610,6 @@ func doIntegrity(ctx context.Context, cliCtx *cli.Command) error {
 	defer clean()
 
 	defer blockRetire.MadvNormal().DisableReadAhead()
-	defer agg.MadvNormal().DisableReadAhead()
 
 	blockReader, _ := blockRetire.IO()
 	heimdallStore, _ := blockRetire.BorStore()
@@ -1618,6 +1617,7 @@ func doIntegrity(ctx context.Context, cliCtx *cli.Command) error {
 	if err != nil {
 		return err
 	}
+	defer db.Debug().EnableReadAhead().DisableReadAhead()
 	defer db.Close()
 
 	var commitmentHistoryEnabled bool
@@ -1814,11 +1814,11 @@ func doCheckCommitmentHistAtBlk(ctx context.Context, cliCtx *cli.Command, logger
 	}
 	defer clean()
 	defer blockRetire.MadvNormal().DisableReadAhead()
-	defer agg.MadvNormal().DisableReadAhead()
 	db, err := temporal.New(chainDB, agg, res.BlockSnaps)
 	if err != nil {
 		return err
 	}
+	defer db.Debug().EnableReadAhead().DisableReadAhead()
 	defer db.Close()
 	blockReader, _ := blockRetire.IO()
 	blockNum := cliCtx.Uint64("block")
@@ -1884,11 +1884,11 @@ func doCheckRCacheRootAtBlk(ctx context.Context, cliCtx *cli.Command, logger log
 	defer clean()
 	blockRetire, agg := res.BlockRetire, res.Aggregator
 	defer blockRetire.MadvNormal().DisableReadAhead()
-	defer agg.MadvNormal().DisableReadAhead()
 	db, err := temporal.New(chainDB, agg, res.BlockSnaps)
 	if err != nil {
 		return err
 	}
+	defer db.Debug().EnableReadAhead().DisableReadAhead()
 	defer db.Close()
 	blockReader, _ := blockRetire.IO()
 	blockNum := cliCtx.Uint64("block")
@@ -1912,11 +1912,11 @@ func doCheckRCacheRootAtBlkRange(ctx context.Context, cliCtx *cli.Command, logge
 	defer clean()
 	blockRetire, agg := res.BlockRetire, res.Aggregator
 	defer blockRetire.MadvNormal().DisableReadAhead()
-	defer agg.MadvNormal().DisableReadAhead()
 	db, err := temporal.New(chainDB, agg, res.BlockSnaps)
 	if err != nil {
 		return err
 	}
+	defer db.Debug().EnableReadAhead().DisableReadAhead()
 	defer db.Close()
 	blockReader, _ := blockRetire.IO()
 
@@ -1966,11 +1966,11 @@ func doVerifyState(ctx context.Context, cliCtx *cli.Command, logger log.Logger) 
 
 	agg := openAgg(ctx, dirs, chainDB, logger)
 	defer agg.Close()
-	defer agg.MadvNormal().DisableReadAhead()
 	db, err := temporal.New(chainDB, agg, nil)
 	if err != nil {
 		return err
 	}
+	defer db.Debug().EnableReadAhead().DisableReadAhead()
 	defer db.Close()
 	failFast := cliCtx.Bool("failFast")
 	fromStep := cliCtx.Uint64("from-step")

--- a/db/integrity/e3_history_no_system_txs.go
+++ b/db/integrity/e3_history_no_system_txs.go
@@ -31,7 +31,6 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
-	"github.com/erigontech/erigon/db/state"
 )
 
 // History - usually don't have anything attributed to 1-st system txs (except genesis)
@@ -81,7 +80,7 @@ func HistoryCheckNoSystemTxsRange(ctx context.Context, prefixFrom, prefixTo []by
 	txNumsReader rawdbv3.TxNumsReader,
 	logEvery *time.Ticker,
 	keysCnt, prefixesDone, prefixesTotal *atomic.Uint64) error {
-	agg := state.AggTx(tx)
+	stepSize := tx.Debug().StepSize()
 
 	var minStep uint64 = math.MaxUint64
 	keys, err := tx.Debug().RangeLatest(kv.AccountsDomain, prefixFrom, prefixTo, -1)
@@ -148,8 +147,8 @@ func HistoryCheckNoSystemTxsRange(ctx context.Context, prefixFrom, prefixTo []by
 			}
 
 			if int64(txNum) == _min {
-				minStep = min(minStep, txNum/agg.StepSize())
-				log.Info(fmt.Sprintf("[integrity] HistoryNoSystemTxs: minStep=%d, step=%d, txNum=%d, blockNum=%d, key=%x", minStep, txNum/agg.StepSize(), txNum, blk, key))
+				minStep = min(minStep, txNum/stepSize)
+				log.Info(fmt.Sprintf("[integrity] HistoryNoSystemTxs: minStep=%d, step=%d, txNum=%d, blockNum=%d, key=%x", minStep, txNum/stepSize, txNum, blk, key))
 				break
 			}
 		}

--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -528,10 +528,16 @@ type TemporalDebugTx interface {
 	NewMemBatch(ioMetrics any) TemporalMemBatch
 }
 
+type BuildAccessorsOption uint8
+
+// SkipCoveredAccessors skips files whose range is covered by other visible
+// sub-files; those self-heal via the background merge cycle.
+const SkipCoveredAccessors BuildAccessorsOption = 1
+
 type TemporalDebugDB interface {
 	DomainTables(names ...Domain) []string
 	InvertedIdxTables(names ...InvertedIdx) []string
-	BuildMissedAccessors(ctx context.Context, workers int) error
+	BuildMissedAccessors(ctx context.Context, workers int, opts ...BuildAccessorsOption) error
 	EnableReadAhead() TemporalDebugDB
 	DisableReadAhead()
 

--- a/db/kv/remotedb/kv_remote.go
+++ b/db/kv/remotedb/kv_remote.go
@@ -193,11 +193,13 @@ func (db *DB) NewMemBatch(ioMetrics any) kv.TemporalMemBatch       { panic("not 
 func (db *DB) DomainTables(domain ...kv.Domain) []string           { panic("not implemented") }
 func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string { panic("not implemented") }
 func (db *DB) ReloadFiles() error                                  { panic("not implemented") }
-func (db *DB) BuildMissedAccessors(_ context.Context, _ int) error { panic("not implemented") }
-func (db *DB) EnableReadAhead() kv.TemporalDebugDB                 { panic("not implemented") }
-func (db *DB) DisableReadAhead()                                   { panic("not implemented") }
-func (db *DB) Files() []string                                     { panic("not implemented") }
-func (db *DB) MergeLoop(ctx context.Context) error                 { panic("not implemented") }
+func (db *DB) BuildMissedAccessors(_ context.Context, _ int, _ ...kv.BuildAccessorsOption) error {
+	panic("not implemented")
+}
+func (db *DB) EnableReadAhead() kv.TemporalDebugDB { panic("not implemented") }
+func (db *DB) DisableReadAhead()                   { panic("not implemented") }
+func (db *DB) Files() []string                     { panic("not implemented") }
+func (db *DB) MergeLoop(ctx context.Context) error { panic("not implemented") }
 func (db *DB) BeginTemporalRo(ctx context.Context) (kv.TemporalTx, error) {
 	t, err := db.BeginRo(ctx) //nolint:gocritic
 	if err != nil {

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -666,8 +666,8 @@ func (db *DB) DomainTables(domain ...kv.Domain) []string {
 func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string {
 	return db.stateFiles.InvertedIdxTables(domain...)
 }
-func (db *DB) BuildMissedAccessors(ctx context.Context, workers int) (err error) {
-	return db.stateFiles.BuildMissedAccessors(ctx, workers)
+func (db *DB) BuildMissedAccessors(ctx context.Context, workers int, opts ...kv.BuildAccessorsOption) (err error) {
+	return db.stateFiles.BuildMissedAccessors(ctx, workers, opts...)
 }
 func (db *DB) EnableReadAhead() kv.TemporalDebugDB {
 	db.stateFiles.MadvNormal()

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -836,11 +836,14 @@ func (a *Aggregator) WaitForBuildAndMerge(ctx context.Context) chan struct{} {
 	return res
 }
 
-func (a *Aggregator) BuildMissedAccessors(ctx context.Context, workers int) error {
+func (a *Aggregator) BuildMissedAccessors(ctx context.Context, workers int, opts ...kv.BuildAccessorsOption) error {
 	rotx := a.DebugBeginDirtyFilesRo()
 	defer rotx.Close()
 
 	missedFilesItems := rotx.FilesWithMissedAccessors()
+	if slices.Contains(opts, kv.SkipCoveredAccessors) {
+		rotx.dropCovered(missedFilesItems)
+	}
 	if !missedFilesItems.IsEmpty() {
 		defer a.onFilesChange(nil)
 	}

--- a/db/state/aggregator_debug.go
+++ b/db/state/aggregator_debug.go
@@ -120,6 +120,26 @@ func (ac *aggDirtyFilesRoTx) FilesWithMissedAccessors() (mf *MissedAccessorAggFi
 	return
 }
 
+func (ac *aggDirtyFilesRoTx) dropCovered(mf *MissedAccessorAggFiles) {
+	drop := func(missed MissedFilesMap, all []*FilesItem, l statecfg.Accessors) {
+		for acc := range missed {
+			missed[acc] = dropCoveredAccessors(missed[acc], all, l)
+		}
+	}
+	for _, d := range ac.domain {
+		df := mf.domain[d.d.Name]
+		drop(df.files, d.files, d.d.Accessors)
+		drop(df.history.files, d.history.files, d.history.h.Accessors)
+		drop(df.history.ii.files, d.history.ii.files, d.history.ii.ii.Accessors)
+	}
+	for _, ii := range ac.ii {
+		if ii == nil {
+			continue
+		}
+		drop(mf.ii[ii.ii.Name].files, ii.files, ii.ii.Accessors)
+	}
+}
+
 func (ac *aggDirtyFilesRoTx) Close() {
 	if ac.agg == nil {
 		return

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -745,6 +746,46 @@ func checkForVisibility(item *FilesItem, l statecfg.Accessors, trace bool) (canB
 		return false
 	}
 	return true
+}
+
+// coveredByVisibleFiles reports whether item's [startTxNum, endTxNum) range is fully
+// covered by other files that are themselves visible (i.e. have their accessors).
+func coveredByVisibleFiles(item *FilesItem, all []*FilesItem, l statecfg.Accessors) bool {
+	subs := make([]*FilesItem, 0, len(all))
+	for _, f := range all {
+		if f == nil || f == item {
+			continue
+		}
+		if f.isProperSubsetOf(item) && checkForVisibility(f, l, false) {
+			subs = append(subs, f)
+		}
+	}
+	slices.SortFunc(subs, func(a, b *FilesItem) int {
+		return cmp.Compare(a.startTxNum, b.startTxNum)
+	})
+	cur := item.startTxNum
+	for _, s := range subs {
+		if s.startTxNum > cur {
+			break
+		}
+		if s.endTxNum > cur {
+			cur = s.endTxNum
+		}
+	}
+	return cur >= item.endTxNum
+}
+
+func dropCoveredAccessors(missed, all []*FilesItem, l statecfg.Accessors) []*FilesItem {
+	if len(missed) == 0 {
+		return missed
+	}
+	out := make([]*FilesItem, 0, len(missed))
+	for _, m := range missed {
+		if !coveredByVisibleFiles(m, all, l) {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // visibleFiles have no garbage (overlaps, unindexed, etc...)

--- a/db/state/dirty_files_coverage_test.go
+++ b/db/state/dirty_files_coverage_test.go
@@ -1,0 +1,59 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/seg"
+)
+
+// visibleItem builds a FilesItem that passes checkForVisibility for accessors==0
+// (only a non-nil decompressor is required).
+func visibleItem(startTxNum, endTxNum uint64) *FilesItem {
+	it := newFilesItem(startTxNum, endTxNum)
+	it.decompressor = &seg.Decompressor{}
+	return it
+}
+
+func TestCoveredByVisibleFiles(t *testing.T) {
+	t.Parallel()
+	merged := visibleItem(0, 4)
+	sub02 := visibleItem(0, 2)
+	sub24 := visibleItem(2, 4)
+
+	t.Run("covered by contiguous subs", func(t *testing.T) {
+		require.True(t, coveredByVisibleFiles(merged, []*FilesItem{sub02, sub24, merged}, 0))
+	})
+	t.Run("uncovered when no subs", func(t *testing.T) {
+		require.False(t, coveredByVisibleFiles(merged, []*FilesItem{merged}, 0))
+	})
+	t.Run("uncovered with a gap in subs", func(t *testing.T) {
+		require.False(t, coveredByVisibleFiles(merged, []*FilesItem{sub02, merged}, 0))
+	})
+	t.Run("uncovered when a sub is not visible", func(t *testing.T) {
+		invisible := newFilesItem(2, 4) // no decompressor => not visible
+		require.False(t, coveredByVisibleFiles(merged, []*FilesItem{sub02, invisible, merged}, 0))
+	})
+}
+
+func TestDropCoveredAccessors(t *testing.T) {
+	t.Parallel()
+	merged := visibleItem(0, 4)
+	sub02 := visibleItem(0, 2)
+	sub24 := visibleItem(2, 4)
+
+	t.Run("drops merged file covered by its subs", func(t *testing.T) {
+		got := dropCoveredAccessors([]*FilesItem{merged}, []*FilesItem{sub02, sub24, merged}, 0)
+		require.Empty(t, got)
+	})
+	t.Run("keeps merged file whose subs are gone", func(t *testing.T) {
+		got := dropCoveredAccessors([]*FilesItem{merged}, []*FilesItem{merged}, 0)
+		require.Equal(t, []*FilesItem{merged}, got)
+	})
+	t.Run("keeps a frontier file with no subsets", func(t *testing.T) {
+		frontier := visibleItem(4, 6)
+		got := dropCoveredAccessors([]*FilesItem{frontier}, []*FilesItem{sub02, sub24, frontier}, 0)
+		require.Equal(t, []*FilesItem{frontier}, got)
+	})
+}

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -295,7 +295,9 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		return err
 	}
 
-	if err := buildOrDeferE3Accessors(ctx, s, cfg, headersProgress); err != nil {
+	// a state file missing its accessor is excluded from the visible set, so E3 accessors
+	// must be rebuilt before execution — there is no background rebuild path
+	if err := cfg.db.Debug().BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers(), kv.SkipCoveredAccessors); err != nil {
 		return err
 	}
 
@@ -370,29 +372,6 @@ func buildOrDeferE2Indices(ctx context.Context, s *StageState, cfg SnapshotsCfg,
 		}
 	} else {
 		log.Debug(fmt.Sprintf("[%s] Deferring E2 indexing to background", s.LogPrefix()), "reason", "restart", "headersProgress", headersProgress)
-	}
-	return nil
-}
-
-// buildOrDeferE3Accessors decides whether to build E3 state accessors synchronously
-// or defer them to background processing.
-// On restart (headersProgress > 0), E3 indexing is skipped at startup. Missing accessors
-// will be built in the background via BuildMissedAccessorsInBackground (called from
-// SnapshotsPrune on every sync cycle).
-// Unindexed state files are safely excluded from visible files by checkForVisibility
-// (which checks accessor presence), so queries correctly reflect only indexed data.
-// Note: unlike E2, there is no Bor exception — the background path calls
-// BuildMissedAccessors directly without any Bor-specific early-exit guards.
-func buildOrDeferE3Accessors(ctx context.Context, s *StageState, cfg SnapshotsCfg, headersProgress uint64) error {
-	canDefer := headersProgress > 0
-
-	indexWorkers := estimate.IndexSnapshot.Workers()
-	if !canDefer {
-		if err := cfg.db.Debug().BuildMissedAccessors(ctx, indexWorkers); err != nil {
-			return err
-		}
-	} else {
-		log.Debug(fmt.Sprintf("[%s] Deferring E3 indexing to background", s.LogPrefix()), "reason", "restart", "headersProgress", headersProgress)
 	}
 	return nil
 }

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -295,7 +295,7 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		return err
 	}
 
-	if err := buildOrDeferE3Accessors(ctx, s, cfg, agg, headersProgress); err != nil {
+	if err := buildOrDeferE3Accessors(ctx, s, cfg, headersProgress); err != nil {
 		return err
 	}
 
@@ -383,12 +383,12 @@ func buildOrDeferE2Indices(ctx context.Context, s *StageState, cfg SnapshotsCfg,
 // (which checks accessor presence), so queries correctly reflect only indexed data.
 // Note: unlike E2, there is no Bor exception — the background path calls
 // BuildMissedAccessors directly without any Bor-specific early-exit guards.
-func buildOrDeferE3Accessors(ctx context.Context, s *StageState, cfg SnapshotsCfg, agg *state.Aggregator, headersProgress uint64) error {
+func buildOrDeferE3Accessors(ctx context.Context, s *StageState, cfg SnapshotsCfg, headersProgress uint64) error {
 	canDefer := headersProgress > 0
 
 	indexWorkers := estimate.IndexSnapshot.Workers()
 	if !canDefer {
-		if err := agg.BuildMissedAccessors(ctx, indexWorkers); err != nil {
+		if err := cfg.db.Debug().BuildMissedAccessors(ctx, indexWorkers); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
`BuildMissedAccessors` is exposed on the TemporalDB (`db.Debug().BuildMissedAccessors`), so callers that already hold a temporal db handle no longer need to reach into the aggregator.

- `buildOrDeferE3Accessors` now calls `cfg.db.Debug().BuildMissedAccessors` and drops the `*state.Aggregator` parameter.
- `doRetireCommand` uses the `temporal.DB` it just created instead of `agg`.

`squeeze_cmd.go` is left as-is: it operates on standalone aggregators (including `aggOld`, which has no temporal db wrapper) rather than a temporal db.

Pure refactor, no behavior change — existing tests are the safety net.