### PR TITLE
rpc: TraceConfig limit in debug_trace* opcode logger

### DIFF
--- a/execution/tracing/tracers/logger/json_stream.go
+++ b/execution/tracing/tracers/logger/json_stream.go
@@ -43,6 +43,7 @@ type JsonStreamLogger struct {
 	stream       jsonstream.Stream
 	hexEncodeBuf [128]byte
 	firstCapture bool
+	opcodeSteps  int // steps captured so far; executed-but-suppressed ones don't count
 
 	locations common.Hashes // For sorting
 	storage   map[accounts.Address]Storage
@@ -126,6 +127,13 @@ func (l *JsonStreamLogger) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope
 		return
 	default:
 	}
+	// check if already captured the specified number of opcode steps. Execution
+	// keeps going, we just stop recording. Must happen before anything is written
+	// to the stream, otherwise a dangling separator would be emitted.
+	if l.cfg.Limit != 0 && l.cfg.Limit <= l.opcodeSteps {
+		return
+	}
+	l.opcodeSteps++
 	if !l.firstCapture {
 		l.stream.WriteMore()
 	} else {

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -110,6 +110,98 @@ func captureOnOpcodeWithReturnData(t *testing.T, cfg *LogConfig, memory []byte, 
 	return outer.StructLogs[0]
 }
 
+// captureOnOpcodes runs n OnOpcode calls through a single logger and returns every
+// structLog entry that made it to the stream. The pc of each step is set to its
+// index so callers can assert which steps were kept.
+func captureOnOpcodes(t *testing.T, cfg *LogConfig, n int) []map[string]json.RawMessage {
+	t.Helper()
+	var buf bytes.Buffer
+	stream := jsonstream.New(&buf)
+	l := NewJsonStreamLogger(cfg, context.Background(), stream)
+	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+	scope := &mockOpContext{}
+	for i := 0; i < n; i++ {
+		l.OnOpcode(uint64(i), byte(vm.MLOAD), 100, 3, scope, nil, 1, nil)
+	}
+
+	// Mirror what ExecuteTraceTx does to close the stream after execution.
+	stream.WriteArrayEnd()
+	stream.WriteObjectEnd()
+	stream.Flush()
+
+	var outer struct {
+		StructLogs []map[string]json.RawMessage `json:"structLogs"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &outer); err != nil {
+		t.Fatalf("invalid JSON output: %v\nraw: %s", err, buf.Bytes())
+	}
+	return outer.StructLogs
+}
+
+// TestJsonStreamLogger_Limit verifies that LogConfig.Limit caps the number of
+// structLog entries emitted by the opcode logger, as required by the TraceConfig
+// `limit` field in execution-apis (src/schemas/opcode-tracer.yaml):
+//
+//	"Maximum number of opcode steps to capture. Zero means no limit. When the
+//	 limit is reached, execution continues but no further StructLog entries are
+//	 recorded."
+func TestJsonStreamLogger_Limit(t *testing.T) {
+	const steps = 5
+	tests := []struct {
+		name  string
+		limit int
+		want  int
+	}{
+		{"limit zero means unlimited", 0, steps},
+		{"limit of one keeps a single entry", 1, 1},
+		{"limit below step count truncates", 2, 2},
+		{"limit equal to step count keeps all", steps, steps},
+		{"limit above step count keeps all", steps + 3, steps},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := captureOnOpcodes(t, &LogConfig{Limit: tt.limit}, steps)
+			if len(logs) != tt.want {
+				t.Fatalf("structLogs count: got %d, want %d", len(logs), tt.want)
+			}
+			// The limit truncates the tail: the entries kept must be the first
+			// ones executed, in order.
+			for i, entry := range logs {
+				var pc uint64
+				if err := json.Unmarshal(entry["pc"], &pc); err != nil {
+					t.Fatalf("cannot parse pc of entry %d: %v", i, err)
+				}
+				if pc != uint64(i) {
+					t.Errorf("entry %d: got pc %d, want %d", i, pc, i)
+				}
+			}
+		})
+	}
+}
+
+// TestJsonStreamLogger_LimitDoesNotCorruptJSON verifies that suppressed steps emit
+// nothing at all — in particular no dangling separator that would break the array.
+func TestJsonStreamLogger_LimitDoesNotCorruptJSON(t *testing.T) {
+	var buf bytes.Buffer
+	stream := jsonstream.New(&buf)
+	l := NewJsonStreamLogger(&LogConfig{Limit: 1}, context.Background(), stream)
+	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
+
+	scope := &mockOpContext{}
+	for i := 0; i < 4; i++ {
+		l.OnOpcode(uint64(i), byte(vm.MLOAD), 100, 3, scope, nil, 1, nil)
+	}
+	stream.WriteArrayEnd()
+	stream.WriteObjectEnd()
+	stream.Flush()
+
+	if !json.Valid(buf.Bytes()) {
+		t.Fatalf("output is not valid JSON: %s", buf.Bytes())
+	}
+}
+
 // TestJsonStreamLogger_MemoryEncoding verifies that memory words are emitted as
 // 0x-prefixed 64-char hex strings and that a partial last word is padded to 32 bytes.
 func TestJsonStreamLogger_MemoryEncoding(t *testing.T) {

--- a/execution/tracing/tracers/logger/json_stream_test.go
+++ b/execution/tracing/tracers/logger/json_stream_test.go
@@ -121,7 +121,7 @@ func captureOnOpcodes(t *testing.T, cfg *LogConfig, n int) []map[string]json.Raw
 	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
 
 	scope := &mockOpContext{}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		l.OnOpcode(uint64(i), byte(vm.MLOAD), 100, 3, scope, nil, 1, nil)
 	}
 
@@ -190,7 +190,7 @@ func TestJsonStreamLogger_LimitDoesNotCorruptJSON(t *testing.T) {
 	l.env = &tracing.VMContext{IntraBlockState: &mockIBS{}}
 
 	scope := &mockOpContext{}
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		l.OnOpcode(uint64(i), byte(vm.MLOAD), 100, 3, scope, nil, 1, nil)
 	}
 	stream.WriteArrayEnd()


### PR DESCRIPTION
## Problem

The streaming opcode logger behind the `debug_trace*` methods never reads `LogConfig.Limit`. A client asking for `{"limit": 10}` gets the **full** trace back — no error, the field is silently dropped.

It does reach the logger: `AssembleTracer` passes `config.LogConfig` into `NewJsonStreamLogger` (`rpc/transactions/tracing.go:206`). It is simply never consulted in `OnOpcode`, unlike `DisableStorage`, `DisableStack`, `EnableMemory` and `EnableReturnData`.

Affects `debug_traceTransaction`, `debug_traceBlockByNumber`, `debug_traceBlockByHash`, `debug_traceCall` and `debug_traceCallMany`.

## Spec

`limit` is a specified field of `TraceConfig` since [execution-apis#762](https://github.com/ethereum/execution-apis/pull/762), in `src/schemas/opcode-tracer.yaml`:

```yaml
    limit:
      title: step limit
      description: >-
        Opcode logger only. Maximum number of opcode steps to capture. Zero
        means no limit. When the limit is reached, execution continues but no
        further StructLog entries are recorded. Ignored when tracer is set.
        Default: 0 (unlimited).
      type: integer
      minimum: 0
```

So the unit is opcode **steps**, not bytes; zero is unlimited; and execution keeps running, only recording stops — `gas`, `failed` and `returnValue` still describe the complete run. *"Ignored when tracer is set"* already holds: with a named tracer, `AssembleTracer` takes the `tracers.New(...)` branch and never builds a `JsonStreamLogger`.

## Tests

**`TestJsonStreamLogger_Limit`** — 5 opcode steps in every case, `limit` = 0 / 1 / 2 / 5 / 8 expecting 5 / 1 / 2 / 5 / 5 entries. The last two are boundary controls against a fix that truncates too eagerly. Also asserts the `pc` of each survivor, so truncation is verified to drop the tail. Written first and verified red against unmodified `json_stream.go` — the `limit` 1 and 2 cases returned all 5 entries.

**`TestJsonStreamLogger_LimitDoesNotCorruptJSON`** — `json.Valid` over the whole response, 4 steps with `limit: 1`. A regression guard for the ordering constraint above; green both before and after the fix, since with no suppression a dangling separator cannot occur.

Both were then checked against four injected mutations — off-by-one in the comparison, missing increment, guard moved after the separator write, constant `pc` — each of which is caught.