### PR TITLE
[r3.6] commitment: ASSERT mutated external variables - cause red "sync from scratch CI"

### DIFF
--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -1046,17 +1046,19 @@ func (sdc *TrieContext) Account(plainKey []byte) (u *commitment.Update, err erro
 		u.CodeHash = acc.CodeHash.Value()
 	}
 
-	if dbg.AssertEnabled { // verify code hash from account encoding matches stored code
+	// Verify only code-bearing accounts whose code is actually in the domain,
+	// and never fold the read into u. A cleared EIP-7702 delegation leaves a
+	// benign CodeDomain residue on a code-less account, and eth_simulateV1
+	// overrides put code in an overlay the domain read doesn't see.
+	if dbg.AssertEnabled && !acc.IsEmptyCodeHash() {
 		code, _, err := sdc.readDomain(kv.CodeDomain, plainKey)
 		if err != nil {
 			return nil, err
 		}
 		if len(code) > 0 {
-			u.CodeHash = crypto.Keccak256Hash(code)
-			u.Flags |= commitment.CodeUpdate
-		}
-		if acc.CodeHash.Value() != u.CodeHash {
-			return nil, fmt.Errorf("code hash mismatch: account '%x' != codeHash '%x'", acc.CodeHash, u.CodeHash[:])
+			if codeHash := crypto.Keccak256Hash(code); acc.CodeHash.Value() != codeHash {
+				return nil, fmt.Errorf("code hash mismatch: account '%x' != codeHash '%x'", acc.CodeHash, codeHash[:])
+			}
 		}
 	}
 	return u, nil


### PR DESCRIPTION
## Problem

The QA `Sync from scratch` jobs (both **minimal node** and **archive**) fail on
**mainnet** at block `25577999`, and only when `ERIGON_ASSERT=true` (which those
jobs set):

```
[4/6 Execution] commitment compute failed block=25577998
  err="...fold: code hash mismatch: account 'c5d2460186f7…d85a470' != codeHash '9b299a00…304bf45'"
[EROR] Wrong trie root of block 25577999: a8cb4f… expected 5af85a…
```

`c5d24601…` is the **empty code hash** — the account correctly has no code.
`release/3.5` passes this exact CI on the same published snapshots, because there
the check is compile-time `assert.Enable` (dormant); #22108 (2026-06-30) migrated
it to runtime `dbg.AssertEnabled`, so `ERIGON_ASSERT=true` switched it on and the
jobs went red (archive: green `aa8dcebcda` 2026-06-27 → red `3ecc257e5e` 2026-07-04).

## Root cause

`TrieContext.Account`'s assert overwrote `u.CodeHash` with
`keccak(CodeDomain[addr])` *before* comparing, so with asserts on it folded a
stale value into the trie and produced a wrong root — the assert itself
manufactured the "wrong trie root". The state root only ever uses the account's
`codeHash`; `CodeDomain` is never consulted to compute the root.

A code-less account (e.g. an **EIP-7702 delegation cleared to the zero address**)
can legitimately carry a stale `CodeDomain` entry (`0xef0100‖addr` designator).
The writer stopped creating these in #21536, but the residues are already baked
into the **published snapshot files** every node downloads, so both node types
trip on the same one. The residue is benign for consensus — proven by 3.5 and all
assert-off production nodes syncing mainnet cleanly (issue #22329 heals the data).

## Fix

Scope the check to code-bearing accounts (`!acc.IsEmptyCodeHash()`) and compare
`keccak(code)` to `acc.CodeHash` via a local, so the assert can never mutate the
commitment input. The protective direction — an account that *claims* code but
whose `CodeDomain` entry is wrong/missing — is still verified.

Related: #22321 (symptom), #22329 (data heal), #21536 (writer fix, already in).

## Testing

`ERIGON_ASSERT=true go test ./execution/commitment/...` is green.
