### PR TITLE
cmd/utils/flags: address Copilot review nits from #22771

### DIFF
--- a/cmd/utils/flags/cobra.go
+++ b/cmd/utils/flags/cobra.go
@@ -18,8 +18,9 @@ package flags
 
 import "github.com/spf13/pflag"
 
-// dirValue is a pflag.Value that expands a leading "~/" and "$VAR" in the
-// assigned path, mirroring the urfave DirectoryFlag used by the main erigon binary.
+// dirValue is a pflag.Value that expands a leading "~/" (or "~\" on Windows) and
+// "$VAR" in the assigned path, mirroring the urfave DirectoryFlag used by the
+// main erigon binary.
 type dirValue struct{ p *string }
 
 func (d *dirValue) String() string {
@@ -39,9 +40,9 @@ func (d *dirValue) Set(s string) error {
 
 func (d *dirValue) Type() string { return "string" }
 
-// DirVar registers a cobra/pflag string flag for a directory path, expanding
-// a leading "~/" and "$VAR" at parse time so all binaries normalize --datadir
-// identically to the erigon binary's DirectoryFlag.
+// DirVar registers a cobra/pflag string flag for a directory path, expanding a
+// leading "~/" (or "~\" on Windows) and "$VAR" at parse time so all binaries
+// normalize --datadir identically to the erigon binary's DirectoryFlag.
 func DirVar(fs *pflag.FlagSet, p *string, name, value, usage string) {
 	if value != "" {
 		value = expandPath(value)

--- a/cmd/utils/flags/cobra.go
+++ b/cmd/utils/flags/cobra.go
@@ -18,8 +18,8 @@ package flags
 
 import "github.com/spf13/pflag"
 
-// dirValue is a pflag.Value that expands "~" and "$VAR" in the assigned path,
-// mirroring the urfave DirectoryFlag used by the main erigon binary.
+// dirValue is a pflag.Value that expands a leading "~/" and "$VAR" in the
+// assigned path, mirroring the urfave DirectoryFlag used by the main erigon binary.
 type dirValue struct{ p *string }
 
 func (d *dirValue) String() string {
@@ -40,8 +40,8 @@ func (d *dirValue) Set(s string) error {
 func (d *dirValue) Type() string { return "string" }
 
 // DirVar registers a cobra/pflag string flag for a directory path, expanding
-// "~" and "$VAR" at parse time so all binaries normalize --datadir identically
-// to the erigon binary's DirectoryFlag.
+// a leading "~/" and "$VAR" at parse time so all binaries normalize --datadir
+// identically to the erigon binary's DirectoryFlag.
 func DirVar(fs *pflag.FlagSet, p *string, name, value, usage string) {
 	if value != "" {
 		value = expandPath(value)

--- a/cmd/utils/flags/cobra_test.go
+++ b/cmd/utils/flags/cobra_test.go
@@ -58,6 +58,9 @@ func TestDirVarExpandsEnv(t *testing.T) {
 	if got != want {
 		t.Fatalf("env var not expanded: got %q want %q", got, want)
 	}
+	if v := fs.Lookup("datadir").Value.String(); v != want {
+		t.Fatalf("flag lookup not expanded: got %q want %q", v, want)
+	}
 }
 
 func TestDirVarEmptyDefaultStaysEmpty(t *testing.T) {


### PR DESCRIPTION
Follow-up to #22771 addressing the two Copilot review comments (both minor; no shipped-behavior change).

## Changes

- **Doc accuracy** — `expandPath` expands a leading `~/` (or `~\`) and `$VAR`, but a *bare* `~` is not expanded. The `dirValue`/`DirVar` doc comments said `"~"`; reworded to `"~/"` so they match actual behavior (and the erigon binary's `DirectoryFlag`, which behaves the same).
- **Test hardening** — `TestDirVarExpandsEnv` asserted only the bound variable was expanded. Added an assertion that `fs.Lookup("datadir").Value.String()` is expanded too, matching the tilde test. That lookup is what `debug.SetupCobra` / log-dir resolution reads, so it's the path most worth pinning.

Comment + test only — no functional change.