### PR TITLE
execution/vm: keep disabled tracing out of the interpreter hot loop

### DIFF
--- a/execution/vm/interpreter.go
+++ b/execution/vm/interpreter.go
@@ -363,6 +363,18 @@ func jumpTable(chainRules *chain.Rules, cfg Config) *JumpTable {
 	return jt
 }
 
+// traceGas picks the figure the dev instruction trace should report: call
+// opcodes forward gas to the callee, so their charged cost is not the
+// interesting number.
+func traceGas(op OpCode, callGas, cost uint64) uint64 {
+	switch op {
+	case CALL, CALLCODE, DELEGATECALL, STATICCALL:
+		return callGas
+	default:
+		return cost
+	}
+}
+
 // Run loops and evaluates the contract's code with the given input data and returns
 // the return byte-slice and an error if one occurred.
 //
@@ -388,16 +400,14 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 		pc   = uint64(0) // program counter
 		cost uint64
 		// copies used by tracer
-		pcCopy                 uint64 // needed for the deferred Tracer
-		gasCopy                uint64 // for Tracer to log gas remaining before execution
-		callGas                uint64
-		logged                 bool   // deferred Tracer should ignore already logged steps
-		res                    []byte // result of the opcode execution function
-		tracer                 = evm.config.Tracer
-		debug                  = tracer != nil && (tracer.OnOpcode != nil || tracer.OnGasChange != nil || tracer.OnFault != nil)
-		trace                  = dbg.TraceInstructions && evm.intraBlockState.Trace()
-		blockNum               uint64
-		txIndex, txIncarnation int
+		pcCopy  uint64 // needed for the deferred Tracer
+		gasCopy uint64 // for Tracer to log gas remaining before execution
+		callGas uint64
+		logged  bool   // deferred Tracer should ignore already logged steps
+		res     []byte // result of the opcode execution function
+		tracer  = evm.config.Tracer
+		debug   = tracer != nil && (tracer.OnOpcode != nil || tracer.OnGasChange != nil || tracer.OnFault != nil)
+		trace   = dbg.TraceInstructions && evm.intraBlockState.Trace()
 	)
 
 	// Make sure the readOnly is only set if we aren't in readOnly yet.
@@ -409,15 +419,6 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 	// Increment the call depth which is restricted to 1024
 	evm.depth++
 	defer func() {
-		// first: capture data/memory/state/depth/etc... then clenup them
-		if debug && err != nil {
-			if !logged && tracer.OnOpcode != nil {
-				tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, evm.returnData, evm.depth, VMErrorFromErr(err))
-			}
-			if logged && tracer.OnFault != nil {
-				tracer.OnFault(pcCopy, byte(op), gasCopy, cost, callContext, evm.depth, VMErrorFromErr(err))
-			}
-		}
 		// EIP-8037: snapshot the spilled portion and derive the frame's net
 		// state-gas usage from the reservoir delta before callContext.put()
 		// clears them. A state charge lowers stateGas (or raises stateGasSpill
@@ -427,7 +428,6 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 		// gasRemaining (covers precompile/no-code paths and the revert burn).
 		gasUsed.StateSpill = callContext.stateGasSpill
 		gasUsed.State = int64(gas.State) - int64(callContext.stateGas) + int64(callContext.stateGasSpill)
-		// this function must execute _after_: the `CaptureState` needs the stacks before
 		callContext.put()
 		if restoreReadonly {
 			evm.readOnly = false
@@ -435,34 +435,43 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 		evm.depth--
 	}()
 
+	// Registered after the cleanup defer so LIFO runs it first: the tracer needs
+	// the stacks before callContext.put() returns them to the pool.
+	if debug {
+		defer func() {
+			if err == nil {
+				return
+			}
+			if !logged && tracer.OnOpcode != nil {
+				tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, evm.returnData, evm.depth, VMErrorFromErr(err))
+			}
+			if logged && tracer.OnFault != nil {
+				tracer.OnFault(pcCopy, byte(op), gasCopy, cost, callContext, evm.depth, VMErrorFromErr(err))
+			}
+		}()
+	}
+
 	// The Interpreter main run loop (contextual). This loop runs until either an
 	// explicit STOP, RETURN or SELFDESTRUCT is executed, an error occurred during
 	// the execution of one of the operations or until the done flag is set by the
 	// parent context.
 
-	var traceGas = func(op OpCode, callGas, cost uint64) uint64 {
-		switch op {
-		case CALL, CALLCODE, DELEGATECALL, STATICCALL:
-			return callGas
-		default:
-			return cost
-		}
-	}
-
 	// Hoist to locals so the compiler sees them as loop-invariant.
 	anyTrace := dbg.TraceDynamicGas || debug || trace
 
