### PR TITLE
exec: remove journal.append, drop redundant journal clears

### DIFF
--- a/execution/state/journal.go
+++ b/execution/state/journal.go
@@ -57,6 +57,7 @@ const (
 	kindAccessListAddAccount
 	kindAccessListAddSlot
 	kindTransientStorage
+	kindEnd // not a kind; bounds the range TestJournalDirtySymmetry must cover
 )
 
 const (
@@ -110,17 +111,8 @@ func (j *journal) release() {
 	journalPool.Put(j)
 }
 func (j *journal) Reset() {
-	clear(j.entries)
 	j.entries = j.entries[:0]
 	clear(j.dirties)
-}
-
-// append inserts a new modification entry to the end of the change journal.
-func (j *journal) append(e journalEntry) {
-	j.entries = append(j.entries, e)
-	if addr, isDirty := e.dirtied(); isDirty {
-		j.dirties[addr]++
-	}
 }
 
 // revert undoes a batch of journalled modifications along with any reverted
@@ -141,7 +133,6 @@ func (j *journal) revert(statedb *IntraBlockState, snapshot int) {
 			}
 		}
 	}
-	clear(j.entries[snapshot:]) // release the reverted entries' extra pointers
 	j.entries = j.entries[:snapshot]
 }
 
@@ -167,14 +158,21 @@ func commitFlag(wasCommitted bool) uint8 {
 
 func (je *journalEntry) committed() bool { return je.flags&flagCommitted != 0 }
 
-// --- entry constructors: one per modification kind, appended by the caller ---
+// --- entry constructors: one per modification kind ---
+//
+// Each updates dirties itself rather than deriving it from the entry: the kind
+// is fixed at the call site, and a shared helper that rediscovers it via
+// dirtied() measured materially slower. revert undoes the accounting through
+// dirtied(), so the two must agree on every kind.
 
 func (j *journal) createObjectChange(account accounts.Address) {
-	j.append(journalEntry{kind: kindCreateObject, account: account})
+	j.entries = append(j.entries, journalEntry{kind: kindCreateObject, account: account})
+	j.dirties[account]++
 }
 
 func (j *journal) resetObjectChange(account accounts.Address, prev *stateObject, prevWrites *createWriteSnapshot) {
-	j.append(journalEntry{kind: kindResetObject, account: account, extra: &journalExtra{prevObj: prev, prevWrites: prevWrites}})
+	j.entries = append(j.entries, journalEntry{kind: kindResetObject, account: account, extra: &journalExtra{prevObj: prev, prevWrites: prevWrites}})
+	j.dirties[account]++
 }
 
 func (j *journal) selfdestructChange(account accounts.Address, prev bool, prevbalance uint256.Int, wasCommitted bool) {
@@ -182,7 +180,8 @@ func (j *journal) selfdestructChange(account accounts.Address, prev bool, prevba
 	if prev {
 		flags |= flagSelfdestructPrev
 	}
-	j.append(journalEntry{kind: kindSelfdestruct, account: account, value: prevbalance, flags: flags})
+	j.entries = append(j.entries, journalEntry{kind: kindSelfdestruct, account: account, value: prevbalance, flags: flags})
+	j.dirties[account]++
 }
 
 // selfdestructChangeVersioned records a self-destruct on the parallel path,
@@ -201,59 +200,67 @@ func (j *journal) selfdestructChangeVersioned(account accounts.Address, prev boo
 		e.flags |= flagSelfdestructHadBalance
 		e.extra = &journalExtra{prevBalanceVersioned: prevBalanceVersioned}
 	}
-	j.append(e)
+	j.entries = append(j.entries, e)
+	j.dirties[account]++
 }
 
 func (j *journal) balanceChange(account accounts.Address, prev uint256.Int, wasCommitted bool) {
-	j.append(journalEntry{kind: kindBalance, account: account, value: prev, flags: commitFlag(wasCommitted)})
+	j.entries = append(j.entries, journalEntry{kind: kindBalance, account: account, value: prev, flags: commitFlag(wasCommitted)})
+	j.dirties[account]++
 }
 
 func (j *journal) balanceIncrease(account accounts.Address, increase uint256.Int) {
-	j.append(journalEntry{kind: kindBalanceIncrease, account: account, value: increase})
+	j.entries = append(j.entries, journalEntry{kind: kindBalanceIncrease, account: account, value: increase})
+	j.dirties[account]++
 }
 
 func (j *journal) balanceIncreaseTransfer(bi *BalanceIncrease) {
-	j.append(journalEntry{kind: kindBalanceIncreaseTransfer, extra: &journalExtra{bi: bi}})
+	j.entries = append(j.entries, journalEntry{kind: kindBalanceIncreaseTransfer, extra: &journalExtra{bi: bi}})
 }
 
 func (j *journal) nonceChange(account accounts.Address, prev uint64, wasCommitted bool) {
-	j.append(journalEntry{kind: kindNonce, account: account, aux: prev, flags: commitFlag(wasCommitted)})
+	j.entries = append(j.entries, journalEntry{kind: kindNonce, account: account, aux: prev, flags: commitFlag(wasCommitted)})
+	j.dirties[account]++
 }
 
 func (j *journal) storageChange(account accounts.Address, key accounts.StorageKey, prevalue uint256.Int, wasCommitted bool) {
-	j.append(journalEntry{kind: kindStorage, account: account, key: key, value: prevalue, flags: commitFlag(wasCommitted)})
+	j.entries = append(j.entries, journalEntry{kind: kindStorage, account: account, key: key, value: prevalue, flags: commitFlag(wasCommitted)})
+	j.dirties[account]++
 }
 
 func (j *journal) fakeStorageChange(account accounts.Address, key accounts.StorageKey, prevalue uint256.Int) {
-	j.append(journalEntry{kind: kindFakeStorage, account: account, key: key, value: prevalue})
+	j.entries = append(j.entries, journalEntry{kind: kindFakeStorage, account: account, key: key, value: prevalue})
+	j.dirties[account]++
 }
 
 func (j *journal) codeChange(account accounts.Address, prevcode []byte, prevhash accounts.CodeHash, wasCommitted bool) {
-	j.append(journalEntry{kind: kindCode, account: account, flags: commitFlag(wasCommitted), extra: &journalExtra{prevcode: prevcode, prevhash: prevhash}})
+	j.entries = append(j.entries, journalEntry{kind: kindCode, account: account, flags: commitFlag(wasCommitted), extra: &journalExtra{prevcode: prevcode, prevhash: prevhash}})
+	j.dirties[account]++
 }
 
 func (j *journal) refundChange(prev uint64) {
-	j.append(journalEntry{kind: kindRefund, aux: prev})
+	j.entries = append(j.entries, journalEntry{kind: kindRefund, aux: prev})
 }
 
 func (j *journal) addLogChange(txIndex int) {
-	j.append(journalEntry{kind: kindAddLog, aux: uint64(txIndex)})
+	j.entries = append(j.entries, journalEntry{kind: kindAddLog, aux: uint64(txIndex)})
 }
 
 func (j *journal) touchAccount(account accounts.Address, wasCommitted bool, prev uint256.Int) {
-	j.append(journalEntry{kind: kindTouch, account: account, value: prev, flags: commitFlag(wasCommitted)})
+	j.entries = append(j.entries, journalEntry{kind: kindTouch, account: account, value: prev, flags: commitFlag(wasCommitted)})
+	j.dirties[account]++
 }
 
 func (j *journal) accessListAddAccountChange(address accounts.Address) {
-	j.append(journalEntry{kind: kindAccessListAddAccount, account: address})
+	j.entries = append(j.entries, journalEntry{kind: kindAccessListAddAccount, account: address})
 }
 
 func (j *journal) accessListAddSlotChange(address accounts.Address, slot accounts.StorageKey) {
-	j.append(journalEntry{kind: kindAccessListAddSlot, account: address, key: slot})
+	j.entries = append(j.entries, journalEntry{kind: kindAccessListAddSlot, account: address, key: slot})
 }
 
 func (j *journal) transientStorageChange(account accounts.Address, key accounts.StorageKey, prevalue uint256.Int) {
-	j.append(journalEntry{kind: kindTransientStorage, account: account, key: key, value: prevalue})
+	j.entries = append(j.entries, journalEntry{kind: kindTransientStorage, account: account, key: key, value: prevalue})
 }
 
 // dirtied returns the address modified by this entry, or (NilAddress, false) for
@@ -267,7 +274,7 @@ func (je *journalEntry) dirtied() (accounts.Address, bool) {
 	case kindCreateObject, kindResetObject, kindSelfdestruct, kindBalance, kindBalanceIncrease, kindNonce, kindStorage, kindFakeStorage, kindCode, kindTouch:
 		return je.account, true
 	}
-	panic(fmt.Sprintf("dirtied: unknown journal entry kind %d", je.kind))
+	panic("dirtied: unknown journal entry kind")
 }
 
 var ripemd = accounts.InternAddress(common.HexToAddress("0000000000000000000000000000000000000003"))

