### PR TITLE
execution/state: seed full code trio in BAL version-map pre-population

### DIFF
--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -224,7 +224,14 @@ func (vm *VersionMap) WriteChanges(changes []*types.AccountChanges) {
 			vm.WriteNonce(accountChanges.Address, Version{TxIndex: int(nonceChange.Index) - 1}, nonceChange.Value, true)
 		}
 		for _, codeChange := range accountChanges.CodeChanges {
-			vm.WriteCode(accountChanges.Address, Version{TxIndex: int(codeChange.Index) - 1}, accounts.NewCode(codeChange.Bytecode), true)
+			// Seed the whole code trio so pre-population matches what tx execution
+			// flushes together; a CodePath cell without its CodeHashPath/CodeSizePath
+			// siblings lets a concurrent reader see code but no code hash.
+			code := accounts.NewCode(codeChange.Bytecode)
+			v := Version{TxIndex: int(codeChange.Index) - 1}
+			vm.WriteCode(accountChanges.Address, v, code, true)
+			vm.WriteCodeHash(accountChanges.Address, v, code.Hash, true)
+			vm.WriteCodeSize(accountChanges.Address, v, code.Len(), true)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #22659 — an intermittent EIP-7928 block-access-list hash mismatch on the EIP-7702 delegation-clear fixtures, caught by the `zkevm-witness-race` CI shard.

## Reproduction

Reproduced byte-for-byte on `main` (block `0xb66958…`, computed `0x7175b7bc…`, expected `0x837c560e…`):

- `bal_7702_delegation_clear` fails ~**2.3%** of runs, **single-threaded, in isolation** (`evm zkevmtest --workers 1` on the one fixture). `-race` produced **no** `WARNING: DATA RACE` across ~24k tests — all version-map access is synchronized; this is a logical inconsistency, not a memory race.
- The BAL is built/validated by the **parallel versionMap executor** (`ExperimentalBAL=true` forces it even under `EXEC3_PARALLEL=false`), so a block's txs execute concurrently.

## Root cause (identified with version-map instrumentation, not inferred)

The fixture is a 2-tx block: tx1 sets a 7702 delegation (23-byte designator), tx2 clears it (empty). The correct BAL is `codeChanges=[1:len(23) 2:len(0)]`; the buggy computation drops index 2.

The versionMap is pre-populated from the block's expected BAL via `WriteChanges`. For code changes it seeded **only the `CodePath` cell** and not its `CodeHashPath`/`CodeSizePath` siblings — unlike `FlushVersionedWrites`, which publishes the whole code trio for a tx atomically under the account lock:

```go
// before — versionmap.go, WriteChanges
for _, codeChange := range accountChanges.CodeChanges {
    vm.WriteCode(addr, Version{TxIndex: int(codeChange.Index) - 1}, accounts.NewCode(codeChange.Bytecode), true)
}
```

Instrumenting every CodePath/CodeHashPath write and read for the address (with a global sequence + goroutine id) showed the exact window: the BAL pre-population seeds `Code` at txIdx 0 (23 bytes) and txIdx 1 (empty) while `CodeHash` stays **empty**; only when the setting tx later *executes and flushes* does the real code hash appear. During that window a concurrent tx's `SetCode` reads the code-hash floor for its net-zero baseline, misses (`ok=false`), and falls back to the pre-block committed hash (empty). The empty baseline makes the clear (empty code) look like a net-zero revert to pre-block, so it is dropped (`DelCode`/`DelCodeHash`/`DelCodeSize`) and the block-BAL hash diverges. It is intermittent because the missing cell is filled once the setting tx flushes, racing the reader.

Proof it is the cause: with no other change, seeding `CodeHashPath` (and `CodeSizePath`) in `WriteChanges` drops the failure from ~2.3% to **0/500** on the fixture and **0** across the full corpus.

## Fix

Seed the whole code trio (`CodePath` + `CodeHashPath` + `CodeSizePath`) in `WriteChanges`, so BAL pre-population is consistent with what execution-time flushes publish and every code-trio reader sees a complete view.

## Validation

- Failing fixture: **0 / 500** (was ~2.3%).
- Full `eest_zkevm` corpus (`--workers 8`), serial and parallel exec, multiple runs: **23822 ran, 0 failed**, with the 57 expected (negative-test) BAL mismatches preserved exactly.
- `go test ./execution/state ./execution/types` green.
- `make lint`: 0 issues.
