### PR TITLE
[r3.6] db/state: retire OpenFolder-invalidated files instead of closing under readers

### DIFF
--- a/db/mvcc/files_retire.go
+++ b/db/mvcc/files_retire.go
@@ -1,0 +1,24 @@
+package mvcc
+
+// RetireReason identifies why a file was removed from dirtyFiles.
+type RetireReason int
+
+const (
+	RetireReasonMerged RetireReason = iota + 1
+	RetireReasonAged
+	RetireReasonWasDeletedFromDisk // imagine you are external RPCDaemon. It subscribing to `OnSnapshotsChanged` event. Erigon can delete from disk files which you still open - it's valid case.
+	// TODO: add one more reason for "we downloaded too much files - let's remove several recent files" case. We have it in stage_snapshots
+)
+
+func (r RetireReason) String() string {
+	switch r {
+	case RetireReasonMerged:
+		return "merged"
+	case RetireReasonAged:
+		return "aged"
+	case RetireReasonWasDeletedFromDisk:
+		return "was-deleted-from-disk"
+	default:
+		return "unknown"
+	}
+}

--- a/db/snapshotsync/merger.go
+++ b/db/snapshotsync/merger.go
@@ -13,6 +13,7 @@ import (
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/mvcc"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/snapcfg"
 	"github.com/erigontech/erigon/db/snaptype"
@@ -265,13 +266,16 @@ func (m *Merger) Merge(
 }
 
 func (m *Merger) integrateMergedDirtyFiles(snapshots *BaseRoSnapshots, in, out map[snaptype.Enum][]*DirtySegment) {
-	var retired []*DirtySegment
+	var retired retiredSegments
 
 	snapshots.dirtyLock.Lock()
 	defer snapshots.dirtyLock.Unlock()
 	// Publish under the same lock so the dirty mutation and the bundle publish are one
 	// atomic step (no window for a concurrent open to re-adopt a just-retired file).
-	defer func() { snapshots.recalcVisibleFiles(snapshots.alignMin, retired) }()
+	defer func() {
+		retire(mvcc.RetireReasonMerged, retired) // merge output is on disk and must be deleted on reclaim
+		snapshots.recalcVisibleFiles(snapshots.alignMin, retired)
+	}()
 
 	// add new segments
 	for enum, newSegs := range in {

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -39,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/mvcc"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/snapcfg"
@@ -205,6 +206,8 @@ type DirtySegment struct {
 	version snaptype.Version
 
 	frozen bool
+
+	canDelete atomic.Bool
 
 	// only caplin state
 	filePath string
@@ -554,7 +557,7 @@ type snapshotVisible struct {
 	segmentsMax uint64            // max visible (indexed, non-subsumed, gap-free) segment height across all types
 
 	refcnt  atomic.Int32     // live readers pinning this generation
-	retired []*DirtySegment  // segments this generation is the last to reference; unlinked on head-drain
+	retired retiredSegments  // segments this generation is the last to reference; unlinked on head-drain
 	next    *snapshotVisible // oldest->newest chain link (set under dirtyLock)
 }
 
@@ -815,7 +818,7 @@ func RecalcVisibleSegments(dirtySegments *btree.BTreeG[*DirtySegment]) VisibleSe
 // (segments removed from dirty during the outgoing bundle's tenure): they are unlinked
 // only once every reader pinning that generation has drained. Must be called with
 // dirtyLock held, so the caller's dirty mutation and this publish are one atomic step.
-func (s *BaseRoSnapshots) recalcVisibleFiles(alignMin bool, retired []*DirtySegment) {
+func (s *BaseRoSnapshots) recalcVisibleFiles(alignMin bool, retired retiredSegments) {
 	defer func() {
 		s.idxMax.Store(s.idxAvailability())
 	}()
@@ -884,7 +887,7 @@ func (s *BaseRoSnapshots) recalcVisibleFiles(alignMin bool, retired []*DirtySegm
 
 	// `recalcVisibleFiles` is rare background operation under `dirtyFilesLock`
 	// it's good idea to delete files here, then hot reader-Close path will more likely be lock-free
-	closeAndRemoveSegments(s.reclaimRetiredLocked())
+	reclaimSegments(s.reclaimRetiredLocked())
 }
 
 // acquireVisible pins the current generation. Load and increment are not atomic together,
@@ -912,7 +915,7 @@ func (s *BaseRoSnapshots) releaseVisible(v *snapshotVisible) {
 // reclaimRetiredLocked walks the oldest->newest chain from the head, collecting the
 // retired files of every fully-drained generation older than the current one. Must be
 // called with dirtyLock held; the returned files are deleted by the caller off-lock.
-func (s *BaseRoSnapshots) reclaimRetiredLocked() (toDelete []*DirtySegment) {
+func (s *BaseRoSnapshots) reclaimRetiredLocked() (toDelete retiredSegments) {
 	cur := s.visible.Load()
 	for h := s.oldestVisible; h != cur && h.refcnt.Load() == 0; h = h.next {
 		toDelete = append(toDelete, h.retired...)
@@ -926,12 +929,43 @@ func (s *BaseRoSnapshots) reclaimRetired() {
 	s.dirtyLock.Lock()
 	toDelete := s.reclaimRetiredLocked()
 	s.dirtyLock.Unlock()
-	closeAndRemoveSegments(toDelete)
+	reclaimSegments(toDelete)
 }
 
-func closeAndRemoveSegments(segs []*DirtySegment) {
+// retiredSegments were removed from the dirty set and handed to the outgoing visible
+// generation; they are closed (and deleted from disk when canDelete) once the last
+// reader of that generation drains. See mvcc.RetireReason.
+type retiredSegments []*DirtySegment
+
+// retire sets the reclaim disposition on segs per reason (mirrors db/state.retire):
+// merge/prune output is deleted from disk, a file an external actor already removed is
+// close-only.
+func retire(reason mvcc.RetireReason, segs retiredSegments) {
+	// canDelete decides whether reclaim also deletes the file from disk, or only closes it.
+	var canDelete bool
+	switch reason {
+	case mvcc.RetireReasonMerged, mvcc.RetireReasonAged:
+		canDelete = true // our merge/prune output is still on disk and must be removed
+	case mvcc.RetireReasonWasDeletedFromDisk:
+		canDelete = false // an external actor already deleted it: close only, never re-delete
+	default:
+		panic(fmt.Sprintf("retire: unknown reason %d", reason))
+	}
 	for _, sn := range segs {
-		sn.closeAndRemoveFiles()
+		sn.canDelete.Store(canDelete)
+	}
+}
+
+// reclaimSegments closes each retired segment, additionally deleting it from disk when it
+// is marked deletable (canDelete). Segments an external actor already removed from disk are
+// close-only, so a same-name recreation before the pinning readers drain is never clobbered.
+func reclaimSegments(segs retiredSegments) {
+	for _, sn := range segs {
+		if sn.canDelete.Load() {
+			sn.closeAndRemoveFiles()
+		} else {
+			sn.close()
+		}
 	}
 }
 
@@ -1131,7 +1165,7 @@ func (s *BaseRoSnapshots) Ranges(align bool) []Range {
 
 func (s *BaseRoSnapshots) OptimisticalyOpenFolder() { _ = s.OpenFolder() }
 func (s *BaseRoSnapshots) OpenFolder() error {
-	var retired []*DirtySegment
+	var retired retiredSegments
 	err := func() error {
 		s.dirtyLock.Lock()
 		defer s.dirtyLock.Unlock()
@@ -1151,7 +1185,7 @@ func (s *BaseRoSnapshots) OpenFolder() error {
 		}
 		// Segments whose file vanished from disk leave the visible set; retire them so
 		// their fds close only after readers of the current generation drain.
-		retired = s.detachNotInList(list)
+		retired = s.retireSegmentsNotInList(mvcc.RetireReasonWasDeletedFromDisk, list)
 		return s.openSegments(list, true, false)
 	}()
 	if err != nil {
@@ -1218,10 +1252,19 @@ func (s *BaseRoSnapshots) Close() {
 	}
 }
 
+// retireSegmentsNotInList detaches segments whose file is not in `protect` and marks their
+// reclaim disposition per reason (mirrors db/state.retireFilesNotInList), returning them for
+// the outgoing visible generation. Must be called with dirtyLock held.
+func (s *BaseRoSnapshots) retireSegmentsNotInList(reason mvcc.RetireReason, protect []string) retiredSegments {
+	detached := s.detachNotInList(protect)
+	retire(reason, detached)
+	return detached
+}
+
 // detachNotInList removes from dirty every segment whose file name is not in `protect`
 // and returns them without closing; the caller owns closing or retiring them. Must be
 // called with dirtyLock held.
-func (s *BaseRoSnapshots) detachNotInList(protect []string) []*DirtySegment {
+func (s *BaseRoSnapshots) detachNotInList(protect []string) retiredSegments {
 	protectFiles := make(map[string]struct{}, len(protect))
 	for _, f := range protect {
 		protectFiles[f] = struct{}{}
@@ -1352,7 +1395,7 @@ func (s *BaseRoSnapshots) RemoveOverlaps(onDelete func(l []string) error) error 
 	func() {
 		s.dirtyLock.Lock()
 		defer s.dirtyLock.Unlock()
-		retired := s.detachNotInList(keepNames)
+		retired := s.retireSegmentsNotInList(mvcc.RetireReasonMerged, keepNames)
 		s.recalcVisibleFiles(s.alignMin, retired)
 	}()
 
@@ -1457,7 +1500,7 @@ func (s *BaseRoSnapshots) delete(fileName string) *DirtySegment {
 
 // retireFiles drops the named segments from the live set. Physical unlink is deferred
 // to the reader watermark via the generation chain, so files pinned by open views survive.
-func (s *BaseRoSnapshots) retireFiles(fileNames ...string) error {
+func (s *BaseRoSnapshots) retireFiles(reason mvcc.RetireReason, fileNames ...string) error {
 	if s == nil {
 		return nil
 	}
@@ -1465,12 +1508,13 @@ func (s *BaseRoSnapshots) retireFiles(fileNames ...string) error {
 	s.dirtyLock.Lock()
 	defer s.dirtyLock.Unlock()
 
-	var retired []*DirtySegment
+	var retired retiredSegments
 	for _, fileName := range fileNames {
 		if sn := s.delete(fileName); sn != nil {
 			retired = append(retired, sn)
 		}
 	}
+	retire(reason, retired)
 	s.recalcVisibleFiles(s.alignMin, retired)
 	return nil
 }
@@ -1510,7 +1554,7 @@ func (s *BaseRoSnapshots) RetireFilesBelow(typ snaptype.Type, blockTo uint64, on
 			return false, fmt.Errorf("onDelete: %w", err)
 		}
 	}
-	return true, s.retireFiles(names...)
+	return true, s.retireFiles(mvcc.RetireReasonAged, names...)
 }
 
 // RetireFilesAbove retires VISIBLE segments whose range ends at or beyond blockNum — the extra
@@ -1542,7 +1586,7 @@ func (s *BaseRoSnapshots) RetireFilesAbove(blockNum uint64, onDelete func(l []st
 			return fmt.Errorf("onDelete: %w", err)
 		}
 	}
-	return s.retireFiles(names...)
+	return s.retireFiles(mvcc.RetireReasonAged, names...)
 }
 
 func (s *BaseRoSnapshots) buildMissedIndices(logPrefix string, ctx context.Context, dirs datadir.Dirs, chainConfig *chain.Config, workers int, logger log.Logger) (newIdxBuilt bool, err error) {

--- a/db/snapshotsync/snapshots_race_test.go
+++ b/db/snapshotsync/snapshots_race_test.go
@@ -19,13 +19,16 @@ package snapshotsync
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/mvcc"
 	"github.com/erigontech/erigon/db/snaptype"
 	"github.com/erigontech/erigon/db/snaptype2"
 	"github.com/erigontech/erigon/db/version"
@@ -78,6 +81,61 @@ func TestRemoveOverlapsDefersUnlinkWhileViewOpen(t *testing.T) {
 	require.True(os.IsNotExist(err), "sub-segment must be unlinked once the last View drained")
 }
 
+// OpenFolder retires a segment whose file vanished from disk as close-only, never
+// re-deleting it: if the same file is recreated (e.g. re-downloaded) before the pinning
+// View drains, reclamation must not clobber the recreation. Mirrors db/state's
+// TestAggregatorOpenFolderReclaimKeepsRecreatedFile.
+func TestOpenFolderReclaimKeepsRecreatedFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	// Unix-only: the test's whole point is to unlink a .seg the store still has mmapped (an
+	// external actor removing a live snapshot). Windows forbids deleting a mapped file, so
+	// neither the setup nor the bug it reproduces can occur there.
+	if runtime.GOOS == "windows" {
+		t.Skip("deletes a file that is still mmapped; not possible on Windows")
+	}
+	logger := log.New()
+	tmpDir := t.TempDir()
+	require := require.New(t)
+
+	for from := uint64(0); from < 2_000; from += 1_000 {
+		for _, snT := range snaptype2.BlockSnapshotTypes {
+			createTestSegmentFile(t, from, from+1_000, snT.Enum(), tmpDir, version.V1_0, logger)
+		}
+	}
+	s := NewBaseRoSnapshots(ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}, tmpDir, snaptype2.BlockSnapshotTypes, snaptype2.Transactions, true, logger)
+	defer s.Close()
+	require.NoError(s.OpenFolder())
+
+	v := s.View() // pins the generation that still references the [0,1000) segments
+	// Close the pin even on an early failure: otherwise s.Close leaves fds open (live reader)
+	// and the tmpdir cleanup can't unlink the still-mapped files.
+	vClosed := false
+	defer func() {
+		if !vClosed {
+			v.Close()
+		}
+	}()
+
+	// An external actor removes the [0,1000) files; OpenFolder retires them close-only
+	// (they are already gone from disk), then the same files are recreated before v drains.
+	for _, snT := range snaptype2.BlockSnapshotTypes {
+		require.NoError(dir.RemoveFile(filepath.Join(tmpDir, snaptype.SegmentFileName(version.V1_0, 0, 1_000, snT.Enum()))))
+	}
+	require.NoError(s.OpenFolder())
+	for _, snT := range snaptype2.BlockSnapshotTypes {
+		createTestSegmentFile(t, 0, 1_000, snT.Enum(), tmpDir, version.V1_0, logger)
+	}
+	headersPath := filepath.Join(tmpDir, snaptype.SegmentFileName(version.V1_0, 0, 1_000, snaptype2.Headers.Enum()))
+
+	v.Close() // drains the pinning generation -> reclaims the retired segments (close-only)
+	vClosed = true
+
+	_, err := os.Stat(headersPath)
+	require.NoError(err, "reclaiming a vanished segment must not delete a same-name recreation")
+}
+
 // TestRemoveOverlapsProtectsPendingRetired covers the case where a merge has already
 // retired the subsumed sub-segments (their files still on disk because a reader pins the
 // pre-merge generation) and a later RemoveOverlaps re-discovers those files on disk.
@@ -124,6 +182,7 @@ func TestRemoveOverlapsProtectsPendingRetired(t *testing.T) {
 	for _, sn := range subs {
 		s.dirty[sn.Type().Enum()].Delete(sn)
 	}
+	retire(mvcc.RetireReasonMerged, subs)  // subsumed by a covering file -> delete on reclaim
 	s.recalcVisibleFiles(s.alignMin, subs) // retire subs to the current generation
 	s.dirtyLock.Unlock()
 
@@ -233,7 +292,7 @@ func TestReadersRaceRetire(t *testing.T) {
 	// Retire subsumed sub-segments concurrently with the readers.
 	require.NoError(s.RemoveOverlaps(nil))
 	for _, f := range subNames {
-		_ = s.retireFiles(f)
+		_ = s.retireFiles(mvcc.RetireReasonAged, f)
 	}
 
 	time.Sleep(20 * time.Millisecond)

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/math"
 	"github.com/erigontech/erigon/common/testlog"
+	"github.com/erigontech/erigon/db/mvcc"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/snapcfg"
@@ -369,7 +370,7 @@ func TestDeleteSnapshots(t *testing.T) {
 	}
 	require.NoError(s.OpenFolder())
 	for _, f := range retireFiles {
-		require.NoError(s.retireFiles(f))
+		require.NoError(s.retireFiles(mvcc.RetireReasonAged, f))
 		require.False(slices.Contains(s.Files(), f))
 	}
 }
@@ -389,14 +390,14 @@ func TestRetireFilesIsIdempotent(t *testing.T) {
 
 	fileName := snaptype.SegmentFileName(version.V1_0, 0, 10_000, snaptype2.Bodies.Enum())
 
-	require.NoError(s.retireFiles(fileName))
+	require.NoError(s.retireFiles(mvcc.RetireReasonAged, fileName))
 	require.False(slices.Contains(s.Files(), fileName))
 
 	require.NotPanics(func() {
-		require.NoError(s.retireFiles(fileName))
+		require.NoError(s.retireFiles(mvcc.RetireReasonAged, fileName))
 	})
 	require.NotPanics(func() {
-		require.NoError(s.retireFiles("v1.0-999999-1000000-bodies.seg"))
+		require.NoError(s.retireFiles(mvcc.RetireReasonAged, "v1.0-999999-1000000-bodies.seg"))
 	})
 }
 
@@ -428,14 +429,14 @@ func TestRetireFilesDetachesFromDirty(t *testing.T) {
 	require.Equal(2, s.dirty[txEnum].Len())
 	require.True(visibleHas(s, txEnum, 0, 10_000))
 
-	require.NoError(s.retireFiles(snaptype.SegmentFileName(version.V1_0, 0, 10_000, txEnum)))
+	require.NoError(s.retireFiles(mvcc.RetireReasonAged, snaptype.SegmentFileName(version.V1_0, 0, 10_000, txEnum)))
 
 	// Detached from dirty, not just hidden...
 	require.Equal(1, s.dirty[txEnum].Len())
 	require.False(visibleHas(s, txEnum, 0, 10_000))
 
 	// ...so a fresh recalc (no-arg RetireFiles rebuilds visible from dirty) can't resurface it.
-	require.NoError(s.retireFiles())
+	require.NoError(s.retireFiles(mvcc.RetireReasonAged))
 	require.False(visibleHas(s, txEnum, 0, 10_000))
 	require.True(visibleHas(s, txEnum, 10_000, 20_000))
 }
@@ -1150,7 +1151,7 @@ func TestRetireVsLiveViewDoesNotCrash(t *testing.T) {
 			subNames = append(subNames, snaptype.SegmentFileName(verOf(i), from, from+1_000, snT.Enum()))
 		}
 	}
-	require.NoError(s.retireFiles(subNames...))
+	require.NoError(s.retireFiles(mvcc.RetireReasonAged, subNames...))
 
 	// Closing the View must not crash.
 	defer func() {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -569,28 +569,46 @@ func (a *Aggregator) openFolder() error {
 		return err
 	}
 
+	standaloneIIs := a.standaloneIIs()
+	retiredByDomain := make([]retiredFiles, len(a.d))
+	retiredByII := make([]retiredFiles, len(standaloneIIs))
+
 	eg, ctx := errgroup.WithContext(a.ctx)
-	for _, d := range a.d {
+	for id, d := range a.d {
 		if d.Disable {
 			continue
 		}
 
-		d := d
-		eg.Go(func() error {
-			return d.openFolder(ctx, scanDirsRes)
+		eg.Go(func() (err error) {
+			retiredByDomain[id], err = d.openFolder(ctx, scanDirsRes)
+			return err
 		})
 	}
-	for _, ii := range a.standaloneIIs() {
+	for id, ii := range standaloneIIs {
 		if ii.Disable {
 			continue
 		}
-		ii := ii
-		eg.Go(func() error { return ii.openFolder(ctx, scanDirsRes) })
+		eg.Go(func() (err error) {
+			retiredByII[id], err = ii.openFolder(ctx, scanDirsRes)
+			return err
+		})
 	}
-	if err := eg.Wait(); err != nil {
-		return fmt.Errorf("openFolder: %w", err)
+	waitErr := eg.Wait()
+
+	var retired retiredFiles
+	for _, r := range retiredByDomain {
+		retired = append(retired, r...)
 	}
-	a.recalcVisibleFiles(nil)
+	for _, r := range retiredByII {
+		retired = append(retired, r...)
+	}
+	// Retire (not close in place); the last existing reader closes them. Attach even when
+	// a sibling open errored (only ctx cancellation): the files are already detached from
+	// dirtyFiles, so skipping recalc would strand them, never reclaimed.
+	a.recalcVisibleFiles(retired)
+	if waitErr != nil {
+		return fmt.Errorf("openFolder: %w", waitErr)
+	}
 	return nil
 }
 
@@ -1752,7 +1770,7 @@ type aggregatorVisible struct {
 	minimaxTxNum uint64                          // min of domain file EndTxNum across kv.StateDomains
 
 	refcnt  atomic.Int32       // live readers
-	retired []*FilesItem       // files marked as "ready for delete"
+	retired retiredFiles       // last reader of  `aggregatorVisible` object will close/remove this files
 	next    *aggregatorVisible // oldest→newest linked-list link (set under dirtyFilesLock)
 }
 
@@ -1762,7 +1780,7 @@ type aggregatorVisible struct {
 // helpers, then publishes the completed snapshot with a.visible.Store(next).
 // Per-entity visibility is not mutated; readers atomically observe one
 // cross-entity-consistent generation.
-func (a *Aggregator) recalcVisibleFiles(retired []*FilesItem) {
+func (a *Aggregator) recalcVisibleFiles(retired retiredFiles) {
 	toTxNum := a.dirtyFilesEndTxNumMinimax()
 	next := &aggregatorVisible{}
 	for id, d := range a.d {
@@ -1786,7 +1804,7 @@ func (a *Aggregator) recalcVisibleFiles(retired []*FilesItem) {
 
 	// `recalcVisibleFiles` is rare background operation under `dirtyFilesLock`
 	// it's good idea to delete files here, then hot reader-Close path will more likely be lock-free
-	closeAndRemoveFiles(a.reclaimRetiredLocked())
+	reclaimFiles(a.reclaimRetiredLocked())
 }
 
 // stateMinimaxTxNum returns min(EndTxNum) across kv.StateDomains. Mirrors
@@ -2364,27 +2382,35 @@ func (a *Aggregator) releaseVisibleFiles(v *aggregatorVisible) {
 }
 
 // reclaimRetiredLocked oldest-first traverse linked-list of visibleFiles objects while `refcnt == 0`
-// collecting retired files for physical delete. Physical delete happen out of `dirtyFilesLock`
-func (a *Aggregator) reclaimRetiredLocked() (toDelete []*FilesItem) {
+// collecting retired files for physical reclaim. Physical reclaim happens out of `dirtyFilesLock`
+func (a *Aggregator) reclaimRetiredLocked() (toReclaim retiredFiles) {
 	cur := a.visible.Load()
 	for h := a.oldestVisible; h != cur && h.refcnt.Load() == 0; h = h.next {
-		toDelete = append(toDelete, h.retired...)
+		toReclaim = append(toReclaim, h.retired...)
 		h.retired = nil
 		a.oldestVisible = h.next
 	}
-	return toDelete
+	return toReclaim
 }
 
 func (a *Aggregator) reclaimRetired() {
 	a.dirtyFilesLock.Lock()
-	toDelete := a.reclaimRetiredLocked()
+	toReclaim := a.reclaimRetiredLocked()
 	a.dirtyFilesLock.Unlock()
-	closeAndRemoveFiles(toDelete)
+	reclaimFiles(toReclaim)
 }
 
-func closeAndRemoveFiles(files []*FilesItem) {
+// reclaimFiles closes each retired file, additionally deleting it from disk when it is
+// marked deletable (canDelete). Files an external actor already removed from disk (an
+// OpenFolder that found them gone) are close-only, so a same-name recreation before the
+// pinning readers drain is never clobbered.
+func reclaimFiles(files retiredFiles) {
 	for _, f := range files {
-		f.closeFilesAndRemove()
+		if f.canDelete.Load() {
+			f.closeFilesAndRemove()
+		} else {
+			f.closeFiles()
+		}
 	}
 }
 

--- a/db/state/aggregator_close_test.go
+++ b/db/state/aggregator_close_test.go
@@ -18,6 +18,8 @@ package state
 
 import (
 	"context"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -26,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -187,4 +190,102 @@ func TestAggregatorCloseReleasesBranchCache(t *testing.T) {
 	require.NotNil(t, cd.branchCache, "Close keeps the cache object reusable")
 	_, _, ok = cd.branchCache.Get(prefix)
 	require.False(t, ok, "Close must clear the cached branch data")
+}
+
+// A reader that pinned the visible-file generation before Aggregator.OpenFolder
+// runs must keep reading the files it still references, even if OpenFolder finds
+// some of them removed from disk. The buggy path closed those files in place
+// (nil-ing FilesItem.decompressor), crashing the reader that still held them.
+func TestAggregatorOpenFolderKeepsReaderFilesAlive(t *testing.T) {
+	t.Parallel()
+	// Unix-only: the test's whole point is to unlink a .kv file the aggregator still has
+	// mmapped (an external actor removing a live snapshot). Windows forbids deleting a mapped
+	// file, so neither the setup nor the bug it reproduces can occur there.
+	if runtime.GOOS == "windows" {
+		t.Skip("deletes a file that is still mmapped; not possible on Windows")
+	}
+	// generate* helpers hardcode stepSize=10; keep the aggregator consistent.
+	const stepSize = uint64(10)
+	_, agg := testDbAndAggregatorv3(t, stepSize)
+	dirs := agg.Dirs()
+
+	// All state domains must have matching coverage or the integrity checker hides
+	// the accounts files (and the reader would then hold nothing).
+	ranges := []testFileRange{{0, 1}, {1, 2}, {2, 3}}
+	generateAccountsFile(t, dirs, ranges)
+	generateStorageFile(t, dirs, ranges)
+	generateCodeFile(t, dirs, ranges)
+	generateCommitmentFile(t, dirs, ranges)
+	require.NoError(t, agg.OpenFolder())
+
+	// Reader pins the current generation, which still references the newest file.
+	at := agg.BeginFilesRo()
+	defer at.Close()
+
+	// An external actor removes the newest accounts file from disk (e.g. after an
+	// unwind or merge cleanup), then the folder is reopened while `at` is still live.
+	require.NoError(t, dir.RemoveFile(domainFileBySuffix(t, dirs.SnapDomain, "accounts.2-3.kv")))
+	require.NoError(t, agg.OpenFolder())
+
+	var err error
+	require.NotPanics(t, func() {
+		_, _, _, _, err = at.DebugGetLatestFromFiles(kv.AccountsDomain, make([]byte, 20), 0)
+	})
+	require.NoError(t, err)
+}
+
+// OpenFolder retires vanished files as close-only, never re-deleting them: if the
+// same file is recreated (e.g. re-downloaded) before the pinning reader drains,
+// reclamation must not clobber the recreation.
+func TestAggregatorOpenFolderReclaimKeepsRecreatedFile(t *testing.T) {
+	t.Parallel()
+	// Unix-only: unlinks a .kv the aggregator still has mmapped (see the sibling test);
+	// Windows forbids deleting a mapped file.
+	if runtime.GOOS == "windows" {
+		t.Skip("deletes a file that is still mmapped; not possible on Windows")
+	}
+	const stepSize = uint64(10)
+	_, agg := testDbAndAggregatorv3(t, stepSize)
+	dirs := agg.Dirs()
+
+	ranges := []testFileRange{{0, 1}, {1, 2}, {2, 3}}
+	generateAccountsFile(t, dirs, ranges)
+	generateStorageFile(t, dirs, ranges)
+	generateCodeFile(t, dirs, ranges)
+	generateCommitmentFile(t, dirs, ranges)
+	require.NoError(t, agg.OpenFolder())
+
+	at := agg.BeginFilesRo() // pins the generation that references accounts.2-3
+	defer func() {
+		if at != nil {
+			at.Close()
+		}
+	}()
+
+	// External actor removes the newest accounts file; the folder reopens (retiring
+	// it), then the same file is recreated on disk before the reader drains.
+	require.NoError(t, dir.RemoveFile(domainFileBySuffix(t, dirs.SnapDomain, "accounts.2-3.kv")))
+	require.NoError(t, agg.OpenFolder())
+	generateAccountsFile(t, dirs, []testFileRange{{2, 3}})
+	recreated := domainFileBySuffix(t, dirs.SnapDomain, "accounts.2-3.kv")
+
+	at.Close() // drains the generation -> reclaims the retired file
+	at = nil   // prevent double-close in the deferred cleanup
+
+	exists, err := dir.FileExist(recreated)
+	require.NoError(t, err)
+	require.True(t, exists, "reclaiming a vanished file must not delete a same-name recreation")
+}
+
+func domainFileBySuffix(t *testing.T, snapDir, suffix string) string {
+	t.Helper()
+	files, err := dir.ListFiles(snapDir, ".kv")
+	require.NoError(t, err)
+	for _, f := range files {
+		if strings.HasSuffix(f, suffix) {
+			return f
+		}
+	}
+	require.Failf(t, "file not found", "no %q under %s", suffix, snapDir)
+	return ""
 }

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -36,6 +36,7 @@ import (
 	"github.com/erigontech/erigon/db/datastruct/btindex"
 	"github.com/erigontech/erigon/db/datastruct/existence"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/mvcc"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
@@ -126,14 +127,16 @@ type FilesItem struct {
 	version  version.Version
 	refcount atomic.Int32
 
-	// Used by the SnapshotRepo mark-and-sweep reclamation path (with refcount); the
-	// aggregator instead reclaims via aggregatorVisible generations (retired + refcnt).
 	canDelete atomic.Bool
 }
 
 func newFilesItem(startTxNum, endTxNum uint64) *FilesItem {
 	return &FilesItem{startTxNum: startTxNum, endTxNum: endTxNum}
 }
+
+// retiredFiles will close in near future (or deleted from disk). `retiredFiles` already was removed from `dirtyFiles` list.
+// See `mvcc.RetireReason`
+type retiredFiles []*FilesItem
 
 func (i *FilesItem) Segment() *seg.Decompressor { return i.decompressor }
 
@@ -339,34 +342,26 @@ func filterDirtyFiles(fileNames []string, stepSize uint64, filenameBase, ext str
 	return res
 }
 
-// retireReason identifies why a file was removed from dirtyFiles.
-type retireReason int
-
-const (
-	retireReasonMerged retireReason = iota + 1
-	retireReasonAged
-)
-
-func (r retireReason) String() string {
-	switch r {
-	case retireReasonMerged:
-		return "merged"
-	case retireReasonAged:
-		return "aged"
+// retire removes outs from dirtyFiles; the caller still owns outs and must attach it
+// to the outgoing visible generation itself. Physical reclaim happens once the last
+// reader of that generation closes — so readers still pinning these files are never
+// surprised.
+func retire(reason mvcc.RetireReason, dirtyFiles *DirtyFiles, outs []*FilesItem, filenameBase string, logger log.Logger) {
+	// canDelete decides whether reclaim also deletes the file from disk, or only closes it.
+	var canDelete bool
+	switch reason {
+	case mvcc.RetireReasonMerged, mvcc.RetireReasonAged:
+		canDelete = true // our merge/prune output is still on disk and must be removed
+	case mvcc.RetireReasonWasDeletedFromDisk:
+		canDelete = false // an external actor already deleted it: close only, never re-delete
 	default:
-		return "unknown"
+		panic(fmt.Sprintf("retire: unknown reason %d", reason))
 	}
-}
-
-// retire removes outs from dirtyFiles; the caller still owns outs and must
-// attach it to the outgoing visible generation itself. Physical deletion
-// (closeFilesAndRemove) happens once the last reader of that generation closes
-// — so readers still pinning these files are never surprised.
-func retire(dirtyFiles *DirtyFiles, outs []*FilesItem, filenameBase string, reason retireReason, logger log.Logger) {
 	for _, out := range outs {
 		if out == nil {
 			panic("must not happen: " + filenameBase)
 		}
+		out.canDelete.Store(canDelete)
 		dirtyFiles.Delete(out)
 		if filenameBase == traceFileLife && out.decompressor != nil {
 			logger.Warn("[agg.dbg] retire", "f", out.decompressor.FileName(), "reason", reason)
@@ -849,18 +844,36 @@ func fileItemsWithMissedAccessors(dirtyFiles []*FilesItem, aggregationStep uint6
 	return
 }
 
-// closeWhatNotInList closes and removes from dirtyFiles all items whose decompressor file name
-// is not in the provided fNames list.
-func closeWhatNotInList(dirtyFiles *DirtyFiles, fNames []string) {
+// filesNotInList collects (without removing or closing) every dirtyFiles item whose
+// decompressor file is not in fNames. A nil decompressor has no backing file, so it
+// always qualifies.
+func filesNotInList(dirtyFiles *DirtyFiles, fNames []string) []*FilesItem {
 	protectFiles := make(map[string]struct{}, len(fNames))
 	for _, f := range fNames {
 		protectFiles[f] = struct{}{}
 	}
-	dirtyFiles.CloseIf(func(item *FilesItem) bool {
+	var outs []*FilesItem
+	dirtyFiles.Scan(func(item *FilesItem) bool {
 		if item.decompressor == nil {
+			outs = append(outs, item)
 			return true
 		}
-		_, protected := protectFiles[item.decompressor.FileName()]
-		return !protected
+		if _, protected := protectFiles[item.decompressor.FileName()]; !protected {
+			outs = append(outs, item)
+		}
+		return true
 	})
+	return outs
+}
+
+// closeWhatNotInList closes and removes from dirtyFiles all items whose decompressor file name
+// is not in the provided fNames list.
+func closeWhatNotInList(dirtyFiles *DirtyFiles, fNames []string) {
+	dirtyFiles.CloseItems(filesNotInList(dirtyFiles, fNames))
+}
+
+func retireFilesNotInList(reason mvcc.RetireReason, dirtyFiles *DirtyFiles, fNames []string, filenameBase string, logger log.Logger) retiredFiles {
+	outs := filesNotInList(dirtyFiles, fNames)
+	retire(reason, dirtyFiles, outs, filenameBase, logger)
+	return outs
 }

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -33,6 +33,7 @@ import (
 
 	mdbx2 "github.com/erigontech/erigon/db/kv/mdbx"
 	"github.com/erigontech/erigon/db/kv/prune"
+	"github.com/erigontech/erigon/db/mvcc"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/background"
@@ -319,22 +320,22 @@ func (d *Domain) minStepInDB(tx kv.Tx) (lstInDb uint64) {
 
 func (dt *DomainRoTx) NewWriter() *DomainBufferedWriter { return dt.newWriter(dt.d.dirs.Tmp, false) }
 
-// OpenList - main method to open list of files.
+// openList - main method to open list of files.
 // It's ok if some files was open earlier.
-// If some file already open: noop.
-// If some file already open but not in provided list: close and remove from `files` field.
-func (d *Domain) OpenList(ctx context.Context, scanResult ScanDirsResult) error {
-	if err := d.History.openList(ctx, scanResult.iiFiles, scanResult.historyFiles, scanResult.accessorFiles); err != nil {
-		return err
+// An already-open file not in the provided list is retired (detached) and returned for deferred reclaim.
+func (d *Domain) openList(ctx context.Context, scanResult ScanDirsResult) (retiredFiles, error) {
+	retired, err := d.History.openList(ctx, scanResult.iiFiles, scanResult.historyFiles, scanResult.accessorFiles)
+	if err != nil {
+		return retired, err
 	}
 
-	d.closeWhatNotInList(scanResult.domainFiles)
+	retired = append(retired, d.retireFilesNotInList(scanResult.domainFiles)...)
 	d.scanDirtyFiles(scanResult.domainFiles)
 	if err := d.openDirtyFiles(ctx, scanResult.domainFiles); err != nil {
-		return fmt.Errorf("Domain(%s).openList: %w", d.FilenameBase, err)
+		return retired, fmt.Errorf("Domain(%s).openList: %w", d.FilenameBase, err)
 	}
 	d.protectFromHistoryFilesAheadOfDomainFiles()
-	return nil
+	return retired, nil
 }
 
 // protectFromHistoryFilesAheadOfDomainFiles - in some corner-cases app may see more .ef/.v files than .kv:
@@ -344,11 +345,11 @@ func (d *Domain) protectFromHistoryFilesAheadOfDomainFiles() {
 	d.closeFilesAfterStep(kv.Step(d.dirtyFilesEndTxNumMinimax() / d.stepSize))
 }
 
-func (d *Domain) openFolder(ctx context.Context, r *ScanDirsResult) error {
+func (d *Domain) openFolder(ctx context.Context, r *ScanDirsResult) (retiredFiles, error) {
 	if d.Disable {
-		return nil
+		return nil, nil
 	}
-	return d.OpenList(ctx, *r)
+	return d.openList(ctx, *r)
 }
 
 func (d *Domain) closeFilesAfterStep(lowerBound kv.Step) {
@@ -381,6 +382,10 @@ func (d *Domain) scanDirtyFiles(fileNames []string) (garbageFiles []*FilesItem) 
 
 func (d *Domain) closeWhatNotInList(fNames []string) {
 	closeWhatNotInList(d.dirtyFiles, fNames)
+}
+
+func (d *Domain) retireFilesNotInList(fNames []string) retiredFiles {
+	return retireFilesNotInList(mvcc.RetireReasonWasDeletedFromDisk, d.dirtyFiles, fNames, d.FilenameBase, d.logger)
 }
 
 // calcVisibleFiles is pure — it does not mutate d, d.History, or d.History.InvertedIndex.

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -155,7 +155,7 @@ func TestDomain_OpenFolder(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(d.dirs)
 	require.NoError(t, err)
-	err = d.openFolder(t.Context(), scanDirsRes)
+	_, err = d.openFolder(t.Context(), scanDirsRes)
 	require.NoError(t, err)
 	d.Close()
 }
@@ -861,7 +861,8 @@ func TestDomain_ScanFiles(t *testing.T) {
 	d.closeWhatNotInList([]string{})
 	scanDirsRes, err := scanDirs(d.dirs)
 	require.NoError(t, err)
-	require.NoError(t, d.openFolder(t.Context(), scanDirsRes))
+	_, err = d.openFolder(t.Context(), scanDirsRes)
+	require.NoError(t, err)
 
 	// Check the history
 	checkHistory(t, db, d, txs)
@@ -1373,7 +1374,7 @@ func TestDomain_OpenFilesWithDeletions(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(dom.dirs)
 	require.NoError(t, err)
-	err = dom.openFolder(t.Context(), scanDirsRes)
+	_, err = dom.openFolder(t.Context(), scanDirsRes)
 
 	require.NoError(t, err)
 

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -40,6 +40,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/kv/stream"
+	"github.com/erigontech/erigon/db/mvcc"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
 	"github.com/erigontech/erigon/db/seg"
@@ -124,21 +125,22 @@ func (h *History) openHashMapAccessor(fPath string) (*recsplit.Index, error) {
 // openList - main method to open list of files.
 // It's ok if some files was open earlier.
 // If some file already open: noop.
-// If some file already open but not in provided list: close and remove from `files` field.
-func (h *History) openList(ctx context.Context, idxFiles, histNames, accessorFiles []string) error {
-	if err := h.InvertedIndex.openList(ctx, idxFiles, accessorFiles); err != nil {
-		return err
+// An already-open file not in the provided list is retired (detached) and returned for deferred reclaim.
+func (h *History) openList(ctx context.Context, idxFiles, histNames, accessorFiles []string) (retiredFiles, error) {
+	retired, err := h.InvertedIndex.openList(ctx, idxFiles, accessorFiles)
+	if err != nil {
+		return retired, err
 	}
 
-	h.closeWhatNotInList(histNames)
+	retired = append(retired, h.retireFilesNotInList(histNames)...)
 	h.scanDirtyFiles(histNames)
 	if err := h.openDirtyFiles(ctx, histNames, accessorFiles); err != nil {
-		return fmt.Errorf("History(%s).openList: %w", h.FilenameBase, err)
+		return retired, fmt.Errorf("History(%s).openList: %w", h.FilenameBase, err)
 	}
-	return nil
+	return retired, nil
 }
 
-func (h *History) openFolder(ctx context.Context, scanDirsRes *ScanDirsResult) error {
+func (h *History) openFolder(ctx context.Context, scanDirsRes *ScanDirsResult) (retiredFiles, error) {
 	return h.openList(ctx, scanDirsRes.iiFiles, scanDirsRes.historyFiles, scanDirsRes.accessorFiles)
 }
 
@@ -158,6 +160,10 @@ func (h *History) scanDirtyFiles(fileNames []string) {
 
 func (h *History) closeWhatNotInList(fNames []string) {
 	closeWhatNotInList(h.dirtyFiles, fNames)
+}
+
+func (h *History) retireFilesNotInList(fNames []string) retiredFiles {
+	return retireFilesNotInList(mvcc.RetireReasonWasDeletedFromDisk, h.dirtyFiles, fNames, h.FilenameBase, h.logger)
 }
 
 func (h *History) Tables() []string { return append(h.InvertedIndex.Tables(), h.ValuesTable) }
@@ -358,7 +364,13 @@ func (h *History) Scan(ctx context.Context, toTxNum uint64) error {
 		return err
 	}
 
-	if err := h.openFolder(ctx, scanResult); err != nil {
+	retired, err := h.openFolder(ctx, scanResult)
+	// Standalone reload: no visible generation to attach to and no concurrent readers, so close
+	// the detached files in place — even on error, else already-retired files are leaked.
+	for _, item := range retired {
+		item.closeFiles()
+	}
+	if err != nil {
 		return err
 	}
 

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -1328,7 +1328,8 @@ func TestHistoryScanFiles(t *testing.T) {
 		// Recreate domain and re-scan the files
 		scanDirsRes, err := scanDirs(h.dirs)
 		require.NoError(err)
-		require.NoError(h.openFolder(t.Context(), scanDirsRes))
+		_, err = h.openFolder(t.Context(), scanDirsRes)
+		require.NoError(err)
 		// Check the history
 		checkHistoryHistory(t, h, txs)
 	}
@@ -1905,7 +1906,7 @@ func TestHistory_OpenFolder(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(h.dirs)
 	require.NoError(t, err)
-	err = h.openFolder(t.Context(), scanDirsRes)
+	_, err = h.openFolder(t.Context(), scanDirsRes)
 	require.NoError(t, err)
 	h.Close()
 }

--- a/db/state/inverted_index.go
+++ b/db/state/inverted_index.go
@@ -46,6 +46,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/prune"
 	"github.com/erigontech/erigon/db/kv/stream"
+	"github.com/erigontech/erigon/db/mvcc"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
 	"github.com/erigontech/erigon/db/seg"
@@ -187,18 +188,18 @@ func filesFromDir(dir string) ([]string, error) {
 	return filtered, nil
 }
 
-func (ii *InvertedIndex) openList(ctx context.Context, fNames, accessorFiles []string) error {
-	ii.closeWhatNotInList(fNames)
+func (ii *InvertedIndex) openList(ctx context.Context, fNames, accessorFiles []string) (retiredFiles, error) {
+	retired := ii.retireFilesNotInList(fNames)
 	ii.scanDirtyFiles(fNames)
 	if err := ii.openDirtyFiles(ctx, fNames, accessorFiles); err != nil {
-		return fmt.Errorf("InvertedIndex(%s).openDirtyFiles: %w", ii.FilenameBase, err)
+		return retired, fmt.Errorf("InvertedIndex(%s).openDirtyFiles: %w", ii.FilenameBase, err)
 	}
-	return nil
+	return retired, nil
 }
 
-func (ii *InvertedIndex) openFolder(ctx context.Context, r *ScanDirsResult) error {
+func (ii *InvertedIndex) openFolder(ctx context.Context, r *ScanDirsResult) (retiredFiles, error) {
 	if ii.Disable {
-		return nil
+		return nil, nil
 	}
 	return ii.openList(ctx, r.iiFiles, r.accessorFiles)
 }
@@ -292,6 +293,10 @@ func (ii *InvertedIndex) BuildMissedAccessors(ctx context.Context, g *errgroup.G
 
 func (ii *InvertedIndex) closeWhatNotInList(fNames []string) {
 	closeWhatNotInList(ii.dirtyFiles, fNames)
+}
+
+func (ii *InvertedIndex) retireFilesNotInList(fNames []string) retiredFiles {
+	return retireFilesNotInList(mvcc.RetireReasonWasDeletedFromDisk, ii.dirtyFiles, fNames, ii.FilenameBase, ii.logger)
 }
 
 func (ii *InvertedIndex) Tables() []string { return []string{ii.KeysTable, ii.ValuesTable} }

--- a/db/state/inverted_index_test.go
+++ b/db/state/inverted_index_test.go
@@ -934,7 +934,7 @@ func TestInvIndexScanFiles(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(ii.dirs)
 	require.NoError(err)
-	err = ii.openFolder(t.Context(), scanDirsRes)
+	_, err = ii.openFolder(t.Context(), scanDirsRes)
 	require.NoError(err)
 
 	mergeInverted(t, db, ii, txs)
@@ -1059,7 +1059,7 @@ func TestInvIndex_OpenFolder(t *testing.T) {
 
 	scanDirsRes, err := scanDirs(ii.dirs)
 	require.NoError(t, err)
-	err = ii.openFolder(t.Context(), scanDirsRes)
+	_, err = ii.openFolder(t.Context(), scanDirsRes)
 	require.NoError(t, err)
 	ii.Close()
 }

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -34,6 +34,7 @@ import (
 	"github.com/erigontech/erigon/db/datastruct/btindex"
 	"github.com/erigontech/erigon/db/datastruct/existence"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/mvcc"
 	"github.com/erigontech/erigon/db/recsplit"
 	"github.com/erigontech/erigon/db/recsplit/multiencseq"
 	"github.com/erigontech/erigon/db/seg"
@@ -955,7 +956,7 @@ func (dt *DomainRoTx) cleanAfterMerge(mergedDomain, mergedHist, mergedIdx *Files
 	for _, out := range outs { // collect file names before files descriptors closed
 		deleted = append(deleted, out.FilePaths(dt.d.dirs.Snap)...)
 	}
-	retire(dt.d.dirtyFiles, outs, dt.d.FilenameBase, retireReasonMerged, dt.d.logger)
+	retire(mvcc.RetireReasonMerged, dt.d.dirtyFiles, outs, dt.d.FilenameBase, dt.d.logger)
 	retired = append(retired, outs...)
 	return deleted, retired
 }
@@ -974,7 +975,7 @@ func (ht *HistoryRoTx) cleanAfterMerge(merged, mergedIdx *FilesItem) (deleted []
 	for _, out := range outs { // collect file names before files descriptors closed
 		deleted = append(deleted, out.FilePaths(ht.h.dirs.Snap)...)
 	}
-	retire(ht.h.dirtyFiles, outs, ht.h.FilenameBase, retireReasonMerged, ht.h.logger)
+	retire(mvcc.RetireReasonMerged, ht.h.dirtyFiles, outs, ht.h.FilenameBase, ht.h.logger)
 	retired = append(retired, outs...)
 	return deleted, retired
 }
@@ -988,7 +989,7 @@ func (iit *InvertedIndexRoTx) cleanAfterMerge(merged *FilesItem) (deleted []stri
 	for _, out := range outs { // collect file names before files descriptors closed
 		deleted = append(deleted, out.FilePaths(iit.ii.dirs.Snap)...)
 	}
-	retire(iit.ii.dirtyFiles, outs, iit.ii.FilenameBase, retireReasonMerged, iit.ii.logger)
+	retire(mvcc.RetireReasonMerged, iit.ii.dirtyFiles, outs, iit.ii.FilenameBase, iit.ii.logger)
 	retired = append(retired, outs...)
 	return deleted, retired
 }

--- a/db/state/retire_history.go
+++ b/db/state/retire_history.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/mvcc"
 )
 
 // cutoffInRetireWindow reports whether cutoffTxNum is strictly inside the visible range:
@@ -132,7 +133,7 @@ func (at *AggregatorRoTx) Retire(ctx context.Context, cutoffs kv.RetireCutoffs) 
 	at.a.dirtyFilesLock.Lock()
 	defer at.a.dirtyFilesLock.Unlock()
 	for _, agedList := range aged {
-		retire(agedList.dirtyFiles, agedList.files, agedList.filenameBase, retireReasonAged, at.a.logger)
+		retire(mvcc.RetireReasonAged, agedList.dirtyFiles, agedList.files, agedList.filenameBase, at.a.logger)
 	}
 	at.a.onFilesDelete(deleted)
 	at.a.recalcVisibleFiles(retired)


### PR DESCRIPTION
Fixes #22646. (Supersedes #22657, which GitHub refused to reopen after the branch history was rewritten.)

## Problem

`Aggregator.OpenFolder` invalidated files that vanished from disk **in place**: `closeWhatNotInList → FilesItem.closeFiles()` nil-s the shared decompressor. A concurrent read-only tx that captured the same `*FilesItem` in `DomainRoTx.files` then panics dereferencing the now-nil decompressor — reachable whenever `OpenFolder` runs at runtime while readers exist (snapshot-stage reopen each sync cycle, rpcdaemon new-snapshot events, unwind), most visibly from the txpool's parallel sender lookups.

## Fix

Route these files through the same visible-generation reclamation the merge/prune path uses (#21397):

- `retireFilesNotInList` detaches them from `dirtyFiles` **without closing**; `openList`/`openFolder` thread the invalidated set up (typed `retiredFiles`), and `Aggregator.openFolder` attaches it to the outgoing generation via `recalcVisibleFiles`. Physical reclaim runs only once the last reader pinning that generation drains — so a reader never observes a nil decompressor.
- Reclaim closes each retired file and, **only if `FilesItem.canDelete` is set**, also deletes it from disk. `canDelete` is decided per `mvcc.RetireReason` in `retire()` (explicit switch, panics on unknown): merge/prune output is still on disk and must be removed, but a file an external actor already deleted (`RetireReasonWasDeletedFromDisk`) is **close-only** — never re-deleted, so a same-name recreation (e.g. a re-download) before readers drain is not clobbered.
- The retired slice is attached even when a sibling open errors (only ctx cancellation), so already-detached files are never stranded/leaked.

Two deterministic (non `-race`) tests: a reader survives `OpenFolder` removing a file it still references, and reclaiming a vanished-then-recreated file does not delete the recreation.