### PR TITLE
[r3.5] release: Erigon v3.5.4

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,23 @@ Aligns Erigon with the `eth_simulateV1` error code specification ([NethermindEth
 
 ---
 
+# Erigon v3.5.4 — Tidal Tails — 2026-07-28
+
+v3.5.4 is a bugfix release recommended for all users, and especially for operators running the RPC daemon with response compression enabled — archive nodes and high-traffic RPC endpoints — where a native-memory leak in the gzip path could grow by ~9-15 GiB/day (#22700). It is a drop-in upgrade from 3.5.3 — no re-sync required.
+
+**Bugfixes**
+
+- node: fix a native (C-allocated) memory leak in the RPC gzip path (#22700) by @AskAlexSharov — the `libdeflate.Compressor` was pooled in a `sync.Pool` whose GC-evicted entries never had `Close()` called, leaking the C context (~9-15 GiB/day on an archive node). Replaced with a bounded channel pool that closes compressors on overflow. Fixes #22672.
+- cmd: expand a leading `~/` (or `~\` on Windows) and `$VAR` in `--datadir` for the cobra-based binaries (#22785) by @lystopad — rpcdaemon and the other cobra commands previously used the raw path, so a tilde/env-prefixed `--datadir` was not resolved the way the main erigon binary resolves it. Fixes #14629.
+
+**Improvements**
+
+- build: update `google.golang.org/grpc` to v1.82.1 (#22690) by @AskAlexSharov — brings `release/3.5` in line with `release/3.6` and `main`.
+
+**Full Changelog**: https://github.com/erigontech/erigon/compare/v3.5.3...v3.5.4
+
+---
+
 # Erigon v3.5.3 — Tidal Tails — 2026-07-23
 
 v3.5.3 is a bugfix release recommended for all users. It is a drop-in upgrade from 3.5.2 — no re-sync required.

--- a/db/version/app.go
+++ b/db/version/app.go
@@ -32,7 +32,7 @@ var (
 const (
 	Major                    = 3             // Major version component of the current release
 	Minor                    = 5             // Minor version component of the current release
-	Micro                    = 3             // Patch version component of the current release
+	Micro                    = 4             // Patch version component of the current release
 	Modifier                 = ""            // Modifier component of the current release
 	DefaultSnapshotGitBranch = "release/3.4" // Branch of erigontech/erigon-snapshot to use in OtterSync.
 	VersionKeyCreated        = "ErigonVersionCreated"


### PR DESCRIPTION
Prepares the **Erigon v3.5.4 — Tidal Tails** release on `release/3.5`.

Mirrors the v3.5.3 release commit (#22686):

- **`db/version/app.go`**: bump `Micro` `3` → `4` (3.5.3 → 3.5.4).
- **`ChangeLog.md`**: add the v3.5.4 release notes section.

## Included since v3.5.3

**Bugfixes**
- node: fix a native (C-allocated) memory leak in the RPC gzip path (#22700, closes #22672)
- cmd: expand `~/` and `$VAR` in `--datadir` for the cobra binaries (#22785, closes #14629)

**Improvements**
- build: update `google.golang.org/grpc` to v1.82.1 (#22690)

The gzip native-memory leak (#22700) is called out in the release-notes intro, since it specifically affects archive nodes and high-traffic RPC endpoints running with response compression enabled.

## Not listed in the release notes

Both still ship in v3.5.4 — they are only omitted from the user-facing notes:

- **#22792** (`polygon/sync: deflake TestEventChannel/ConsumeEvents (#22510, #21827)`) — an internal CI-stability change (a lost-wakeup race fix plus a test deflake) with no user-observable behavior change, so it is treated like a non-functional change and left out of the notes.
- **#22793** (docs) — docs-only, per the established convention of omitting docs commits from release notes.

Full changelog: https://github.com/erigontech/erigon/compare/v3.5.3...v3.5.4

## Follow-up
After this release, the v3.5.4 notes should be ported to `main`'s `ChangeLog.md`. `main`'s `db/version/app.go` is on a separate line (3.7.0) and is **not** touched here.
