### PR TITLE
cl,db,diagnostics,p2p: pass log values as attributes

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -2152,7 +2152,7 @@ func (a *ApiHandler) electraMergedAttestationCandidates(s abstract.BeaconState) 
 		}
 		committeeBits := candidate.CommitteeBits.GetOnIndices()
 		if len(committeeBits) != 1 {
-			log.Warn("invalid candidate commitee bit length %v in attestation pool.", len(committeeBits))
+			log.Warn("invalid candidate committee bit length in attestation pool", "len", len(committeeBits))
 			continue
 		}
 		candCommitteeBit := uint64(committeeBits[0])

--- a/db/state/history_stream.go
+++ b/db/state/history_stream.go
@@ -772,14 +772,14 @@ func (ht *HistoryTraceKeyFiles) advance() error {
 
 			offset, ok := idxReader.TwoLayerLookup(ht.key)
 			if !ok {
-				ht.logger.Debug("weird thing - no offset found for %s in file %s", hexutil.Encode(ht.key), item.src.decompressor.FileName())
+				ht.logger.Debug("weird thing - no offset found", "key", hexutil.Encode(ht.key), "file", item.src.decompressor.FileName())
 				moveToNextFileFn()
 				continue
 			}
 			getter.Reset(offset)
 			gkey, _ := getter.Next(ht.efbuf[:0]) // skip key
 			if !bytes.Equal(gkey, ht.key) {
-				ht.logger.Debug("weird thing - key mismatch for %s in file %s", hexutil.Encode(ht.key), item.src.decompressor.FileName())
+				ht.logger.Debug("weird thing - key mismatch", "key", hexutil.Encode(ht.key), "file", item.src.decompressor.FileName())
 				moveToNextFileFn()
 				continue
 			}

--- a/diagnostics/sysutils/sysutils.go
+++ b/diagnostics/sysutils/sysutils.go
@@ -53,7 +53,7 @@ const (
 func GetProcessesInfo() []*ProcessInfo {
 	procs, err := process.Processes()
 	if err != nil {
-		log.Debug("[Sysutil] Error retrieving processes: %v", err)
+		log.Debug("[Sysutil] error retrieving processes", "err", err)
 	}
 
 	return averageProceses(procs)
@@ -161,13 +161,13 @@ func allProcesses(procs []*process.Process) []*ProcessInfo {
 
 		cpuPercent, err := proc.CPUPercent()
 		if err != nil {
-			log.Trace("[Sysutil] Error retrieving CPU percent for PID %d: %v Name: %s", pid, err, name)
+			log.Trace("[Sysutil] error retrieving CPU percent", "pid", pid, "name", name, "err", err)
 			continue
 		}
 
 		memPercent, err := proc.MemoryPercent()
 		if err != nil {
-			log.Trace("[Sysutil] Error retrieving memory percent for PID %d: %v Name: %s", pid, err, name)
+			log.Trace("[Sysutil] error retrieving memory percent", "pid", pid, "name", name, "err", err)
 			continue
 		}
 
@@ -180,7 +180,7 @@ func allProcesses(procs []*process.Process) []*ProcessInfo {
 func TotalCPUUsage() float64 {
 	totalCPUPercent, err := cpu.Percent(time.Second, false)
 	if err != nil {
-		log.Debug("[Sysutil] Error retrieving total CPU usage: %v", err)
+		log.Debug("[Sysutil] error retrieving total CPU usage", "err", err)
 	}
 
 	return float64(totalCPUPercent[0])
@@ -189,7 +189,7 @@ func TotalCPUUsage() float64 {
 func CPUUsageByCores() []float64 {
 	cpuPercent, err := cpu.Percent(time.Second, true)
 	if err != nil {
-		log.Debug("[Sysutil] Error retrieving CPU usage by cores: %v", err)
+		log.Debug("[Sysutil] error retrieving CPU usage by cores", "err", err)
 	}
 
 	return cpuPercent
@@ -205,7 +205,7 @@ func CPUUsage() CPUUsageInfo {
 func TotalMemoryUsage() float64 {
 	totalMemory, err := mem.VirtualMemory()
 	if err != nil {
-		log.Debug("[Sysutil] Error retrieving total memory usage: %v", err)
+		log.Debug("[Sysutil] error retrieving total memory usage", "err", err)
 	}
 
 	return float64(totalMemory.UsedPercent)

--- a/p2p/sentry/sentry_grpc_server.go
+++ b/p2p/sentry/sentry_grpc_server.go
@@ -800,7 +800,7 @@ func runWitPeer(
 
 			var query wit.NewWitnessPacket
 			if err := rlp.DecodeBytes(b, &query); err != nil {
-				logger.Error("decoding NewWitnessMsg: %w, data: %x", err, b)
+				logger.Error("[sentry] decoding NewWitnessMsg", "err", err, "data", hex.EncodeToString(b))
 				return p2p.NewPeerError(p2p.PeerErrorInvalidMessage, p2p.DiscSubprotocolError, err, "decoding NewWitnessMsg")
 			}
 
@@ -820,7 +820,7 @@ func runWitPeer(
 
 			var query wit.NewWitnessHashesPacket
 			if err := rlp.DecodeBytes(b, &query); err != nil {
-				logger.Error("decoding NewWitnessHashesMsg: %w, data: %x", err, b)
+				logger.Error("[sentry] decoding NewWitnessHashesMsg", "err", err, "data", hex.EncodeToString(b))
 				return p2p.NewPeerError(p2p.PeerErrorInvalidMessage, p2p.DiscSubprotocolError, err, "decoding NewWitnessHashesMsg")
 			}
 


### PR DESCRIPTION
`log/v3` does not format the message. These 11 calls pass a printf format string, so the verb prints literally and the argument meant to fill it is consumed as an attribute *key* instead:

```
logger.Error("decoding NewWitnessMsg: %w, data: %x", err, b)
EROR[...] decoding NewWitnessMsg: %w, data: %x  LOG15_ERROR="unexpected EOF"
```

`b` never reaches the log at all. Where the argument count is odd, the record also picks up a second `LOG15_ERROR` from the logger's own arity guard.

## Changes

- Converts the format strings to key/value pairs.
- Byte slices that relied on `%x` go through `hex.EncodeToString`.
- `commitee` -> `committee` in the attestation pool warning.