### PR TITLE
.github: least-privilege contents: read for read-only workflows (#21132)

### DIFF
--- a/.github/workflows/backups-dashboards.yml
+++ b/.github/workflows/backups-dashboards.yml
@@ -20,7 +20,10 @@ on:
         type: string
         default: main
         description: 'The branch to pull the backup script from (default: main)'
-  
+
+permissions:
+  contents: read
+
 jobs:
   # 
   # NOTE: This workflow splits the backup process in 2 jobs to spot any pulling issue early on

--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -27,6 +27,9 @@ on:
       - performance-stable
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: ./.github/workflows/test-all-erigon.yml

--- a/.github/workflows/docker-image-remove.yml
+++ b/.github/workflows/docker-image-remove.yml
@@ -17,6 +17,9 @@ on:
         default: 'not_yet_defined'
         description: 'Docker image tag to remove from hub.docker.com. Works only for erigontech/erigon'
 
+permissions:
+  contents: read
+
 jobs:
 
   build-release:

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -19,6 +19,9 @@ on:
       - ready_for_review
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ManifestCheck:
     # != true rather than == false: outside a pull_request event,

--- a/.github/workflows/qa-clean-exit-block-downloading.yml
+++ b/.github/workflows/qa-clean-exit-block-downloading.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   clean-exit-bd-test:
     runs-on: [self-hosted, qa, Ethereum, tip-tracking]

--- a/.github/workflows/qa-clean-exit-snapshot-downloading.yml
+++ b/.github/workflows/qa-clean-exit-snapshot-downloading.yml
@@ -13,6 +13,9 @@ on:
       - ready_for_review
   workflow_dispatch:     # Run manually
 
+permissions:
+  contents: read
+
 jobs:
   clean-exit-sd-test:
     concurrency:

--- a/.github/workflows/qa-constrained-tip-tracking.yml
+++ b/.github/workflows/qa-constrained-tip-tracking.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 20 * * 0'  # Run on Sunday at 08:00 PM UTC
   workflow_dispatch:     # Run manually
 
+permissions:
+  contents: read
+
 jobs:
   constrained-tip-tracking-test:
     strategy:

--- a/.github/workflows/qa-rpc-integration-tests-clients.yml
+++ b/.github/workflows/qa-rpc-integration-tests-clients.yml
@@ -9,6 +9,9 @@ concurrency:
   group: rpc-clients-integration-${{ github.run_id }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   client-rpc-integ-tests:
     name: RPC Integration Tests - ${{ matrix.client }}

--- a/.github/workflows/qa-rpc-integration-tests-gnosis.yml
+++ b/.github/workflows/qa-rpc-integration-tests-gnosis.yml
@@ -27,6 +27,9 @@ concurrency:
     }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   gnosis-rpc-integ-tests:
     runs-on: [ self-hosted, qa, Gnosis, rpc-integration ]

--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -21,6 +21,9 @@ on:
     paths:
       - '.github/workflows/qa-rpc-integration-tests-latest.yml'
 
+permissions:
+  contents: read
+
 jobs:
   mainnet-rpc-integ-tests-latest:
     name: mainnet-rpc-integ-tests-latest (${{ matrix.exec_mode }})

--- a/.github/workflows/qa-rpc-integration-tests-polygon.yml
+++ b/.github/workflows/qa-rpc-integration-tests-polygon.yml
@@ -17,6 +17,8 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+  contents: read
 
 jobs:
   bor-mainnet-rpc-integ-tests:

--- a/.github/workflows/qa-rpc-integration-tests-remote.yml
+++ b/.github/workflows/qa-rpc-integration-tests-remote.yml
@@ -21,6 +21,9 @@ concurrency:
     }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   mainnet-rpc-integ-tests-remote:
     runs-on: [ self-hosted, qa, Ethereum, rpc-integration-commitment ]

--- a/.github/workflows/qa-rpc-integration-tests.yml
+++ b/.github/workflows/qa-rpc-integration-tests.yml
@@ -27,6 +27,9 @@ concurrency:
     }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   mainnet-rpc-integ-tests:
     runs-on: [ self-hosted, qa, Ethereum, rpc-integration-commitment ]

--- a/.github/workflows/qa-rpc-performance-tests.yml
+++ b/.github/workflows/qa-rpc-performance-tests.yml
@@ -32,6 +32,9 @@ env:
   ERIGON_QA_PATH: /home/qarunner/erigon-qa
   RPC_PAST_TEST_DIR: /opt/rpc-past-tests
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup benchmark run

