### PR TITLE
[r3.6] minimal node: download not enough logIndex files

### DIFF
--- a/db/snapshotsync/snapshotsync.go
+++ b/db/snapshotsync/snapshotsync.go
@@ -374,7 +374,7 @@ func isReceiptsSegmentPruned(ctx context.Context, tx kv.RwTx, txNumsReader rawdb
 		return false
 	}
 	minStep := minTxNum / stepSize
-	return s.From < minStep
+	return s.To <= minStep // files storing data [from, to)
 }
 
 // unblackListFilesBySubstring - removes files from the blacklist that match any of the provided substrings.

--- a/db/snapshotsync/snapshotsync_test.go
+++ b/db/snapshotsync/snapshotsync_test.go
@@ -18,6 +18,7 @@ package snapshotsync
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
 	"github.com/erigontech/erigon/db/kv/prune"
+	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/snapcfg"
 	"github.com/erigontech/erigon/db/snaptype"
 	"github.com/erigontech/erigon/execution/chain"
@@ -508,6 +510,53 @@ func TestReceiptsSegmentRetentionCutoff(t *testing.T) {
 	assert.Equal(t, uint64(0), receiptsSegmentRetentionCutoff(prune.BlocksMode, nil, head, logIdxSeg))
 
 	assert.Equal(t, blocksRetentionCutoff(prune.MinimalMode, nil, head), receiptsSegmentRetentionCutoff(prune.MinimalMode, nil, head, rcacheSeg))
+}
+
+// TestIsReceiptsSegmentPruned verifies segments are skipped at download time
+// only when they lie entirely below the prune height: the segment containing
+// the cutoff step must still be downloaded, otherwise blocks inside the
+// retention window would have receipts but no log index.
+func TestIsReceiptsSegmentPruned(t *testing.T) {
+	const stepSize = 100
+	const pruneHeight = 50 // minTxNum(50)=5000 → cutoff step 50
+
+	db := memdb.NewTestDB(t, dbcfg.ChainDB)
+	tx, err := db.BeginRw(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	for b := uint64(0); b <= 60; b++ {
+		if err := rawdbv3.TxNums.Append(tx, b, (b+1)*stepSize-1); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	logIdx := func(from, to int) string {
+		return fmt.Sprintf("idx/v1.0-%s.%d-%d.ef", kv.LogTopicIdx.String(), from, to)
+	}
+	cases := []struct {
+		name   string
+		seg    string
+		pruned bool
+	}{
+		{"segment spanning the cutoff is kept", logIdx(32, 64), false},
+		{"segment entirely below the cutoff is pruned", logIdx(16, 32), true},
+		{"segment ending exactly at the cutoff is pruned", logIdx(48, 50), true},
+		{"segment above the cutoff is kept", logIdx(64, 96), false},
+		{"domain segment is never pruned", "domain/v1.0-rcache.16-32.kv", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := snapcfg.PreverifiedItem{Name: tc.seg}
+			assert.Equal(t, tc.pruned, isReceiptsSegmentPruned(context.Background(), tx, rawdbv3.TxNums, p, stepSize, pruneHeight))
+		})
+	}
+
+	t.Run("pruneHeight=0 keeps everything", func(t *testing.T) {
+		p := snapcfg.PreverifiedItem{Name: logIdx(0, 16)}
+		assert.False(t, isReceiptsSegmentPruned(context.Background(), tx, rawdbv3.TxNums, p, stepSize, 0))
+	})
 }
 
 func TestGetMaxStepRangeInSnapshots(t *testing.T) {

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -2266,6 +2266,18 @@ func (at *AggregatorRoTx) HistoryStartFrom(name kv.Domain, tx kv.Tx) uint64 {
 	return at.d[name].HistoryStartFrom(tx)
 }
 
+// Returns the first known txNum available in a standalone inverted index (files, then DB)
+func (at *AggregatorRoTx) IIStartFrom(name kv.InvertedIdx, tx kv.Tx) uint64 {
+	iit := at.searchII(name)
+	if iit == nil {
+		return 0
+	}
+	if len(iit.files) == 0 {
+		return iit.ii.minTxNumInDB(tx)
+	}
+	return iit.files[0].startTxNum
+}
+
 func (at *AggregatorRoTx) IndexRange(name kv.InvertedIdx, k []byte, fromTs, toTs int, asc order.By, limit int, tx kv.Tx) (timestamps stream.U64, err error) {
 	// check domain iis
 	for _, d := range at.d {

--- a/db/state/stats/agg_log_stats.go
+++ b/db/state/stats/agg_log_stats.go
@@ -74,7 +74,7 @@ func warnUnevenIIAvailability(at *state.AggregatorRoTx, tx kv.Tx, logger log.Log
 		}
 		iiFromBlock, err := tx2block(iiStartTxNum)
 		if err != nil {
-			logger.Warn("[snapshots:history] Stat", "err", err)
+			logger.Debug("[snapshots:history] Stat", "err", err)
 			return
 		}
 		late = append(late, fmt.Sprintf("%s=%d", name.String(), iiFromBlock))
@@ -84,10 +84,10 @@ func warnUnevenIIAvailability(at *state.AggregatorRoTx, tx kv.Tx, logger log.Log
 	}
 	historyFromBlock, err := tx2block(historyStartTxNum)
 	if err != nil {
-		logger.Warn("[snapshots:history] Stat", "err", err)
+		logger.Debug("[snapshots:history] Stat", "err", err)
 		return
 	}
-	logger.Warn("[snapshots:history] uneven old-data availability: indices start later than state history; filtered eth_getLogs/trace_filter may return incomplete results for older blocks",
+	logger.Debug("[snapshots:history] uneven old-data availability: indices start later than state history; filtered eth_getLogs/trace_filter may return incomplete results for older blocks",
 		"state_history_from_block", historyFromBlock,
 		"index_from_block", strings.Join(late, ","))
 }

--- a/db/state/stats/agg_log_stats.go
+++ b/db/state/stats/agg_log_stats.go
@@ -59,7 +59,12 @@ func LogStats(at *state.AggregatorRoTx, tx kv.Tx, logger log.Logger, tx2block fu
 // expected to cover at least the state-history window; an index starting later
 // makes filtered eth_getLogs/trace_filter silently incomplete in the gap.
 func warnUnevenIIAvailability(at *state.AggregatorRoTx, tx kv.Tx, logger log.Logger, tx2block func(txNum uint64) (uint64, error)) {
-	historyStartTxNum := at.HistoryStartFrom(kv.AccountsDomain, tx)
+	// same definition of "state history starts here" as state.StateHistoryStartTxNum
+	historyStartTxNum := min(
+		at.HistoryStartFrom(kv.AccountsDomain, tx),
+		at.HistoryStartFrom(kv.StorageDomain, tx),
+		at.HistoryStartFrom(kv.CodeDomain, tx),
+	)
 	var late []string
 	for id := range at.InvertedIndicesLen() {
 		name := at.InvertedIndexName(id)

--- a/db/state/stats/agg_log_stats.go
+++ b/db/state/stats/agg_log_stats.go
@@ -51,4 +51,38 @@ func LogStats(at *state.AggregatorRoTx, tx kv.Tx, logger log.Logger, tx2block fu
 		"txs", common.PrettyCounter(at.Agg().EndTxNumMinimax()),
 		"first_history_idx_in_db", firstHistoryIndexBlockInDB,
 		"alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
+
+	warnUnevenIIAvailability(at, tx, logger, tx2block)
+}
+
+// Standalone inverted indices (logtopics, logaddrs, tracesfrom, tracesto) are
+// expected to cover at least the state-history window; an index starting later
+// makes filtered eth_getLogs/trace_filter silently incomplete in the gap.
+func warnUnevenIIAvailability(at *state.AggregatorRoTx, tx kv.Tx, logger log.Logger, tx2block func(txNum uint64) (uint64, error)) {
+	historyStartTxNum := at.HistoryStartFrom(kv.AccountsDomain, tx)
+	var late []string
+	for id := range at.InvertedIndicesLen() {
+		name := at.InvertedIndexName(id)
+		iiStartTxNum := at.IIStartFrom(name, tx)
+		if iiStartTxNum <= historyStartTxNum {
+			continue
+		}
+		iiFromBlock, err := tx2block(iiStartTxNum)
+		if err != nil {
+			logger.Warn("[snapshots:history] Stat", "err", err)
+			return
+		}
+		late = append(late, fmt.Sprintf("%s=%d", name.String(), iiFromBlock))
+	}
+	if len(late) == 0 {
+		return
+	}
+	historyFromBlock, err := tx2block(historyStartTxNum)
+	if err != nil {
+		logger.Warn("[snapshots:history] Stat", "err", err)
+		return
+	}
+	logger.Warn("[snapshots:history] uneven old-data availability: indices start later than state history; filtered eth_getLogs/trace_filter may return incomplete results for older blocks",
+		"state_history_from_block", historyFromBlock,
+		"index_from_block", strings.Join(late, ","))
 }


### PR DESCRIPTION
Found by `rpctest invariantsEthGetLogs` on a fresh `--prune.mode=minimal` mainnet sync: unfiltered `eth_getLogs` returned logs while every topic- and address-filtered query over the same blocks silently returned nothing, for ~45k blocks right above the advertised availability mark (`history is available from block N`).

## Root cause

`isReceiptsSegmentPruned` — the download-time filter for `logtopics`/`logaddrs` segments (and `rcache` history when receipts follow history) — skipped any segment whose `From` step was below the cutoff, which drops the one segment that *spans* the cutoff. Every other datatype goes through `buildBlackListForPruning`'s To-based rule, which keeps the spanning file. That asymmetry is why the same sync downloaded `v2.0-accounts.9216-9344.v` but skipped `v3.0-logtopics.9216-9344.ef` (cutoff step ≈9334, inside that file):

```
[DBUG] [1/6 OtterSync] skipping expired receipt-related segment name=idx/v3.0-logtopics.9216-9344.ef cutoffBlock=25477999
```

Blocks between the prune mark and the first kept `.ef` file end up with receipts/history but no `LogTopicIdx`/`LogAddrIdx`, and the filtered `eth_getLogs` path intersects with the missing index and returns empty instead of erroring.

## Fix

Skip only segments entirely below the cutoff: `s.To <= minStep`. The new `TestIsReceiptsSegmentPruned` subtest "segment spanning the cutoff is kept" was red before the fix; the other subtests pin the fully-below / boundary / above / domain / disabled cases.

## Startup warning

For datadirs that already synced with such a gap, `LogStats` (erigon snapshots stage, rpcdaemon, integration) now emits a warning when a standalone inverted index starts later than state history. Verified against the affected datadir:

```
[WARN] [snapshots:history] uneven old-data availability: indices start later than state history; filtered eth_getLogs/trace_filter may return incomplete results for older blocks state_history_from_block=25373975 index_from_block="logaddrs=25525269,logtopics=25525269"
```

(The warning is log-only observability; it has no unit test.)

The same bug exists on `main`; will forward-port after this lands.

## Out of scope, same family

The chain-history-expiry branch in `buildBlackListForPruning` blacklists tx segments with `IsPreMerge(res.From)`, so the segment spanning the merge block (`v1.1-015500-016000-transactions.seg`) is dropped whole, losing post-merge bodies for blocks 15537394–15999999. Only reachable via the explicit `--prune.distance.blocks=18446744073709551615` hybrid, not default `full` mode (its `Blocks` is a finite distance and takes the To-based branch). Tracked separately.
