### PR TITLE
docs(site): Schema.org structured data + SEO improvements

### DIFF
--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -144,8 +144,8 @@ export default async function createConfig(): Promise<Config> {
         theme: {customCss: './src/css/custom.css'},
         sitemap: {
           // Emit <lastmod> per URL (from git history via showLastUpdateTime) so
-          // crawlers can prioritise changed pages. Drop the client-side search
-          // route, which has no indexable content.
+          // crawlers can prioritise changed pages. Exclude /search from the
+          // sitemap — it has no indexable content (the route itself still exists).
           lastmod: 'date',
           changefreq: 'weekly',
           priority: 0.5,

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -108,6 +108,7 @@ export default async function createConfig(): Promise<Config> {
           path: 'help-center',
           routeBasePath: 'help-center',
           sidebarPath: './sidebars-help-center.ts',
+          showLastUpdateTime: true,
         },
       ],
       [
@@ -137,9 +138,19 @@ export default async function createConfig(): Promise<Config> {
             },
           },
           remarkPlugins: [[versionReplace, {currentVersion: latestVersion, versionStrings}]],
+          showLastUpdateTime: true,
         },
         blog: false as false,
         theme: {customCss: './src/css/custom.css'},
+        sitemap: {
+          // Emit <lastmod> per URL (from git history via showLastUpdateTime) so
+          // crawlers can prioritise changed pages. Drop the client-side search
+          // route, which has no indexable content.
+          lastmod: 'date',
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['/search'],
+        },
       } satisfies Preset.Options],
     ],
 

--- a/docs/site/help-center/frequently-asked-questions-faqs.mdx
+++ b/docs/site/help-center/frequently-asked-questions-faqs.mdx
@@ -2,7 +2,64 @@
 title: "Frequently Asked Questions (FAQs)"
 description: "Answers to the most common questions about installing, syncing, and operating Erigon."
 sidebar_position: 2
+structured_data: false
 ---
