### PR TITLE
execution/stagedsync,diagnostics: name the recovered panic log field

### DIFF
--- a/diagnostics/diaglib/provider.go
+++ b/diagnostics/diaglib/provider.go
@@ -134,7 +134,7 @@ func startProvider(ctx context.Context, infoType Type, provider Provider, logger
 func Send[I Info](info I) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Debug("diagnostic Send panic recovered: %v, stack: %s", r, dbg.Stack())
+			log.Debug("diagnostic Send panic recovered", "panic", r, "stack", dbg.Stack())
 		}
 	}()
 

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -473,7 +473,7 @@ func (te *txExecutor) reconstructPriorReceipts(ctx context.Context, applyTx kv.T
 func (te *txExecutor) onBlockStart(ctx context.Context, blockNum uint64, blockHash common.Hash) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			te.logger.Warn("hook paniced: %s", rec, "stack", dbg.Stack())
+			te.logger.Warn("hook panicked", "panic", rec, "stack", dbg.Stack())
 		}
 	}()
 


### PR DESCRIPTION
Both panic-recovery handlers pass the recovered value to a printf verb that `log/v3` never expands, so the panic reason is consumed as an attribute key and the record picks up a `LOG15_ERROR` from the logger's arity guard. The stack trace survives; the reason for the panic does not.

```
te.logger.Warn("hook paniced: %s", rec, "stack", dbg.Stack())
WARN[...] hook paniced: %s  LOG15_ERROR="runtime error: ..." stack=...
```

## Changes

- The recovered value moves to a named `panic` attribute.
- `hook paniced` -> `hook panicked`.