### PR TITLE
execmoduletester, backends, requests, engineapitester: release resources leaks

### DIFF
--- a/execution/abi/bind/backends/simulated.go
+++ b/execution/abi/bind/backends/simulated.go
@@ -136,8 +136,15 @@ func (b *SimulatedBackend) BlockReader() dbservices.FullBlockReader { return b.m
 
 // Close terminates the underlying blockchain's update loop.
 func (b *SimulatedBackend) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if b.pendingReaderTx != nil {
 		b.pendingReaderTx.Rollback()
+		b.pendingReaderTx = nil
+	}
+	if b.pendingState != nil {
+		b.pendingState.Release(false)
+		b.pendingState = nil
 	}
 	b.m.Close()
 }
@@ -181,6 +188,9 @@ func (b *SimulatedBackend) emptyPendingBlock() {
 	b.pendingGasUsed = new(protocol.GasUsed)
 	if b.pendingReaderTx != nil {
 		b.pendingReaderTx.Rollback()
+	}
+	if b.pendingState != nil {
+		b.pendingState.Release(false)
 	}
 	tx, err := b.m.DB.BeginTemporalRo(context.Background()) //nolint:gocritic
 	if err != nil {

--- a/execution/engineapi/engineapitester/engine_api_tester.go
+++ b/execution/engineapi/engineapitester/engine_api_tester.go
@@ -364,6 +364,7 @@ func InitialiseEngineApiTester(ctx context.Context, args EngineApiTesterInitArgs
 
 	rpcDaemonHttpUrl := fmt.Sprintf("%s:%d", httpConfig.HttpListenAddress, httpConfig.HttpPort)
 	rpcApiClient := requests.NewRequestGenerator(rpcDaemonHttpUrl, logger)
+	addCleanup(func() error { rpcApiClient.UnsubscribeAll(); return nil })
 	contractBackend := contracts.NewJsonRpcBackend(rpcDaemonHttpUrl, logger)
 	//goland:noinspection HttpUrlsUsage
 	engineApiClientOpts := []engineapi.JsonRpcClientOption{

--- a/execution/execmodule/execmoduletester/close_leak_test.go
+++ b/execution/execmodule/execmoduletester/close_leak_test.go
@@ -49,17 +49,22 @@ func TestCloseStopsAllGoroutines(t *testing.T) {
 	t.Fatalf("Close leaked goroutines: baseline=%d now=%d\n%s", baseline, n, buf.String())
 }
 
-// stableGoroutines waits until the goroutine count stops decreasing and
-// returns it.
+// stableGoroutines waits until the goroutine count holds steady for a few
+// consecutive samples and returns it.
 func stableGoroutines() int {
+	stable := 0
 	n := runtime.NumGoroutine()
 	for range 100 {
 		runtime.GC()
 		time.Sleep(50 * time.Millisecond)
 		next := runtime.NumGoroutine()
-		if next >= n {
-			return n
+		if next == n {
+			if stable++; stable >= 3 {
+				break
+			}
+			continue
 		}
+		stable = 0
 		n = next
 	}
 	return n

--- a/execution/execmodule/execmoduletester/close_leak_test.go
+++ b/execution/execmodule/execmoduletester/close_leak_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execmoduletester_test
+
+import (
+	"bytes"
+	"runtime"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
+)
+
+// A goroutine surviving Close roots the tester's whole object graph (DB,
+// aggregator, caches), so every goroutine the tester starts must stop.
+func TestCloseStopsAllGoroutines(t *testing.T) {
+	execmoduletester.New(nil).Close() // warm lazily-started package singletons
+	baseline := stableGoroutines()
+
+	execmoduletester.New(nil).Close()
+
+	deadline := time.Now().Add(15 * time.Second)
+	n := runtime.NumGoroutine()
+	for time.Now().Before(deadline) {
+		n = runtime.NumGoroutine()
+		if n <= baseline {
+			return
+		}
+		runtime.GC()
+		time.Sleep(50 * time.Millisecond)
+	}
+	var buf bytes.Buffer
+	_ = pprof.Lookup("goroutine").WriteTo(&buf, 1)
+	t.Fatalf("Close leaked goroutines: baseline=%d now=%d\n%s", baseline, n, buf.String())
+}
+
+// stableGoroutines waits until the goroutine count stops decreasing and
+// returns it.
+func stableGoroutines() int {
+	n := runtime.NumGoroutine()
+	for range 100 {
+		runtime.GC()
+		time.Sleep(50 * time.Millisecond)
+		next := runtime.NumGoroutine()
+		if next >= n {
+			return n
+		}
+		n = next
+	}
+	return n
+}

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -140,6 +140,7 @@ type ExecModuleTester struct {
 	HistoryV3      bool
 	cfg            ethconfig.Config
 	BlockSnapshots *blocksnapshots.RoSnapshots
+	borSnapshots   *heimdall.RoSnapshots
 	blockRetire    dbservices.BlockRetire
 	BlockReader    dbservices.FullBlockReader
 	ReceiptsReader *receipts.Generator
@@ -160,6 +161,9 @@ func (emt *ExecModuleTester) Close() {
 	}
 	if emt.BlockSnapshots != nil {
 		emt.BlockSnapshots.Close()
+	}
+	if emt.borSnapshots != nil {
+		emt.borSnapshots.Close()
 	}
 	if emt.DB != nil {
 		emt.DB.Close()
@@ -557,6 +561,7 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 		stateChangesClient: direct.NewStateDiffClientDirect(erigonGrpcServer),
 		PeerId:             gointerfaces.ConvertHashToH512([64]byte{0x12, 0x34, 0x50}), // "12345"
 		BlockSnapshots:     allSnapshots,
+		borSnapshots:       allBorSnapshots,
 		BlockReader:        br,
 		ReceiptsReader:     receipts.NewGenerator(dirs, br, engine, nil, 5*time.Second),
 		HistoryV3:          true,

--- a/rpc/jsonrpc/eth_filters_test.go
+++ b/rpc/jsonrpc/eth_filters_test.go
@@ -273,6 +273,10 @@ func TestPendingTxsFilterChangesReturnsAllBatches(t *testing.T) {
 	changes, err := api.GetFilterChanges(ctx, ptf)
 	require.NoError(t, err)
 	require.Equal(t, []any{tx0.Hash(), tx1.Hash(), tx2.Hash()}, changes)
+
+	ok, err := api.UninstallFilter(ctx, ptf)
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 func TestGetFilterChangesReturnsFilterNotFoundForUnknownID(t *testing.T) {

--- a/rpc/requests/request_generator.go
+++ b/rpc/requests/request_generator.go
@@ -84,6 +84,7 @@ type RequestGenerator interface {
 	FilterLogs(ctx context.Context, query bind.FilterQuery) ([]types.Log, error)
 	SubscribeFilterLogs(ctx context.Context, query bind.FilterQuery, ch chan<- types.Log) (event.Subscription, error)
 	Subscribe(ctx context.Context, method SubMethod, subChan any, args ...any) (event.Subscription, error)
+	UnsubscribeAll()
 	TxpoolContent() (int, int, int, error)
 	Call(args ethapi.CallArgs, blockRef rpc.BlockReference, overrides *ethapi.StateOverrides) ([]byte, error)
 	TraceCall(blockRef rpc.BlockReference, args ethapi.CallArgs, traceOpts ...TraceOpt) (*TraceCallResult, error)


### PR DESCRIPTION
Audit of `SimulatedBackend.Close` / `ExecModuleTester.Close` driven by an end-of-run memory profile of the `rpc/jsonrpc` test suite: everything a tester acquires must be released by `Close`, and no goroutine it (or the test harness around it) starts may survive it — a surviving goroutine roots the tester's whole object graph (DB, aggregator, caches).

Leaks found and fixed:

- `requests.requestGenerator.Subscribe` lazily dials a websocket `rpc.Client` and caches it. `UnsubscribeAll` existed to close it but was dead code, and `rpc.Client.dispatch` only exits on `Close` (not on read error), so an abandoned subscription client parks its dispatch goroutine forever. `UnsubscribeAll` is now part of the `RequestGenerator` interface and `EngineApiTester` registers it as a cleanup — this was rooting a whole Erigon node graph after `TestSendRawTransactionSync`.
- `TestPendingTxsFilterChangesReturnsAllBatches` never uninstalled its pending-tx filter, leaving the filter forwarder goroutine (`eth_filters.go`) parked on its subscription channel and rooting the tester. It now uninstalls like the sibling filter tests.
- `ExecModuleTester` created bor `RoSnapshots` but never closed them; the tester now holds them and `Close` closes them.
- `SimulatedBackend.Close` now takes the backend mutex, and returns `pendingState`'s pooled resources via `Release`; `emptyPendingBlock` likewise releases the previous `pendingState` on every `Commit`/`Rollback` swap instead of dropping pooled journal/stateObjects to GC.

The new `TestCloseStopsAllGoroutines` pins the goroutine side of the `Close` contract. Heap side verified manually: six `New(nil)`+`Close` cycles grow the heap by ~95KB total (~16KB/instance noise), and after these fixes a full `rpc/jsonrpc` run exits with zero non-global goroutines (only the by-design `ethash.meterArbiter` ticker remains).

Note for future profile-driven leak hunts: `-memprofile` inuse data at test-binary exit overstates leaks — testing runs a single final GC while `sync.Pool` needs two to drain (the etl buffer pool alone shows as hundreds of MB), and finished tests' object graphs can stay rooted by the harness. Cross-check suspected leaks against a `New(nil)`+`Close`+double-GC heap diff.
