### PR TITLE
execution/cache, execution/commitment: make Clear coherence race-safe

### DIFF
--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1435,8 +1435,8 @@ func (sd *SharedDomains) codeHashForAddr(tx kv.TemporalTx, addr []byte, txNum ui
 		if len(h) == 32 {
 			copy(fixed[:], h)
 		}
-		// Always populate, including the zero-hash sentinel for misses —
-		// repeat lookups skip the whole resolve() chain. txNum is a
+		// Always offer the mapping, including the zero-hash sentinel for
+		// misses — repeat lookups skip the whole resolve() chain. txNum is a
 		// conservative upper bound (>= the resolved account's write txNum), so
 		// the mapping drops on any unwind that reverts that account.
 		sd.stateCache.PutAddrCodeHash(addr, fixed, txNum)

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -153,7 +153,9 @@ type CodeCache struct {
 
 	// Unwind coherence shared by every layer (content-addressed ones included):
 	// an entry is valid iff written in the current epoch OR its txNum is below
-	// the unwind floor. See execution/cache/coherence.
+	// the unwind floor. Serving reads snapshot coherence before loading a layer,
+	// while Clear purges every layer before Reset; together those orderings keep
+	// the lifted floor from revalidating a retired entry.
 	coh coherence.Gen
 
 	// addrBindMu serializes addr→code binding writers so PutIfAbsent's
@@ -274,6 +276,8 @@ func (c *CodeCache) Get(addr []byte) ([]byte, bool) {
 // path can apply the same step bound the DomainCache/BranchCache reads do.
 func (c *CodeCache) GetWithTxNum(addr []byte) ([]byte, uint64, bool) {
 	k := common.BytesToAddress(addr)
+	// Snapshot before either layer read so an entry captured while Clear purges
+	// the layers retains the pre-Clear unwind floor used to judge it.
 	coh := c.coh.Snapshot()
 	vID, ok := c.addrToHash.Get(k)
 	if !ok {
@@ -507,7 +511,9 @@ func (c *CodeCache) Delete(addr []byte) {
 	c.addrToHash.Remove(common.BytesToAddress(addr))
 }
 
-// Clear removes every layer and starts a new coherence generation.
+// Clear removes every layer, resets accounting, and starts a new coherence
+// generation. Coherence is reset only after every purge, so snapshot-before-
+// read paths cannot pair a retired entry with the lifted unwind floor.
 func (c *CodeCache) Clear() {
 	c.addrToHash.Purge()
 	c.addrToCodeHash.Purge()

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -162,11 +162,12 @@ type CodeCache struct {
 	// check+bind is atomic w.r.t. a concurrent authoritative rebind.
 	addrBindMu sync.Mutex
 
-	// putStripes serializes putContent's membership-check + size-account +
+	// putStripes serializes putContentLocked's membership-check + size-account +
 	// insert per key hash: freelru has no LoadOrStore, so without this two
 	// concurrent Puts of the same cold code both miss the check and both add to
 	// the byte counter while only one entry survives, drifting the stat upward.
-	// Striped by key so distinct keys still put in parallel.
+	// Clear locks every stripe so epoch sampling and publication cannot straddle
+	// a generation reset. Distinct keys still put in parallel.
 	putStripes [256]sync.Mutex
 
 	// Stats counters (atomic for concurrent access)
@@ -187,7 +188,7 @@ type CodeCache struct {
 	closed atomic.Bool
 }
 
-// putContent is the shared insert path for the content-addressed code layers
+// putContentLocked is the shared insert path for the content-addressed code layers
 // (hashToCode, codeHashToCode, codeSizeByCodeHash). Each is a freelru.ShardedLRU
 // of per-key-immutable entries carrying a (txNum, epoch) stamp: a live entry is
 // kept (its bytes/size are invariant for a given key), a stale one is removed
@@ -195,8 +196,9 @@ type CodeCache struct {
 // the entry-count cap is reached freelru.Add evicts the coldest entry (whose
 // OnEvict decrements counter) rather than freezing. counter tracks resident
 // bytes as a stat; the hard bound is the LRU's entry cap. stamp/valCost are
-// non-capturing so passing them allocates nothing on the put path.
-func putContent[T any](
+// non-capturing so passing them allocates nothing on the put path. The caller
+// holds the key's put stripe.
+func putContentLocked[T any](
 	lru *growLRU[T],
 	h uint64,
 	newEntry T,
@@ -205,10 +207,7 @@ func putContent[T any](
 	coh *coherence.Gen,
 	counter *atomic.Int64,
 	keyCost int64,
-	stripe *sync.Mutex,
 ) {
-	stripe.Lock()
-	defer stripe.Unlock()
 	if existing, ok := lru.Get(h); ok {
 		if txNum, epoch := stamp(existing); !coh.IsStale(txNum, epoch) {
 			return
@@ -338,9 +337,15 @@ func (c *CodeCache) putCode(addr []byte, code []byte, keyHash [32]byte, txNum ui
 	if len(code) == 0 {
 		return
 	}
-	ep := c.coh.Epoch()
 	codeID := maphash.Hash(code)
+	stripe := &c.putStripes[uint8(codeID)]
+	stripe.Lock()
+	defer stripe.Unlock()
 
+	c.putCodeLocked(addr, code, keyHash, codeID, txNum, c.coh.Epoch(), overwriteAddr)
+}
+
+func (c *CodeCache) putCodeLocked(addr []byte, code []byte, keyHash [32]byte, codeID, txNum uint64, ep uint32, overwriteAddr bool) {
 	a := common.BytesToAddress(addr)
 	c.addrBindMu.Lock()
 	bindAddr := overwriteAddr
@@ -355,8 +360,8 @@ func (c *CodeCache) putCode(addr []byte, code []byte, keyHash [32]byte, txNum ui
 
 	entry := codeEntry{code: code, keyHash: keyHash, txNum: txNum, epoch: ep}
 	// freelru keyed by the codeID (maphash of code) directly; 8-byte key cost.
-	putContent(c.hashToCode, codeID, entry, codeEntryStamp, codeEntryCodeLen,
-		&c.coh, &c.codeSize, 8, &c.putStripes[uint8(codeID)])
+	putContentLocked(c.hashToCode, codeID, entry, codeEntryStamp, codeEntryCodeLen,
+		&c.coh, &c.codeSize, 8)
 }
 
 // GetAddrCodeHash returns the Ethereum codeHash for addr if cached. Lets
@@ -382,7 +387,12 @@ func (c *CodeCache) GetAddrCodeHash(addr []byte) ([32]byte, bool) {
 // readAhead's BAL prefetch when it learns the codeHash from the decoded
 // account record. txNum stamps the mapping for unwind invalidation.
 func (c *CodeCache) PutAddrCodeHash(addr []byte, h [32]byte, txNum uint64) {
-	c.addrToCodeHash.Add(common.BytesToAddress(addr), addrCodeHashEntry{hash: h, txNum: txNum, epoch: c.coh.Epoch()})
+	a := common.BytesToAddress(addr)
+	stripe := &c.putStripes[a[len(a)-1]]
+	stripe.Lock()
+	defer stripe.Unlock()
+
+	c.addrToCodeHash.Add(a, addrCodeHashEntry{hash: h, txNum: txNum, epoch: c.coh.Epoch()})
 }
 
 // DeleteAddrCodeHash drops the addr → codeHash mapping. Called on
@@ -440,26 +450,65 @@ func (c *CodeCache) PutWithCodeHashIfAbsent(addr []byte, code []byte, codeHash [
 	c.putWithCodeHash(addr, code, codeHash, txNum, false)
 }
 
+func (c *CodeCache) lockPutStripes(a, b uint8) {
+	if a > b {
+		a, b = b, a
+	}
+	c.putStripes[a].Lock()
+	if a != b {
+		c.putStripes[b].Lock()
+	}
+}
+
+func (c *CodeCache) unlockPutStripes(a, b uint8) {
+	if a > b {
+		a, b = b, a
+	}
+	if a != b {
+		c.putStripes[b].Unlock()
+	}
+	c.putStripes[a].Unlock()
+}
+
+func (c *CodeCache) lockAllPutStripes() {
+	for i := range c.putStripes {
+		c.putStripes[i].Lock()
+	}
+}
+
+func (c *CodeCache) unlockAllPutStripes() {
+	for i := len(c.putStripes) - 1; i >= 0; i-- {
+		c.putStripes[i].Unlock()
+	}
+}
+
 func (c *CodeCache) putWithCodeHash(addr []byte, code []byte, codeHash []byte, txNum uint64, overwriteAddr bool) {
 	if len(code) == 0 || len(codeHash) == 0 {
 		return
 	}
+	hcc := maphash.Hash(codeHash)
+	codeID := hcc
+	if len(addr) > 0 {
+		codeID = maphash.Hash(code)
+	}
+	c.lockPutStripes(uint8(codeID), uint8(hcc))
+	defer c.unlockPutStripes(uint8(codeID), uint8(hcc))
+
 	ep := c.coh.Epoch()
 	kh := hash32(codeHash)
 
 	if len(addr) > 0 {
-		c.putCode(addr, code, kh, txNum, overwriteAddr)
+		c.putCodeLocked(addr, code, kh, codeID, txNum, ep, overwriteAddr)
 	}
 
 	// Populate the size-only layer alongside the bytes layer — every time
 	// we touch the bytes we can answer a future EXTCODESIZE for free.
-	c.PutCodeSizeByCodeHash(codeHash, len(code), txNum)
+	c.putCodeSizeByCodeHashLocked(codeHash, len(code), hcc, txNum, ep)
 
 	entry := codeEntry{code: code, keyHash: kh, txNum: txNum, epoch: ep}
 	// freelru keyed by maphash(codeHash); 32-byte key cost.
-	hcc := maphash.Hash(codeHash)
-	putContent(c.codeHashToCode, hcc, entry, codeEntryStamp, codeEntryCodeLen,
-		&c.coh, &c.codeHashCodeSize, int64(len(codeHash)), &c.putStripes[uint8(hcc)])
+	putContentLocked(c.codeHashToCode, hcc, entry, codeEntryStamp, codeEntryCodeLen,
+		&c.coh, &c.codeHashCodeSize, int64(len(codeHash)))
 }
 
 // GetCodeSizeByCodeHash retrieves the size (in bytes) of a contract by its
@@ -497,13 +546,20 @@ func (c *CodeCache) PutCodeSizeByCodeHash(codeHash []byte, size int, txNum uint6
 	if len(codeHash) == 0 || size < 0 {
 		return
 	}
-	ep := c.coh.Epoch()
+	hcs := maphash.Hash(codeHash)
+	stripe := &c.putStripes[uint8(hcs)]
+	stripe.Lock()
+	defer stripe.Unlock()
+
+	c.putCodeSizeByCodeHashLocked(codeHash, size, hcs, txNum, c.coh.Epoch())
+}
+
+func (c *CodeCache) putCodeSizeByCodeHashLocked(codeHash []byte, size int, hcs, txNum uint64, ep uint32) {
 	kh := hash32(codeHash)
 	entry := codeSizeEntry{size: size, keyHash: kh, txNum: txNum, epoch: ep}
 	// Entry-counted layer: each entry costs 1 against the entry cap.
-	hcs := maphash.Hash(codeHash)
-	putContent(c.codeSizeByCodeHash, hcs, entry, codeSizeEntryStamp, zeroCost,
-		&c.coh, &c.codeSizeEntries, 1, &c.putStripes[uint8(hcs)])
+	putContentLocked(c.codeSizeByCodeHash, hcs, entry, codeSizeEntryStamp, zeroCost,
+		&c.coh, &c.codeSizeEntries, 1)
 }
 
 // Delete removes the address → code mapping for addr.
@@ -515,6 +571,9 @@ func (c *CodeCache) Delete(addr []byte) {
 // generation. Coherence is reset only after every purge, so snapshot-before-
 // read paths cannot pair a retired entry with the lifted unwind floor.
 func (c *CodeCache) Clear() {
+	c.lockAllPutStripes()
+	defer c.unlockAllPutStripes()
+
 	c.addrToHash.Purge()
 	c.addrToCodeHash.Purge()
 	c.hashToCode.Purge()

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -185,13 +185,6 @@ type CodeCache struct {
 	closed atomic.Bool
 }
 
-// isStale reports whether an entry stamped (txNum, epoch) reflects dead-fork
-// state after an unwind: it was written in a superseded epoch and its txNum is
-// at or above the unwind floor (the first unwound txNum). Mirrors GenericCache.
-func (c *CodeCache) isStale(txNum uint64, epoch uint32) bool {
-	return c.coh.IsStale(txNum, epoch)
-}
-
 // putContent is the shared insert path for the content-addressed code layers
 // (hashToCode, codeHashToCode, codeSizeByCodeHash). Each is a freelru.ShardedLRU
 // of per-key-immutable entries carrying a (txNum, epoch) stamp: a live entry is
@@ -281,12 +274,13 @@ func (c *CodeCache) Get(addr []byte) ([]byte, bool) {
 // path can apply the same step bound the DomainCache/BranchCache reads do.
 func (c *CodeCache) GetWithTxNum(addr []byte) ([]byte, uint64, bool) {
 	k := common.BytesToAddress(addr)
+	coh := c.coh.Snapshot()
 	vID, ok := c.addrToHash.Get(k)
 	if !ok {
 		c.addrMisses.Add(1)
 		return nil, 0, false
 	}
-	if c.isStale(vID.txNum, vID.epoch) {
+	if coh.IsStale(vID.txNum, vID.epoch) {
 		c.addrToHash.Remove(k)
 		c.addrMisses.Add(1)
 		return nil, 0, false
@@ -298,7 +292,7 @@ func (c *CodeCache) GetWithTxNum(addr []byte) ([]byte, uint64, bool) {
 		c.codeMisses.Add(1)
 		return nil, 0, false
 	}
-	if c.isStale(ce.txNum, ce.epoch) {
+	if coh.IsStale(ce.txNum, ce.epoch) {
 		c.hashToCode.Remove(vID.addrID) // OnEvict decrements codeSize
 		c.codeMisses.Add(1)
 		return nil, 0, false
@@ -348,7 +342,7 @@ func (c *CodeCache) putCode(addr []byte, code []byte, keyHash [32]byte, txNum ui
 	bindAddr := overwriteAddr
 	if !bindAddr {
 		e, ok := c.addrToHash.Get(a)
-		bindAddr = !ok || c.isStale(e.txNum, e.epoch)
+		bindAddr = !ok || c.coh.IsStale(e.txNum, e.epoch)
 	}
 	if bindAddr {
 		c.addrToHash.Add(a, versionedAddressID{addrID: codeID, codeHash: keyHash, txNum: txNum, epoch: ep})
@@ -367,11 +361,12 @@ func (c *CodeCache) putCode(addr []byte, code []byte, keyHash [32]byte, txNum ui
 // replace coldest entries.
 func (c *CodeCache) GetAddrCodeHash(addr []byte) ([32]byte, bool) {
 	k := common.BytesToAddress(addr)
+	coh := c.coh.Snapshot()
 	e, ok := c.addrToCodeHash.Get(k)
 	if !ok {
 		return [32]byte{}, false
 	}
-	if c.isStale(e.txNum, e.epoch) {
+	if coh.IsStale(e.txNum, e.epoch) {
 		c.addrToCodeHash.Remove(k)
 		return [32]byte{}, false
 	}
@@ -402,6 +397,7 @@ func (c *CodeCache) DeleteAddrCodeHash(addr []byte) {
 // single codeHashToCode entry after the first population.
 func (c *CodeCache) GetByCodeHash(codeHash []byte) ([]byte, bool) {
 	h := maphash.Hash(codeHash)
+	coh := c.coh.Snapshot()
 	ce, ok := c.codeHashToCode.Get(h)
 	if !ok || len(ce.code) == 0 {
 		c.codeHashMisses.Add(1)
@@ -413,7 +409,7 @@ func (c *CodeCache) GetByCodeHash(codeHash []byte) ([]byte, bool) {
 		c.codeHashMisses.Add(1)
 		return nil, false
 	}
-	if c.isStale(ce.txNum, ce.epoch) {
+	if coh.IsStale(ce.txNum, ce.epoch) {
 		c.codeHashToCode.Remove(h) // OnEvict decrements codeHashCodeSize
 		c.codeHashMisses.Add(1)
 		return nil, false
@@ -470,6 +466,7 @@ func (c *CodeCache) putWithCodeHash(addr []byte, code []byte, codeHash []byte, t
 // the file-accessor + decompression stack for the full bytes.
 func (c *CodeCache) GetCodeSizeByCodeHash(codeHash []byte) (int, bool) {
 	h := maphash.Hash(codeHash)
+	coh := c.coh.Snapshot()
 	e, ok := c.codeSizeByCodeHash.Get(h)
 	if !ok {
 		c.codeSizeMisses.Add(1)
@@ -480,7 +477,7 @@ func (c *CodeCache) GetCodeSizeByCodeHash(codeHash []byte) (int, bool) {
 		c.codeSizeMisses.Add(1)
 		return 0, false
 	}
-	if c.isStale(e.txNum, e.epoch) {
+	if coh.IsStale(e.txNum, e.epoch) {
 		c.codeSizeByCodeHash.Remove(h) // OnEvict decrements codeSizeEntries
 		c.codeSizeMisses.Add(1)
 		return 0, false
@@ -510,8 +507,7 @@ func (c *CodeCache) Delete(addr []byte) {
 	c.addrToHash.Remove(common.BytesToAddress(addr))
 }
 
-// Clear hard-resets every layer and the epoch/floor. Use on Reset /
-// fork-validation paths where no entry may carry over.
+// Clear removes every layer and starts a new coherence generation.
 func (c *CodeCache) Clear() {
 	c.addrToHash.Purge()
 	c.addrToCodeHash.Purge()
@@ -521,7 +517,7 @@ func (c *CodeCache) Clear() {
 	c.codeSize.Store(0)
 	c.codeHashCodeSize.Store(0)
 	c.codeSizeEntries.Store(0)
-	c.coh.Init()
+	c.coh.Reset()
 }
 
 // Close returns the content layers' envelope reservations. Idempotent.

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -254,9 +254,6 @@ func NewCodeCache(codeCapacityBytes, addrCapacityBytes datasize.ByteSize) *CodeC
 	cc.codeSizeByCodeHash = newGrowLRU[codeSizeEntry](
 		datasize.ByteSize(DefaultCodeSizeCacheEntries*codeSizeEntryBytes), codeSizeEntryBytes,
 		func(_ uint64, _ codeSizeEntry) { cc.codeSizeEntries.Add(-1) })
-	// Before any unwind every entry's txNum is below the floor, so the epoch
-	// check never strands a valid entry.
-	cc.coh.Init()
 	return cc
 }
 

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -63,11 +63,11 @@ const (
 //   - L1  addr → maphash(code)
 //   - L2  maphash(code) → code
 //   - L2b codeHash(code) → code — lets a caller that already knows the Ethereum
-//         codeHash (EXTCODESIZE/EXTCODEHASH/CALL after an account read) skip L1.
+//     codeHash (EXTCODESIZE/EXTCODEHASH/CALL after an account read) skip L1.
 //
-// Capacity is byte-based; once full new puts are dropped, but updates to
-// existing entries and deletions still apply.
-
+// Configured byte budgets are translated into LRU entry caps; full layers
+// evict their coldest entries.
+//
 // Every cached layer carries (txNum, epoch) so an unwind invalidates code the
 // same way as the account/storage/branch caches: a contract's code
 // value never changes for a given hash, but its EXISTENCE does — code deployed
@@ -327,9 +327,7 @@ func (c *CodeCache) PutIfAbsent(addr []byte, code []byte, txNum uint64) {
 
 // putCode populates the addr→codeID and codeID→code layers. keyHash is the
 // code's keccak codeHash when known (zero otherwise), stored so Get can reject
-// a 64-bit maphash collision. Size is accounted only on the goroutine that
-// actually inserts (LoadOrStore is atomic), so concurrent Puts of the same
-// cold code can't both Add and permanently inflate codeSize.
+// a 64-bit maphash collision.
 func (c *CodeCache) putCode(addr []byte, code []byte, keyHash [32]byte, txNum uint64, overwriteAddr bool) {
 	if len(code) == 0 {
 		return
@@ -538,8 +536,7 @@ func (c *CodeCache) GetCodeSizeByCodeHash(codeHash []byte) (int, bool) {
 }
 
 // PutCodeSizeByCodeHash stores the size of code keyed by its Ethereum
-// codeHash. No-op when the entry cap is reached. txNum stamps the entry for
-// unwind invalidation.
+// codeHash. txNum stamps the entry for unwind invalidation.
 func (c *CodeCache) PutCodeSizeByCodeHash(codeHash []byte, size int, txNum uint64) {
 	if len(codeHash) == 0 || size < 0 {
 		return
@@ -567,8 +564,8 @@ func (c *CodeCache) Delete(addr []byte) {
 
 // Clear removes every layer, resets accounting, and starts a new coherence
 // generation. It holds every writer stripe through the purges and reset, so a
-// publication cannot cross generations. Reset follows every purge, so a reader
-// cannot pair a retired entry with the lifted unwind floor.
+// publication cannot cross generations. Reset runs after all purges, so a
+// reader cannot pair a retired entry with the lifted unwind floor.
 func (c *CodeCache) Clear() {
 	c.lockAllPutStripes()
 	defer c.unlockAllPutStripes()

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -58,24 +58,6 @@ const (
 	codeSizeEntryBytes = 64
 )
 
-// CodeCache is a multi-level concurrent cache for contract code, keyed by the
-// cheap maphash rather than Keccak256 so many shared-code addresses cost little:
-//   - L1  addr → maphash(code)
-//   - L2  maphash(code) → code
-//   - L2b codeHash(code) → code — lets a caller that already knows the Ethereum
-//     codeHash (EXTCODESIZE/EXTCODEHASH/CALL after an account read) skip L1.
-//
-// Configured byte budgets are translated into LRU entry caps; full layers
-// evict their coldest entries.
-//
-// Every cached layer carries (txNum, epoch) so an unwind invalidates code the
-// same way as the account/storage/branch caches: a contract's code
-// value never changes for a given hash, but its EXISTENCE does — code deployed
-// on a fork that is later unwound must no longer be discoverable, even by
-// codeHash. So the content-addressed layers are NOT treated as immutable; they
-// honor the same (txNum, epoch) lazy-drop as the addr layers. This can re-fetch
-// code shared across deployments when one is unwound (a multiplicity cost), but
-// keeps stale code out of the cache.
 type versionedAddressID struct {
 	addrID uint64
 	// codeHash is the addr's keccak codeHash, used to reject a hashToCode
@@ -120,6 +102,24 @@ type codeSizeEntry struct {
 	epoch   uint32
 }
 
+// CodeCache is a multi-level concurrent cache for contract code, keyed by the
+// cheap maphash rather than Keccak256 so many shared-code addresses cost little:
+//   - L1  addr → maphash(code)
+//   - L2  maphash(code) → code
+//   - L2b codeHash(code) → code — lets a caller that already knows the Ethereum
+//     codeHash (EXTCODESIZE/EXTCODEHASH/CALL after an account read) skip L1.
+//
+// Configured byte budgets are translated into LRU entry caps; full layers
+// evict their coldest entries.
+//
+// Every cached layer carries (txNum, epoch) so an unwind invalidates code the
+// same way as the account/storage/branch caches: a contract's code
+// value never changes for a given hash, but its EXISTENCE does — code deployed
+// on a fork that is later unwound must no longer be discoverable, even by
+// codeHash. So the content-addressed layers are NOT treated as immutable; they
+// honor the same (txNum, epoch) lazy-drop as the addr layers. This can re-fetch
+// code shared across deployments when one is unwound (a multiplicity cost), but
+// keeps stale code out of the cache.
 type CodeCache struct {
 	// addrToHash maps a 20-byte Ethereum address to the maphash-derived
 	// codeID for the code at that address. An LRU so fresh-address workloads

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -162,12 +162,12 @@ type CodeCache struct {
 	// check+bind is atomic w.r.t. a concurrent authoritative rebind.
 	addrBindMu sync.Mutex
 
-	// putStripes serializes putContentLocked's membership-check + size-account +
-	// insert per key hash: freelru has no LoadOrStore, so without this two
+	// putStripes serializes putContentLocked's membership check, accounting, and
+	// insertion per key hash: freelru has no LoadOrStore, so without this two
 	// concurrent Puts of the same cold code both miss the check and both add to
 	// the byte counter while only one entry survives, drifting the stat upward.
-	// Clear locks every stripe so epoch sampling and publication cannot straddle
-	// a generation reset. Distinct keys still put in parallel.
+	// Every epoch-stamped writer also uses a stripe, so Clear can fence all
+	// publications while distinct keys still write in parallel.
 	putStripes [256]sync.Mutex
 
 	// Stats counters (atomic for concurrent access)
@@ -379,11 +379,10 @@ func (c *CodeCache) GetAddrCodeHash(addr []byte) ([32]byte, bool) {
 	return e.hash, true
 }
 
-// PutAddrCodeHash records the addr → codeHash mapping. Called from the
-// account-decode populate path inside SD.codeHashForAddr; also called by
-// readAhead's BAL prefetch when it learns the codeHash from the decoded
-// account record. A live mapping is kept; an unwind-stale mapping is replaced.
-// txNum stamps the mapping for unwind invalidation.
+// PutAddrCodeHash records a committed-state addr → codeHash mapping. An
+// existing live mapping remains authoritative until DeleteAddrCodeHash
+// invalidates it; an unwind-stale mapping can be replaced. txNum stamps the
+// mapping for unwind invalidation.
 func (c *CodeCache) PutAddrCodeHash(addr []byte, h [32]byte, txNum uint64) {
 	a := common.BytesToAddress(addr)
 	stripe := &c.putStripes[a[len(a)-1]]
@@ -396,9 +395,7 @@ func (c *CodeCache) PutAddrCodeHash(addr []byte, h [32]byte, txNum uint64) {
 	c.addrToCodeHash.Add(a, addrCodeHashEntry{hash: h, txNum: txNum, epoch: c.coh.Epoch()})
 }
 
-// DeleteAddrCodeHash drops the addr → codeHash mapping. Called on
-// SELFDESTRUCT / CREATE2-replace / unwind where the account's codeHash
-// has been mutated.
+// DeleteAddrCodeHash removes the mapping when its account record is invalidated.
 func (c *CodeCache) DeleteAddrCodeHash(addr []byte) {
 	c.addrToCodeHash.Remove(common.BytesToAddress(addr))
 }
@@ -569,8 +566,9 @@ func (c *CodeCache) Delete(addr []byte) {
 }
 
 // Clear removes every layer, resets accounting, and starts a new coherence
-// generation. Coherence is reset only after every purge, so snapshot-before-
-// read paths cannot pair a retired entry with the lifted unwind floor.
+// generation. It holds every writer stripe through the purges and reset, so a
+// publication cannot cross generations. Reset follows every purge, so a reader
+// cannot pair a retired entry with the lifted unwind floor.
 func (c *CodeCache) Clear() {
 	c.lockAllPutStripes()
 	defer c.unlockAllPutStripes()

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -382,13 +382,17 @@ func (c *CodeCache) GetAddrCodeHash(addr []byte) ([32]byte, bool) {
 // PutAddrCodeHash records the addr → codeHash mapping. Called from the
 // account-decode populate path inside SD.codeHashForAddr; also called by
 // readAhead's BAL prefetch when it learns the codeHash from the decoded
-// account record. txNum stamps the mapping for unwind invalidation.
+// account record. A live mapping is kept; an unwind-stale mapping is replaced.
+// txNum stamps the mapping for unwind invalidation.
 func (c *CodeCache) PutAddrCodeHash(addr []byte, h [32]byte, txNum uint64) {
 	a := common.BytesToAddress(addr)
 	stripe := &c.putStripes[a[len(a)-1]]
 	stripe.Lock()
 	defer stripe.Unlock()
 
+	if e, ok := c.addrToCodeHash.Get(a); ok && !c.coh.IsStale(e.txNum, e.epoch) {
+		return
+	}
 	c.addrToCodeHash.Add(a, addrCodeHashEntry{hash: h, txNum: txNum, epoch: c.coh.Epoch()})
 }
 

--- a/execution/cache/code_cache_codehash_test.go
+++ b/execution/cache/code_cache_codehash_test.go
@@ -33,6 +33,35 @@ func makeCodeHash(i int) []byte {
 	return h
 }
 
+func TestCodeCache_PutAddrCodeHashKeepsLiveEntry(t *testing.T) {
+	c := closeOnCleanup(t, NewCodeCache(1*datasize.MB, 1*datasize.MB))
+	addr := makeAddr(1)
+	freshHash := [32]byte{1}
+	staleHash := [32]byte{2}
+
+	c.PutAddrCodeHash(addr, freshHash, 20)
+	c.PutAddrCodeHash(addr, staleHash, 10)
+
+	got, ok := c.GetAddrCodeHash(addr)
+	require.True(t, ok)
+	require.Equal(t, freshHash, got)
+}
+
+func TestCodeCache_PutAddrCodeHashReplacesStaleEntry(t *testing.T) {
+	c := closeOnCleanup(t, NewCodeCache(1*datasize.MB, 1*datasize.MB))
+	addr := makeAddr(1)
+	oldHash := [32]byte{1}
+	newHash := [32]byte{2}
+
+	c.PutAddrCodeHash(addr, oldHash, 100)
+	c.Unwind(50)
+	c.PutAddrCodeHash(addr, newHash, 100)
+
+	got, ok := c.GetAddrCodeHash(addr)
+	require.True(t, ok)
+	require.Equal(t, newHash, got)
+}
+
 func TestCodeCache_GetByCodeHash_HitAfterPut(t *testing.T) {
 	c := closeOnCleanup(t, NewCodeCache(1*datasize.MB, 1*datasize.MB))
 	addr := makeAddr(1)

--- a/execution/cache/code_cache_concurrency_test.go
+++ b/execution/cache/code_cache_concurrency_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/maphash"
 )
@@ -137,4 +138,23 @@ func TestCodeCache_PutIfAbsentAtomicWithPut(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, fresh, v, "round %d: PutIfAbsent raced past a concurrent Put", round)
 	}
+}
+
+func TestCodeCache_ClearRacingPut_EpochAlias(t *testing.T) {
+	cc := closeOnCleanup(t, NewCodeCache(64*datasize.MB, 16*datasize.MB))
+	cc.Unwind(300)
+
+	addr := make([]byte, 20)
+	addr[0] = 0xef
+	code := []byte("dead-fork-code")
+	codeID := maphash.Hash(code)
+	preClearEpoch := cc.coh.Epoch()
+
+	cc.Clear()
+	cc.addrToHash.Add(common.BytesToAddress(addr), versionedAddressID{addrID: codeID, txNum: 200, epoch: preClearEpoch})
+	cc.hashToCode.Add(codeID, codeEntry{code: code, txNum: 200, epoch: preClearEpoch})
+	cc.Unwind(150)
+
+	_, ok := cc.Get(addr)
+	require.False(t, ok, "pre-Clear epoch must not alias the live epoch after a later unwind")
 }

--- a/execution/cache/code_cache_concurrency_test.go
+++ b/execution/cache/code_cache_concurrency_test.go
@@ -30,13 +30,8 @@ import (
 	"github.com/erigontech/erigon/common/maphash"
 )
 
-// TestCodeCache_ConcurrentPutSameCode_NoSizeDrift guards against the size
-// accounting drift that the pre-LoadOrStore code had: parallel workers Putting
-// the same cold code all missed the membership check, all passed the cap gate,
-// and all added to the byte counter, leaving a permanent positive surplus that
-// eventually wedged the cap. With the atomic LoadOrStore insert, only the
-// goroutine that actually inserts accounts the size, so the counters must equal
-// exactly one entry regardless of how many concurrent Puts raced.
+// Concurrent puts of the same cold code must account each content layer once.
+// The per-key stripe keeps the membership check, accounting, and insertion atomic.
 func TestCodeCache_ConcurrentPutSameCode_NoSizeDrift(t *testing.T) {
 	cc := closeOnCleanup(t, NewCodeCache(64*datasize.MB, 16*datasize.MB))
 
@@ -163,7 +158,8 @@ func TestCodeCache_ClearRacingPut_EpochAlias(t *testing.T) {
 }
 
 func TestCodeCache_ClearFencesStartedPut(t *testing.T) {
-	// One P makes each Gosched establish the intended lock order without timing assumptions.
+	// Limit Go execution to one logical processor. Each runtime.Gosched call
+	// yields to the queued goroutine, which runs until it reaches the blocked lock.
 	previousProcs := runtime.GOMAXPROCS(1)
 	defer runtime.GOMAXPROCS(previousProcs)
 

--- a/execution/cache/code_cache_concurrency_test.go
+++ b/execution/cache/code_cache_concurrency_test.go
@@ -18,9 +18,9 @@ package cache
 
 import (
 	"encoding/binary"
+	"runtime"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
@@ -163,6 +163,10 @@ func TestCodeCache_ClearRacingPut_EpochAlias(t *testing.T) {
 }
 
 func TestCodeCache_ClearFencesStartedPut(t *testing.T) {
+	// One P makes each Gosched establish the intended lock order without timing assumptions.
+	previousProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previousProcs)
+
 	cc := closeOnCleanup(t, NewCodeCache(64*datasize.MB, 16*datasize.MB))
 	cc.Unwind(300)
 
@@ -171,10 +175,22 @@ func TestCodeCache_ClearFencesStartedPut(t *testing.T) {
 	cc.addrBindMu.Lock()
 
 	var wg sync.WaitGroup
-	wg.Go(func() { cc.Put(addr, code, 200) })
-	time.Sleep(5 * time.Millisecond)
-	wg.Go(cc.Clear)
-	time.Sleep(5 * time.Millisecond)
+	putStarted := make(chan struct{})
+	wg.Go(func() {
+		close(putStarted)
+		cc.Put(addr, code, 200)
+	})
+	<-putStarted
+	runtime.Gosched()
+
+	clearStarted := make(chan struct{})
+	wg.Go(func() {
+		close(clearStarted)
+		cc.Clear()
+	})
+	<-clearStarted
+	runtime.Gosched()
+
 	cc.addrBindMu.Unlock()
 	wg.Wait()
 

--- a/execution/cache/code_cache_concurrency_test.go
+++ b/execution/cache/code_cache_concurrency_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
@@ -159,4 +160,24 @@ func TestCodeCache_ClearRacingPut_EpochAlias(t *testing.T) {
 
 	_, ok := cc.Get(addr)
 	require.False(t, ok, "pre-Clear epoch must not alias the live epoch after a later unwind")
+}
+
+func TestCodeCache_ClearFencesStartedPut(t *testing.T) {
+	cc := closeOnCleanup(t, NewCodeCache(64*datasize.MB, 16*datasize.MB))
+	cc.Unwind(300)
+
+	addr := []byte{0xef}
+	code := []byte("dead-fork-code")
+	cc.addrBindMu.Lock()
+
+	var wg sync.WaitGroup
+	wg.Go(func() { cc.Put(addr, code, 200) })
+	time.Sleep(5 * time.Millisecond)
+	wg.Go(cc.Clear)
+	time.Sleep(5 * time.Millisecond)
+	cc.addrBindMu.Unlock()
+	wg.Wait()
+
+	_, ok := cc.Get(addr)
+	require.False(t, ok, "Clear must remove a write that started in the retiring generation")
 }

--- a/execution/cache/code_cache_concurrency_test.go
+++ b/execution/cache/code_cache_concurrency_test.go
@@ -151,6 +151,8 @@ func TestCodeCache_ClearRacingPut_EpochAlias(t *testing.T) {
 	preClearEpoch := cc.coh.Epoch()
 
 	cc.Clear()
+	// Model a writer that sampled the epoch before Clear and published after
+	// the relevant layers were purged.
 	cc.addrToHash.Add(common.BytesToAddress(addr), versionedAddressID{addrID: codeID, txNum: 200, epoch: preClearEpoch})
 	cc.hashToCode.Add(codeID, codeEntry{code: code, txNum: 200, epoch: preClearEpoch})
 	cc.Unwind(150)

--- a/execution/cache/coherence/coherence.go
+++ b/execution/cache/coherence/coherence.go
@@ -32,6 +32,9 @@ type gen struct {
 	floor uint64
 }
 
+// gen values are immutable, so zero-value readers can share pristine.
+var pristine = &gen{floor: math.MaxUint64}
+
 // Gen tracks unwind coherence for a cache: every entry is stamped (txNum, epoch),
 // and is stale iff it was written in a superseded epoch AND its txNum is at or
 // above the unwind floor (the first rolled-back txNum). Unwind bumps the epoch
@@ -39,15 +42,9 @@ type gen struct {
 // next read. The floor only ever decreases, so a shallower later unwind can't
 // resurrect entries a deeper one invalidated.
 //
-// Constructors must call Init.
+// The zero value is ready to use.
 type Gen struct {
 	state atomic.Pointer[gen]
-}
-
-// Init sets the pre-unwind state: epoch 0, floor = MaxUint64 (every entry
-// predates the nonexistent floor, so all reads are valid until the first unwind).
-func (g *Gen) Init() {
-	g.state.Store(&gen{epoch: 0, floor: math.MaxUint64})
 }
 
 // Reset starts an empty cache generation without reusing an epoch. It advances
@@ -75,8 +72,7 @@ func (g *Gen) load() *gen {
 	if s := g.state.Load(); s != nil {
 		return s
 	}
-	// Defensive: an un-Init'd Gen reads as pre-unwind rather than panicking.
-	return &gen{epoch: 0, floor: math.MaxUint64}
+	return pristine
 }
 
 // IsStale reports whether an entry stamped (txNum, epoch) reflects dead-fork

--- a/execution/cache/coherence/coherence.go
+++ b/execution/cache/coherence/coherence.go
@@ -32,24 +32,24 @@ type gen struct {
 	floor uint64
 }
 
-// gen values are immutable, so zero-value readers can share pristine.
+// gen values are immutable, so all zero-value Gen reads can share pristine.
 var pristine = &gen{floor: math.MaxUint64}
 
 // Gen tracks unwind coherence for a cache: every entry is stamped (txNum, epoch),
 // and is stale iff it was written in a superseded epoch AND its txNum is at or
 // above the unwind floor (the first rolled-back txNum). Unwind bumps the epoch
 // and lowers the floor — O(1), scan-free; stale entries drop lazily on their
-// next read. The floor only ever decreases, so a shallower later unwind can't
-// resurrect entries a deeper one invalidated.
+// next read. Within one cache generation, the floor only decreases, so a
+// shallower later unwind can't resurrect entries a deeper one invalidated.
 //
 // The zero value is ready to use.
 type Gen struct {
 	state atomic.Pointer[gen]
 }
 
-// Reset starts an empty cache generation without reusing an epoch. It advances
-// the epoch and lifts the unwind floor in one CAS, so concurrent Reset and
-// Unwind calls cannot lose a generation change.
+// Reset starts a new generation for an empty cache without reusing an epoch.
+// It advances the epoch and lifts the unwind floor in one CAS, so concurrent
+// Reset and Unwind calls are ordered without losing either update.
 func (g *Gen) Reset() {
 	for {
 		cur := g.state.Load()
@@ -82,10 +82,8 @@ func (g *Gen) IsStale(txNum uint64, epoch uint32) bool {
 }
 
 // Snapshot is an immutable (epoch, floor) pair for judging entries against
-// the coherence state captured at a chosen point — e.g. before loading a
-// cache generation, so a concurrent Clear's reset (new epoch, lifted
-// floor) cannot revalidate a dead entry captured from the retiring
-// generation.
+// coherence captured at a chosen point. Taking it before loading cache storage
+// prevents a concurrent Clear from pairing a retired entry with a reset floor.
 type Snapshot struct {
 	epoch uint32
 	floor uint64

--- a/execution/cache/coherence/coherence.go
+++ b/execution/cache/coherence/coherence.go
@@ -39,7 +39,7 @@ type gen struct {
 // next read. The floor only ever decreases, so a shallower later unwind can't
 // resurrect entries a deeper one invalidated.
 //
-// The zero value is not usable — call Init from constructors.
+// Constructors must call Init.
 type Gen struct {
 	state atomic.Pointer[gen]
 }

--- a/execution/cache/coherence/coherence.go
+++ b/execution/cache/coherence/coherence.go
@@ -39,7 +39,7 @@ type gen struct {
 // next read. The floor only ever decreases, so a shallower later unwind can't
 // resurrect entries a deeper one invalidated.
 //
-// The zero value is not usable — call Init (constructors and Clear).
+// The zero value is not usable — call Init from constructors.
 type Gen struct {
 	state atomic.Pointer[gen]
 }
@@ -48,6 +48,20 @@ type Gen struct {
 // predates the nonexistent floor, so all reads are valid until the first unwind).
 func (g *Gen) Init() {
 	g.state.Store(&gen{epoch: 0, floor: math.MaxUint64})
+}
+
+// Reset starts an empty cache generation without reusing an epoch.
+func (g *Gen) Reset() {
+	for {
+		cur := g.state.Load()
+		epoch := uint32(0)
+		if cur != nil {
+			epoch = cur.epoch
+		}
+		if g.state.CompareAndSwap(cur, &gen{epoch: epoch + 1, floor: math.MaxUint64}) {
+			return
+		}
+	}
 }
 
 // Epoch returns the current epoch, for stamping freshly written entries.
@@ -71,7 +85,7 @@ func (g *Gen) IsStale(txNum uint64, epoch uint32) bool {
 
 // Snapshot is an immutable (epoch, floor) pair for judging entries against
 // the coherence state captured at a chosen point — e.g. before loading a
-// cache generation, so a concurrent Clear's re-init (fresh epoch, lifted
+// cache generation, so a concurrent Clear's reset (new epoch, lifted
 // floor) cannot revalidate a dead entry captured from the retiring
 // generation.
 type Snapshot struct {

--- a/execution/cache/coherence/coherence.go
+++ b/execution/cache/coherence/coherence.go
@@ -50,7 +50,9 @@ func (g *Gen) Init() {
 	g.state.Store(&gen{epoch: 0, floor: math.MaxUint64})
 }
 
-// Reset starts an empty cache generation without reusing an epoch.
+// Reset starts an empty cache generation without reusing an epoch. It advances
+// the epoch and lifts the unwind floor in one CAS, so concurrent Reset and
+// Unwind calls cannot lose a generation change.
 func (g *Gen) Reset() {
 	for {
 		cur := g.state.Load()

--- a/execution/cache/coherence/coherence_test.go
+++ b/execution/cache/coherence/coherence_test.go
@@ -24,9 +24,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGen_CannotReinitializeAfterUnwind(t *testing.T) {
+	var g Gen
+	entryEpoch := g.Epoch()
+	g.Unwind(50)
+
+	if initializer, ok := any(&g).(interface{ Init() }); ok {
+		initializer.Init()
+	}
+
+	require.Equal(t, uint32(1), g.Epoch())
+	require.True(t, g.IsStale(60, entryEpoch))
+}
+
 func TestGen_FloorAndEpoch(t *testing.T) {
 	var g Gen
-	g.Init()
 	require.Equal(t, uint32(0), g.Epoch())
 
 	// Before any unwind nothing is stale.
@@ -52,7 +64,6 @@ func TestGen_FloorAndEpoch(t *testing.T) {
 // the number of Unwinds.
 func TestGen_ConcurrentUnwindNoTear(t *testing.T) {
 	var g Gen
-	g.Init()
 
 	const unwinds = 200
 	var wg sync.WaitGroup
@@ -76,7 +87,6 @@ func TestGen_ConcurrentUnwindNoTear(t *testing.T) {
 
 func TestGen_ResetAdvancesEpochAndLiftsFloor(t *testing.T) {
 	var g Gen
-	g.Init()
 	g.Unwind(50)
 
 	g.Reset()
@@ -88,7 +98,6 @@ func TestGen_ResetAdvancesEpochAndLiftsFloor(t *testing.T) {
 
 func TestGen_SnapshotKeepsDeadEntryStaleAcrossReset(t *testing.T) {
 	var g Gen
-	g.Init()
 	entryEpoch := g.Epoch()
 	g.Unwind(50)
 	read := g.Snapshot()
@@ -101,7 +110,6 @@ func TestGen_SnapshotKeepsDeadEntryStaleAcrossReset(t *testing.T) {
 
 func TestGen_ConcurrentResetAndUnwindPreserveEveryEpochBump(t *testing.T) {
 	var g Gen
-	g.Init()
 
 	const operations = 200
 	var wg sync.WaitGroup

--- a/execution/cache/coherence/coherence_test.go
+++ b/execution/cache/coherence/coherence_test.go
@@ -24,19 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGen_CannotReinitializeAfterUnwind(t *testing.T) {
-	var g Gen
-	entryEpoch := g.Epoch()
-	g.Unwind(50)
-
-	if initializer, ok := any(&g).(interface{ Init() }); ok {
-		initializer.Init()
-	}
-
-	require.Equal(t, uint32(1), g.Epoch())
-	require.True(t, g.IsStale(60, entryEpoch))
-}
-
 func TestGen_FloorAndEpoch(t *testing.T) {
 	var g Gen
 	require.Equal(t, uint32(0), g.Epoch())

--- a/execution/cache/coherence/coherence_test.go
+++ b/execution/cache/coherence/coherence_test.go
@@ -17,6 +17,7 @@
 package coherence
 
 import (
+	"math"
 	"sync"
 	"testing"
 
@@ -71,4 +72,44 @@ func TestGen_ConcurrentUnwindNoTear(t *testing.T) {
 	wg.Wait()
 	require.Equal(t, uint32(unwinds), g.Epoch())
 	require.True(t, g.IsStale(1, 0), "deepest floor reached 1")
+}
+
+func TestGen_ResetAdvancesEpochAndLiftsFloor(t *testing.T) {
+	var g Gen
+	g.Init()
+	g.Unwind(50)
+
+	g.Reset()
+
+	s := g.Snapshot()
+	require.Equal(t, uint32(2), s.epoch)
+	require.Equal(t, uint64(math.MaxUint64), s.floor)
+}
+
+func TestGen_SnapshotKeepsDeadEntryStaleAcrossReset(t *testing.T) {
+	var g Gen
+	g.Init()
+	entryEpoch := g.Epoch()
+	g.Unwind(50)
+	read := g.Snapshot()
+
+	g.Reset()
+
+	require.True(t, read.IsStale(60, entryEpoch))
+	require.False(t, g.IsStale(60, entryEpoch))
+}
+
+func TestGen_ConcurrentResetAndUnwindPreserveEveryEpochBump(t *testing.T) {
+	var g Gen
+	g.Init()
+
+	const operations = 200
+	var wg sync.WaitGroup
+	for range operations {
+		wg.Go(g.Reset)
+		wg.Go(func() { g.Unwind(50) })
+	}
+	wg.Wait()
+
+	require.Equal(t, uint32(operations*2), g.Epoch())
 }

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -316,8 +316,12 @@ func (c *GenericCache[T]) Get(key []byte) (T, bool) {
 // maxStep — the same coherence the BranchCache read applies for commitment.
 func (c *GenericCache[T]) GetWithTxNum(key []byte) (T, uint64, bool) {
 	h := maphash.Hash(key)
-	// Snapshot before loading the generation so an entry from the retiring
-	// generation is judged by coherence that still carries its unwind.
+	// Snapshot coherence before loading the generation. Clear publishes the
+	// replacement generation before lifting the unwind floor, so an entry
+	// captured from the retiring generation is always judged by coherence that
+	// still carries its unwind. A replacement-generation entry judged by an old
+	// snapshot can only cause a safe miss because dropStale rechecks the current
+	// generation before removing it.
 	coh := c.coh.Snapshot()
 	lru := c.data.Load()
 	e, ok := lru.Get(h)
@@ -379,8 +383,9 @@ func (c *GenericCache[T]) putStriped(key []byte, value T, txNum uint64, overwrit
 	mu.Lock()
 	defer mu.Unlock()
 
-	// Sample the epoch under the stripe so Clear cannot split the stamp from
-	// the generation where the entry lands.
+	// Sample the epoch under the stripe. Clear holds every stripe across the
+	// generation swap and coherence reset, so the stamp cannot belong to a
+	// different generation from the one where the entry lands.
 	ep := c.coh.Epoch()
 	lru := c.data.Load()
 	existing, hasExisting := lru.Get(h)
@@ -474,8 +479,12 @@ func (c *GenericCache[T]) dropStale(h uint64, key []byte) {
 	}
 }
 
-// Clear removes all entries, restores the starting capacity, and starts a new
-// coherence generation. The generation swap and accounting reset fence writers.
+// Clear removes all entries and restores the starting capacity. It starts an
+// empty coherence generation by advancing the epoch and lifting the unwind
+// floor, so subsequent puts are not constrained by an unwind that belongs to
+// the retired data. The accounting reset, data swap, and coherence reset run
+// with every put stripe held, so a racing writer cannot split those
+// publications.
 func (c *GenericCache[T]) Clear() {
 	// Shrink back to the start size and return the grown budget to the envelope,
 	// keeping the cache adaptive across fork-validation/reset (it regrows on
@@ -495,9 +504,9 @@ func (c *GenericCache[T]) Clear() {
 	c.shardCount = shards
 	c.curCap.Store(c.startCap)
 	c.data.Store(next)
-	// Reset coherence only after the swap: paired with GetWithTxNum's
-	// snapshot-before-load ordering, an entry captured from the retiring
-	// generation is then always judged by pre-reset coherence that still
+	// Reset coherence only after publishing the empty generation. Paired with
+	// GetWithTxNum's snapshot-before-load ordering, this ensures an entry from
+	// the retiring generation is judged by pre-Reset coherence that still
 	// carries the unwind.
 	c.coh.Reset()
 	for i := range c.putStripes {

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -316,14 +316,8 @@ func (c *GenericCache[T]) Get(key []byte) (T, bool) {
 // maxStep — the same coherence the BranchCache read applies for commitment.
 func (c *GenericCache[T]) GetWithTxNum(key []byte) (T, uint64, bool) {
 	h := maphash.Hash(key)
-	// Snapshot coherence before loading the generation: judged against the live
-	// state instead, a Clear landing between the load and the staleness check
-	// re-inits coherence (fresh epoch, lifted floor) and revalidates a dead
-	// entry captured from the retiring generation. Paired with Clear re-initing
-	// only after its swap, an old-generation entry is always judged by a
-	// pre-init snapshot that still carries the unwind. A live entry judged by a
-	// pre-Clear snapshot only degrades to a miss (dropStale re-checks and keeps
-	// it).
+	// Snapshot before loading the generation so an entry from the retiring
+	// generation is judged by coherence that still carries its unwind.
 	coh := c.coh.Snapshot()
 	lru := c.data.Load()
 	e, ok := lru.Get(h)
@@ -385,9 +379,8 @@ func (c *GenericCache[T]) putStriped(key []byte, value T, txNum uint64, overwrit
 	mu.Lock()
 	defer mu.Unlock()
 
-	// Sample the epoch under the stripe: Clear resets the epoch counter inside
-	// the fence, so a stamp read outside could alias a future epoch and let a
-	// dead-fork entry survive a later unwind.
+	// Sample the epoch under the stripe so Clear cannot split the stamp from
+	// the generation where the entry lands.
 	ep := c.coh.Epoch()
 	lru := c.data.Load()
 	existing, hasExisting := lru.Get(h)
@@ -481,13 +474,8 @@ func (c *GenericCache[T]) dropStale(h uint64, key []byte) {
 	}
 }
 
-// Clear removes all entries from the cache. It also resets the (epoch,
-// unwindFloor) coherence pair: with no entries left, no stale (txNum, epoch)
-// can survive, so a fresh floor keeps subsequent Puts at the live epoch
-// serviceable. Mirrors CodeCache.Clear (which already did this — the two had
-// drifted). The counter reset and the generation swap run with every put
-// stripe held — like maybeGrow's — so a racing put can neither land in the
-// retired generation nor add its size after the reset.
+// Clear removes all entries, restores the starting capacity, and starts a new
+// coherence generation. The generation swap and accounting reset fence writers.
 func (c *GenericCache[T]) Clear() {
 	// Shrink back to the start size and return the grown budget to the envelope,
 	// keeping the cache adaptive across fork-validation/reset (it regrows on
@@ -507,11 +495,11 @@ func (c *GenericCache[T]) Clear() {
 	c.shardCount = shards
 	c.curCap.Store(c.startCap)
 	c.data.Store(next)
-	// Re-init coherence only after the swap: paired with GetWithTxNum's
+	// Reset coherence only after the swap: paired with GetWithTxNum's
 	// snapshot-before-load ordering, an entry captured from the retiring
-	// generation is then always judged by pre-init coherence that still
+	// generation is then always judged by pre-reset coherence that still
 	// carries the unwind.
-	c.coh.Init()
+	c.coh.Reset()
 	for i := range c.putStripes {
 		c.putStripes[i].Unlock()
 	}

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -183,9 +183,6 @@ func newGenericCacheEntries[T any](capacityBytes datasize.ByteSize, capacityEntr
 	c.curCap.Store(capacityEntries)
 	c.shardCeil = uint32(math.NextPowerOfTwo(uint64(runtime.GOMAXPROCS(0) * 16)))
 	c.shardCount = initialShardCount(capacityEntries, c.shardCeil)
-	// Before any unwind every entry predates the (nonexistent) floor, so all
-	// reads are valid; the floor only drops once an unwind happens.
-	c.coh.Init()
 	c.data.Store(c.newShards(capacityEntries, c.shardCount))
 	return c
 }

--- a/execution/cache/generic_cache_concurrency_test.go
+++ b/execution/cache/generic_cache_concurrency_test.go
@@ -303,17 +303,8 @@ func TestGenericCache_CapacityEvictionAtomicWithPut_NoSizeDrift(t *testing.T) {
 	require.Zero(t, c.SizeBytes(), "capacity eviction raced the update-path delta")
 }
 
-// A put samples the coherence epoch and then contends for its stripe; a Clear
-// that wins the stripe first resets the epoch counter, so the put would stamp
-// a pre-Clear epoch onto an entry landing in the post-Clear generation. Once
-// a later unwind re-reaches that epoch value, the entry aliases the live
-// epoch and serves dead-fork state despite its txNum being at or above the
-// floor.
-//
-// The test holds the key's stripe to park Clear on it (before the reset,
-// which runs inside the fence) and then the put behind it; waits beyond 1ms
-// put the mutex in starvation mode, so unlocking hands the stripe FIFO to
-// Clear first.
+// Clear owns every put stripe through its generation reset. This test queues
+// Clear before Put so the entry must be stamped in the post-Clear generation.
 func TestGenericCache_ClearRacingPut_EpochAlias(t *testing.T) {
 	c := NewGenericCache[[]byte](64*datasize.MB, func(v []byte) int { return len(v) }, ModeEvictLRU)
 	defer c.Close()
@@ -331,18 +322,18 @@ func TestGenericCache_ClearRacingPut_EpochAlias(t *testing.T) {
 	mu.Unlock()
 	wg.Wait()
 
-	c.Unwind(150) // epoch 0 -> 1 again, floor 150
+	c.Unwind(150)
 
 	_, ok := c.Get(key)
-	require.False(t, ok, "entry at txNum 200 outlived an unwind to 150: its pre-Clear epoch stamp aliases the live epoch")
+	require.False(t, ok, "entry at txNum 200 outlived an unwind to 150")
 }
 
 // A reader that captures a dead (unwind-invalidated) entry from the retiring
-// generation must not have it revalidated by Clear's coherence re-init:
-// judged against the post-Init state (fresh epoch, lifted floor), the entry
+// generation must not have it revalidated by Clear's coherence reset:
+// judged against the post-Reset state (new epoch, lifted floor), the entry
 // passes IsStale and dead-fork state is served. Coherence is snapshotted
 // before the generation load, so an old-generation entry is always judged by
-// coherence that still carries the unwind.
+// pre-Reset coherence that still carries the unwind.
 //
 // The reader gates on the fence reaching the key's stripe — the last one the
 // sweep locks — so its Get lands next to the Init that follows.

--- a/execution/cache/generic_cache_concurrency_test.go
+++ b/execution/cache/generic_cache_concurrency_test.go
@@ -303,8 +303,14 @@ func TestGenericCache_CapacityEvictionAtomicWithPut_NoSizeDrift(t *testing.T) {
 	require.Zero(t, c.SizeBytes(), "capacity eviction raced the update-path delta")
 }
 
-// Clear owns every put stripe through its generation reset. This test queues
-// Clear before Put so the entry must be stamped in the post-Clear generation.
+// The failure mode is a pre-Clear epoch stamped on post-Clear storage. If Clear
+// reused that epoch value, a later unwind could reach the same value and treat
+// the entry as current even though its txNum is above the unwind floor.
+//
+// The test holds the key's stripe, then queues Clear before Put. Waiting beyond
+// the mutex starvation threshold makes the unlock hand the stripe to Clear
+// first. Clear must keep the stripe through the data and coherence generation
+// changes, so Put stamps the post-Clear epoch and a later unwind invalidates it.
 func TestGenericCache_ClearRacingPut_EpochAlias(t *testing.T) {
 	c := NewGenericCache[[]byte](64*datasize.MB, func(v []byte) int { return len(v) }, ModeEvictLRU)
 	defer c.Close()
@@ -336,7 +342,7 @@ func TestGenericCache_ClearRacingPut_EpochAlias(t *testing.T) {
 // pre-Reset coherence that still carries the unwind.
 //
 // The reader gates on the fence reaching the key's stripe — the last one the
-// sweep locks — so its Get lands next to the Init that follows.
+// sweep locks — so its Get lands next to the Reset that follows.
 func TestGenericCache_ClearRacingGet_DeadEntryStaysDead(t *testing.T) {
 	var key []byte
 	for i := 0; ; i++ {

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -204,7 +204,8 @@ func (c *StateCache) GetAddrCodeHash(addr []byte) ([32]byte, bool) {
 
 // PutAddrCodeHash records the addr → codeHash mapping in the addr-keyed
 // LRU above SD. Callers that have just decoded an account record should
-// call this so subsequent lookups skip the account-domain read.
+// call this so subsequent lookups skip the account-domain read. A live
+// mapping is kept; an unwind-stale mapping is replaced.
 func (c *StateCache) PutAddrCodeHash(addr []byte, h [32]byte, txNum uint64) {
 	cc, ok := c.caches[kv.CodeDomain].(*CodeCache)
 	if !ok {

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -192,8 +192,7 @@ func (c *StateCache) PutCodeSizeByHash(codeHash []byte, size int, txNum uint64) 
 }
 
 // GetAddrCodeHash returns the Ethereum codeHash for addr without an
-// account-domain round-trip. (0xff..ff/false, no entry on miss; (h, true)
-// on hit.)
+// account-domain round-trip. The hash is zero when ok is false.
 func (c *StateCache) GetAddrCodeHash(addr []byte) ([32]byte, bool) {
 	cc, ok := c.caches[kv.CodeDomain].(*CodeCache)
 	if !ok {
@@ -202,10 +201,9 @@ func (c *StateCache) GetAddrCodeHash(addr []byte) ([32]byte, bool) {
 	return cc.GetAddrCodeHash(addr)
 }
 
-// PutAddrCodeHash records the addr → codeHash mapping in the addr-keyed
-// LRU above SD. Callers that have just decoded an account record should
-// call this so subsequent lookups skip the account-domain read. A live
-// mapping is kept; an unwind-stale mapping is replaced.
+// PutAddrCodeHash records a committed-state addr → codeHash mapping in the
+// addr-keyed LRU. An existing live mapping remains authoritative until
+// DeleteAddrCodeHash invalidates it; an unwind-stale mapping can be replaced.
 func (c *StateCache) PutAddrCodeHash(addr []byte, h [32]byte, txNum uint64) {
 	cc, ok := c.caches[kv.CodeDomain].(*CodeCache)
 	if !ok {
@@ -214,9 +212,7 @@ func (c *StateCache) PutAddrCodeHash(addr []byte, h [32]byte, txNum uint64) {
 	cc.PutAddrCodeHash(addr, h, txNum)
 }
 
-// DeleteAddrCodeHash drops the addr → codeHash mapping. Used by
-// invalidation paths (SELFDESTRUCT / CREATE2-replace / unwind diffsets)
-// where the account's codeHash has been mutated.
+// DeleteAddrCodeHash removes the mapping when its account record is invalidated.
 func (c *StateCache) DeleteAddrCodeHash(addr []byte) {
 	cc, ok := c.caches[kv.CodeDomain].(*CodeCache)
 	if !ok {

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -49,8 +49,8 @@ func isCommitmentStateKey(prefix []byte) bool {
 // BranchCache stores commitment-trie branch data: a bounded LRU tail plus a
 // never-evicted root slot, aggregator-scope and passive (the trie drives all
 // reads/writes). Concurrent Get/Put/Invalidate are mechanically safe, but the
-// writer stripes only coordinate writes with Clear — callers must still ensure
-// a single mutation per prefix at the orchestrator.
+// writer stripes only make stamped publications atomic with Clear; callers must
+// still ensure one logical mutation per prefix at the orchestrator.
 type BranchCache struct {
 	// Root tier — single slot for the root branch (always hottest, always
 	// present). Atomic-pointer access so no lock is needed for the hot
@@ -118,7 +118,7 @@ type BranchCache struct {
 	lastPublishedPinnedHits   atomic.Uint64
 	lastPublishedPinnedMisses atomic.Uint64
 
-	// putStripes keep epoch sampling and publication on one side of Clear while
+	// putStripes make epoch sampling and publication atomic with Clear while
 	// preserving parallel writes to unrelated prefixes.
 	putStripes [256]sync.Mutex
 
@@ -747,16 +747,17 @@ func (c *BranchCache) Invalidate(prefix []byte) {
 // txN the chain is rewound to. O(1) and scan-free: bump the epoch (so entries
 // written in the new, live epoch stay valid) and lower the unwind floor to
 // unwindToTxN (so old-epoch entries at or above it are dropped lazily on their
-// next Get). The floor only ever decreases, so a shallow unwind cannot
-// resurrect entries a deeper one invalidated. Mirrors GenericCache.Unwind so
-// branch and state caches honor one (txN, epoch) model.
+// next Get). Within the current cache generation, the floor only decreases, so
+// a shallow unwind cannot resurrect entries a deeper one invalidated. Mirrors
+// GenericCache.Unwind so branch and state caches honor one (txN, epoch) model.
 func (c *BranchCache) Unwind(unwindToTxN uint64) {
 	c.coh.Unwind(unwindToTxN)
 }
 
 // Clear empties the root, trunk, pinned, and tail tiers, resets their stats, and
-// starts a new coherence generation. Coherence is reset only after every tier's
-// clear operation completes, so snapshot-before-lookup readers cannot pair a
+// starts a new coherence generation. It holds every writer stripe until all
+// tiers are empty and coherence is reset, so a publication cannot cross
+// generations. Reset follows every tier clear, so a reader cannot pair a
 // retired entry with the lifted unwind floor.
 func (c *BranchCache) Clear() {
 	c.lockAllPutStripes()

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -642,6 +642,7 @@ func (c *BranchCache) Get(prefix []byte) ([]byte, uint64, bool) {
 	if isCommitmentStateKey(prefix) {
 		return nil, 0, false
 	}
+	coh := c.coh.Snapshot()
 	entry, ok := c.lookup(prefix)
 	if !ok {
 		return nil, 0, false
@@ -651,7 +652,7 @@ func (c *BranchCache) Get(prefix []byte) ([]byte, uint64, bool) {
 	// the read falls through to the reverted domain and repopulates. The floor
 	// is the first unwound txN (>= matches GenericCache: an entry stamped exactly
 	// at the floor belongs to a rolled-back block).
-	if c.coh.IsStale(entry.txN, entry.epoch) {
+	if coh.IsStale(entry.txN, entry.epoch) {
 		c.Invalidate(prefix)
 		c.staleEvicted.Add(1)
 		return nil, 0, false
@@ -716,10 +717,7 @@ func (c *BranchCache) Unwind(unwindToTxN uint64) {
 	c.coh.Unwind(unwindToTxN)
 }
 
-// Clear empties the cache and resets stats counters across ALL tiers
-// (root slot, LRU tail). Use on Reset / fork-validation paths to
-// ensure stale entries from one trie root are not served against a
-// different root.
+// Clear empties every tier, resets stats, and starts a new coherence generation.
 func (c *BranchCache) Clear() {
 	c.root.Store(nil)
 	c.clearTrunk()
@@ -742,7 +740,7 @@ func (c *BranchCache) Clear() {
 	c.tailMisses.Store(0)
 	c.bytesServed.Store(0)
 	c.staleEvicted.Store(0)
-	c.coh.Init()
+	c.coh.Reset()
 }
 
 // Stats returns a one-line summary of the cache tiers' hit/miss counters plus

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -19,7 +19,6 @@ package commitment
 import (
 	"bytes"
 	"fmt"
-	"math/bits"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -320,7 +319,7 @@ func (c *BranchCache) putStripe(prefix []byte) *sync.Mutex {
 	if len(prefix) > 1 {
 		stripe ^= prefix[0]
 	}
-	return &c.putStripes[bits.RotateLeft8(stripe, 3)]
+	return &c.putStripes[stripe]
 }
 
 func (c *BranchCache) lockAllPutStripes() {

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -119,7 +119,9 @@ type BranchCache struct {
 
 	// coh is the (epoch, floor) unwind-coherence primitive shared with the state
 	// and code caches: an entry is valid iff written in the current epoch OR its
-	// txN is below the unwind floor. See execution/cache/coherence.
+	// txN is below the unwind floor. Serving reads snapshot coherence before
+	// lookup, while Clear empties every tier before Reset; together those
+	// orderings keep the lifted floor from revalidating a retired entry.
 	coh coherence.Gen
 }
 
@@ -642,6 +644,8 @@ func (c *BranchCache) Get(prefix []byte) ([]byte, uint64, bool) {
 	if isCommitmentStateKey(prefix) {
 		return nil, 0, false
 	}
+	// Snapshot before lookup so an entry captured while Clear empties the tiers
+	// retains the pre-Clear unwind floor used to judge it.
 	coh := c.coh.Snapshot()
 	entry, ok := c.lookup(prefix)
 	if !ok {
@@ -717,7 +721,10 @@ func (c *BranchCache) Unwind(unwindToTxN uint64) {
 	c.coh.Unwind(unwindToTxN)
 }
 
-// Clear empties every tier, resets stats, and starts a new coherence generation.
+// Clear empties the root, trunk, pinned, and tail tiers, resets their stats, and
+// starts a new coherence generation. Coherence is reset only after every tier
+// is empty, so snapshot-before-lookup readers cannot pair a retired entry with
+// the lifted unwind floor.
 func (c *BranchCache) Clear() {
 	c.root.Store(nil)
 	c.clearTrunk()

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -348,9 +348,6 @@ func NewBranchCache(tailCapacity int) *BranchCache {
 		accountTrunk:  newAccountTrunk(maxDepth),
 		trunkDisabled: os.Getenv("BRANCH_CACHE_TRUNK_DISABLE") != "",
 	}
-	// Before any unwind every entry's txN is at/below the floor, so the epoch
-	// check never strands a valid entry.
-	bc.coh.Init()
 	log.Debug("[branch-cache] init", "trunkEnabled", !bc.trunkDisabled, "tailCap", tailCapacity, "trunkDepth", maxDepth)
 	return bc
 }

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -120,8 +120,9 @@ type BranchCache struct {
 	// coh is the (epoch, floor) unwind-coherence primitive shared with the state
 	// and code caches: an entry is valid iff written in the current epoch OR its
 	// txN is below the unwind floor. Serving reads snapshot coherence before
-	// lookup, while Clear empties every tier before Reset; together those
-	// orderings keep the lifted floor from revalidating a retired entry.
+	// lookup, while Clear completes every tier's clear operation before Reset;
+	// together those orderings keep the lifted floor from revalidating a retired
+	// entry.
 	coh coherence.Gen
 }
 
@@ -722,9 +723,9 @@ func (c *BranchCache) Unwind(unwindToTxN uint64) {
 }
 
 // Clear empties the root, trunk, pinned, and tail tiers, resets their stats, and
-// starts a new coherence generation. Coherence is reset only after every tier
-// is empty, so snapshot-before-lookup readers cannot pair a retired entry with
-// the lifted unwind floor.
+// starts a new coherence generation. Coherence is reset only after every tier's
+// clear operation completes, so snapshot-before-lookup readers cannot pair a
+// retired entry with the lifted unwind floor.
 func (c *BranchCache) Clear() {
 	c.root.Store(nil)
 	c.clearTrunk()

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -19,6 +19,7 @@ package commitment
 import (
 	"bytes"
 	"fmt"
+	"math/bits"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -48,8 +49,8 @@ func isCommitmentStateKey(prefix []byte) bool {
 // BranchCache stores commitment-trie branch data: a bounded LRU tail plus a
 // never-evicted root slot, aggregator-scope and passive (the trie drives all
 // reads/writes). Concurrent Get/Put/Invalidate are mechanically safe, but the
-// cache does not coordinate writers — callers must ensure a single writer per
-// prefix, coordinated at the orchestrator, not by locking the cache.
+// writer stripes only coordinate writes with Clear — callers must still ensure
+// a single mutation per prefix at the orchestrator.
 type BranchCache struct {
 	// Root tier — single slot for the root branch (always hottest, always
 	// present). Atomic-pointer access so no lock is needed for the hot
@@ -117,12 +118,13 @@ type BranchCache struct {
 	lastPublishedPinnedHits   atomic.Uint64
 	lastPublishedPinnedMisses atomic.Uint64
 
+	// putStripes keep epoch sampling and publication on one side of Clear while
+	// preserving parallel writes to unrelated prefixes.
+	putStripes [256]sync.Mutex
+
 	// coh is the (epoch, floor) unwind-coherence primitive shared with the state
 	// and code caches: an entry is valid iff written in the current epoch OR its
-	// txN is below the unwind floor. Serving reads snapshot coherence before
-	// lookup, while Clear completes every tier's clear operation before Reset;
-	// together those orderings keep the lifted floor from revalidating a retired
-	// entry.
+	// txN is below the unwind floor.
 	coh coherence.Gen
 }
 
@@ -309,6 +311,29 @@ type AdaptivePinControllerProvider interface {
 // branchCacheTailShards splits the LRU tail into independently-locked shards so
 // concurrent commitment mounts / warmup workers don't serialize on one mutex.
 const branchCacheTailShards = 256
+
+func (c *BranchCache) putStripe(prefix []byte) *sync.Mutex {
+	if len(prefix) == 0 {
+		return &c.putStripes[0]
+	}
+	stripe := prefix[len(prefix)-1]
+	if len(prefix) > 1 {
+		stripe ^= prefix[0]
+	}
+	return &c.putStripes[bits.RotateLeft8(stripe, 3)]
+}
+
+func (c *BranchCache) lockAllPutStripes() {
+	for i := range c.putStripes {
+		c.putStripes[i].Lock()
+	}
+}
+
+func (c *BranchCache) unlockAllPutStripes() {
+	for i := len(c.putStripes) - 1; i >= 0; i-- {
+		c.putStripes[i].Unlock()
+	}
+}
 
 // NewBranchCache constructs a BranchCache with the given LRU tail capacity.
 // Capacity <= 0 panics — pass a positive value or DefaultBranchCacheTailCapacity.
@@ -614,6 +639,11 @@ func (c *BranchCache) PinEntry(prefix []byte, data []byte, step, txN uint64) {
 	}
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
+
+	stripe := c.putStripe(prefix)
+	stripe.Lock()
+	defer stripe.Unlock()
+
 	entry := &branchCacheEntry{data: dataCopy, step: step, txN: txN, epoch: c.coh.Epoch()}
 	st, _, stor, ok := c.storageRoute(prefix, true)
 	if !ok {
@@ -675,6 +705,11 @@ func (c *BranchCache) Put(prefix []byte, data []byte, step, txN uint64) {
 	}
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
+
+	stripe := c.putStripe(prefix)
+	stripe.Lock()
+	defer stripe.Unlock()
+
 	c.store(prefix, &branchCacheEntry{
 		data:  dataCopy,
 		step:  step,
@@ -727,6 +762,9 @@ func (c *BranchCache) Unwind(unwindToTxN uint64) {
 // clear operation completes, so snapshot-before-lookup readers cannot pair a
 // retired entry with the lifted unwind floor.
 func (c *BranchCache) Clear() {
+	c.lockAllPutStripes()
+	defer c.unlockAllPutStripes()
+
 	c.root.Store(nil)
 	c.clearTrunk()
 	c.pinned.Store(nil)

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -756,7 +756,7 @@ func (c *BranchCache) Unwind(unwindToTxN uint64) {
 // Clear empties the root, trunk, pinned, and tail tiers, resets their stats, and
 // starts a new coherence generation. It holds every writer stripe until all
 // tiers are empty and coherence is reset, so a publication cannot cross
-// generations. Reset follows every tier clear, so a reader cannot pair a
+// generations. Reset runs after every tier is cleared, so a reader cannot pair a
 // retired entry with the lifted unwind floor.
 func (c *BranchCache) Clear() {
 	c.lockAllPutStripes()

--- a/execution/commitment/branch_cache_test.go
+++ b/execution/commitment/branch_cache_test.go
@@ -185,6 +185,8 @@ func TestBranchCache_ClearRacingPut_EpochAlias(t *testing.T) {
 }
 
 func clearDuringBlockedBranchCacheWrite(c *BranchCache, block *sync.Mutex, write func()) {
+	// Limit Go execution to one logical processor. Each runtime.Gosched call
+	// yields to the queued goroutine, which runs until it reaches the blocked lock.
 	previousProcs := runtime.GOMAXPROCS(1)
 	defer runtime.GOMAXPROCS(previousProcs)
 

--- a/execution/commitment/branch_cache_test.go
+++ b/execution/commitment/branch_cache_test.go
@@ -174,6 +174,8 @@ func TestBranchCache_ClearRacingPut_EpochAlias(t *testing.T) {
 	key := []byte{0x00}
 	preClearEpoch := c.coh.Epoch()
 	c.Clear()
+	// Model a writer that sampled the epoch before Clear and published after
+	// its target tier was emptied.
 	c.store(key, &branchCacheEntry{data: []byte("dead-fork-branch"), txN: 200, epoch: preClearEpoch})
 	c.Unwind(150)
 

--- a/execution/commitment/branch_cache_test.go
+++ b/execution/commitment/branch_cache_test.go
@@ -166,6 +166,21 @@ func TestBranchCache_Clear(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestBranchCache_ClearRacingPut_EpochAlias(t *testing.T) {
+	c := NewBranchCache(100)
+	defer c.Close()
+	c.Unwind(300)
+
+	key := []byte{0x00}
+	preClearEpoch := c.coh.Epoch()
+	c.Clear()
+	c.store(key, &branchCacheEntry{data: []byte("dead-fork-branch"), txN: 200, epoch: preClearEpoch})
+	c.Unwind(150)
+
+	_, _, ok := c.Get(key)
+	require.False(t, ok, "pre-Clear epoch must not alias the live epoch after a later unwind")
+}
+
 // TestBranchCache_Stats verifies the format of the stats string is
 // deterministic and contains the expected per-tier counts.
 func TestBranchCache_Stats(t *testing.T) {

--- a/execution/commitment/branch_cache_test.go
+++ b/execution/commitment/branch_cache_test.go
@@ -17,6 +17,7 @@
 package commitment
 
 import (
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -181,6 +182,62 @@ func TestBranchCache_ClearRacingPut_EpochAlias(t *testing.T) {
 
 	_, _, ok := c.Get(key)
 	require.False(t, ok, "pre-Clear epoch must not alias the live epoch after a later unwind")
+}
+
+func clearDuringBlockedBranchCacheWrite(c *BranchCache, block *sync.Mutex, write func()) {
+	previousProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previousProcs)
+
+	block.Lock()
+	writerStarted := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		close(writerStarted)
+		write()
+		close(writerDone)
+	}()
+	<-writerStarted
+	runtime.Gosched()
+
+	clearDone := make(chan struct{})
+	go func() {
+		c.Clear()
+		close(clearDone)
+	}()
+	runtime.Gosched()
+
+	block.Unlock()
+	<-writerDone
+	<-clearDone
+}
+
+func TestBranchCache_ClearFencesStartedPut(t *testing.T) {
+	c := NewBranchCache(100)
+	defer c.Close()
+	c.Unwind(300)
+
+	key := []byte{0x12, 0x34, 0x56}
+	clearDuringBlockedBranchCacheWrite(c, &c.tailMu, func() {
+		c.Put(key, []byte("dead-fork-branch"), 0, 200)
+	})
+
+	_, _, ok := c.Get(key)
+	require.False(t, ok, "Clear must remove a Put that started in the retiring generation")
+}
+
+func TestBranchCache_ClearFencesStartedPinEntry(t *testing.T) {
+	c := NewBranchCache(100)
+	defer c.Close()
+	c.Unwind(300)
+
+	key := make([]byte, 33)
+	key[32] = 1
+	clearDuringBlockedBranchCacheWrite(c, &c.pinnedMu, func() {
+		c.PinEntry(key, []byte("dead-fork-branch"), 0, 200)
+	})
+
+	_, _, ok := c.Get(key)
+	require.False(t, ok, "Clear must remove a PinEntry that started in the retiring generation")
 }
 
 // TestBranchCache_Stats verifies the format of the stats string is


### PR DESCRIPTION
Closes #22474.

## Summary

- `coherence.Gen` has a ready-to-use zero value and a CAS-based `Reset` that advances the epoch and lifts the unwind floor
- `GenericCache`, `CodeCache`, and `BranchCache` snapshot coherence before stale-checked storage reads and reset coherence only after clearing storage
- `CodeCache` and `BranchCache` fence epoch-stamped writers with striped locks while `Clear` purges every tier and resets coherence
- address → codeHash population keeps an existing live mapping and replaces an unwind-stale mapping
- regression tests cover epoch aliasing, read-side revalidation, writer exclusion, and concurrent reset/unwind operations

## Correctness

`Clear` now linearizes cache storage with its coherence generation:

- writers sample the epoch and publish while holding the required put stripes; `Clear` holds every stripe from the first purge through `Reset`, so a publication cannot cross generations
- readers snapshot coherence before loading storage; because `Reset` runs after all purges, an entry captured from retiring storage is judged with the pre-Clear unwind floor and remains stale
- `Reset` advances the epoch in one CAS, preventing epoch reuse and preserving the ordering of concurrent reset and unwind operations

The coherence check adds one atomic snapshot and no new read-side mutex. Writers acquire one or two of 256 put stripes; the rare `Clear` path acquires all stripes.

## Testing

- `go test ./execution/cache/... ./execution/commitment -count=1`
- `go test -race ./execution/cache/... ./execution/commitment -count=1`
- focused Clear/coherence regressions with `-count=100`
- `make test-short`
- `make lint` (repeated clean runs)
- `make erigon integration`
