### PR TITLE
ci(dependabot): ignore typescript major bumps for docs/site

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,17 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+    ignore:
+      # TypeScript 7 removed `baseUrl` (TS5102), which @docusaurus/tsconfig
+      # still sets as of 3.10.2 — and an inherited compilerOption cannot be
+      # unset by the extending config, so docs/site/tsconfig.json's
+      # `ignoreDeprecations: "6.0"` (which only silences TS 6's TS5101) does
+      # not help. `npm run typecheck` is gated in docs-site-build.yml, so a
+      # TS 7 bump turns docs CI red. PR #22395 was closed for this reason;
+      # without this rule Dependabot re-proposes on every new 7.x release.
+      #
+      # Taking TS 7 requires inlining @docusaurus/tsconfig's options minus
+      # baseUrl (deleting our local baseUrl alone would just inherit theirs).
+      # Drop this rule once Docusaurus ships a tsconfig without baseUrl.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Why

PR #22395 (`typescript` 6.0.3 → 7.0.2) was closed because TypeScript 7 **removed** `baseUrl` (`TS5102`), which `@docusaurus/tsconfig` still sets as of 3.10.2:

```
docs/site/tsconfig.json: error TS5102: Option 'baseUrl' has been removed.
                                       Please remove it from your configuration.
```

An inherited `compilerOption` cannot be unset by the extending config, and `docs/site/tsconfig.json`'s `"ignoreDeprecations": "6.0"` only silences TS 6's TS5101 *deprecation* — TS 7 rejects the option itself. Since `docs-site-build.yml` gates `npm run typecheck`, a TS 7 bump turns docs CI red.

## What

Closing a Dependabot PR suppresses only that exact version, so 7.0.3 and every later 7.x would re-propose it. This encodes the decision instead. Minor and patch TypeScript updates keep flowing.

No behaviour change — Dependabot config only.

## If we want TS 7 later

It requires inlining `@docusaurus/tsconfig`'s options minus `baseUrl`. Note that deleting our local `baseUrl: "."` alone would **not** work — it would just inherit theirs. That fix is already proven in erigontech/cocoon#36 and erigontech/zilkworm-docs#13.

Aside: our local `baseUrl: "."` is also why `@site/*` resolves correctly here. In both sibling repos the option was purely inherited, which made it resolve to `node_modules/@docusaurus/tsconfig` and silently broke the alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)