+	jt := evm.jt
+	_ = jt[0] // nil-check the jump table out of the loop
+
 	for {
 		callContext.cacheGen++
-		if anyTrace {
+		if debug {
 			// Capture pre-execution values for tracing.
 			logged, pcCopy, gasCopy = false, pc, callContext.gas
-			blockNum, txIndex, txIncarnation = evm.intraBlockState.BlockNumber(), evm.intraBlockState.TxIndex(), evm.intraBlockState.Incarnation()
 		}
 		// Get the operation from the jump table and validate the stack to ensure there are
 		// enough stack items available to perform the operation.
 		op = contract.GetOp(pc)
-		operation := evm.jt[op]
+		operation := jt[op]
 		cost = operation.constantGas // For tracing
 		// Validate stack
 		if sLen := callContext.Stack.len(); sLen < operation.numPop {
@@ -511,7 +520,7 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 				cost += dynamicCost.Regular
 				callGas = operation.constantGas + dynamicCost.Regular - evm.CallGasTemp()
 				if dbg.TraceDynamicGas && dynamicCost.Regular > 0 {
-					fmt.Printf("%d (%d.%d) Dynamic Gas: %d (%s)\n", blockNum, txIndex, txIncarnation, traceGas(op, callGas, cost), op)
+					fmt.Printf("%d (%d.%d) Dynamic Gas: %d (%s)\n", evm.intraBlockState.BlockNumber(), evm.intraBlockState.TxIndex(), evm.intraBlockState.Incarnation(), traceGas(op, callGas, cost), op)
 				}
 			}
 			// EIP-8037: "Regular gas charge MUST be applied first. If the regular
@@ -560,7 +569,7 @@ func (evm *EVM) Run(contract Contract, gas mdgas.MdGas, input []byte, readOnly b
 				opstr = op.String()
 			}
 
-			fmt.Printf("%d (%d.%d) %5d %5d %s\n", blockNum, txIndex, txIncarnation, pc, traceGas(op, callGas, cost), opstr)
+			fmt.Printf("%d (%d.%d) %5d %5d %s\n", evm.intraBlockState.BlockNumber(), evm.intraBlockState.TxIndex(), evm.intraBlockState.Incarnation(), pc, traceGas(op, callGas, cost), opstr)
 		}
 
 		// execute the operation


### PR DESCRIPTION
`Run` carried its tracing scaffolding through the per-opcode loop whether or not anything was actually tracing. Removing it entirely measures **-15.5%** on a pure ADD loop, so the scaffolding — not the opcodes — accounted for a sixth of dispatch cost.

None of it allocated. Escape analysis reports no `moved to heap` and no `func literal escapes to heap` anywhere in `Run`, and the loop holds a constant 8 allocs/op from 10M to 100M gas. The `fmt.Printf` arguments do escape, but only as call-site boxing inside the `if trace` branches, so they cost nothing when tracing is off. `tracer.OnOpcode` likewise forces nothing to the heap — it only allocates the `*VMError` from `VMErrorFromErr`, which returns nil for a nil error. The cost was branches and register pressure, not garbage.

## Changes

Each of these is something geth's equivalent loop already does:

- **Register the tracer's exit-path defer only when a tracer is installed.** Previously one unconditional defer tested `debug` internally, so the closure existed on every call. It is registered *after* the cleanup defer, so LIFO still runs it first while the stacks are alive.

  This is also strictly safer than before: with tracing and cleanup in one defer, a panic inside `OnOpcode`/`OnFault` skipped `callContext.put()` and leaked the frame's stack back from the pool. Split, the cleanup defer still runs.
- **Drop `blockNum`/`txIndex`/`txIncarnation`.** These existed solely for the `dbg.TraceInstructions` / `dbg.TraceDynamicGas` dev Printfs, but were populated through **three `IntraBlockState` interface calls on every opcode** whenever any trace was enabled. The Printfs now read them at the call site.
- **Hoist the jump table into a local and lift its nil check out of the loop.**

`traceGas` also moves from a per-`Run` closure to a package function, so the hot frame stops carrying one.

Together this takes nine trace-only locals down to six, and keys the per-opcode capture on `debug` rather than the broader `anyTrace`.

## Measurements

Idle 16-core EPYC, `-count=10`, baseline verified byte-identical to `origin/main`:

| benchmark | before | after | |
|---|---|---|---|
| `PureArithmetic/add/1M` | 1.642m | 1.467m | **-10.66%** |
| `PureArithmetic/add/10M` | 15.93m | 14.43m | **-9.41%** |
| `PureArithmetic/add/100M` | 159.1m | 145.7m | **-8.44%** (p=0.007) |
| `PureArithmetic/mul/100M` | 153.7m | 149.8m | -2.52% (p=0.002) |
| `StackOps/dup-swap/100M` | 199.5m | 179.0m | **-10.27%** |
| `Keccak256/32B/100M` | 544.4m | 524.7m | -3.62% |
| `MixedCompute/mixed/100M` | 197.7m | 182.1m | **-7.89%** |
| **geomean** | 75.30m | 69.58m | **-7.59%** |

p=0.000 unless noted. `B/op` and `allocs/op` are unchanged everywhere (818 B, 8 allocs), as expected — this removes branches and register pressure, not garbage.

The gain tracks how opcode-dense the workload is: pure dispatch loops gain ~10%, while `Keccak256` and `mul` gain least because more of their time sits inside the opcode itself rather than in dispatch.

For reference, deleting the tracing scaffolding altogether — not shippable, it removes the feature — measures **-15.46%** on `add/10M`. This PR captures roughly half of that ceiling without changing what tracing does.

## Deliberately not done

- **Merging the `if debug` and `if trace` blocks.** The `if memorySize > 0` resize sits between them and `operation.string` can read memory, so merging would reorder dev trace output across memory expansion.
- **Splitting the loop into traced and untraced copies.** That is what it would take to reach the -15.5% ceiling, but it means two copies of consensus-critical gas and stack logic, where a fix applied to one and not the other is a consensus divergence. Not worth the remaining percentage points.
- **`callContext.cacheGen++`.** Worth recording that the line-level profile makes this the single hottest instruction in the loop, at 60ms of `Run`'s 320ms flat time. It is load-bearing for the per-opcode intern cache, so it is out of scope here.

For context on how much of the cost is dispatch rather than execution, `Run`'s own flat time is 47% of the whole profile on the ADD loop.
