### PR TITLE
[r3.5] polygon/sync: deflake TestEventChannel/ConsumeEvents (#22510, #21827)

### DIFF
--- a/polygon/sync/event_channel.go
+++ b/polygon/sync/event_channel.go
@@ -118,8 +118,11 @@ func (ec *EventChannel[TEvent]) waitForEvent(ctx context.Context) (TEvent, error
 	// wait for the waiting goroutine or the parent context to finish, whichever happens first
 	<-waitCtx.Done()
 
-	// if the parent context is done, force the waiting goroutine to exit
+	// Signal under the mutex to avoid a lost-wakeup: without the lock, Signal can
+	// fire between the inner goroutine's condition check and its Wait() call.
+	ec.queueMutex.Lock()
 	ec.queueCond.Signal()
+	ec.queueMutex.Unlock()
 	wg.Wait()
 
 	return e, ctx.Err()

--- a/polygon/sync/event_channel_test.go
+++ b/polygon/sync/event_channel_test.go
@@ -64,6 +64,14 @@ func TestEventChannel(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			ch := NewEventChannel[string](2)
+
+			// Fill past capacity before Run starts consuming: a consumer that takes
+			// event1 off the queue first leaves the queue below capacity, so event1 is
+			// never evicted and arrives instead of event2.
+			ch.PushEvent("event1")
+			ch.PushEvent("event2")
+			ch.PushEvent("event3")
+
 			eg := errgroup.Group{}
 			eg.Go(func() error {
 				return ch.Run(ctx)
@@ -72,10 +80,6 @@ func TestEventChannel(t *testing.T) {
 				err := eg.Wait()
 				require.ErrorIs(t, err, context.Canceled)
 			})
-
-			ch.PushEvent("event1")
-			ch.PushEvent("event2")
-			ch.PushEvent("event3")
 
 			events := ch.Events()
 			require.Equal(t, "event2", <-events)


### PR DESCRIPTION
Cherry-picks the `polygon/sync` `TestEventChannel/ConsumeEvents` flake fix (and the underlying race fix it depends on) to `release/3.5`, so the pre-release check runs on `release/3.5` don't hit the first-run flake seen on #22686.

Two commits, applied in chronological order:

- **#21827** — `polygon/sync: fix lost-wakeup race in EventChannel.waitForEvent` (cherry-pick of 78e767e21d). The actual fix: `queueCond.Signal()` is now issued under `queueMutex` so it can't fire in the window between the inner goroutine's condition check and its `Wait()`.
- **#22510** — `polygon/sync: fix flaky TestEventChannel/ConsumeEvents` (cherry-pick of 868f0bbbcb). Fills the channel past capacity **before** `Run` starts consuming, so the eviction the test asserts is deterministic.

Both are already on `release/3.6` and `main`.

## Excluded

- **#22563** (`all: enable and modernize stringscut/testingcontext/waitgroup linters`) is intentionally **not** cherry-picked — it is an unrelated repo-wide linter change, not part of this flake fix.

## Verification

- `make lint` — clean (0 issues).
- `go test ./polygon/sync/ -run TestEventChannel -race -count=20` — pass.
- `go test ./polygon/sync/ -race` — pass.

Both cherry-picks applied with no conflicts.
