### PR TITLE
http: compression leaked C-allocated memory in sync.Pool

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -184,7 +185,7 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // gzPoolBufCap is the maximum dst capacity retained in the pool to bound RSS growth.
-const gzPoolBufCap = 1 << 20
+const gzPoolBufCap = 1024 * 1024
 
 // minGzipBodySize is the minimum response body size to compress. Responses
 // smaller than this are sent as-is: gzip framing overhead would exceed savings.
@@ -203,18 +204,79 @@ var libdeflateWarnOnce sync.Once
 var libdeflateCompressWarnOnce sync.Once
 var libdeflateDisabled atomic.Bool
 
-var gzCompressorPool = sync.Pool{
-	New: func() any {
-		c, err := libdeflate.NewCompressor(libdeflate.DefaultCompression)
-		if err != nil {
-			libdeflateDisabled.Store(true)
-			libdeflateWarnOnce.Do(func() {
-				log.Warn("libdeflate unavailable, falling back to stdlib gzip", "err", err)
-			})
-			return nil
-		}
+var (
+	libdeflatePoolHit      = metrics.GetOrCreateCounter(`libdeflate_pool_hit_total`)
+	libdeflatePoolMiss     = metrics.GetOrCreateCounter(`libdeflate_pool_miss_total`)
+	libdeflatePoolOverflow = metrics.GetOrCreateCounter(`libdeflate_pool_overflow_total`)
+)
+
+// libdeflateCompressorsPool pools libdeflate compressors. sync.Pool is unsafe for these: a
+// libdeflate.Compressor owns a C context freed only by Close(), and sync.Pool
+// drops entries on GC with no hook to Close them, so every evicted compressor
+// leaks its C memory. A buffered channel with Close-on-overflow instead frees the
+// C context deterministically and bounds the pooled working set.
+//
+// Each pooled compressor is a single ~653 KiB libdeflate C allocation (level 6),
+// so pool peak RAM = cap × 653 KiB. The cap floors at 64 and is capped at 512, so
+// peak stays ~41 MiB (64) .. ~326 MiB (512) regardless of GOMAXPROCS.
+var libdeflateCompressorsPool = make(chan *libdeflate.Compressor, min(512, max(64, runtime.GOMAXPROCS(0)*8)))
+
+func getLibdeflateCompressor() *libdeflate.Compressor {
+	if libdeflateDisabled.Load() {
+		return nil
+	}
+	select {
+	case c := <-libdeflateCompressorsPool:
+		libdeflatePoolHit.Inc()
 		return c
-	},
+	default:
+	}
+	libdeflatePoolMiss.Inc()
+	c, err := libdeflate.NewCompressor(libdeflate.DefaultCompression)
+	if err != nil {
+		libdeflateDisabled.Store(true)
+		libdeflateWarnOnce.Do(func() {
+			log.Warn("libdeflate unavailable, falling back to stdlib gzip", "err", err)
+		})
+		closePooledLibdeflateCompressors()
+		return nil
+	}
+	return c
+}
+
+// putLibdeflateCompressor returns c for reuse, or frees its C context via Close when
+// the pool is full or libdeflate has been disabled — never dropping it uncollected
+// the way sync.Pool eviction would.
+func putLibdeflateCompressor(c *libdeflate.Compressor) {
+	if libdeflateDisabled.Load() {
+		c.Close()
+		return
+	}
+	select {
+	case libdeflateCompressorsPool <- c:
+		// If disable raced with this send, drain: once disabled, get returns nil early,
+		// so a compressor left in the pool would never be handed out again.
+		if libdeflateDisabled.Load() {
+			closePooledLibdeflateCompressors()
+		}
+	default:
+		libdeflatePoolOverflow.Inc()
+		c.Close()
+	}
+}
+
+// closePooledLibdeflateCompressors frees every compressor currently in the pool.
+// Called once libdeflate is disabled, so the pool can't retain C contexts that
+// getLibdeflateCompressor would never hand out again.
+func closePooledLibdeflateCompressors() {
+	for {
+		select {
+		case c := <-libdeflateCompressorsPool:
+			c.Close()
+		default:
+			return
+		}
+	}
 }
 
 var gzDstPool = sync.Pool{
@@ -287,20 +349,16 @@ func writeStdlibGzip(w http.ResponseWriter, src []byte, status int) {
 // Returns false if libdeflate is unavailable or compression fails; the caller
 // should then fall back to writeStdlibGzip.
 func compressLibdeflate(w http.ResponseWriter, src []byte, status int) bool {
-	if libdeflateDisabled.Load() {
+	c := getLibdeflateCompressor()
+	if c == nil {
 		return false
 	}
-	raw := gzCompressorPool.Get()
-	if raw == nil {
-		return false
-	}
-	c := raw.(*libdeflate.Compressor)
-	defer gzCompressorPool.Put(c)
+	defer putLibdeflateCompressor(c)
 
 	dst := gzDstPool.Get().([]byte)
 	gzBound := c.GzipCompressBound(len(src))
 	dst = slices.Grow(dst[:0], gzBound)[:gzBound]
-	defer putDst(dst)
+	defer putDst(dst) // return the grown buffer for reuse (putDst drops it if over gzPoolBufCap)
 
 	n, err := c.CompressGzip(dst, src)
 	if err != nil {


### PR DESCRIPTION
Fixes #22672.

Fix: replace the `sync.Pool` with a bounded non-blocking channel (`max(64, GOMAXPROCS*8)` entries) that `Close()`s compressors on overflow 


## How it was found — jemalloc heap profile

Go's `pprof` can't see cgo/C-`malloc` memory, so the leak was invisible to `go tool pprof` (Go heap stayed flat at ~15 GB while RSS climbed). Profiled the **native** allocator instead: ran a live archive node under RPC load with libdeflate compression on, allocator swapped to jemalloc:

```
LD_PRELOAD=libjemalloc.so.2 \
MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19,lg_prof_interval:31 \
  erigon --http --http.compression=true ...
```

then `jeprof --inuse_space --show_bytes --text <erigon-bin> <heap>`.

**Before (leaking, `sync.Pool`):**
```
Total: 509 MB native C-malloc
  506 MB  99.4%  libdeflate_alloc_compressor   <- the leak
    2 MB   0.4%  mdbx (txn_dpl_reserve / txn_alloc / env_page_auxbuffer)
```

**After (bounded channel pool):**
```
Total: 8.2 MB native C-malloc
  7.1 MB  81.4%  libdeflate_alloc_compressor   <- flat across dumps
  1.1 MB  12.1%  mdbx txn_alloc
  0.6 MB   6.5%  libstdc++ static init (one-time)
```

libdeflate held flat at ~7 MB across many heap dumps under sustained ~21k-rps compression load, vs 506 MB and climbing before. A per-path counter confirmed the load actually exercised the libdeflate path (`libdeflate` compressions ≫ stdlib-`streaming`, ~3.7:1).
