### PR TITLE
.claude: refresh branch-naming rules for the 3.7 cycle

### DIFF
--- a/.claude/rules/branch-naming.md
+++ b/.claude/rules/branch-naming.md
@@ -2,10 +2,10 @@
 
 ## Release branches
 
-- `release/3.3` — Stable 3.3.x
 - `release/3.4` — Stable 3.4.x
-- `release/3.5` — Stable 3.5.x (current)
-- `main` — Next feature release (3.6)
+- `release/3.5` — Stable 3.5.x (current — v3.5.3 is the Latest release)
+- `release/3.6` — Upcoming 3.6.x (release-candidate stage: v3.6.0-rc.1 is a draft)
+- `main` — Next feature release (3.7)
 
 The "current" marker goes stale: before choosing a backport base, verify against `gh release list --repo erigontech/erigon --limit 5` (the Latest tag) and the recent `[rX.Y]`-prefixed PR stream, and update this file if it disagrees.
 
@@ -24,7 +24,7 @@ When creating a branch for someone else, sample their recent branches first (`gi
 
 ### Optional variants
 
-Some contributors append a release-number suffix to mark which release the branch targets — Alex's convention is `alex/<short_desc>_<release_num>[_suffix]` (e.g. `alex/seg_header_meta2_34`, `alex/all7_34_dbg`). Release number is two digits without the dot: `35` = release/3.5, `36` = main, `34` = release/3.4. Suffixes: `_dbg` (debug), `_auto` (automated), `_<n>` (revision). This is one contributor's personal scheme — do not apply it to others.
+Some contributors append a release-number suffix to mark which release the branch targets — Alex's convention is `alex/<short_desc>_<release_num>[_suffix]` (e.g. `alex/seg_header_meta2_34`, `alex/all7_34_dbg`). Release number is two digits without the dot: `34` = release/3.4, `35` = release/3.5, `36` = release/3.6, `37` = main. Suffixes: `_dbg` (debug), `_auto` (automated), `_<n>` (revision). This is one contributor's personal scheme — do not apply it to others.
 
 Non-personal prefixes that show up for cross-cutting work:
 


### PR DESCRIPTION
Refreshes `.claude/rules/branch-naming.md`, which had gone stale (it still listed main as 3.6 and 3.4 as pre-current).

Current reality:
- `main` = 3.7.0-dev → next feature release is **3.7**.
- `release/3.6` now exists (v3.6.0-rc.1, draft) — added to the list.
- `release/3.5` is current stable (**v3.5.3** is the Latest release) — annotated.

Also fixes the stale release-number mapping in the per-contributor suffix example (`36` = release/3.6, `37` = main).

Docs only.