### PR TITLE
docs: clarify why the drift guard preserves array order

### DIFF
--- a/docs/site/scripts/check-tsconfig-drift.mjs
+++ b/docs/site/scripts/check-tsconfig-drift.mjs
@@ -69,9 +69,13 @@ function stripJsonc(text) {
 }
 
 // Order-insensitive comparison key. Object key order carries no meaning in
-// tsconfig, so upstream reordering must not read as drift. Array order IS
-// meaningful — `paths` entries are an ordered fallback list — so arrays keep
-// their order and a genuine reordering there still reports.
+// tsconfig, so upstream reordering must not read as drift.
+//
+// Arrays keep their order. Order matters in some (a `paths` entry is an ordered
+// fallback list) and not in others (`lib`, `types`). Preserving it everywhere is
+// the safe direction: a reordered `lib` reports drift that turns out to be
+// harmless, costing one reconciliation, whereas sorting arrays would silently
+// hide a real `paths` change.
 function canon(v) {
   const norm = (x) =>
     Array.isArray(x)

--- a/docs/site/scripts/check-tsconfig-drift.mjs
+++ b/docs/site/scripts/check-tsconfig-drift.mjs
@@ -71,8 +71,8 @@ function stripJsonc(text) {
 // Order-insensitive comparison key. Object key order carries no meaning in
 // tsconfig, so upstream reordering must not read as drift.
 //
-// Arrays keep their order. Order matters in some (a `paths` entry is an ordered
-// fallback list) and not in others (`lib`, `types`). Preserving it everywhere is
+// Arrays keep their order. Order is meaningful in some arrays (a `paths` entry
+// is an ordered fallback list) but not in others (`lib`, `types`). Preserving it everywhere is
 // the safe direction: a reordered `lib` reports drift that turns out to be
 // harmless, costing one reconciliation, whereas sorting arrays would silently
 // hide a real `paths` change.


### PR DESCRIPTION
Comment-only follow-up to #22764.

The guard's comment claimed "Array order IS meaningful" for tsconfig arrays in general, which overstates it: order matters for a `paths` fallback list, but not for `lib` or `types`. Flagged by Copilot on erigontech/cocoon#39.

The implementation is unchanged and stays correct. Preserving array order everywhere is the safe direction because the failure modes are asymmetric — a reordered `lib` reports drift that turns out to be harmless (one reconciliation), whereas sorting arrays would silently hide a real `paths` change. The comment now says that, instead of implying all tsconfig arrays carry ordered semantics.

Propagated in identical wording to erigontech/cocoon#39 and erigontech/zilkworm-docs#14, so the three copies stay byte-identical — the docs-sites alignment routine now hashes the guard's content, so a fix landing in one repo alone shows up as drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)