### PR TITLE
execution: validate blocks resumed mid-block

### DIFF
--- a/execution/receipts/derive.go
+++ b/execution/receipts/derive.go
@@ -189,32 +189,14 @@ func gasUsedFromCachedReceipts(cached types.Receipts, txns types.Transactions) *
 	return gasUsed
 }
 
-// DerivePriorReceipts returns receipts for transactions 0..startTxIndex-1.
+// DerivePriorReceipts returns receipts for transactions 0..startTxIndex-1,
+// together with the block gas totals they accumulated.
 // Pre-Amsterdam it uses RCacheV2 when the full prefix is cached. Amsterdam
 // blocks are replayed because receipts do not preserve both block-gas dimensions.
 //
 // Used when execution resumes mid-block from a snapshot boundary and Finalize
 // needs the full receipt set for requests hash computation.
 func DerivePriorReceipts(
-	ctx context.Context,
-	cfg *chain.Config,
-	engine rules.EngineReader,
-	header *types.Header,
-	txns types.Transactions,
-	startTxIndex int,
-	blockStartTxNum uint64,
-	tx kv.TemporalTx,
-	ibs *state.IntraBlockState,
-	gp *protocol.GasPool,
-	getHeader GetHeaderFunc,
-) (types.Receipts, error) {
-	receipts, _, err := DerivePriorReceiptsWithGas(ctx, cfg, engine, header, txns, startTxIndex, blockStartTxNum, tx, ibs, gp, getHeader)
-	return receipts, err
-}
-
-// DerivePriorReceiptsWithGas also returns the block gas totals accumulated by
-// the prefix transactions.
-func DerivePriorReceiptsWithGas(
 	ctx context.Context,
 	cfg *chain.Config,
 	engine rules.EngineReader,

--- a/execution/receipts/derive.go
+++ b/execution/receipts/derive.go
@@ -59,6 +59,22 @@ func DeriveForRange(
 	gp *protocol.GasPool,
 	getHeader GetHeaderFunc,
 ) (types.Receipts, error) {
+	receipts, _, err := deriveForRange(ctx, cfg, engine, header, txns, fromIdx, toIdx, ibs, gp, getHeader)
+	return receipts, err
+}
+
+func deriveForRange(
+	ctx context.Context,
+	cfg *chain.Config,
+	engine rules.EngineReader,
+	header *types.Header,
+	txns types.Transactions,
+	fromIdx int,
+	toIdx int,
+	ibs *state.IntraBlockState,
+	gp *protocol.GasPool,
+	getHeader GetHeaderFunc,
+) (types.Receipts, *protocol.GasUsed, error) {
 	if fromIdx < 0 {
 		fromIdx = 0
 	}
@@ -66,7 +82,7 @@ func DeriveForRange(
 		toIdx = len(txns)
 	}
 	if fromIdx >= toIdx {
-		return nil, nil
+		return nil, new(protocol.GasUsed), nil
 	}
 
 	blockNum := header.Number.Uint64()
@@ -80,14 +96,14 @@ func DeriveForRange(
 	for i := 0; i < fromIdx; i++ {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		default:
 		}
 		ibs.SetTxContext(blockNum, i)
 		evm := protocol.CreateEVM(cfg, hashFn, engine, accounts.NilAddress, ibs, header, vmCfg)
 		_, err := protocol.ApplyTransactionWithEVM(cfg, engine, gp, ibs, noopWriter, header, txns[i], gasUsed, vmCfg, evm)
 		if err != nil {
-			return nil, fmt.Errorf("receipts.DeriveForRange: replay tx %d (warmup): %w", i, err)
+			return nil, nil, fmt.Errorf("receipts.DeriveForRange: replay tx %d (warmup): %w", i, err)
 		}
 	}
 
@@ -96,7 +112,7 @@ func DeriveForRange(
 	for i := fromIdx; i < toIdx; i++ {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		default:
 		}
 		ibs.SetTxContext(blockNum, i)
@@ -117,15 +133,15 @@ func DeriveForRange(
 		receipt, err := protocol.ApplyTransactionWithEVM(cfg, engine, gp, ibs, noopWriter, header, txns[i], gasUsed, vmCfg, evm)
 		close(txDone)
 		if err != nil {
-			return nil, fmt.Errorf("receipts.DeriveForRange: replay tx %d: %w", i, err)
+			return nil, nil, fmt.Errorf("receipts.DeriveForRange: replay tx %d: %w", i, err)
 		}
 		if evm.Cancelled() {
-			return nil, fmt.Errorf("receipts.DeriveForRange: execution aborted (context cancelled)")
+			return nil, nil, fmt.Errorf("receipts.DeriveForRange: execution aborted (context cancelled)")
 		}
 		receipts = append(receipts, receipt)
 	}
 
-	return receipts, nil
+	return receipts, gasUsed, nil
 }
 
 // DeriveBlockReceipts replays all transactions in a block and returns their receipts.
@@ -161,10 +177,21 @@ func DeriveFields(receipts types.Receipts, blockHash common.Hash) {
 	}
 }
 
+func gasUsedFromCachedReceipts(cached types.Receipts, txns types.Transactions) *protocol.GasUsed {
+	cumulativeGasUsed := cached.CumulativeGasUsed()
+	gasUsed := &protocol.GasUsed{
+		Receipt:      cumulativeGasUsed,
+		BlockRegular: cumulativeGasUsed,
+	}
+	for _, txn := range txns {
+		gasUsed.Blob += txn.GetBlobGas()
+	}
+	return gasUsed
+}
+
 // DerivePriorReceipts returns receipts for transactions 0..startTxIndex-1.
-// It first tries to read them from RCacheV2 (persistent receipt cache). If all
-// prior receipts are cached, no replay is needed. Otherwise falls back to
-// replaying via DeriveForRange.
+// Pre-Amsterdam it uses RCacheV2 when the full prefix is cached. Amsterdam
+// blocks are replayed because receipts do not preserve both block-gas dimensions.
 //
 // Used when execution resumes mid-block from a snapshot boundary and Finalize
 // needs the full receipt set for requests hash computation.
@@ -181,36 +208,56 @@ func DerivePriorReceipts(
 	gp *protocol.GasPool,
 	getHeader GetHeaderFunc,
 ) (types.Receipts, error) {
+	receipts, _, err := DerivePriorReceiptsWithGas(ctx, cfg, engine, header, txns, startTxIndex, blockStartTxNum, tx, ibs, gp, getHeader)
+	return receipts, err
+}
+
+// DerivePriorReceiptsWithGas also returns the block gas totals accumulated by
+// the prefix transactions.
+func DerivePriorReceiptsWithGas(
+	ctx context.Context,
+	cfg *chain.Config,
+	engine rules.EngineReader,
+	header *types.Header,
+	txns types.Transactions,
+	startTxIndex int,
+	blockStartTxNum uint64,
+	tx kv.TemporalTx,
+	ibs *state.IntraBlockState,
+	gp *protocol.GasPool,
+	getHeader GetHeaderFunc,
+) (types.Receipts, *protocol.GasUsed, error) {
 	if startTxIndex <= 0 {
-		return nil, nil
+		return nil, new(protocol.GasUsed), nil
+	}
+	if startTxIndex > len(txns) {
+		return nil, nil, fmt.Errorf("start transaction index %d exceeds transaction count %d", startTxIndex, len(txns))
 	}
 
-	// Try RCacheV2 first — read each prior receipt from the persistent cache.
-	blockHash := header.Hash()
-	blockNum := header.Number.Uint64()
-	cached := make(types.Receipts, 0, startTxIndex)
-	allCached := true
-	for i := 0; i < startTxIndex && i < len(txns); i++ {
-		// blockStartTxNum = firstTask.TxNum - firstTask.TxIndex, which is
-		// already the first user tx's txNum (system tx has TxIndex=-1).
-		txNum := blockStartTxNum + uint64(i)
-		receipt, ok, err := rawdb.ReadReceiptCacheV2(tx, rawdb.RCacheV2Query{
-			BlockNum:      blockNum,
-			BlockHash:     blockHash,
-			TxnHash:       txns[i].Hash(),
-			TxNum:         txNum,
-			DontCalcBloom: true,
-		})
-		if err != nil || !ok {
-			allCached = false
-			break
+	if !cfg.IsAmsterdam(header.Time) {
+		blockHash := header.Hash()
+		blockNum := header.Number.Uint64()
+		cached := make(types.Receipts, 0, startTxIndex)
+		allCached := true
+		for i := 0; i < startTxIndex && i < len(txns); i++ {
+			txNum := blockStartTxNum + uint64(i)
+			receipt, ok, err := rawdb.ReadReceiptCacheV2(tx, rawdb.RCacheV2Query{
+				BlockNum:      blockNum,
+				BlockHash:     blockHash,
+				TxnHash:       txns[i].Hash(),
+				TxNum:         txNum,
+				DontCalcBloom: true,
+			})
+			if err != nil || !ok {
+				allCached = false
+				break
+			}
+			cached = append(cached, receipt)
 		}
-		cached = append(cached, receipt)
-	}
-	if allCached && len(cached) == startTxIndex {
-		return cached, nil
+		if allCached && len(cached) == startTxIndex {
+			return cached, gasUsedFromCachedReceipts(cached, txns[:startTxIndex]), nil
+		}
 	}
 
-	// Fall back to replay.
-	return DeriveForRange(ctx, cfg, engine, header, txns, 0, startTxIndex, ibs, gp, getHeader)
+	return deriveForRange(ctx, cfg, engine, header, txns, 0, startTxIndex, ibs, gp, getHeader)
 }

--- a/execution/receipts/derive.go
+++ b/execution/receipts/derive.go
@@ -239,7 +239,7 @@ func DerivePriorReceiptsWithGas(
 		blockNum := header.Number.Uint64()
 		cached := make(types.Receipts, 0, startTxIndex)
 		allCached := true
-		for i := 0; i < startTxIndex && i < len(txns); i++ {
+		for i := range startTxIndex {
 			txNum := blockStartTxNum + uint64(i)
 			receipt, ok, err := rawdb.ReadReceiptCacheV2(tx, rawdb.RCacheV2Query{
 				BlockNum:      blockNum,

--- a/execution/receipts/derive_test.go
+++ b/execution/receipts/derive_test.go
@@ -64,3 +64,16 @@ func TestDeriveFieldsPreservesExistingBloom(t *testing.T) {
 
 	assert.Equal(t, preset, withPresetBloom.Bloom)
 }
+
+func TestGasUsedFromCachedReceipts(t *testing.T) {
+	cached := types.Receipts{
+		{CumulativeGasUsed: 21000},
+		{CumulativeGasUsed: 51000},
+	}
+
+	gasUsed := gasUsedFromCachedReceipts(cached, nil)
+
+	assert.Equal(t, uint64(51000), gasUsed.Receipt)
+	assert.Equal(t, uint64(51000), gasUsed.BlockRegular)
+	assert.Zero(t, gasUsed.BlockState)
+}

--- a/execution/receipts/derive_test.go
+++ b/execution/receipts/derive_test.go
@@ -76,4 +76,19 @@ func TestGasUsedFromCachedReceipts(t *testing.T) {
 	assert.Equal(t, uint64(51000), gasUsed.Receipt)
 	assert.Equal(t, uint64(51000), gasUsed.BlockRegular)
 	assert.Zero(t, gasUsed.BlockState)
+	assert.Zero(t, gasUsed.Blob)
+}
+
+func TestGasUsedFromCachedReceiptsCountsBlobGas(t *testing.T) {
+	cached := types.Receipts{
+		{CumulativeGasUsed: 21000},
+		{CumulativeGasUsed: 42000},
+	}
+	blobTxn := &types.BlobTx{BlobVersionedHashes: []common.Hash{{1}, {1, 2}}}
+	txns := types.Transactions{&types.LegacyTx{}, blobTxn}
+
+	gasUsed := gasUsedFromCachedReceipts(cached, txns)
+
+	assert.NotZero(t, blobTxn.GetBlobGas())
+	assert.Equal(t, blobTxn.GetBlobGas(), gasUsed.Blob)
 }

--- a/execution/stagedsync/block_post_validator.go
+++ b/execution/stagedsync/block_post_validator.go
@@ -15,6 +15,10 @@ type blockValidator struct {
 	done chan error // buffered(1); written once, then re-stuffed on each Wait
 }
 
+func shouldValidateBlockPostExecution(blockNum uint64, receiptsComplete bool) bool {
+	return blockNum > 0 && receiptsComplete
+}
+
 func newBlockValidator(engine rules.Engine, blockGasUsed, blobGasUsed uint64, checkReceipts, checkBloom bool, receipts types.Receipts,
 	header *types.Header, txns types.Transactions,
 	chainConfig *chain.Config, logger log.Logger) *blockValidator {

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -468,6 +468,22 @@ func (te *txExecutor) reconstructPriorReceipts(ctx context.Context, applyTx kv.T
 	return priorReceipts, priorGasUsed, nil
 }
 
+func consumePriorGas(gasPool *protocol.GasPool, gasUsed *protocol.GasUsed) error {
+	if gasUsed == nil {
+		return nil
+	}
+	if err := gasPool.ConsumeRegular(gasUsed.BlockRegular); err != nil {
+		return fmt.Errorf("regular gas: %w", err)
+	}
+	if err := gasPool.ConsumeState(gasUsed.BlockState); err != nil {
+		return fmt.Errorf("state gas: %w", err)
+	}
+	if err := gasPool.SubBlobGas(gasUsed.Blob); err != nil {
+		return fmt.Errorf("blob gas: %w", err)
+	}
+	return nil
+}
+
 func (te *txExecutor) onBlockStart(ctx context.Context, blockNum uint64, blockHash common.Hash) {
 	defer func() {
 		if rec := recover(); rec != nil {

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -446,28 +446,26 @@ func (te *txExecutor) getHeader(ctx context.Context, hash common.Hash, number ui
 	return h, nil
 }
 
-// reconstructPriorReceipts re-derives receipts of a resumed block's prefix txs
-// (executed in an earlier batch) so Finalize and the notification cache can see
-// the block's full receipt set.
+// reconstructPriorReceipts re-derives receipts and gas totals of a resumed
+// block's prefix transactions.
 //
 // Best-effort. At a mid-block step boundary the committed domain latest is the
 // step-edge value, not the block-start pre-state, so the prefix is not always
 // reconstructable (and minimal nodes retain no receipts at all). Callers MUST
-// treat a failure as non-fatal: the node still resumes from a mid-step boundary
-// and the block's own receipts and cumulative gas stay correct — only the prior
-// receipts are absent (block then left not receipts-complete).
-func (te *txExecutor) reconstructPriorReceipts(ctx context.Context, applyTx kv.TemporalTx, header *types.Header, txs types.Transactions, startTxIndex int, blockStartTxNum uint64) (types.Receipts, error) {
+// treat a failure as non-fatal: the block remains incomplete for receipt-based
+// notifications and post-execution validation.
+func (te *txExecutor) reconstructPriorReceipts(ctx context.Context, applyTx kv.TemporalTx, header *types.Header, txs types.Transactions, startTxIndex int, blockStartTxNum uint64) (types.Receipts, *protocol.GasUsed, error) {
 	priorIbs := state.New(state.NewHistoryReaderV3(applyTx, blockStartTxNum))
 	defer priorIbs.Release(true)
 	priorGp := protocol.NewGasPool(header.GasLimit, te.cfg.chainConfig.GetMaxBlobGasPerBlock(header.Time))
 	getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
 		return te.cfg.blockReader.Header(ctx, applyTx, hash, number)
 	}
-	priorReceipts, err := receipts.DerivePriorReceipts(ctx, te.cfg.chainConfig, te.cfg.engine, header, txs, startTxIndex, blockStartTxNum, applyTx, priorIbs, priorGp, getHeader)
+	priorReceipts, priorGasUsed, err := receipts.DerivePriorReceiptsWithGas(ctx, te.cfg.chainConfig, te.cfg.engine, header, txs, startTxIndex, blockStartTxNum, applyTx, priorIbs, priorGp, getHeader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to reconstruct prior receipts for partial block %d (startTxIndex %d): %w", header.Number.Uint64(), startTxIndex, err)
+		return nil, nil, fmt.Errorf("failed to reconstruct prior receipts for partial block %d (startTxIndex %d): %w", header.Number.Uint64(), startTxIndex, err)
 	}
-	return priorReceipts, nil
+	return priorReceipts, priorGasUsed, nil
 }
 
 func (te *txExecutor) onBlockStart(ctx context.Context, blockNum uint64, blockHash common.Hash) {

--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -461,7 +461,7 @@ func (te *txExecutor) reconstructPriorReceipts(ctx context.Context, applyTx kv.T
 	getHeader := func(hash common.Hash, number uint64) (*types.Header, error) {
 		return te.cfg.blockReader.Header(ctx, applyTx, hash, number)
 	}
-	priorReceipts, priorGasUsed, err := receipts.DerivePriorReceiptsWithGas(ctx, te.cfg.chainConfig, te.cfg.engine, header, txs, startTxIndex, blockStartTxNum, applyTx, priorIbs, priorGp, getHeader)
+	priorReceipts, priorGasUsed, err := receipts.DerivePriorReceipts(ctx, te.cfg.chainConfig, te.cfg.engine, header, txs, startTxIndex, blockStartTxNum, applyTx, priorIbs, priorGp, getHeader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to reconstruct prior receipts for partial block %d (startTxIndex %d): %w", header.Number.Uint64(), startTxIndex, err)
 	}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -679,7 +679,7 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 					// sd.mem already has all TX writes when we reach here.
 
 					var blockValidatorWaiter *blockValidator
-					if applyResult.BlockNum > 0 && !applyResult.isPartial { //Disable check for genesis. Maybe need somehow improve it in future - to satisfy TestExecutionSpec
+					if shouldValidateBlockPostExecution(applyResult.BlockNum, applyResult.receiptsComplete) {
 						checkBloom := !pe.cfg.vmConfig.StatelessExec && !pe.cfg.vmConfig.NoReceipts
 						checkReceipts := checkBloom && pe.cfg.chainConfig.IsByzantium(applyResult.BlockNum)
 
@@ -2956,18 +2956,24 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			receiptsComplete = startTxIndex == 0
 			if startTxIndex > 0 && len(txs) > 0 {
 				blockStartTxNum := be.tasks[0].Version().TxNum - uint64(startTxIndex)
-				priorReceipts, err := pe.reconstructPriorReceipts(ctx, applyTx, header, txs, startTxIndex, blockStartTxNum)
+				priorReceipts, priorGasUsed, err := pe.reconstructPriorReceipts(ctx, applyTx, header, txs, startTxIndex, blockStartTxNum)
 				if err != nil {
 					pe.logger.Warn("["+pe.logPrefix+"] failed to reconstruct prior receipts for partial block",
 						"block", be.blockNum, "startTxIndex", startTxIndex, "err", err)
 				} else {
 					blockReceipts = append(priorReceipts, blockReceipts...)
+					be.blockRegularGasUsed += priorGasUsed.BlockRegular
+					be.blockStateGasUsed += priorGasUsed.BlockState
+					be.blockGasUsed = max(be.blockRegularGasUsed, be.blockStateGasUsed)
+					be.blobGasUsed = priorGasUsed.Blob
+					for _, tx := range txs[startTxIndex:] {
+						be.blobGasUsed += tx.GetBlobGas()
+					}
 					receiptsComplete = true
 				}
 			}
-			// The post-exec validator, which fills receipt blooms for full
-			// blocks, skips partial ones — do it here, even when prior receipts
-			// couldn't be reconstructed (the suffix receipts still need blooms).
+			// Fill suffix metadata even when reconstruction fails and validation
+			// remains disabled.
 			receipts.DeriveFields(blockReceipts, be.blockHash)
 		}
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2298,11 +2298,14 @@ type blockExecutor struct {
 	// final blockGasUsed = max(regular, state) matches EIP-8037 / EIP-7778
 	// block-level accounting and equals what the builder set in header.GasUsed
 	// via protocol.SetGasUsed (= max(cumRegular, cumState)).
-	blockRegularGasUsed uint64
-	blockStateGasUsed   uint64
-	blockGasUsed        uint64
-	blobGasUsed         uint64
-	gasPool             *protocol.GasPool
+	blockRegularGasUsed  uint64
+	blockStateGasUsed    uint64
+	blockGasUsed         uint64
+	blobGasUsed          uint64
+	gasPool              *protocol.GasPool
+	resumePrefixPrepared bool
+	resumePrefixComplete bool
+	resumePrefixReceipts types.Receipts
 
 	execFailed, execAborted []int
 
@@ -2428,11 +2431,52 @@ func (be *blockExecutor) tooManyRetries(tx, txIndex int, label string, origin er
 		rules.ErrInvalidBlock, be.blockNum, txIndex, be.tasks[tx].TxHash(), label, be.txIncarnations[tx], len(be.tasks)))
 }
 
+func (be *blockExecutor) prepareResumePrefix(ctx context.Context, pe *parallelExecutor, applyTx kv.TemporalTx) error {
+	if be.resumePrefixPrepared {
+		return nil
+	}
+	be.resumePrefixPrepared = true
+	if len(be.tasks) == 0 || be.blockNum == 0 {
+		return nil
+	}
+
+	firstTask, ok := be.tasks[0].Task.(*exec.TxTask)
+	if !ok {
+		return nil
+	}
+	startTxIndex := be.tasks[0].Version().TxIndex
+	if startTxIndex <= 0 || firstTask.Header == nil || len(firstTask.Txs) == 0 {
+		return nil
+	}
+
+	blockStartTxNum := be.tasks[0].Version().TxNum - uint64(startTxIndex)
+	priorReceipts, priorGasUsed, err := pe.reconstructPriorReceipts(ctx, applyTx, firstTask.Header, firstTask.Txs, startTxIndex, blockStartTxNum)
+	if err != nil {
+		pe.logger.Warn("["+pe.logPrefix+"] failed to reconstruct prior receipts for partial block",
+			"block", be.blockNum, "startTxIndex", startTxIndex, "err", err)
+		return nil
+	}
+	if err := consumePriorGas(be.gasPool, priorGasUsed); err != nil {
+		return fmt.Errorf("block gas used overflow while restoring resumed prefix: %w", err)
+	}
+
+	be.resumePrefixReceipts = priorReceipts
+	be.blockRegularGasUsed += priorGasUsed.BlockRegular
+	be.blockStateGasUsed += priorGasUsed.BlockState
+	be.blockGasUsed = max(be.blockRegularGasUsed, be.blockStateGasUsed)
+	be.blobGasUsed = priorGasUsed.Blob
+	be.resumePrefixComplete = true
+	return nil
+}
+
 func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, res *exec.TxResult, applyTx kv.TemporalTx) (result *blockResult, err error) {
 	task, ok := res.Task.(*taskVersion)
 
 	if !ok {
 		return nil, fmt.Errorf("unexpected task type: %T", res.Task)
+	}
+	if err := be.prepareResumePrefix(ctx, pe, applyTx); err != nil {
+		return be.invalidBlockResult(fmt.Errorf("%w: block=%d: %w", rules.ErrInvalidBlock, be.blockNum, err)), nil
 	}
 
 	tx := task.index
@@ -2711,7 +2755,9 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 						}
 						cumulativeGasUsed = cumGasUsed
 						firstLogIndex = logIndexAfterTx
-						be.blobGasUsed = cumBlobGasUsed
+						if !be.resumePrefixComplete {
+							be.blobGasUsed = cumBlobGasUsed
+						}
 					}
 				}
 
@@ -2957,23 +3003,11 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 		if isPartial && be.blockNum > 0 && header != nil {
 			startTxIndex := be.tasks[0].Version().TxIndex
 			receiptsComplete = startTxIndex == 0
-			if startTxIndex > 0 && len(txs) > 0 {
-				blockStartTxNum := be.tasks[0].Version().TxNum - uint64(startTxIndex)
-				priorReceipts, priorGasUsed, err := pe.reconstructPriorReceipts(ctx, applyTx, header, txs, startTxIndex, blockStartTxNum)
-				if err != nil {
-					pe.logger.Warn("["+pe.logPrefix+"] failed to reconstruct prior receipts for partial block",
-						"block", be.blockNum, "startTxIndex", startTxIndex, "err", err)
-				} else {
-					blockReceipts = append(priorReceipts, blockReceipts...)
-					be.blockRegularGasUsed += priorGasUsed.BlockRegular
-					be.blockStateGasUsed += priorGasUsed.BlockState
-					be.blockGasUsed = max(be.blockRegularGasUsed, be.blockStateGasUsed)
-					be.blobGasUsed = priorGasUsed.Blob
-					for _, txn := range txs[startTxIndex:] {
-						be.blobGasUsed += txn.GetBlobGas()
-					}
-					receiptsComplete = true
-				}
+			if startTxIndex > 0 && be.resumePrefixComplete {
+				completeReceipts := be.resumePrefixReceipts
+				completeReceipts = append(completeReceipts, blockReceipts...)
+				blockReceipts = completeReceipts
+				receiptsComplete = true
 			}
 			// Fill suffix metadata even when reconstruction fails and validation
 			// remains disabled.

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -743,9 +743,6 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 						// than bare-returning — a bare return here would strand the exec
 						// loop in a terminal mustDeliver send on a full applyResults and
 						// wedge pe.wait. No cancel: mirror the blockResult.Err path.
-						if applyResult.isPartial {
-							err = fmt.Errorf("resumed block with reconstructed prefix: %w", err)
-						}
 						appliedBlocks[applyResult.BlockNum] = struct{}{}
 						fail.consider(applyResult.BlockNum, applyResult.BlockHash, true, fmt.Errorf("%w, block=%d, %v", rules.ErrInvalidBlock, applyResult.BlockNum, err))
 						finalized = true

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -743,6 +743,9 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 						// than bare-returning — a bare return here would strand the exec
 						// loop in a terminal mustDeliver send on a full applyResults and
 						// wedge pe.wait. No cancel: mirror the blockResult.Err path.
+						if applyResult.isPartial {
+							err = fmt.Errorf("resumed block with reconstructed prefix: %w", err)
+						}
 						appliedBlocks[applyResult.BlockNum] = struct{}{}
 						fail.consider(applyResult.BlockNum, applyResult.BlockHash, true, fmt.Errorf("%w, block=%d, %v", rules.ErrInvalidBlock, applyResult.BlockNum, err))
 						finalized = true

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2966,8 +2966,8 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 					be.blockStateGasUsed += priorGasUsed.BlockState
 					be.blockGasUsed = max(be.blockRegularGasUsed, be.blockStateGasUsed)
 					be.blobGasUsed = priorGasUsed.Blob
-					for _, tx := range txs[startTxIndex:] {
-						be.blobGasUsed += tx.GetBlobGas()
+					for _, txn := range txs[startTxIndex:] {
+						be.blobGasUsed += txn.GetBlobGas()
 					}
 					receiptsComplete = true
 				}

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1478,6 +1478,7 @@ func TestParallelResumeBoundaryOffsets(t *testing.T) {
 	// RecentReceipts.Add in the apply loop.
 	assert.True(res.isPartial)
 	assert.False(res.receiptsComplete)
+	assert.False(shouldValidateBlockPostExecution(res.BlockNum, res.receiptsComplete))
 }
 
 // TestParallelResumeReconstructsPriorReceipts pins the block-end prefix
@@ -1540,7 +1541,8 @@ func TestParallelResumeReconstructsPriorReceipts(t *testing.T) {
 	txResult := &exec.TxResult{
 		Task: tVersion,
 		ExecutionResult: evmtypes.ExecutionResult{
-			ReceiptGasUsed: 10000,
+			ReceiptGasUsed:      10000,
+			BlockRegularGasUsed: 10000,
 		},
 	}
 
@@ -1550,12 +1552,51 @@ func TestParallelResumeReconstructsPriorReceipts(t *testing.T) {
 
 	assert.True(res.isPartial)
 	assert.True(res.receiptsComplete)
+	assert.Equal(uint64(31000), res.BlockGasUsed)
+	assert.True(shouldValidateBlockPostExecution(res.BlockNum, res.receiptsComplete))
 	if assert.Len(res.Receipts, 2) {
 		assert.Equal(uint(0), res.Receipts[0].TransactionIndex)
 		assert.Equal(uint64(21000), res.Receipts[0].CumulativeGasUsed)
 		assert.Equal(uint(1), res.Receipts[1].TransactionIndex)
 		assert.Equal(uint64(31000), res.Receipts[1].CumulativeGasUsed)
 	}
+}
+
+func TestResumeReconstructionReplaysAmsterdamGasDimensions(t *testing.T) {
+	db := newResumeTestDB(t)
+	config := chain.AllProtocolChanges
+	header := &types.Header{
+		Number:   *uint256.NewInt(1),
+		GasLimit: 10_000_000,
+	}
+	to := common.HexToAddress("0x01")
+	unsignedTx := &types.LegacyTx{
+		CommonTx: types.CommonTx{
+			To:       &to,
+			Value:    *uint256.NewInt(1),
+			GasLimit: 1_000_000,
+		},
+		GasPrice: *uint256.NewInt(1),
+	}
+	tx, err := types.SignTx(unsignedTx, *types.MakeSigner(config, 1, 0), senderIsCoinbaseKey.key)
+	require.NoError(t, err)
+
+	seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
+		acc := accounts.NewAccount()
+		acc.Balance = *uint256.NewInt(1_000_000_000)
+		return putter.DomainPut(kv.AccountsDomain, senderIsCoinbaseKey.rawAddress[:], accounts.SerialiseV3(&acc), 0, nil)
+	})
+
+	pe, roTx := newResumeTestExec(t, db, config)
+	priorReceipts, priorGasUsed, err := pe.reconstructPriorReceipts(
+		context.Background(), roTx, header, types.Transactions{tx}, 1, 1,
+	)
+	require.NoError(t, err)
+	require.Len(t, priorReceipts, 1)
+	assert.Equal(t, priorReceipts[0].CumulativeGasUsed, priorGasUsed.Receipt)
+	assert.NotZero(t, priorGasUsed.BlockRegular)
+	assert.NotZero(t, priorGasUsed.BlockState)
+	assert.Less(t, priorGasUsed.BlockGasUsed(), priorGasUsed.Receipt)
 }
 
 // TestParallelResumeReconstructionFailureIsNonFatal pins the failure policy when
@@ -1621,6 +1662,7 @@ func TestParallelResumeReconstructionFailureIsNonFatal(t *testing.T) {
 	assert.NoError(err)
 	if assert.NotNil(res) {
 		assert.False(res.receiptsComplete)
+		assert.False(shouldValidateBlockPostExecution(res.BlockNum, res.receiptsComplete))
 	}
 }
 

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1562,6 +1562,77 @@ func TestParallelResumeReconstructsPriorReceipts(t *testing.T) {
 	}
 }
 
+func TestParallelResumeRestoresGasPool(t *testing.T) {
+	db := newResumeTestDB(t)
+	config := chain.TestChainBerlinConfig
+	tx0 := signSelfSendTx(t, 0, 0, 1, 21000, config, 0)
+	tx1 := signSelfSendTx(t, 1, 0, 1, 30000, config, 0)
+
+	seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
+		acc := accounts.NewAccount()
+		acc.Balance = *uint256.NewInt(1_000_000_000)
+		if err := putter.DomainPut(kv.AccountsDomain, senderIsCoinbaseKey.rawAddress[:], accounts.SerialiseV3(&acc), 0, nil); err != nil {
+			return err
+		}
+		return rawtemporaldb.AppendReceipt(putter, 0, 21000, 0, 1)
+	})
+
+	txTask := &exec.TxTask{
+		Header: &types.Header{
+			Number:   *uint256.NewInt(1),
+			GasLimit: 42000,
+		},
+		TxNum:   2,
+		TxIndex: 1,
+		Config:  config,
+		Txs:     types.Transactions{tx0, tx1},
+	}
+
+	pe, roTx := newResumeTestExec(t, db, config)
+	be := newBlockExec(1, common.Hash{}, protocol.NewGasPool(42000, 0), nil, make(chan applyResult, 4), nil, false, nil)
+	eTask := &execTask{Task: txTask}
+	be.tasks = []*execTask{eTask}
+	be.results = []*execResult{nil}
+	be.execTasks.setInProgress(0)
+
+	txResult := &exec.TxResult{
+		Task: &taskVersion{
+			execTask: eTask,
+			version: state.Version{
+				BlockNum:    1,
+				TxIndex:     1,
+				Incarnation: 1,
+				TxNum:       2,
+			},
+		},
+		ExecutionResult: evmtypes.ExecutionResult{
+			ReceiptGasUsed:      21000,
+			BlockRegularGasUsed: 21000,
+		},
+	}
+
+	res, err := be.nextResult(context.Background(), pe, txResult, roTx)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.ErrorIs(t, res.Err, rules.ErrInvalidBlock)
+	require.ErrorContains(t, res.Err, "block gas used overflow")
+}
+
+func TestConsumePriorGas(t *testing.T) {
+	gasPool := protocol.NewGasPool(100, 30)
+
+	err := consumePriorGas(gasPool, &protocol.GasUsed{
+		BlockRegular: 40,
+		BlockState:   60,
+		Blob:         10,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(60), gasPool.RegularGasAvailable())
+	require.Equal(t, uint64(40), gasPool.StateGasAvailable())
+	require.Equal(t, uint64(20), gasPool.BlobGas())
+}
+
 func TestResumeReconstructionReplaysAmsterdamGasDimensions(t *testing.T) {
 	db := newResumeTestDB(t)
 	config := chain.AllProtocolChanges

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1599,6 +1599,46 @@ func TestResumeReconstructionReplaysAmsterdamGasDimensions(t *testing.T) {
 	assert.Less(t, priorGasUsed.BlockGasUsed(), priorGasUsed.Receipt)
 }
 
+func TestResumeReconstructionReplaysBlobGas(t *testing.T) {
+	db := newResumeTestDB(t)
+	config := chain.AllProtocolChanges
+	header := &types.Header{
+		Number:        *uint256.NewInt(1),
+		GasLimit:      10_000_000,
+		ExcessBlobGas: common.NewUint64(0),
+	}
+	to := common.HexToAddress("0x01")
+	unsignedTx := &types.BlobTx{
+		DynamicFeeTransaction: types.DynamicFeeTransaction{
+			CommonTx: types.CommonTx{
+				To:       &to,
+				GasLimit: 1_000_000,
+			},
+			ChainID: *config.ChainID,
+			FeeCap:  *uint256.NewInt(1),
+		},
+		MaxFeePerBlobGas:    *uint256.NewInt(1_000_000),
+		BlobVersionedHashes: []common.Hash{{1}, {1, 2}},
+	}
+	tx, err := types.SignTx(unsignedTx, *types.MakeSigner(config, 1, 0), senderIsCoinbaseKey.key)
+	require.NoError(t, err)
+
+	seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
+		acc := accounts.NewAccount()
+		acc.Balance = *uint256.NewInt(1_000_000_000_000)
+		return putter.DomainPut(kv.AccountsDomain, senderIsCoinbaseKey.rawAddress[:], accounts.SerialiseV3(&acc), 0, nil)
+	})
+
+	pe, roTx := newResumeTestExec(t, db, config)
+	priorReceipts, priorGasUsed, err := pe.reconstructPriorReceipts(
+		context.Background(), roTx, header, types.Transactions{tx}, 1, 1,
+	)
+	require.NoError(t, err)
+	require.Len(t, priorReceipts, 1)
+	assert.NotZero(t, priorGasUsed.Blob)
+	assert.Equal(t, unsignedTx.GetBlobGas(), priorGasUsed.Blob)
+}
+
 // TestParallelResumeReconstructionFailureIsNonFatal pins the failure policy when
 // prior receipts cannot be reconstructed: reconstruction is best-effort, so the
 // batch proceeds (prior receipts absent, block left not receipts-complete)

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -429,6 +429,9 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					// Block gas = max(regular, state). Pre-Amsterdam: blockStateGasUsed is 0.
 					blockGasUsed := max(se.blockGasUsed, se.blockStateGasUsed)
 					if err := validateBlockPostExecution(se.cfg.engine, se.cfg.chainConfig, txTask.Header, blockGasUsed, se.blobGasUsed, checkReceipts, checkBloom, finalizeReceipts, txTask.Txs, se.logger); err != nil {
+						if startTxIndex > 0 {
+							err = fmt.Errorf("resumed block with reconstructed prefix (startTxIndex %d): %w", startTxIndex, err)
+						}
 						return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err) //same as in stage_exec.go
 					}
 				}

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -401,8 +401,8 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 						se.blockGasUsed += priorGasUsed.BlockRegular
 						se.blockStateGasUsed += priorGasUsed.BlockState
 						se.blobGasUsed = priorGasUsed.Blob
-						for _, tx := range txTask.Txs[startTxIndex:] {
-							se.blobGasUsed += tx.GetBlobGas()
+						for _, txn := range txTask.Txs[startTxIndex:] {
+							se.blobGasUsed += txn.GetBlobGas()
 						}
 						priorComplete = true
 					}

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -391,18 +391,23 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 				if startTxIndex > 0 && len(txTask.Txs) > 0 {
 					firstTask := tasks[0].(*exec.TxTask)
 					blockStartTxNum := firstTask.TxNum - uint64(firstTask.TxIndex)
-					priorReceipts, priorErr := se.reconstructPriorReceipts(ctx, se.applyTx, txTask.Header, txTask.Txs, startTxIndex, blockStartTxNum)
+					priorReceipts, priorGasUsed, priorErr := se.reconstructPriorReceipts(ctx, se.applyTx, txTask.Header, txTask.Txs, startTxIndex, blockStartTxNum)
 					if priorErr != nil {
 						se.logger.Warn(fmt.Sprintf("[%s] failed to reconstruct prior receipts for partial block", se.logPrefix),
 							"block", txTask.BlockNumber(), "startTxIndex", startTxIndex, "err", priorErr)
 					} else {
 						finalizeReceipts = priorReceipts
 						finalizeReceipts = append(finalizeReceipts, blockReceipts...)
+						se.blockGasUsed += priorGasUsed.BlockRegular
+						se.blockStateGasUsed += priorGasUsed.BlockState
+						se.blobGasUsed = priorGasUsed.Blob
+						for _, tx := range txTask.Txs[startTxIndex:] {
+							se.blobGasUsed += tx.GetBlobGas()
+						}
 						priorComplete = true
 					}
-					// The post-exec validator, which fills receipt blooms for full
-					// blocks, skips partial ones — do it here, even when prior
-					// receipts couldn't be reconstructed (suffix still needs blooms).
+					// Fill suffix metadata even when reconstruction fails and
+					// validation remains disabled.
 					receipts.DeriveFields(finalizeReceipts, txTask.BlockHash())
 				}
 
@@ -420,11 +425,10 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 				checkBloom := !se.cfg.vmConfig.StatelessExec && !se.cfg.vmConfig.NoReceipts
 				checkReceipts := checkBloom && se.cfg.chainConfig.IsByzantium(txTask.BlockNumber())
 
-				if txTask.BlockNumber() > 0 && startTxIndex == 0 {
-					//Disable check for genesis. Maybe need somehow improve it in future - to satisfy TestExecutionSpec
+				if shouldValidateBlockPostExecution(txTask.BlockNumber(), priorComplete) {
 					// Block gas = max(regular, state). Pre-Amsterdam: blockStateGasUsed is 0.
 					blockGasUsed := max(se.blockGasUsed, se.blockStateGasUsed)
-					if err := validateBlockPostExecution(se.cfg.engine, se.cfg.chainConfig, txTask.Header, blockGasUsed, se.blobGasUsed, checkReceipts, checkBloom, blockReceipts, txTask.Txs, se.logger); err != nil {
+					if err := validateBlockPostExecution(se.cfg.engine, se.cfg.chainConfig, txTask.Header, blockGasUsed, se.blobGasUsed, checkReceipts, checkBloom, finalizeReceipts, txTask.Txs, se.logger); err != nil {
 						return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err) //same as in stage_exec.go
 					}
 				}

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -232,7 +232,8 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 		}
 
 		isBatchFull := se.isApplyingBlocks && se.readState().SizeEstimateBeforeCommitment() >= se.cfg.batchSize.Bytes()
-		// havePartialBlock: partial first block isn't validated, compute root ASAP for fail-fast.
+		// havePartialBlock: a resumed block isn't always fully validated (prefix
+		// reconstruction is best-effort), so compute the root ASAP for fail-fast.
 		needCalcRoot := se.isApplyingBlocks && (isBatchFull || havePartialBlock)
 		havePartialBlock = false
 
@@ -334,9 +335,9 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 	}(time.Now())
 
 	if len(tasks) > 0 {
-		// During the first block execution, we may have half-block data in the snapshots.
-		// Thus, we need to skip the first txs in the block, however, this causes the GasUsed to be incorrect.
-		// So we need to skip that check for the first block, if we find half-executed data (startTxIndex>0).
+		// During the first block execution, we may have half-block data in the
+		// snapshots, so tasks may start mid-block (startTxIndex > 0). The prefix
+		// receipts and gas are then reconstructed below when possible.
 		startTxIndex = max(tasks[0].(*exec.TxTask).TxIndex, 0)
 	}
 

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -340,12 +340,37 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 		startTxIndex = max(tasks[0].(*exec.TxTask).TxIndex, 0)
 	}
 
+	priorComplete := startTxIndex == 0
+	var priorReceipts types.Receipts
+	var priorGasUsed *protocol.GasUsed
+	if startTxIndex > 0 {
+		firstTask := tasks[0].(*exec.TxTask)
+		if len(firstTask.Txs) > 0 {
+			blockStartTxNum := firstTask.TxNum - uint64(firstTask.TxIndex)
+			priorReceipts, priorGasUsed, err = se.reconstructPriorReceipts(ctx, se.applyTx, firstTask.Header, firstTask.Txs, startTxIndex, blockStartTxNum)
+			if err != nil {
+				se.logger.Warn(fmt.Sprintf("[%s] failed to reconstruct prior receipts for partial block", se.logPrefix),
+					"block", firstTask.BlockNumber(), "startTxIndex", startTxIndex, "err", err)
+			} else {
+				se.blockGasUsed += priorGasUsed.BlockRegular
+				se.blockStateGasUsed += priorGasUsed.BlockState
+				se.blobGasUsed += priorGasUsed.Blob
+				priorComplete = true
+			}
+		}
+	}
+
 	var gasPool *protocol.GasPool
 	for _, task := range tasks {
 		txTask := task.(*exec.TxTask)
 
 		if gasPool == nil {
 			gasPool = protocol.NewGasPool(task.BlockGasLimit(), se.cfg.chainConfig.GetMaxBlobGasPerBlock(tasks[0].BlockTime()))
+			if priorComplete && startTxIndex > 0 {
+				if err := consumePriorGas(gasPool, priorGasUsed); err != nil {
+					return false, fmt.Errorf("%w, block=%d: restore prior block gas: %w", rules.ErrInvalidBlock, txTask.BlockNumber(), err)
+				}
+			}
 		}
 
 		txTask.ResetGasPool(gasPool)
@@ -387,25 +412,11 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 				chainReader := consensuschain.NewReader(se.cfg.chainConfig, se.applyTx, se.cfg.blockReader, se.logger)
 
 				finalizeReceipts := blockReceipts
-				priorComplete := startTxIndex == 0
-				if startTxIndex > 0 && len(txTask.Txs) > 0 {
-					firstTask := tasks[0].(*exec.TxTask)
-					blockStartTxNum := firstTask.TxNum - uint64(firstTask.TxIndex)
-					priorReceipts, priorGasUsed, priorErr := se.reconstructPriorReceipts(ctx, se.applyTx, txTask.Header, txTask.Txs, startTxIndex, blockStartTxNum)
-					if priorErr != nil {
-						se.logger.Warn(fmt.Sprintf("[%s] failed to reconstruct prior receipts for partial block", se.logPrefix),
-							"block", txTask.BlockNumber(), "startTxIndex", startTxIndex, "err", priorErr)
-					} else {
-						finalizeReceipts = priorReceipts
-						finalizeReceipts = append(finalizeReceipts, blockReceipts...)
-						se.blockGasUsed += priorGasUsed.BlockRegular
-						se.blockStateGasUsed += priorGasUsed.BlockState
-						se.blobGasUsed = priorGasUsed.Blob
-						for _, txn := range txTask.Txs[startTxIndex:] {
-							se.blobGasUsed += txn.GetBlobGas()
-						}
-						priorComplete = true
-					}
+				if priorComplete && startTxIndex > 0 {
+					finalizeReceipts = priorReceipts
+					finalizeReceipts = append(finalizeReceipts, blockReceipts...)
+				}
+				if startTxIndex > 0 {
 					// Fill suffix metadata even when reconstruction fails and
 					// validation remains disabled.
 					receipts.DeriveFields(finalizeReceipts, txTask.BlockHash())
@@ -460,7 +471,9 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					}
 					// This tx's own blob gas was accumulated above; fold in the
 					// pre-resume cumulative so ApplyTxIndexes persists correct values.
-					se.blobGasUsed += cumBlobGasUsed
+					if !priorComplete {
+						se.blobGasUsed += cumBlobGasUsed
+					}
 					receipt, err = result.CreateReceipt(txTask.TxIndex, cumGasUsed+result.ExecutionResult.ReceiptGasUsed, logIndexAfterTx)
 					if err != nil {
 						return err

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -440,9 +440,6 @@ func (se *serialExecutor) executeBlock(ctx context.Context, tasks []exec.Task, i
 					// Block gas = max(regular, state). Pre-Amsterdam: blockStateGasUsed is 0.
 					blockGasUsed := max(se.blockGasUsed, se.blockStateGasUsed)
 					if err := validateBlockPostExecution(se.cfg.engine, se.cfg.chainConfig, txTask.Header, blockGasUsed, se.blobGasUsed, checkReceipts, checkBloom, finalizeReceipts, txTask.Txs, se.logger); err != nil {
-						if startTxIndex > 0 {
-							err = fmt.Errorf("resumed block with reconstructed prefix (startTxIndex %d): %w", startTxIndex, err)
-						}
 						return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err) //same as in stage_exec.go
 					}
 				}

--- a/execution/stagedsync/exec3_serial_test.go
+++ b/execution/stagedsync/exec3_serial_test.go
@@ -1,0 +1,131 @@
+package stagedsync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
+	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/exec"
+	"github.com/erigontech/erigon/execution/protocol"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/protocol/rules/ethash"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
+)
+
+// newSerialResumeTestExec wires a serialExecutor with a real worker over db.
+func newSerialResumeTestExec(t *testing.T, db kv.TemporalRwDB, config *chain.Config, engine rules.Engine) *serialExecutor {
+	logger := log.New()
+	roTx, err := db.BeginTemporalRo(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(roTx.Rollback)
+
+	domains, err := execctx.NewSharedDomains(context.Background(), roTx, logger)
+	require.NoError(t, err)
+	t.Cleanup(domains.Close)
+
+	se := &serialExecutor{
+		txExecutor: txExecutor{
+			cfg: ExecuteBlockCfg{
+				chainConfig: config,
+				db:          db,
+				engine:      engine,
+				vmConfig:    &vm.Config{},
+			},
+			doms:   domains,
+			rs:     state.NewStateV3Buffered(state.NewStateV3(domains, false, logger)),
+			logger: logger,
+		},
+	}
+	require.NoError(t, se.resetWorkers(context.Background(), se.rs, roTx))
+	return se
+}
+
+// TestSerialResumeValidatesRestoredBlockGas pins the serial resumed-block path:
+// the suffix executes against latest state, the prefix replays from history, and
+// post-execution validation checks full-block gas and receipts. A header carrying
+// only the suffix gas must be rejected — proving validation runs with restored
+// totals rather than batch-local ones.
+func TestSerialResumeValidatesRestoredBlockGas(t *testing.T) {
+	config := chain.TestChainBerlinConfig
+
+	run := func(t *testing.T, headerGasUsed uint64) error {
+		db := newResumeTestDB(t)
+		engine := ethash.NewFaker()
+
+		tx0 := signSelfSendTx(t, 0, 1, 1, 21000, config, 0)
+		tx1 := signSelfSendTx(t, 1, 1, 1, 21000, config, 0)
+		txs := types.Transactions{tx0, tx1}
+
+		expectedReceipts := types.Receipts{
+			{Type: types.LegacyTxType, Status: types.ReceiptStatusSuccessful, CumulativeGasUsed: 21000},
+			{Type: types.LegacyTxType, Status: types.ReceiptStatusSuccessful, CumulativeGasUsed: 42000},
+		}
+		header := &types.Header{
+			Number:      *uint256.NewInt(1),
+			GasLimit:    10_000_000,
+			GasUsed:     headerGasUsed,
+			ReceiptHash: types.DeriveSha(expectedReceipts),
+			Bloom:       types.CreateBloom(expectedReceipts),
+		}
+
+		// The prefix tx0 ran in an earlier batch: seed its post-state as latest
+		// (pre-state as history) plus its receipt-domain row.
+		seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
+			preState := accounts.NewAccount()
+			preState.Balance = *uint256.NewInt(1_000_000_000)
+			preStateEnc := accounts.SerialiseV3(&preState)
+			if err := putter.DomainPut(kv.AccountsDomain, senderIsCoinbaseKey.rawAddress[:], preStateEnc, 0, nil); err != nil {
+				return err
+			}
+			postState := accounts.NewAccount()
+			postState.Nonce = 1
+			postState.Balance = *uint256.NewInt(1_000_000_000 - 21000)
+			if err := putter.DomainPut(kv.AccountsDomain, senderIsCoinbaseKey.rawAddress[:], accounts.SerialiseV3(&postState), 1, preStateEnc); err != nil {
+				return err
+			}
+			return rawtemporaldb.AppendReceipt(putter, 0, 21000, 0, 1)
+		})
+
+		se := newSerialResumeTestExec(t, db, config, engine)
+
+		suffixTask := &exec.TxTask{
+			Header:  header,
+			TxNum:   2,
+			TxIndex: 1,
+			Config:  config,
+			Txs:     txs,
+			EvmBlockContext: protocol.NewEVMBlockContext(
+				header, protocol.GetHashFn(header, nil), engine, accounts.NilAddress, config),
+		}
+		blockEndTask := &exec.TxTask{
+			Header:  header,
+			TxNum:   3,
+			TxIndex: 2,
+			Config:  config,
+			Txs:     txs,
+		}
+
+		_, err := se.executeBlock(context.Background(), []exec.Task{suffixTask, blockEndTask}, true, false)
+		return err
+	}
+
+	t.Run("restored gas matches header", func(t *testing.T) {
+		require.NoError(t, run(t, 42000))
+	})
+
+	t.Run("suffix-only gas in header is rejected", func(t *testing.T) {
+		err := run(t, 21000)
+		require.ErrorIs(t, err, rules.ErrInvalidBlock)
+		require.ErrorContains(t, err, "gas used by execution: 42000")
+	})
+}

--- a/execution/stagedsync/exec3_serial_test.go
+++ b/execution/stagedsync/exec3_serial_test.go
@@ -127,5 +127,6 @@ func TestSerialResumeValidatesRestoredBlockGas(t *testing.T) {
 		err := run(t, 21000)
 		require.ErrorIs(t, err, rules.ErrInvalidBlock)
 		require.ErrorContains(t, err, "gas used by execution: 42000")
+		require.ErrorContains(t, err, "resumed block with reconstructed prefix")
 	})
 }

--- a/execution/stagedsync/exec3_serial_test.go
+++ b/execution/stagedsync/exec3_serial_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/erigontech/erigon/execution/vm"
 )
 
-// newSerialResumeTestExec wires a serialExecutor with a real worker over db.
 func newSerialResumeTestExec(t *testing.T, db kv.TemporalRwDB, config *chain.Config, engine rules.Engine) *serialExecutor {
 	logger := log.New()
 	roTx, err := db.BeginTemporalRo(context.Background())
@@ -50,11 +49,6 @@ func newSerialResumeTestExec(t *testing.T, db kv.TemporalRwDB, config *chain.Con
 	return se
 }
 
-// TestSerialResumeValidatesRestoredBlockGas pins the serial resumed-block path:
-// the suffix executes against latest state, the prefix replays from history, and
-// post-execution validation checks full-block gas and receipts. A header carrying
-// only the suffix gas must be rejected — proving validation runs with restored
-// totals rather than batch-local ones.
 func TestSerialResumeValidatesRestoredBlockGas(t *testing.T) {
 	config := chain.TestChainBerlinConfig
 
@@ -78,8 +72,6 @@ func TestSerialResumeValidatesRestoredBlockGas(t *testing.T) {
 			Bloom:       types.CreateBloom(expectedReceipts),
 		}
 
-		// The prefix tx0 ran in an earlier batch: seed its post-state as latest
-		// (pre-state as history) plus its receipt-domain row.
 		seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
 			preState := accounts.NewAccount()
 			preState.Balance = *uint256.NewInt(1_000_000_000)
@@ -127,7 +119,6 @@ func TestSerialResumeValidatesRestoredBlockGas(t *testing.T) {
 		err := run(t, 21000, 10_000_000, 21000)
 		require.ErrorIs(t, err, rules.ErrInvalidBlock)
 		require.ErrorContains(t, err, "gas used by execution: 42000")
-		require.ErrorContains(t, err, "resumed block with reconstructed prefix")
 	})
 
 	t.Run("prefix gas reduces the suffix gas pool", func(t *testing.T) {

--- a/execution/stagedsync/exec3_serial_test.go
+++ b/execution/stagedsync/exec3_serial_test.go
@@ -58,12 +58,12 @@ func newSerialResumeTestExec(t *testing.T, db kv.TemporalRwDB, config *chain.Con
 func TestSerialResumeValidatesRestoredBlockGas(t *testing.T) {
 	config := chain.TestChainBerlinConfig
 
-	run := func(t *testing.T, headerGasUsed uint64) error {
+	run := func(t *testing.T, headerGasUsed, blockGasLimit, suffixGasLimit uint64) error {
 		db := newResumeTestDB(t)
 		engine := ethash.NewFaker()
 
 		tx0 := signSelfSendTx(t, 0, 1, 1, 21000, config, 0)
-		tx1 := signSelfSendTx(t, 1, 1, 1, 21000, config, 0)
+		tx1 := signSelfSendTx(t, 1, 1, 1, suffixGasLimit, config, 0)
 		txs := types.Transactions{tx0, tx1}
 
 		expectedReceipts := types.Receipts{
@@ -72,7 +72,7 @@ func TestSerialResumeValidatesRestoredBlockGas(t *testing.T) {
 		}
 		header := &types.Header{
 			Number:      *uint256.NewInt(1),
-			GasLimit:    10_000_000,
+			GasLimit:    blockGasLimit,
 			GasUsed:     headerGasUsed,
 			ReceiptHash: types.DeriveSha(expectedReceipts),
 			Bloom:       types.CreateBloom(expectedReceipts),
@@ -120,13 +120,19 @@ func TestSerialResumeValidatesRestoredBlockGas(t *testing.T) {
 	}
 
 	t.Run("restored gas matches header", func(t *testing.T) {
-		require.NoError(t, run(t, 42000))
+		require.NoError(t, run(t, 42000, 10_000_000, 21000))
 	})
 
 	t.Run("suffix-only gas in header is rejected", func(t *testing.T) {
-		err := run(t, 21000)
+		err := run(t, 21000, 10_000_000, 21000)
 		require.ErrorIs(t, err, rules.ErrInvalidBlock)
 		require.ErrorContains(t, err, "gas used by execution: 42000")
 		require.ErrorContains(t, err, "resumed block with reconstructed prefix")
+	})
+
+	t.Run("prefix gas reduces the suffix gas pool", func(t *testing.T) {
+		err := run(t, 42000, 42000, 30000)
+		require.ErrorIs(t, err, rules.ErrInvalidBlock)
+		require.ErrorContains(t, err, "gas limit reached")
 	})
 }


### PR DESCRIPTION
Fixes #22237.

Blocked by #22102.

## Summary

- recover prefix receipts and regular, state, and blob gas when execution resumes partway through a block
- deduct prefix gas from the serial and parallel block gas pools before suffix transactions are accepted
- use cached receipts before Amsterdam, and replay the prefix when cached receipts are unavailable or separate Amsterdam gas dimensions are required
- run complete post-execution validation for reconstructable resumed blocks in both execution paths
- preserve best-effort resume behavior when the prefix cannot be reconstructed; receipt notifications and post-execution validation remain disabled for that block
