### PR TITLE
cl: reject sidecars and blocks with inconsistent fork schema

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -814,6 +814,15 @@ func (b *BeaconChainConfig) GetCurrentStateVersion(epoch uint64) StateVersion {
 	return stateVersion
 }
 
+// ForkSchemaMatchesSlot reports whether an object decoded with decodedVersion is
+// consistent with the fork implied by slot. A peer picks the response fork digest,
+// so the two are independent inputs; Gloas changed which fields BeaconBody and
+// DataColumnSidecar carry, so a disagreement reaches a field left unset.
+func (b *BeaconChainConfig) ForkSchemaMatchesSlot(slot uint64, decodedVersion StateVersion) bool {
+	slotIsGloas := b.GetCurrentStateVersion(slot/b.SlotsPerEpoch) >= GloasVersion
+	return slotIsGloas == (decodedVersion >= GloasVersion)
+}
+
 // AttestationDueMs returns the attestation deadline in milliseconds from slot start.
 func (b *BeaconChainConfig) AttestationDueMs(gloas bool) uint64 {
 	if b == nil || b.SecondsPerSlot == 0 {

--- a/cl/clparams/config_test.go
+++ b/cl/clparams/config_test.go
@@ -218,3 +218,47 @@ func TestMaxBlobsPerBlockUpperBound(t *testing.T) {
 	noSchedule := &BeaconChainConfig{MaxBlobsPerBlock: 6, MaxBlobsPerBlockElectra: 9}
 	require.EqualValues(t, 9, noSchedule.MaxBlobsPerBlockUpperBound())
 }
+
+func TestForkSchemaMatchesSlot(t *testing.T) {
+	cfg := MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 1
+	cfg.GloasForkEpoch = 2
+	cfg.InitializeForkSchedule()
+	spe := cfg.SlotsPerEpoch
+
+	for _, tc := range []struct {
+		name           string
+		slot           uint64
+		decodedVersion StateVersion
+		want           bool
+	}{
+		// Schemas diverge only across the Gloas boundary, so a disagreement
+		// below it is not a mismatch.
+		{"both pre-Gloas", spe, DenebVersion, true},
+		{"both Gloas", 2 * spe, GloasVersion, true},
+		{"Gloas schema at a pre-Gloas slot", spe, GloasVersion, false},
+		{"pre-Gloas schema at a Gloas slot", 2 * spe, FuluVersion, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, cfg.ForkSchemaMatchesSlot(tc.slot, tc.decodedVersion))
+		})
+	}
+}
+
+// Mainnet keeps Gloas at FAR_FUTURE_EPOCH, so no slot maps to it and every
+// Gloas-schema object is inconsistent whatever slot it claims.
+func TestForkSchemaMatchesSlotFarFutureGloas(t *testing.T) {
+	cfg := MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	require.Equal(t, uint64(math.MaxUint64), cfg.GloasForkEpoch)
+
+	fuluSlot := cfg.FuluForkEpoch * cfg.SlotsPerEpoch
+	require.True(t, cfg.ForkSchemaMatchesSlot(fuluSlot, FuluVersion))
+	require.False(t, cfg.ForkSchemaMatchesSlot(fuluSlot, GloasVersion))
+	require.False(t, cfg.ForkSchemaMatchesSlot(math.MaxUint64/cfg.SlotsPerEpoch, GloasVersion))
+}

