### PR TITLE
common/hexutil: align Big.ToUint256 signature with geth

### DIFF
--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -118,6 +118,7 @@ func (b *Big) ToInt() *big.Int {
 	return (*big.Int)(b)
 }
 
+// ToUint256 converts b to a uint256.Int and reports whether it overflows 256 bits.
 func (b *Big) ToUint256() (*uint256.Int, bool) {
 	return uint256.FromBig((*big.Int)(b))
 }

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -118,8 +118,9 @@ func (b *Big) ToInt() *big.Int {
 	return (*big.Int)(b)
 }
 
-// ToUint256 converts b to a uint256.Int.
-func (b *Big) ToUint256() *uint256.Int { return uint256.MustFromBig(b.ToInt()) }
+func (b *Big) ToUint256() (*uint256.Int, bool) {
+	return uint256.FromBig((*big.Int)(b))
+}
 
 // String returns the hex encoding of b.
 func (b *Big) String() string {

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -24,6 +24,7 @@ import (
 	"math/bits"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,6 +120,30 @@ func TestMarshalBig(t *testing.T) {
 			want := `"` + test.want + `"`
 			require.Equal(t, want, string(out))
 			require.Equal(t, test.want, (*Big)(in).String())
+		})
+	}
+}
+
+func TestBigToUint256(t *testing.T) {
+	tests := []struct {
+		input        *big.Int
+		want         *uint256.Int
+		wantOverflow bool
+	}{
+		{input: big.NewInt(0), want: uint256.NewInt(0)},
+		{input: big.NewInt(12345678), want: uint256.NewInt(12345678)},
+		{input: bigFromString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), want: new(uint256.Int).SetAllOne()},
+		// negative values wrap two's-complement style, they do not overflow
+		{input: big.NewInt(-1), want: new(uint256.Int).SetAllOne()},
+		{input: new(big.Int).Lsh(big.NewInt(1), 256), wantOverflow: true},
+	}
+	for idx, test := range tests {
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			got, overflow := (*Big)(test.input).ToUint256()
+			require.Equal(t, test.wantOverflow, overflow)
+			if !test.wantOverflow {
+				require.Equal(t, test.want, got)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Port of ethereum/go-ethereum#34934's hexutil change: `Big.ToUint256` now returns `(*uint256.Int, bool)` via the non-panicking `uint256.FromBig`, replacing `uint256.MustFromBig`, which panicked on values over 256 bits. The returned bool is the overflow flag — true when the value does not fit in 256 bits; negative values wrap two's-complement style without overflow, as in both old and new forms. The method has no callers in erigon, so aligning the signature now is free and avoids a semantic trap when porting geth code that uses it.
