### PR TITLE
execution/stagedsync: rebuild missing E3 accessors synchronously (skip covered files)

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -528,10 +528,16 @@ type TemporalDebugTx interface {
 	NewMemBatch(ioMetrics any) TemporalMemBatch
 }
 
+type BuildAccessorsOption uint8
+
+// SkipCoveredAccessors skips files whose range is covered by other visible
+// sub-files; those self-heal via the background merge cycle.
+const SkipCoveredAccessors BuildAccessorsOption = 1
+
 type TemporalDebugDB interface {
 	DomainTables(names ...Domain) []string
 	InvertedIdxTables(names ...InvertedIdx) []string
-	BuildMissedAccessors(ctx context.Context, workers int) error
+	BuildMissedAccessors(ctx context.Context, workers int, opts ...BuildAccessorsOption) error
 	EnableReadAhead() TemporalDebugDB
 	DisableReadAhead()
 

--- a/db/kv/remotedb/kv_remote.go
+++ b/db/kv/remotedb/kv_remote.go
@@ -193,11 +193,13 @@ func (db *DB) NewMemBatch(ioMetrics any) kv.TemporalMemBatch       { panic("not 
 func (db *DB) DomainTables(domain ...kv.Domain) []string           { panic("not implemented") }
 func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string { panic("not implemented") }
 func (db *DB) ReloadFiles() error                                  { panic("not implemented") }
-func (db *DB) BuildMissedAccessors(_ context.Context, _ int) error { panic("not implemented") }
-func (db *DB) EnableReadAhead() kv.TemporalDebugDB                 { panic("not implemented") }
-func (db *DB) DisableReadAhead()                                   { panic("not implemented") }
-func (db *DB) Files() []string                                     { panic("not implemented") }
-func (db *DB) MergeLoop(ctx context.Context) error                 { panic("not implemented") }
+func (db *DB) BuildMissedAccessors(_ context.Context, _ int, _ ...kv.BuildAccessorsOption) error {
+	panic("not implemented")
+}
+func (db *DB) EnableReadAhead() kv.TemporalDebugDB { panic("not implemented") }
+func (db *DB) DisableReadAhead()                   { panic("not implemented") }
+func (db *DB) Files() []string                     { panic("not implemented") }
+func (db *DB) MergeLoop(ctx context.Context) error { panic("not implemented") }
 func (db *DB) BeginTemporalRo(ctx context.Context) (kv.TemporalTx, error) {
 	t, err := db.BeginRo(ctx) //nolint:gocritic
 	if err != nil {

--- a/db/kv/temporal/kv_temporal.go
+++ b/db/kv/temporal/kv_temporal.go
@@ -666,8 +666,8 @@ func (db *DB) DomainTables(domain ...kv.Domain) []string {
 func (db *DB) InvertedIdxTables(domain ...kv.InvertedIdx) []string {
 	return db.stateFiles.InvertedIdxTables(domain...)
 }
-func (db *DB) BuildMissedAccessors(ctx context.Context, workers int) (err error) {
-	return db.stateFiles.BuildMissedAccessors(ctx, workers)
+func (db *DB) BuildMissedAccessors(ctx context.Context, workers int, opts ...kv.BuildAccessorsOption) (err error) {
+	return db.stateFiles.BuildMissedAccessors(ctx, workers, opts...)
 }
 func (db *DB) EnableReadAhead() kv.TemporalDebugDB {
 	db.stateFiles.MadvNormal()

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -836,11 +836,14 @@ func (a *Aggregator) WaitForBuildAndMerge(ctx context.Context) chan struct{} {
 	return res
 }
 
-func (a *Aggregator) BuildMissedAccessors(ctx context.Context, workers int) error {
+func (a *Aggregator) BuildMissedAccessors(ctx context.Context, workers int, opts ...kv.BuildAccessorsOption) error {
 	rotx := a.DebugBeginDirtyFilesRo()
 	defer rotx.Close()
 
 	missedFilesItems := rotx.FilesWithMissedAccessors()
+	if slices.Contains(opts, kv.SkipCoveredAccessors) {
+		rotx.dropCovered(missedFilesItems)
+	}
 	if !missedFilesItems.IsEmpty() {
 		defer a.onFilesChange(nil)
 	}

--- a/db/state/aggregator_debug.go
+++ b/db/state/aggregator_debug.go
@@ -120,6 +120,26 @@ func (ac *aggDirtyFilesRoTx) FilesWithMissedAccessors() (mf *MissedAccessorAggFi
 	return
 }
 
+func (ac *aggDirtyFilesRoTx) dropCovered(mf *MissedAccessorAggFiles) {
+	drop := func(missed MissedFilesMap, all []*FilesItem, l statecfg.Accessors) {
+		for acc := range missed {
+			missed[acc] = dropCoveredAccessors(missed[acc], all, l)
+		}
+	}
+	for _, d := range ac.domain {
+		df := mf.domain[d.d.Name]
+		drop(df.files, d.files, d.d.Accessors)
+		drop(df.history.files, d.history.files, d.history.h.Accessors)
+		drop(df.history.ii.files, d.history.ii.files, d.history.ii.ii.Accessors)
+	}
+	for _, ii := range ac.ii {
+		if ii == nil {
+			continue
+		}
+		drop(mf.ii[ii.ii.Name].files, ii.files, ii.ii.Accessors)
+	}
+}
+
 func (ac *aggDirtyFilesRoTx) Close() {
 	if ac.agg == nil {
 		return

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -745,6 +746,46 @@ func checkForVisibility(item *FilesItem, l statecfg.Accessors, trace bool) (canB
 		return false
 	}
 	return true
+}
+
+// coveredByVisibleFiles reports whether item's [startTxNum, endTxNum) range is fully
+// covered by other files that are themselves visible (i.e. have their accessors).
+func coveredByVisibleFiles(item *FilesItem, all []*FilesItem, l statecfg.Accessors) bool {
+	subs := make([]*FilesItem, 0, len(all))
+	for _, f := range all {
+		if f == nil || f == item {
+			continue
+		}
+		if f.isProperSubsetOf(item) && checkForVisibility(f, l, false) {
+			subs = append(subs, f)
+		}
+	}
+	slices.SortFunc(subs, func(a, b *FilesItem) int {
+		return cmp.Compare(a.startTxNum, b.startTxNum)
+	})
+	cur := item.startTxNum
+	for _, s := range subs {
+		if s.startTxNum > cur {
+			break
+		}
+		if s.endTxNum > cur {
+			cur = s.endTxNum
+		}
+	}
+	return cur >= item.endTxNum
+}
+
+func dropCoveredAccessors(missed, all []*FilesItem, l statecfg.Accessors) []*FilesItem {
+	if len(missed) == 0 {
+		return missed
+	}
+	out := make([]*FilesItem, 0, len(missed))
+	for _, m := range missed {
+		if !coveredByVisibleFiles(m, all, l) {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // visibleFiles have no garbage (overlaps, unindexed, etc...)

--- a/db/state/dirty_files_coverage_test.go
+++ b/db/state/dirty_files_coverage_test.go
@@ -1,0 +1,59 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/seg"
+)
+
+// visibleItem builds a FilesItem that passes checkForVisibility for accessors==0
+// (only a non-nil decompressor is required).
+func visibleItem(startTxNum, endTxNum uint64) *FilesItem {
+	it := newFilesItem(startTxNum, endTxNum)
+	it.decompressor = &seg.Decompressor{}
+	return it
+}
+
+func TestCoveredByVisibleFiles(t *testing.T) {
+	t.Parallel()
+	merged := visibleItem(0, 4)
+	sub02 := visibleItem(0, 2)
+	sub24 := visibleItem(2, 4)
+
+	t.Run("covered by contiguous subs", func(t *testing.T) {
+		require.True(t, coveredByVisibleFiles(merged, []*FilesItem{sub02, sub24, merged}, 0))
+	})
+	t.Run("uncovered when no subs", func(t *testing.T) {
+		require.False(t, coveredByVisibleFiles(merged, []*FilesItem{merged}, 0))
+	})
+	t.Run("uncovered with a gap in subs", func(t *testing.T) {
+		require.False(t, coveredByVisibleFiles(merged, []*FilesItem{sub02, merged}, 0))
+	})
+	t.Run("uncovered when a sub is not visible", func(t *testing.T) {
+		invisible := newFilesItem(2, 4) // no decompressor => not visible
+		require.False(t, coveredByVisibleFiles(merged, []*FilesItem{sub02, invisible, merged}, 0))
+	})
+}
+
+func TestDropCoveredAccessors(t *testing.T) {
+	t.Parallel()
+	merged := visibleItem(0, 4)
+	sub02 := visibleItem(0, 2)
+	sub24 := visibleItem(2, 4)
+
+	t.Run("drops merged file covered by its subs", func(t *testing.T) {
+		got := dropCoveredAccessors([]*FilesItem{merged}, []*FilesItem{sub02, sub24, merged}, 0)
+		require.Empty(t, got)
+	})
+	t.Run("keeps merged file whose subs are gone", func(t *testing.T) {
+		got := dropCoveredAccessors([]*FilesItem{merged}, []*FilesItem{merged}, 0)
+		require.Equal(t, []*FilesItem{merged}, got)
+	})
+	t.Run("keeps a frontier file with no subsets", func(t *testing.T) {
+		frontier := visibleItem(4, 6)
+		got := dropCoveredAccessors([]*FilesItem{frontier}, []*FilesItem{sub02, sub24, frontier}, 0)
+		require.Equal(t, []*FilesItem{frontier}, got)
+	})
+}

--- a/execution/stagedsync/stage_snapshots.go
+++ b/execution/stagedsync/stage_snapshots.go
@@ -295,7 +295,9 @@ func DownloadAndIndexSnapshotsIfNeed(s *StageState, ctx context.Context, tx kv.R
 		return err
 	}
 
-	if err := buildOrDeferE3Accessors(ctx, s, cfg, headersProgress); err != nil {
+	// a state file missing its accessor is excluded from the visible set, so E3 accessors
+	// must be rebuilt before execution — there is no background rebuild path
+	if err := cfg.db.Debug().BuildMissedAccessors(ctx, estimate.IndexSnapshot.Workers(), kv.SkipCoveredAccessors); err != nil {
 		return err
 	}
 
@@ -370,29 +372,6 @@ func buildOrDeferE2Indices(ctx context.Context, s *StageState, cfg SnapshotsCfg,
 		}
 	} else {
 		log.Debug(fmt.Sprintf("[%s] Deferring E2 indexing to background", s.LogPrefix()), "reason", "restart", "headersProgress", headersProgress)
-	}
-	return nil
-}
-
-// buildOrDeferE3Accessors decides whether to build E3 state accessors synchronously
-// or defer them to background processing.
-// On restart (headersProgress > 0), E3 indexing is skipped at startup. Missing accessors
-// will be built in the background via BuildMissedAccessorsInBackground (called from
-// SnapshotsPrune on every sync cycle).
-// Unindexed state files are safely excluded from visible files by checkForVisibility
-// (which checks accessor presence), so queries correctly reflect only indexed data.
-// Note: unlike E2, there is no Bor exception — the background path calls
-// BuildMissedAccessors directly without any Bor-specific early-exit guards.
-func buildOrDeferE3Accessors(ctx context.Context, s *StageState, cfg SnapshotsCfg, headersProgress uint64) error {
-	canDefer := headersProgress > 0
-
-	indexWorkers := estimate.IndexSnapshot.Workers()
-	if !canDefer {
-		if err := cfg.db.Debug().BuildMissedAccessors(ctx, indexWorkers); err != nil {
-			return err
-		}
-	} else {
-		log.Debug(fmt.Sprintf("[%s] Deferring E3 indexing to background", s.LogPrefix()), "reason", "restart", "headersProgress", headersProgress)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #21556.

On a restarted node (`headersProgress > 0`), `buildOrDeferE3Accessors` deferred E3 state-accessor building to a `BuildMissedAccessorsInBackground` path that **does not exist** — so a state file whose accessor (`.kvi`/`.bt`/`.vi`/`.efi`) went missing was never rebuilt on restart. It was silently dropped from the visible set, regressing the visible frontier and (when the source data was already pruned and sub-files cleaned up) leaving the node stuck with `gap between snapshots and MDBX — refusing to build files`.

The snapshots stage now rebuilds missing accessors **synchronously**, before execution — a missing E3 accessor can gate correct execution, so it must not proceed against a regressed state frontier. It passes `kv.SkipCoveredAccessors`, skipping files whose range is still covered by other visible sub-files:

- **Uncovered** (frontier file, or a merged file whose subs were already cleaned up — the issue's primary bite case) → rebuilt synchronously; without it the range vanishes from the visible set.
- **Covered** (a merged file whose sub-files are still present, e.g. crash after writing the merged `.kv` but before its accessor) → left to the background merge cycle, which re-merges the subs and rebuilds it. `calcVisibleFiles` already keeps the subs visible in the meantime, so the range stays covered and correct. Rebuilding it eagerly would only duplicate the merge builder's work and risk racing it.

## Commits
1. `db/state`: `BuildMissedAccessors` gains a variadic `kv.BuildAccessorsOption`; `kv.SkipCoveredAccessors` drops files whose range is covered by other visible sub-files, applied as a single post-pass (`aggDirtyFilesRoTx.dropCovered`) over the collected missed files — no signature changes below the `Aggregator` entry point, and all existing callers (squeeze, retire, indices, tests) are untouched.
2. `execution/stagedsync`: the snapshots stage rebuilds missing E3 accessors synchronously with `kv.SkipCoveredAccessors`. The stale comment referencing the non-existent `BuildMissedAccessorsInBackground` is removed.

## Testing
Unit tests for the coverage predicate (`TestCoveredByVisibleFiles`, `TestDropCoveredAccessors`): covered-by-contiguous-subs, uncovered-when-no-subs, gap-in-subs, sub-not-visible.

Empirically on a fully-synced Chiado node (snapshot frontier step 172): mirror the datadir (cheap hardlink clone), delete a latest-step accessor, restart with `--no-downloader` so the torrent downloader can't re-fetch it (isolating the local rebuild path — the issue's "source already gone" scenario).

| Binary | Accessor deleted | Result |
|---|---|---|
| This PR | commitment `v2.1-commitment.168-172.kvi` (uncovered frontier) | rebuilt synchronously at startup, downloader off; node healthy |
| This PR | account history `v1.2-accounts.168-172.vi` (uncovered frontier) | rebuilt synchronously at startup, downloader off; node healthy |
| pre-fix | commitment `v2.1-commitment.168-172.kvi` | **still missing after 90s** — node stuck: `gap between snapshots and MDBX — refusing to build files`, visible frontier regressed 172→168 |

The merged-with-subs (covered → skipped) case is covered by the unit tests; it can't easily be constructed on Chiado since merged sub-files are cleaned up.

Verified with `make lint` (clean) and `make erigon integration`.

Stacked on #22660 — review/merge that first.
