### PR TITLE
.github: fix startup_failure in cache-warming / sonar-branch-scan (reusable-workflow perms)

### DIFF
--- a/.github/workflows/cache-warming-kurtosis-cl-images.yml
+++ b/.github/workflows/cache-warming-kurtosis-cl-images.yml
@@ -35,6 +35,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   warm:

--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -29,6 +29,8 @@ on:
 
 permissions:
   contents: read
+  actions: write
+  pull-requests: read
 
 jobs:
   tests:

--- a/.github/workflows/sonar-branch-scan.yml
+++ b/.github/workflows/sonar-branch-scan.yml
@@ -17,8 +17,9 @@ concurrency:
   queue: max
 
 permissions:
-  actions: read
   contents: read
+  actions: write
+  pull-requests: read
 
 jobs:
   sonar:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,15 +16,19 @@ rules:
       - qa-rpc-integration-tests.yml
       - qa-sync-from-scratch.yml
 
-  # ci-gate orchestrates the reusable test leaves. A called workflow's token
-  # permissions are capped by the caller, so ci-gate's workflow-level
-  # actions: write is the cap that lets every self-cancelling leaf run
-  # `gh run cancel`; pull-requests: write is used by the gate's own
-  # dequeuePullRequest mutation. Both are genuinely needed workflow-wide and
-  # can't be scoped to a single job. Tracked in #21132.
+  # These workflows call the reusable test leaves. A called workflow's declared
+  # token permissions must be granted by the caller (else the run fails at
+  # startup), so each caller declares at the workflow level the union its leaves
+  # need: actions: write (the cap the self-cancelling leaves' `gh run cancel`
+  # needs) and pull-requests: read (sonar's PR context). ci-gate additionally
+  # uses pull-requests: write for its own dequeuePullRequest mutation. These are
+  # needed workflow-wide and can't be scoped to a single job. Tracked in #21132.
   excessive-permissions:
     ignore:
       - ci-gate.yml
+      - cache-warming.yml
+      - sonar-branch-scan.yml
+      - cache-warming-kurtosis-cl-images.yml
 
   # The remaining `secrets: inherit` calls target same-repo reusable workflows
   # that genuinely consume secrets — sonar (SONAR_TOKEN) and the DockerHub-pull

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,10 +19,10 @@ rules:
   # These workflows call the reusable test leaves. A called workflow's declared
   # token permissions must be granted by the caller (else the run fails at
   # startup), so each caller declares at the workflow level the union its leaves
-  # need: actions: write (the cap the self-cancelling leaves' `gh run cancel`
-  # needs) and pull-requests: read (sonar's PR context). ci-gate additionally
-  # uses pull-requests: write for its own dequeuePullRequest mutation. These are
-  # needed workflow-wide and can't be scoped to a single job. Tracked in #21132.
+  # need: actions: write (cap for the self-cancelling leaves' `gh run cancel`).
+  # Callers that include sonar additionally grant pull-requests: read (PR context).
+  # ci-gate additionally uses pull-requests: write for its own dequeuePullRequest mutation.
+  # These are needed workflow-wide and can't be scoped to a single job. Tracked in #21132.
   excessive-permissions:
     ignore:
       - ci-gate.yml


### PR DESCRIPTION
## Regression fix — `startup_failure` on main since #22677

The `excessive-permissions` cleanup (#22677, #22687) gave the reusable test leaves explicit permissions (`actions: write` for their merge-queue `gh run cancel`, `pull-requests: read` for sonar). GitHub validates a **called** workflow's declared permissions against the **caller's** grant *at startup* and rejects the whole run if the caller grants less. Callers that only granted `contents: read` therefore began failing to start:

| Caller | Calls | Broke at | Effect |
|---|---|---|---|
| `cache-warming` | lint, sonar, test-bench, test-all-erigon, … | #22677 | `startup_failure`, **33 checks** dropped |
| `sonar-branch-scan` | sonar | #22677 | `startup_failure`, **1 check** dropped |
| `cache-warming-kurtosis-cl-images` | test-kurtosis-assertoor | #22687 | `startup_failure` |

Both cache-warming and sonar-branch-scan went `success` → `startup_failure` exactly at commit `6f7557ebec` (#22677) and have failed on **every main commit since** — silently dropping ~34 checks per commit (this is the "134 → 99" drop visible in main's commit history). `ci-gate` was unaffected because it already grants `actions: write` + `pull-requests: write`; `cache-warming-kurtosis-gloas-images` is unaffected because its leaf (`test-kurtosis-gloas`) was never modified and still declares only `contents: read` — a clean control confirming the mechanism.

## Fix
Grant each broken caller the union of its leaves' declared permissions:
- `cache-warming` → `contents: read`, `actions: write`, `pull-requests: read`
- `sonar-branch-scan` → `contents: read`, `actions: write`, `pull-requests: read`
- `cache-warming-kurtosis-cl-images` → `contents: read`, `actions: write`

These callers are orchestrators that must grant the leaf permission cap workflow-wide (exactly like `ci-gate`), so they're added to the `excessive-permissions` ignore list with a generalized justification.

## Verification
- `zizmor` (real `.github/zizmor.yml`, audit enabled): **exit 0, "No findings to report."**
- `actionlint` clean on the diff (the pre-existing `concurrency.queue` note is unrelated).
- `make lint` = 0 issues.
- Post-merge confirmation: the push-triggered `Cache Warming` and `SonarCloud Branch Scan` runs on main should return to `success` (from `startup_failure`).

## Note / lesson
Root cause was mine: when adding the leaves' `permissions:` in #22677/#22687 I didn't account for GitHub's caller-must-grant rule for reusable workflows, so non-ci-gate callers broke. This restores them without weakening the least-privilege scoping.