### PR TITLE
common/hexutil: improve performance of EncodeBig

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -19,7 +19,6 @@ package hexutil
 import (
 	"encoding/binary"
 	"encoding/hex"
-	"fmt"
 	"math/big"
 	"strconv"
 )
@@ -123,13 +122,14 @@ func MustDecodeBig(input string) *big.Int {
 }
 
 // EncodeBig encodes bigint as a hex string with 0x prefix.
-// The sign of the integer is ignored.
 func EncodeBig(bigint *big.Int) string {
-	nbits := bigint.BitLen()
-	if nbits == 0 {
+	if sign := bigint.Sign(); sign == 0 {
 		return "0x0"
+	} else if sign > 0 {
+		return "0x" + bigint.Text(16)
+	} else {
+		return "-0x" + bigint.Text(16)[1:]
 	}
-	return fmt.Sprintf("%#x", bigint)
 }
 
 func has0xPrefix(input string) bool {

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -191,10 +191,14 @@ func TestEncodeBig(t *testing.T) {
 }
 
 func BenchmarkEncodeBig(b *testing.B) {
+	inputs := make([]*big.Int, len(encodeBigTests))
+	for i, test := range encodeBigTests {
+		inputs[i] = test.input.(*big.Int)
+	}
 	b.ReportAllocs()
 	for b.Loop() {
-		for _, test := range encodeBigTests {
-			EncodeBig(test.input.(*big.Int))
+		for _, bigint := range inputs {
+			EncodeBig(bigint)
 		}
 	}
 }

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -190,6 +190,15 @@ func TestEncodeBig(t *testing.T) {
 	}
 }
 
+func BenchmarkEncodeBig(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		for _, test := range encodeBigTests {
+			EncodeBig(test.input.(*big.Int))
+		}
+	}
+}
+
 func TestDecodeBig(t *testing.T) {
 	for idx, test := range decodeBigTests {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -64,7 +64,7 @@ func (b Big) AppendText(dst []byte) ([]byte, error) {
 	case 0:
 		return append(dst, `0x0`...), nil
 	case -1:
-		// EncodeBig (fmt %#x) writes the sign before the prefix ("-0x…"); big.Int.Append
+		// EncodeBig writes the sign before the prefix ("-0x…"); big.Int.Append
 		// writes it after ("0x-…"). Append "-0x", let Append add the magnitude with its
 		// own leading '-', then drop that duplicate '-'.
 		dst = append(dst, `-0x`...)


### PR DESCRIPTION
Rewrite `EncodeBig` to use `big.Int.Text(16)` plus string concatenation instead of `fmt.Sprintf("%#x", ...)`. This is a port of ethereum/go-ethereum#23780, which erigon never picked up; `EncodeBig` is hot since all `hexutil.Big` JSON-RPC marshaling routes through it. The incorrect "sign of the integer is ignored" doc line is dropped (negative values encode as `-0x...`).

BenchmarkEncodeBig (one op = all 6 `encodeBigTests` cases, Apple M4 Max):

|         | sec/op  | B/op    | allocs/op |
|---------|---------|---------|-----------|
| before  | 541.8n  | 352.0   | 31.00     |
| after   | 182.5n  | 172.0   | 10.00     |
| vs base | -66.32% | -51.14% | -67.74%   |

No behavior change — the existing `encodeBigTests` (including the negative `-0x80a7f2c1bcc396c00` case) pin the output, so no new correctness tests were added, only the benchmark.
