### PR TITLE
cmd/downloader: log under [Downloader] in the standalone binary too

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -248,7 +248,7 @@ func Downloader(cmd *cobra.Command, logger log.Logger) error {
 	}
 
 	logger.Info(
-		"[snapshots] cli flags",
+		"[Downloader] cli flags",
 		"chain", chain,
 		"addr", downloaderApiAddr,
 		"datadir", dirs.DataDir,
@@ -313,14 +313,12 @@ func Downloader(cmd *cobra.Command, logger log.Logger) error {
 	manualDataVerification := verify || verifyFailfast || len(verifyFiles) > 0
 	cfg.ManualDataVerification = manualDataVerification
 
-	cfg.LogPrefix = "[snapshots] "
-
 	d, err := downloader.New(ctx, cfg, logger)
 	if err != nil {
 		return err
 	}
 	defer d.Close()
-	logger.Info("[snapshots] Start bittorrent server", "my_peer_id", fmt.Sprintf("%x", d.TorrentClient().PeerID()))
+	logger.Info("[Downloader] Start bittorrent server", "my_peer_id", fmt.Sprintf("%x", d.TorrentClient().PeerID()))
 
 	d.HandleTorrentClientStatus(nil)
 


### PR DESCRIPTION
`downloadercfg` sets `LogPrefix` to `"[Downloader] "`, and `Downloader.log` prepends it to all 29 call sites in `db/downloader`. The standalone binary overwrites it with `"[snapshots] "` at `cmd/downloader/main.go:316`, so the same code logs under a different component name depending on which binary is running — a grep for either prefix silently misses half the fleet.

`[snapshots]` is also already taken: 74 call sites use it for unrelated subsystems (aggregator file building, block retirement, the merger), so the override folds two different components under one name.

## Changes

- Drops the `LogPrefix` override so both binaries emit `[Downloader]`.
- The standalone binary's own two startup lines move to `[Downloader]` as well.