### PR TITLE
common/hexutil: restore error mapping in Bytes.UnmarshalText

### DIFF
--- a/common/hexutil/bytes.go
+++ b/common/hexutil/bytes.go
@@ -61,8 +61,9 @@ func (b *Bytes) UnmarshalText(input []byte) error {
 		return err
 	}
 	dec := make([]byte, len(raw)/2)
-	_, err = hex.Decode(dec, raw)
-	if err == nil {
+	if _, err = hex.Decode(dec, raw); err != nil {
+		err = mapError(err)
+	} else {
 		*b = dec
 	}
 	return err

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -50,6 +50,47 @@ func bigFromString(s string) *big.Int {
 
 var errJSONEOF = errors.New("unexpected end of JSON input")
 
+var unmarshalBytesTests = []unmarshalTest{
+	{input: "", wantErr: errJSONEOF},
+	{input: "null", wantErr: errNonString(bytesT)},
+	{input: "10", wantErr: errNonString(bytesT)},
+	{input: `"0"`, wantErr: wrapTypeError(ErrMissingPrefix, bytesT)},
+	{input: `"0x0"`, wantErr: wrapTypeError(ErrOddLength, bytesT)},
+	{input: `"0xxx"`, wantErr: wrapTypeError(ErrSyntax, bytesT)},
+	{input: `"0x01zz01"`, wantErr: wrapTypeError(ErrSyntax, bytesT)},
+	{input: `""`, want: []byte{}},
+	{input: `"0x"`, want: []byte{}},
+	{input: `"0x02"`, want: []byte{0x02}},
+	{input: `"0X02"`, want: []byte{0x02}},
+	{input: `"0xffffffffff"`, want: []byte{0xff, 0xff, 0xff, 0xff, 0xff}},
+}
+
+func TestUnmarshalBytes(t *testing.T) {
+	for idx, test := range unmarshalBytesTests {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			var v Bytes
+			err := json.Unmarshal([]byte(test.input), &v)
+			checkError(t, test.input, err, test.wantErr)
+			if test.want != nil {
+				require.EqualValues(t, test.want, []byte(v))
+			}
+		})
+	}
+}
+
+func TestBytesUnmarshalTextInvalidHex(t *testing.T) {
+	var v Bytes
+	require.ErrorIs(t, v.UnmarshalText([]byte("0x01zz01")), ErrSyntax)
+}
+
+func TestBytesUnmarshalJSONInvalidHex(t *testing.T) {
+	var v Bytes
+	err := json.Unmarshal([]byte(`"0x01zz01"`), &v)
+	var typeErr *json.UnmarshalTypeError
+	require.ErrorAs(t, err, &typeErr)
+	require.Equal(t, ErrSyntax.Error(), typeErr.Value)
+}
+
 var unmarshalBigTests = []unmarshalTest{
 	// invalid encoding
 	{input: "", wantErr: errJSONEOF},


### PR DESCRIPTION
`Bytes.UnmarshalText` dropped go-ethereum's `mapError` wrapping of `hex.Decode` failures, so an invalid hex byte in any RPC `Bytes` param (e.g. `eth_call` data `"0xzz"`) leaked Go's raw `encoding/hex: invalid byte: U+007A 'z'` error and skipped the `json.UnmarshalTypeError` wrap instead of returning geth's `invalid hex string`. This restores the `mapError` call to match geth's `common/hexutil/json.go` behavior exactly, and adds the missing `TestUnmarshalBytes` coverage. Note: the RPC error text for invalid hex inputs changes back from the raw `encoding/hex: ...` message to `invalid hex string` — external QA rpc-tests golden files should be checked for the old message.
