### PR TITLE
.github: scope actions: write to merge-queue self-cancel jobs (#21132)

### DIFF
--- a/.github/workflows/check-large-files.yml
+++ b/.github/workflows/check-large-files.yml
@@ -8,6 +8,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -8,6 +8,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   reproducible-build:
     strategy:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,6 +17,11 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+  actions: write
+  pull-requests: read
+
 jobs:
   sonar:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-all-erigon-race.yml
+++ b/.github/workflows/test-all-erigon-race.yml
@@ -8,12 +8,18 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   # Workflow files can't read local files directly — they must be loaded via a
   # job step. We do this so the matrix group names come from the same source as
   # the test code (tools/test-groups), keeping CI and local runs in sync.
   load-matrix:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 60
     outputs:
       test-groups: ${{ steps.load.outputs.groups }}
@@ -57,6 +63,9 @@ jobs:
           - parallel
     name: tests-linux (${{ matrix.os }}, ${{ matrix.test-group }}, ${{ matrix.exec_mode }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      actions: write
 
     steps:
       - name: Declare runners

--- a/.github/workflows/test-all-erigon.yml
+++ b/.github/workflows/test-all-erigon.yml
@@ -8,6 +8,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   tests-mac-linux:
     strategy:

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -20,6 +20,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   benchmarks:
     name: benchmarks (${{ matrix.exec_mode }})

--- a/.github/workflows/test-eest-spec.yml
+++ b/.github/workflows/test-eest-spec.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   # Matrix entries (shard / workers / max-allowed-failures) come from
   # tools/eest-spec-shards.yml so this workflow and tools/run-eest-spec-test.sh
@@ -53,6 +56,9 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.load-matrix.outputs.matrix) }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 60
     env:
       RAMDISK_SIZE_MB: '8192'
@@ -139,6 +145,9 @@ jobs:
     if: ${{ !inputs.cache-warming-only }}
     name: eest-shard-coverage
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test-integration-caplin.yml
+++ b/.github/workflows/test-integration-caplin.yml
@@ -7,6 +7,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     strategy:
@@ -14,6 +17,9 @@ jobs:
         #        disable macos-15 until https://github.com/erigontech/erigon/issues/8789
         os: [ ubuntu-24.04 ] # required check includes runner version. Do not change it only here.
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 60
 
     steps:
@@ -66,6 +72,9 @@ jobs:
       matrix:
         os: [ windows-2025 ]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
Part of the zizmor `excessive-permissions` cleanup (#21132). Follow-up to #22662.

## What
These CI test workflows self-cancel the CI Gate run on the first merge-queue failure via `gh run cancel ${{ github.run_id }}` (so the gate doesn't stall on still-running siblings). That call needs `actions: write`. Instead of relying on the repo's broad default token grant, each now declares explicit least-privilege permissions.

**Single-job** — top-level block:
- `check-large-files`, `lint`, `reproducible-build`, `test-all-erigon`, `test-bench` → `contents: read` + `actions: write`
- `sonar` → `contents: read` + `actions: write` + `pull-requests: read`

**Multi-job** — top-level `contents: read`, with `actions: write` added only to the jobs that run the cancel step:
- `test-all-erigon-race` → `load-matrix`, `tests-linux`
- `test-eest-spec` → `eest-spec-tests`, `eest-shard-coverage`
- `test-integration-caplin` → `tests`, `tests-windows`

## Notes on the non-obvious scopes
- **`sonar`** also reads the Actions API (`gh api .../runs`, `.../artifacts`, and `download-artifact` for merge-queue coverage reuse) — covered by `actions: write`. `pull-requests: read` preserves SonarCloud's PR-analysis context (the scan step runs only outside the merge queue).
- On multi-job workflows, `actions: write` is deliberately **not** placed at the workflow level (zizmor flags that as "overly broad") — it's scoped to the specific cancel jobs.

## Verification
- zizmor `excessive-permissions`: **28 → 12** — all 9 files here resolved, no new "overly broad at the workflow level" findings introduced.
- `actionlint` clean w.r.t. this change; `make lint` = 0 issues.

## Rollout note
The audit stays `disable: true` in `.github/zizmor.yml` until the series finishes (docker/packages group + the `ci-gate`/`test-fuzz` per-job rescoping remain); the final PR flips it on so the gate enforces it.