### PR TITLE
[r3.6] db/state, db/snapshotsync: mark retired files canDelete; last releaser closes or deletes

### DIFF
--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -206,6 +206,10 @@ type DirtySegment struct {
 
 	frozen bool
 
+	// Set when the segment is retired for physical deletion; the last releaser
+	// deletes files from disk only when set, otherwise it just closes them.
+	canDelete atomic.Bool
+
 	// only caplin state
 	filePath string
 }
@@ -884,7 +888,7 @@ func (s *BaseRoSnapshots) recalcVisibleFiles(alignMin bool, retired []*DirtySegm
 
 	// `recalcVisibleFiles` is rare background operation under `dirtyFilesLock`
 	// it's good idea to delete files here, then hot reader-Close path will more likely be lock-free
-	closeAndRemoveSegments(s.reclaimRetiredLocked())
+	reclaimSegments(s.reclaimRetiredLocked())
 }
 
 // acquireVisible pins the current generation. Load and increment are not atomic together,
@@ -926,13 +930,24 @@ func (s *BaseRoSnapshots) reclaimRetired() {
 	s.dirtyLock.Lock()
 	toDelete := s.reclaimRetiredLocked()
 	s.dirtyLock.Unlock()
-	closeAndRemoveSegments(toDelete)
+	reclaimSegments(toDelete)
 }
 
-func closeAndRemoveSegments(segs []*DirtySegment) {
+func reclaimSegments(segs []*DirtySegment) {
 	for _, sn := range segs {
-		sn.closeAndRemoveFiles()
+		if sn.canDelete.Load() {
+			sn.closeAndRemoveFiles()
+		} else {
+			sn.close()
+		}
 	}
+}
+
+func markCanDelete(segs []*DirtySegment) []*DirtySegment {
+	for _, sn := range segs {
+		sn.canDelete.Store(true)
+	}
+	return segs
 }
 
 // minimax of existing indices
@@ -1151,7 +1166,7 @@ func (s *BaseRoSnapshots) OpenFolder() error {
 		}
 		// Segments whose file vanished from disk leave the visible set; retire them so
 		// their fds close only after readers of the current generation drain.
-		retired = s.detachNotInList(list)
+		retired = markCanDelete(s.detachNotInList(list))
 		return s.openSegments(list, true, false)
 	}()
 	if err != nil {
@@ -1352,7 +1367,7 @@ func (s *BaseRoSnapshots) RemoveOverlaps(onDelete func(l []string) error) error 
 	func() {
 		s.dirtyLock.Lock()
 		defer s.dirtyLock.Unlock()
-		retired := s.detachNotInList(keepNames)
+		retired := markCanDelete(s.detachNotInList(keepNames))
 		s.recalcVisibleFiles(s.alignMin, retired)
 	}()
 
@@ -1471,7 +1486,7 @@ func (s *BaseRoSnapshots) retireFiles(fileNames ...string) error {
 			retired = append(retired, sn)
 		}
 	}
-	s.recalcVisibleFiles(s.alignMin, retired)
+	s.recalcVisibleFiles(s.alignMin, markCanDelete(retired))
 	return nil
 }
 

--- a/db/snapshotsync/snapshots_candelete_test.go
+++ b/db/snapshotsync/snapshots_candelete_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshotsync
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dir2 "github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/snaptype2"
+	"github.com/erigontech/erigon/db/version"
+)
+
+// The last releaser of a retired segment consults canDelete: segments retired
+// for deletion are unlinked, segments that merely left the visible set are only closed.
+func TestReclaimSegmentsRespectsCanDelete(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	logger := log.New()
+
+	newSeg := func(from, to uint64) *DirtySegment {
+		createTestSegmentFile(t, from, to, snaptype2.Enums.Headers, dir, version.V1_0, logger)
+		s := NewDirtySegment(snaptype2.Headers, version.V1_0, from, to, false)
+		require.NoError(t, s.Open(dir))
+		return s
+	}
+
+	keep := newSeg(0, 1000)
+	del := newSeg(1000, 2000)
+	del.canDelete.Store(true)
+
+	keepPath := filepath.Join(dir, keep.FileName())
+	delPath := filepath.Join(dir, del.FileName())
+
+	reclaimSegments([]*DirtySegment{keep, del})
+
+	require.Nil(t, keep.Decompressor)
+	require.Nil(t, del.Decompressor)
+
+	exists, err := dir2.FileExist(keepPath)
+	require.NoError(t, err)
+	require.True(t, exists, "canDelete=false: close only, file stays on disk")
+
+	exists, err = dir2.FileExist(delPath)
+	require.NoError(t, err)
+	require.False(t, exists, "canDelete=true: file is deleted")
+}

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -1786,7 +1786,7 @@ func (a *Aggregator) recalcVisibleFiles(retired []*FilesItem) {
 
 	// `recalcVisibleFiles` is rare background operation under `dirtyFilesLock`
 	// it's good idea to delete files here, then hot reader-Close path will more likely be lock-free
-	closeAndRemoveFiles(a.reclaimRetiredLocked())
+	reclaimFiles(a.reclaimRetiredLocked())
 }
 
 // stateMinimaxTxNum returns min(EndTxNum) across kv.StateDomains. Mirrors
@@ -2379,12 +2379,16 @@ func (a *Aggregator) reclaimRetired() {
 	a.dirtyFilesLock.Lock()
 	toDelete := a.reclaimRetiredLocked()
 	a.dirtyFilesLock.Unlock()
-	closeAndRemoveFiles(toDelete)
+	reclaimFiles(toDelete)
 }
 
