### PR TITLE
[r3.5] cmd: expand ~ and $VAR in --datadir for cobra binaries

### DIFF
--- a/cmd/bumper/cmd/rename.go
+++ b/cmd/bumper/cmd/rename.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/erigontech/erigon/cmd/utils/flags"
 	datadir2 "github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/snaptype"
@@ -63,7 +64,7 @@ var renameCmd = &cobra.Command{
 }
 
 func init() {
-	renameCmd.Flags().StringVar(&datadir, "datadir", "", "Directory containing versioned files")
+	flags.DirVar(renameCmd.Flags(), &datadir, "datadir", "", "Directory containing versioned files")
 	renameCmd.Flags().StringSliceVar(&includeDomains, "include-domains", []string{}, "Domains to include (default: all)")
 	renameCmd.Flags().StringSliceVar(&excludeDomains, "exclude-domains", []string{}, "Domains to exclude")
 	renameCmd.Flags().StringSliceVar(&includeExts, "include-exts", []string{}, "Extensions to include (default: all)")

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -51,6 +51,7 @@ import (
 
 	"github.com/erigontech/erigon/cmd/downloader/downloadernat"
 	"github.com/erigontech/erigon/cmd/utils"
+	"github.com/erigontech/erigon/cmd/utils/flags"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
@@ -191,7 +192,7 @@ func init() {
 }
 
 func withDataDir(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&cobraFlagValues.datadir, utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
+	flags.DirVar(cmd.Flags(), &cobraFlagValues.datadir, utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
 	panicif.Err(cmd.MarkFlagRequired(utils.DataDirFlag.Name))
 	panicif.Err(cmd.MarkFlagDirname(utils.DataDirFlag.Name))
 }

--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/erigontech/erigon/cmd/utils"
+	"github.com/erigontech/erigon/cmd/utils/flags"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/node/cli"
@@ -149,7 +150,7 @@ func withBucket(cmd *cobra.Command) {
 
 func withDataDir2(cmd *cobra.Command) {
 	// --datadir is required, but no --chain flag: read chainConfig from db instead
-	cmd.Flags().StringVar(&datadirCli, utils.DataDirFlag.Name, "", utils.DataDirFlag.Usage)
+	flags.DirVar(cmd.Flags(), &datadirCli, utils.DataDirFlag.Name, "", utils.DataDirFlag.Usage)
 	must(cmd.MarkFlagDirname(utils.DataDirFlag.Name))
 	must(cmd.MarkFlagRequired(utils.DataDirFlag.Name))
 
@@ -160,7 +161,7 @@ func withDataDir2(cmd *cobra.Command) {
 func withDataDir(cmd *cobra.Command) {
 	withDataDir2(cmd)
 
-	cmd.Flags().StringVar(&chaindata, "chaindata", "", "path to the db")
+	flags.DirVar(cmd.Flags(), &chaindata, "chaindata", "", "path to the db")
 	must(cmd.MarkFlagDirname("chaindata"))
 }
 

--- a/cmd/integration/commands/root.go
+++ b/cmd/integration/commands/root.go
@@ -19,9 +19,7 @@ package commands
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/semaphore"
@@ -38,29 +36,12 @@ import (
 	"github.com/erigontech/erigon/node/logging"
 )
 
-func expandHomeDir(dirpath string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return dirpath
-	}
-	prefix := fmt.Sprintf("~%c", os.PathSeparator)
-	if strings.HasPrefix(dirpath, prefix) {
-		return filepath.Join(home, dirpath[len(prefix):])
-	} else if dirpath == "~" {
-		return home
-	}
-	return dirpath
-}
-
 var rootCmd = &cobra.Command{
 	Use:   "integration",
 	Short: "long and heavy integration tests for Erigon",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		datadirCli = expandHomeDir(datadirCli)
 		if chaindata == "" {
 			chaindata = filepath.Join(datadirCli, "chaindata")
-		} else {
-			chaindata = expandHomeDir(chaindata)
 		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/cmd/rpcdaemon/cli"
 	"github.com/erigontech/erigon/cmd/rpcdaemon/cli/httpcfg"
 	"github.com/erigontech/erigon/cmd/utils"
+	"github.com/erigontech/erigon/cmd/utils/flags"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv/kvcache"
@@ -150,7 +151,7 @@ Examples:
 
 	rootCmd.Flags().StringVar(&rpcURL, "rpc.url", "http://127.0.0.1:8545", "Erigon JSON-RPC endpoint URL")
 	rootCmd.Flags().UintVar(&port, "port", 0, "Erigon JSON-RPC port (shorthand for --rpc.url=http://127.0.0.1:{port})")
-	rootCmd.Flags().StringVar(&dataDir, "datadir", "", "Erigon data directory (enables direct DB access mode)")
+	flags.DirVar(rootCmd.Flags(), &dataDir, "datadir", "", "Erigon data directory (enables direct DB access mode)")
 	rootCmd.Flags().StringVar(&privAPI, "private.api.addr", "127.0.0.1:9090", "Erigon gRPC private API address (used with --datadir)")
 	rootCmd.Flags().StringVar(&transport, "transport", "stdio", "MCP transport: 'stdio' or 'sse'")
 	rootCmd.Flags().StringVar(&sseAddr, "sse.addr", "127.0.0.1:8553", "SSE server listen address (when transport=sse)")

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -81,7 +81,6 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/node/logging"
 	"github.com/erigontech/erigon/node/nodecfg"
-	"github.com/erigontech/erigon/node/paths"
 	"github.com/erigontech/erigon/node/shards"
 	"github.com/erigontech/erigon/polygon/bor"
 	"github.com/erigontech/erigon/polygon/bor/borcfg"
@@ -121,7 +120,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 
 	cfg := &httpcfg.HttpCfg{Sync: ethconfig.Defaults.Sync, Enabled: true, StateCache: kvcache.DefaultCoherentConfig}
 	rootCmd.PersistentFlags().StringVar(&cfg.PrivateApiAddr, "private.api.addr", "127.0.0.1:9090", "Erigon's components (txpool, rpcdaemon, sentry, downloader, ...) can be deployed as independent Processes on same/another server. Then components will connect to erigon by this internal grpc API. Example: 127.0.0.1:9090")
-	rootCmd.PersistentFlags().StringVar(&cfg.DataDir, "datadir", "", "path to Erigon working directory")
+	flags.DirVar(rootCmd.PersistentFlags(), &cfg.DataDir, "datadir", "", "path to Erigon working directory")
 	rootCmd.PersistentFlags().BoolVar(&cfg.GraphQLEnabled, "graphql", false, "enables graphql endpoint (disabled by default)")
 	rootCmd.PersistentFlags().Uint64Var(&cfg.Gascap, "rpc.gascap", 50_000_000, "Sets a cap on gas that can be used in eth_call/estimateGas")
 	rootCmd.PersistentFlags().Uint64Var(&cfg.MaxTraces, "trace.maxtraces", 200, "Sets a limit on traces that can be returned in trace_filter")
@@ -214,12 +213,7 @@ func RootCommand() (*cobra.Command, *httpcfg.HttpCfg) {
 
 		cfg.WithDatadir = cfg.DataDir != ""
 		if cfg.WithDatadir {
-			if cfg.DataDir == "" {
-				cfg.DataDir = paths.DefaultDataDir()
-			}
-			var dataDir flags.DirectoryString
-			dataDir.Set(cfg.DataDir)
-			cfg.Dirs = datadir.New(string(dataDir))
+			cfg.Dirs = datadir.New(cfg.DataDir)
 		}
 		if cfg.TxPoolApiAddr == "" {
 			cfg.TxPoolApiAddr = cfg.PrivateApiAddr

--- a/cmd/sentry/main.go
+++ b/cmd/sentry/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/erigontech/erigon/cmd/erigon/node"
 	"github.com/erigontech/erigon/cmd/utils"
+	"github.com/erigontech/erigon/cmd/utils/flags"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/node/debug"
@@ -57,7 +58,7 @@ func init() {
 	utils.CobraFlags(rootCmd, debug.Flags, utils.MetricFlags, logging.Flags)
 
 	rootCmd.Flags().StringVar(&sentryAddr, "sentry.api.addr", "localhost:9091", "grpc addresses")
-	rootCmd.Flags().StringVar(&datadirCli, utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
+	flags.DirVar(rootCmd.Flags(), &datadirCli, utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
 	rootCmd.Flags().StringVar(&natSetting, utils.NATFlag.Name, utils.NATFlag.Value, utils.NATFlag.Usage)
 	rootCmd.Flags().IntVar(&port, utils.ListenPortFlag.Name, utils.ListenPortFlag.Value, utils.ListenPortFlag.Usage)
 	rootCmd.Flags().StringSliceVar(&staticPeers, utils.StaticPeersFlag.Name, []string{}, utils.StaticPeersFlag.Usage)

--- a/cmd/txpool/main.go
+++ b/cmd/txpool/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/erigontech/erigon/cmd/rpcdaemon/rpcdaemontest"
 	"github.com/erigontech/erigon/cmd/utils"
+	"github.com/erigontech/erigon/cmd/utils/flags"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -82,7 +83,7 @@ func init() {
 	rootCmd.Flags().StringSliceVar(&sentryAddr, "sentry.api.addr", []string{"localhost:9091"}, "comma separated sentry addresses '<host>:<port>,<host>:<port>'")
 	rootCmd.Flags().StringVar(&privateApiAddr, "private.api.addr", "localhost:9090", "execution service <host>:<port>")
 	rootCmd.Flags().StringVar(&txpoolApiAddr, "txpool.api.addr", "localhost:9094", "txpool service <host>:<port>")
-	rootCmd.Flags().StringVar(&datadirCli, utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
+	flags.DirVar(rootCmd.Flags(), &datadirCli, utils.DataDirFlag.Name, paths.DefaultDataDir(), utils.DataDirFlag.Usage)
 	if err := rootCmd.MarkFlagDirname(utils.DataDirFlag.Name); err != nil {
 		panic(err)
 	}

--- a/cmd/utils/flags/cobra.go
+++ b/cmd/utils/flags/cobra.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package flags
+
+import "github.com/spf13/pflag"
+
+// dirValue is a pflag.Value that expands "~" and "$VAR" in the assigned path,
+// mirroring the urfave DirectoryFlag used by the main erigon binary.
+type dirValue struct{ p *string }
+
+func (d *dirValue) String() string {
+	if d.p == nil {
+		return ""
+	}
+	return *d.p
+}
+
+func (d *dirValue) Set(s string) error {
+	if s != "" {
+		s = expandPath(s)
+	}
+	*d.p = s
+	return nil
+}
+
+func (d *dirValue) Type() string { return "string" }
+
+// DirVar registers a cobra/pflag string flag for a directory path, expanding
+// "~" and "$VAR" at parse time so all binaries normalize --datadir identically
+// to the erigon binary's DirectoryFlag.
+func DirVar(fs *pflag.FlagSet, p *string, name, value, usage string) {
+	if value != "" {
+		value = expandPath(value)
+	}
+	*p = value
+	fs.Var(&dirValue{p}, name, usage)
+}

--- a/cmd/utils/flags/cobra.go
+++ b/cmd/utils/flags/cobra.go
@@ -18,8 +18,9 @@ package flags
 
 import "github.com/spf13/pflag"
 
-// dirValue is a pflag.Value that expands "~" and "$VAR" in the assigned path,
-// mirroring the urfave DirectoryFlag used by the main erigon binary.
+// dirValue is a pflag.Value that expands a leading "~/" (or "~\" on Windows) and
+// "$VAR" in the assigned path, mirroring the urfave DirectoryFlag used by the
+// main erigon binary.
 type dirValue struct{ p *string }
 
 func (d *dirValue) String() string {
@@ -39,9 +40,9 @@ func (d *dirValue) Set(s string) error {
 
 func (d *dirValue) Type() string { return "string" }
 
-// DirVar registers a cobra/pflag string flag for a directory path, expanding
-// "~" and "$VAR" at parse time so all binaries normalize --datadir identically
-// to the erigon binary's DirectoryFlag.
+// DirVar registers a cobra/pflag string flag for a directory path, expanding a
+// leading "~/" (or "~\" on Windows) and "$VAR" at parse time so all binaries
+// normalize --datadir identically to the erigon binary's DirectoryFlag.
 func DirVar(fs *pflag.FlagSet, p *string, name, value, usage string) {
 	if value != "" {
 		value = expandPath(value)

--- a/cmd/utils/flags/cobra_test.go
+++ b/cmd/utils/flags/cobra_test.go
@@ -58,6 +58,9 @@ func TestDirVarExpandsEnv(t *testing.T) {
 	if got != want {
 		t.Fatalf("env var not expanded: got %q want %q", got, want)
 	}
+	if v := fs.Lookup("datadir").Value.String(); v != want {
+		t.Fatalf("flag lookup not expanded: got %q want %q", v, want)
+	}
 }
 
 func TestDirVarEmptyDefaultStaysEmpty(t *testing.T) {

--- a/cmd/utils/flags/cobra_test.go
+++ b/cmd/utils/flags/cobra_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package flags
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestDirVarExpandsTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	var got string
+	DirVar(fs, &got, "datadir", "", "")
+	if err := fs.Parse([]string{"--datadir=~/erigon"}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(home, "erigon")
+	if got != want {
+		t.Fatalf("bound var not expanded: got %q want %q", got, want)
+	}
+	if v := fs.Lookup("datadir").Value.String(); v != want {
+		t.Fatalf("flag lookup not expanded: got %q want %q", v, want)
+	}
+}
+
+func TestDirVarExpandsEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("MYDATA", filepath.Join(home, "d"))
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	var got string
+	DirVar(fs, &got, "datadir", "", "")
+	if err := fs.Parse([]string{"--datadir=$MYDATA/chain"}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(home, "d", "chain")
+	if got != want {
+		t.Fatalf("env var not expanded: got %q want %q", got, want)
+	}
+}
+
+func TestDirVarEmptyDefaultStaysEmpty(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	var got string
+	DirVar(fs, &got, "datadir", "", "")
+	if err := fs.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Fatalf("empty default must stay empty, got %q", got)
+	}
+}


### PR DESCRIPTION
Cherry-pick of #22771 and #22775 to release/3.5.

- #22771 — expand `~/` and `$VAR` in `--datadir` for the cobra binaries (rpcdaemon, mcp, bumper, integration, downloader, sentry, txpool) via a shared `flags.DirVar`, matching the erigon binary's `DirectoryFlag`.
- #22775 — follow-up doc/test accuracy nits on the new `cmd/utils/flags/cobra.go`.

Clean cherry-picks; no release-branch adaptations needed.