### PR TITLE
execution/stagedsync: rename BAL fold-ahead to compute-ahead

### DIFF
--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -2634,82 +2634,84 @@ func TestUpdateForkChoiceShallowReorgAfterLargeBatchExec(t *testing.T) {
 	}))
 }
 
-// TestBALDrivenFoldAheadChangesetIntegrity guards against the fold misrouting a
-// block's commitment branch deltas into the wrong block's changeset. The BAL
-// fold computes a pre-window block ahead of its blockResult; if it recorded its
-// deferred branch writes into a later window block's changeset (instead of
-// isolated), that window block's saved diffset would gain entries it must not
-// have, and a later unwind would restore a wrong trie root.
+// TestBALDrivenComputeAheadChangesetIntegrity guards against compute-ahead
+// misrouting a block's commitment branch deltas into the wrong block's changeset.
+// BAL-driven compute-ahead computes a pre-window block ahead of its blockResult;
+// if it recorded its deferred branch writes into a later window block's changeset
+// (instead of isolated), that window block's saved diffset would gain entries it
+// must not have, and a later unwind would restore a wrong trie root.
 //
 // The batch uses a mid-batch changeset window (MaxReorgDepth places windowStart
-// inside the batch) so early blocks fold ahead (pre-window, isolated) while the
+// inside the batch) so early blocks compute ahead (pre-window, isolated) while the
 // later window blocks keep per-block changesets. The check is differential and
 // per-key: the window blocks' CommitmentDomain diffsets must be byte-identical
-// whether the earlier blocks were folded (fold-on) or computed incrementally
-// (fold-off). A leak would show up as extra/changed entries under fold-on — the
-// vacuous NotEmpty check the previous version used could not see that. It also
-// asserts the fold path actually engaged (a real fold count) so a silent
-// degrade-to-incremental can't make the differential pass trivially.
+// whether the earlier blocks were computed ahead (compute-ahead-on) or computed
+// incrementally (compute-ahead-off). A leak would show up as extra/changed entries
+// under compute-ahead-on — the vacuous NotEmpty check the previous version used
+// could not see that. It also asserts the compute-ahead path actually engaged (a
+// real count) so a silent degrade-to-incremental can't make the differential pass
+// trivially.
 //
 // (An end-to-end divergent-fork reorg would be a stronger check, but blockgen
 // randomises ParentBeaconBlockRoot per block, so under Amsterdam — required for
 // BALs — two chains can't share a prefix and a mid-chain parent has no state.)
