### PR TITLE
rlp, types: amortize per-transaction To-address allocation via Stream.AddrRef

### DIFF
--- a/execution/rlp/decode.go
+++ b/execution/rlp/decode.go
@@ -617,14 +617,15 @@ type Stream struct {
 	// Inline storage for NewBytesStream so the slice header doesn't escape per call.
 	sliceRdr sliceReader
 
-	remaining uint64   // number of bytes remaining to be read from r
-	size      uint64   // size of value ahead
-	kinderr   error    // error from last readKind
-	stack     []uint64 // list sizes
-	uintbuf   [32]byte // auxiliary buffer for integer decoding
-	kind      Kind     // kind of value ahead
-	byteval   byte     // value of single byte in type tag
-	limited   bool     // true if input limit is in effect
+	remaining uint64           // number of bytes remaining to be read from r
+	size      uint64           // size of value ahead
+	kinderr   error            // error from last readKind
+	stack     []uint64         // list sizes
+	addrs     []common.Address // bump-allocation chunk for AddrRef
+	uintbuf   [32]byte         // auxiliary buffer for integer decoding
+	kind      Kind             // kind of value ahead
+	byteval   byte             // value of single byte in type tag
+	limited   bool             // true if input limit is in effect
 }
 
 // Remaining returns number of bytes remaining to be read.
@@ -971,6 +972,25 @@ func (s *Stream) Addr() (a common.Address, err error) {
 	}
 	copy(a[:], s.uintbuf[:len(a)])
 	return a, nil
+}
+
+// AddrRef decodes an RLP string of exactly 20 bytes as an address and returns
+// a pointer to it. Each pointer gets a slot of its own, handed out from a
+// chunk that survives Reset and pool reuse, so one heap allocation is
+// amortized over many decoded addresses. A returned address stays valid
+// forever but must not be mutated: it pins its chunk, and callers may share it.
+func (s *Stream) AddrRef() (*common.Address, error) {
+	a, err := s.Addr()
+	if err != nil {
+		return nil, err
+	}
+	if len(s.addrs) == 0 {
+		s.addrs = make([]common.Address, 16)
+	}
+	p := &s.addrs[0]
+	s.addrs = s.addrs[1:]
+	*p = a
+	return p, nil
 }
 
 // ReadHash decodes an RLP string of exactly 32 bytes as a hash. Like Addr, it

--- a/execution/rlp/decode_test.go
+++ b/execution/rlp/decode_test.go
@@ -1410,3 +1410,78 @@ func TestStreamResetSliceRdrCoherency(t *testing.T) {
 		check(t, s, false)
 	})
 }
+
+// TestAddrRefSlotImmutability pins the contract that lets transaction decoders
+// hold AddrRef results long-term: a returned slot is a copy that never aliases
+// the input or the stream's scratch storage, and no later use of the stream —
+// chunk refills, Reset, or pooled reuse — may overwrite it.
+func TestAddrRefSlotImmutability(t *testing.T) {
+	const n = 40
+	want := make([]common.Address, n)
+	var enc []byte
+	for i := range want {
+		for j := range want[i] {
+			want[i][j] = byte(1 + i + j)
+		}
+		enc = append(enc, 0x80+20)
+		enc = append(enc, want[i][:]...)
+	}
+
+	input := bytes.Clone(enc)
+	s := NewBytesStream(input)
+	got := make([]*common.Address, n)
+	for i := range got {
+		p, err := s.AddrRef()
+		if err != nil {
+			t.Fatalf("AddrRef %d: %v", i, err)
+		}
+		got[i] = p
+	}
+
+	checkAll := func(stage string) {
+		t.Helper()
+		for i, p := range got {
+			if *p != want[i] {
+				t.Fatalf("%s: address %d changed: got %x, want %x", stage, i, *p, want[i])
+			}
+		}
+	}
+
+	for i := range input {
+		input[i] = 0xFF
+	}
+	for i := range s.uintbuf {
+		s.uintbuf[i] = 0xFF
+	}
+	checkAll("after scribbling input and scratch")
+
+	seen := make(map[*common.Address]struct{}, n)
+	for _, p := range got {
+		if _, dup := seen[p]; dup {
+			t.Fatalf("slot handed out twice: %p", p)
+		}
+		seen[p] = struct{}{}
+	}
+
+	other := common.Address{19: 0xEE}
+	encOther := append([]byte{0x80 + 20}, other[:]...)
+	for range n {
+		s.Reset(bytes.NewReader(encOther), 0)
+		p, err := s.AddrRef()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if *p != other {
+			t.Fatalf("after Reset: got %x, want %x", *p, other)
+		}
+	}
+	checkAll("after Reset reuse")
+
+	PutStream(s)
+	s2 := NewBytesStream(encOther)
+	if p, err := s2.AddrRef(); err != nil || *p != other {
+		t.Fatalf("pooled reuse decode: %v %v", p, err)
+	}
+	PutStream(s2)
+	checkAll("after pooled reuse")
+}

--- a/execution/types/blob_tx.go
+++ b/execution/types/blob_tx.go
@@ -377,11 +377,9 @@ func (stx *BlobTx) DecodeRLP(s *rlp.Stream) error {
 	} else if size != length.Addr {
 		return fmt.Errorf("wrong size for To: %d", size)
 	}
