### PR TITLE
.github: least-privilege permissions for docker/hive/kurtosis workflows (#21132)

### DIFF
--- a/.github/workflows/ci-cd-main-branch-docker-images.yml
+++ b/.github/workflows/ci-cd-main-branch-docker-images.yml
@@ -23,6 +23,9 @@ on:
         default: ''
         description: 'The branch to checkout and build artifacts from (in case of manual run). Important: the Docker image tag is generated automatically from the branch name by removing everything before the last slash. For example, for the branch "feature/user/my-cool-change", the tag will be "my-cool-change". Default is "" .'
 
+permissions:
+  contents: read
+
 jobs:
 
   Build:

--- a/.github/workflows/qa-txpool-performance-test.yml
+++ b/.github/workflows/qa-txpool-performance-test.yml
@@ -16,6 +16,9 @@ on:
     paths:
       - '.github/workflows/qa-txpool-performance-test.yml'
 
+permissions:
+  contents: read
+
 jobs:
   tx_pool_assertoor_test:
     name: tx_pool_assertoor_test (${{ matrix.exec_mode }})

--- a/.github/workflows/test-hive-eest.yml
+++ b/.github/workflows/test-hive-eest.yml
@@ -9,6 +9,10 @@ concurrency:
   group: hive-eest-tests-${{ github.run_id }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   test-hive-eest:
     runs-on: ${{ matrix.runner == 'ubuntu-latest' && 'ubuntu-latest' || fromJSON('{"group":"hive"}') }}

--- a/.github/workflows/test-hive.yml
+++ b/.github/workflows/test-hive.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || format('push-{0}-{1}', github.run_id, github.run_attempt) }}
   cancel-in-progress: ${{ github.event.pull_request.number != 0 }}
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   test-hive:
     name: test-hive (${{ matrix.sim }}, ${{ matrix.sim-limit }}, ${{ matrix.exec_mode }})

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -51,6 +51,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # Build the erigon image once for the whole matrix. The matrix below has
   # grown to suite × {serial, parallel} entries — having every entry run its
@@ -315,6 +318,9 @@ jobs:
     # cache; there's nothing for the matrix to do (the test step is skipped).
     if: ${{ !inputs.cache-warming-only && !inputs.cl-images-only && !contains(github.event.pull_request.labels.*.name, 'skip-uncaching') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 60
     strategy:
       # In merge_group: cancel sibling shards on first failure so ci-gate's


### PR DESCRIPTION
Part of the zizmor `excessive-permissions` cleanup (#21132). Follow-up to #22662 and #22677.

## What
Adds explicit least-privilege `permissions:` blocks to 5 workflows that were running on the broad default token:

| Workflow | Scope | Why |
|---|---|---|
| `ci-cd-main-branch-docker-images` | `contents: read` | DockerHub only — auth via DockerHub secrets, no GitHub token used |
| `qa-txpool-performance-test` | `contents: read` | DockerHub **pull** only |
| `test-hive` | `contents: read` + `actions: write` | merge-queue self-cancel via `gh run cancel` |
| `test-hive-eest` | `contents: read` + `actions: write` | merge-queue self-cancel via `gh run cancel` |
| `test-kurtosis-assertoor` | top-level `contents: read`; `actions: write` on `assertoor_test` only | only that job runs `gh run cancel` |

## Notes
- DockerHub login/push uses DockerHub secrets, not the GitHub token, so it needs **no** GitHub permission.
- `test-kurtosis-assertoor` builds the erigon image with `load: true` (no registry push), so **no `packages: write`** is required; `actions: write` is scoped to the single job that self-cancels rather than the workflow level (which would trip "overly broad").

## Verification
- zizmor `excessive-permissions`: **12 → 3** for these files (the remaining 3 are `ci-gate`/`test-fuzz`, handled next).
- `actionlint` clean w.r.t. this change (only pre-existing shellcheck notes remain); `make lint` = 0 issues.

## Rollout note
The audit stays `disable: true` in `.github/zizmor.yml` until the series finishes; the final PR flips it on so the gate enforces it.

> Note: `docker-tags.yml` — originally slated for this batch — is being **removed** in a separate PR instead of scoped, as it is a dead 2023 experiment (0 runs ever, references a non-existent `make release-dry-run` target, triggers only on `y*.*.*` test tags).