### PR TITLE
[wip] execution/vm/benchmark: bench EVM through the parallel-exec versioned-map path

### DIFF
--- a/execution/vm/benchmark/bench_versioned_test.go
+++ b/execution/vm/benchmark/bench_versioned_test.go
@@ -1,0 +1,81 @@
+package benchmark
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/vm"
+	"github.com/erigontech/erigon/execution/vm/program"
+	"github.com/erigontech/erigon/execution/vm/runtime"
+)
+
+// configBuilder builds a runtime.Config + state for one benchmark.
+type configBuilder func(b *testing.B, gasLimit uint64) (*runtime.Config, *state.IntraBlockState)
+
+// stateReaders is the plain-vs-versioned A/B. "plain" is what every other EVM
+// benchmark uses (reads via NewReaderV3). "versioned" routes reads through the
+// VersionedStateReader / VersionMap OCC path that the default parallel executor
+// uses, so the delta between the two isolates the per-read overhead ParallelExec
+// pays but the existing benchmarks do not measure.
+var stateReaders = []struct {
+	name  string
+	build configBuilder
+}{
+	{"plain", benchConfig},
+	{"versioned", benchConfigVersioned},
+}
+
+// BenchmarkVersionedSLOADWarm runs the warm-SLOAD workload through both the plain
+// and versioned readers.
+func BenchmarkVersionedSLOADWarm(b *testing.B) {
+	for _, n := range []int{50, 500} {
+		p, lbl := program.New().Jumpdest()
+		slots := make(map[uint256.Int]uint256.Int, n)
+		for i := range n {
+			slots[*uint256.NewInt(uint64(i))] = *uint256.NewInt(0xDEAD)
+			p.Push(i).Op(vm.SLOAD, vm.POP)
+		}
+		code := p.Jump(lbl).Bytes()
+
+		for _, r := range stateReaders {
+			b.Run(fmt.Sprintf("%dslots/%s", n, r.name), func(b *testing.B) {
+				b.ReportAllocs()
+				cfg, statedb := r.build(b, 100_000_000)
+				deployContract(statedb, addrContract, code)
+				setStorage(statedb, addrContract, slots)
+				prepareAndCall(cfg, addrContract, nil) //nolint:errcheck // OOG is expected termination for looping benchmarks
+				for b.Loop() {
+					prepareAndCall(cfg, addrContract, nil) //nolint:errcheck
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkVersionedSSTORE runs the zero-to-nonzero SSTORE workload through both
+// readers, exercising the write path under the version map.
+func BenchmarkVersionedSSTORE(b *testing.B) {
+	const n = 100
+	p := program.New()
+	for i := range n {
+		p.Sstore(i, 0xBEEF)
+	}
+	code := p.Op(vm.STOP).Bytes()
+
+	for _, r := range stateReaders {
+		b.Run(r.name, func(b *testing.B) {
+			b.ReportAllocs()
+			cfg, statedb := r.build(b, uint64(n)*22_100+100_000)
+			deployContract(statedb, addrContract, code)
+			for b.Loop() {
+				snap := statedb.PushSnapshot()
+				prepareAndCall(cfg, addrContract, nil) //nolint:errcheck
+				statedb.RevertToSnapshot(snap, nil)
+				statedb.PopSnapshot(snap)
+			}
+		})
+	}
+}

--- a/execution/vm/benchmark/helpers.go
+++ b/execution/vm/benchmark/helpers.go
@@ -81,6 +81,39 @@ func benchConfig(b *testing.B, gasLimit uint64) (*runtime.Config, *state.IntraBl
 	return cfg, statedb
 }
 
+// benchConfigVersioned mirrors benchConfig but routes state reads through the
+// parallel executor's OCC path: a VersionedStateReader that consults the
+// VersionMap and records every account/storage read into a ReadSet, exactly as
+// exec3_parallel wires up a task. benchConfig only attaches a VersionMap to the
+// write side (reads go straight through NewReaderV3), so it does not measure the
+// per-read overhead ParallelExec — now the default — pays on every SLOAD.
+func benchConfigVersioned(b *testing.B, gasLimit uint64) (*runtime.Config, *state.IntraBlockState) {
+	b.Helper()
+
+	db := testutil.TemporalDB(b)
+	tx, domains := testutil.TemporalTxSD(b, db)
+
+	err := rawdbv3.TxNums.Append(tx, 1, 1)
+	require.NoError(b, err)
+
+	versionMap := state.NewVersionMap(nil)
+	statedb := state.New(state.NewVersionedStateReader(0, state.ReadSet{}, versionMap, state.NewReaderV3(domains.AsGetter(tx))))
+	statedb.SetVersionMap(versionMap)
+
+	cfg := &runtime.Config{
+		ChainConfig: cancunConfig(),
+		Origin:      addrSender,
+		Coinbase:    accounts.ZeroAddress,
+		BlockNumber: 1,
+		Time:        1,
+		GasLimit:    gasLimit,
+		Difficulty:  uint256.NewInt(0),
+		State:       statedb,
+	}
+
+	return cfg, statedb
+}
+
 // deployContract deploys code at the given address in the state.
 func deployContract(statedb *state.IntraBlockState, addr accounts.Address, code []byte) {
 	statedb.CreateAccount(addr, true)


### PR DESCRIPTION
## Motivation

ParallelExec is now the default execution path, but our EVM benchmarks don't
exercise it. Concretely:

- The benchmark harness (`benchConfig`) builds state via
  `state.NewWithVersionMap(NewReaderV3(...), NewVersionMap(nil))`. That attaches
  a `VersionMap` to the **write** side, but `NewWithVersionMap` leaves the
  **reader** as a plain `NewReaderV3` — reads never touch the version map.
- The parallel executor (`exec3_parallel`) instead reads through
  `state.NewVersionedStateReader(txIndex, ReadSet{}, versionMap, reader)`, whose
  `ReadAccountData` / `ReadAccountStorage` / `ReadAccountCode` do a per-key
  `versionMap.Read(...)` MVHashMap lookup **and** append every read to a
  `ReadSet` for OCC validation.

So the per-read OCC overhead that ParallelExec pays on every `SLOAD` / account
access is currently unmeasured by any EVM benchmark.

## What this adds

- `benchConfigVersioned` — mirrors `benchConfig` but wires state exactly like a
  parallel task: `state.New(NewVersionedStateReader(0, ReadSet{}, vm, NewReaderV3(...)))`
  + `SetVersionMap(vm)`.
- `BenchmarkVersionedSLOADWarm` / `BenchmarkVersionedSSTORE` run the same
  workloads through both readers (`/plain` vs `/versioned` sub-benchmarks), so
  the OCC read/write overhead can be compared head-to-head.

## Status / WIP caveat

Harness is correct and matches `exec3_parallel`'s wiring; lint + vet clean.

Known fidelity gap to resolve before this is a faithful measurement: `SLOAD` of
slots pre-populated via `setStorage` is served from the IBS dirty/origin cache,
so the underlying (versioned) reader may not be hit on the hot path — the
initial plain-vs-versioned delta is expected to be small. A follow-up should
force reads through the versioned reader (e.g. commit state to the domains and
read cold, or drive `ReadAccountStorage` directly) so the MVHashMap lookup +
ReadSet cost is actually on the measured path. Benchstat numbers (n5) to be
posted in a comment.