+
+import Head from '@docusaurus/Head';
+
+{/*
+  FAQPage structured data (schema.org) for Google FAQ rich results and AI
+  citation. Concise plain-text answers live here; the human-facing answers are
+  the list below. Keep this array in sync with that list when questions are
+  added, removed, or reworded.
+*/}
+export const faqSchema = [
+  ['What is the difference between Erigon and Geth?', 'Erigon began as a fork of Geth but was rewritten to prioritise disk space and sync speed, using a flat MDBX key-value database instead of a Merkle Patricia Trie for a much smaller footprint and faster synchronisation.'],
+  ['Is Erigon a good choice for client diversity?', 'Yes. Erigon has diverged far enough from Geth to be considered a separate client, making it a strong choice for supporting Ethereum client diversity.'],
+  ['What are the minimum hardware requirements?', 'A high-end NVMe or SSD with low latency is the most critical component. 16 GB of RAM and a fast SSD are generally the minimum for a full node; exact needs vary by network and pruning mode.'],
+  ['How long does it take to sync a node?', 'It depends on hardware and bandwidth. A fast system with a high-end NVMe can sync a full node in a few hours, while slower hardware can take several days.'],
+  ['How much disk space is required?', 'It grows with the blockchain and varies by network and pruning mode — a full node needs far less than an archive node. Check the Hardware Requirements page for current figures rather than a fixed value.'],
+  ['Can I run Erigon on an HDD?', 'No. Erigon depends on high-speed disk I/O, and an HDD will almost certainly cause the node to fall behind the chain tip.'],
+  ['What is the --prune.mode flag, and which mode should I use?', 'It controls which historical data is discarded. Use full (the Erigon 3 default) for most users, minimal for validators with limited disk, and archive for a complete historical record.'],
+  ['Can I change my pruning mode after starting the node?', 'No. The pruning mode is fixed at first sync; changing it requires deleting the datadir and re-syncing from scratch.'],
+  ['Do I need a separate consensus client?', 'No. Erigon includes Caplin, an embedded consensus client that runs by default, though some validators prefer a separate consensus client for added reliability.'],
+  ['How do I upgrade my Erigon binary?', 'Gracefully shut down the node, replace the old binary with the new one, and restart. Back up your datadir before any major upgrade.'],
+  ['How do I gracefully shut down Erigon?', 'Use a process manager such as systemd or supervisor, or press Ctrl+C in the terminal, so the database closes cleanly.'],
+  ["What is Erigon's RPC daemon?", 'The RPC daemon is a separate process that serves JSON-RPC API requests and can run on a different machine from the core client for security and scalability.'],
+  ['Is it possible to recover from database corruption?', 'The most reliable fix is to delete the corrupted datadir and re-sync, though repair tools may also help. Ungraceful shutdowns are the usual cause.'],
+  ['What are the required ports?', 'P2P networking uses 30303 (TCP/UDP) and RPC uses 8545 (HTTP), 8546 (WS), and 8551 (Engine API). See Default Ports for the full list.'],
+  ['What is a snapshot sync?', 'Snapshot sync downloads pre-made snapshots of the blockchain state to greatly accelerate the initial sync instead of processing from genesis.'],
+  ["How do I monitor my node's sync progress?", 'Read the stage prefix in the live log line (e.g. [4/6 Execution]), query eth_syncing on the RPC daemon, or ask an AI assistant through the built-in MCP server.'],
+  ['Can I use Erigon with Docker?', 'Yes. Erigon provides official Docker images on Docker Hub; see the Installation guide for setup.'],
+  ['Does Erigon support other chains besides Ethereum?', 'Yes. Erigon is EVM-compatible and supports networks such as Gnosis and Polygon; select the chain with the --chain flag.'],
+  ['Where can I find official support?', 'The official Erigon Discord and GitHub repository are the primary channels for support and community discussion.'],
+  ['What is Caplin?', "Caplin is Erigon's built-in beacon API server, letting Erigon act as both a consensus and execution client."],
+  ['What is OtterSync?', 'OtterSync is a syncing algorithm that shifts most computation to network bandwidth, reducing sync times and improving chain-tip performance, disk footprint, and decentralisation.'],
+  ["Why can't I query blocks before a certain height?", 'In full and minimal pruning modes Erigon discards historical state older than the pruning window. To query early blocks you must run an archive node, chosen at first sync.'],
+  ['Can I run Erigon on a Raspberry Pi or low-power ARM device?', 'It is not recommended for Mainnet, which needs a high-end NVMe SSD and at least 16 GB of RAM. A testnet like Sepolia may be feasible on higher-end ARM hardware.'],
+  ['What is the MCP server?', 'The MCP (Model Context Protocol) server is a built-in component that exposes Erigon blockchain data to AI assistants. It is enabled by default on 127.0.0.1:8553 and can be turned off with --mcp.disable.'],
+  ['How do I connect Claude Desktop to my Erigon node?', 'Build the standalone mcp binary with make mcp and add it to your Claude Desktop configuration pointing to your node JSON-RPC endpoint or datadir.'],
+  ['My node keeps falling behind the chain tip after running for a while. How do I fix it?', 'Delete only datadir/chaindata (not the whole datadir) and restart — Erigon rebuilds it from snapshots in minutes. Make sure you are on the latest release, as Erigon 3.4+ greatly reduces this problem.'],
+  ['What is the difference between deleting chaindata and deleting the whole datadir?', 'chaindata is the small mutable MDBX database that Erigon re-derives from snapshots quickly; the snapshots hold ~95% of the data. Delete only chaindata for a cheap recovery; deleting the whole datadir forces a full re-sync.'],
+  ["My node has no peers or won't sync. Which ports do I need to open?", 'Open 30303/30304 (execution P2P), 4000/4001 (Caplin), and 42069 (snapshot download), TCP and UDP where applicable; keep 8545 local. Behind NAT, set --nat and --caplin.nat to stun or upnp.'],
+  ['How do I reduce Erigon memory use or stop it from being OOM-killed?', 'Make Erigon and the Go runtime more conservative with GOMEMLIMIT, a lower GOGC, a capped GOMAXPROCS, and a smaller --batchSize.'],
+  ['Where do I report a security vulnerability?', "Report security issues through the Ethereum Foundation's Bug Bounty Program rather than public Discord or GitHub, so they can be handled responsibly."],
+  ["Where are Erigon's log files stored?", 'By default Erigon writes logs to <datadir>/logs/erigon.log, in addition to standard output. Attach this file when opening a bug report.'],
+];
+
+<Head>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: faqSchema.map(([question, answer]) => ({
+        '@type': 'Question',
+        name: question,
+        acceptedAnswer: {'@type': 'Answer', text: answer},
+      })),
+    })}
+  </script>
+</Head>
 
 # Frequently Asked Questions (FAQs)
 

