### PR TITLE
execution/stagedsync: drop self-destruct storage enumeration in commitment

### DIFF
--- a/execution/stagedsync/calc_state.go
+++ b/execution/stagedsync/calc_state.go
@@ -89,8 +89,9 @@ type calcState struct {
 	// domainReader provides lazy-load from the domain via asOfStateReader.
 	domainReader *calcDomainReader
 
-	// storageEnum enumerates an account's persisted storage subtree for
-	// self-destruct; nil disables the on-disk subtree wipe.
+	// storageEnum is a test injection point; production leaves it nil. The
+	// self-destruct path no longer reads it — the account delete collapses the
+	// subtree — so it exists only to assert that in tests.
 	storageEnum storageEnumerator
 
 	// lazyLoadErr captures the first error encountered during ensureAccount /
@@ -115,7 +116,6 @@ func newCalcState(reader *asOfStateReader, logger log.Logger, logPrefix string) 
 		storageState: make(map[accounts.Address]map[accounts.StorageKey]uint256.Int),
 		storageDirty: make(map[accounts.Address]map[accounts.StorageKey]bool),
 		domainReader: &calcDomainReader{reader: reader},
-		storageEnum:  &asOfStorageEnumerator{reader: reader},
 		logger:       logger,
 		logPrefix:    logPrefix,
 	}
@@ -244,14 +244,14 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 	}
 }
 
