### PR TITLE
[r3.6] commitment: ASSERT mutated external variables - cause red "sync from scratch CI"

### DIFF
--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -1041,17 +1041,19 @@ func (sdc *TrieContext) Account(plainKey []byte) (u *commitment.Update, err erro
 		u.CodeHash = acc.CodeHash.Value()
 	}
 
-	if dbg.AssertEnabled { // verify code hash from account encoding matches stored code
+	// Verify only code-bearing accounts whose code is actually in the domain,
+	// and never fold the read into u. A cleared EIP-7702 delegation leaves a
+	// benign CodeDomain residue on a code-less account, and eth_simulateV1
+	// overrides put code in an overlay the domain read doesn't see.
+	if dbg.AssertEnabled && !acc.IsEmptyCodeHash() {
 		code, _, err := sdc.readDomain(kv.CodeDomain, plainKey)
 		if err != nil {
 			return nil, err
 		}
 		if len(code) > 0 {
-			u.CodeHash = crypto.Keccak256Hash(code)
-			u.Flags |= commitment.CodeUpdate
-		}
-		if acc.CodeHash.Value() != u.CodeHash {
-			return nil, fmt.Errorf("code hash mismatch: account '%x' != codeHash '%x'", acc.CodeHash, u.CodeHash[:])
+			if codeHash := crypto.Keccak256Hash(code); acc.CodeHash.Value() != codeHash {
+				return nil, fmt.Errorf("code hash mismatch: account '%x' != codeHash '%x'", acc.CodeHash, codeHash[:])
+			}
 		}
 	}
 	return u, nil


### PR DESCRIPTION
Same fix as the `main` PR, opened directly against `release/3.6` (the failing
run linked below is `release/3.6`).

## Problem

The QA `Sync from scratch` jobs (minimal node **and** archive) fail on **mainnet**
at block `25577999`, only under `ERIGON_ASSERT=true`:

```
[4/6 Execution] commitment compute failed block=25577998
  err="...fold: code hash mismatch: account 'c5d2460186f7…d85a470' != codeHash '9b299a00…304bf45'"
[EROR] Wrong trie root of block 25577999: a8cb4f… expected 5af85a…
```

`c5d24601…` is the empty code hash. `release/3.5` passes the same CI on the same
snapshots — its check is compile-time `assert.Enable` (dormant); #22108 migrated
it to runtime `dbg.AssertEnabled`, which `ERIGON_ASSERT=true` switches on.

## Root cause

`TrieContext.Account`'s assert overwrote `u.CodeHash` with `keccak(CodeDomain[addr])`
before comparing, folding a stale value into the trie and producing the wrong root.
A code-less account (an EIP-7702 delegation cleared to the zero address) can carry
a benign stale `CodeDomain` residue that never reaches the trie leaf; the residues
persist in already-published snapshot files, so every downloading node trips it.
Benign for consensus — 3.5 and assert-off production sync mainnet cleanly.

## Fix

Scope the check to code-bearing accounts (`!acc.IsEmptyCodeHash()`) and compare via
a local hash, so the assert can never mutate the commitment input. The
'account claims code but CodeDomain is wrong/missing' direction is still verified.

Related: #22321 (symptom), #22329 (data heal), #21536 (writer fix, already in).

## Testing

`ERIGON_ASSERT=true go test ./execution/commitment/...` is green.
