### PR TITLE
chore(ci): remove unused adm-zip dependency from test_report script

### DIFF
--- a/.github/workflows/scripts/test_report/package-lock.json
+++ b/.github/workflows/scripts/test_report/package-lock.json
@@ -7,8 +7,7 @@
       "name": "gha-test-report",
       "dependencies": {
         "@actions/core": "^2.0.3",
-        "@actions/github": "^9.0.0",
-        "adm-zip": "^0.5.10"
+        "@actions/github": "^9.0.0"
       },
       "devDependencies": {
         "@types/node": "^20.19.37",
@@ -287,14 +286,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/arg": {

--- a/.github/workflows/scripts/test_report/package.json
+++ b/.github/workflows/scripts/test_report/package.json
@@ -8,8 +8,7 @@
   },
   "dependencies": {
     "@actions/core": "^2.0.3",
-    "@actions/github": "^9.0.0",
-    "adm-zip": "^0.5.10"
+    "@actions/github": "^9.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.37",


### PR DESCRIPTION
## What

Removes the unused `adm-zip` dependency from `.github/workflows/scripts/test_report`.

## Why

`adm-zip` was declared in `package.json` (`^0.5.10`, resolved 0.5.16) but is **never imported** — the script's only sources (`generate-test-report.ts`, `debug.ts`) import just `@actions/core` and `@actions/github`, and query the GitHub API (`listWorkflowRunsForRepo` / `listJobsForWorkflowRun`). Nothing reads a ZIP/artifact. It was dead weight.

Removing it (rather than bumping to 0.6.0) resolves the Dependabot alert for **CVE-2026-39244 / GHSA-xcpc-8h2w-3j85** (`adm-zip` <0.6.0 — crafted ZIP triggers a 4 GB memory allocation, DoS) by dropping the vulnerable code path entirely. A version bump would only update dead code.

Real-world exposure here was already nil: the code path is unreachable, and the only workflow using this package (`qa-test-report.yml`) is `workflow_dispatch`-only with a read-only token.

## Verification

`package.json` and `package-lock.json` updated together (npm ci requires consistency):

```
npm ci        # clean, 0 vulnerabilities
npm run build # tsc, passes
```

Scoped to `main` only (release/3.5 carries the same dead dep but is archived at the v3.6 cut; not worth the churn).
