### PR TITLE
docs: drop baseUrl from docs/site tsconfig so TypeScript 7 can land

### DIFF
--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -84,6 +84,13 @@ jobs:
         if: steps.guard.outputs.present == 'true'
         working-directory: docs/site
 
+      # docs/site/tsconfig.json inlines @docusaurus/tsconfig instead of
+      # extending it (TS 7 removed `baseUrl`, which upstream still sets), so
+      # guard the copy against upstream drift.
+      - run: npm run check:tsconfig
+        if: steps.guard.outputs.present == 'true'
+        working-directory: docs/site
+
       - run: npm run typecheck
         if: steps.guard.outputs.present == 'true'
         working-directory: docs/site

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -12,7 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "check:tsconfig": "node scripts/check-tsconfig-drift.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.2",

--- a/docs/site/scripts/check-tsconfig-drift.mjs
+++ b/docs/site/scripts/check-tsconfig-drift.mjs
@@ -68,6 +68,20 @@ function stripJsonc(text) {
   return out;
 }
 
+// Order-insensitive comparison key. Object key order carries no meaning in
+// tsconfig, so upstream reordering must not read as drift. Array order IS
+// meaningful — `paths` entries are an ordered fallback list — so arrays keep
+// their order and a genuine reordering there still reports.
+function canon(v) {
+  const norm = (x) =>
+    Array.isArray(x)
+      ? x.map(norm)
+      : x && typeof x === 'object'
+        ? Object.fromEntries(Object.keys(x).sort().map((k) => [k, norm(x[k])]))
+        : x;
+  return JSON.stringify(norm(v));
+}
+
 function readOptions(file) {
   if (!fs.existsSync(file)) {
     console.error(`check-tsconfig-drift: missing ${file}\nRun \`npm ci\` first.`);
@@ -102,7 +116,7 @@ for (const key of [...seen].sort()) {
     problems.push(`  ${key}: added upstream (${JSON.stringify(upstream[key])}) — missing from our copy`);
   } else if (inOurs && !inUpstream) {
     problems.push(`  ${key}: removed upstream — still in our copy (${JSON.stringify(ours[key])})`);
-  } else if (JSON.stringify(ours[key]) !== JSON.stringify(upstream[key])) {
+  } else if (canon(ours[key]) !== canon(upstream[key])) {
     problems.push(`  ${key}: upstream ${JSON.stringify(upstream[key])} != ours ${JSON.stringify(ours[key])}`);
   }
 }

--- a/docs/site/scripts/check-tsconfig-drift.mjs
+++ b/docs/site/scripts/check-tsconfig-drift.mjs
@@ -1,0 +1,129 @@
+// Guards the inlined tsconfig against upstream drift.
+//
+// docs/site/tsconfig.json inlines @docusaurus/tsconfig's compilerOptions instead
+// of extending them, because the upstream config sets `baseUrl` and TypeScript 7
+// removed that option (an inherited option can't be unset by the extending file).
+// The cost of inlining is that upstream changes no longer reach us. This script
+// pays that cost down: it fails if upstream's options stop matching our copy,
+// modulo the deltas declared below.
+//
+// Run: npm run check:tsconfig
+
+// Deliberately depends on nothing but Node: a guard must not break when the
+// thing it guards changes. The first version imported `typescript` to parse
+// JSONC and died under TS 7 (`ts.parseConfigFileTextToJson is not a function` —
+// the native port does not expose the old namespace API), taking CI with it.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const siteDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const OURS = path.join(siteDir, 'tsconfig.json');
+const UPSTREAM = path.join(siteDir, 'node_modules/@docusaurus/tsconfig/tsconfig.json');
+
+// Deltas we intend to carry. Keep this list minimal and justified.
+const DROPPED = new Set(['baseUrl']); // removed in TS 7; see tsconfig.json comment
+const OURS_ONLY = new Set(['strict']); // this site's own choice, predates inlining
+
+// Minimal JSONC -> JSON. String-aware, so it does not maul the `//` inside the
+// "$schema": "https://..." value, and it drops trailing commas the way tsc does.
+function stripJsonc(text) {
+  let out = '';
+  let inString = false;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    const next = text[i + 1];
+
+    if (inLineComment) {
+      if (c === '\n') { inLineComment = false; out += c; }
+      continue;
+    }
+    if (inBlockComment) {
+      if (c === '*' && next === '/') { inBlockComment = false; i++; }
+      continue;
+    }
+    if (inString) {
+      out += c;
+      if (escaped) escaped = false;
+      else if (c === '\\') escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') { inString = true; out += c; continue; }
+    if (c === '/' && next === '/') { inLineComment = true; i++; continue; }
+    if (c === '/' && next === '*') { inBlockComment = true; i++; continue; }
+
+    // Trailing comma: rewind past whitespace and drop it before } or ].
+    if (c === '}' || c === ']') {
+      const trimmed = out.replace(/\s+$/, '');
+      if (trimmed.endsWith(',')) out = trimmed.slice(0, -1);
+    }
+    out += c;
+  }
+  return out;
+}
+
+function readOptions(file) {
+  if (!fs.existsSync(file)) {
+    console.error(`check-tsconfig-drift: missing ${file}\nRun \`npm ci\` first.`);
+    process.exit(2);
+  }
+  const raw = fs.readFileSync(file, 'utf8');
+  try {
+    return JSON.parse(stripJsonc(raw)).compilerOptions ?? {};
+  } catch (err) {
+    console.error(`check-tsconfig-drift: cannot parse ${file}: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+const ours = readOptions(OURS);
+const upstream = readOptions(UPSTREAM);
+
+const problems = [];
+const seen = new Set([...Object.keys(ours), ...Object.keys(upstream)]);
+
+for (const key of [...seen].sort()) {
+  const inOurs = Object.hasOwn(ours, key);
+  const inUpstream = Object.hasOwn(upstream, key);
+
+  if (inUpstream && DROPPED.has(key)) {
+    if (inOurs) problems.push(`  ${key}: expected to be dropped from our copy, but it is present`);
+    continue; // upstream still ships it — that's the status quo this file documents
+  }
+  if (inOurs && OURS_ONLY.has(key)) continue;
+
+  if (inUpstream && !inOurs) {
+    problems.push(`  ${key}: added upstream (${JSON.stringify(upstream[key])}) — missing from our copy`);
+  } else if (inOurs && !inUpstream) {
+    problems.push(`  ${key}: removed upstream — still in our copy (${JSON.stringify(ours[key])})`);
+  } else if (JSON.stringify(ours[key]) !== JSON.stringify(upstream[key])) {
+    problems.push(`  ${key}: upstream ${JSON.stringify(upstream[key])} != ours ${JSON.stringify(ours[key])}`);
+  }
+}
+
+// If upstream ever drops baseUrl, the whole workaround can go away.
+if (!Object.hasOwn(upstream, 'baseUrl')) {
+  console.log(
+    'check-tsconfig-drift: @docusaurus/tsconfig no longer sets baseUrl.\n' +
+    'The inlining workaround is obsolete — restore `"extends": "@docusaurus/tsconfig"`\n' +
+    'in docs/site/tsconfig.json (keeping "strict": true) and delete this script.',
+  );
+}
+
+if (problems.length > 0) {
+  console.error(
+    'check-tsconfig-drift: docs/site/tsconfig.json has drifted from @docusaurus/tsconfig:\n' +
+    problems.join('\n') +
+    '\n\nReconcile the inline copy against node_modules/@docusaurus/tsconfig/tsconfig.json,\n' +
+    'or update the DROPPED / OURS_ONLY sets in this script if the delta is intentional.',
+  );
+  process.exit(1);
+}
+
+console.log('check-tsconfig-drift: inline tsconfig matches @docusaurus/tsconfig (modulo declared deltas).');

--- a/docs/site/tsconfig.json
+++ b/docs/site/tsconfig.json
@@ -2,10 +2,39 @@
 // It is here to improve your IDE experience (type-checking, autocompletion...),
 // and can also run the package.json "typecheck" script manually.
 {
-  "extends": "@docusaurus/tsconfig",
+  "$schema": "https://json.schemastore.org/tsconfig",
+  // Inlined from @docusaurus/tsconfig, minus `baseUrl`, rather than extending it.
+  // TypeScript 7 removed baseUrl outright (TS5102). The previous
+  // `"ignoreDeprecations": "6.0"` silenced TS 6's TS5101 deprecation, but TS 7
+  // rejects the option itself, so that escape hatch is gone. Removing only our
+  // own `baseUrl` line would not help either — `extends` would just inherit
+  // upstream's, and an inherited compilerOption cannot be unset by the
+  // extending config. While @docusaurus/tsconfig still ships baseUrl (it does
+  // as of 3.10.2), `extends` and a green `npm run typecheck` are mutually
+  // exclusive under TS 7.
+  //
+  // `@site/*` is unaffected: with baseUrl gone, `paths` resolves against this
+  // file's directory, which is the same docs/site root our explicit
+  // `baseUrl: "."` was providing. (In repos that only *inherited* baseUrl it
+  // resolved to node_modules/@docusaurus/tsconfig and the alias was silently
+  // broken — that was never the case here.)
+  //
+  // scripts/check-tsconfig-drift.mjs fails CI if upstream's options change, so
+  // this copy cannot silently rot. Revert to `"extends": "@docusaurus/tsconfig"`
+  // once Docusaurus drops baseUrl.
   "compilerOptions": {
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "noEmit": true,
+    "paths": {
+      "@site/*": ["./*"]
+    },
+    "skipLibCheck": true,
     "strict": true
   },
   "exclude": [".docusaurus", "build"]


### PR DESCRIPTION
## Why

Dependabot #22395 (`typescript` 6.0.3 → 7.0.2) was closed because it failed docs-site CI:

```
docs/site/tsconfig.json(7,5): error TS5102: Option 'baseUrl' has been removed.
                              Please remove it from your configuration.
```

TypeScript 7 **removed** `baseUrl`. Our `"ignoreDeprecations": "6.0"` silenced TS 6's TS5101 *deprecation*, but TS 7 rejects the option itself, so that escape hatch expires at the major boundary.

**Deleting only our own `baseUrl` line would not fix it.** `extends: @docusaurus/tsconfig` would inherit upstream's — it still ships one as of 3.10.2 — and an inherited `compilerOption` cannot be unset by the extending config. The error would simply move from `(7,5)` to `(6,3)`.

## What

1. **`docs/site/tsconfig.json`** — inline the base config minus `baseUrl`, dropping the now-useless `ignoreDeprecations`.
2. **`docs/site/scripts/check-tsconfig-drift.mjs`** (+ `npm run check:tsconfig`) — inlining means upstream changes stop reaching us, so this diffs our copy against `node_modules/@docusaurus/tsconfig` modulo declared deltas, and reports when upstream drops `baseUrl` and the whole workaround can be reverted. Wired into `docs-site-build.yml` ahead of the existing typecheck.

The guard depends on nothing but Node, deliberately: a version that imported `typescript` to parse JSONC broke under the very upgrade it guards (erigontech/cocoon#37).

## `@site/*` is unaffected here

Verified via the TypeScript API — `@site/docusaurus.config` resolves to `docs/site/docusaurus.config.ts` both before and after:

```
OLD (extends + our own baseUrl: "."):  @site/docusaurus.config -> <site>/docusaurus.config.ts
NEW (inlined, no baseUrl):             @site/docusaurus.config -> <site>/docusaurus.config.ts
```

Worth noting because this is where erigon differed from its siblings: in cocoon and zilkworm-docs `baseUrl` was *only inherited*, so it resolved to `node_modules/@docusaurus/tsconfig` and left `@site/*` silently broken. Our explicit `baseUrl: "."` is what kept the alias correct — and dropping it costs nothing, because `paths` now resolves against the tsconfig's own directory, which is the same `docs/site` root.

## Verification

In `docs/site`, under **both** toolchains:

| | TS 6.0.3 | TS 7.0.2 |
|---|---|---|
| `npm run check:tsconfig` | exit 0 | exit 0 |
| `npm run typecheck` | exit 0 | exit 0 |
| `npm run build` | exit 0 | exit 0 |

## Relationship to #22763

**Supersedes #22763**, which added a Dependabot ignore rule for `typescript` majors to stop the closed PR resurfacing on every 7.x release. That deferral is unnecessary if this lands — recommend closing #22763. If you'd rather stay on TS 6 for now, do the opposite: merge #22763 and close this.

Same fix as erigontech/cocoon#36 and erigontech/zilkworm-docs#13, both now merged and running TypeScript 7.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)