### PR TITLE
db/snapshotsync: keep merge-spanning transaction segment

### DIFF
--- a/db/snapshotsync/snapshotsync.go
+++ b/db/snapshotsync/snapshotsync.go
@@ -176,7 +176,7 @@ func buildBlackListForPruning(
 				blackList[name] = struct{}{}
 			}
 		case applyChainHistoryExpiry:
-			if cc.IsPreMerge(res.From) {
+			if cc.IsPreMerge(res.To - 1) {
 				blackList[name] = struct{}{}
 			}
 		}

--- a/db/snapshotsync/snapshotsync_test.go
+++ b/db/snapshotsync/snapshotsync_test.go
@@ -279,8 +279,8 @@ func TestBlackListForPruning_ChainHistoryExpiry(t *testing.T) {
 		if !ok {
 			continue
 		}
-		if info.From >= mergeHeight {
-			t.Errorf("post-merge tx segment unexpectedly blacklisted: %s (From=%d)", p, info.From)
+		if info.To > mergeHeight {
+			t.Errorf("merge-spanning or post-merge tx segment unexpectedly blacklisted: %s (To=%d)", p, info.To)
 		} else {
 			sawPreMergeTx = true
 		}


### PR DESCRIPTION
Fix transaction snapshot pruning around the Merge boundary.

Previously, a transaction segment was blacklisted based only on its starting block, which could incorrectly skip a segment containing post-Merge transactions. This change only blacklists segments whose full range ends at or before MergeHeight.