### PR TITLE
.github: enable excessive-permissions audit — final #21132 cleanup

### DIFF
--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -40,7 +40,6 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write   # notify job opens/updates the tracking issue
 
 jobs:
   fuzz:
@@ -131,6 +130,9 @@ jobs:
     # whoever triggered them. `always()` lets this run despite `fuzz` failing.
     if: ${{ always() && needs.fuzz.result == 'failure' && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Open or update tracking issue
         env:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,10 +16,15 @@ rules:
       - qa-rpc-integration-tests.yml
       - qa-sync-from-scratch.yml
 
-  # Workflows missing explicit permissions: blocks — needs a cleanup pass
-  # to add least-privilege permissions to each workflow; tracked in #21132.
+  # ci-gate orchestrates the reusable test leaves. A called workflow's token
+  # permissions are capped by the caller, so ci-gate's workflow-level
+  # actions: write is the cap that lets every self-cancelling leaf run
+  # `gh run cancel`; pull-requests: write is used by the gate's own
+  # dequeuePullRequest mutation. Both are genuinely needed workflow-wide and
+  # can't be scoped to a single job. Tracked in #21132.
   excessive-permissions:
-    disable: true
+    ignore:
+      - ci-gate.yml
 
   # The remaining `secrets: inherit` calls target same-repo reusable workflows
   # that genuinely consume secrets — sonar (SONAR_TOKEN) and the DockerHub-pull


### PR DESCRIPTION
**Final PR of the zizmor `excessive-permissions` cleanup — closes #21132** (with #22688).

Follows #22662, #22677, #22687 (and the dead-workflow removal #22688).

## What
1. **`test-fuzz.yml`** — move `issues: write` from the workflow level to the `notify` job (the only job that opens/updates the `nightly-fuzz` tracking issue). The fuzz matrix job keeps `contents: read`.
2. **`.github/zizmor.yml`** — replace the blanket `excessive-permissions: disable: true` with a per-file `ignore` of just `ci-gate.yml`, and **enable the audit** for every other workflow.

## Why `ci-gate` is ignored rather than scoped
`ci-gate` orchestrates the reusable test leaves. Per GitHub's rules, **a called workflow's `GITHUB_TOKEN` permissions are capped by the caller** — so ci-gate's workflow-level grants are not "for itself", they're the ceiling every leaf inherits:
- **`actions: write`** is the cap that lets all ~12 self-cancelling leaves (scoped in #22677/#22687) actually run `gh run cancel` on merge-queue failure. Dropping it silently breaks fast-cancel and the gate stalls.
- **`pull-requests: write`** drives the gate's own `dequeuePullRequest` GraphQL mutation (GitHub doesn't auto-remove UNMERGEABLE queue entries), and is also the cap for sonar's inherited `pull-requests: read`.

Neither can be scoped to a single job without adding per-job `permissions` caps to every leaf-call job on the merge gate — high risk for no real privilege gain. The in-file comment documents this, mirrored into the ignore justification.

## Verification
- Full repo, real `.github/zizmor.yml`, **with `docker-tags.yml` removed (as #22688 does)**: `zizmor` → **exit 0, "No findings to report"** (17 ignored, 299 suppressed).
- On this branch alone (docker-tags still present until #22688 merges): exit 13 — one *medium* `docker-tags` finding that #22688 removes; the gate passes regardless (< 14).
- `actionlint` clean; `make lint` = 0 issues.

## Merge order
Pairs with **#22688** (docker-tags removal). Either order is safe (the gate passes both ways); once both land, `excessive-permissions` reports zero findings and **#21132 can close**. The only remaining zizmor exceptions repo-wide are the deliberate policy ones (`unpinned-uses`, `concurrency-limits`) and the justified per-file ignores (`cache-poisoning`, `secrets-inherit`, and now `excessive-permissions` → ci-gate).