-// deleteStorageSubtree zeroes and dirties every storage slot under a
-// self-destructed account, including untouched on-disk slots pulled via
-// storageEnum, so FlushToUpdates emits a DeleteUpdate for each.
+// deleteStorageSubtree handles a self-destructed account's storage. Only slots
+// touched this window (already in the maps) get explicit deletes; the account's
+// own DeleteUpdate collapses the rest of the subtree, so untouched on-disk slots
+// need not be read.
 func (cs *calcState) deleteStorageSubtree(addr accounts.Address) {
 	slots := cs.storageState[addr]
-	if slots == nil {
-		slots = make(map[accounts.StorageKey]uint256.Int)
-		cs.storageState[addr] = slots
+	if len(slots) == 0 {
+		return
 	}
 	dirty := cs.storageDirty[addr]
 	if dirty == nil {
@@ -261,25 +261,6 @@ func (cs *calcState) deleteStorageSubtree(addr accounts.Address) {
 	for key := range slots {
 		slots[key] = uint256.Int{}
 		dirty[key] = true
-	}
-	if cs.storageEnum == nil {
-		return
-	}
-	if err := cs.storageEnum.EachStorageSlot(addr, func(key accounts.StorageKey) error {
-		if _, ok := slots[key]; !ok {
-			slots[key] = uint256.Int{}
-			dirty[key] = true
-		}
-		return nil
-	}); err != nil {
-		// Sticky — a partial subtree wipe yields a wrong root, so fail the
-		// next compute rather than silently leaving stale slots.
-		if cs.lazyLoadErr == nil {
-			cs.lazyLoadErr = fmt.Errorf("deleteStorageSubtree(%x): %w", addr.Value(), err)
-		}
-		if cs.logger != nil {
-			cs.logger.Warn("["+cs.logPrefix+"] commitmentCalculator: SD storage enumeration failed", "addr", addr, "err", err)
-		}
 	}
 }
 

--- a/execution/stagedsync/calc_state_test.go
+++ b/execution/stagedsync/calc_state_test.go
@@ -547,11 +547,12 @@ func (m *mockStorageEnum) EachStorageSlot(addr accounts.Address, fn func(key acc
 	return nil
 }
 
-// TestSDOfPreExistingContract_DeletesUntouchedSlots checks that a self-destruct
-// deletes the whole persisted storage subtree, not just the EVM-touched slots.
-func TestSDOfPreExistingContract_DeletesUntouchedSlots(t *testing.T) {
+// TestSDOfPreExistingContract_DropsSubtreeViaAccountDelete pins that a
+// self-destruct emits no per-slot deletes for untouched on-disk storage: the
+// account DeleteUpdate collapses the subtree, so the injected enumerator must
+// not be consulted.
+func TestSDOfPreExistingContract_DropsSubtreeViaAccountDelete(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x40, 0x55, 0xca, 0xe5})
-	// On-disk slots never read/written this block, so they never enter storageState.
 	untouched1 := accounts.InternKey(common.Hash{0x11})
 	untouched2 := accounts.InternKey(common.Hash{0x22})
 
@@ -570,24 +571,24 @@ func TestSDOfPreExistingContract_DeletesUntouchedSlots(t *testing.T) {
 	cs.FlushToUpdates(updates)
 
 	addrBytes := addr.Value()
-	gotSlots := map[common.Hash]commitment.Update{}
+	storageUpdates := 0
+	var accountUpdate *commitment.Update
 	require.NoError(t, updates.HashSort(t.Context(), nil, func(_, k []byte, u *commitment.Update) error {
-		if len(k) == 52 && bytes.Equal(k[:20], addrBytes[:]) {
-			var h common.Hash
-			copy(h[:], k[20:])
-			gotSlots[h] = *u
+		switch {
+		case len(k) == 52 && bytes.Equal(k[:20], addrBytes[:]):
+			storageUpdates++
+		case len(k) == 20 && bytes.Equal(k, addrBytes[:]):
+			cp := *u
+			accountUpdate = &cp
 		}
 		return nil
 	}))
 
-	require.Len(t, gotSlots, 2,
-		"both untouched on-disk slots must be deleted on SD (matches serial's DomainDelPrefix)")
-	for _, sk := range []accounts.StorageKey{untouched1, untouched2} {
-		u, ok := gotSlots[sk.Value()]
-		require.True(t, ok, "untouched slot %x must emit a delete", sk.Value())
-		assert.Equal(t, commitment.DeleteUpdate, u.Flags,
-			"untouched slot %x must emit DeleteUpdate", sk.Value())
-	}
+	assert.Zero(t, storageUpdates,
+		"self-destruct must not enumerate/emit per-slot deletes for untouched on-disk slots — the account delete collapses the subtree")
+	require.NotNil(t, accountUpdate, "the self-destructed account must emit an update")
+	assert.Equal(t, commitment.DeleteUpdate, accountUpdate.Flags,
+		"a fully self-destructed account emits DeleteUpdate, which collapses its storage subtree in the trie")
 }
 
 func lookupKeyUpdate(t *testing.T, updates *commitment.Updates, plainKey string) *commitment.Update {

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -14,12 +14,10 @@ import (
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
-	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
-	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
 // commitmentResult is the outcome of a single commitment computation.
@@ -980,40 +978,6 @@ func (r *asOfStateReader) Clone(tx kv.TemporalTx) commitmentdb.StateReader {
 // must not write the shared main accumulator).
 func (r *asOfStateReader) CloneForWorker(workerCtx context.Context, tx kv.TemporalTx) commitmentdb.StateReader {
 	return &asOfStateReader{sd: r.sd, roTx: tx, txNum: r.txNum, workerCtx: workerCtx}
-}
-
-// asOfStorageEnumerator lists the persisted storage slots under an address via
-// the calculator's stable roTx snapshot (the pre-cycle baseline the trie was
-// built from), so a self-destruct deletes the whole subtree. The exec loop's
-// DomainDelPrefix runs with inline TouchKey disabled in parallel mode, so this
-// is the parallel path's equivalent of serial's per-slot delete touches.
-type asOfStorageEnumerator struct {
-	reader *asOfStateReader
-}
-
-func (e *asOfStorageEnumerator) EachStorageSlot(addr accounts.Address, fn func(key accounts.StorageKey) error) error {
-	addrVal := addr.Value()
-	toKey, _ := kv.NextSubtree(addrVal[:])
-	it, err := e.reader.roTx.RangeAsOf(kv.StorageDomain, addrVal[:], toKey, e.reader.txNum, order.Asc, kv.Unlim)
-	if err != nil {
-		return err
-	}
-	defer it.Close()
-	for it.HasNext() {
-		k, v, err := it.Next()
-		if err != nil {
-			return err
-		}
-		if len(v) == 0 || len(k) != 52 || !bytes.HasPrefix(k, addrVal[:]) {
-			continue
-		}
-		var h common.Hash
-		copy(h[:], k[20:])
-		if err := fn(accounts.InternKey(h)); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // Keep imports used.


### PR DESCRIPTION
On a `SELFDESTRUCT` the commitment calculator enumerated every on-disk storage slot of the account — `RangeAsOf(StorageDomain, .., Unlim)` — to emit a per-slot `DeleteUpdate`. That read holds the account's entire storage range in memory and OOMs the parallel / streaming commitment on mainnet's 2.6-2.7M mass-self-destruct spam blocks (~40G, where the same blocks otherwise fit in ~16G).

## Changes
The account's own `DeleteUpdate` already collapses the storage subtree in the trie, and the storage domain is wiped separately by `DomainDelPrefix` during exec, so the commitment never needs to read the slots. `deleteStorageSubtree` now only keeps explicit per-slot deletes for slots touched this window; untouched on-disk slots are left to the account-delete collapse. Drops the now-unused `asOfStorageEnumerator`.
