### PR TITLE
common: fix PrettyCounter on negative values, add PrettyExact

### DIFF
--- a/common/pretty.go
+++ b/common/pretty.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -19,26 +21,58 @@ const (
 
 // PrettyCounter print counter number in human readable format
 func PrettyCounter[N number](num N) string {
-	if num < N(numK) {
-		if num < 1 && num > 0 {
-			return fmt.Sprintf("%.2f", float64(num))
+	if num < 0 {
+		// float64 is the only comparison that compiles against the unsigned members of the type set
+		if f := float64(num); f > -1 {
+			return fmt.Sprintf("%.2f", f)
 		}
-		return fmt.Sprintf("%d", uint64(num))
+		return "-" + prettyCounter(uint64(-num))
 	}
-	if num < N(numM) {
+	if num < 1 && num > 0 {
+		return fmt.Sprintf("%.2f", float64(num))
+	}
+	return prettyCounter(uint64(num))
+}
+
+const digitGroupSep = '.'
+
+// PrettyExact prints num in full, grouping digits from five digits up: 4356854 -> "4.356.854".
+// Use it for values an operator reads back out of the log - block numbers, key totals in a
+// report. Use PrettyCounter when only the order of magnitude matters.
+func PrettyExact(num uint64) string {
+	d := strconv.FormatUint(num, 10)
+	if len(d) < 5 {
+		return d
+	}
+	var b strings.Builder
+	b.Grow(len(d) + (len(d)-1)/3)
+	for i := range len(d) {
+		if i > 0 && (len(d)-i)%3 == 0 {
+			b.WriteByte(digitGroupSep)
+		}
+		b.WriteByte(d[i])
+	}
+	return b.String()
+}
+
+func prettyCounter(num uint64) string {
+	if num < numK {
+		return strconv.FormatUint(num, 10)
+	}
+	if num < numM {
 		// sequence %02d does not always print 2 first digits but prints whole value so we have to divide by expected /100th part
-		return fmt.Sprintf("%d.%02dk", uint64(num)/numK, (uint64(num)%numK)/10)
+		return fmt.Sprintf("%d.%02dk", num/numK, (num%numK)/10)
 	}
-	if num < N(numG) {
-		return fmt.Sprintf("%d.%02dM", uint64(num)/numM, (uint64(num)%numM)/(numK*10))
+	if num < numG {
+		return fmt.Sprintf("%d.%02dM", num/numM, (num%numM)/(numK*10))
 	}
-	if num < N(numT) {
-		return fmt.Sprintf("%d.%02dG", uint64(num)/numG, (uint64(num)%numG)/(numM*10))
+	if num < numT {
+		return fmt.Sprintf("%d.%02dG", num/numG, (num%numG)/(numM*10))
 	}
-	if num < N(numQ) {
-		return fmt.Sprintf("%d.%02dT", uint64(num)/numT, (uint64(num)%numT)/(numG*10))
+	if num < numQ {
+		return fmt.Sprintf("%d.%02dT", num/numT, (num%numT)/(numG*10))
 	}
-	return fmt.Sprintf("%d.%02dQ", uint64(num)/numQ, (uint64(num)%numQ)/(numT*10))
+	return fmt.Sprintf("%d.%02dQ", num/numQ, (num%numQ)/(numT*10))
 }
 
 var divs = []time.Duration{

--- a/common/pretty_test.go
+++ b/common/pretty_test.go
@@ -1,6 +1,159 @@
 package common
 
-import "testing"
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPrettyCounterSigned(t *testing.T) {
+	tests := []struct {
+		num int64
+		out string
+	}{
+		{num: math.MinInt64, out: "-9223.37Q"},
+		{num: math.MinInt64 + 1, out: "-9223.37Q"},
+		{num: -4356854, out: "-4.35M"},
+		{num: -1500, out: "-1.50k"},
+		{num: -1000, out: "-1.00k"},
+		{num: -999, out: "-999"},
+		{num: -5, out: "-5"},
+		{num: -1, out: "-1"},
+		{num: 0, out: "0"},
+		{num: 1, out: "1"},
+		{num: 999, out: "999"},
+		{num: 1000, out: "1.00k"},
+		{num: math.MaxInt64, out: "9223.37Q"},
+	}
+
+	for _, test := range tests {
+		if got := PrettyCounter(test.num); got != test.out {
+			t.Errorf("PrettyCounter(int64(%d)) = %s, want %s", test.num, got, test.out)
+		}
+	}
+}
+
+func TestPrettyCounterNegativeFloat(t *testing.T) {
+	tests := []struct {
+		num float64
+		out string
+	}{
+		{num: -4356854, out: "-4.35M"},
+		{num: -1000.5, out: "-1.00k"},
+		{num: -2.7, out: "-2"},
+		{num: -1, out: "-1"},
+		{num: -0.99, out: "-0.99"},
+		{num: -0.5, out: "-0.50"},
+		{num: 0.5, out: "0.50"},
+	}
+
+	for _, test := range tests {
+		if got := PrettyCounter(test.num); got != test.out {
+			t.Errorf("PrettyCounter(float64(%v)) = %s, want %s", test.num, got, test.out)
+		}
+	}
+}
+
+func TestPrettyExact(t *testing.T) {
+	tests := []struct {
+		num uint64
+		out string
+	}{
+		{num: 0, out: "0"},
+		{num: 1, out: "1"},
+		{num: 999, out: "999"},
+		{num: 1000, out: "1000"},
+		{num: 9999, out: "9999"},
+		{num: 10000, out: "10.000"},
+		{num: 100000, out: "100.000"},
+		{num: 999999, out: "999.999"},
+		{num: 1000000, out: "1.000.000"},
+		{num: 1005000, out: "1.005.000"},
+		{num: 4356854, out: "4.356.854"},
+		{num: 14866176, out: "14.866.176"},
+		{num: 23847119, out: "23.847.119"},
+		{num: math.MaxUint64, out: "18.446.744.073.709.551.615"},
+	}
+
+	for _, test := range tests {
+		if got := PrettyExact(test.num); got != test.out {
+			t.Errorf("PrettyExact(%d) = %s, want %s", test.num, got, test.out)
+		}
+	}
+}
+
+// The point of the helper is that the operator can read the original value back out of the log.
+func TestPrettyExactRoundTrips(t *testing.T) {
+	nums := []uint64{0, 1, 999, 1000, 9999, 10000, math.MaxUint64}
+	for i := range uint64(20000) {
+		nums = append(nums, i, math.MaxUint64-i)
+	}
+	for _, n := range nums {
+		got, err := strconv.ParseUint(strings.ReplaceAll(PrettyExact(n), ".", ""), 10, 64)
+		if err != nil {
+			t.Fatalf("PrettyExact(%d) = %q does not parse back: %v", n, PrettyExact(n), err)
+		}
+		if got != n {
+			t.Fatalf("PrettyExact(%d) round-tripped to %d", n, got)
+		}
+	}
+}
+
+// prettyCounterBeforeSignFix is the implementation as it stood before negative inputs were
+// handled, kept verbatim so the sign fix can be proven to leave non-negative output untouched.
+func prettyCounterBeforeSignFix[N number](num N) string {
+	if num < N(numK) {
+		if num < 1 && num > 0 {
+			return fmt.Sprintf("%.2f", float64(num))
+		}
+		return fmt.Sprintf("%d", uint64(num))
+	}
+	if num < N(numM) {
+		return fmt.Sprintf("%d.%02dk", uint64(num)/numK, (uint64(num)%numK)/10)
+	}
+	if num < N(numG) {
+		return fmt.Sprintf("%d.%02dM", uint64(num)/numM, (uint64(num)%numM)/(numK*10))
+	}
+	if num < N(numT) {
+		return fmt.Sprintf("%d.%02dG", uint64(num)/numG, (uint64(num)%numG)/(numM*10))
+	}
+	if num < N(numQ) {
+		return fmt.Sprintf("%d.%02dT", uint64(num)/numT, (uint64(num)%numT)/(numG*10))
+	}
+	return fmt.Sprintf("%d.%02dQ", uint64(num)/numQ, (uint64(num)%numQ)/(numT*10))
+}
+
+// The sign fix must be invisible to every existing call site. NaN and +Inf are excluded: both
+// were already garbage before the fix and remain so, just differently shaped.
+func TestPrettyCounterUnchangedForNonNegative(t *testing.T) {
+	var uints []uint64
+	for _, decade := range []uint64{0, numK, numM, numG, numT, numQ, math.MaxUint64} {
+		for _, d := range []uint64{0, 1, 9, 99, 499, 500, 501, 999, 12345} {
+			if decade >= d {
+				uints = append(uints, decade-d)
+			}
+			if math.MaxUint64-decade >= d {
+				uints = append(uints, decade+d)
+			}
+		}
+	}
+	for i := range uint64(5000) {
+		uints = append(uints, i)
+	}
+	for _, n := range uints {
+		if got, want := PrettyCounter(n), prettyCounterBeforeSignFix(n); got != want {
+			t.Fatalf("PrettyCounter(uint64(%d)) = %s, was %s", n, got, want)
+		}
+	}
+
+	for _, f := range []float64{0, 0.001, 0.5, 0.99, 1, 1.5, 999.99, 1000, 1000.5, 4356854, 1e12, 1e15, 1e18} {
+		if got, want := PrettyCounter(f), prettyCounterBeforeSignFix(f); got != want {
+			t.Fatalf("PrettyCounter(float64(%v)) = %s, was %s", f, got, want)
+		}
+	}
+}
 
 func TestPrettyCounter(t *testing.T) {
 	tests := []struct {

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -1154,7 +1154,7 @@ func CheckCommitmentHistAtBlkRange(ctx context.Context, sc SamplerCfg, db kv.Tem
 					"blks/s", fmt.Sprintf("%.1f", blkRate),
 					"checked", fmt.Sprintf("%s/%s", common.PrettyCounter(done), common.PrettyCounter(expectedBlks)),
 					"windows", fmt.Sprintf("%d/%d", wDone, totalWindows),
-					"blkRange", fmt.Sprintf("%s-%s", common.PrettyCounter(from), common.PrettyCounter(to)),
+					"blkRange", fmt.Sprintf("%s-%s", common.PrettyExact(from), common.PrettyExact(to)),
 				)
 			}
 		}

--- a/db/integrity/e3_history_no_system_txs.go
+++ b/db/integrity/e3_history_no_system_txs.go
@@ -25,6 +25,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/estimate"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/dbservices"
@@ -157,7 +158,7 @@ func HistoryCheckNoSystemTxsRange(ctx context.Context, prefixFrom, prefixTo []by
 
 		select {
 		case <-logEvery.C:
-			log.Info(fmt.Sprintf("[integrity] HistoryNoSystemTxs: progress=%d/%d, keys=%.3fm", prefixesDone.Load(), prefixesTotal.Load(), float64(keysCnt.Load())/1_000_000))
+			log.Info(fmt.Sprintf("[integrity] HistoryNoSystemTxs: progress=%d/%d, keys=%s", prefixesDone.Load(), prefixesTotal.Load(), common.PrettyCounter(keysCnt.Load())))
 		default:
 		}
 	}

--- a/db/integrity/no_gaps_in_canonical_headers.go
+++ b/db/integrity/no_gaps_in_canonical_headers.go
@@ -79,7 +79,7 @@ func NoGapsInCanonicalHeaders(ctx context.Context, db kv.RoDB, br dbservices.Ful
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-logEvery.C:
-			log.Info("[integrity] HeaderNoGaps", "progress", fmt.Sprintf("%s/%s", common.PrettyCounter(i), common.PrettyCounter(lastBlockNum)))
+			log.Info("[integrity] HeaderNoGaps", "progress", fmt.Sprintf("%s/%s", common.PrettyExact(i), common.PrettyExact(lastBlockNum)))
 		default:
 		}
 	}

--- a/db/integrity/snap_blocks_read.go
+++ b/db/integrity/snap_blocks_read.go
@@ -64,7 +64,7 @@ func SnapBlocksRead(ctx context.Context, db kv.TemporalRoDB, blockReader dbservi
 		case <-ctx.Done():
 			return nil
 		case <-logEvery.C:
-			log.Info("[integrity] Blocks", "blockNum", fmt.Sprintf("%s/%s", common.PrettyCounter(i), common.PrettyCounter(maxBlockNum)))
+			log.Info("[integrity] Blocks", "blockNum", fmt.Sprintf("%s/%s", common.PrettyExact(i), common.PrettyExact(maxBlockNum)))
 		default:
 		}
 	}

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -220,7 +220,7 @@ func (s *CaplinStateSnapshots) SegmentsMax() uint64 { return s.segmentsMax.Load(
 
 func (s *CaplinStateSnapshots) LogStat(str string) {
 	s.logger.Info(fmt.Sprintf("[snapshots:%s] Stat", str),
-		"blocks", common.PrettyCounter(s.SegmentsMax()+1), "indices", common.PrettyCounter(s.IndicesMax()+1))
+		"blocks", common.PrettyExact(s.SegmentsMax()+1), "indices", common.PrettyExact(s.IndicesMax()+1))
 }
 
 func (s *CaplinStateSnapshots) LS() {

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -279,7 +279,7 @@ func (br *BlockRetire) buildFiles(
 			return false, nil
 		}
 		logger.Log(lvl, "[snapshots] Retire Blocks", "range",
-			fmt.Sprintf("%s-%s", common.PrettyCounter(blockFrom), common.PrettyCounter(blockTo)))
+			fmt.Sprintf("%s-%s", common.PrettyExact(blockFrom), common.PrettyExact(blockTo)))
 		// in future we will do it in background
 		if err := DumpBlocks(ctx, blockFrom, blockTo, br.chainConfig, tmpDir, snapshots.Dir(), db, int(workers), lvl, logger, blockReader, br.snCfg, &snapshots.BaseRoSnapshots); err != nil {
 			return ok, fmt.Errorf("DumpBlocks: %w", err)

--- a/db/snapshotsync/freezeblocks/bor_snapshots.go
+++ b/db/snapshotsync/freezeblocks/bor_snapshots.go
@@ -73,7 +73,7 @@ func (br *BlockRetire) retireBorBlocks(
 			}
 
 			logger.Log(lvl, "[bor snapshots] Retire Bor Blocks", "type", snap,
-				"range", fmt.Sprintf("%s-%s", common.PrettyCounter(blockFrom), common.PrettyCounter(blockTo)))
+				"range", fmt.Sprintf("%s-%s", common.PrettyExact(blockFrom), common.PrettyExact(blockTo)))
 
 			var firstKeyGetter snaptype.FirstKeyGetter
 

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -99,7 +99,7 @@ func (s *CaplinSnapshots) SegmentsMax() uint64 { return s.segmentsMax.Load() }
 
 func (s *CaplinSnapshots) LogStat(str string) {
 	s.logger.Info(fmt.Sprintf("[snapshots:%s] Stat", str),
-		"blocks", common.PrettyCounter(s.SegmentsMax()+1), "indices", common.PrettyCounter(s.IndicesMax()+1))
+		"blocks", common.PrettyExact(s.SegmentsMax()+1), "indices", common.PrettyExact(s.IndicesMax()+1))
 }
 
 func (s *CaplinSnapshots) LS() {

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -690,7 +690,7 @@ func (s *BaseRoSnapshots) LogStat(label string) {
 	var m runtime.MemStats
 	dbg.ReadMemStats(&m)
 	s.logger.Info(fmt.Sprintf("[snapshots:%s] Stat", label),
-		"blocks", fmt.Sprintf("%dk", (s.SegmentsMax()+1)/1_000), "indices", fmt.Sprintf("%dk", (s.IndicesMax()+1)/1_000),
+		"blocks", common.PrettyExact(s.SegmentsMax()+1), "indices", common.PrettyExact(s.IndicesMax()+1),
 		"alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
 }
 

--- a/execution/exec/historical_trace_worker.go
+++ b/execution/exec/historical_trace_worker.go
@@ -561,7 +561,7 @@ func CustomTraceMapReduce(ctx context.Context, fromBlock, toBlock uint64, consum
 		if err != nil {
 			return err
 		}
-		log.Info("[custom_trace] batch start", "blocks", fmt.Sprintf("%.1fm-%.1fm", float64(fromBlock)/1_000_000, float64(toBlock)/1_000_000), "steps", fmt.Sprintf("%.2f-%.2f", fromStep, toStep), "workers", cfg.Workers)
+		log.Info("[custom_trace] batch start", "blocks", fmt.Sprintf("%s-%s", common.PrettyExact(fromBlock), common.PrettyExact(toBlock)), "steps", fmt.Sprintf("%.2f-%.2f", fromStep, toStep), "workers", cfg.Workers)
 	}
 
 	getHeaderFunc := func(hash common.Hash, number uint64) (h *types.Header, err error) {

--- a/execution/stagedsync/rawdbreset/reset_stages.go
+++ b/execution/stagedsync/rawdbreset/reset_stages.go
@@ -348,7 +348,7 @@ func FillDBFromSnapshots(logPrefix string, ctx context.Context, tx kv.RwTx, dirs
 					return ctx.Err()
 				case <-logEvery.C:
 					logger.Info(fmt.Sprintf("[%s] Total difficulty index: %s/%s", logPrefix,
-						common.PrettyCounter(header.Number.Uint64()), common.PrettyCounter(blockReader.FrozenBlocks())))
+						common.PrettyExact(header.Number.Uint64()), common.PrettyExact(blockReader.FrozenBlocks())))
 				default:
 				}
 				return nil
@@ -381,7 +381,7 @@ func FillDBFromSnapshots(logPrefix string, ctx context.Context, tx kv.RwTx, dirs
 				case <-ctx.Done():
 					return ctx.Err()
 				case <-logEvery.C:
-					logger.Info(fmt.Sprintf("[%s] MaxTxNums index: %s/%s", logPrefix, common.PrettyCounter(blockNum), common.PrettyCounter(blockReader.FrozenBlocks())))
+					logger.Info(fmt.Sprintf("[%s] MaxTxNums index: %s/%s", logPrefix, common.PrettyExact(blockNum), common.PrettyExact(blockReader.FrozenBlocks())))
 				default:
 				}
 				if baseTxNum+txAmount == 0 {

--- a/execution/stagedsync/stage_custom_trace.go
+++ b/execution/stagedsync/stage_custom_trace.go
@@ -410,7 +410,7 @@ func customTraceBatch(ctx context.Context, produce Produce, cfg *exec.ExecArgs, 
 				if prevTxNumLog > 0 {
 					dbg.ReadMemStats(&m)
 					txsPerSec := (txTask.TxNum - prevTxNumLog) / uint64(logPeriod.Seconds())
-					log.Info(fmt.Sprintf("[%s] Scanned", logPrefix), "block", fmt.Sprintf("%.3fm", float64(txTask.BlockNumber())/1_000_000), "tx/s", fmt.Sprintf("%.1fK", float64(txsPerSec)/1_000.0), "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
+					log.Info(fmt.Sprintf("[%s] Scanned", logPrefix), "block", common.PrettyExact(txTask.BlockNumber()), "tx/s", common.PrettyCounter(txsPerSec), "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
 				}
 				prevTxNumLog = txTask.TxNum
 			default:


### PR DESCRIPTION
`PrettyCounter` converts through `uint64`, so a negative argument prints as a wrapped unsigned value — `PrettyCounter(int64(-5))` returns `18446744073709551611`. `int`, `int64` and `float64` are all in its type set. No call site can reach it today; the fix is to the signature's promise, not to a live incident.

`PrettyCounter` is also lossy by design: it keeps three significant digits, so a block number `4356854` prints as `4.35M` and `1005000` as `1.00M`. That is right for a rate or a running total, but it destroys a value an operator has to read back out of the log and paste into an RPC call or a grep.

## Changes

- `PrettyCounter` handles negatives: `-4356854` now prints `-4.35M` instead of `18446744073705194762`. Output for every non-negative input is unchanged, pinned by a differential test against the previous implementation over the decade boundaries, 5k consecutive values and a float ladder.
- Adds `PrettyExact`, which prints every digit and groups from five digits up: `4356854` -> `4.356.854`. A round-trip test asserts the original `uint64` is recoverable by stripping the separators, since that is the whole point of the helper.
- The unit ladder moves to an unexported `uint64` function; the generic entry point now only dispatches on sign.