--- a/execution/state/journal_test.go
+++ b/execution/state/journal_test.go
@@ -18,6 +18,82 @@ func TestJournalEntrySize(t *testing.T) {
 	}
 }
 
+// TestJournalDirtySymmetry pins every constructor's dirties accounting against
+// dirtied(), which revert uses to undo it. A kind the two disagree about leaves
+// the dirties refcount unbalanced — under-dirtying drops a modified account and
+// diverges the state root, over-dirtying leaks entries across the revert.
+func TestJournalDirtySymmetry(t *testing.T) {
+	addr := accounts.InternAddress(common.HexToAddress("0x00000000000000000000000000000000000000aa"))
+	key := accounts.InternKey(common.HexToHash("0x01"))
+	val := *uint256.NewInt(42)
+
+	cases := []struct {
+		name string
+		kind entryKind
+		call func(j *journal)
+	}{
+		{"createObjectChange", kindCreateObject, func(j *journal) { j.createObjectChange(addr) }},
+		{"resetObjectChange", kindResetObject, func(j *journal) { j.resetObjectChange(addr, nil, nil) }},
+		{"selfdestructChange", kindSelfdestruct, func(j *journal) { j.selfdestructChange(addr, false, val, false) }},
+		{"selfdestructChangeVersioned", kindSelfdestruct, func(j *journal) {
+			j.selfdestructChangeVersioned(addr, false, val, false, false, 0, false, val)
+		}},
+		{"balanceChange", kindBalance, func(j *journal) { j.balanceChange(addr, val, false) }},
+		{"balanceIncrease", kindBalanceIncrease, func(j *journal) { j.balanceIncrease(addr, val) }},
+		{"balanceIncreaseTransfer", kindBalanceIncreaseTransfer, func(j *journal) {
+			j.balanceIncreaseTransfer(&BalanceIncrease{})
+		}},
+		{"nonceChange", kindNonce, func(j *journal) { j.nonceChange(addr, 1, false) }},
+		{"storageChange", kindStorage, func(j *journal) { j.storageChange(addr, key, val, false) }},
+		{"fakeStorageChange", kindFakeStorage, func(j *journal) { j.fakeStorageChange(addr, key, val) }},
+		{"codeChange", kindCode, func(j *journal) { j.codeChange(addr, nil, accounts.CodeHash{}, false) }},
+		{"refundChange", kindRefund, func(j *journal) { j.refundChange(7) }},
+		{"addLogChange", kindAddLog, func(j *journal) { j.addLogChange(3) }},
+		{"touchAccount", kindTouch, func(j *journal) { j.touchAccount(addr, false, val) }},
+		{"accessListAddAccountChange", kindAccessListAddAccount, func(j *journal) { j.accessListAddAccountChange(addr) }},
+		{"accessListAddSlotChange", kindAccessListAddSlot, func(j *journal) { j.accessListAddSlotChange(addr, key) }},
+		{"transientStorageChange", kindTransientStorage, func(j *journal) { j.transientStorageChange(addr, key, val) }},
+	}
+
+	covered := map[entryKind]bool{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			j := newJournal()
+			defer j.release()
+			tc.call(j)
+
+			if len(j.entries) != 1 {
+				t.Fatalf("appended %d entries, want 1", len(j.entries))
+			}
+			if j.entries[0].kind != tc.kind {
+				t.Fatalf("appended kind %d, want %d", j.entries[0].kind, tc.kind)
+			}
+			// revert decrements exactly once, for exactly the address dirtied()
+			// names, so the constructor must have incremented exactly that.
+			wantAddr, wantDirty := j.entries[0].dirtied()
+			if !wantDirty {
+				if len(j.dirties) != 0 {
+					t.Errorf("dirtied %d accounts, but dirtied() reports the kind is clean", len(j.dirties))
+				}
+				return
+			}
+			if len(j.dirties) != 1 {
+				t.Fatalf("dirtied %d accounts, want exactly 1", len(j.dirties))
+			}
+			if got := j.dirties[wantAddr]; got != 1 {
+				t.Errorf("dirties[%v] = %d, want 1", wantAddr, got)
+			}
+		})
+		covered[tc.kind] = true
+	}
+
+	for k := range kindEnd {
+		if !covered[k] {
+			t.Errorf("kind %d has no constructor case — add one so its dirty accounting stays pinned", k)
+		}
+	}
+}
+
 // BenchmarkJournalStorageChange measures the hot append path; it must stay at
 // zero allocs per op once the entries slice has warmed up.
 func BenchmarkJournalStorageChange(b *testing.B) {


### PR DESCRIPTION
`(*journal).append` was not inlinable, so all 16 journal entry constructors inlined into their callers and then made a real call passing a 72-byte `journalEntry` by value.

The cause was entirely `panic(fmt.Sprintf(...))` in `dirtied()` — Sprintf accounts for 64 of its 95 inline-cost units, which pushed `append` to 82 against a budget of 80.

Rather than shave `append` back under the budget, this removes it. Every constructor's kind — and so whether it dirties an account — is fixed at the call site, so rediscovering it at runtime through `dirtied()` was never necessary. Each constructor now appends its entry and states its own `dirties` accounting.

`dirtied()` stays (with a constant panic message) for `revert`'s generic backwards walk, now its only caller.

### Every constructor becomes inlinable

| constructor | before | after |
|---|---|---|
| `addLogChange` | 64 | **12** |
| `transientStorageChange` | 67 | **15** |
| `storageChange` | 77 | **31** |
| `codeChange` | 80 *(exactly at budget)* | **34** |
| `selfdestructChange` | **85 — not inlinable** | **39** |
| `selfdestructChangeVersioned` | **110 — not inlinable** | **64** |

The two `selfdestruct` constructors were over budget and are now inlinable. This also removes the single chokepoint where one stray `Sprintf` silently un-inlined all sixteen.

### Redundant clears

Both `clear` calls on `j.entries` are removed. `entries` is only appended to, truncated (`[:0]` / `[:snapshot]`), and read within `len` — never re-extended — so the cleared tail is unreachable either way. They only released `*journalExtra` pointers slightly earlier for the GC, and only the infrequent kinds (`kindResetObject`, `kindCode`, `kindBalanceIncreaseTransfer`, versioned `kindSelfdestruct`) set `extra` at all; the common entries are pointer-free.

## Measurements

Idle 16-core EPYC, `-count=10 -cpu=1`, compared with benchstat. All p=0.000 unless noted.

### Removing `append`

| benchmark | before | after | |
|---|---|---|---|
| `storageChange` | 16.795 ns/op | 9.223 ns/op | **-45.1%** |
| `addLogChange` | 5.989 ns/op | 5.433 ns/op | **-9.3%** |

geomean **-29.4%**. The win exceeds the call overhead alone because routing through `append` meant invoking a *pointer*-receiver method on the entry, which forces the 72-byte `journalEntry` into addressable memory instead of registers — `je.account` became a memory reload.

For reference, merely making `append` inlinable (keeping it) was worth only -2.7% / -5.5%, and interposing a no-dirty-check `appendClean` helper was still 5.45% slower than no helper at all.

### `Reset` — dropping `clear(j.entries)`

Fill-then-Reset cycle, so the delta is the clear alone (~0.43 ns/entry):

| entries | with clear | without | |
|---|---|---|---|
| 16 | 288.7 ns | 279.3 ns | -3.3% |
| 128 | 2260.9 ns | 2201.5 ns | -2.6% |
| 1024 | 17979.5 ns | 17529.0 ns | -2.5% |
| 8192 | 143881.1 ns | 140364.5 ns | -2.4% |

### `revert` — dropping `clear(j.entries[snapshot:])`

The hotter of the two: `revert` runs on every failed CALL/CREATE frame (`evm.go:168`). Measured over entries whose revert is self-contained — `kindRefund` (never dirty) and `kindTouch` with a nil version map (dirty, exercising the `dirties` decrement/delete path).

| entries | clean kinds | dirty kinds |
|---|---|---|
| 8 | **-10.47%** | ~ (p=0.060) |
| 64 | **-11.46%** | -1.63% |
| 512 | **-10.35%** | -1.30% |

geomean **-6.48%**. Zero allocations on every variant, unchanged.

For scale, revert costs ~1.9 ns/entry for clean kinds and ~11-29 ns/entry for dirty ones, the latter dominated by the `dirties` map bookkeeping. There was no benchmark for `revert` anywhere in the tree before this.

### Rejected alternatives

- **Value receiver on `dirtied()`** — copying the 72-byte entry made `addLogChange` **22% slower** (7.727 vs 6.335 ns/op).
- **Dropping the panic entirely** (inverted switch, unknown kinds default to dirty) — inline cost falls 31 to 17, but both are already under budget so it buys nothing measurable: `addLogChange` unchanged (p=0.109), `storageChange` 0.51% *worse*. Keeping the panic preserves the exhaustiveness check for free.
- **Returning an error instead of panicking** — `dirtied()` goes to 120 and `append()` to 93, both non-inlinable and worse than the 82 we started from; `addLogChange` +8.87%, `storageChange` +2.50%. It would also thread `error` through 16 constructors and their call sites for a condition that can only be a programming error.
- **Folding revert's `dirties` bookkeeping from 3 map ops to 2** — -9.59% at 8 dirty entries and -2.94% at 64, but +0.57% at 512. Not carried, since the win doesn't hold across sizes.

## Safety

Previously `append` incremented and `revert` decremented through the same `dirtied()`, and that shared source of truth is what kept the refcount balanced. With constructors owning the increment, `TestJournalDirtySymmetry` pins each one against `dirtied()` and fails if a kind is added without a case. Verified non-vacuous: deleting a single `j.dirties[account]++` fails exactly that constructor's subtest.
