### PR TITLE
[r3.6] db/snaptype: tolerate files deleted during dir scan

### DIFF
--- a/db/snaptype/files.go
+++ b/db/snaptype/files.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -473,11 +474,19 @@ func ParseDir(name string) (res []FileInfo, err error) {
 		}
 		return nil, err
 	}
+	return parseDirEntries(name, files)
+}
 
+func parseDirEntries(name string, files []os.DirEntry) (res []FileInfo, err error) {
 	for _, f := range files {
 		fileInfo, err := f.Info()
 		if err != nil {
-			return nil, err
+			// Deleted between ReadDir and this stat: merged-over segments are unlinked
+			// concurrently with directory scans.
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("ParseDir: %s: %w", name, err)
 		}
 		if f.IsDir() || fileInfo.Size() == 0 || len(f.Name()) < 3 {
 			continue

--- a/db/snaptype/files_test.go
+++ b/db/snaptype/files_test.go
@@ -1,6 +1,35 @@
 package snaptype
 
-import "testing"
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type vanishedDirEntry struct{ name string }
+
+func (e vanishedDirEntry) Name() string               { return e.name }
+func (e vanishedDirEntry) IsDir() bool                { return false }
+func (e vanishedDirEntry) Type() fs.FileMode          { return 0 }
+func (e vanishedDirEntry) Info() (fs.FileInfo, error) { return nil, fs.ErrNotExist }
+
+// A file may be deleted between ReadDir and the per-entry stat by concurrent
+// snapshot merge/prune; the scan must skip it instead of failing.
+func TestParseDirSkipsFileDeletedDuringScan(t *testing.T) {
+	d := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(d, "v1.0-047370-047380-beaconblocks.seg"), []byte("x"), 0o644))
+	entries, err := os.ReadDir(d)
+	require.NoError(t, err)
+	entries = append(entries, vanishedDirEntry{name: "v1.1-047370-047371-transactions.seg"})
+
+	res, err := parseDirEntries(d, entries)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, "v1.0-047370-047380-beaconblocks.seg", res[0].Name())
+}
 
 func TestStateSeedable(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Cherry-pick of #22853 to release/3.6.

Fixes the QA sync-from-scratch (gnosis archive) abort: https://github.com/erigontech/erigon/actions/runs/30347797880/job/90237994145