### PR TITLE
cl/beacon: cover the migrated-validator and duplicate-per-validator BLS change cases

### DIFF
--- a/cl/beacon/handler/block_production_bls_changes_test.go
+++ b/cl/beacon/handler/block_production_bls_changes_test.go
@@ -30,41 +30,91 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// A change is only valid for a validator that still carries BLS_WITHDRAWAL_PREFIX, and a block
-// may carry at most MaxBlsToExecutionChanges of them.
+// blsChangeFor builds a validator whose credentials satisfy the spec's
+// withdrawal_credentials[1:] == hash(from_bls_pubkey)[1:] under the given prefix, plus a change
+// for it. Signatures are not verified here: the pool only ever admits changes whose signature
+// already verified, so getBlockOperations does not re-check them.
+func blsChangeFor(cfg *clparams.BeaconChainConfig, seed int, prefix byte) (solid.Validator, common.Bytes48) {
+	var from common.Bytes48
+	binary.LittleEndian.PutUint64(from[:], uint64(seed))
+
+	hashedFrom := crypto.Sha256(from[:])
+	var creds common.Hash
+	creds[0] = prefix
+	copy(creds[1:], hashedFrom[1:])
+
+	return solid.NewValidatorFromParameters(
+		from, creds, cfg.MaxEffectiveBalance, false, 0, 0, cfg.FarFutureEpoch, cfg.FarFutureEpoch,
+	), from
+}
+
+func sig96(i int) common.Bytes96 {
+	var sig common.Bytes96
+	binary.LittleEndian.PutUint64(sig[:], uint64(i))
+	return sig
+}
+
 func TestGetBlockOperationsBLSToExecutionChanges(t *testing.T) {
-	cfg := clparams.MainnetBeaconConfig
-	candidates := int(cfg.MaxBlsToExecutionChanges) + 4
+	// A block may carry at most MaxBlsToExecutionChanges. ListSSZ.Append does not enforce the
+	// limit and HashSSZ merkleizes to the limit's depth regardless of length, so an over-long
+	// list is published with a wrong body root instead of failing locally.
+	t.Run("caps at MaxBlsToExecutionChanges", func(t *testing.T) {
+		cfg := clparams.MainnetBeaconConfig
+		s := state.New(&cfg)
+		opPool := pool.NewOperationsPool(&cfg)
 
-	s := state.New(&cfg)
-	opPool := pool.NewOperationsPool(&cfg)
+		for i := range int(cfg.MaxBlsToExecutionChanges) + 4 {
+			v, from := blsChangeFor(&cfg, i+1, byte(cfg.BLSWithdrawalPrefixByte))
+			s.AddValidator(v, cfg.MaxEffectiveBalance)
+			opPool.BLSToExecutionChangesPool.Insert(sig96(i+1), &cltypes.SignedBLSToExecutionChange{
+				Message:   &cltypes.BLSToExecutionChange{ValidatorIndex: uint64(i), From: from},
+				Signature: sig96(i + 1),
+			})
+		}
 
-	for i := range candidates {
-		var from common.Bytes48
-		binary.LittleEndian.PutUint64(from[:], uint64(i+1))
+		a := &ApiHandler{beaconChainCfg: &cfg, operationsPool: opPool}
+		_, _, _, changes := a.getBlockOperations(s, 0)
+		require.Equal(t, int(cfg.MaxBlsToExecutionChanges), changes.Len())
+	})
 
-		hashedFrom := crypto.Sha256(from[:])
-		var creds common.Hash
-		creds[0] = byte(cfg.BLSWithdrawalPrefixByte)
-		copy(creds[1:], hashedFrom[1:])
+	// A change is only valid while the validator still carries BLS_WITHDRAWAL_PREFIX. Packing one
+	// for an already-migrated validator would fail ProcessBlsToExecutionChange and cost the slot.
+	t.Run("skips validators that already migrated", func(t *testing.T) {
+		cfg := clparams.MainnetBeaconConfig
+		s := state.New(&cfg)
+		opPool := pool.NewOperationsPool(&cfg)
 
-		s.AddValidator(solid.NewValidatorFromParameters(
-			from, creds, cfg.MaxEffectiveBalance, false, 0, 0, cfg.FarFutureEpoch, cfg.FarFutureEpoch,
-		), cfg.MaxEffectiveBalance)
-
-		var sig common.Bytes96
-		binary.LittleEndian.PutUint64(sig[:], uint64(i+1))
-		opPool.BLSToExecutionChangesPool.Insert(sig, &cltypes.SignedBLSToExecutionChange{
-			Message: &cltypes.BLSToExecutionChange{
-				ValidatorIndex: uint64(i),
-				From:           from,
-			},
-			Signature: sig,
+		v, from := blsChangeFor(&cfg, 1, byte(cfg.ETH1AddressWithdrawalPrefixByte))
+		s.AddValidator(v, cfg.MaxEffectiveBalance)
+		opPool.BLSToExecutionChangesPool.Insert(sig96(1), &cltypes.SignedBLSToExecutionChange{
+			Message:   &cltypes.BLSToExecutionChange{ValidatorIndex: 0, From: from},
+			Signature: sig96(1),
 		})
-	}
 
-	a := &ApiHandler{beaconChainCfg: &cfg, operationsPool: opPool}
-	_, _, _, changes := a.getBlockOperations(s, 0)
+		a := &ApiHandler{beaconChainCfg: &cfg, operationsPool: opPool}
+		_, _, _, changes := a.getBlockOperations(s, 0)
+		require.Zero(t, changes.Len())
+	})
 
-	require.Equal(t, int(cfg.MaxBlsToExecutionChanges), changes.Len())
+	// The pool is keyed by signature, so one validator can hold several changes. Only the first
+	// may be packed: processing one flips the credentials to 0x01, so a second in the same block
+	// fails the prefix assert and takes the whole block down with it.
+	t.Run("packs at most one change per validator", func(t *testing.T) {
+		cfg := clparams.MainnetBeaconConfig
+		s := state.New(&cfg)
+		opPool := pool.NewOperationsPool(&cfg)
+
+		v, from := blsChangeFor(&cfg, 1, byte(cfg.BLSWithdrawalPrefixByte))
+		s.AddValidator(v, cfg.MaxEffectiveBalance)
+		for i := range 3 {
+			opPool.BLSToExecutionChangesPool.Insert(sig96(i+1), &cltypes.SignedBLSToExecutionChange{
+				Message:   &cltypes.BLSToExecutionChange{ValidatorIndex: 0, From: from},
+				Signature: sig96(i + 1),
+			})
+		}
+
+		a := &ApiHandler{beaconChainCfg: &cfg, operationsPool: opPool}
+		_, _, _, changes := a.getBlockOperations(s, 0)
+		require.Equal(t, 1, changes.Len())
+	})
 }


### PR DESCRIPTION
Follow-up to #22827, which landed with one test covering the cap. Two conditions it relies on were left uncovered, and both cost the proposer a slot if they regress.

`getBlockOperations` does not verify signatures — the pool only ever admits changes whose signature already verified (`bls_to_execution_change_service.go` inserts inside the batch verifier's success callback, and the REST POST path goes through the same `ProcessMessage`). So what block production must get right is the state-dependent part, and the produced block is re-run through `ProcessBlock` before it is returned, where a wrong answer aborts production.

## Changes

- `skips validators that already migrated` — pins the prefix constant. Reverting it to `ETH1AddressWithdrawalPrefixByte` packs a change for an already-migrated validator, which then fails `ProcessBlsToExecutionChange`.
- `packs at most one change per validator` — the pool is keyed by signature, so one validator can hold several changes. Processing one flips the credentials to 0x01, so a second in the same block fails the prefix assert and takes the block down. Drop the `slashedIndicies` guard and this packs 3 instead of 1.

Both were mutation-checked against the fix they protect.
