### PR TITLE
ci(docs): auto-archive previous docs version when a release branch is cut

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -133,8 +133,239 @@ jobs:
             echo "- **Manual step required:** add the branch-protection rule in **Settings → Branches**."
           } >> "$GITHUB_STEP_SUMMARY"
 
-  notify:
+  # ---------------------------------------------------------------------------
+  # Q1 of the docs version transition: archive the OUTGOING stable version onto
+  # the freshly-cut branch. Runs right after the cut (same run, already knows the
+  # incoming branch name). Opens a review-ready PR labelled `docs`; a human
+  # reviews and merges it. This does NOT flip the live docs deploy — that's Q2,
+  # still the manual retire+publish PR pair (see #22062 / #22063). See
+  # docs-version-bump.yml for the manual escape hatch.
+  #
+  # The PR is opened with the default GITHUB_TOKEN and left for manual approval.
+  # Note: a GITHUB_TOKEN-opened PR does not itself trigger pull_request-based CI
+  # (Actions recursion guard). The archive is already build-verified in this job
+  # before the PR opens; a reviewer merges after inspecting the diff. If a
+  # release branch's protection ever requires status checks that must run on the
+  # PR, either re-trigger them (close/reopen) or open via the release App token.
+  #
+  # Correctness: the snapshot is generated from the OUTGOING release branch's
+  # own docs (release/N.<M-1>), never from the just-cut branch — which was cut
+  # from main and already holds the NEXT version's content. And it ports the
+  # outgoing branch's FULL versioned state (versions.json + all versioned_docs +
+  # all versioned_sidebars) plus the fresh snapshot, so no older version silently
+  # drops off the site at the next cut.
+  archive-previous-docs-version:
     needs: [create-release-branch]
