### PR TITLE
rpc, execution: release IntraBlockState in more one-shot and reset paths

### DIFF
--- a/execution/bal/regenerator.go
+++ b/execution/bal/regenerator.go
@@ -120,6 +120,7 @@ func (g *Regenerator) GetBlockAccessListBytes(ctx context.Context, cfg *chain.Co
 		return nil, err
 	}
 	ibs := state.New(reader)
+	defer ibs.Release(false)
 	ibs.SetVersionMap(state.NewVersionMap(nil))
 	getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
 		return g.blockReader.Header(ctx, tx, hash, number)

--- a/execution/exec/historical_trace_worker.go
+++ b/execution/exec/historical_trace_worker.go
@@ -128,6 +128,7 @@ func (rw *HistoricalTraceWorker) Run() (err error) {
 		}
 	}()
 	defer rw.LogStats()
+	defer rw.ibs.Release(true)
 	for txTask, ok := rw.in.Next(rw.ctx); ok; txTask, ok = rw.in.Next(rw.ctx) {
 		result := rw.RunTxTask(txTask.(*TxTask))
 		if err := rw.out.Add(rw.ctx, result); err != nil {

--- a/execution/exec/state.go
+++ b/execution/exec/state.go
@@ -472,6 +472,9 @@ func (rw *Worker) SetReader(reader state.StateReader) {
 	case historic:
 		typedReader.SetTx(rw.chainTx)
 	}
+	if rw.ibs != nil {
+		rw.ibs.Release(true)
+	}
 	rw.ibs = state.New(rw.stateReader)
 
 	switch reader.(type) {

--- a/execution/exec/trace_worker.go
+++ b/execution/exec/trace_worker.go
@@ -84,7 +84,9 @@ func NewTraceWorker(tx kv.TemporalTx, cc *chain.Config, engine rules.EngineReade
 	return ie
 }
 
-func (e *TraceWorker) Close() {}
+func (e *TraceWorker) Close() {
+	e.ibs.Release(false)
+}
 
 func (e *TraceWorker) ChangeBlock(header *types.Header) {
 	e.blockNum = header.Number.Uint64()

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2116,6 +2116,7 @@ func (result *execResult) runPostApplyMessageOnMinIBS(
 		return err
 	}
 	ibs := state.New(state.NewVersionedStateReader(txIndex, result.TxIn, vm, stateReader))
+	defer ibs.Release(false)
 	ibs.SetTxContext(blockNum, txIndex)
 	postApplyMessageFunc(ibs, message.From(), result.Coinbase, &execResult, chainRules)
 	result.Logs = append(result.Logs, ibs.GetLogs(txTask.TxIndex, txTask.TxHash(), blockNum, txTask.BlockHash())...)

--- a/rpc/jsonrpc/otterscan_api.go
+++ b/rpc/jsonrpc/otterscan_api.go
@@ -151,6 +151,7 @@ func (api *OtterscanAPIImpl) runTracer(ctx context.Context, tx kv.TemporalTx, ha
 	if err != nil {
 		return nil, err
 	}
+	defer ibs.Release(false)
 
 	msg, txCtx, err := transactions.ComputeTxContext(ibs, engine, rules, signer, block, chainConfig, int(txIndex))
 	if err != nil {

--- a/rpc/jsonrpc/receipts/bor_receipts_generator.go
+++ b/rpc/jsonrpc/receipts/bor_receipts_generator.go
@@ -70,6 +70,7 @@ func (g *BorGenerator) GenerateBorReceipt(ctx context.Context, tx kv.TemporalTx,
 	if err != nil {
 		return nil, err
 	}
+	defer ibs.Release(false)
 
 	txNum, err := txNumsReader.Max(ctx, tx, block.NumberU64())
 	if err != nil {
@@ -98,6 +99,7 @@ func (g *BorGenerator) GenerateBorLogs(ctx context.Context, msgs []*types.Messag
 	if err != nil {
 		return nil, err
 	}
+	defer ibs.Release(false)
 
 	_, _, logIdxAfterTx, err := rawtemporaldb.ReceiptAsOf(tx, txNum+1)
 	if err != nil {

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -275,6 +275,11 @@ func (g *Generator) GetReceipt(ctx context.Context, cfg *chain.Config, tx kv.Tem
 
 	var evm *vm.EVM
 	var genEnv *ReceiptEnv
+	defer func() {
+		if genEnv != nil {
+			genEnv.ibs.Release(false)
+		}
+	}()
 
 	err = rpchelper.CheckBlockExecuted(g.filters.WithOverlay(tx), blockNum)
 	if err != nil {
@@ -506,6 +511,7 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 	if err != nil {
 		return nil, err
 	}
+	defer genEnv.ibs.Release(false)
 
 	ctx, cancel := context.WithTimeout(ctx, g.evmTimeout)
 	defer cancel()

--- a/rpc/transactions/call.go
+++ b/rpc/transactions/call.go
@@ -215,6 +215,9 @@ func (r *ReusableCaller) DoCallWithNewGas(
 		}
 		r.evm.SetPrecompiles(precompiles)
 	}
+	if prev := r.evm.IntraBlockState(); prev != nil {
+		prev.Release(false)
+	}
 	r.evm.Reset(txCtx, ibs)
 
 	// done is closed on return to stop the watcher goroutine before it can


### PR DESCRIPTION
Follow-up to #22777: wires the existing `Release()` end-of-life hook into more places where an `IntraBlockState` dies without returning its pooled resources (stateObjects, journal, revisions).

- `receipts_generator.go` `GetReceipt`/`GetReceipts`: release the `ReceiptEnv` IBS at handler end (nil-guarded; `GetReceipt` has three creation branches).
- `bor_receipts_generator.go` `GenerateBorReceipt`/`GenerateBorLogs`: function-scoped IBS; only receipt/logs escape, and `Release` does not touch logs.
- `otterscan_api.go` `runTracer`: function-scoped IBS; `ExecutionResult` carries no IBS references.
- `exec.TraceWorker.Close`: was empty; both users already `defer Close()`.
- `transactions.DoCallWithNewGas`: release the previous iteration's IBS before installing the new one into the reusable EVM. `eth_estimateGas` creates one IBS per binary-search iteration; the final one stays installed, as before.
- `exec3_parallel.go` `runPostApplyMessageOnMinIBS`: minimal log-buffer IBS, function-scoped.
- `bal/regenerator.go`: function-scoped IBS used to re-derive a block access list.
- `exec.Worker.resetTx`: release the old IBS before replacing it. Safe because `RunTxTask` and `ResetTx` hold the same worker lock, and `TxResult` retains only logs and read/write sets — none touched by `Release`.
- `exec.HistoricalTraceWorker.Run`: release the worker-lifetime IBS on exit; results carry only logs.

No behavior change; mechanical call-site wiring following the pattern of #22777 (no TDD cycle for the same reason). Files are disjoint from #22777 except `rpc/transactions/call.go`, where the hunks don't overlap.
