### PR TITLE
commitment/trie, seg, fusefilter: shrink GC scan range on three hot structs

### DIFF
--- a/db/datastruct/fusefilter/fusefilter_writer.go
+++ b/db/datastruct/fusefilter/fusefilter_writer.go
@@ -21,12 +21,12 @@ const bufSize = 4096
 
 // WriterOffHeap does write all keys to temporary mmap file - and using it as a source for `fusefilter` building
 type WriterOffHeap struct {
+	tmpFile     *os.File
+	tmpFilePath string
+
 	count    int
 	buf      [bufSize]uint64
 	features Features
-
-	tmpFile     *os.File
-	tmpFilePath string
 }
 
 func initFeatures() Features {

--- a/db/seg/parallel_compress.go
+++ b/db/seg/parallel_compress.go
@@ -46,8 +46,8 @@ const posCounterSmall = 512
 // posCounter counts position-code frequencies. Positions are bounded by word
 // length, so nearly all increments hit the array; the map is the overflow path.
 type posCounter struct {
-	small [posCounterSmall]uint64
 	big   map[uint64]uint64
+	small [posCounterSmall]uint64
 }
 
 func (p *posCounter) add(k uint64) {

--- a/execution/commitment/trie/hasher.go
+++ b/execution/commitment/trie/hasher.go
@@ -32,12 +32,13 @@ import (
 )
 
 type hasher struct {
-	sha                  keccak.KeccakState
+	sha      keccak.KeccakState
+	bw       *ByteArrayWriter
+	callback func(common.Hash, Node)
+
 	valueNodesRlpEncoded bool
-	buffers              [1024 * 1024]byte
 	prefixBuf            [8]byte
-	bw                   *ByteArrayWriter
-	callback             func(common.Hash, Node)
+	buffers              [1024 * 1024]byte
 }
 
 const rlpPrefixLength = 4


### PR DESCRIPTION
Reorder the fields of three structs so their pointer-bearing fields come *before* their large value arrays. The Go GC scans a struct only up to its last pointer; with a pointer field sitting behind a big array, the scan spans the whole struct. Leading the pointers collapses the scan range to a few words.

These are GC-scan-range wins, not padding wins — the struct sizes are unchanged. Surfaced by `betteralign` (each figure is the pointer-scan range removed):

| Struct | File | Scan range removed |
|---|---|---|
| `hasher` | `execution/commitment/trie/hasher.go` | ~1 MB (pooled, trie hot path — `bw`/`callback` behind a 1 MB `buffers`) |
| `WriterOffHeap` | `db/datastruct/fusefilter/fusefilter_writer.go` | ~32 KB (`tmpFile`/`tmpFilePath` behind a 4096×u64 `buf`) |
| `posCounter` | `db/seg/parallel_compress.go` | ~4 KB (`big` map behind a 512×u64 `small`) |

Behaviour is unchanged: all construction sites use keyed literals, and none of these types are serialized by struct-field order (no reflection-over-layout, no whole-struct `unsafe`/mmap), so field order here is purely cosmetic. `hasher` is the meaningful win — it's pooled and allocated on the commitment/trie hot path.

Deliberately left out of this PR: `AhoCorasick` (built once, shared read-only → single instance, no real GC benefit), `BlobSidecar` (safe but consensus code, low payoff), and `GenericCache` (concurrency-tuned layout — atomics/mutex/stripe array — where field placement is intentional).