### PR TITLE
cmd/scripts: validate RPC URL in bench_eth_getlogs to prevent SSRF

### DIFF
--- a/cmd/scripts/bench_eth_getlogs.py
+++ b/cmd/scripts/bench_eth_getlogs.py
@@ -33,6 +33,7 @@ import csv
 import json
 import sys
 import time
+import urllib.parse
 import urllib.request
 from collections import defaultdict
 from datetime import datetime
@@ -84,8 +85,20 @@ FILTER_CONFIGS = [
 
 MAX_LOGS_WARN = 20_000
 
+ALLOWED_URL_SCHEMES = ("http", "https")
+
+
+def validate_rpc_url(url: str) -> str:
+    """Reject non-HTTP(S) endpoints so a malformed --url can't be turned into an
+    SSRF or local-file read — urllib otherwise honours file://, gopher://, etc."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ALLOWED_URL_SCHEMES or not parsed.netloc:
+        raise ValueError(f"unsupported --url {url!r}: expected http(s)://host[:port]")
+    return url
+
 
 def rpc(url: str, method: str, params: list, timeout: int = 120) -> dict:
+    validate_rpc_url(url)
     payload = json.dumps({"jsonrpc": "2.0", "method": method, "params": params, "id": 1}).encode()
     req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
     with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -98,6 +111,7 @@ def get_block_number(url: str) -> int:
 
 def call_getlogs(url, from_block, to_block, addresses=None, topics=None):
     """Returns (latency_ms, status, log_count)."""
+    validate_rpc_url(url)
     filter_obj = {"fromBlock": hex(from_block), "toBlock": hex(to_block)}
     if addresses:
         filter_obj["address"] = addresses if len(addresses) > 1 else addresses[0]
@@ -140,7 +154,11 @@ def build_scenarios(tip, ranges):
 
 
 def run_bench(args):
-    url     = args.url
+    try:
+        url = validate_rpc_url(args.url)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
     label   = args.label
     repeats = args.repeats
     ranges  = [int(x) for x in args.ranges.split(",")]


### PR DESCRIPTION
Fixes SonarQube Cloud `pythonsecurity:S8703` — **alerts #853 (line 90) and #854 (line 108)**.

## Problem
`bench_eth_getlogs.py` takes `--url` from argparse and passes it straight into `urllib.request.urlopen` in both network sinks (`rpc`, `call_getlogs`) with no validation. A faulty or malicious value could be turned into an SSRF or a local-file read — `urllib` honours `file://`, `gopher://`, `ftp://`, etc.

## Fix
Add `validate_rpc_url()` — an allowlist that accepts only `http`/`https` URLs with a host — and apply it:
- at the CLI entry (`run_bench`) so a bad `--url` fails fast with a clear message, and
- inside both network sinks (`rpc`, `call_getlogs`) so a request can never be issued for a disallowed URL, regardless of caller.

Behaviour for valid endpoints (`http://localhost:8546`, the default) is unchanged.

## Verification
There is no Python test harness in the repo (no `*_test.py`/`conftest`/`pytest` config anywhere under `cmd/`), so per the TDD "pragmatism" clause I verified the pure validator manually rather than adding un-wired CI infra:

- Accepts: `http://localhost:8546`, `https://rpc.example.com:8545`, `http://127.0.0.1:8546/`
- Rejects: `file:///etc/passwd`, `gopher://…`, `ftp://…`, `javascript:…`, `notaurl`, `""`, `http://` (no host), `///etc/passwd`
- `--url file:///etc/passwd` → `ERROR: unsupported --url … expected http(s)://host[:port]`, exit 1
- Both `rpc()` and `call_getlogs()` raise before any network access on a disallowed URL

## Related (not in this PR)
Same file has two `pythonsecurity:S8707` (path-injection) alerts — **#856 (line 169, `--out`)** and **#855 (line 209, `--compare`/`--show`)** — same "faulty CLI argument" class. Holding those for a follow-up because the right validation policy (restrict paths to the working tree vs. allow arbitrary output locations) is a UX call worth confirming first.