### PR TITLE
cl/transition: gate BLS-to-execution change signature verification on FullValidation

### DIFF
--- a/cl/transition/impl/eth2/operations.go
+++ b/cl/transition/impl/eth2/operations.go
@@ -1088,29 +1088,29 @@ func (I *impl) ProcessBlsToExecutionChange(
 		return errors.New("ProcessBlsToExecutionChange: withdrawal credentials mismatch")
 	}
 
-	// Fork-agnostic domain since address changes are valid across forks
-	domain, err := fork.ComputeDomain(
-		s.BeaconConfig().DomainBLSToExecutionChange[:],
-		utils.Uint32ToBytes4(uint32(s.BeaconConfig().GenesisForkVersion)),
-		s.GenesisValidatorsRoot(),
-	)
-	if err != nil {
-		return err
-	}
-	signingRoot, err := fork.ComputeSigningRoot(change, domain)
-	if err != nil {
-		return err
-	}
-	// Verify the signature
-	ok, err := bls.Verify(signedChange.Signature[:], signingRoot[:], change.From[:])
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return errors.New("ProcessBlsToExecutionChange: invalid signature")
+	if I.FullValidation {
+		// Fork-agnostic domain since address changes are valid across forks
+		domain, err := fork.ComputeDomain(
+			s.BeaconConfig().DomainBLSToExecutionChange[:],
+			utils.Uint32ToBytes4(uint32(s.BeaconConfig().GenesisForkVersion)),
+			s.GenesisValidatorsRoot(),
+		)
+		if err != nil {
+			return err
+		}
+		signingRoot, err := fork.ComputeSigningRoot(change, domain)
+		if err != nil {
+			return err
+		}
+		ok, err := bls.Verify(signedChange.Signature[:], signingRoot[:], change.From[:])
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errors.New("ProcessBlsToExecutionChange: invalid signature")
+		}
 	}
 
-	// Perform full validation if requested.
 	// Reset the validator's withdrawal credentials.
 	credentials[0] = byte(beaconConfig.ETH1AddressWithdrawalPrefixByte)
 	copy(credentials[1:], make([]byte, 11))