--- a/.github/workflows/qa-rpc-test-bisection-tool.yml
+++ b/.github/workflows/qa-rpc-test-bisection-tool.yml
@@ -13,6 +13,9 @@ on:
         description: 'Name of the test to run'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   rpc-test-bisect:
     runs-on: [self-hosted, qa, RpcSpecific]

--- a/.github/workflows/qa-snap-download.yml
+++ b/.github/workflows/qa-snap-download.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   snap-download-test:
     runs-on: [self-hosted, qa, long-running]

--- a/.github/workflows/qa-stage-exec.yml
+++ b/.github/workflows/qa-stage-exec.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   stage-exec-test:
     name: stage-exec-test (${{ matrix.mode_name }}, ${{ matrix.exec_mode }})

--- a/.github/workflows/qa-sync-from-scratch-full-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-full-node.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   full-node-sync-from-scratch-test:
     runs-on: [self-hosted, qa, long-running]

--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   minimal-node-sync-from-scratch-test:
     runs-on: [self-hosted, qa, long-running]

--- a/.github/workflows/qa-sync-from-scratch.yml
+++ b/.github/workflows/qa-sync-from-scratch.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   sync-from-scratch-test:
     name: sync-from-scratch-test-${{ matrix.chain }}

--- a/.github/workflows/qa-sync-test-bisection-tool.yml
+++ b/.github/workflows/qa-sync-test-bisection-tool.yml
@@ -18,6 +18,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   sync-test-bisect:
     runs-on: [self-hosted, qa, long-running]

--- a/.github/workflows/qa-sync-with-externalcl.yml
+++ b/.github/workflows/qa-sync-with-externalcl.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   sync-with-externalcl:
     runs-on: [self-hosted, qa, linux, X64, long-running]

--- a/.github/workflows/qa-tip-tracking-gnosis.yml
+++ b/.github/workflows/qa-tip-tracking-gnosis.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   gnosis-tip-tracking-test:
     runs-on: [self-hosted, qa, Gnosis, tip-tracking]

--- a/.github/workflows/qa-tip-tracking-with-load.yml
+++ b/.github/workflows/qa-tip-tracking-with-load.yml
@@ -33,6 +33,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   tip-tracking-with-load-test:
     name: Tip-tracking with load ${{ matrix.client }}

--- a/.github/workflows/qa-tip-tracking.yml
+++ b/.github/workflows/qa-tip-tracking.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   mainnet-tip-tracking-test:
     runs-on: [self-hosted, qa, Ethereum, tip-tracking]


### PR DESCRIPTION
Part of the zizmor `excessive-permissions` cleanup (#21132).

## What
Adds a top-level `permissions: contents: read` block to **25 workflows** that only read the repository and never use the `GITHUB_TOKEN` for a write operation. Without an explicit block these workflows run with GitHub's broad default token grant.

Files touched (QA suites + a few utilities):
- `cache-warming`, `manifest`, `backups-dashboards`, `docker-image-remove`
- QA sync: `qa-sync-from-scratch{,-full-node,-minimal-node}`, `qa-sync-test-bisection-tool`, `qa-sync-with-externalcl`
- QA rpc: `qa-rpc-integration-tests{,-clients,-gnosis,-latest,-polygon,-remote}`, `qa-rpc-performance-tests`, `qa-rpc-test-bisection-tool`
- QA misc: `qa-clean-exit-{block,snapshot}-downloading`, `qa-constrained-tip-tracking`, `qa-tip-tracking{,-gnosis,-with-load}`, `qa-snap-download`, `qa-stage-exec`

## Why these are safe
Each was scanned for token-using patterns (`gh` CLI, `git push`, `create-github-app-token`, issue/PR/release actions, `packages`/GHCR pushes, `github-script`). None use any of them. `docker-image-remove` deletes from **DockerHub** via `DOCKERHUB_PUSH_TOKEN`, not GitHub — no GitHub permission needed.

## Verification
- zizmor `excessive-permissions` findings: **66 → 28** — all 25 files here resolved, remaining 28 are the token-using workflows handled in follow-up PRs.
- `actionlint` clean w.r.t. this change (only pre-existing shellcheck/`workspace`-expression notes remain, none on the added lines).

## Rollout note
The `excessive-permissions` audit stays `disable: true` in `.github/zizmor.yml` until the remaining token-using workflows are scoped; the final PR in this series flips it on so the gate enforces it. This keeps the merge gate green throughout the incremental cleanup.