### PR TITLE
rpc: match JWT auth-scheme case-insensitively

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -391,8 +391,8 @@ func validateRequest(r *http.Request) (int, error) {
 func CheckJwtSecret(w http.ResponseWriter, r *http.Request, jwtSecret []byte) bool {
 	var tokenStr string
 	// Check if JWT signature is correct
-	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
-		tokenStr = strings.TrimPrefix(auth, "Bearer ")
+	if auth := r.Header.Get("Authorization"); len(auth) >= 7 && strings.EqualFold(auth[:7], "bearer ") {
+		tokenStr = auth[7:]
 	}
 
 	if len(tokenStr) == 0 {

--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -27,7 +27,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common/log/v3"
@@ -233,4 +235,41 @@ func TestWithGzipStreamingHookPanicsOnNilHook(t *testing.T) {
 	require.Panics(t, func() {
 		WithGzipStreamingHook(context.Background(), nil)
 	})
+}
+
+func signJwt(t *testing.T, secret []byte) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"iat": time.Now().Unix()})
+	signed, err := token.SignedString(secret)
+	require.NoError(t, err)
+	return signed
+}
+
+// Auth-scheme names are case-insensitive (RFC 7235 §2.1).
+func TestCheckJwtSecretAuthScheme(t *testing.T) {
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	token := signJwt(t, secret)
+
+	cases := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"canonical scheme", "Bearer " + token, true},
+		{"lowercase scheme", "bearer " + token, true},
+		{"uppercase scheme", "BEARER " + token, true},
+		{"mixed case scheme", "BeArEr " + token, true},
+		{"empty header", "", false},
+		{"scheme without token", "Bearer ", false},
+		{"header shorter than scheme", "Bear", false},
+		{"other scheme", "Basic " + token, false},
+		{"foreign secret", "Bearer " + signJwt(t, []byte("fedcba9876543210fedcba9876543210")), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "http://url.com", nil)
+			r.Header.Set("Authorization", tc.header)
+			require.Equal(t, tc.want, CheckJwtSecret(httptest.NewRecorder(), r, secret))
+		})
+	}
 }


### PR DESCRIPTION
Ports go-ethereum [#35022](https://github.com/ethereum/go-ethereum/pull/35022) + [#35408](https://github.com/ethereum/go-ethereum/pull/35408) — the first alone is not enough, it leaves `TrimPrefix(auth, "Bearer ")` in place, which silently returns the header unchanged on a casing mismatch.

`CheckJwtSecret` matched `"Bearer "` with `strings.HasPrefix`, so a consensus client sending `bearer` or `BEARER` was rejected — with a misleading `missing token` error, since the unmatched prefix left `tokenStr` empty. Both spellings are legal: the auth-scheme token is case-insensitive.

`CheckJwtSecret` is the only inbound `Authorization` parser in the repo, so this single edit covers both the HTTP handler and the WebSocket upgrade path.

Behaviour outside the scheme casing is unchanged: missing header, `Basic`, scheme without token and foreign-secret tokens all still return 403. Double-space (`Bearer  <tok>`) stays rejected, matching geth, which keeps it in its own `expFail` list.

## Tests

New `TestCheckJwtSecretAuthScheme` in `rpc/http_test.go`, a table over nine `Authorization` shapes:

- **accepted** — `Bearer`, `bearer`, `BEARER`, `BeArEr`
- **rejected** — empty header; `Bearer ` (well-formed scheme, no credential); `Bear` (shorter than the scheme prefix, pinning the length guard that makes the new slice expression safe); `Basic <tok>`; token signed with a foreign secret

The four rejected shapes already passed before the fix, so the red was confined to the three casing rows.

## Specs

- [RFC 9110 §11.1](https://www.rfc-editor.org/rfc/rfc9110#section-11.1) (Authentication Scheme) — current normative reference: *"It uses a case-insensitive token to identify the authentication scheme"*.
- [RFC 7235 §2.1](https://www.rfc-editor.org/rfc/rfc7235#section-2.1) (Challenge and Response) — obsoleted by 9110, same requirement: *"It uses a case-insensitive token as a means to identify the authentication scheme"*. This is the section the upstream geth PR title cites.
- [Engine API — authentication](https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md) — mandates JWT (HS256, `iat` claim, 60s clock-drift window) supplied *"in the HTTP header"*, but pins neither the scheme spelling nor a status code, so the HTTP specs above govern the parsing.

Not addressed here: erigon answers 403 Forbidden where geth answers 401 Unauthorized. Pre-existing divergence, and unconstrained by the engine API spec — separate PR if we want parity.