-	to, err := s.Addr()
-	if err != nil {
+	if stx.To, err = s.AddrRef(); err != nil {
 		return err
 	}
-	stx.To = &to
 	if err = s.ReadUint256(&stx.Value); err != nil {
 		return err
 	}

--- a/execution/types/encdec_test.go
+++ b/execution/types/encdec_test.go
@@ -542,6 +542,29 @@ func compareBodies(t *testing.T, a, b *Body) error {
 	return nil
 }
 
+func TestDecodeTransactionOptionalTo(t *testing.T) {
+	to := common.HexToAddress("0x000000000000000000000000000000000000dEaD")
+	for _, tc := range []struct {
+		name string
+		txn  Transaction
+	}{
+		{"LegacyCall", &LegacyTx{CommonTx: CommonTx{To: &to}}},
+		{"LegacyCreate", &LegacyTx{}},
+		{"AccessListCall", &AccessListTx{LegacyTx: LegacyTx{CommonTx: CommonTx{To: &to}}}},
+		{"AccessListCreate", &AccessListTx{}},
+		{"DynamicFeeCall", &DynamicFeeTransaction{CommonTx: CommonTx{To: &to}}},
+		{"DynamicFeeCreate", &DynamicFeeTransaction{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			require.NoError(t, tc.txn.EncodeRLP(&buf))
+			dec, err := DecodeTransaction(buf.Bytes())
+			require.NoError(t, err)
+			require.Equal(t, tc.txn.GetTo(), dec.GetTo())
+		})
+	}
+}
+
 func TestTransactionEncodeDecodeRLP(t *testing.T) {
 	tr := NewTRand()
 	var buf bytes.Buffer

--- a/execution/types/rlp_address.go
+++ b/execution/types/rlp_address.go
@@ -47,10 +47,10 @@ func DecodeOptionalAddress(dst **common.Address, s *rlp.Stream) error {
 		*dst = nil
 		return s.ReadBytes(nil)
 	}
-	a, err := s.Addr()
+	a, err := s.AddrRef()
 	if err != nil {
 		return err
 	}
-	*dst = &a
+	*dst = a
 	return nil
 }

--- a/execution/types/set_code_tx.go
+++ b/execution/types/set_code_tx.go
@@ -262,11 +262,9 @@ func (tx *SetCodeTransaction) DecodeRLP(s *rlp.Stream) error {
 	} else if size != length.Addr {
 		return fmt.Errorf("wrong size for To: %d", size)
 	}
-	to, err := s.Addr()
-	if err != nil {
+	if tx.To, err = s.AddrRef(); err != nil {
 		return err
 	}
-	tx.To = &to
 	if err = s.ReadUint256(&tx.Value); err != nil {
 		return err
 	}


### PR DESCRIPTION
A mainnet heap profile taken under RPC load (`alloc_objects`) showed `types.DecodeOptionalAddress` as the largest single allocator under the `DecodeTransaction` tree:

- `DecodeTransaction` subtree: 271M objects, 3.38% of all allocations
- `DecodeOptionalAddress` flat: 102.6M objects (38% of the subtree) — one heap `common.Address` per transaction with a To field
- the rest: 86.5M tx struct allocations, 62.9M `Stream.Bytes` payload allocations

`inuse_objects` for the frame is ~0.15M, so this is pure churn / GC pressure, not retention.

Root cause: after the `Stream.Addr()` delegation (#22589), `DecodeOptionalAddress` still ends with `*dst = &a`, which heap-escapes one 20-byte address per decoded transaction. `BlobTx`/`SetCodeTransaction` had the same `tx.To = &to` pattern.

Fix: new `Stream.AddrRef()` hands out `*common.Address` slots from a 16-element bump-allocation chunk owned by the stream. All To decodes (`DecodeOptionalAddress`, `BlobTx`, `SetCodeTransaction`) go through it; AA `Deployer`/`Paymaster` benefit as well. Transaction struct layouts are untouched (an earlier variant that stored the address in a new `CommonTx` field was rejected for that reason).

Safety contract, pinned by `TestAddrRefSlotImmutability` in `execution/rlp`:

- a returned address is a **copy** — it never aliases the stream's input bytes or its `uintbuf` scratch storage (the test scribbles both after decoding and asserts every returned address is intact);
- handed-out slots are **structurally unreusable**: the chunk window only moves forward (`s.addrs = s.addrs[1:]`), `Reset`/pool reuse never rewind it, and refill allocates a fresh array — the test drives >2 chunk refills, per-decode `Reset`s, and `PutStream`/`NewBytesStream` pooled reuse, asserting all previously returned addresses keep their values and no pointer is handed out twice.

Accepted trade-off: allocations are amortized 16x rather than eliminated (102.6M → ~6.4M objects for the profiled workload), and a single long-surviving address pins its 320-byte chunk. Decoded addresses from the same batch typically live and die together.

Also added `TestDecodeTransactionOptionalTo` pinning both optional-To arms (empty string = nil To for contract creation vs 20-byte address).

benchstat, M4 Max, 6 interleaved before/after rounds of `BenchmarkDecodeTransactionRLP` + `BenchmarkUnmarshalTransactionFromBinary` + `BenchmarkDecodeOptionalAddress`:

| metric | result |
|---|---|
| allocs/op | −1 for every tx type: Legacy 3→2, AccessList/DynamicFee 7→6, Blob 10→9, SetCode 5→4 |
| sec/op | geomean −3.41%, all tx types improved (−2…−4.6%); `DecodeOptionalAddress/Address` −8.9% |
| B/op | −4 B/op per tx (24-byte address object → 20-byte chunk share) |
