### PR TITLE
ci: fix kurtosis for glamsterdam-devnet-7

### DIFF
--- a/.github/workflows/kurtosis/glamsterdam-caplin.io
+++ b/.github/workflows/kurtosis/glamsterdam-caplin.io
@@ -8,7 +8,7 @@ participants:
     el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: lighthouse
-    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-6
+    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-7
     count: 1
 global_log_level: 'debug'
 network_params:
@@ -18,7 +18,7 @@ network_params:
   fulu_fork_epoch: 0
   gloas_fork_epoch: 1
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.1.2
+  image: ethpandaops/ethereum-genesis-generator:6.1.4
 additional_services: [assertoor]
 assertoor_params:
   image: ethpandaops/assertoor:v0.1.3

--- a/.github/workflows/kurtosis/glamsterdam.io
+++ b/.github/workflows/kurtosis/glamsterdam.io
@@ -1,6 +1,6 @@
 participants:
   - cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-6
+    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-7
     el_type: erigon
     el_image: test/erigon:current
     el_log_level: "debug"
@@ -29,7 +29,7 @@ spamoor_params:
     - scenario: setcodetx
       config: {throughput: 20, funding_gas_limit: 200000}
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.1.2
+  image: ethpandaops/ethereum-genesis-generator:6.1.4
 additional_services: [spamoor, assertoor]
 assertoor_params:
   run_stability_check: false  # re-enable once go-eth2-client supports alpha.8 (#21442)

--- a/.github/workflows/kurtosis/gloas-caplin-mixed.io
+++ b/.github/workflows/kurtosis/gloas-caplin-mixed.io
@@ -1,6 +1,6 @@
 participants:
   - cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-6
+    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-7
     el_type: erigon
     el_image: test/erigon:current
     el_log_level: "debug"
@@ -17,7 +17,7 @@ participants:
     el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: lighthouse
-    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-6
+    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-7
     count: 1
 global_log_level: 'debug'
 network_params:
@@ -27,7 +27,7 @@ network_params:
   fulu_fork_epoch: 0
   gloas_fork_epoch: 1
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.1.2
+  image: ethpandaops/ethereum-genesis-generator:6.1.4
 additional_services: [assertoor]
 assertoor_params:
   run_stability_check: false

--- a/.github/workflows/kurtosis/gloas-three-cl-mixed.io
+++ b/.github/workflows/kurtosis/gloas-three-cl-mixed.io
@@ -1,6 +1,6 @@
 participants:
   - cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-6
+    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-7
     el_type: erigon
     el_image: test/erigon:current
     el_log_level: "debug"
@@ -8,14 +8,14 @@ participants:
     supernode: true
     count: 1
   - cl_type: prysm
-    cl_image: ethpandaops/prysm-beacon-chain:glamsterdam-devnet-6-minimal
+    cl_image: ethpandaops/prysm-beacon-chain:glamsterdam-devnet-7-minimal
     el_type: erigon
     el_image: test/erigon:current
     el_log_level: "debug"
     el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: prysm
-    vc_image: ethpandaops/prysm-validator:glamsterdam-devnet-6-minimal
+    vc_image: ethpandaops/prysm-validator:glamsterdam-devnet-7-minimal
     count: 1
   - cl_type: caplin
     cl_image: test/erigon:current
@@ -27,7 +27,7 @@ participants:
     el_extra_params: ["--experimental.bal"]
     use_separate_vc: true
     vc_type: lighthouse
-    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-6
+    vc_image: ethpandaops/lighthouse:glamsterdam-devnet-7
     count: 1
 global_log_level: 'debug'
 network_params:
@@ -37,7 +37,7 @@ network_params:
   fulu_fork_epoch: 0
   gloas_fork_epoch: 1
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.1.2
+  image: ethpandaops/ethereum-genesis-generator:6.1.4
 additional_services: [assertoor]
 assertoor_params:
   run_stability_check: false


### PR DESCRIPTION
## Summary

- update all four GLOAS/Glamsterdam Kurtosis configs to use the Glamsterdam devnet-7 Lighthouse and Prysm images
- bump `ethereum-genesis-generator` from `6.1.2` to `6.1.4`
- align the generated EIP-8282 builder contracts with Erigon's devnet-7 contract addresses

Fixes #22809.

## Root cause

Erigon uses the Glamsterdam devnet-7 EIP-8282 builder deposit and exit addresses, while generator `6.1.2` provisioned the contracts at the former devnet-6 addresses. At the first Gloas block, Erigon therefore found empty code at the configured builder deposit address, failed block finalization, and stopped block production.

## Validation

- reproduced the original failure with `gloas-caplin-mixed.io`: block production stalled at height 6 and all three Erigon ELs reported an EIP-8282 empty-code syscall failure
- reran the updated Lighthouse/Caplin topology through the Gloas transition; it reached height 17 with successful assertoor results and clean EL/CL logs
- ran the updated Lighthouse/Prysm/Caplin topology through the Gloas transition; it reached height 20 with successful assertoor results and clean EL/CL logs
- verified both devnet-7 builder contracts contain code in the generated genesis
- ran `make lint` twice
- ran `make erigon integration`
