### PR TITLE
rpc: extract api config pkg more

### DIFF
--- a/cmd/evm/zkevmrunner.go
+++ b/cmd/evm/zkevmrunner.go
@@ -249,7 +249,7 @@ func runWitnessTest(test *testutil.WitnessBlockTest) error {
 	}
 
 	baseApi := jsonrpc.NewBaseApi(nil, m.StateCache, m.BlockReader, m.Engine, nil, &rpccfg.BaseApiConfig{Dirs: m.Dirs})
-	debugApi := jsonrpc.NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false)
+	debugApi := jsonrpc.NewPrivateDebugAPI(baseApi, m.DB, nil, &rpccfg.DebugApiConfig{})
 	canonicalMode := "canonical"
 
 	for i := 0; i < test.NumBlocks(); i++ {

--- a/cmd/evm/zkevmrunner.go
+++ b/cmd/evm/zkevmrunner.go
@@ -249,7 +249,7 @@ func runWitnessTest(test *testutil.WitnessBlockTest) error {
 	}
 
 	baseApi := jsonrpc.NewBaseApi(nil, m.StateCache, m.BlockReader, m.Engine, nil, &rpccfg.BaseApiConfig{Dirs: m.Dirs})
-	debugApi := jsonrpc.NewPrivateDebugAPI(baseApi, m.DB, nil, &rpccfg.DebugApiConfig{})
+	debugApi := jsonrpc.NewPrivateDebugAPI(baseApi, m.DB, nil, rpccfg.DefaultDebugApiConfig())
 	canonicalMode := "canonical"
 
 	for i := 0; i < test.NumBlocks(); i++ {

--- a/rpc/jsonrpc/call_traces_test.go
+++ b/rpc/jsonrpc/call_traces_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fastjson"
 
-	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/execution/chain"
@@ -74,7 +73,7 @@ func TestCallTraceOneByOne(t *testing.T) {
 		t.Fatalf("generate chain: %v", err)
 	}
 
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	// Insert blocks 1 by 1 to trigger possible "off by one" errors
 	for i := 0; i < chain.Length(); i++ {
 		if err = m.InsertChain(chain.Slice(i, i+1)); err != nil {
@@ -119,7 +118,7 @@ func TestCallTraceUnwind(t *testing.T) {
 		t.Fatalf("generate chainB: %v", err)
 	}
 
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	if err = m.InsertChain(chainA); err != nil {
 		t.Fatalf("inserting chainA: %v", err)
@@ -183,7 +182,7 @@ func TestFilterNoAddresses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate chain: %v", err)
 	}
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	// Insert blocks 1 by 1 to trigger possible "off by one" errors
 	for i := 0; i < chain.Length(); i++ {
 		if err = m.InsertChain(chain.Slice(i, i+1)); err != nil {
@@ -207,7 +206,7 @@ func TestFilterNoAddresses(t *testing.T) {
 
 func TestFilterAddressIntersection(t *testing.T) {
 	m := execmoduletester.New(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	toAddress1, toAddress2, other := common.Address{1}, common.Address{2}, common.Address{3}
 

--- a/rpc/jsonrpc/daemon.go
+++ b/rpc/jsonrpc/daemon.go
@@ -57,6 +57,36 @@ func NewEthApiConfig(cfg *httpcfg.HttpCfg) *rpccfg.EthApiConfig {
 	}
 }
 
+func NewDebugApiConfig(cfg *httpcfg.HttpCfg) *rpccfg.DebugApiConfig {
+	return &rpccfg.DebugApiConfig{
+		GasCap:            cfg.Gascap,
+		GethCompatibility: cfg.GethCompatibility,
+	}
+}
+
+func NewTraceApiConfig(cfg *httpcfg.HttpCfg) *rpccfg.TraceApiConfig {
+	return &rpccfg.TraceApiConfig{
+		MaxTraces:     cfg.MaxTraces,
+		GasCap:        cfg.Gascap,
+		Compatibility: cfg.TraceCompatibility,
+	}
+}
+
+func NewGraphQLApiConfig(cfg *httpcfg.HttpCfg) *rpccfg.GraphQLApiConfig {
+	return &rpccfg.GraphQLApiConfig{
+		GasCap:          cfg.Gascap,
+		ReturnDataLimit: cfg.ReturnDataLimit,
+	}
+}
+
+func NewOverlayApiConfig(cfg *httpcfg.HttpCfg) *rpccfg.OverlayApiConfig {
+	return &rpccfg.OverlayApiConfig{
+		GasCap:                    cfg.Gascap,
+		OverlayGetLogsTimeout:     cfg.OverlayGetLogsTimeout,
+		OverlayReplayBlockTimeout: cfg.OverlayReplayBlockTimeout,
+	}
+}
+
 // APIList describes the list of available RPC apis
 func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.TxpoolClient, mining txpoolproto.MiningClient,
 	filters *rpchelper.Filters, stateCache kvcache.Cache,
@@ -69,8 +99,8 @@ func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.Tx
 	erigonImpl := NewErigonAPI(base, db, eth)
 	txpoolImpl := NewTxPoolAPI(base, db, txPool)
 	netImpl := NewNetAPIImpl(eth)
-	debugImpl := NewPrivateDebugAPI(base, db, eth, cfg.Gascap, cfg.GethCompatibility)
-	traceImpl := NewTraceAPI(base, db, cfg)
+	debugImpl := NewPrivateDebugAPI(base, db, eth, NewDebugApiConfig(cfg))
+	traceImpl := NewTraceAPI(base, db, NewTraceApiConfig(cfg))
 	web3Impl := NewWeb3APIImpl(eth)
 	adminImpl := NewAdminAPI(eth)
 	parityImpl := NewParityAPIImpl(base, db)
@@ -93,8 +123,8 @@ func APIList(db kv.TemporalRoDB, eth rpchelper.ApiBackend, txPool txpoolproto.Tx
 
 	otsImpl := NewOtterscanAPI(base, db, cfg.OtsMaxPageSize)
 	internalImpl := NewInternalAPI(base, db)
-	gqlImpl := NewGraphQLAPI(base, db, ethImpl, txPool, cfg.Gascap, cfg.ReturnDataLimit)
-	overlayImpl := NewOverlayAPI(base, db, cfg.Gascap, cfg.OverlayGetLogsTimeout, cfg.OverlayReplayBlockTimeout, otsImpl)
+	gqlImpl := NewGraphQLAPI(base, db, ethImpl, txPool, NewGraphQLApiConfig(cfg))
+	overlayImpl := NewOverlayAPI(base, db, NewOverlayApiConfig(cfg), otsImpl)
 
 	if cfg.GraphQLEnabled {
 		list = append(list, rpc.API{

--- a/rpc/jsonrpc/debug_api.go
+++ b/rpc/jsonrpc/debug_api.go
@@ -40,6 +40,7 @@ import (
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/ethapi"
 	"github.com/erigontech/erigon/rpc/jsonstream"
+	"github.com/erigontech/erigon/rpc/rpccfg"
 	"github.com/erigontech/erigon/rpc/rpchelper"
 )
 
@@ -87,13 +88,13 @@ type DebugAPIImpl struct {
 }
 
 // NewPrivateDebugAPI returns PrivateDebugAPIImpl instance
-func NewPrivateDebugAPI(base *BaseAPI, db kv.TemporalRoDB, ethBackend rpchelper.ApiBackend, gascap uint64, gethCompatibility bool) *DebugAPIImpl {
+func NewPrivateDebugAPI(base *BaseAPI, db kv.TemporalRoDB, ethBackend rpchelper.ApiBackend, cfg *rpccfg.DebugApiConfig) *DebugAPIImpl {
 	return &DebugAPIImpl{
 		BaseAPI:           base,
 		db:                db,
 		ethBackend:        ethBackend,
-		GasCap:            gascap,
-		gethCompatibility: gethCompatibility,
+		GasCap:            cfg.GasCap,
+		gethCompatibility: cfg.GethCompatibility,
 	}
 }
 

--- a/rpc/jsonrpc/debug_api_test.go
+++ b/rpc/jsonrpc/debug_api_test.go
@@ -122,7 +122,7 @@ func TestTraceBlockByNumber(t *testing.T) {
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, m.Engine, nil, &rpccfg.BaseApiConfig{Dirs: m.Dirs})
 	ethApi := newEthApiForTest(baseApi, m.DB, nil, nil)
-	api := NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(baseApi, m.DB, nil, &rpccfg.DebugApiConfig{})
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
 		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -173,7 +173,7 @@ func TestTraceBlockByNumber(t *testing.T) {
 func TestTraceBlockByHash(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
 	ethApi := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
 		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -262,7 +262,7 @@ func TestTraceBlockByHashPrestateTracerCreate2MemoryOverflow(t *testing.T) {
 	tracer := "prestateTracer"
 	var buf bytes.Buffer
 	stream := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 	require.NoError(t, api.TraceBlockByHash(m.Ctx, generated.TopBlock.Hash(), &tracersConfig.TraceConfig{Tracer: &tracer}, stream))
 	require.NoError(t, stream.Flush())
 	var traces []struct {
@@ -290,7 +290,7 @@ func TestTraceBlockByHashPrestateTracerCreate2MemoryOverflow(t *testing.T) {
 
 func TestTraceTransaction(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 	for _, tt := range debugTraceTransactionTests {
 		var buf bytes.Buffer
 		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -319,7 +319,7 @@ func TestTraceTransaction(t *testing.T) {
 
 func TestTraceTransactionNotFound(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 
 	var buf bytes.Buffer
 	s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -332,7 +332,7 @@ func TestTraceTransactionNotFound(t *testing.T) {
 // the "result" field when the stream is untouched, producing {error:...} without result:null.
 func TestTraceErrorPathsWriteNoStream(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 
 	newStream := func() (*bytes.Buffer, jsonstream.Stream) {
 		var buf bytes.Buffer
@@ -416,7 +416,7 @@ func TestTraceErrorPathsWriteNoStream(t *testing.T) {
 }
 
 func (c *baseFeeTestChain) debugAPI() *DebugAPIImpl {
-	return NewPrivateDebugAPI(newBaseApiForTest(c.m), c.m.DB, nil, 0, false)
+	return newDebugApiForTest(c.m)
 }
 
 // callDebugTraceCall invokes debug_traceCall with the given args and
@@ -516,7 +516,7 @@ func TestTxResultFieldStreamLazy(t *testing.T) {
 // before any write (inner.Written stays false): each tx object has "error" but no "result" field.
 func TestTraceBlockErrorBeforeWrite(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 	ethApi := newEthApiForTest(newBaseApiForTest(m), m.DB, nil, nil)
 
 	tx, err := ethApi.GetTransactionByHash(m.Ctx, common.HexToHash(debugTraceTransactionTests[0].txHash))
@@ -591,7 +591,7 @@ func TestTraceBlockErrorAfterWrite(t *testing.T) {
 
 func TestTraceTransactionNoRefund(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 	for _, tt := range debugTraceTransactionNoRefundTests {
 		var buf bytes.Buffer
 		s := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
@@ -621,7 +621,7 @@ func TestTraceTransactionNoRefund(t *testing.T) {
 
 func TestStorageRangeAt(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 	t.Run("invalid addr", func(t *testing.T) {
 		var block4 *types.Block
 		var err error
@@ -715,7 +715,7 @@ func TestStorageRangeAt(t *testing.T) {
 
 func TestStorageRangeAtGethCompat(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, true) // gethCompatibility=true
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, &rpccfg.DebugApiConfig{GethCompatibility: true})
 	t.Run("block latest, addr 1", func(t *testing.T) {
 		var latestBlock *types.Block
 		err := m.DB.View(m.Ctx, func(tx kv.Tx) (err error) {
@@ -781,7 +781,7 @@ func TestStorageRangeAtGethCompat(t *testing.T) {
 
 func TestAccountRange(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 
 	t.Run("valid account", func(t *testing.T) {
 		addr := common.HexToAddress("0x537e697c7ab75a26f9ecf0ce810e3154dfcaaf55")
@@ -880,7 +880,7 @@ func TestAccountRange(t *testing.T) {
 
 func TestGetModifiedAccountsByNumber(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 
 	t.Run("correct input", func(t *testing.T) {
 		n, n2 := rpc.BlockNumber(1), rpc.BlockNumber(2)
@@ -995,7 +995,7 @@ func TestMapTxNum2BlockNum(t *testing.T) {
 
 func TestAccountAt(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 
 	var blockHash0, blockHash1, blockHash3, blockHash10, blockHashNonExistent common.Hash
 	_ = m.DB.View(m.Ctx, func(tx kv.Tx) error {
@@ -1058,7 +1058,7 @@ func TestAccountAt(t *testing.T) {
 
 func TestGetBadBlocks(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 5000000, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, &rpccfg.DebugApiConfig{GasCap: 5000000})
 	ctx := context.Background()
 
 	require := require.New(t)
@@ -1131,7 +1131,7 @@ func TestGetBadBlocks(t *testing.T) {
 
 func TestGetRawTransaction(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 5000000, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, &rpccfg.DebugApiConfig{GasCap: 5000000})
 	ctx := context.Background()
 
 	require := require.New(t)
@@ -1172,7 +1172,7 @@ func TestGetRawTransaction(t *testing.T) {
 
 func TestGetRawReceipts(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 5000000, false)
+	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, &rpccfg.DebugApiConfig{GasCap: 5000000})
 	ctx := context.Background()
 
 	require := require.New(t)
@@ -1213,7 +1213,7 @@ func TestExecutionWitness(t *testing.T) {
 	})
 
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, 0, false)
+	api := newDebugApiForTest(m)
 	ctx := context.Background()
 
 	// Write the DB flag so that debug_executionWitness accepts the request.
@@ -1376,7 +1376,7 @@ func TestSetHead(t *testing.T) {
 		backendServer := privateapi.NewEthBackendServer(ctx, mock, m.DB, m.Notifications, m.BlockReader, nil, logger, builder.NewLatestBlockBuiltStore(), nil)
 		backendClient := direct.NewEthBackendClientDirect(backendServer)
 		backend := rpcservices.NewRemoteBackend(backendClient, m.DB, m.BlockReader)
-		return NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, backend, 0, false)
+		return NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, backend, &rpccfg.DebugApiConfig{})
 	}
 
 	// Rewinding one block below the current head is the simplest valid rewind.

--- a/rpc/jsonrpc/eth_api_test.go
+++ b/rpc/jsonrpc/eth_api_test.go
@@ -69,6 +69,14 @@ func newEthApiForTest(base *BaseAPI, db kv.TemporalRoDB, txPool txpoolproto.Txpo
 	return NewEthAPI(base, db, nil, txPool, mining, cfg, log.New())
 }
 
+func newTraceApiForTest(m *execmoduletester.ExecModuleTester) *TraceAPIImpl {
+	return NewTraceAPI(newBaseApiForTest(m), m.DB, &rpccfg.TraceApiConfig{})
+}
+
+func newDebugApiForTest(m *execmoduletester.ExecModuleTester) *DebugAPIImpl {
+	return NewPrivateDebugAPI(newBaseApiForTest(m), m.DB, nil, &rpccfg.DebugApiConfig{})
+}
+
 func TestNewBaseApiEvmCallTimeout(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
 

--- a/rpc/jsonrpc/eth_block_test.go
+++ b/rpc/jsonrpc/eth_block_test.go
@@ -89,7 +89,7 @@ func newBlockAccessListRPCFixture(t *testing.T) (*blockgen.ChainPack, *rpc.Clien
 	m, chainPack := rpcdaemontest.CreateTestBlockAccessListExecModule(t)
 	base := newBaseApiForTest(m)
 	ethAPI := newEthApiForTest(base, m.DB, nil, nil)
-	debugAPI := NewPrivateDebugAPI(base, m.DB, nil, 0, false)
+	debugAPI := NewPrivateDebugAPI(base, m.DB, nil, &rpccfg.DebugApiConfig{})
 	server := rpc.NewServer(50, false, false, true, log.New(), 100)
 	require.NoError(t, server.RegisterName("eth", EthAPI(ethAPI)))
 	require.NoError(t, server.RegisterName("debug", PrivateDebugAPI(debugAPI)))

--- a/rpc/jsonrpc/eth_callMany_test.go
+++ b/rpc/jsonrpc/eth_callMany_test.go
@@ -68,7 +68,7 @@ func TestCallManyEmptyBundles(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
 	baseApi := newBaseApiForTest(m)
 	api := newEthApiForTest(baseApi, m.DB, nil, nil)
-	debugApi := NewPrivateDebugAPI(baseApi, m.DB, nil, 5000000, false)
+	debugApi := NewPrivateDebugAPI(baseApi, m.DB, nil, &rpccfg.DebugApiConfig{GasCap: 5000000})
 	ctx := context.Background()
 
 	txIndex := -1

--- a/rpc/jsonrpc/gen_traces_test.go
+++ b/rpc/jsonrpc/gen_traces_test.go
@@ -25,7 +25,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv/kvcache"
@@ -47,7 +46,7 @@ func TestGeneratedDebugApi(t *testing.T) {
 	m := rpcdaemontest.CreateTestExecModuleForTraces(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, m.Engine, nil, &rpccfg.BaseApiConfig{Dirs: m.Dirs})
-	api := NewPrivateDebugAPI(baseApi, m.DB, nil, 0, false)
+	api := NewPrivateDebugAPI(baseApi, m.DB, nil, &rpccfg.DebugApiConfig{})
 	var buf bytes.Buffer
 	stream := jsonstream.New(jsoniter.NewStream(jsoniter.ConfigDefault, &buf, 4096))
 	callTracer := "callTracer"
@@ -134,7 +133,7 @@ func TestGeneratedTraceApi(t *testing.T) {
 	m := rpcdaemontest.CreateTestExecModuleForTraces(t)
 	stateCache := kvcache.New(kvcache.DefaultCoherentConfig)
 	baseApi := NewBaseApi(nil, stateCache, m.BlockReader, m.Engine, nil, &rpccfg.BaseApiConfig{Dirs: m.Dirs})
-	api := NewTraceAPI(baseApi, m.DB, &httpcfg.HttpCfg{})
+	api := NewTraceAPI(baseApi, m.DB, &rpccfg.TraceApiConfig{})
 	traces, err := api.Block(context.Background(), rpc.BlockNumber(1), new(bool), nil)
 	if err != nil {
 		t.Errorf("trace_block %d: %v", 0, err)
@@ -289,7 +288,7 @@ func TestGeneratedTraceApi(t *testing.T) {
 
 func TestGeneratedTraceApiCollision(t *testing.T) {
 	m := rpcdaemontest.CreateTestExecModuleForTracesCollision(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	traces, err := api.Transaction(context.Background(), common.HexToHash("0xb2b9fa4c999c1c8370ce1fbd1c4315a9ce7f8421fe2ebed8a9051ff2e4e7e3da"), new(bool), nil)
 	if err != nil {
 		t.Errorf("trace_block %d: %v", 0, err)

--- a/rpc/jsonrpc/graphql_api.go
+++ b/rpc/jsonrpc/graphql_api.go
@@ -36,6 +36,7 @@ import (
 	"github.com/erigontech/erigon/rpc"
 	ethapi "github.com/erigontech/erigon/rpc/ethapi"
 	"github.com/erigontech/erigon/rpc/filters"
+	"github.com/erigontech/erigon/rpc/rpccfg"
 	"github.com/erigontech/erigon/rpc/rpchelper"
 	"github.com/erigontech/erigon/rpc/transactions"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -72,14 +73,14 @@ type GraphQLAPIImpl struct {
 	returnDataLimit int
 }
 
-func NewGraphQLAPI(base *BaseAPI, db kv.TemporalRoDB, eth EthAPI, txPool txpoolproto.TxpoolClient, gasCap uint64, returnDataLimit int) *GraphQLAPIImpl {
+func NewGraphQLAPI(base *BaseAPI, db kv.TemporalRoDB, eth EthAPI, txPool txpoolproto.TxpoolClient, cfg *rpccfg.GraphQLApiConfig) *GraphQLAPIImpl {
 	return &GraphQLAPIImpl{
 		BaseAPI:         base,
 		db:              db,
 		eth:             eth,
 		txPool:          txPool,
-		gasCap:          gasCap,
-		returnDataLimit: returnDataLimit,
+		gasCap:          cfg.GasCap,
+		returnDataLimit: cfg.ReturnDataLimit,
 	}
 }
 

--- a/rpc/jsonrpc/overlay_api.go
+++ b/rpc/jsonrpc/overlay_api.go
@@ -43,6 +43,7 @@ import (
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/ethapi"
 	"github.com/erigontech/erigon/rpc/filters"
+	"github.com/erigontech/erigon/rpc/rpccfg"
 	"github.com/erigontech/erigon/rpc/rpchelper"
 	"github.com/erigontech/erigon/rpc/transactions"
 )
@@ -78,13 +79,13 @@ type blockReplayResult struct {
 }
 
 // NewOverlayAPI returns OverlayAPIImpl instance
-func NewOverlayAPI(base *BaseAPI, db kv.TemporalRoDB, gascap uint64, overlayGetLogsTimeout time.Duration, overlayReplayBlockTimeout time.Duration, otsApi OtterscanAPI) *OverlayAPIImpl {
+func NewOverlayAPI(base *BaseAPI, db kv.TemporalRoDB, cfg *rpccfg.OverlayApiConfig, otsApi OtterscanAPI) *OverlayAPIImpl {
 	return &OverlayAPIImpl{
 		BaseAPI:                   base,
 		db:                        db,
-		GasCap:                    gascap,
-		OverlayGetLogsTimeout:     overlayGetLogsTimeout,
-		OverlayReplayBlockTimeout: overlayReplayBlockTimeout,
+		GasCap:                    cfg.GasCap,
+		OverlayGetLogsTimeout:     cfg.OverlayGetLogsTimeout,
+		OverlayReplayBlockTimeout: cfg.OverlayReplayBlockTimeout,
 		OtsAPI:                    otsApi,
 	}
 }

--- a/rpc/jsonrpc/trace_adhoc_test.go
+++ b/rpc/jsonrpc/trace_adhoc_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dir"
@@ -55,7 +54,7 @@ import (
 
 func TestEmptyQuery(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	// Call GetTransactionReceipt for transaction which is not in the database
 	var latest = rpc.LatestBlockNumber
 	results, err := api.CallMany(context.Background(), json.RawMessage("[]"), &rpc.BlockNumberOrHash{BlockNumber: &latest}, nil)
@@ -71,7 +70,7 @@ func TestEmptyQuery(t *testing.T) {
 }
 func TestCoinbaseBalance(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	// Call GetTransactionReceipt for transaction which is not in the database
 	var latest = rpc.LatestBlockNumber
 	results, err := api.CallMany(context.Background(), json.RawMessage(`
@@ -101,7 +100,7 @@ func internedAddress(addr string) accounts.Address {
 
 func TestSwapBalance(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	// Call GetTransactionReceipt for transaction which is not in the database
 	var latest = rpc.LatestBlockNumber
 	results, err := api.CallMany(context.Background(), json.RawMessage(`
@@ -186,7 +185,7 @@ func TestSwapBalance(t *testing.T) {
 
 func TestCorrectStateDiff(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	// Call GetTransactionReceipt for transaction which is not in the database
 	var latest = rpc.LatestBlockNumber
 	results, err := api.CallMany(context.Background(), json.RawMessage(`
@@ -318,7 +317,7 @@ func TestCorrectStateDiff(t *testing.T) {
 
 func TestReplayTransaction(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	var txnHash common.Hash
 	if err := m.DB.View(context.Background(), func(tx kv.Tx) error {
 		b, err := m.BlockReader.BlockByNumber(m.Ctx, tx, 6)
@@ -345,7 +344,7 @@ func TestReplayTransaction(t *testing.T) {
 
 func TestReplayBlockTransactions(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	// Call GetTransactionReceipt for transaction which is not in the database
 	n := rpc.BlockNumber(6)
@@ -499,7 +498,7 @@ func rawTxFromBlock(t *testing.T, m *execmoduletester.ExecModuleTester, blockNum
 
 func TestRawTransaction(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	encoded, _, _ := rawTxFromBlock(t, m, 6)
 	result, err := api.RawTransaction(context.Background(), encoded, []string{"trace"})
@@ -510,7 +509,7 @@ func TestRawTransaction(t *testing.T) {
 
 func TestRawTransactionStateDiff(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	encoded, from, to := rawTxFromBlock(t, m, 6)
 
@@ -563,7 +562,7 @@ func TestRawTransactionStateDiff(t *testing.T) {
 
 func TestRawTransactionVmTrace(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	encoded, _, _ := rawTxFromBlock(t, m, 6)
 
@@ -578,7 +577,7 @@ func TestRawTransactionVmTrace(t *testing.T) {
 
 func TestRawTransactionAllTraceTypes(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	encoded, _, _ := rawTxFromBlock(t, m, 6)
 
@@ -607,7 +606,7 @@ func TestParseOeTracerConfigToleratesEmptyTracer(t *testing.T) {
 
 func TestTraceCallRejectsCustomTracer(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	tracer := "callTracer"
 	var latest = rpc.LatestBlockNumber
@@ -619,7 +618,7 @@ func TestTraceCallRejectsCustomTracer(t *testing.T) {
 
 func TestRawTransactionInvalidType(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	encoded, _, _ := rawTxFromBlock(t, m, 6)
 
@@ -634,7 +633,7 @@ func TestTraceCallBlockOverridesBaseFeeAffectsGasPrice(t *testing.T) {
 	}
 
 	m, bankAddr, contractAddr, _ := chainWithDeployedContractAndConfig(t, chain.AllProtocolChanges)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	// EVM bytecode: GASPRICE (0x3a), PUSH1 0x00, MSTORE, PUSH1 0x20, PUSH1 0x00, RETURN
 	gasPriceCode := hexutil.Bytes{0x3a, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3}
@@ -797,7 +796,7 @@ func traceConfigWithBaseFeeOverride(baseFee *uint256.Int) *config.TraceConfig {
 }
 
 func (c *baseFeeTestChain) traceAPI() *TraceAPIImpl {
-	return NewTraceAPI(newBaseApiForTest(c.m), c.m.DB, &httpcfg.HttpCfg{})
+	return newTraceApiForTest(c.m)
 }
 
 // setupBaseFeeOverrideCall deploys an opcode-emitting contract, mines a

--- a/rpc/jsonrpc/trace_api.go
+++ b/rpc/jsonrpc/trace_api.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/tracing/tracers/config"
 	"github.com/erigontech/erigon/rpc"
 	"github.com/erigontech/erigon/rpc/jsonstream"
+	"github.com/erigontech/erigon/rpc/rpccfg"
 )
 
 // TraceAPI RPC interface into tracing API
@@ -57,12 +57,12 @@ type TraceAPIImpl struct {
 }
 
 // NewTraceAPI returns NewTraceAPI instance
-func NewTraceAPI(base *BaseAPI, kv kv.TemporalRoDB, cfg *httpcfg.HttpCfg) *TraceAPIImpl {
+func NewTraceAPI(base *BaseAPI, kv kv.TemporalRoDB, cfg *rpccfg.TraceApiConfig) *TraceAPIImpl {
 	return &TraceAPIImpl{
 		BaseAPI:       base,
 		kv:            kv,
 		maxTraces:     cfg.MaxTraces,
-		gasCap:        cfg.Gascap,
-		compatibility: cfg.TraceCompatibility,
+		gasCap:        cfg.GasCap,
+		compatibility: cfg.Compatibility,
 	}
 }

--- a/rpc/jsonrpc/trace_filtering_test.go
+++ b/rpc/jsonrpc/trace_filtering_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
@@ -50,7 +49,7 @@ import (
 // worker-pool path of doCallBlockParallel.
 func TestCallBlockParallelMatchesSequential(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	ctx := context.Background()
 	const blockNum = uint64(6) // block 6 has 32 txs (case i=5 in test chain generation)
@@ -152,7 +151,7 @@ func TestCallBlockParallelMatchesSequential(t *testing.T) {
 // a JSON-RPC error instead of dereferencing the nil transaction.
 func TestCallTransactionNilTxnReturnsError(t *testing.T) {
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	ctx := context.Background()
 	const blockNum = uint64(6)
@@ -226,7 +225,7 @@ func TestBlockWithdrawalTraceEntries(t *testing.T) {
 	withdrawalAddr := common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 
 	m, blk := chainWithWithdrawal(t, withdrawalAddr, withdrawalGwei)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	n := rpc.BlockNumber(blk.NumberU64())
 
 	traces, err := api.Block(context.Background(), n, new(bool), traceConfigWithWithdrawals())
@@ -263,7 +262,7 @@ func TestBlockWithdrawalNoEntriesWithoutFlag(t *testing.T) {
 	withdrawalAddr := common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 
 	m, blk := chainWithWithdrawal(t, withdrawalAddr, withdrawalGwei)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	n := rpc.BlockNumber(blk.NumberU64())
 
 	traces, err := api.Block(context.Background(), n, new(bool), nil)
@@ -276,7 +275,7 @@ func TestBlockWithdrawalNoEntriesWithoutFlag(t *testing.T) {
 func TestBlockWithdrawalNoEntriesPreShanghai(t *testing.T) {
 	// Default test chain uses TestChainBerlinConfig which has no ShanghaiTime.
 	m, _, _ := rpcdaemontest.CreateTestExecModule(t)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	// Block 1 is pre-Shanghai on the default test chain.
 	n := rpc.BlockNumber(1)
@@ -293,7 +292,7 @@ func TestReplayBlockTransactionsWithdrawalStateDiff(t *testing.T) {
 	withdrawalAddr := common.HexToAddress("0xcafecafecafecafecafecafecafecafecafecafe")
 
 	m, blk := chainWithWithdrawal(t, withdrawalAddr, withdrawalGwei)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 
 	n := rpc.BlockNumber(blk.NumberU64())
 	bnOrHash := rpc.BlockNumberOrHash{BlockNumber: &n}
@@ -349,7 +348,7 @@ func TestReplayBlockTransactionsMultiWithdrawalSameAddr(t *testing.T) {
 	require.NoError(t, err)
 	blk := generated.Blocks[0]
 
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	n := rpc.BlockNumber(blk.NumberU64())
 	bnOrHash := rpc.BlockNumberOrHash{BlockNumber: &n}
 	results, err := api.ReplayBlockTransactions(context.Background(), bnOrHash, []string{"stateDiff"}, new(bool), traceConfigWithWithdrawals())
@@ -393,7 +392,7 @@ func TestReplayBlockTransactionsWithdrawalNewAddress(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, m.InsertChain(generated))
 
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	n := rpc.BlockNumber(generated.Blocks[0].NumberU64())
 	bnOrHash := rpc.BlockNumberOrHash{BlockNumber: &n}
 	results, err := api.ReplayBlockTransactions(context.Background(), bnOrHash, []string{"stateDiff"}, new(bool), traceConfigWithWithdrawals())
@@ -438,7 +437,7 @@ func TestReplayBlockTransactionsMultiWithdrawalNewAddress(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, m.InsertChain(generated))
 
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	n := rpc.BlockNumber(generated.Blocks[0].NumberU64())
 	bnOrHash := rpc.BlockNumberOrHash{BlockNumber: &n}
 	results, err := api.ReplayBlockTransactions(context.Background(), bnOrHash, []string{"stateDiff"}, new(bool), traceConfigWithWithdrawals())
@@ -469,7 +468,7 @@ func TestReplayBlockTransactionsWithdrawalNoEntriesWithoutFlag(t *testing.T) {
 	withdrawalAddr := common.HexToAddress("0xcafecafecafecafecafecafecafecafecafecafe")
 
 	m, blk := chainWithWithdrawal(t, withdrawalAddr, withdrawalGwei)
-	api := NewTraceAPI(newBaseApiForTest(m), m.DB, &httpcfg.HttpCfg{})
+	api := newTraceApiForTest(m)
 	n := rpc.BlockNumber(blk.NumberU64())
 	bnOrHash := rpc.BlockNumberOrHash{BlockNumber: &n}
 

--- a/rpc/rpccfg/rpccfg.go
+++ b/rpc/rpccfg/rpccfg.go
@@ -84,6 +84,32 @@ type EthApiConfig struct {
 	RpcTxSyncMaxTimeout         time.Duration
 }
 
+// DebugApiConfig defines the configurable parameters for the debug_ namespace
+type DebugApiConfig struct {
+	GasCap            uint64
+	GethCompatibility bool // Geth-compatible storage iteration order for debug_storageRangeAt
+}
+
+// TraceApiConfig defines the configurable parameters for the trace_ namespace
+type TraceApiConfig struct {
+	MaxTraces     uint64
+	GasCap        uint64
+	Compatibility bool // Bug for bug compatibility with OpenEthereum
+}
+
+// GraphQLApiConfig defines the configurable parameters for the GraphQL API
+type GraphQLApiConfig struct {
+	GasCap          uint64
+	ReturnDataLimit int
+}
+
+// OverlayApiConfig defines the configurable parameters for the overlay_ namespace
+type OverlayApiConfig struct {
+	GasCap                    uint64
+	OverlayGetLogsTimeout     time.Duration
+	OverlayReplayBlockTimeout time.Duration
+}
+
 var SlowLogBlackList = []string{
 	"eth_getBlock", "eth_getBlockByNumber", "eth_getBlockByHash", "eth_blockNumber",
 	"erigon_blockNumber", "erigon_getHeaderByNumber", "erigon_getHeaderByHash", "erigon_getBlockByTimestamp",

--- a/rpc/rpccfg/rpccfg.go
+++ b/rpc/rpccfg/rpccfg.go
@@ -62,6 +62,7 @@ const DefaultOverlayGetLogsTimeout = 5 * time.Minute
 const DefaultOverlayReplayBlockTimeout = 10 * time.Second
 const DefaultRpcTxSyncDefaultTimeout = 25 * time.Second
 const DefaultRpcTxSyncMaxTimeout = 1 * time.Minute
+const DefaultGasCap = 50_000_000
 
 type BaseApiConfig struct {
 	SingleNodeMode    bool
@@ -88,6 +89,12 @@ type EthApiConfig struct {
 type DebugApiConfig struct {
 	GasCap            uint64
 	GethCompatibility bool // Geth-compatible storage iteration order for debug_storageRangeAt
+}
+
+// DefaultDebugApiConfig returns the DebugApiConfig used outside the RPC daemon
+// (e.g. block-test runners), where no HttpCfg is available.
+func DefaultDebugApiConfig() *DebugApiConfig {
+	return &DebugApiConfig{GasCap: DefaultGasCap}
 }
 
 // TraceApiConfig defines the configurable parameters for the trace_ namespace


### PR DESCRIPTION
Follow-up to #22609. 
Extends the same pattern (BaseApiConfig/EthApiConfig) to the remaining APIs: 
- NewPrivateDebugAPI
- NewTraceAPI
- NewGraphQLAPI 
- NewOverlayAPI 

constructors no longer take loose scalar parameters, but a dedicated config defined in rpc/rpccfg