### PR TITLE
common: add AppendText (encoding.TextAppender) to hex value types

### DIFF
--- a/common/address.go
+++ b/common/address.go
@@ -132,6 +132,9 @@ func (a *Address) SetBytes(b []byte) { fixedSetBytes(a[:], b) }
 // MarshalText returns the hex representation of a.
 func (a Address) MarshalText() ([]byte, error) { return hexutil.Bytes(a[:]).MarshalText() }
 
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (a Address) AppendText(dst []byte) ([]byte, error) { return hexutil.Bytes(a[:]).AppendText(dst) }
+
 // UnmarshalText parses a hash in hex syntax.
 func (a *Address) UnmarshalText(input []byte) error {
 	return hexutil.UnmarshalFixedText("Address", input, a[:])

--- a/common/appendtext_test.go
+++ b/common/appendtext_test.go
@@ -38,6 +38,7 @@ func TestAppendTextByteIdentical(t *testing.T) {
 	checkByteIdentical(t, "hexutil.Uint", hexutil.Uint(0xabcd))
 	checkByteIdentical(t, "hexutil.Big/0", hexutil.Big(*big.NewInt(0)))
 	checkByteIdentical(t, "hexutil.Big", hexutil.Big(*new(big.Int).SetBytes([]byte{0x12, 0x34, 0x56, 0x78, 0x9a})))
+	checkByteIdentical(t, "hexutil.Big/neg", hexutil.Big(*big.NewInt(-0x123456789)))
 	checkByteIdentical(t, "Hash", Hash{0x00, 0x11, 0xaa, 0xff})
 	checkByteIdentical(t, "Address", Address{0x00, 0x1a, 0xff})
 	checkByteIdentical(t, "Bytes4", Bytes4{0x00, 0xab, 0xcd, 0xef})

--- a/common/appendtext_test.go
+++ b/common/appendtext_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/erigontech/erigon/common/hexutil"
+)
+
+type textAppendMarshaler interface {
+	MarshalText() ([]byte, error)
+	AppendText(dst []byte) ([]byte, error)
+}
+
+// AppendText must be byte-identical to MarshalText (only the destination differs).
+func checkByteIdentical(t *testing.T, name string, v textAppendMarshaler) {
+	t.Helper()
+	mt, err := v.MarshalText()
+	if err != nil {
+		t.Fatalf("%s MarshalText: %v", name, err)
+	}
+	const pfx = "PFX"
+	at, err := v.AppendText([]byte(pfx))
+	if err != nil {
+		t.Fatalf("%s AppendText: %v", name, err)
+	}
+	if want := append([]byte(pfx), mt...); !bytes.Equal(at, want) {
+		t.Fatalf("%s: AppendText=%q, want %q", name, at, want)
+	}
+}
+
+func TestAppendTextByteIdentical(t *testing.T) {
+	checkByteIdentical(t, "hexutil.Bytes/empty", hexutil.Bytes{})
+	checkByteIdentical(t, "hexutil.Bytes", hexutil.Bytes{0x00, 0x1a, 0xff, 0xcd})
+	checkByteIdentical(t, "hexutil.Uint64/0", hexutil.Uint64(0))
+	checkByteIdentical(t, "hexutil.Uint64", hexutil.Uint64(0x1a2b3c4d5e))
+	checkByteIdentical(t, "hexutil.Uint", hexutil.Uint(0xabcd))
+	checkByteIdentical(t, "hexutil.Big/0", hexutil.Big(*big.NewInt(0)))
+	checkByteIdentical(t, "hexutil.Big", hexutil.Big(*new(big.Int).SetBytes([]byte{0x12, 0x34, 0x56, 0x78, 0x9a})))
+	checkByteIdentical(t, "Hash", Hash{0x00, 0x11, 0xaa, 0xff})
+	checkByteIdentical(t, "Address", Address{0x00, 0x1a, 0xff})
+	checkByteIdentical(t, "Bytes4", Bytes4{0x00, 0xab, 0xcd, 0xef})
+	checkByteIdentical(t, "Bytes48", Bytes48{})
+	checkByteIdentical(t, "Bytes64", Bytes64{})
+	checkByteIdentical(t, "Bytes96", Bytes96{})
+	checkByteIdentical(t, "UnprefixedHash", UnprefixedHash{0x00, 0x1a, 0xff})
+	checkByteIdentical(t, "UnprefixedAddress", UnprefixedAddress{0x00, 0x1a, 0xff})
+}

--- a/common/bytes4.go
+++ b/common/bytes4.go
@@ -48,6 +48,9 @@ func (b *Bytes4) UnmarshalText(input []byte) error {
 // MarshalText returns the hex representation of a.
 func (b Bytes4) MarshalText() ([]byte, error) { return hexutil.Bytes(b[:]).MarshalText() }
 
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (b Bytes4) AppendText(dst []byte) ([]byte, error) { return hexutil.Bytes(b[:]).AppendText(dst) }
+
 // Format implements fmt.Formatter.
 // Hash supports the %v, %s, %v, %x, %X and %d format verbs.
 func (b Bytes4) Format(s fmt.State, c rune) { fixedFormat(s, c, "hash", b[:]) }

--- a/common/bytes48.go
+++ b/common/bytes48.go
@@ -48,6 +48,9 @@ func (b *Bytes48) UnmarshalText(input []byte) error {
 // MarshalText returns the hex representation of a.
 func (b Bytes48) MarshalText() ([]byte, error) { return hexutil.Bytes(b[:]).MarshalText() }
 
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (b Bytes48) AppendText(dst []byte) ([]byte, error) { return hexutil.Bytes(b[:]).AppendText(dst) }
+
 // Format implements fmt.Formatter.
 // Hash supports the %v, %s, %v, %x, %X and %d format verbs.
 func (b Bytes48) Format(s fmt.State, c rune) { fixedFormat(s, c, "hash", b[:]) }

--- a/common/bytes64.go
+++ b/common/bytes64.go
@@ -47,6 +47,9 @@ func (b *Bytes64) UnmarshalText(input []byte) error {
 // MarshalText returns the hex representation of a.
 func (b Bytes64) MarshalText() ([]byte, error) { return hexutil.Bytes(b[:]).MarshalText() }
 
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (b Bytes64) AppendText(dst []byte) ([]byte, error) { return hexutil.Bytes(b[:]).AppendText(dst) }
+
 // Format implements fmt.Formatter.
 // Hash supports the %v, %s, %v, %x, %X and %d format verbs.
 func (b Bytes64) Format(s fmt.State, c rune) { fixedFormat(s, c, "hash", b[:]) }

--- a/common/bytes96.go
+++ b/common/bytes96.go
@@ -48,6 +48,9 @@ func (b *Bytes96) UnmarshalText(input []byte) error {
 // MarshalText returns the hex representation of a.
 func (b Bytes96) MarshalText() ([]byte, error) { return hexutil.Bytes(b[:]).MarshalText() }
 
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (b Bytes96) AppendText(dst []byte) ([]byte, error) { return hexutil.Bytes(b[:]).AppendText(dst) }
+
 // Format implements fmt.Formatter.
 // Hash supports the %v, %s, %v, %x, %X and %d format verbs.
 func (b Bytes96) Format(s fmt.State, c rune) { fixedFormat(s, c, "hash", b[:]) }

--- a/common/hash.go
+++ b/common/hash.go
@@ -97,6 +97,11 @@ func (h Hash) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(h[:]).MarshalText()
 }
 
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (h Hash) AppendText(dst []byte) ([]byte, error) {
+	return hexutil.Bytes(h[:]).AppendText(dst)
+}
+
 // SetBytes sets the hash to the value of b.
 // If b is larger than len(h), b will be cropped from the left.
 func (h *Hash) SetBytes(b []byte) { fixedSetBytes(h[:], b) }

--- a/common/hexutil/bytes.go
+++ b/common/hexutil/bytes.go
@@ -39,6 +39,13 @@ func (b Bytes) MarshalText() ([]byte, error) {
 	return result, nil
 }
 
+// AppendText implements encoding.TextAppender: the alloc-free, byte-identical
+// counterpart to MarshalText. Only encoding/json/v2 consults it today.
+func (b Bytes) AppendText(dst []byte) ([]byte, error) {
+	dst = append(dst, HexPrefix...)
+	return hex.AppendEncode(dst, b), nil
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Bytes) UnmarshalJSON(input []byte) error {
 	if !isString(input) {

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -60,10 +60,16 @@ func (b Big) MarshalText() ([]byte, error) {
 // AppendText implements encoding.TextAppender (alloc-free MarshalText).
 func (b Big) AppendText(dst []byte) ([]byte, error) {
 	i := (*big.Int)(&b)
-	if i.BitLen() == 0 {
+	switch i.Sign() {
+	case 0:
 		return append(dst, `0x0`...), nil
+	case -1:
+		// EncodeBig (fmt %#x) places the sign before the prefix ("-0x…"), whereas
+		// big.Int.Append would place it after ("0x-…").
+		return new(big.Int).Abs(i).Append(append(dst, `-0x`...), 16), nil
+	default:
+		return i.Append(append(dst, `0x`...), 16), nil
 	}
-	return i.Append(append(dst, `0x`...), 16), nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -57,6 +57,15 @@ func (b Big) MarshalText() ([]byte, error) {
 	return []byte(EncodeBig((*big.Int)(&b))), nil
 }
 
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (b Big) AppendText(dst []byte) ([]byte, error) {
+	i := (*big.Int)(&b)
+	if i.BitLen() == 0 {
+		return append(dst, `0x0`...), nil
+	}
+	return i.Append(append(dst, `0x`...), 16), nil
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Big) UnmarshalJSON(input []byte) error {
 	if !isString(input) {
@@ -121,6 +130,11 @@ func (b Uint64) MarshalText() ([]byte, error) {
 	copy(buf, `0x`)
 	buf = strconv.AppendUint(buf, uint64(b), 16)
 	return buf, nil
+}
+
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (b Uint64) AppendText(dst []byte) ([]byte, error) {
+	return strconv.AppendUint(append(dst, `0x`...), uint64(b), 16), nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -297,6 +311,11 @@ type Uint uint
 // MarshalText implements encoding.TextMarshaler.
 func (b Uint) MarshalText() ([]byte, error) {
 	return Uint64(b).MarshalText()
+}
+
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (b Uint) AppendText(dst []byte) ([]byte, error) {
+	return Uint64(b).AppendText(dst)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -66,7 +66,9 @@ func (b Big) AppendText(dst []byte) ([]byte, error) {
 	case -1:
 		// EncodeBig (fmt %#x) places the sign before the prefix ("-0x…"), whereas
 		// big.Int.Append would place it after ("0x-…").
-		return new(big.Int).Abs(i).Append(append(dst, `-0x`...), 16), nil
+		var abs big.Int
+		abs.Abs(i)
+		return abs.Append(append(dst, `-0x`...), 16), nil
 	default:
 		return i.Append(append(dst, `0x`...), 16), nil
 	}

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -47,9 +47,9 @@ func UnmarshalFixedUnprefixedText(typeName string, input, out []byte) error {
 // Big marshals/unmarshals as a JSON string with 0x prefix.
 // The zero value marshals as "0x0".
 //
-// Negative integers are not supported at this time. Attempting to marshal them will
-// return an error. Values larger than 256bits are rejected by Unmarshal but will be
-// marshaled without error.
+// Negative integers are not round-trippable: MarshalText/AppendText encode them as
+// "-0x…", but UnmarshalText rejects that form. Values larger than 256 bits are
+// rejected by Unmarshal but will be marshaled without error.
 type Big big.Int
 
 // MarshalText implements encoding.TextMarshaler
@@ -64,11 +64,13 @@ func (b Big) AppendText(dst []byte) ([]byte, error) {
 	case 0:
 		return append(dst, `0x0`...), nil
 	case -1:
-		// EncodeBig (fmt %#x) places the sign before the prefix ("-0x…"), whereas
-		// big.Int.Append would place it after ("0x-…").
-		var abs big.Int
-		abs.Abs(i)
-		return abs.Append(append(dst, `-0x`...), 16), nil
+		// EncodeBig (fmt %#x) writes the sign before the prefix ("-0x…"); big.Int.Append
+		// writes it after ("0x-…"). Append "-0x", let Append add the magnitude with its
+		// own leading '-', then drop that duplicate '-'.
+		dst = append(dst, `-0x`...)
+		dash := len(dst)
+		dst = i.Append(dst, 16)
+		return append(dst[:dash], dst[dash+1:]...), nil
 	default:
 		return i.Append(append(dst, `0x`...), 16), nil
 	}

--- a/common/types.go
+++ b/common/types.go
@@ -53,6 +53,11 @@ func (h UnprefixedHash) MarshalText() ([]byte, error) {
 	return []byte(hex.EncodeToString(h[:])), nil
 }
 
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (h UnprefixedHash) AppendText(dst []byte) ([]byte, error) {
+	return hex.AppendEncode(dst, h[:]), nil
+}
+
 /////////// Address
 
 var addressT = reflect.TypeFor[Address]()
@@ -68,6 +73,11 @@ func (a *UnprefixedAddress) UnmarshalText(input []byte) error {
 // MarshalText encodes the address as hex.
 func (a UnprefixedAddress) MarshalText() ([]byte, error) {
 	return []byte(hex.EncodeToString(a[:])), nil
+}
+
+// AppendText implements encoding.TextAppender (alloc-free MarshalText).
+func (a UnprefixedAddress) AppendText(dst []byte) ([]byte, error) {
+	return hex.AppendEncode(dst, a[:]), nil
 }
 
 // MixedcaseAddress retains the original string, which may or may not be


### PR DESCRIPTION
Adds `AppendText` — the alloc-free, byte-identical counterpart of `MarshalText` (Go 1.24+ `encoding.TextAppender`) — to the core hex-encoded value types:
`hexutil.Bytes/Uint64/Uint/Big` and `common.Hash/Address/Bytes4/Bytes48/Bytes64/Bytes96/UnprefixedHash/UnprefixedAddress`.

`GOEXPERIMENT=jsonv2` will be enabled by default in Go 1.27 (but users can enable it now by experiment flag too). Anyway good to know that `jsonv2` can show much better perf than `v1` - just need add couple low-level-types append-style-methods. 

### Measured (under `GOEXPERIMENT=jsonv2`)
Marshaling a worst-case 128-blob `getBlobs` response:

| | allocs |
|---|--:|
| before (`MarshalText`) | 16,514 |
| after (`AppendText`) | **3** |

(hand-written `MarshalFastJSON` is still ~2× faster in this case - and `alloc` = `1`. But stdlib jsonv2 closing the gap well)

### Safety
- `MarshalText` is unchanged; `AppendText` output is byte-for-byte identical.
- `TestAppendTextByteIdentical` asserts parity for every type.
- `hexutil.Uint16`/`Uint32` are intentionally omitted (their even-length padding needs separate care).