### PR TITLE
fix log attribute keys that break logfmt

### DIFF
--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -706,7 +706,7 @@ func (d *peerdas) DownloadColumnsAndRecoverBlobs(ctx context.Context, blocks []c
 		for _, block := range blocks {
 			slots = append(slots, block.GetSlot())
 		}
-		log.Debug("DownloadColumnsAndRecoverBlobs", "elapsed time", time.Since(begin), "slots", slots)
+		log.Debug("DownloadColumnsAndRecoverBlobs", "elapsed", time.Since(begin), "slots", slots)
 	}()
 
 	// initialize the download request

--- a/cmd/integration/commands/state_domains.go
+++ b/cmd/integration/commands/state_domains.go
@@ -98,7 +98,7 @@ var readDomains = &cobra.Command{
 			}
 			addr, err := hex.DecodeString(strings.TrimPrefix(args[i], "0x"))
 			if err != nil {
-				logger.Warn("invalid address passed", "str", args[i], "at position", i, "err", err)
+				logger.Warn("invalid address passed", "str", args[i], "position", i, "err", err)
 				continue
 			}
 			addrs = append(addrs, addr)

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -399,7 +399,7 @@ func loopExec(db kv.TemporalRwDB, ctx context.Context, unwind uint64, logger log
 		if _, err = sync.Run(sd, tx, initialCycle, false); err != nil {
 			return err
 		}
-		logger.Info("[Integration] ", "loop time", time.Since(t))
+		logger.Info("[Integration] ", "loopTime", time.Since(t))
 		sd.Close()
 		tx.Rollback()
 		tx, err = db.BeginTemporalRw(ctx)

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -3518,7 +3518,7 @@ func doRetireCommand(ctx context.Context, cliCtx *cli.Command, dirs datadir.Dirs
 		allDeletedBlocks += deletedBlocks
 	}
 
-	logger.Info("Pruning has ended", "deleted blocks", allDeletedBlocks)
+	logger.Info("Pruning has ended", "deletedBlocks", allDeletedBlocks)
 
 	temporalDb, err := temporal.New(db, agg, res.BlockSnaps)
 	if err != nil {

--- a/db/downloader/webseeds/verify.go
+++ b/db/downloader/webseeds/verify.go
@@ -67,8 +67,8 @@ func Verify(
 		// Strict evaluation for the win.
 		err = cmp.Or(err, json.NewEncoder(os.Stdout).Encode(checker.state))
 		logger.Info("finished check",
-			"total bytes read", checker.totalBytesRead.Load(),
-			"total request count", checker.totalRequestCount.Load())
+			"totalBytesRead", checker.totalBytesRead.Load(),
+			"totalRequestCount", checker.totalRequestCount.Load())
 	}()
 	for _, chain := range chains {
 		// Shift left?
@@ -196,7 +196,7 @@ func (me *webseedChecker) checkPreverifiedItem(
 	}
 	info, err := mi.UnmarshalInfo()
 	panicif.Err(err)
-	me.logger.Debug("got metainfo", "piece length", info.PieceLength, "length", info.Length)
+	me.logger.Debug("got metainfo", "pieceLength", info.PieceLength, "length", info.Length)
 	dataUrl := baseUrl + "/" + item.Name
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dataUrl, nil)
 	panicif.Err(err)
@@ -212,14 +212,14 @@ func (me *webseedChecker) checkPreverifiedItem(
 	}
 	etag := resp.Header.Get("ETag")
 	stateItem.Etag = etag
-	me.logger.Debug("item response", "etag", etag, "content length", resp.ContentLength)
+	me.logger.Debug("item response", "etag", etag, "contentLength", resp.ContentLength)
 	done, err = me.matchHashes(&info, resp, stateItem)
 	if err == nil {
 		stateItem.DataMatchesTorrent = true
 		me.logger.Info("snapshot matches",
 			"url", dataUrl,
 			//"name", item.Name,
-			"content length", resp.ContentLength,
+			"contentLength", resp.ContentLength,
 			//"etag", resp.Header.Get("etag"),
 		)
 	}

--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -149,8 +149,8 @@ func HashSeekingPrune(
 		select {
 		case <-logEvery.C:
 			txNum := binary.BigEndian.Uint64(txnm)
-			logger.Info("[snapshots] prune index", "name", filenameBase, "pruned tx", stat.PruneCountTx,
-				"pruned values", stat.PruneCountValues,
+			logger.Info("[snapshots] prune index", "name", filenameBase, "prunedTx", stat.PruneCountTx,
+				"prunedValues", stat.PruneCountValues,
 				"steps", fmt.Sprintf("%.2f-%.2f", float64(txFrom)/float64(stepSize), float64(txNum)/float64(stepSize)))
 		default:
 		}

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -967,7 +967,7 @@ func (g *Getter) Next(buf []byte) ([]byte, uint64) {
 	} else {
 		// Expand buffer
 		if len(buf)+int(wordLen) < 0 {
-			log.Error("can't expand buffer", "filename", g.fName, "pos", savePos, "buf len", len(buf))
+			log.Error("can't expand buffer", "filename", g.fName, "pos", savePos, "bufLen", len(buf))
 			return nil, 0
 		}
 		buf = buf[:len(buf)+int(wordLen)]

--- a/db/snapshotsync/freezeblocks/block_snapshots.go
+++ b/db/snapshotsync/freezeblocks/block_snapshots.go
@@ -867,9 +867,9 @@ func DumpTxs(ctx context.Context, db kv.RoDB, chainConfig *chain.Config, blockFr
 			if lvl >= log.LvlInfo {
 				var m runtime.MemStats
 				dbg.ReadMemStats(&m)
-				logger.Log(lvl, "[snapshots] Dumping txs", "block num", blockNum, "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
+				logger.Log(lvl, "[snapshots] Dumping txs", "blockNum", blockNum, "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
 			} else {
-				logger.Log(lvl, "[snapshots] Dumping txs", "block num", blockNum)
+				logger.Log(lvl, "[snapshots] Dumping txs", "blockNum", blockNum)
 			}
 		default:
 		}
@@ -954,7 +954,7 @@ func DumpHeadersRaw(ctx context.Context, db kv.RoDB, _ *chain.Config, blockFrom,
 			if lvl >= log.LvlInfo {
 				dbg.ReadMemStats(&m)
 			}
-			logger.Log(lvl, "[snapshots] Dumping headers", "block num", blockNum,
+			logger.Log(lvl, "[snapshots] Dumping headers", "blockNum", blockNum,
 				"alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys),
 			)
 		default:
@@ -1036,7 +1036,7 @@ func DumpBodies(ctx context.Context, db kv.RoDB, _ *chain.Config, blockFrom, blo
 			if lvl >= log.LvlInfo {
 				dbg.ReadMemStats(&m)
 			}
-			logger.Log(lvl, "[snapshots] Wrote into file", "block num", blockNum,
+			logger.Log(lvl, "[snapshots] Wrote into file", "blockNum", blockNum,
 				"alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys),
 			)
 		default:

--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -851,8 +851,8 @@ func (a *Aggregator) WaitForBuildAndMerge(ctx context.Context) chan struct{} {
 				return
 			case <-chkEvery.C:
 				a.logger.Trace("[agg] waiting for files",
-					"building files", a.buildingFiles.Load(),
-					"merging files", a.mergingFiles.Load())
+					"buildingFiles", a.buildingFiles.Load(),
+					"mergingFiles", a.mergingFiles.Load())
 			}
 		}
 	}()
@@ -1400,7 +1400,7 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 				fullStat.Accumulate(stat)
 				return true, nil
 			}
-			at.a.logger.Warn("[snapshots] PruneSmallBatches failed", "err", err, "is deadline?", errors.Is(err, context.DeadlineExceeded))
+			at.a.logger.Warn("[snapshots] PruneSmallBatches failed", "err", err, "isDeadline", errors.Is(err, context.DeadlineExceeded))
 			return false, err
 		}
 		if stat == nil || stat.PrunedNothing() {
@@ -1439,7 +1439,7 @@ func (at *AggregatorRoTx) PruneSmallBatches(ctx context.Context, timeout time.Du
 				)
 			} else {
 				at.a.logger.Info("[prune] state",
-					"until commit", time.Until(started.Add(timeout)).String(),
+					"untilCommit", time.Until(started.Add(timeout)).String(),
 					//"pruneLimit", pruneLimit,
 					//"aggregatedStep", at.StepsInFiles(kv.AccountsDomain),
 					"stepsRangeInDB", at.stepsRangeInDBAsStr(tx),

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -67,7 +67,7 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTimeSecs
 			log.Warn("Failed to build a block", "err", err)
 		} else {
 			block := result.Block
-			log.Info("Built block", "hash", block.Hash(), "height", block.NumberU64(), "txs", len(block.Transactions()), "executionRequests", len(result.Requests), "gas used %", 100*float64(block.GasUsed())/float64(block.GasLimit()), "time", time.Since(t))
+			log.Info("Built block", "hash", block.Hash(), "height", block.NumberU64(), "txs", len(block.Transactions()), "executionRequests", len(result.Requests), "gasUsedPct", 100*float64(block.GasUsed())/float64(block.GasLimit()), "time", time.Since(t))
 		}
 	}()
 

--- a/execution/builder/exec.go
+++ b/execution/builder/exec.go
@@ -528,7 +528,7 @@ func filterBadTransactions(transactions []types.Transaction, chainID *uint256.In
 		filtered = append(filtered, transaction)
 		transactions = transactions[1:]
 	}
-	logger.Debug("Filtration", "initial", initialCnt, "no sender", noSenderCnt, "no account", noAccountCnt, "nonce too low", nonceTooLowCnt, "nonceTooHigh", missedTxs, "sender not EOA", notEOACnt, "fee too low", feeTooLowCnt, "overflow", overflowCnt, "balance too low", balanceTooLowCnt, "bad chain id", badChainId, "filtered", len(filtered))
+	logger.Debug("Filtration", "initial", initialCnt, "noSender", noSenderCnt, "noAccount", noAccountCnt, "nonceTooLow", nonceTooLowCnt, "nonceTooHigh", missedTxs, "senderNotEOA", notEOACnt, "feeTooLow", feeTooLowCnt, "overflow", overflowCnt, "balanceTooLow", balanceTooLowCnt, "badChainID", badChainId, "filtered", len(filtered))
 	if stats != nil {
 		stats.filtered += len(filtered)
 		stats.badChainID += badChainId

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1584,7 +1584,7 @@ func (hph *HexPatriciaHashed) needFolding(hashedKey []byte) bool {
 }
 
 // Process-cumulative trie-compute counters feeding the KVReadLevelledMetrics
-// "skip ratio"/"reset ratio" Debug log at the end of ComputeCommitment.
+// "skipRatio"/"resetRatio" Debug log at the end of ComputeCommitment.
 var (
 	hadToLoad   atomic.Uint64
 	skippedLoad atomic.Uint64
@@ -2629,8 +2629,8 @@ func (hph *HexPatriciaHashed) Process(ctx context.Context, updates *Updates, log
 		log.Debug("commitment finished, counters updated (no reset)",
 			//"hadToLoad", common.PrettyCounter(hadToLoad.Load()), "skippedLoad", common.PrettyCounter(skippedLoad.Load()),
 			//"hadToReset", common.PrettyCounter(hadToReset.Load()),
-			"skip ratio", fmt.Sprintf("%.1f%%", 100*(float64(skippedLoad.Load())/float64(hadToLoad.Load()+skippedLoad.Load()))),
-			"reset ratio", fmt.Sprintf("%.1f%%", 100*(float64(hadToReset.Load())/float64(hadToLoad.Load()))),
+			"skipRatio", fmt.Sprintf("%.1f%%", 100*(float64(skippedLoad.Load())/float64(hadToLoad.Load()+skippedLoad.Load()))),
+			"resetRatio", fmt.Sprintf("%.1f%%", 100*(float64(hadToReset.Load())/float64(hadToLoad.Load()))),
 			"keys", common.PrettyCounter(ki), "spent", time.Since(start),
 		)
 		ends := make([]uint64, 0, len(hph.hadToLoadL))

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -647,7 +647,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 			if blockHashBlockNum != nil {
 				hashBlockNum = strconv.FormatUint(*blockHashBlockNum, 10)
 			}
-			e.logger.Warn("bad forkchoice", "head", headHash, "head block", headNum, "hash", blockHash, "hash block", hashBlockNum)
+			e.logger.Warn("bad forkchoice", "head", headHash, "headBlock", headNum, "hash", blockHash, "hashBlockNum", hashBlockNum)
 		}
 		currentContext.Close()
 		currentContext = nil

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -797,14 +797,14 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 
 		// 1. chainId check
 		if !auth.ChainID.IsZero() && chainID != auth.ChainID.String() {
-			log.Debug("invalid chainID, skipping", "chainId", auth.ChainID, "auth index", i)
+			log.Debug("invalid chainID, skipping", "chainId", auth.ChainID, "authIndex", i)
 			continue
 		}
 
 		// 2. authority recover
 		authorityPtr, err := auth.RecoverSigner(data, b[:])
 		if err != nil {
-			log.Trace("authority recover failed, skipping", "err", err, "auth index", i)
+			log.Trace("authority recover failed, skipping", "err", err, "authIndex", i)
 			continue
 		}
 		authority := accounts.InternAddress(*authorityPtr)
@@ -825,7 +825,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 				return gasRemaining, gasUsed, fmt.Errorf("%w: %w", ErrTxnExecutionFailed, err)
 			}
 			if !ok {
-				log.Debug("authority code is not empty or not delegated, skipping", "auth index", i)
+				log.Debug("authority code is not empty or not delegated, skipping", "authIndex", i)
 				continue
 			}
 		}
@@ -836,7 +836,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			return gasRemaining, gasUsed, fmt.Errorf("%w: %w", ErrTxnExecutionFailed, err)
 		}
 		if authorityNonce != auth.Nonce {
-			log.Trace("invalid nonce, skipping", "auth index", i)
+			log.Trace("invalid nonce, skipping", "authIndex", i)
 			continue
 		}
 

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -1276,7 +1276,7 @@ func (s *Ethereum) NetVersion() (uint64, error) { return s.networkID, nil }
 func (s *Ethereum) NetPeerCount() (uint64, error) {
 	var sentryPc uint64 = 0
 
-	s.logger.Trace("sentry", "peer count", sentryPc)
+	s.logger.Trace("sentry", "peerCount", sentryPc)
 	for _, sc := range s.sentryProvider.Client.Sentries() {
 		ctx := context.Background()
 		reply, err := sc.PeerCount(ctx, &sentryproto.PeerCountRequest{})

--- a/node/logging/logging.go
+++ b/node/logging/logging.go
@@ -281,7 +281,7 @@ func initSeparatedLogging(
 
 	mux := log.MultiHandler(consoleHandler, log.LvlFilterHandler(dirLevel, userLog))
 	logger.SetHandler(mux)
-	logger.Info("logging to file system", "log dir", dirPath, "file prefix", filePrefix, "log level", dirLevel, "json", dirJson)
+	logger.Info("logging to file system", "logDir", dirPath, "filePrefix", filePrefix, "logLevel", dirLevel, "json", dirJson)
 }
 
 // GetLogLevel parses a log level given as a name ("info") or a numeric string ("3").

--- a/node/privateapi/mining.go
+++ b/node/privateapi/mining.go
@@ -150,7 +150,7 @@ func (s *MiningServer) OnMinedBlock(req *txpoolproto.OnMinedBlockRequest, reply 
 }
 
 func (s *MiningServer) BroadcastMinedBlock(block *types.Block) error {
-	s.logger.Debug("BroadcastMinedBlock", "block hash", block.Hash(), "block number", block.Number(), "root", block.Root(), "gas", block.GasUsed())
+	s.logger.Debug("BroadcastMinedBlock", "blockHash", block.Hash(), "blockNum", block.Number(), "root", block.Root(), "gas", block.GasUsed())
 	var buf bytes.Buffer
 	if err := block.EncodeRLP(&buf); err != nil {
 		return err

--- a/polygon/heimdall/types.go
+++ b/polygon/heimdall/types.go
@@ -147,7 +147,7 @@ func (e EventRangeExtractor) Extract(ctx context.Context, blockFrom, blockTo uin
 			if lvl >= log.LvlInfo {
 				dbg.ReadMemStats(&m)
 			}
-			logger.Log(lvl, "[bor snapshots] Dumping bor events", "block num", blockNum,
+			logger.Log(lvl, "[bor snapshots] Dumping bor events", "blockNum", blockNum,
 				"alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys),
 			)
 		default:

--- a/rpc/jsonrpc/receipts/receipts_generator.go
+++ b/rpc/jsonrpc/receipts/receipts_generator.go
@@ -231,7 +231,7 @@ func (g *Generator) GetReceipt(ctx context.Context, cfg *chain.Config, tx kv.Tem
 				"blockNum", blockNum,
 				"firstLogIndex", firstLogIndex,
 				"logIdxAfterTx", logIdxAfterTx,
-				"nil receipt in db", receiptFromDB == nil,
+				"nilReceiptInDB", receiptFromDB == nil,
 				"err", err)
 		}
 	}()
@@ -462,7 +462,7 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 		if dbg.Enabled(ctx) {
 			log.Info("[dbg] ReceiptGenerator.GetReceipts",
 				"blockNum", blockNum,
-				"nil receipts in db", receiptsFromDB == nil)
+				"nilReceiptsInDB", receiptsFromDB == nil)
 		}
 	}()
 

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -1788,7 +1788,7 @@ func (p *TxPool) addLocked(mt *metaTxn, announcements *Announcements) txpoolcfg.
 				return txpoolcfg.NonceTooLow
 			}
 			if _, ok := p.auths[AuthAndNonce{a.authority, a.nonce}]; ok {
-				p.logger.Debug("setCodeTxn ", "DUPLICATE authority", a.authority, "at nonce", a.nonce, "txn", fmt.Sprintf("%x", mt.TxnSlot.IDHash))
+				p.logger.Debug("setCodeTxn ", "duplicateAuthority", a.authority, "nonce", a.nonce, "txn", fmt.Sprintf("%x", mt.TxnSlot.IDHash))
 				return txpoolcfg.ErrAuthorityReserved
 			}
 		}
@@ -2449,12 +2449,12 @@ func (p *TxPool) Run(ctx context.Context) error {
 				const localTxnsBroadcastMaxPeers uint64 = 10
 				txnSentTo := p.p2pSender.BroadcastPooledTxns(localTxnRlps, localTxnsBroadcastMaxPeers)
 				for i, peer := range txnSentTo {
-					p.logger.Trace("Local txn broadcast", "txHash", hex.EncodeToString(broadcastHashes.At(i)), "to peer", peer)
+					p.logger.Trace("Local txn broadcast", "txHash", hex.EncodeToString(broadcastHashes.At(i)), "toPeer", peer)
 				}
 				hashSentTo := p.p2pSender.AnnouncePooledTxns(localTxnTypes, localTxnSizes, localTxnHashes, localTxnsBroadcastMaxPeers*2)
 				for i := 0; i < localTxnHashes.Len(); i++ {
 					hash := localTxnHashes.At(i)
-					p.logger.Trace("Local txn announced", "txHash", hex.EncodeToString(hash), "to peer", hashSentTo[i], "baseFee", p.pendingBaseFee.Load())
+					p.logger.Trace("Local txn announced", "txHash", hex.EncodeToString(hash), "toPeer", hashSentTo[i], "baseFee", p.pendingBaseFee.Load())
 				}
 
 				// broadcast remote transactions


### PR DESCRIPTION
The terminal formatter writes attribute keys unquoted, so a key containing a space or `?` emits output no logfmt parser can read back — `"block num"` renders as `block num=23847119`, which parses as key `block` with value `num=23847119`.

## Changes

- Renames 39 such keys to the repo-dominant camelCase spelling: `"block num"` -> `"blockNum"`, `"is deadline?"` -> `"isDeadline"`, `"peer count"` -> `"peerCount"`.
- Key names only. No message text, prefix or level changes.