-func closeAndRemoveFiles(files []*FilesItem) {
+func reclaimFiles(files []*FilesItem) {
 	for _, f := range files {
-		f.closeFilesAndRemove()
+		if f.canDelete.Load() {
+			f.closeFilesAndRemove()
+		} else {
+			f.closeFiles()
+		}
 	}
 }
 

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -126,8 +126,8 @@ type FilesItem struct {
 	version  version.Version
 	refcount atomic.Int32
 
-	// Used by the SnapshotRepo mark-and-sweep reclamation path (with refcount); the
-	// aggregator instead reclaims via aggregatorVisible generations (retired + refcnt).
+	// Set when the file is retired for physical deletion; the last releaser
+	// deletes files from disk only when set, otherwise it just closes them.
 	canDelete atomic.Bool
 }
 
@@ -358,16 +358,22 @@ func (r retireReason) String() string {
 	}
 }
 
-// retire removes outs from dirtyFiles; the caller still owns outs and must
-// attach it to the outgoing visible generation itself. Physical deletion
-// (closeFilesAndRemove) happens once the last reader of that generation closes
-// — so readers still pinning these files are never surprised.
+// retire removes outs from dirtyFiles and marks them for deletion; the caller
+// still owns outs and must attach it to the outgoing visible generation itself.
+// Physical deletion (closeFilesAndRemove) happens once the last reader of that
+// generation closes — so readers still pinning these files are never surprised.
 func retire(dirtyFiles *DirtyFiles, outs []*FilesItem, filenameBase string, reason retireReason, logger log.Logger) {
 	for _, out := range outs {
 		if out == nil {
 			panic("must not happen: " + filenameBase)
 		}
 		dirtyFiles.Delete(out)
+		switch reason {
+		case retireReasonMerged, retireReasonAged:
+			out.canDelete.Store(true)
+		default:
+			panic(fmt.Sprintf("unknown retire reason: %d", reason))
+		}
 		if filenameBase == traceFileLife && out.decompressor != nil {
 			logger.Warn("[agg.dbg] retire", "f", out.decompressor.FileName(), "reason", reason)
 		}

--- a/db/state/dirty_files_test.go
+++ b/db/state/dirty_files_test.go
@@ -191,3 +191,64 @@ func writeTestKVFile(t *testing.T, path, tmp string, logger log.Logger) {
 	require.NoError(t, comp.AddWord([]byte("v")))
 	require.NoError(t, comp.Compress())
 }
+
+// The last releaser of a retired file consults canDelete: files retired for
+// deletion are unlinked, files that merely left the visible set are only closed.
+func TestReclaimFilesRespectsCanDelete(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	logger := log.New()
+
+	newItem := func(name string) *FilesItem {
+		fPath := filepath.Join(tmp, name)
+		writeTestKVFile(t, fPath, tmp, logger)
+		dec, err := seg.NewDecompressor(fPath)
+		require.NoError(t, err)
+		item := newFilesItem(0, 10)
+		item.decompressor = dec
+		return item
+	}
+
+	keep := newItem("v1.0-keep.0-1.kv")
+	del := newItem("v1.0-del.0-1.kv")
+	del.canDelete.Store(true)
+
+	reclaimFiles([]*FilesItem{keep, del})
+
+	require.Nil(t, keep.decompressor)
+	require.Nil(t, del.decompressor)
+
+	exists, err := dir.FileExist(filepath.Join(tmp, "v1.0-keep.0-1.kv"))
+	require.NoError(t, err)
+	require.True(t, exists, "canDelete=false: close only, file stays on disk")
+
+	exists, err = dir.FileExist(filepath.Join(tmp, "v1.0-del.0-1.kv"))
+	require.NoError(t, err)
+	require.False(t, exists, "canDelete=true: file is deleted")
+}
+
+// Everything entering the generation chain via retire() is retired for deletion.
+func TestRetireMarksCanDelete(t *testing.T) {
+	t.Parallel()
+	for _, reason := range []retireReason{retireReasonMerged, retireReasonAged} {
+		t.Run(reason.String(), func(t *testing.T) {
+			tmp := t.TempDir()
+			logger := log.New()
+			fPath := filepath.Join(tmp, "v1.0-x.0-1.kv")
+			writeTestKVFile(t, fPath, tmp, logger)
+			dec, err := seg.NewDecompressor(fPath)
+			require.NoError(t, err)
+			item := newFilesItem(0, 10)
+			item.decompressor = dec
+			defer item.closeFiles()
+
+			df := newDirtyFiles()
+			df.Set(item)
+
+			retire(df, []*FilesItem{item}, "x", reason, logger)
+
+			require.True(t, item.canDelete.Load())
+			require.Equal(t, 0, df.Len(), "retire removes the item from dirtyFiles")
+		})
+	}
+}


### PR DESCRIPTION
Prep for #22646-class reclamation fixes: routing `OpenFolder`/`Close` detach paths through the generation chain needs retired items the last reader must close but **not** delete. This PR gives both stores a per-item `canDelete` flag and makes the last releaser consult it: delete files from disk when set, close only otherwise.

- `db/state`: `retire()` decides `canDelete` by an explicit switch on the retire reason (`merged`/`aged` → true, unknown → panic); the generation reclaimer `reclaimFiles` (ex `closeAndRemoveFiles`) partitions on it.
- `db/snapshotsync`: new `DirtySegment.canDelete` field; the three `retired` feeder sites (`OpenFolder` detach, the delete path, `retireFiles`) mark it via `markCanDelete`; `reclaimSegments` (ex `closeAndRemoveSegments`) partitions on it.

Non-behavior-changing: every item entering the retired chain today is marked `canDelete=true`, so the reclaimer's decision is identical to before. Released separately to reduce the size of the future #22646 fix PR (re-landing the `detachFilesNotInList` + close-only retire reason from the closed draft #22657 on top of this).