--- a/docs/site/src/theme/DocItem/Layout/index.tsx
+++ b/docs/site/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,57 @@
+import React, {type ReactNode} from 'react';
+import Layout from '@theme-original/DocItem/Layout';
+import type LayoutType from '@theme/DocItem/Layout';
+import type {WrapperProps} from '@docusaurus/types';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {useDoc, useDocsVersion} from '@docusaurus/plugin-content-docs/client';
+
+type Props = WrapperProps<typeof LayoutType>;
+
+// Wraps every doc page (main docs + Help Center) to:
+//  1. Emit TechArticle JSON-LD so search engines and AI assistants can extract
+//     a clean title/description/URL per page (Docusaurus already emits
+//     BreadcrumbList; this adds the article-level entity). Pages can opt out
+//     with `structured_data: false` in front matter — e.g. the FAQ page, which
+//     emits its own FAQPage schema instead.
+//  2. Mark archived versions (banner === 'unmaintained') noindex so search
+//     engines consolidate ranking signals on the current version rather than
+//     splitting them across near-duplicate versioned pages. `follow` keeps the
+//     links crawlable.
+export default function LayoutWrapper(props: Props): ReactNode {
+  const {siteConfig} = useDocusaurusContext();
+  const {metadata, frontMatter} = useDoc();
+  const {banner} = useDocsVersion();
+
+  const isArchived = banner === 'unmaintained';
+  // `structured_data: false` is a custom front-matter opt-out (e.g. the FAQ page,
+  // which emits its own FAQPage schema). It isn't part of DocFrontMatter, so read
+  // it from metadata.frontMatter, which carries an index signature for extra keys.
+  const optedOut = (metadata.frontMatter.structured_data as boolean | undefined) === false;
+
+  const url = new URL(metadata.permalink, siteConfig.url).toString();
+  const description = (frontMatter.description as string | undefined) ?? metadata.description;
+
+  const techArticle = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: metadata.title,
+    ...(description ? {description} : {}),
+    url,
+    inLanguage: 'en',
+    isPartOf: {'@type': 'WebSite', name: siteConfig.title, url: siteConfig.url},
+    publisher: {'@type': 'Organization', name: 'Erigon', url: 'https://erigon.tech'},
+  };
+
+  return (
+    <>
+      <Head>
+        {isArchived && <meta name="robots" content="noindex, follow" />}
+        {!optedOut && !isArchived && (
+          <script type="application/ld+json">{JSON.stringify(techArticle)}</script>
+        )}
+      </Head>
+      <Layout {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
Improves search-engine and AI-assistant discoverability of docs.erigon.tech.

> **Stacked on #22696** (help-center refresh). Base is `docs/help-center-refresh`; GitHub will auto-retarget this to `main` once #22696 merges. Review the 3-file SEO diff here.

## What it adds
- **`TechArticle` JSON-LD** on every doc + Help Center page — a wrapper swizzle of `DocItem/Layout` (complements Docusaurus's native `BreadcrumbList`). Pages can opt out with `structured_data: false`.
- **`FAQPage` JSON-LD** (31 Q&As) on the FAQ page for Google FAQ rich results and AI citation. Concise plain-text answers curated alongside the human-facing list; the page opts out of `TechArticle` to avoid a duplicate article entity.
- **`noindex, follow` on archived versions** (`v3.3`/`v3.4`) so ranking signals consolidate on the current version instead of splitting across near-duplicate versioned pages.
- **Sitemap `<lastmod>`** per URL (from git via `showLastUpdateTime`); dropped the client-side `/search` route.
- **`showLastUpdateTime`** enabled — freshness dates on pages and in the sitemap.

## Verified in the production build
- `TechArticle` on doc pages; **`FAQPage` with 31 questions**; archived pages carry `noindex` and no `TechArticle`; current pages indexed; `BreadcrumbList` preserved; sitemap has `lastmod` and excludes `/search`.
- `npm run build` (with `onBrokenLinks: throw`) and `tsc` both pass.

## Why (context)
Audit of the live site found only `BreadcrumbList` structured data. `FAQPage`/`TechArticle` are the schema types most associated with rich results and AI citation; `noindex` on old versions is a standard fix for versioned-docs duplication.

Why not fully data-drive the FAQ: several answers contain code blocks and nested lists, so the visible answers stay authored Markdown while the schema uses curated concise answers (which is also what FAQ rich results prefer). A build-time remark extractor could unify them later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)