### PR TITLE
go.mod: update libsecp256k1 to v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268
 	github.com/erigontech/go-libdeflate v0.1.0
 	github.com/erigontech/mdbx-go v0.40.3
-	github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410
+	github.com/erigontech/secp256k1 v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/erigontech/go-libdeflate v0.1.0 h1:WtKiuNpuAP/Qyq3mbPwFB0DoQikabtOeZF
 github.com/erigontech/go-libdeflate v0.1.0/go.mod h1:OCQBWlynNqNCYb1ckqNjY69H1LAhg2TyyfYZalO03BM=
 github.com/erigontech/mdbx-go v0.40.3 h1:tNFzVF4gs0DxCWGBb91jRKQNA+IeMonOK3LHvuxh5qo=
 github.com/erigontech/mdbx-go v0.40.3/go.mod h1:QmkpLmcJX5+Fyu9u8eGsyPwoBDrIZJBBLgJHBMFStWE=
-github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410 h1:5YD7JJ5PaqOdjKA84lTDtQby9nbI4podqrkUhyIyFDw=
-github.com/erigontech/secp256k1 v1.2.1-0.20260218182123-377cc1bd6410/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
+github.com/erigontech/secp256k1 v1.3.0 h1:lf/lNUBtgZ21yJjn1sYNkYnEy4bkZIcxvcEdlrHs14I=
+github.com/erigontech/secp256k1 v1.3.0/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
 github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=


### PR DESCRIPTION
Updates the bundled bitcoin-core/secp256k1 C library from **v0.6.0** to **v0.7.1**, via `erigontech/secp256k1` **v1.3.0**.

Fixes #18822.

## Why it's low-risk
- The fork's `libsecp256k1/` was a byte-identical copy of upstream v0.6.0, so the fork change was a clean subtree swap. All fork-local code (`ext.h`, `curve.go`, the finite-field bounds check) is outside the subtree and unchanged.
- Erigon uses only the recovery/verify/pubkey public API plus a few internal symbols in `secp256k1_ext_scalar_mul` — all still present in 0.7.1. None of the aliases removed in 0.7.0 are used.
- The fork's **Go module graph is unchanged** (the `/go.mod` hash in go.sum is identical); only vendored C content differs, so there is no transitive-dependency impact.
- 0.7.0→0.7.1 relevant changes: extra stack secret-clearing, x86_64 asm CFLAGS fix. CMake/autotools changes don't affect us (we compile via cgo `#include`).

## Verification
- `erigontech/secp256k1` v1.3.0: fork CI green (build/vet/fmt/test, golangci-lint, zizmor).
- erigon: `make erigon integration` build green; `go test ./common/crypto/...` green (incl. `ecies`); `go mod verify` OK, `go mod tidy` no-op.