--- a/cl/transition/impl/eth2/operations_bls_change_test.go
+++ b/cl/transition/impl/eth2/operations_bls_change_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package eth2
+
+import (
+	"testing"
+
+	blst "github.com/supranational/blst/bindings/go"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/fork"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/cl/utils/bls"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+// blsChangeFixture builds a state holding one validator with BLS withdrawal credentials derived
+// from a real keypair, plus a change for it signed with that key.
+func blsChangeFixture(t *testing.T) (*state.CachingBeaconState, *cltypes.SignedBLSToExecutionChange) {
+	t.Helper()
+	cfg := clparams.MainnetBeaconConfig
+	s := state.New(&cfg)
+
+	sk, err := bls.GenerateKey()
+	require.NoError(t, err)
+
+	var from common.Bytes48
+	copy(from[:], (*blst.P1Affine)(sk.PublicKey()).Compress())
+
+	hashedFrom := crypto.Sha256(from[:])
+	var creds common.Hash
+	creds[0] = byte(cfg.BLSWithdrawalPrefixByte)
+	copy(creds[1:], hashedFrom[1:])
+
+	s.AddValidator(solid.NewValidatorFromParameters(
+		from, creds, cfg.MaxEffectiveBalance, false, 0, 0, cfg.FarFutureEpoch, cfg.FarFutureEpoch,
+	), cfg.MaxEffectiveBalance)
+
+	change := &cltypes.BLSToExecutionChange{ValidatorIndex: 0, From: from, To: common.Address{0xab}}
+	domain, err := fork.ComputeDomain(
+		cfg.DomainBLSToExecutionChange[:],
+		utils.Uint32ToBytes4(uint32(cfg.GenesisForkVersion)),
+		s.GenesisValidatorsRoot(),
+	)
+	require.NoError(t, err)
+	signingRoot, err := fork.ComputeSigningRoot(change, domain)
+	require.NoError(t, err)
+
+	var sig common.Bytes96
+	copy(sig[:], sk.Sign(signingRoot[:]).Bytes())
+	return s, &cltypes.SignedBLSToExecutionChange{Message: change, Signature: sig}
+}
+
+func migratedTo(t *testing.T, s *state.CachingBeaconState) bool {
+	t.Helper()
+	v, err := s.ValidatorForValidatorIndex(0)
+	require.NoError(t, err)
+	creds := v.WithdrawalCredentials()
+	return creds[0] == byte(clparams.MainnetBeaconConfig.ETH1AddressWithdrawalPrefixByte)
+}
+
+// Signature verification is the expensive part of this operation and is skipped when the caller
+// does not ask for full validation, matching how attestation signatures are handled. Everything
+// that determines the resulting state stays unconditional.
+func TestProcessBlsToExecutionChangeSignatureGating(t *testing.T) {
+	t.Run("valid signature is accepted under full validation", func(t *testing.T) {
+		s, signed := blsChangeFixture(t)
+		require.NoError(t, (&impl{FullValidation: true}).ProcessBlsToExecutionChange(s, signed))
+		require.True(t, migratedTo(t, s))
+	})
+
+	t.Run("bad signature is rejected under full validation", func(t *testing.T) {
+		s, signed := blsChangeFixture(t)
+		signed.Signature[0] ^= 0xff
+		require.Error(t, (&impl{FullValidation: true}).ProcessBlsToExecutionChange(s, signed))
+		require.False(t, migratedTo(t, s))
+	})
+
+	t.Run("signature is not checked without full validation", func(t *testing.T) {
+		s, signed := blsChangeFixture(t)
+		signed.Signature[0] ^= 0xff
+		require.NoError(t, (&impl{}).ProcessBlsToExecutionChange(s, signed))
+		require.True(t, migratedTo(t, s))
+	})
+
+	// The state-dependent asserts are what block production relies on, so they must hold
+	// whether or not signatures are being verified.
+	t.Run("credential asserts still apply without full validation", func(t *testing.T) {
+		s, signed := blsChangeFixture(t)
+		require.NoError(t, (&impl{}).ProcessBlsToExecutionChange(s, signed))
+		require.Error(t, (&impl{}).ProcessBlsToExecutionChange(s, signed))
+	})
+}


### PR DESCRIPTION
`ProcessBlsToExecutionChange` verifies the signature unconditionally. Its neighbours don't — attestation signature verification sits behind `FullValidation` (`operations.go:1144`), and block production builds its machine as `&eth2.Impl{}` with that off. Since #22827 started packing these changes, every produced block pays a full BLS pairing per change on the proposal path.

Measured on this machine (blst v0.3.17), per change:

| | ns/op |
|---|---|
| with `FullValidation` | 562,000 |
| gated | 366 |

A full block of 16 goes from ~9.0 ms to ~5.9 us. The cost is the pairing (397 us of a 462 us `bls.Verify`); it is inherent to BLS12-381, which is why the ingest path batch-verifies instead.

## Why this is safe

No untrusted block reaches `ProcessBlock` with `FullValidation` off:

- gossip (`block_service.go:286`), chain-tip sync (`chain_tip_sync.go:269`) and forward sync (`forward_sync.go:157`) all pass `true`
- the `false` paths are a proposer's own freshly built block (`block_production.go:506,2094`), fork-graph replay of already-accepted blocks (`fork_graph_disk.go:538`), and antiquary replay of finalized blocks (`state_antiquary.go:472`)

Operations reach the pool only through `blsToExecutionChangeService.ProcessMessage`, which inserts inside the batch verifier's success callback — so a pool entry has already had its signature verified. The REST pool endpoint goes through the same path.

This mirrors the existing argument for skipping attestation signature verification during production. Note it is an erigon-side optimisation, not something the spec sanctions: `process_bls_to_execution_change` asserts `bls.Verify` unconditionally, which is why the assert must stay for imports.

## Changes

- Signature verification (and the domain/signing-root computation it needs) moved behind `FullValidation`. The `validator_index`, prefix and credential-hash asserts stay unconditional, so the resulting state is identical either way.
- Test pins all four arms: valid accepted under full validation, bad rejected under full validation, bad not checked without it, and the credential asserts still applying without it.

The full consensus spec suite passes — 8119 cases, including the 42 `bls_to_execution_change` invalid vectors, which still fail correctly because `cl/spectest` runs `transition.ValidatingMachine`.