-func TestBALDrivenFoldAheadChangesetIntegrity(t *testing.T) {
-	off := runBALFoldAheadChangeset(t, false, false)
-	on := runBALFoldAheadChangeset(t, true, false)
+func TestBALDrivenComputeAheadChangesetIntegrity(t *testing.T) {
+	off := runBALComputeAheadChangeset(t, false, false)
+	on := runBALComputeAheadChangeset(t, true, false)
 
-	require.Zero(t, off.folds, "fold-off must not fold any block")
-	require.Positive(t, on.folds, "fold-on must actually fold the pre-window blocks (else the differential is vacuous)")
+	require.Zero(t, off.computedAhead, "compute-ahead-off must not compute any block ahead")
+	require.Positive(t, on.computedAhead, "compute-ahead-on must actually compute the pre-window blocks ahead (else the differential is vacuous)")
 	// Compare the SET OF KEYS each window block's commitment changeset touched,
-	// not the raw diff bytes: per-block folds and a merged batch transition
+	// not the raw diff bytes: per-block compute-ahead and a merged batch transition
 	// legitimately encode the same branches differently (step references), so
 	// byte-equality is too strict. But the set of branches a window block's own
-	// compute touches is fixed by the post-pre-window trie shape — a fold that
-	// leaked a pre-window block's deltas into a window block's changeset would
-	// add keys that block never touched, so the key sets must match.
+	// compute touches is fixed by the post-pre-window trie shape — misrouting
+	// a pre-window block's deltas into a window block's changeset would add
+	// keys that block never touched, so the key sets must match.
 	require.Equal(t, off.windowCommitmentKeys, on.windowCommitmentKeys,
 		"a window block's commitment-changeset key set differs between incremental and "+
-			"fold-ahead — the fold misrouted a pre-window block's branch deltas into a "+
+			"compute-ahead — a pre-window block's branch deltas were misrouted into a "+
 			"window block's changeset")
 }
 
 // TestBALShadowCompute_MatchesIncremental exercises BAL_SHADOW_COMPUTE's success
-// path end-to-end: with fold-ahead AND shadow cross-check on, every folded block
-// is recomputed incrementally and the two roots must agree. runBALFoldAheadChangeset
-// asserts the batch validates cleanly, so a shadow mismatch would fail the block
-// with ErrWrongTrieRoot; a clean run with folds>0 proves the match path ran.
+// path end-to-end: with compute-ahead AND shadow cross-check on, every block
+// computed ahead is recomputed incrementally and the two roots must agree.
+// runBALComputeAheadChangeset asserts the batch validates cleanly, so a shadow
+// mismatch would fail the block with ErrWrongTrieRoot; a clean run with
+// computedAhead>0 proves the match path ran.
 func TestBALShadowCompute_MatchesIncremental(t *testing.T) {
-	res := runBALFoldAheadChangeset(t, true, true)
-	require.Positive(t, res.folds, "the fold must have run so shadow cross-check exercised the match path")
+	res := runBALComputeAheadChangeset(t, true, true)
+	require.Positive(t, res.computedAhead, "compute-ahead must have run so shadow cross-check exercised the match path")
 }
 
-type balFoldResult struct {
+type balComputeAheadResult struct {
 	// windowCommitmentKeys maps each window block number to the sorted set of
 	// CommitmentDomain changeset keys (branch prefixes) it touched — compared
-	// across modes to catch a fold misrouting deltas into the wrong block.
+	// across modes to catch compute-ahead misrouting deltas into the wrong block.
 	windowCommitmentKeys map[uint64][]string
-	folds                int64
+	computedAhead        int64
 }
 
-func runBALFoldAheadChangeset(t *testing.T, foldAhead, shadow bool) balFoldResult {
+func runBALComputeAheadChangeset(t *testing.T, computeAhead, shadow bool) balComputeAheadResult {
 	defer func(prev bool) { dbg.BALDrivenCommitment = prev }(dbg.BALDrivenCommitment)
 	defer func(prev bool) { dbg.IgnoreBAL = prev }(dbg.IgnoreBAL)
 	defer func(prev bool) { dbg.BALShadowCompute = prev }(dbg.BALShadowCompute)
-	dbg.BALDrivenCommitment = foldAhead
+	dbg.BALDrivenCommitment = computeAhead
 	dbg.IgnoreBAL = false
 	dbg.BALShadowCompute = shadow
-	stagedsync.ResetFoldsAheadForTest()
+	stagedsync.ResetComputedAheadForTest()
 
 	const chainLen = 12
 	// maxReorgDepth places the changeset window at maxBlock-depth = 12-4 = 8, so
-	// blocks 1..7 are pre-window (fold candidates) and 8..12 own changesets.
+	// blocks 1..7 are pre-window (compute-ahead candidates) and 8..12 own changesets.
 	const maxReorgDepth = 4
 	const windowStart = chainLen - maxReorgDepth
 
 	ctx := t.Context()
-	// Deterministic key: fold-off and fold-on must execute the identical chain
+	// Deterministic key: compute-ahead-off and compute-ahead-on must execute the identical chain
 	// (same sender → same trie branches) so the only difference between the two
-	// runs is fold-ahead vs incremental. A random key would give each run a
+	// runs is compute-ahead vs incremental. A random key would give each run a
 	// different address and thus different branch keys, making the cross-mode
 	// changeset comparison meaningless (and flaky).
 	privKey, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
@@ -2745,22 +2747,22 @@ func runBALFoldAheadChangeset(t *testing.T, foldAhead, shadow bool) balFoldResul
 	fcuRes, err := updateForkChoice(ctx, m.ExecModule, canonical.TopBlock.Header())
 	require.NoError(t, err)
 	require.Equal(t, execmodule.ExecutionStatusSuccess, fcuRes.Status,
-		"batch with fold-ahead=%v must execute cleanly; validationError=%q", foldAhead, fcuRes.ValidationError)
+		"batch with compute-ahead=%v must execute cleanly; validationError=%q", computeAhead, fcuRes.ValidationError)
 
 	m.ExecModule.WaitIdle(ctx)
 
-	res := balFoldResult{
+	res := balComputeAheadResult{
 		windowCommitmentKeys: map[uint64][]string{},
-		folds:                stagedsync.FoldsAheadPerformedForTest(),
+		computedAhead:        stagedsync.ComputedAheadCountForTest(),
 	}
 	require.NoError(t, m.DB.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
 		// Confirm blocks carry BALs (checked on the tip, which is inside the
 		// window and so not pruned — pre-window BAL sidecars are pruned beyond
-		// MaxReorgDepth, but the fold reads them in-memory during execution, and
-		// on.folds asserts the fold path actually engaged).
+		// MaxReorgDepth, but compute-ahead reads them in-memory during execution,
+		// and on.computedAhead asserts the compute-ahead path actually engaged).
 		balBytes, err := rawdb.ReadBlockAccessListBytes(tx, canonical.TopBlock.Hash(), canonical.TopBlock.NumberU64())
 		require.NoError(t, err)
-		require.NotEmpty(t, balBytes, "blocks must carry a BAL so BAL-driven fold-ahead actually engages")
+		require.NotEmpty(t, balBytes, "blocks must carry a BAL so BAL-driven compute-ahead actually engages")
 
 		// Window blocks own per-block changesets; capture their CommitmentDomain
 		// deltas for the cross-mode differential.
@@ -2772,8 +2774,8 @@ func runBALFoldAheadChangeset(t *testing.T, foldAhead, shadow bool) balFoldResul
 			require.NoError(t, err)
 			require.Truef(t, ok, "window block %d must have a saved diffset", blk.NumberU64())
 			require.NotEmptyf(t, diffs[kv.CommitmentDomain],
-				"window block %d changeset is missing CommitmentDomain deltas (fold-ahead=%v)",
-				blk.NumberU64(), foldAhead)
+				"window block %d changeset is missing CommitmentDomain deltas (compute-ahead=%v)",
+				blk.NumberU64(), computeAhead)
 			keys := make([]string, 0, len(diffs[kv.CommitmentDomain]))
 			for _, d := range diffs[kv.CommitmentDomain] {
 				keys = append(keys, d.Key)
@@ -2785,8 +2787,8 @@ func runBALFoldAheadChangeset(t *testing.T, foldAhead, shadow bool) balFoldResul
 	}))
 
 	// End-to-end: FCU back into the window unwinds using those changesets, then
-	// FCU forward re-executes. If the fold-built state were wrong, the unwind
-	// restores a bad root and the forward re-exec fails.
+	// FCU forward re-executes. If the compute-ahead-built state were wrong, the
+	// unwind restores a bad root and the forward re-exec fails.
 	const reorgBackTo = chainLen - 2 // within the window (>= windowStart)
 	back, err := updateForkChoice(ctx, m.ExecModule, canonical.Blocks[reorgBackTo-1].Header())
 	require.NoError(t, err)
@@ -2802,8 +2804,8 @@ func runBALFoldAheadChangeset(t *testing.T, foldAhead, shadow bool) balFoldResul
 	fwd, err := updateForkChoice(ctx, m.ExecModule, canonical.TopBlock.Header())
 	require.NoError(t, err)
 	require.Equal(t, execmodule.ExecutionStatusSuccess, fwd.Status,
-		"forward re-exec after unwind must reach the correct root (fold-ahead=%v); validationError=%q",
-		foldAhead, fwd.ValidationError)
+		"forward re-exec after unwind must reach the correct root (compute-ahead=%v); validationError=%q",
+		computeAhead, fwd.ValidationError)
 	m.ExecModule.WaitIdle(ctx)
 	require.NoError(t, m.DB.ViewTemporal(ctx, func(tx kv.TemporalTx) error {
 		execProg, err := stages.GetStageProgress(tx, stages.Execution)

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -44,15 +44,15 @@ type pendingBlock struct {
 	mode calcMode
 }
 
-// foldsAheadPerformed counts BAL fold-ahead computations across all calculators;
-// only tests read it (to assert the fold path actually engaged rather than
+// computedAheadCount counts BAL compute-ahead computations across all calculators;
+// only tests read it (to assert compute-ahead actually engaged rather than
 // silently degrading to incremental).
-var foldsAheadPerformed atomic.Int64
+var computedAheadCount atomic.Int64
 
-// FoldsAheadPerformedForTest reports the number of BAL fold-ahead computations
-// performed so far; ResetFoldsAheadForTest zeroes it. Test-only observability.
-func FoldsAheadPerformedForTest() int64 { return foldsAheadPerformed.Load() }
-func ResetFoldsAheadForTest()           { foldsAheadPerformed.Store(0) }
+// ComputedAheadCountForTest reports the number of BAL compute-ahead computations
+// performed so far; ResetComputedAheadForTest zeroes it. Test-only observability.
+func ComputedAheadCountForTest() int64 { return computedAheadCount.Load() }
+func ResetComputedAheadForTest()       { computedAheadCount.Store(0) }
 
 // commitmentCalculator receives the same txResult/blockResult stream as the
 // apply loop (via a fan-out channel). For each txResult it accumulates key
@@ -132,34 +132,35 @@ type commitmentCalculator struct {
 
 	// firstBlockNum is the block number of the first blockRequest this
 	// calculator sees — the batch's first block, whose baseline is already
-	// committed by the prior cycle, so its BAL fold gate is open at once.
+	// committed by the prior cycle, so its compute-ahead gate is open at once.
 	firstBlockNum uint64
 	hasFirstBlock bool
 
 	// lastBlockResultSeen is the highest block whose blockResult has arrived
-	// on `in`. The BAL fold gate for block N is lastBlockResultSeen >= N-1:
+	// on `in`. The compute-ahead gate for block N is lastBlockResultSeen >= N-1:
 	// block N-1's state must be flushed to sd.mem (blockResult signals it)
 	// before N's baseline reads.
 	lastBlockResultSeen uint64
 	hasSeenBlockResult  bool
 
-	// foldedAhead marks blocks already computed by foldBlockFromBAL, so the
+	// computedAhead marks blocks already computed by computeBlockFromBAL, so the
 	// later blockResult(N) does not recompute them. balRoots holds each
 	// BAL-driven root for the shadow-mode cross-check.
-	foldedAhead map[uint64]bool
-	balRoots    map[uint64][]byte
+	computedAhead map[uint64]bool
+	balRoots      map[uint64][]byte
 
-	// lastFoldedBlock is the highest block folded so far. A fold reads the
-	// commitment domain for its baseline, so it may only run when the
-	// preceding block advanced the domain — i.e. was itself folded (or is the
-	// batch's first block, whose baseline the prior cycle committed). This
-	// stops a fold from reading a stale trie across a block whose BAL sidecar
-	// was missing (eth/71 backfill is best-effort) and so never advanced it.
-	lastFoldedBlock uint64
-	hasFolded       bool
+	// lastComputedAheadBlock is the highest block computed ahead so far. Computing
+	// ahead reads the commitment domain for its baseline, so it may only run when
+	// the preceding block advanced the domain — i.e. was itself computed ahead
+	// (or is the batch's first block, whose baseline the prior cycle committed).
+	// This stops compute-ahead from reading a stale trie across a block whose
+	// BAL sidecar was missing (eth/71 backfill is best-effort) and so never
+	// advanced it.
+	lastComputedAheadBlock uint64
+	hasComputedAhead       bool
 
 	// signalCtx is the shared executor context carrying the stopCause. The
-	// calculator reads it (never its own compute ctx) to cap fold-ahead at the
+	// calculator reads it (never its own compute ctx) to cap compute-ahead at the
 	// batch's coalesce block M — compute/publish run on the separate uncancelled
 	// workCtx so a clean-stop cancel never aborts an in-flight commitment.
 	signalCtx context.Context
@@ -244,7 +245,7 @@ func newCommitmentCalculator(
 		blockRequests:        blockRequests,
 		out:                  out,
 		pending:              map[uint64]*pendingBlock{},
-		foldedAhead:          map[uint64]bool{},
+		computedAhead:        map[uint64]bool{},
 		balRoots:             map[uint64][]byte{},
 		forcePerBlockCompute: forcePerBlockCompute,
 		perBlockFrom:         perBlockFrom,
@@ -278,8 +279,8 @@ func (cc *commitmentCalculator) loop(ctx context.Context) {
 	// Context cancellation is handled by the exec loop which closes
 	// cc.in after stopping.
 	//
-	// blockRequests is multiplexed but not a gate: it is only a fold-ahead
-	// heads-up, and draining leftovers after cc.in closes would re-fold
+	// blockRequests is multiplexed but not a gate: it is only a compute-ahead
+	// heads-up, and draining leftovers after cc.in closes would recompute
 	// already-finalized blocks. It is set to nil once closed.
 	in, reqs := cc.in, cc.blockRequests
 	for in != nil {
@@ -339,16 +340,16 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 			cc.state.ApplyWrites(r.writes, r.rules.IsAmsterdam)
 		}
 
-		// A folded-ahead block already emitted its interior step checkpoints from
-		// the BAL (foldStepCheckpoints), computed while the domain sat exactly at
+		// A computed-ahead block already emitted its interior step checkpoints from
+		// the BAL (checkpointStepsFromBAL), computed while the domain sat exactly at
 		// each edge. Re-checkpointing here from the partially-accumulated cc.state
 		// on an already-advanced domain would let the last writer win and leave the
 		// step's commitment .kv inconsistent — so the incremental path is normally
 		// the sole checkpointer for a block. The in/reqs select has no cross-channel
-		// priority, so a late-consumed blockRequest can leave foldedAhead[n] unset
+		// priority, so a late-consumed blockRequest can leave computedAhead[n] unset
 		// when this hook fires and let both paths checkpoint the same edge; that is
 		// benign — both emit identical values at the same txNum (idempotent).
-		if !cc.foldedAhead[r.blockNum] && cc.doms.IsUnfrozenStepEdge(cc.roTx, r.txNum) {
+		if !cc.computedAhead[r.blockNum] && cc.doms.IsUnfrozenStepEdge(cc.roTx, r.txNum) {
 			cc.computeStepBoundary(ctx, &blockResult{BlockNum: r.blockNum, BlockHash: r.blockHash, lastTxNum: r.txNum})
 		}
 
@@ -370,8 +371,8 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 			return
 		}
 
-		// Track the latest block boundary. lastBlockResultSeen opens the BAL
-		// fold gate for the next block (its baseline is now in sd.mem).
+		// Track the latest block boundary. lastBlockResultSeen opens the
+		// compute-ahead gate for the next block (its baseline is now in sd.mem).
 		cc.lastBlockResult = r
 		cc.lastBlockResultSeen = r.BlockNum
 		cc.hasSeenBlockResult = true
@@ -385,8 +386,8 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		// (reorg support, KeepExecutionProofs). Blocks from the changeset
 		// window (perBlockFrom) onward compute per-block for the same reason.
 		switch {
-		case cc.foldedAhead[r.BlockNum]:
-			// Folded ahead from its BAL (pre-window: computeIsolated already
+		case cc.computedAhead[r.BlockNum]:
+			// Computed ahead from its BAL (pre-window: computeIsolated already
 			// advanced the domain and flushed its deferred update under a nil
 			// accumulator, so nothing leaks into a later block's changeset). In
 			// shadow mode, recompute incrementally and cross-check the roots;
@@ -425,11 +426,11 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		// accumulate — compute only on explicit commitComputeRequest from
 		// the apply loop.
 
-		// Block N is done; its boundary opens the fold gate for N+1.
+		// Block N is done; its boundary opens the compute-ahead gate for N+1.
 		delete(cc.pending, r.BlockNum)
-		delete(cc.foldedAhead, r.BlockNum)
+		delete(cc.computedAhead, r.BlockNum)
 		delete(cc.balRoots, r.BlockNum)
-		cc.maybeFoldAhead(ctx, r.BlockNum+1)
+		cc.maybeComputeAhead(ctx, r.BlockNum+1)
 
 	case *commitComputeRequest:
 		// Explicit compute signal from the apply loop at batch boundary.
@@ -444,22 +445,22 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 
 // handleBlockRequest records the per-block mode from a blockRequest —
 // BAL-driven when the block carries a BAL, BAL I/O is enabled and
-// BALDrivenCommitment is set, else incremental — then tries to fold the
-// block ahead of its result stream (maybeFoldAhead).
+// BALDrivenCommitment is set, else incremental — then tries to compute the
+// block ahead of its result stream (maybeComputeAhead).
 func (cc *commitmentCalculator) handleBlockRequest(ctx context.Context, req *blockRequest) {
 	// Record the batch's first block before the drop-guard: if blockResult(n) is
 	// consumed before blockRequest(n) (the in/reqs select has no cross-channel
 	// ordering), a dropped first request must still set firstBlockNum to n rather
-	// than leave n+1 to claim it — else foldGateOpen and the contiguity guard are
-	// both bypassed via n == firstBlockNum and n+1 folds on a baseline missing n.
+	// than leave n+1 to claim it — else computeAheadGateOpen and the contiguity guard
+	// are both bypassed via n == firstBlockNum and n+1 computes ahead on a baseline missing n.
 	if !cc.hasFirstBlock {
 		cc.firstBlockNum = req.blockNum
 		cc.hasFirstBlock = true
 	}
 	// Drop a request whose block result was already processed: re-inserting
-	// pending[n] would let a late fold read a trie that has since advanced (batch
-	// boundary, step checkpoint, per-block compute), poisoning a valid block, and
-	// would leak pending/foldedAhead/balRoots (retaining the decoded BAL).
+	// pending[n] would let a late compute-ahead read a trie that has since advanced
+	// (batch boundary, step checkpoint, per-block compute), poisoning a valid block,
+	// and would leak pending/computedAhead/balRoots (retaining the decoded BAL).
 	if cc.hasSeenBlockResult && req.blockNum <= cc.lastBlockResultSeen {
 		return
 	}
@@ -468,41 +469,44 @@ func (cc *commitmentCalculator) handleBlockRequest(ctx context.Context, req *blo
 		mode = calcModeBALDriven
 	}
 	cc.pending[req.blockNum] = &pendingBlock{req: req, mode: mode}
-	cc.maybeFoldAhead(ctx, req.blockNum)
+	cc.maybeComputeAhead(ctx, req.blockNum)
 }
 
-// foldGateOpen reports whether block n's BAL fold can run: block n-1's
-// committed state must be in sd.mem. blockResult(n-1) signals that; the
-// batch's first block has it already from the prior cycle.
-func (cc *commitmentCalculator) foldGateOpen(n uint64) bool {
+// computeAheadGateOpen reports whether block n's BAL compute-ahead can run:
+// block n-1's committed state must be in sd.mem. blockResult(n-1) signals
+// that; the batch's first block has it already from the prior cycle.
+func (cc *commitmentCalculator) computeAheadGateOpen(n uint64) bool {
 	if cc.hasFirstBlock && n == cc.firstBlockNum {
 		return true
 	}
 	return cc.hasSeenBlockResult && cc.lastBlockResultSeen+1 >= n
 }
 
-// maybeFoldAhead folds block n from its BAL when it is BAL-driven, the fold
-// gate is open, and folding it is safe. Folding overlaps the execution of
-// block n — the parallel-commitment win. Idempotent (foldedAhead guard).
+// maybeComputeAhead computes block n from its BAL when it is BAL-driven, the
+// compute-ahead gate is open, and computing it ahead is safe. This overlaps
+// with the execution of block n — the parallel-commitment win. Idempotent
+// (computedAhead guard).
 //
 // Two safety restrictions, both preserving the well-tested incremental path:
-//   - Only pre-window blocks (!ownsChangeset) fold. A block that owns a
-//     changeset computes incrementally at its own boundary so its per-block
-//     branch deltas are captured; folding it ahead would race the exec loop's
-//     changeset-accumulator install. Pre-window folds run under computeIsolated
-//     (nil accumulator), so nothing leaks into a later window block's changeset.
-//   - Fold only contiguously from the batch's first block: n's baseline is read
-//     from the commitment domain, which only a prior fold (or the prior cycle,
-//     for the first block) advanced. A missing-BAL block accumulates without
-//     advancing the domain, so folding across it would read a stale trie.
-func (cc *commitmentCalculator) maybeFoldAhead(ctx context.Context, n uint64) {
+//   - Only pre-window blocks (!ownsChangeset) compute ahead. A block that owns
+//     a changeset computes incrementally at its own boundary so its per-block
+//     branch deltas are captured; computing it ahead would race the exec loop's
+//     changeset-accumulator install. Pre-window compute-aheads run under
+//     computeIsolated (nil accumulator), so nothing leaks into a later window
+//     block's changeset.
+//   - Compute ahead only contiguously from the batch's first block: n's
+//     baseline is read from the commitment domain, which only a prior
+//     compute-ahead (or the prior cycle, for the first block) advanced. A
+//     missing-BAL block accumulates without advancing the domain, so computing
+//     ahead across it would read a stale trie.
+func (cc *commitmentCalculator) maybeComputeAhead(ctx context.Context, n uint64) {
 	pb, ok := cc.pending[n]
-	if !ok || pb.mode != calcModeBALDriven || cc.foldedAhead[n] {
+	if !ok || pb.mode != calcModeBALDriven || cc.computedAhead[n] {
 		return
 	}
-	// Batch cut: the shared executor context carries the coalesce block M. Fold
-	// no further than M so commitment cannot outrun the state exec will stop at
-	// (an orphan → wrong root on restart). Read the signal context, never the
+	// Batch cut: the shared executor context carries the coalesce block M. Compute
+	// ahead no further than M so commitment cannot outrun the state exec will stop
+	// at (an orphan → wrong root on restart). Read the signal context, never the
 	// compute ctx — compute must still finish blocks up to M.
 	if sc, stopping := stopCauseOf(cc.signalCtx); stopping && n > sc.block {
 		return
@@ -510,21 +514,21 @@ func (cc *commitmentCalculator) maybeFoldAhead(ctx context.Context, n uint64) {
 	if cc.ownsChangeset(n) {
 		return
 	}
-	if !cc.foldGateOpen(n) {
+	if !cc.computeAheadGateOpen(n) {
 		return
 	}
-	if n != cc.firstBlockNum && !(cc.hasFolded && cc.lastFoldedBlock == n-1) {
+	if n != cc.firstBlockNum && !(cc.hasComputedAhead && cc.lastComputedAheadBlock == n-1) {
 		return
 	}
-	cc.foldBlockFromBAL(ctx, pb)
+	cc.computeBlockFromBAL(ctx, pb)
 }
 
-// foldBlockFromBAL computes block pb's commitment from its BAL, ahead of the
+// computeBlockFromBAL computes block pb's commitment from its BAL, ahead of the
 // per-tx result stream. The root is verified against the block header's
 // stateRoot — a mismatch fails the block. The fresh calcState is used because
 // a BAL-driven block's changed-key set comes wholly from the BAL, never from
 // the cross-block incremental accumulator.
-func (cc *commitmentCalculator) foldBlockFromBAL(ctx context.Context, pb *pendingBlock) {
+func (cc *commitmentCalculator) computeBlockFromBAL(ctx context.Context, pb *pendingBlock) {
 	req := pb.req
 	br := &blockResult{
 		BlockNum:  req.blockNum,
@@ -534,20 +538,20 @@ func (cc *commitmentCalculator) foldBlockFromBAL(ctx context.Context, pb *pendin
 	}
 	// EIP-161 empty-removal inputs, matching Normalize on the exec path.
 	// IsEIP161Enabled (not IsSpuriousDragon) so a chain with EIP-161 in disabledEIPs
-	// keeps empty leaves in the fold exactly as exec does.
+	// keeps empty leaves in the compute-ahead exactly as exec does.
 	emptyRemoval := req.blockNum != 0 && cc.chainConfig.IsEIP161Enabled(req.blockNum)
 	eip8246 := cc.chainConfig.IsAmsterdam(req.blockTime)
 	// A block straddling an unfrozen step edge must leave a commitment checkpoint
 	// at that edge (else the step's commitment .kv lags its account/storage .kv).
-	// The per-tx BAL lets the fold checkpoint mid-block, so a straddling block
-	// stays on the fold path instead of dropping to the incremental one.
-	if err := cc.foldStepCheckpoints(ctx, req, emptyRemoval, eip8246); err != nil {
+	// The per-tx BAL lets compute-ahead checkpoint mid-block, so a straddling
+	// block stays on the compute-ahead path instead of dropping to the incremental one.
+	if err := cc.checkpointStepsFromBAL(ctx, req, emptyRemoval, eip8246); err != nil {
 		cc.fail(ctx, br, err)
 		return
 	}
-	rh, err := cc.foldBALToRoot(ctx, req, math.MaxUint32, emptyRemoval, eip8246, targetOf(br))
+	rh, err := cc.computeRootFromBAL(ctx, req, math.MaxUint32, emptyRemoval, eip8246, targetOf(br))
 	if err != nil {
-		cc.fail(ctx, br, fmt.Errorf("BAL-driven fold block %d: %w", req.blockNum, err))
+		cc.fail(ctx, br, fmt.Errorf("BAL-driven compute-ahead block %d: %w", req.blockNum, err))
 		return
 	}
 	if !bytes.Equal(rh, req.stateRoot[:]) {
@@ -555,11 +559,11 @@ func (cc *commitmentCalculator) foldBlockFromBAL(ctx context.Context, pb *pendin
 			ErrWrongTrieRoot, req.blockNum, rh, req.stateRoot))
 		return
 	}
-	cc.foldedAhead[req.blockNum] = true
+	cc.computedAhead[req.blockNum] = true
 	cc.balRoots[req.blockNum] = rh
-	cc.lastFoldedBlock = req.blockNum
-	cc.hasFolded = true
-	foldsAheadPerformed.Add(1)
+	cc.lastComputedAheadBlock = req.blockNum
+	cc.hasComputedAhead = true
+	computedAheadCount.Add(1)
 	cc.lastComputedBlock = req.blockNum
 	cc.hasComputed = true
 	// Shadow mode defers publish to the incremental cross-check at
@@ -569,16 +573,16 @@ func (cc *commitmentCalculator) foldBlockFromBAL(ctx context.Context, pb *pendin
 	}
 }
 
-// foldStepCheckpoints emits a commitment checkpoint at each unfrozen step edge
-// interior to the block (edge < block-end txNum), folding the per-tx BAL up to
+// checkpointStepsFromBAL emits a commitment checkpoint at each unfrozen step edge
+// interior to the block (edge < block-end txNum), applying the per-tx BAL up to
 // that edge. Without it a block straddling a step edge would leave the step's
 // commitment .kv lagging its account/storage .kv. The BAL index of a txNum is
 // txNum-firstTxNum (blockAccessIndex == TxIndex+1 and txNum == firstTxNum+
-// TxIndex+1), so folding changes at index ≤ edge-firstTxNum is the state as of
+// TxIndex+1), so applying changes at index ≤ edge-firstTxNum is the state as of
 // the edge. computeRootFromUpdates saves the checkpoint (ComputeCommitmentLocked
 // with saveStateAfter); the returned root is discarded — there is no header to
-// verify mid-block. Runs before the block-end fold so that builds on it.
-func (cc *commitmentCalculator) foldStepCheckpoints(ctx context.Context, req *blockRequest, emptyRemoval bool, eip8246 bool) error {
+// verify mid-block. Runs before the block-end compute so that builds on it.
+func (cc *commitmentCalculator) checkpointStepsFromBAL(ctx context.Context, req *blockRequest, emptyRemoval bool, eip8246 bool) error {
 	ss := cc.doms.StepSize()
 	if ss == 0 {
 		return nil
@@ -588,17 +592,17 @@ func (cc *commitmentCalculator) foldStepCheckpoints(ctx context.Context, req *bl
 			continue
 		}
 		stepBr := &blockResult{BlockNum: req.blockNum, BlockHash: req.blockHash, lastTxNum: edge}
-		if _, err := cc.foldBALToRoot(ctx, req, uint32(edge-req.firstTxNum), emptyRemoval, eip8246, targetOf(stepBr)); err != nil {
+		if _, err := cc.computeRootFromBAL(ctx, req, uint32(edge-req.firstTxNum), emptyRemoval, eip8246, targetOf(stepBr)); err != nil {
 			return fmt.Errorf("BAL-driven step-checkpoint at txNum %d: %w", edge, err)
 		}
 	}
 	return nil
 }
 
-// foldBALToRoot builds a calcState from the BAL restricted to maxTxIndex,
+// computeRootFromBAL builds a calcState from the BAL restricted to maxTxIndex,
 // flushes it to a fresh updates buffer, and computes the root at t. Shared by
-// the block-end fold and the mid-block step checkpoints so the two can't drift.
-func (cc *commitmentCalculator) foldBALToRoot(ctx context.Context, req *blockRequest, maxTxIndex uint32, emptyRemoval bool, eip8246 bool, t commitTarget) ([]byte, error) {
+// the block-end compute-ahead and the mid-block step checkpoints so the two can't drift.
+func (cc *commitmentCalculator) computeRootFromBAL(ctx context.Context, req *blockRequest, maxTxIndex uint32, emptyRemoval bool, eip8246 bool, t commitTarget) ([]byte, error) {
 	reader := &asOfStateReader{sd: cc.doms, roTx: cc.roTx, txNum: t.lastTxNum + 1}
 	balState := newCalcState(reader, cc.logger, cc.logPrefix)
 	balState.LoadFromBALUpTo(req.bal, maxTxIndex, emptyRemoval, cc.chainConfig.Aura != nil, eip8246)
@@ -607,7 +611,7 @@ func (cc *commitmentCalculator) foldBALToRoot(ctx context.Context, req *blockReq
 	}
 	balUpdates := cc.updates.NewEmpty()
 	// Match the calculator's constructor: only ModeDirect needs upgrading to
-	// ModeUpdate to carry the fold's BAL-sourced values; ModeParallel already
+	// ModeUpdate to carry compute-ahead's BAL-sourced values; ModeParallel already
 	// carries them (and ParallelPatriciaHashed rejects any other mode).
 	if balUpdates.Mode() != commitment.ModeParallel {
 		balUpdates.SetMode(commitment.ModeUpdate)
@@ -620,8 +624,8 @@ func (cc *commitmentCalculator) foldBALToRoot(ctx context.Context, req *blockReq
 // commitment context and computes the root, routed by ownsChangeset exactly
 // like compute(): a pre-window block computes isolated (nil accumulator,
 // flushing its own deferred update) so its branch deltas never pend into a
-// later window block's changeset. Used by the BAL fold, which supplies its
-// own balState-derived updates rather than cc.state.
+// later window block's changeset. Used by BAL compute-ahead, which supplies
+// its own balState-derived updates rather than cc.state.
 func (cc *commitmentCalculator) computeRootFromUpdates(ctx context.Context, t commitTarget, updates *commitment.Updates, reader *asOfStateReader) ([]byte, error) {
 	sdCtx := cc.doms.GetCommitmentContext()
 	sdCtx.SetUpdates(updates)
@@ -634,7 +638,7 @@ func (cc *commitmentCalculator) computeRootFromUpdates(ctx context.Context, t co
 }
 
 // shadowCrossCheck recomputes block N the incremental way and asserts the
-// root matches the BAL-driven root folded ahead by foldBlockFromBAL — the
+// root matches the BAL-driven root computed ahead by computeBlockFromBAL — the
 // dual-compute consistency net. Divergence fails the block. Publishes the
 // incremental root (the proven oracle). BALShadowCompute only.
 func (cc *commitmentCalculator) shadowCrossCheck(ctx context.Context, r *blockResult) {
@@ -662,7 +666,7 @@ func (cc *commitmentCalculator) shadowCrossCheck(ctx context.Context, r *blockRe
 
 // fail publishes a calculator error. It does NOT cancel execution: the apply
 // loop is the sole cancellation authority — it classifies the published error
-// (deferring a fold-ahead wrong-root until the block's own exec verdict) and
+// (deferring a compute-ahead wrong-root until the block's own exec verdict) and
 // drives the single UnwindTo.
 func (cc *commitmentCalculator) fail(ctx context.Context, br *blockResult, err error) {
 	if cc.logger != nil {

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -564,13 +564,13 @@ func setupStepTest(t *testing.T) (kv.TemporalRwDB, kv.TemporalRwTx, *execctx.Sha
 	return db, tx, doms
 }
 
-// TestFold_StepBoundaryCheckpointMidBlock pins the batch-end-in-BAL behaviour:
-// a BAL-driven fold of a block straddling an unfrozen step edge must leave a
-// commitment checkpoint at that edge (as of the edge txNum), so the step's
-// commitment .kv stays consistent with its account/storage .kv — the same
-// invariant the incremental path holds, now met by the fold itself rather than
-// by dropping the block to the incremental path.
-func TestFold_StepBoundaryCheckpointMidBlock(t *testing.T) {
+// TestComputeAhead_StepBoundaryCheckpointMidBlock pins the batch-end-in-BAL
+// behaviour: computing ahead a block straddling an unfrozen step edge must
+// leave a commitment checkpoint at that edge (as of the edge txNum), so the
+// step's commitment .kv stays consistent with its account/storage .kv — the
+// same invariant the incremental path holds, now met by compute-ahead itself
+// rather than by dropping the block to the incremental path.
+func TestComputeAhead_StepBoundaryCheckpointMidBlock(t *testing.T) {
 	defer func(p bool) { dbg.BALDrivenCommitment = p }(dbg.BALDrivenCommitment)
 	defer func(p bool) { dbg.IgnoreBAL = p }(dbg.IgnoreBAL)
 	dbg.BALDrivenCommitment = true
@@ -589,8 +589,8 @@ func TestFold_StepBoundaryCheckpointMidBlock(t *testing.T) {
 	cc, err := newCommitmentCalculator(ctx, ctx, doms, db, &chain.Config{}, "test", logger, false, 1<<62, in, nil, out)
 	require.NoError(t, err)
 	defer cc.Stop()
-	// Make block 2 the batch's first block so the fold gate opens with no prior
-	// blockResult, and the fold runs synchronously from handleBlockRequest.
+	// Make block 2 the batch's first block so the compute-ahead gate opens with
+	// no prior blockResult, and compute-ahead runs synchronously from handleBlockRequest.
 	cc.hasFirstBlock = true
 	cc.firstBlockNum = 2
 
@@ -615,10 +615,10 @@ func TestFold_StepBoundaryCheckpointMidBlock(t *testing.T) {
 		})
 	}
 
-	// Drive the fold. The block-end stateRoot is a dummy: the step checkpoints are
-	// written before the block-end root check, so a mismatch there still exercises
-	// the mid-block checkpoint under test (we assert on the checkpoint, not on the
-	// fold verifying the block-end root).
+	// Drive compute-ahead. The block-end stateRoot is a dummy: the step checkpoints
+	// are written before the block-end root check, so a mismatch there still
+	// exercises the mid-block checkpoint under test (we assert on the checkpoint,
+	// not on compute-ahead verifying the block-end root).
 	cc.handleBlockRequest(ctx, &blockRequest{
 		blockNum:   2,
 		firstTxNum: firstTxNum,
@@ -630,22 +630,22 @@ func TestFold_StepBoundaryCheckpointMidBlock(t *testing.T) {
 	require.NoError(t, doms.Flush(ctx, tx))
 
 	// As of just past the edge, the latest commitment checkpoint must be the one
-	// the fold wrote at the step edge — not the pre-block-2 checkpoint. Without
-	// foldStepCheckpoints the fold would write only the block-end (txNum 20)
-	// checkpoint and this as-of read would miss the edge.
+	// compute-ahead wrote at the step edge — not the pre-block-2 checkpoint.
+	// Without checkpointStepsFromBAL, compute-ahead would write only the
+	// block-end (txNum 20) checkpoint and this as-of read would miss the edge.
 	blob, ok, err := doms.GetAsOf(kv.CommitmentDomain, commitmentdb.KeyCommitmentState, edgeTxNum+1)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.GreaterOrEqual(t, len(blob), 16)
 	gotTx, gotBlock := commitmentdb.DecodeTxBlockNums(blob)
-	require.Equal(t, edgeTxNum, gotTx, "fold must checkpoint commitment at the mid-block step edge (txNum 15)")
+	require.Equal(t, edgeTxNum, gotTx, "compute-ahead must checkpoint commitment at the mid-block step edge (txNum 15)")
 	require.Equal(t, uint64(2), gotBlock, "the checkpoint sits inside the straddling block 2")
 
 	requireBranchesConsistentWithAccounts(t, doms, tx, accountValues)
 }
 
 // feedBlock1Shadow builds a calculator, feeds block 1's n writes (seed 42) into
-// cc.state, marks the block folded-ahead with balRoots[1]=balRoot, then delivers
+// cc.state, marks the block computed-ahead with balRoots[1]=balRoot, then delivers
 // blockResult(1) with BAL_SHADOW_COMPUTE on so shadowCrossCheck recomputes the
 // incremental root and cross-checks it against balRoot. Returns the published result.
 func feedBlock1Shadow(t *testing.T, n uint64, balRoot []byte) commitmentResult {
@@ -669,7 +669,7 @@ func feedBlock1Shadow(t *testing.T, n uint64, balRoot []byte) commitmentResult {
 		addr := accounts.InternAddress([20]byte(addrBytes))
 		cc.handleMessage(ctx, &txResult{rules: &chain.Rules{}, blockNum: 1, txNum: txNum, writes: nonceBalanceWrites(addr, txNum, *uint256.NewInt(txNum * 1000))})
 	}
-	cc.foldedAhead[1] = true
+	cc.computedAhead[1] = true
 	cc.balRoots[1] = balRoot
 
 	cc.handleMessage(ctx, &blockResult{BlockNum: 1, BlockHash: common.Hash{0x01}, lastTxNum: n})
@@ -683,11 +683,11 @@ func feedBlock1Shadow(t *testing.T, n uint64, balRoot []byte) commitmentResult {
 	}
 }
 
-// TestShadowCrossCheck_Mismatch pins the safety path: a folded block whose
-// recorded balRoot disagrees with the incremental recompute must fail the block
-// with ErrWrongTrieRoot rather than publish silently.
+// TestShadowCrossCheck_Mismatch pins the safety path: a computed-ahead block
+// whose recorded balRoot disagrees with the incremental recompute must fail
+// the block with ErrWrongTrieRoot rather than publish silently.
 func TestShadowCrossCheck_Mismatch(t *testing.T) {
 	res := feedBlock1Shadow(t, 4, bytes.Repeat([]byte{0xEE}, 32))
-	require.Error(t, res.err, "a divergent folded root must fail the block")
+	require.Error(t, res.err, "a divergent computed-ahead root must fail the block")
 	require.ErrorIs(t, res.err, ErrWrongTrieRoot, "shadow mismatch must surface as ErrWrongTrieRoot")
 }

--- a/execution/stagedsync/committer_test.go
+++ b/execution/stagedsync/committer_test.go
@@ -199,7 +199,7 @@ func TestHandleMessage_TxResultPinsAsOfReaderTxNum(t *testing.T) {
 
 // TestHandleBlockRequest_EmptyBALFallsToIncremental pins the empty-BAL gate.
 // A genuine empty BAL (0xc0) decodes to a non-nil empty slice, so a nil check
-// alone selects BAL-driven mode and folds zero changes → parent root →
+// alone selects BAL-driven mode and computes zero changes → parent root →
 // spurious wrong-trie-root. Mode selection must gate on len(bal) > 0.
 func TestHandleBlockRequest_EmptyBALFallsToIncremental(t *testing.T) {
 	defer func(prev bool) { dbg.BALDrivenCommitment = prev }(dbg.BALDrivenCommitment)
@@ -208,12 +208,12 @@ func TestHandleBlockRequest_EmptyBALFallsToIncremental(t *testing.T) {
 	dbg.IgnoreBAL = false
 
 	cc := &commitmentCalculator{
-		pending:     map[uint64]*pendingBlock{},
-		foldedAhead: map[uint64]bool{},
-		balRoots:    map[uint64][]byte{},
+		pending:       map[uint64]*pendingBlock{},
+		computedAhead: map[uint64]bool{},
+		balRoots:      map[uint64][]byte{},
 		// Not the batch's first block and no blockResult seen yet, so the
-		// fold gate is shut — maybeFoldAhead returns before touching the
-		// (nil) doms/updates, isolating the mode-selection under test.
+		// compute-ahead gate is shut — maybeComputeAhead returns before touching
+		// the (nil) doms/updates, isolating the mode-selection under test.
 		hasFirstBlock:      true,
 		firstBlockNum:      100,
 		hasSeenBlockResult: false,
@@ -228,15 +228,16 @@ func TestHandleBlockRequest_EmptyBALFallsToIncremental(t *testing.T) {
 	require.True(t, ok, "block request must be recorded")
 	assert.Equal(t, calcModeIncremental, pb.mode,
 		"an empty (non-nil) BAL declares no changes and must fall to "+
-			"incremental mode; folding it would compute the parent root and "+
+			"incremental mode; computing it ahead would compute the parent root and "+
 			"fail an otherwise-valid block with ErrWrongTrieRoot")
 }
 
-// TestFoldCap_StopsFoldAhead pins the orphan guard: once the shared executor
-// context carries a stopCause, the calculator must not fold any block past the
-// coalesce block M — otherwise commitment would advance past the state exec
-// stops at. The signal is read from the context cause, not a shared flag.
-func TestFoldCap_StopsFoldAhead(t *testing.T) {
+// TestComputeAheadCap_StopsComputeAhead pins the orphan guard: once the shared
+// executor context carries a stopCause, the calculator must not compute any
+// block ahead past the coalesce block M — otherwise commitment would advance
+// past the state exec stops at. The signal is read from the context cause, not
+// a shared flag.
+func TestComputeAheadCap_StopsComputeAhead(t *testing.T) {
 	defer func(prev bool) { dbg.BALDrivenCommitment = prev }(dbg.BALDrivenCommitment)
 	dbg.BALDrivenCommitment = true
 
@@ -248,15 +249,15 @@ func TestFoldCap_StopsFoldAhead(t *testing.T) {
 		pending: map[uint64]*pendingBlock{
 			5: {req: &blockRequest{blockNum: 5, bal: make(types.BlockAccessList, 1)}, mode: calcModeBALDriven},
 		},
-		foldedAhead:   map[uint64]bool{},
+		computedAhead: map[uint64]bool{},
 		balRoots:      map[uint64][]byte{},
 		hasFirstBlock: true,
 		firstBlockNum: 5, // gate open for block 5 without a prior blockResult
 	}
 
-	// Coalesce block M=4: block 5 is past M and must not fold.
+	// Coalesce block M=4: block 5 is past M and must not compute ahead.
 	cancel(&stopCause{block: 4, kind: stopMoreWork})
-	cc.maybeFoldAhead(context.Background(), 5) // must return before foldBlockFromBAL
+	cc.maybeComputeAhead(context.Background(), 5) // must return before computeBlockFromBAL
 
-	assert.False(t, cc.foldedAhead[5], "a fold past the coalesce block M must not run")
+	assert.False(t, cc.computedAhead[5], "a compute-ahead past the coalesce block M must not run")
 }


### PR DESCRIPTION
The BAL-driven scheduling code in `commitmentCalculator` used "fold"/"folded"/"foldAhead" for the same concept the trie itself uses "fold"/"unfold" for (row-by-row hash collapse in `HexPatriciaHashed`). Same subsystem, two meanings for the same word, confusing when reading `committer.go` next to `hex_patricia_hashed.go`.

Renamed the scheduler-layer identifiers into the `compute*` family the incremental path already uses, instead of a separate verb:

- `maybeFoldAhead` -> `maybeComputeAhead`
- `foldGateOpen` -> `computeAheadGateOpen`
- `foldBlockFromBAL` -> `computeBlockFromBAL`
- `foldStepCheckpoints` -> `checkpointStepsFromBAL`
- `foldBALToRoot` -> `computeRootFromBAL`
- `foldedAhead` -> `computedAhead`
- `lastFoldedBlock`/`hasFolded` -> `lastComputedAheadBlock`/`hasComputedAhead`
- `foldsAheadPerformed` + test helpers -> `computedAheadCount` / `ComputedAheadCountForTest` / `ResetComputedAheadForTest`

Test names/messages updated to match. Left the trie's own `fold`/`unfold` (`hex_patricia_hashed.go`) and the handful of `committer.go` comments that genuinely describe the trie's own fold untouched.

Pure rename, no behavior change — existing tests are the safety net.
