### PR TITLE
execution/state: keep ripemd's touch across a revert on the versioned path

### DIFF
--- a/execution/state/eip161_ripemd_revert_test.go
+++ b/execution/state/eip161_ripemd_revert_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// emptyAccountReader serves one existing, already-empty account.
+type emptyAccountReader struct {
+	NoopReader
+	addr accounts.Address
+	acc  *accounts.Account
+}
+
+func (r *emptyAccountReader) ReadAccountData(address accounts.Address) (*accounts.Account, error) {
+	if address == r.addr {
+		return r.acc, nil
+	}
+	return nil, nil
+}
+
+func (r *emptyAccountReader) ReadAccountDataForDebug(address accounts.Address) (*accounts.Account, error) {
+	return r.ReadAccountData(address)
+}
+
+// normalizeTouchThenRevert touches an already-empty account on the versioned
+// (parallel) path, reverts the transaction, and reports whether the normalized
+// write set sweeps the account under EIP-161.
+func normalizeTouchThenRevert(t *testing.T, addr accounts.Address) bool {
+	t.Helper()
+
+	empty := accounts.NewAccount() // balance 0, nonce 0, empty code hash
+	reader := &emptyAccountReader{addr: addr, acc: &empty}
+
+	vm := NewVersionMap(nil)
+	ibs := NewWithVersionMap(reader, vm)
+	ibs.SetNoMaterialize(true)
+	defer ibs.Release(false)
+	ibs.SetTxContext(0, 0)
+	ibs.SetVersion(0)
+
+	snap := ibs.PushSnapshot()
+	require.NoError(t, ibs.AddBalance(addr, uint256.Int{}, 0))
+	ibs.RevertToSnapshot(snap, nil)
+
+	writes := ibs.FinalizedWrites()
+	if writes == nil {
+		return false
+	}
+	normalized, err := writes.Normalize(vm, 0, 0, reader, nil, true /*emptyRemoval*/, false /*isAura*/, false)
+	require.NoError(t, err)
+	if normalized == nil {
+		return false
+	}
+	for a, w := range normalized.SelfDestructs() {
+		if a == addr && w.Val {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEIP161RipemdTouchSurvivesRevertOnVersionedPath pins RIPEMD-160's special
+// case on the parallel state path.
+//
+// touchAccount deliberately bumps ripemd's journal dirty count so a touch
+// outlives the reverting transaction, and serial therefore still sweeps the
+// account under EIP-161. The versioned path derives its write set from
+// versionedWrites, and reverting the touch's zero-balance write dropped that
+// sweep — so the account kept its trie leaf and mainnet's Spurious Dragon
+// clearing blocks re-executed to a wrong state root (first observed at block
+// 2,675,119).
+//
+// An ordinary account is the control: its reverted touch must NOT sweep, which
+// is what makes ripemd's exemption specific rather than a blanket rule.
+func TestEIP161RipemdTouchSurvivesRevertOnVersionedPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ripemd is swept despite the revert", func(t *testing.T) {
+		t.Parallel()
+		require.True(t, normalizeTouchThenRevert(t, accounts.InternAddress(ripemd.Value())),
+			"ripemd's touch outlives a revert, so EIP-161 must still remove it")
+	})
+
+	t.Run("ordinary account is not swept", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, normalizeTouchThenRevert(t, toAddr([]byte("ordinary-empty"))),
+			"a reverted touch must not remove an ordinary empty account")
+	})
+}

--- a/execution/state/journal.go
+++ b/execution/state/journal.go
@@ -512,7 +512,12 @@ func (je *journalEntry) revert(s *IntraBlockState) error {
 		// lets Normalize's EIP-161 pass delete an account whose touch was rolled back.
 		// Mirror kindBalance — drop the write if the touch created it, else restore
 		// the prior value.
-		if s.versionMap != nil {
+		//
+		// RIPEMD-160 is the exception: touchAccount bumps its dirty count so the
+		// touch outlives the revert and EIP-161 still sweeps it. Undoing the write
+		// here would drop that sweep on the versioned path only, leaving the
+		// account in the trie and diverging from serial's root.
+		if s.versionMap != nil && je.account != ripemd {
 			if je.committed() {
 				s.versionedWrites.DelBalance(je.account)
 			} else if _, ok := s.versionedWrites.GetBalance(je.account); ok {


### PR DESCRIPTION
Re-executing mainnet from genesis computes a wrong trie root at block 2,675,119, in the Spurious Dragon empty-account clearing range:

```
computed  8dac6476e3444420de57f554980cddf9af57da6fa2fee3da7ce7a774133af2b0
expected  727fc87b6a13c3a4d1097b7cf8a1f183b0d4e944ef2abca1583250bbafaa76f8
```

Tracing the block's commitment updates against the last-good commit shows the sets differ by exactly one operation out of 728 — the delete of RIPEMD-160 (`0x…03`).

`touchAccount` bumps ripemd's journal dirty count so its touch outlives the transaction that rolled back, and the serial path therefore still sweeps the account under EIP-161. The versioned path builds its write set from `versionedWrites`, and the `kindTouch` revert dropped the touch's zero-balance write — so the sweep never happened and the account kept its trie leaf.

Bisected to #22409, which moved parallel execution off resident `stateObject`s onto `versionMap + journal`. Only re-execution reaches this range; snapshot-synced nodes never execute these blocks, which is why it went unnoticed.

## Changes
- `journal.go`: exempt ripemd from the `kindTouch` revert on the versioned path, mirroring the dirty-count bump serial already relies on.
- Regression test covering ripemd (swept despite the revert) and an ordinary empty account (not swept), so the exemption stays specific.