--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -829,28 +829,13 @@ mainloop:
 			var wg sync.WaitGroup
 			for _, sidecar := range result.sidecars {
 				wg.Go(func() {
-					// [Modified in Gloas:EIP7732] Get slot first, then use epoch-based version detection
-					var slot uint64
-					if sidecar.SignedBlockHeader != nil && sidecar.SignedBlockHeader.Header != nil {
-						slot = sidecar.SignedBlockHeader.Header.Slot
-					} else {
-						slot = sidecar.Slot
+					slot, blockRoot, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+					if !ok {
+						log.Debug("rejecting column sidecar with inconsistent fork schema", "pid", result.pid)
+						d.rpc.BanPeer(result.pid)
+						return
 					}
-					epoch := slot / d.beaconConfig.SlotsPerEpoch
-					isGloasSidecar := d.beaconConfig.GetCurrentStateVersion(epoch) >= clparams.GloasVersion
-
-					var blockRoot common.Hash
-					if isGloasSidecar {
-						blockRoot = sidecar.BeaconBlockRoot
-					} else {
-						var err error
-						blockRoot, err = sidecar.SignedBlockHeader.Header.HashSSZ()
-						if err != nil {
-							log.Debug("failed to get block root", "err", err)
-							d.rpc.BanPeer(result.pid)
-							return
-						}
-					}
+					isGloasSidecar := sidecar.Version() >= clparams.GloasVersion
 					defer func() {
 						// check if need to schedule recover whenever we download a column sidecar
 						if needToRecoverBlobs &&
@@ -933,6 +918,35 @@ mainloop:
 	}
 
 	return nil
+}
+
+// resolveColumnSidecarSlotAndRoot reads a received column sidecar's slot and
+// block root from the fields populated by the schema it was decoded with. A peer
+// picks that schema via the response fork-digest, independently of the slot the
+// sidecar claims, so it returns ok=false unless the fork implied by the slot
+// agrees with the decoded schema across the Gloas boundary (which removed
+// SignedBlockHeader) — otherwise a peer could reach a field its schema left unset.
+func (d *peerdas) resolveColumnSidecarSlotAndRoot(sidecar *cltypes.DataColumnSidecar) (slot uint64, blockRoot common.Hash, ok bool) {
+	isGloas := sidecar.Version() >= clparams.GloasVersion
+	if isGloas {
+		slot = sidecar.Slot
+	} else {
+		if sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil {
+			return 0, common.Hash{}, false
+		}
+		slot = sidecar.SignedBlockHeader.Header.Slot
+	}
+	if (d.beaconConfig.GetCurrentStateVersion(slot/d.beaconConfig.SlotsPerEpoch) >= clparams.GloasVersion) != isGloas {
+		return 0, common.Hash{}, false
+	}
+	if isGloas {
+		return slot, sidecar.BeaconBlockRoot, true
+	}
+	root, err := sidecar.SignedBlockHeader.Header.HashSSZ()
+	if err != nil {
+		return 0, common.Hash{}, false
+	}
+	return slot, root, true
 }
 
 func isExpectedColumnDownloadMiss(err error) bool {

--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -831,7 +831,7 @@ mainloop:
 				wg.Go(func() {
 					slot, blockRoot, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
 					if !ok {
-						log.Debug("rejecting column sidecar with inconsistent fork schema", "pid", result.pid)
+						log.Debug("rejecting malformed or schema-inconsistent column sidecar", "pid", result.pid)
 						d.rpc.BanPeer(result.pid)
 						return
 					}
@@ -921,11 +921,12 @@ mainloop:
 }
 
 // resolveColumnSidecarSlotAndRoot reads a received column sidecar's slot and
-// block root from the fields populated by the schema it was decoded with. A peer
-// picks that schema via the response fork-digest, independently of the slot the
-// sidecar claims, so it returns ok=false unless the fork implied by the slot
-// agrees with the decoded schema across the Gloas boundary (which removed
-// SignedBlockHeader) — otherwise a peer could reach a field its schema left unset.
+// block root from the fields populated by the schema it was decoded with,
+// returning ok=false for a malformed sidecar. A peer picks that schema via the
+// response fork-digest, independently of the slot the sidecar claims, so ok is
+// also false when the fork implied by the slot disagrees with the decoded schema
+// across the Gloas boundary (which removed SignedBlockHeader) — otherwise a peer
+// could reach a field its schema left unset.
 func (d *peerdas) resolveColumnSidecarSlotAndRoot(sidecar *cltypes.DataColumnSidecar) (slot uint64, blockRoot common.Hash, ok bool) {
 	isGloas := sidecar.Version() >= clparams.GloasVersion
 	if isGloas {

--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -921,33 +921,28 @@ mainloop:
 }
 
 // resolveColumnSidecarSlotAndRoot reads a received column sidecar's slot and
-// block root from the fields populated by the schema it was decoded with,
-// returning ok=false for a malformed sidecar. A peer picks that schema via the
-// response fork-digest, independently of the slot the sidecar claims, so ok is
-// also false when the fork implied by the slot disagrees with the decoded schema
-// across the Gloas boundary (which removed SignedBlockHeader) — otherwise a peer
-// could reach a field its schema left unset.
+// block root from the fields populated by the schema it was decoded with. ok is
+// false for a malformed sidecar, or one whose slot disagrees with that schema —
+// see BeaconChainConfig.ForkSchemaMatchesSlot.
 func (d *peerdas) resolveColumnSidecarSlotAndRoot(sidecar *cltypes.DataColumnSidecar) (slot uint64, blockRoot common.Hash, ok bool) {
-	isGloas := sidecar.Version() >= clparams.GloasVersion
-	if isGloas {
-		slot = sidecar.Slot
-	} else {
-		if sidecar.SignedBlockHeader == nil || sidecar.SignedBlockHeader.Header == nil {
+	if sidecar.Version() >= clparams.GloasVersion {
+		if !d.beaconConfig.ForkSchemaMatchesSlot(sidecar.Slot, sidecar.Version()) {
 			return 0, common.Hash{}, false
 		}
-		slot = sidecar.SignedBlockHeader.Header.Slot
+		return sidecar.Slot, sidecar.BeaconBlockRoot, true
 	}
-	if (d.beaconConfig.GetCurrentStateVersion(slot/d.beaconConfig.SlotsPerEpoch) >= clparams.GloasVersion) != isGloas {
+	header := sidecar.SignedBlockHeader
+	if header == nil || header.Header == nil {
 		return 0, common.Hash{}, false
 	}
-	if isGloas {
-		return slot, sidecar.BeaconBlockRoot, true
+	if !d.beaconConfig.ForkSchemaMatchesSlot(header.Header.Slot, sidecar.Version()) {
+		return 0, common.Hash{}, false
 	}
-	root, err := sidecar.SignedBlockHeader.Header.HashSSZ()
+	root, err := header.Header.HashSSZ()
 	if err != nil {
 		return 0, common.Hash{}, false
 	}
-	return slot, root, true
+	return header.Header.Slot, root, true
 }
 
 func isExpectedColumnDownloadMiss(err error) bool {

--- a/cl/das/peer_das_download_test.go
+++ b/cl/das/peer_das_download_test.go
@@ -40,16 +40,6 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
 )
 
-// initTestBeaconConfig installs cfg as the global config if no test has done so
-// yet. InitGlobalStaticConfig panics on a second call, so tests here must agree
-// on every global-only field; they may differ only in fork epochs, which each
-// test reads from its own local config.
-func initTestBeaconConfig(cfg *clparams.BeaconChainConfig) {
-	if clparams.GetBeaconConfig() == nil {
-		clparams.InitGlobalStaticConfig(cfg, &clparams.CaplinConfig{})
-	}
-}
-
 // maliciousColumnSentinel stands in for a selected custody peer. It answers
 // metadata honestly so it becomes eligible for column requests, then serves a
 // fixed response to every column request.

--- a/cl/das/peer_das_download_test.go
+++ b/cl/das/peer_das_download_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes"
 	peerdasstate "github.com/erigontech/erigon/cl/das/state"
 	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/rpc"
 	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
@@ -127,11 +128,16 @@ func TestRunDownloadRejectsGloasSidecarWithPreGloasSlot(t *testing.T) {
 		t.Fatal("malicious peer was not added to the custody-peer queue")
 	}
 
+	// gloasDataCache is populated so that a sidecar wrongly accepted as Gloas
+	// fails this test's ban assertion rather than nil-panicking downstream.
+	gloasDataCache, err := lru.New[common.Hash, *gloasBlockData]("gloasDataCacheTest", 8)
+	require.NoError(t, err)
 	d := &peerdas{
-		rpc:           rpcClient,
-		beaconConfig:  &cfg,
-		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
-		columnStorage: blob_storage.NewDataColumnStore(afero.NewMemMapFs(), 0, &cfg, clock, beaconevents.NewEventEmitter()),
+		rpc:            rpcClient,
+		beaconConfig:   &cfg,
+		state:          peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:  blob_storage.NewDataColumnStore(afero.NewMemMapFs(), 0, &cfg, clock, beaconevents.NewEventEmitter()),
+		gloasDataCache: gloasDataCache,
 	}
 	req := &downloadRequest{
 		beaconConfig: &cfg,

--- a/cl/das/peer_das_download_test.go
+++ b/cl/das/peer_das_download_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package das
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/erigontech/erigon/cl/beacon/beaconevents"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	peerdasstate "github.com/erigontech/erigon/cl/das/state"
+	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	"github.com/erigontech/erigon/cl/rpc"
+	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
+	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
+)
+
+// initTestBeaconConfig installs cfg as the global config if no test has done so
+// yet. InitGlobalStaticConfig panics on a second call, so tests here must agree
+// on every global-only field; they may differ only in fork epochs, which each
+// test reads from its own local config.
+func initTestBeaconConfig(cfg *clparams.BeaconChainConfig) {
+	if clparams.GetBeaconConfig() == nil {
+		clparams.InitGlobalStaticConfig(cfg, &clparams.CaplinConfig{})
+	}
+}
+
+// maliciousColumnSentinel stands in for a selected custody peer. It answers
+// metadata honestly so it becomes eligible for column requests, then serves a
+// fixed response to every column request.
+type maliciousColumnSentinel struct {
+	sentinelproto.SentinelClient
+	metadataResponse []byte
+	columnResponse   []byte
+
+	metadataOnce  sync.Once
+	metadataReady chan struct{}
+	banOnce       sync.Once
+	banned        chan struct{}
+}
+
+func (s *maliciousColumnSentinel) PeersInfo(context.Context, *sentinelproto.PeersInfoRequest, ...grpc.CallOption) (*sentinelproto.PeersInfoResponse, error) {
+	return &sentinelproto.PeersInfoResponse{Peers: []*sentinelproto.Peer{{Pid: "malicious-peer"}}}, nil
+}
+
+func (s *maliciousColumnSentinel) BanPeer(context.Context, *sentinelproto.Peer, ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
+	s.banOnce.Do(func() { close(s.banned) })
+	return &sentinelproto.EmptyMessage{}, nil
+}
+
+func (s *maliciousColumnSentinel) SendPeerRequest(_ context.Context, req *sentinelproto.RequestDataWithPeer, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	peer := &sentinelproto.Peer{Pid: "malicious-peer"}
+	if strings.Contains(req.Topic, "metadata") {
+		s.metadataOnce.Do(func() { close(s.metadataReady) })
+		return &sentinelproto.ResponseData{Data: s.metadataResponse, Peer: peer}, nil
+	}
+	return &sentinelproto.ResponseData{Data: s.columnResponse, Peer: peer}, nil
+}
+
+// A peer selects the response fork digest, so it can serve a Gloas-schema
+// sidecar (no SignedBlockHeader) that claims a pre-Gloas slot. runDownload must
+// ban the peer rather than dereference the header the schema left unset; the
+// per-sidecar goroutine has no recover, so a nil deref there kills the process.
+//
+// This drives the real BeaconRpcP2P decode path, so it also pins that
+// DataColumnSidecar.Version() reflects the peer's digest choice.
+func TestRunDownloadRejectsGloasSidecarWithPreGloasSlot(t *testing.T) {
+	// Kept at mainnet's schedule: Gloas sits at FAR_FUTURE_EPOCH, so its digest is
+	// registered and resolvable even though no slot maps to Gloas.
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+
+	currentSlot := (cfg.FuluForkEpoch + 1) * cfg.SlotsPerEpoch
+	genesisTime := uint64(time.Now().Unix()) - currentSlot*cfg.SecondsPerSlot
+	clock := eth_clock.NewEthereumClock(genesisTime, common.Hash{}, &cfg)
+
+	gloasDigest, err := clock.ComputeForkDigest(cfg.GloasForkEpoch)
+	require.NoError(t, err)
+	decodeVersion, err := clock.StateVersionByForkDigest(gloasDigest)
+	require.NoError(t, err)
+	require.Equal(t, clparams.GloasVersion, decodeVersion, "far-future Gloas digest must resolve")
+
+	// Advertising every custody group makes this peer eligible for any column.
+	cgc := cfg.NumberOfColumns
+	syncnets := [1]byte{}
+	metadata := &cltypes.Metadata{Syncnets: &syncnets, CustodyGroupCount: &cgc}
+	var metadataWire bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&metadataWire, metadata))
+
+	sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+	sidecar.Slot = 0
+	sidecar.BeaconBlockRoot = common.HexToHash("0x1234")
+	require.Nil(t, sidecar.SignedBlockHeader, "Gloas schema must leave SignedBlockHeader unset")
+	var columnWire bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&columnWire, sidecar, gloasDigest[:]...))
+
+	sentinel := &maliciousColumnSentinel{
+		metadataResponse: metadataWire.Bytes(),
+		columnResponse:   columnWire.Bytes(),
+		metadataReady:    make(chan struct{}),
+		banned:           make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rpcClient := rpc.NewBeaconRpcP2P(ctx, sentinel, &cfg, clock, nil)
+
+	select {
+	case <-sentinel.metadataReady:
+	case <-time.After(30 * time.Second):
+		t.Fatal("malicious peer was not added to the custody-peer queue")
+	}
+
+	d := &peerdas{
+		rpc:           rpcClient,
+		beaconConfig:  &cfg,
+		state:         peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage: blob_storage.NewDataColumnStore(afero.NewMemMapFs(), 0, &cfg, clock, beaconevents.NewEventEmitter()),
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: common.HexToHash("0xbeef"), slot: currentSlot}: {0: true},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- d.runDownload(ctx, req, false) }()
+
+	select {
+	case <-sentinel.banned:
+	case <-time.After(30 * time.Second):
+		t.Fatal("malicious sidecar was never rejected")
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runDownload did not return after cancellation")
+	}
+
+	// Nothing may be stored: the sidecar is rejected before any write.
+	saved, err := d.columnStorage.GetSavedColumnIndex(context.Background(), currentSlot, common.HexToHash("0xbeef"))
+	require.NoError(t, err)
+	require.Empty(t, saved)
+}

--- a/cl/das/peer_das_test.go
+++ b/cl/das/peer_das_test.go
@@ -23,7 +23,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/sentinel/httpreqresp"
+	"github.com/erigontech/erigon/common"
 )
 
 func TestIsExpectedColumnDownloadMiss(t *testing.T) {
@@ -43,4 +46,59 @@ func TestIsExpectedColumnDownloadMiss(t *testing.T) {
 		Body:       "Read Code: EOF",
 	}))
 	require.False(t, isExpectedColumnDownloadMiss(errors.New("peer error code: 2 (server error). Error message: broken")))
+}
+
+func TestResolveColumnSidecarSlotAndRoot(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 1
+	cfg.GloasForkEpoch = 2
+	cfg.InitializeForkSchedule()
+	clparams.InitGlobalStaticConfig(&cfg, &clparams.CaplinConfig{})
+	d := &peerdas{beaconConfig: &cfg}
+	spe := cfg.SlotsPerEpoch
+
+	t.Run("rejects Gloas schema carrying a pre-Gloas slot", func(t *testing.T) {
+		// A peer selects the Gloas decode schema (no SignedBlockHeader) via the
+		// response fork-digest, then claims slot 0, which maps to a pre-Gloas
+		// fork. The pre-Gloas branch must not dereference the absent header.
+		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+		sidecar.Slot = 0
+		require.Nil(t, sidecar.SignedBlockHeader)
+		_, _, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+		require.False(t, ok)
+	})
+
+	t.Run("rejects pre-Gloas schema with nil signed block header", func(t *testing.T) {
+		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+		sidecar.SignedBlockHeader = nil
+		_, _, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+		require.False(t, ok)
+	})
+
+	t.Run("accepts a consistent Fulu sidecar", func(t *testing.T) {
+		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+		require.NotNil(t, sidecar.SignedBlockHeader)
+		sidecar.SignedBlockHeader.Header.Slot = spe // epoch 1 => Fulu
+		slot, blockRoot, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+		require.True(t, ok)
+		require.Equal(t, spe, slot)
+		want, err := sidecar.SignedBlockHeader.Header.HashSSZ()
+		require.NoError(t, err)
+		require.Equal(t, common.Hash(want), blockRoot)
+	})
+
+	t.Run("accepts a consistent Gloas sidecar", func(t *testing.T) {
+		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+		sidecar.Slot = 2 * spe // epoch 2 => Gloas
+		sidecar.BeaconBlockRoot = common.HexToHash("0xabc")
+		slot, blockRoot, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+		require.True(t, ok)
+		require.Equal(t, 2*spe, slot)
+		require.Equal(t, common.HexToHash("0xabc"), blockRoot)
+	})
 }

--- a/cl/das/peer_das_test.go
+++ b/cl/das/peer_das_test.go
@@ -58,7 +58,7 @@ func TestResolveColumnSidecarSlotAndRoot(t *testing.T) {
 	cfg.FuluForkEpoch = 1
 	cfg.GloasForkEpoch = 2
 	cfg.InitializeForkSchedule()
-	clparams.InitGlobalStaticConfig(&cfg, &clparams.CaplinConfig{})
+	initTestBeaconConfig(&cfg)
 	d := &peerdas{beaconConfig: &cfg}
 	spe := cfg.SlotsPerEpoch
 

--- a/cl/das/peer_das_test.go
+++ b/cl/das/peer_das_test.go
@@ -29,6 +29,16 @@ import (
 	"github.com/erigontech/erigon/common"
 )
 
+// initTestBeaconConfig installs cfg as the global config if no test has done so
+// yet. InitGlobalStaticConfig panics on a second call, so tests in this package
+// must agree on every global-only field; they may differ only in fork epochs,
+// which each test reads from its own local config.
+func initTestBeaconConfig(cfg *clparams.BeaconChainConfig) {
+	if clparams.GetBeaconConfig() == nil {
+		clparams.InitGlobalStaticConfig(cfg, &clparams.CaplinConfig{})
+	}
+}
+
 func TestIsExpectedColumnDownloadMiss(t *testing.T) {
 	require.False(t, isExpectedColumnDownloadMiss(nil))
 	require.True(t, isExpectedColumnDownloadMiss(&httpreqresp.PeerResponseError{

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -90,6 +90,14 @@ func collectOnBlockLatencyToUnixTime(ethClock eth_clock.EthereumClock, slot, cur
 	monitor.ObserveBlockImportingLatency(initialSlotTime)
 }
 
+// forkSchemaMatchesSlot reports whether a block's decoded SSZ schema agrees with
+// the fork implied by its slot. A peer picks the response fork digest, so the two
+// are independent; Gloas moved ExecutionPayload and BlobKzgCommitments out of
+// BeaconBody, which the pre-Gloas path reads unconditionally.
+func forkSchemaMatchesSlot(slotVersion, decodedVersion clparams.StateVersion) bool {
+	return (slotVersion >= clparams.GloasVersion) == (decodedVersion >= clparams.GloasVersion)
+}
+
 func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeaconBlock, newPayload, fullValidation, checkDataAvaiability bool) error {
 	f.mu.Lock()
 	unlocked := false
@@ -134,13 +142,10 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	// Validate parent payload status path early (before expensive operations)
 	blockEpoch := f.computeEpochAtSlot(block.Block.Slot)
 	blockVersion := f.beaconCfg.GetCurrentStateVersion(blockEpoch)
-	isGloas := blockVersion >= clparams.GloasVersion
-	// A peer picks the response fork digest, so the decoded schema is independent of
-	// the block's slot. Gloas moved ExecutionPayload and BlobKzgCommitments out of
-	// BeaconBody, so on a disagreement either branch reads fields left unset.
-	if isGloas != (block.Version() >= clparams.GloasVersion) {
+	if !forkSchemaMatchesSlot(blockVersion, block.Version()) {
 		return ErrForkSchemaSlotMismatch
 	}
+	isGloas := blockVersion >= clparams.GloasVersion
 	headBeforeBlock := common.Hash{}
 	if isGloas && f.Slot() == block.Block.Slot {
 		justifiedCheckpoint := f.justifiedCheckpoint.Load().(solid.Checkpoint)

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -53,6 +53,7 @@ var (
 	ErrMissingSegment                = errors.New("missing segment: parent state not available")
 	ErrParentEnvelopePending         = errors.New("parent execution payload envelope not yet available")
 	ErrNotFinalizedDescendant        = errors.New("block is not a descendant of the finalized checkpoint")
+	ErrForkSchemaSlotMismatch        = errors.New("block schema fork disagrees with the fork implied by its slot")
 )
 
 func verifyKzgCommitmentsAgainstTransactions(cfg *clparams.BeaconChainConfig, block *cltypes.BeaconBlock) error {
@@ -134,6 +135,12 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	blockEpoch := f.computeEpochAtSlot(block.Block.Slot)
 	blockVersion := f.beaconCfg.GetCurrentStateVersion(blockEpoch)
 	isGloas := blockVersion >= clparams.GloasVersion
+	// A peer picks the response fork digest, so the decoded schema is independent of
+	// the block's slot. Gloas moved ExecutionPayload and BlobKzgCommitments out of
+	// BeaconBody, so on a disagreement either branch reads fields left unset.
+	if isGloas != (block.Version() >= clparams.GloasVersion) {
+		return ErrForkSchemaSlotMismatch
+	}
 	headBeforeBlock := common.Hash{}
 	if isGloas && f.Slot() == block.Block.Slot {
 		justifiedCheckpoint := f.justifiedCheckpoint.Load().(solid.Checkpoint)

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -90,14 +90,6 @@ func collectOnBlockLatencyToUnixTime(ethClock eth_clock.EthereumClock, slot, cur
 	monitor.ObserveBlockImportingLatency(initialSlotTime)
 }
 
-// forkSchemaMatchesSlot reports whether a block's decoded SSZ schema agrees with
-// the fork implied by its slot. A peer picks the response fork digest, so the two
-// are independent; Gloas moved ExecutionPayload and BlobKzgCommitments out of
-// BeaconBody, which the pre-Gloas path reads unconditionally.
-func forkSchemaMatchesSlot(slotVersion, decodedVersion clparams.StateVersion) bool {
-	return (slotVersion >= clparams.GloasVersion) == (decodedVersion >= clparams.GloasVersion)
-}
-
 func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeaconBlock, newPayload, fullValidation, checkDataAvaiability bool) error {
 	f.mu.Lock()
 	unlocked := false
@@ -139,12 +131,13 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 	}
 	currentSlotOnEntry := f.ethClock.GetCurrentSlot()
 
+	if !f.beaconCfg.ForkSchemaMatchesSlot(block.Block.Slot, block.Version()) {
+		return ErrForkSchemaSlotMismatch
+	}
+
 	// Validate parent payload status path early (before expensive operations)
 	blockEpoch := f.computeEpochAtSlot(block.Block.Slot)
 	blockVersion := f.beaconCfg.GetCurrentStateVersion(blockEpoch)
-	if !forkSchemaMatchesSlot(blockVersion, block.Version()) {
-		return ErrForkSchemaSlotMismatch
-	}
 	isGloas := blockVersion >= clparams.GloasVersion
 	headBeforeBlock := common.Hash{}
 	if isGloas && f.Slot() == block.Block.Slot {

--- a/cl/phase1/forkchoice/on_block_fork_consistency_test.go
+++ b/cl/phase1/forkchoice/on_block_fork_consistency_test.go
@@ -55,23 +55,3 @@ func TestOnBlockRejectsForkSchemaSlotMismatch(t *testing.T) {
 	err := store.OnBlock(context.Background(), mismatched, false, true, true)
 	require.ErrorIs(t, err, ErrForkSchemaSlotMismatch)
 }
-
-func TestForkSchemaMatchesSlot(t *testing.T) {
-	for _, tc := range []struct {
-		name           string
-		slotVersion    clparams.StateVersion
-		decodedVersion clparams.StateVersion
-		want           bool
-	}{
-		// Schemas differ only across the Gloas boundary as far as OnBlock is
-		// concerned, so a disagreement below it is not a mismatch.
-		{"both pre-Gloas", clparams.FuluVersion, clparams.DenebVersion, true},
-		{"both Gloas", clparams.GloasVersion, clparams.GloasVersion, true},
-		{"Gloas schema at a pre-Gloas slot", clparams.FuluVersion, clparams.GloasVersion, false},
-		{"pre-Gloas schema at a Gloas slot", clparams.GloasVersion, clparams.FuluVersion, false},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, forkSchemaMatchesSlot(tc.slotVersion, tc.decodedVersion))
-		})
-	}
-}

--- a/cl/phase1/forkchoice/on_block_fork_consistency_test.go
+++ b/cl/phase1/forkchoice/on_block_fork_consistency_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package forkchoice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/utils"
+)
+
+// A response's decoded schema comes from the peer-chosen fork digest, so it is
+// independent of the slot the block claims. Gloas removed ExecutionPayload and
+// BlobKzgCommitments from BeaconBody, so a Gloas-decoded block whose slot maps
+// to a pre-Gloas fork must be rejected before the pre-Gloas branch reads them.
+func TestOnBlockRejectsForkSchemaSlotMismatch(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	store := buildExAnteStore(t)
+
+	// Borrow slot/parent from a block the store already accepted, so the block
+	// clears the early ancestry and timing checks and reaches version dispatch.
+	ref := cltypes.NewSignedBeaconBlock(cfg, clparams.DenebVersion)
+	require.NoError(t, utils.DecodeSSZSnappy(ref, diffBlock3aEnc, int(clparams.AltairVersion)))
+
+	mismatched := cltypes.NewSignedBeaconBlock(cfg, clparams.GloasVersion)
+	mismatched.Block.Slot = ref.Block.Slot
+	mismatched.Block.ProposerIndex = ref.Block.ProposerIndex
+	mismatched.Block.ParentRoot = ref.Block.ParentRoot
+	mismatched.Block.StateRoot = ref.Block.StateRoot
+
+	require.Equal(t, clparams.GloasVersion, mismatched.Version(), "decoded schema must be Gloas")
+	require.Nil(t, mismatched.Block.Body.BlobKzgCommitments, "Gloas schema leaves BlobKzgCommitments unset")
+	require.Nil(t, mismatched.Block.Body.ExecutionPayload, "Gloas schema leaves ExecutionPayload unset")
+	require.Less(t, cfg.GetCurrentStateVersion(mismatched.Block.Slot/cfg.SlotsPerEpoch), clparams.GloasVersion,
+		"slot must map to a pre-Gloas fork for the mismatch to exist")
+
+	err := store.OnBlock(context.Background(), mismatched, false, true, true)
+	require.ErrorIs(t, err, ErrForkSchemaSlotMismatch)
+}
+
+// The mirror case: a pre-Gloas schema claiming a Gloas slot must be rejected
+// too, since the Gloas branch reads fields that schema leaves unset.
+func TestOnBlockRejectsPreGloasSchemaAtGloasSlot(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	store := buildExAnteStore(t)
+
+	ref := cltypes.NewSignedBeaconBlock(cfg, clparams.DenebVersion)
+	require.NoError(t, utils.DecodeSSZSnappy(ref, diffBlock3aEnc, int(clparams.AltairVersion)))
+
+	mismatched := cltypes.NewSignedBeaconBlock(cfg, clparams.FuluVersion)
+	mismatched.Block.Slot = ref.Block.Slot
+	mismatched.Block.ProposerIndex = ref.Block.ProposerIndex
+	mismatched.Block.ParentRoot = ref.Block.ParentRoot
+	mismatched.Block.StateRoot = ref.Block.StateRoot
+
+	// Activate every fork at genesis so the block's slot implies Gloas while the
+	// decoded schema stays pre-Gloas.
+	gloasCfg := *cfg
+	gloasCfg.AltairForkEpoch = 0
+	gloasCfg.BellatrixForkEpoch = 0
+	gloasCfg.CapellaForkEpoch = 0
+	gloasCfg.DenebForkEpoch = 0
+	gloasCfg.ElectraForkEpoch = 0
+	gloasCfg.FuluForkEpoch = 0
+	gloasCfg.GloasForkEpoch = 0
+	gloasCfg.InitializeForkSchedule()
+	store.beaconCfg = &gloasCfg
+
+	require.Nil(t, mismatched.Block.Body.SignedExecutionPayloadBid, "pre-Gloas schema leaves the bid unset")
+	require.GreaterOrEqual(t, gloasCfg.GetCurrentStateVersion(mismatched.Block.Slot/gloasCfg.SlotsPerEpoch), clparams.GloasVersion,
+		"slot must map to Gloas for the mismatch to exist")
+
+	err := store.OnBlock(context.Background(), mismatched, false, true, true)
+	require.ErrorIs(t, err, ErrForkSchemaSlotMismatch)
+}

--- a/cl/phase1/forkchoice/on_block_fork_consistency_test.go
+++ b/cl/phase1/forkchoice/on_block_fork_consistency_test.go
@@ -56,38 +56,22 @@ func TestOnBlockRejectsForkSchemaSlotMismatch(t *testing.T) {
 	require.ErrorIs(t, err, ErrForkSchemaSlotMismatch)
 }
 
-// The mirror case: a pre-Gloas schema claiming a Gloas slot must be rejected
-// too, since the Gloas branch reads fields that schema leaves unset.
-func TestOnBlockRejectsPreGloasSchemaAtGloasSlot(t *testing.T) {
-	cfg := &clparams.MainnetBeaconConfig
-	store := buildExAnteStore(t)
-
-	ref := cltypes.NewSignedBeaconBlock(cfg, clparams.DenebVersion)
-	require.NoError(t, utils.DecodeSSZSnappy(ref, diffBlock3aEnc, int(clparams.AltairVersion)))
-
-	mismatched := cltypes.NewSignedBeaconBlock(cfg, clparams.FuluVersion)
-	mismatched.Block.Slot = ref.Block.Slot
-	mismatched.Block.ProposerIndex = ref.Block.ProposerIndex
-	mismatched.Block.ParentRoot = ref.Block.ParentRoot
-	mismatched.Block.StateRoot = ref.Block.StateRoot
-
-	// Activate every fork at genesis so the block's slot implies Gloas while the
-	// decoded schema stays pre-Gloas.
-	gloasCfg := *cfg
-	gloasCfg.AltairForkEpoch = 0
-	gloasCfg.BellatrixForkEpoch = 0
-	gloasCfg.CapellaForkEpoch = 0
-	gloasCfg.DenebForkEpoch = 0
-	gloasCfg.ElectraForkEpoch = 0
-	gloasCfg.FuluForkEpoch = 0
-	gloasCfg.GloasForkEpoch = 0
-	gloasCfg.InitializeForkSchedule()
-	store.beaconCfg = &gloasCfg
-
-	require.Nil(t, mismatched.Block.Body.SignedExecutionPayloadBid, "pre-Gloas schema leaves the bid unset")
-	require.GreaterOrEqual(t, gloasCfg.GetCurrentStateVersion(mismatched.Block.Slot/gloasCfg.SlotsPerEpoch), clparams.GloasVersion,
-		"slot must map to Gloas for the mismatch to exist")
-
-	err := store.OnBlock(context.Background(), mismatched, false, true, true)
-	require.ErrorIs(t, err, ErrForkSchemaSlotMismatch)
+func TestForkSchemaMatchesSlot(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		slotVersion    clparams.StateVersion
+		decodedVersion clparams.StateVersion
+		want           bool
+	}{
+		// Schemas differ only across the Gloas boundary as far as OnBlock is
+		// concerned, so a disagreement below it is not a mismatch.
+		{"both pre-Gloas", clparams.FuluVersion, clparams.DenebVersion, true},
+		{"both Gloas", clparams.GloasVersion, clparams.GloasVersion, true},
+		{"Gloas schema at a pre-Gloas slot", clparams.FuluVersion, clparams.GloasVersion, false},
+		{"pre-Gloas schema at a Gloas slot", clparams.GloasVersion, clparams.FuluVersion, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, forkSchemaMatchesSlot(tc.slotVersion, tc.decodedVersion))
+		})
+	}
 }


### PR DESCRIPTION
## Problem

The SSZ schema a req/resp response decodes with is chosen by the **peer**, via the fork-context digest it sends. Two consumers derived the fork a second time from the object's own slot and read whichever fields that second inference implied. Where the two disagree across the Gloas boundary, the branch taken reads a field the decoded schema never populated — a nil dereference, in paths with no `recover`.

`NewEthereumClock` registers every configured fork digest, including forks scheduled at `FAR_FUTURE_EPOCH`, so a peer can select the Gloas decoder on mainnet today.

**Data column sidecars** (`cl/das/peer_das.go`). Gloas removed `SignedBlockHeader` from `DataColumnSidecar`, replacing it with `Slot` and `BeaconBlockRoot`. A peer answers `DataColumnSidecarsByRoot` with the Gloas digest so `SignedBlockHeader` decodes as nil, sets the embedded `Slot` to a pre-Gloas value, and the pre-Gloas branch dereferences the absent header. This runs in a per-sidecar `wg.Go` goroutine, ahead of all KZG, inclusion-proof and signature validation. Requires a post-Fulu, pre-Gloas network and a node with a column download in flight, i.e. one missing a custody column.

**Beacon blocks** (`cl/phase1/forkchoice/on_block.go`). Gloas moved `ExecutionPayload` and `BlobKzgCommitments` out of `BeaconBody`. `OnBlock` gated its pre-Gloas branch on the slot-derived version while the reads inside that branch are gated on the decoded `block.Version()`, so a Gloas-digest block at a pre-Gloas slot reaches several nil reads — `solid.ListSSZ` has no nil-receiver guard. It precedes the pipeline's only version cross-check (`ProcessBlock`) and all signature validation, so an unsigned crafted block suffices. Requires a pre-Gloas network with Gloas in the fork schedule, a Deneb-or-later block, and `newPayload` with an execution engine attached. Nothing need be in flight, so wider than the sidecar path.

Impact in both cases is a remote liveness kill: process exit, Beacon API down until restart. Caplin-only; no consensus split, state corruption or code execution.

## Fix

Both sites require the fork implied by the slot to agree with the decoded schema across the Gloas boundary before reading any schema-specific field. The two inferences are independent peer-influenced inputs, so they are checked against each other rather than trusted separately.

The check is `BeaconChainConfig.ForkSchemaMatchesSlot(slot, decodedVersion)`, shared by both call sites so the invariant carries one name and one rationale rather than two copies of the expression.

- `cl/das`: `resolveColumnSidecarSlotAndRoot` takes slot and block root only from the fields the decoded schema populates — `sidecar.Version()` is the structural truth — and bans the peer on a mismatch or a malformed sidecar.
- `cl/phase1/forkchoice`: `OnBlock` returns `ErrForkSchemaSlotMismatch`. Both directions are rejected, keeping schema dispatch below the check uniform.

Honest traffic is unaffected: a req/resp server encodes each object with the fork digest of that object's own slot, so decode-fork and slot-fork always agree unless the peer is lying. Disagreement *below* the Gloas boundary is allowed, since no double inference exists there. Consensus spec fixtures are unaffected because `ReadBeaconState` activates every fork up to the test's version at epoch 0, matching the slot-derived version to the decoded one.

## Tests

- `TestResolveColumnSidecarSlotAndRoot` — the sidecar resolver's accept and reject cases.
- `TestRunDownloadRejectsGloasSidecarWithPreGloasSlot` — a malicious sentinel driven through the real `BeaconRpcP2P` decode path into `runDownload`; asserts the peer is banned and nothing reaches column storage.
- `TestOnBlockRejectsForkSchemaSlotMismatch` — a Gloas-decoded block at a pre-Gloas slot through the real `ForkChoiceStore.OnBlock`.
- `TestForkSchemaMatchesSlot` — the shared predicate in both mismatch directions and both agreement cases, including that a disagreement *below* the Gloas boundary is not a mismatch.
- `TestForkSchemaMatchesSlotFarFutureGloas` — the mainnet shape: with Gloas at `FAR_FUTURE_EPOCH` no slot maps to it, so a Gloas-schema object is inconsistent whatever slot it claims.

Each fails if the check it covers is removed.

## Credit

The data-column sidecar issue was reported through the Ethereum bug bounty program (private PoC, `ethereum-bounty/erigon#19`).