+    # Real cut → open a PR. Dry-run → validate the port + build, but open nothing.
+    if: >-
+      needs.create-release-branch.outputs.outcome == 'success' ||
+      needs.create-release-branch.outputs.outcome == 'dry-run'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # contents:write to push the PR branch; pull-requests:write to open it.
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      outcome: ${{ steps.pr.outputs.outcome || steps.plan.outputs.outcome }}
+      pr_url: ${{ steps.pr.outputs.pr_url }}
+      detail: ${{ steps.pr.outputs.detail || steps.plan.outputs.detail }}
+    steps:
+      - name: Determine outgoing series to archive
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          INCOMING_BRANCH: ${{ inputs.release_branch }}
+        run: |
+          set -euo pipefail
+          # Defensive re-validate (job 1 already checked) and capture MAJOR.MINOR.
+          if [[ ! "$INCOMING_BRANCH" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::incoming '$INCOMING_BRANCH' is not release/N.N"; exit 1
+          fi
+          in_major="${BASH_REMATCH[1]}"; in_minor="${BASH_REMATCH[2]}"
+
+          # Enumerate existing release/N.N branches (fail-closed: a gh API error
+          # aborts the job rather than guessing). Exact regex excludes patch-style
+          # names like release/3.0.10; numeric per-component sort so 3.10 > 3.9.
+          all=$(gh api "repos/$REPO/branches" --paginate --jq '.[].name')
+          series=$(printf '%s\n' "$all" \
+            | grep -E '^release/[0-9]+\.[0-9]+$' \
+            | sed 's#^release/##' \
+            | sort -t. -k1,1n -k2,2n || true)
+
+          # Highest series strictly below the incoming one (list is ascending, so
+          # the last match wins). Robust across major bumps (e.g. 3.9 → 4.0).
+          outgoing=""
+          while IFS= read -r s; do
+            [ -n "$s" ] || continue
+            maj="${s%%.*}"; min="${s##*.}"
+            if [ "$maj" -lt "$in_major" ] || { [ "$maj" -eq "$in_major" ] && [ "$min" -lt "$in_minor" ]; }; then
+              outgoing="$s"
+            fi
+          done <<< "$series"
+
+          if [ -z "$outgoing" ]; then
+            echo "No release/* series below $INCOMING_BRANCH — nothing to archive (first release branch)."
+            echo "outcome=skipped" >> "$GITHUB_OUTPUT"
+            echo "detail=no previous series to archive" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "outgoing_branch=release/$outgoing"
+            echo "archive_label=v$outgoing"
+            echo "outcome=proceed"
+          } >> "$GITHUB_OUTPUT"
+          echo "Will archive v$outgoing (docs from release/$outgoing) onto $INCOMING_BRANCH."
+
+      - name: Checkout outgoing branch (authoritative docs for the archived version)
+        if: steps.plan.outputs.outcome == 'proceed'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.plan.outputs.outgoing_branch }}
+          path: outgoing
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        if: steps.plan.outputs.outcome == 'proceed'
+        with:
+          node-version: '20'
+
+      - uses: actions/setup-python@v6
+        if: steps.plan.outputs.outcome == 'proceed'
+        with:
+          python-version: '3.11'
+
+      - name: Snapshot outgoing docs and capture full versioned state
+        if: steps.plan.outputs.outcome == 'proceed'
+        working-directory: outgoing/docs/site
+        env:
+          ARCHIVE_LABEL: ${{ steps.plan.outputs.archive_label }}
+        run: |
+          set -euo pipefail
+          npm ci
+          # docusaurus keys the snapshot off the argument, not current.label, so
+          # this freezes the outgoing branch's live docs as $ARCHIVE_LABEL and
+          # prepends it to that branch's versions.json (newest-first).
+          npx docusaurus docs:version "$ARCHIVE_LABEL"
+          # Stash the COMPLETE versioned state outside the workspace so the next
+          # checkout's clean step can't wipe it. This state already carries the
+          # prior archived versions + the freshly-frozen one.
+          dest="$RUNNER_TEMP/versioned-state"
+          rm -rf "$dest"; mkdir -p "$dest"
+          cp versions.json "$dest/versions.json"
+          cp -R versioned_docs "$dest/versioned_docs"
+          cp -R versioned_sidebars "$dest/versioned_sidebars"
+          echo "Captured versioned state:"; cat "$dest/versions.json"
+
+      - name: Checkout target branch
+        if: steps.plan.outputs.outcome == 'proceed'
+        uses: actions/checkout@v7
+        with:
+          # Real cut → the new branch. Dry-run → the base commit (identical docs
+          # content to what the new branch would hold), so the port + build are
+          # exercised without the branch existing.
+          ref: ${{ inputs.dry_run && needs.create-release-branch.outputs.base_sha || inputs.release_branch }}
+          path: incoming
+          persist-credentials: false
+
+      - name: Port versioned state, enforce cap, regenerate llms, build-verify
+        if: steps.plan.outputs.outcome == 'proceed'
+        working-directory: incoming/docs/site
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          src="$RUNNER_TEMP/versioned-state"
+          # Full-state port: replace the target's archived state wholesale.
+          rm -rf versioned_docs versioned_sidebars versions.json
+          cp "$src/versions.json" versions.json
+          cp -R "$src/versioned_docs" versioned_docs
+          cp -R "$src/versioned_sidebars" versioned_sidebars
+
+          # 3-archived-version cap (versions.json is newest-first; prune the rest).
+          count=$(jq 'length' versions.json)
+          if [ "$count" -gt 3 ]; then
+            for v in $(jq -r '.[3:][]' versions.json); do
+              echo "Pruning archived version $v"
+              rm -rf "versioned_docs/version-$v"
+              rm -f  "versioned_sidebars/version-$v-sidebars.json"
+            done
+            jq '.[:3]' versions.json > versions.json.tmp && mv versions.json.tmp versions.json
+          fi
+
+          npm ci
+          python3 scripts/generate-llms.py
+          # onBrokenLinks/onBrokenAnchors are 'throw' → a bad ported link fails
+          # here, before any PR is opened.
+          npm run build
+
+      - name: Open archive PR
+        id: pr
+        if: steps.plan.outputs.outcome == 'proceed' && !inputs.dry_run
+        working-directory: incoming
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          INCOMING_BRANCH: ${{ inputs.release_branch }}
+          OUTGOING_BRANCH: ${{ steps.plan.outputs.outgoing_branch }}
+          ARCHIVE_LABEL: ${{ steps.plan.outputs.archive_label }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "No changes — $ARCHIVE_LABEL is already archived on $INCOMING_BRANCH. Skipping PR."
+            echo "outcome=skipped" >> "$GITHUB_OUTPUT"
+            echo "detail=$ARCHIVE_LABEL already archived on $INCOMING_BRANCH" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Suffix the run id so re-runs don't collide with an existing remote branch.
+          pr_branch="docs/auto-archive-$ARCHIVE_LABEL-$RUN_ID"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$pr_branch"
+          git add -A
+          git commit -m "docs(site): archive $ARCHIVE_LABEL for $INCOMING_BRANCH"
+          # persist-credentials:false on checkout → authenticate this push explicitly.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/$pr_branch"
+          url=$(gh pr create \
+            --base "$INCOMING_BRANCH" \
+            --head "$pr_branch" \
+            --label "docs" \
+            --title "docs(site): archive $ARCHIVE_LABEL on $INCOMING_BRANCH" \
+            --body "Automated docs archive opened when \`$INCOMING_BRANCH\` was cut (\`create-release-branch.yml\`). Labelled \`docs\` for manual review and merge.
+
+          - Snapshotted **$ARCHIVE_LABEL** from its authoritative branch \`$OUTGOING_BRANCH\` (not from \`$INCOMING_BRANCH\`, which already holds the next version's docs).
+          - Ported the full versioned state (versions.json + all versioned_docs/ + versioned_sidebars/) and enforced the 3-archived-version cap.
+          - Regenerated llms.txt artifacts; \`npm run build\` passed in CI before this PR was opened.
+
+          This does **not** flip the live docs deploy. Making $INCOMING_BRANCH the default on docs.erigon.tech is the separate manual step (retire the old \`docs-deploy.yml\` + publish, per #22062 / #22063).")
+          {
+            echo "pr_url=$url"
+            echo "outcome=pr_opened"
+            echo "detail=opened $url"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### Docs archive PR opened"
+            echo "- $ARCHIVE_LABEL archived onto \`$INCOMING_BRANCH\`: $url"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dry-run summary
+        if: steps.plan.outputs.outcome == 'proceed' && inputs.dry_run
+        env:
+          ARCHIVE_LABEL: ${{ steps.plan.outputs.archive_label }}
+          INCOMING_BRANCH: ${{ inputs.release_branch }}
+          OUTGOING_BRANCH: ${{ steps.plan.outputs.outgoing_branch }}
+        run: |
+          {
+            echo "### Dry-run: docs archive validated"
+            echo ""
+            echo "- Would archive **$ARCHIVE_LABEL** (from \`$OUTGOING_BRANCH\`) onto **$INCOMING_BRANCH**."
+            echo "- Full versioned-state port + \`npm run build\` succeeded. No PR opened (dry-run)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  notify:
+    needs: [create-release-branch, archive-previous-docs-version]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -149,6 +380,9 @@ jobs:
           FROM_REF: ${{ inputs.from_ref }}
           ACTOR: ${{ github.actor }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ARCHIVE_OUTCOME: ${{ needs.archive-previous-docs-version.outputs.outcome }}
+          ARCHIVE_PR_URL: ${{ needs.archive-previous-docs-version.outputs.pr_url }}
+          ARCHIVE_DETAIL: ${{ needs.archive-previous-docs-version.outputs.detail }}
         run: |
           set -euo pipefail
           if [ -z "${DISCORD_WEBHOOK:-}" ]; then
@@ -158,6 +392,15 @@ jobs:
 
           now=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+          # Summarize the docs-archive job (Q1) for the audit embed.
+          if [ -n "${ARCHIVE_PR_URL:-}" ]; then
+            archive_field="[Archive PR opened]($ARCHIVE_PR_URL)"
+          elif [ "${ARCHIVE_OUTCOME:-}" = "skipped" ]; then
+            archive_field=":information_source: ${ARCHIVE_DETAIL:-skipped}"
+          else
+            archive_field="n/a"
+          fi
 
           # A cancelled/skipped upstream job (e.g. environment approval denied or
           # timed out) reports as failure to the team.
@@ -189,6 +432,7 @@ jobs:
             --arg when "$now" \
             --arg ts "$ts" \
             --arg url "$RUN_URL" \
+            --arg archive "$archive_field" \
             '{
               content: $mention,
               allowed_mentions: {parse: ["everyone"]},
@@ -204,6 +448,7 @@ jobs:
                   {name: "Commit",       value: ("`" + $sha + "`"),    inline: false},
                   {name: "Triggered by", value: ("[" + $actor + "](https://github.com/" + $actor + ")"), inline: true},
                   {name: "When (UTC)",   value: $when,                 inline: true},
+                  {name: "Docs archive", value: $archive,              inline: false},
                   {name: "Run",          value: ("[Open workflow run](" + $url + ")"), inline: false}
                 ],
                 footer: {text: "erigon • create-release-branch"}

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -167,9 +167,9 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      outcome: ${{ steps.pr.outputs.outcome || steps.plan.outputs.outcome }}
+      outcome: ${{ steps.pr.outputs.outcome || steps.dryrun.outputs.outcome || steps.plan.outputs.outcome }}
       pr_url: ${{ steps.pr.outputs.pr_url }}
-      detail: ${{ steps.pr.outputs.detail || steps.plan.outputs.detail }}
+      detail: ${{ steps.pr.outputs.detail || steps.dryrun.outputs.detail || steps.plan.outputs.detail }}
     steps:
       - name: Determine outgoing series to archive
         id: plan
@@ -351,12 +351,19 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dry-run summary
+        id: dryrun
         if: steps.plan.outputs.outcome == 'proceed' && inputs.dry_run
         env:
           ARCHIVE_LABEL: ${{ steps.plan.outputs.archive_label }}
           INCOMING_BRANCH: ${{ inputs.release_branch }}
           OUTGOING_BRANCH: ${{ steps.plan.outputs.outgoing_branch }}
         run: |
+          # Emit a terminal outcome so the job output isn't the non-terminal
+          # 'proceed' from the plan step, and notify can report the dry-run.
+          {
+            echo "outcome=dry-run"
+            echo "detail=dry-run: validated $ARCHIVE_LABEL (from $OUTGOING_BRANCH) → $INCOMING_BRANCH, no PR opened"
+          } >> "$GITHUB_OUTPUT"
           {
             echo "### Dry-run: docs archive validated"
             echo ""
@@ -396,8 +403,8 @@ jobs:
           # Summarize the docs-archive job (Q1) for the audit embed.
           if [ -n "${ARCHIVE_PR_URL:-}" ]; then
             archive_field="[Archive PR opened]($ARCHIVE_PR_URL)"
-          elif [ "${ARCHIVE_OUTCOME:-}" = "skipped" ]; then
-            archive_field=":information_source: ${ARCHIVE_DETAIL:-skipped}"
+          elif [ "${ARCHIVE_OUTCOME:-}" = "skipped" ] || [ "${ARCHIVE_OUTCOME:-}" = "dry-run" ]; then
+            archive_field=":information_source: ${ARCHIVE_DETAIL:-${ARCHIVE_OUTCOME}}"
           else
             archive_field="n/a"
           fi

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -283,15 +283,15 @@ jobs:
           cp -R "$src/versioned_docs" versioned_docs
           cp -R "$src/versioned_sidebars" versioned_sidebars
 
-          # 3-archived-version cap (versions.json is newest-first; prune the rest).
+          # 5-archived-version cap (versions.json is newest-first; prune the rest).
           count=$(jq 'length' versions.json)
-          if [ "$count" -gt 3 ]; then
-            for v in $(jq -r '.[3:][]' versions.json); do
+          if [ "$count" -gt 5 ]; then
+            for v in $(jq -r '.[5:][]' versions.json); do
               echo "Pruning archived version $v"
               rm -rf "versioned_docs/version-$v"
               rm -f  "versioned_sidebars/version-$v-sidebars.json"
             done
-            jq '.[:3]' versions.json > versions.json.tmp && mv versions.json.tmp versions.json
+            jq '.[:5]' versions.json > versions.json.tmp && mv versions.json.tmp versions.json
           fi
 
           npm ci
@@ -336,7 +336,7 @@ jobs:
             --body "Automated docs archive opened when \`$INCOMING_BRANCH\` was cut (\`create-release-branch.yml\`). Labelled \`docs\` for manual review and merge.
 
           - Snapshotted **$ARCHIVE_LABEL** from its authoritative branch \`$OUTGOING_BRANCH\` (not from \`$INCOMING_BRANCH\`, which already holds the next version's docs).
-          - Ported the full versioned state (versions.json + all versioned_docs/ + versioned_sidebars/) and enforced the 3-archived-version cap.
+          - Ported the full versioned state (versions.json + all versioned_docs/ + versioned_sidebars/) and enforced the 5-archived-version cap.
           - Regenerated llms.txt artifacts; \`npm run build\` passed in CI before this PR was opened.
 
           This does **not** flip the live docs deploy. Making $INCOMING_BRANCH the default on docs.erigon.tech is the separate manual step (retire the old \`docs-deploy.yml\` + publish, per #22062 / #22063).")

--- a/.github/workflows/docs-version-bump.yml
+++ b/.github/workflows/docs-version-bump.yml
@@ -8,7 +8,7 @@ run-name: "Docs Version Bump — archive ${{ inputs.archive_version }}, publish 
 # still holds the about-to-be-archived version's content.
 #
 # It snapshots the current docs as an archived version, bumps the "current"
-# version label, enforces the 3-archived-version cap, regenerates the llms.txt
+# version label, enforces the 5-archived-version cap, regenerates the llms.txt
 # artifacts, verifies the build, and opens a PR.
 #
 # NOTE on {ERIGON_VERSION} injection: the remark plugin
@@ -97,17 +97,17 @@ jobs:
           grep -q "label: '$NEW_LABEL'" docusaurus.config.ts \
             || { echo "::error::failed to update current version label"; exit 1; }
 
-      - name: Enforce 3-archived-version cap (prune oldest)
+      - name: Enforce 5-archived-version cap (prune oldest)
         run: |
           count=$(jq 'length' versions.json)
-          if [ "$count" -gt 3 ]; then
-            # versions.json is newest-first; everything past index 2 is pruned.
-            for v in $(jq -r '.[3:][]' versions.json); do
+          if [ "$count" -gt 5 ]; then
+            # versions.json is newest-first; everything past index 4 is pruned.
+            for v in $(jq -r '.[5:][]' versions.json); do
               echo "Pruning archived version $v"
               rm -rf "versioned_docs/version-$v"
               rm -f  "versioned_sidebars/version-$v-sidebars.json"
             done
-            jq '.[:3]' versions.json > versions.json.tmp && mv versions.json.tmp versions.json
+            jq '.[:5]' versions.json > versions.json.tmp && mv versions.json.tmp versions.json
           fi
 
       - name: Regenerate llms.txt artifacts
@@ -146,7 +146,7 @@ jobs:
 
           - Snapshotted the current docs as **$ARCHIVE_VERSION** (\`versioned_docs/version-$ARCHIVE_VERSION\`).
           - Bumped the current version label to **$NEW_LABEL**.
-          - Enforced the 3-archived-version cap and regenerated llms.txt artifacts.
+          - Enforced the 5-archived-version cap and regenerated llms.txt artifacts.
           - \`npm run build\` passed in CI before this PR was opened.
 
           If the Pages deploy still lives on a per-release branch, move \`docs-deploy.yml\` to this branch separately."


### PR DESCRIPTION
## What

Adds an `archive-previous-docs-version` job to `create-release-branch.yml` that runs right after a `release/N.N` branch is cut and opens a **`docs`-labelled PR** archiving the previous stable docs version onto the freshly-cut branch (Docusaurus native versioning). A human reviews and merges that PR.

This automates **Q1** of the docs version transition (archive the outgoing version). **Q2** — flipping the live deploy on docs.erigon.tech to the new series — is intentionally left as the existing manual retire+publish pair (#22062 / #22063).

## Why

Versioning is not automatic today: cutting `release/3.6` leaves `versions.json` without a `v3.5` snapshot, so the previous stable version would silently drop out of the version dropdown. Doing it by hand is easy to forget or get wrong.

## How it works

- **Sources the snapshot from the OUTGOING release branch** (`release/N.<M-1>`), not the just-cut branch — which was cut from `main` and already holds the *next* version's docs. (This is the correctness bug the manual `docs-version-bump.yml` path is prone to.)
- **Ports the outgoing branch's full versioned state** (`versions.json` + all `versioned_docs/` + `versioned_sidebars/`) plus the fresh snapshot, then enforces the 3-archived-version cap — so no older version drops off at the *next* cut.
- **Fail-closed series selection**: enumerates `release/N.N` branches via the GitHub API, exact regex (excludes patch-style names like `release/3.0.10`), numeric per-component sort (so `3.10 > 3.9`); aborts on API error rather than guessing.
- **Build-verified before opening** (`onBrokenLinks: throw`), llms.txt regenerated.
- **`dry_run`** validates the full port + build without opening a PR.
- Opens the PR with the default `GITHUB_TOKEN` (scoped `contents:write` + `pull-requests:write`) for manual review/merge. Note: a `GITHUB_TOKEN`-opened PR does not itself trigger `pull_request` CI (Actions recursion guard); the archive is already build-verified in-job, and a reviewer merges after inspecting the diff.

## Notes for reviewers

- The version chain stays intact only if each cycle's archive PR is merged into its release branch before the next cut (inherent to the human-merge model; no worse than today's fully-manual state).
- Passed `actionlint` (with shellcheck) and `zizmor` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)