### PR TITLE
execution/engineapi: catch up from NewPayload when far behind the CL (fix #20419)

### DIFF
--- a/execution/engineapi/engine_block_downloader/block_downloader.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader.go
@@ -148,14 +148,28 @@ func (e *EngineBlockDownloader) download(ctx context.Context, req BackwardDownlo
 	e.status.Store(Synced)
 }
 
-// newPayloadForwardGapExceedsLimit reports whether the new payload's parent is more than maxReorgDepth blocks ahead of the current head.
-func newPayloadForwardGapExceedsLimit(currentHeadNum, parentNum, maxReorgDepth uint64) bool {
-	return parentNum > currentHeadNum && parentNum-currentHeadNum > maxReorgDepth
-}
+// newPayloadGapAction describes how a NewPayload backward download should treat the gap between the
+// local head and the payload's parent.
+type newPayloadGapAction int
 
-// newPayloadBackwardGapExceedsLimit reports whether the new payload's parent is more than maxReorgDepth blocks behind the current head.
-func newPayloadBackwardGapExceedsLimit(currentHeadNum, parentNum, maxReorgDepth uint64) bool {
-	return currentHeadNum > parentNum && currentHeadNum-parentNum > maxReorgDepth
+const (
+	newPayloadBoundedDownload newPayloadGapAction = iota // normal download bounded by MaxReorgDepth
+	newPayloadForwardCatchUp                             // parent far ahead: we are behind, catch up in full
+	newPayloadReorgTooDeep                               // parent far behind: reorg too deep to bridge
+)
+
+// classifyNewPayloadGap decides how to handle a NewPayload whose parent is parentNum given the local
+// head and the reorg-depth limit. A parent more than maxReorgDepth ahead is not a reorg — the node is
+// simply behind — so it catches up in full; a parent more than maxReorgDepth behind is a reorg too deep.
+func classifyNewPayloadGap(currentHead, parentNum, maxReorgDepth uint64) newPayloadGapAction {
+	switch {
+	case parentNum > currentHead && parentNum-currentHead > maxReorgDepth:
+		return newPayloadForwardCatchUp
+	case currentHead > parentNum && currentHead-parentNum > maxReorgDepth:
+		return newPayloadReorgTooDeep
+	default:
+		return newPayloadBoundedDownload
+	}
 }
 
 func (e *EngineBlockDownloader) processReq(ctx context.Context, req BackwardDownloadRequest) error {
@@ -195,10 +209,11 @@ func (e *EngineBlockDownloader) downloadBlocks(ctx context.Context, req Backward
 	if req.Trigger == NewPayloadTrigger {
 		forwardCatchUp := false
 		currentHeader := e.chainRW.CurrentHeader(ctx)
-		if currentHeader != nil && req.ValidateChainTip != nil {
+		if currentHeader != nil && req.ValidateChainTip != nil && req.ValidateChainTip.NumberU64() > 0 {
 			currentHead := currentHeader.Number.Uint64()
 			parentNum := req.ValidateChainTip.NumberU64() - 1
-			if newPayloadBackwardGapExceedsLimit(currentHead, parentNum, e.syncCfg.MaxReorgDepth) {
+			switch classifyNewPayloadGap(currentHead, parentNum, e.syncCfg.MaxReorgDepth) {
+			case newPayloadReorgTooDeep:
 				return fmt.Errorf(
 					"%w: currentHead=%d, parent=%d, limit=%d",
 					p2p.ErrChainLengthExceedsLimit,
@@ -206,8 +221,9 @@ func (e *EngineBlockDownloader) downloadBlocks(ctx context.Context, req Backward
 					parentNum,
 					e.syncCfg.MaxReorgDepth,
 				)
+			case newPayloadForwardCatchUp:
+				forwardCatchUp = true
 			}
-			forwardCatchUp = newPayloadForwardGapExceedsLimit(currentHead, parentNum, e.syncCfg.MaxReorgDepth)
 		}
 		if forwardCatchUp {
 			// catch up in full: the CL's initial-sync phase may feed new payloads without a follow-up FCU

--- a/execution/engineapi/engine_block_downloader/block_downloader.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
-	"github.com/erigontech/erigon/common/math"
 	"github.com/erigontech/erigon/db/dbservices"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/chain"
@@ -149,9 +148,14 @@ func (e *EngineBlockDownloader) download(ctx context.Context, req BackwardDownlo
 	e.status.Store(Synced)
 }
 
-// newPayloadGapExceedsLimit reports whether the head-to-parent gap exceeds maxReorgDepth in either direction.
-func newPayloadGapExceedsLimit(currentHeadNum, missingBlockNum, maxReorgDepth uint64) bool {
-	return math.AbsoluteDifference(currentHeadNum, missingBlockNum) > maxReorgDepth
+// newPayloadForwardGapExceedsLimit reports whether the new payload's parent is more than maxReorgDepth blocks ahead of the current head.
+func newPayloadForwardGapExceedsLimit(currentHeadNum, parentNum, maxReorgDepth uint64) bool {
+	return parentNum > currentHeadNum && parentNum-currentHeadNum > maxReorgDepth
+}
+
+// newPayloadBackwardGapExceedsLimit reports whether the new payload's parent is more than maxReorgDepth blocks behind the current head.
+func newPayloadBackwardGapExceedsLimit(currentHeadNum, parentNum, maxReorgDepth uint64) bool {
+	return currentHeadNum > parentNum && currentHeadNum-parentNum > maxReorgDepth
 }
 
 func (e *EngineBlockDownloader) processReq(ctx context.Context, req BackwardDownloadRequest) error {
@@ -187,20 +191,31 @@ func (e *EngineBlockDownloader) processReq(ctx context.Context, req BackwardDown
 func (e *EngineBlockDownloader) downloadBlocks(ctx context.Context, req BackwardDownloadRequest) error {
 	blocksBatchSize := min(500, uint64(e.syncCfg.LoopBlockLimit))
 	opts := []p2p.BbdOption{p2p.WithBlocksBatchSize(blocksBatchSize)}
+	execForwardInBatches := req.Trigger == FcuTrigger
 	if req.Trigger == NewPayloadTrigger {
-		opts = append(opts, p2p.WithChainLengthLimit(e.syncCfg.MaxReorgDepth))
+		forwardCatchUp := false
 		currentHeader := e.chainRW.CurrentHeader(ctx)
-		if currentHeader != nil {
-			opts = append(opts, p2p.WithChainLengthCurrentHead(currentHeader.Number.Uint64()))
-			if req.ValidateChainTip != nil &&
-				newPayloadGapExceedsLimit(currentHeader.Number.Uint64(), req.ValidateChainTip.NumberU64()-1, e.syncCfg.MaxReorgDepth) {
+		if currentHeader != nil && req.ValidateChainTip != nil {
+			currentHead := currentHeader.Number.Uint64()
+			parentNum := req.ValidateChainTip.NumberU64() - 1
+			if newPayloadBackwardGapExceedsLimit(currentHead, parentNum, e.syncCfg.MaxReorgDepth) {
 				return fmt.Errorf(
 					"%w: currentHead=%d, parent=%d, limit=%d",
 					p2p.ErrChainLengthExceedsLimit,
-					currentHeader.Number.Uint64(),
-					req.ValidateChainTip.NumberU64()-1,
+					currentHead,
+					parentNum,
 					e.syncCfg.MaxReorgDepth,
 				)
+			}
+			forwardCatchUp = newPayloadForwardGapExceedsLimit(currentHead, parentNum, e.syncCfg.MaxReorgDepth)
+		}
+		if forwardCatchUp {
+			// catch up in full: the CL's initial-sync phase may feed new payloads without a follow-up FCU
+			execForwardInBatches = true
+		} else {
+			opts = append(opts, p2p.WithChainLengthLimit(e.syncCfg.MaxReorgDepth))
+			if currentHeader != nil {
+				opts = append(opts, p2p.WithChainLengthCurrentHead(currentHeader.Number.Uint64()))
 			}
 		}
 	}
@@ -243,7 +258,7 @@ func (e *EngineBlockDownloader) downloadBlocks(ctx context.Context, req Backward
 		}
 		insertedBlocksWithoutExec += len(blocks)
 		lastTip = blocks[len(blocks)-1]
-		if req.Trigger == FcuTrigger && uint(insertedBlocksWithoutExec) >= e.syncCfg.LoopBlockLimit {
+		if execForwardInBatches && uint(insertedBlocksWithoutExec) >= e.syncCfg.LoopBlockLimit {
 			e.logger.Info(
 				"[EngineBlockDownloader] executing downloaded batch as it reached sync loop block limit",
 				"to", lastTip.NumberU64(),
@@ -259,7 +274,7 @@ func (e *EngineBlockDownloader) downloadBlocks(ctx context.Context, req Backward
 	if err != nil {
 		return err
 	}
-	if req.Trigger == FcuTrigger && insertedBlocksWithoutExec > 0 && lastTip != nil {
+	if execForwardInBatches && insertedBlocksWithoutExec > 0 && lastTip != nil {
 		e.logger.Info(
 			"[EngineBlockDownloader] executing final downloaded batch",
 			"to", lastTip.NumberU64(),

--- a/execution/engineapi/engine_block_downloader/block_downloader_test.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader_test.go
@@ -77,46 +77,25 @@ func TestBadHeader_LaterReportOverridesValidationErr(t *testing.T) {
 	require.Equal(t, "second reason", gotErr)
 }
 
-func TestNewPayloadForwardGapExceedsLimit(t *testing.T) {
+func TestClassifyNewPayloadGap(t *testing.T) {
+	const limit = 96
 	tests := []struct {
 		name        string
 		currentHead uint64
 		parentNum   uint64
-		limit       uint64
-		want        bool
+		want        newPayloadGapAction
 	}{
-		{"parent far ahead", 100, 500, 96, true},
-		{"parent far behind", 500, 100, 96, false},
-		{"parent ahead by exact limit", 100, 196, 96, false},
-		{"parent ahead by one over limit", 100, 197, 96, true},
-		{"parent behind by one over limit", 197, 100, 96, false},
-		{"same block", 100, 100, 96, false},
+		{"parent far ahead catches up", 100, 500, newPayloadForwardCatchUp},
+		{"parent far behind is too deep", 500, 100, newPayloadReorgTooDeep},
+		{"parent ahead by exact limit stays bounded", 100, 196, newPayloadBoundedDownload},
+		{"parent ahead by one over limit catches up", 100, 197, newPayloadForwardCatchUp},
+		{"parent behind by exact limit stays bounded", 196, 100, newPayloadBoundedDownload},
+		{"parent behind by one over limit is too deep", 197, 100, newPayloadReorgTooDeep},
+		{"parent equals head stays bounded", 100, 100, newPayloadBoundedDownload},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, newPayloadForwardGapExceedsLimit(tt.currentHead, tt.parentNum, tt.limit))
-		})
-	}
-}
-
-func TestNewPayloadBackwardGapExceedsLimit(t *testing.T) {
-	tests := []struct {
-		name        string
-		currentHead uint64
-		parentNum   uint64
-		limit       uint64
-		want        bool
-	}{
-		{"parent far behind", 500, 100, 96, true},
-		{"parent far ahead", 100, 500, 96, false},
-		{"parent behind by exact limit", 196, 100, 96, false},
-		{"parent behind by one over limit", 197, 100, 96, true},
-		{"parent ahead by one over limit", 100, 197, 96, false},
-		{"same block", 100, 100, 96, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, newPayloadBackwardGapExceedsLimit(tt.currentHead, tt.parentNum, tt.limit))
+			require.Equal(t, tt.want, classifyNewPayloadGap(tt.currentHead, tt.parentNum, limit))
 		})
 	}
 }

--- a/execution/engineapi/engine_block_downloader/block_downloader_test.go
+++ b/execution/engineapi/engine_block_downloader/block_downloader_test.go
@@ -77,25 +77,46 @@ func TestBadHeader_LaterReportOverridesValidationErr(t *testing.T) {
 	require.Equal(t, "second reason", gotErr)
 }
 
-func TestNewPayloadGapExceedsLimit(t *testing.T) {
+func TestNewPayloadForwardGapExceedsLimit(t *testing.T) {
 	tests := []struct {
 		name        string
 		currentHead uint64
-		missingNum  uint64
+		parentNum   uint64
 		limit       uint64
 		want        bool
 	}{
-		{"behind by more than limit", 100, 500, 96, true},
-		{"ahead by more than limit", 500, 100, 96, true},
-		{"behind by exact limit", 100, 196, 96, false},
-		{"behind by one over limit", 100, 197, 96, true},
-		{"ahead by exact limit", 196, 100, 96, false},
-		{"ahead by one over limit", 197, 100, 96, true},
+		{"parent far ahead", 100, 500, 96, true},
+		{"parent far behind", 500, 100, 96, false},
+		{"parent ahead by exact limit", 100, 196, 96, false},
+		{"parent ahead by one over limit", 100, 197, 96, true},
+		{"parent behind by one over limit", 197, 100, 96, false},
 		{"same block", 100, 100, 96, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, newPayloadGapExceedsLimit(tt.currentHead, tt.missingNum, tt.limit))
+			require.Equal(t, tt.want, newPayloadForwardGapExceedsLimit(tt.currentHead, tt.parentNum, tt.limit))
+		})
+	}
+}
+
+func TestNewPayloadBackwardGapExceedsLimit(t *testing.T) {
+	tests := []struct {
+		name        string
+		currentHead uint64
+		parentNum   uint64
+		limit       uint64
+		want        bool
+	}{
+		{"parent far behind", 500, 100, 96, true},
+		{"parent far ahead", 100, 500, 96, false},
+		{"parent behind by exact limit", 196, 100, 96, false},
+		{"parent behind by one over limit", 197, 100, 96, true},
+		{"parent ahead by one over limit", 100, 197, 96, false},
+		{"same block", 100, 100, 96, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, newPayloadBackwardGapExceedsLimit(tt.currentHead, tt.parentNum, tt.limit))
 		})
 	}
 }


### PR DESCRIPTION
## Problem

Syncing from genesis with an external CL can get **permanently stuck** far behind the tip, with `eth_syncing` reporting `false` while the node makes no progress (issue #20419):

```
[EngineBlockDownloader] could not process backward download request
err="could not process backward download of blocks: chain length exceeds limit: num=24832931, ..."
```

## Root cause

Confirmed by @taratorio's triage on #21311 / #21309:

- Prysm's initial-sync **phase 1** (`syncToFinalizedEpoch`) sends `engine_newPayload` per block but **not** `engine_forkchoiceUpdated`.
- Erigon caps `NewPayloadTrigger` backward downloads at `MaxReorgDepth` (default 96) and only runs the *unbounded* catch-up download on `FcuTrigger`. So while the CL is in phase 1, Erigon correctly returns `SYNCING` and drops the far-ahead payload, **relying on a later FCU** to bridge the gap.
- If the CL is slow enough that its slot catch-up rate stays below mainnet's finalization rate, it **never exits phase 1**, never sends an FCU, and the EL stays stuck forever.

#21489 already downgraded the log and fail-fast on this path, but left the underlying "no FCU ⇒ stuck" behaviour open (explicitly tracked here).

## Fix

The `MaxReorgDepth` gap check was **symmetric** — a payload far *ahead* of our head (we are simply behind) was rejected identically to a payload far *behind* it (a genuinely too-deep reorg). A forward gap is not a reorg.

Split the check by direction (`downloadBlocks`):

- **Backward gap beyond the limit** → still fails fast with `ErrChainLengthExceedsLimit` (deep reorg we refuse — unchanged).
- **Forward gap beyond the limit** → triggers the unbounded catch-up: download to the current head and execute forward in `LoopBlockLimit` batches, exactly like an FCU-driven sync. The EL no longer depends on the CL sending an FCU during initial sync.

The symmetric `newPayloadGapExceedsLimit` is replaced by two directional predicates (`newPayloadForwardGapExceedsLimit` / `newPayloadBackwardGapExceedsLimit`), each unit-tested for the boundary conditions.