### PR TITLE
cl/phase1/execution_client: persist BAL in ExecutionClientDirect.NewPayload

### DIFF
--- a/cl/phase1/execution_client/execution_client_direct.go
+++ b/cl/phase1/execution_client/execution_client_direct.go
@@ -82,8 +82,13 @@ func (cc *ExecutionClientDirect) NewPayload(
 		return PayloadStatusInvalidated, err
 	}
 
+	var bal []byte
+	if payload.Version() >= clparams.GloasVersion && payload.BlockAccessList != nil {
+		bal = payload.BlockAccessList.Bytes()
+	}
+
 	startInsertBlock := time.Now()
-	if err := cc.chainRW.InsertBlock(ctx, types.NewBlockFromStorageWithBinaryTxs(payload.BlockHash, header, txs, body.Transactions, nil, body.Withdrawals), nil); err != nil {
+	if err := cc.chainRW.InsertBlock(ctx, types.NewBlockFromStorageWithBinaryTxs(payload.BlockHash, header, txs, body.Transactions, nil, body.Withdrawals), bal); err != nil {
 		if errors.Is(err, types.ErrBlockExceedsMaxRlpSize) {
 			return PayloadStatusInvalidated, err
 		}


### PR DESCRIPTION
## What

`ExecutionClientDirect.NewPayload` (the integrated, single-process CL→EL path used by an embedded-Caplin node) built the block and called `InsertBlock` with a `nil` block access list, dropping the gloas payload's `BlockAccessList` even though it is populated on the `Eth1Block`. This threads it through instead.

## Why

`ExecutionClientEngine.NewPayload` (the external-EL-over-RPC path) already forwards the BAL (`request.BlockAccessList = payload.BlockAccessList.Bytes()`), but the direct path did not — so on an embedded-Caplin node `kv.BlockAccessList` was **never written**. Anything keyed off that table is silently degraded, most visibly the BAL-driven read-ahead warmuper (`execution/exec/blocks_read_ahead.go`): `warmBody` reads the block's BAL from `kv.BlockAccessList` and, finding it empty, always falls back to TX-decode warming. In practice the BAL warm path never runs on the integrated path.

## Change

In `ExecutionClientDirect.NewPayload`, for gloas payloads pass `payload.BlockAccessList.Bytes()` as the `bal` argument to `InsertBlock` (was `nil`). The bytes flow through `blocksToRaw` → `RawBlock.BlockAccessList` and are persisted by the existing insert path; `RlpHeader` already sets `header.BlockAccessListHash` for gloas so the insert guard is satisfied. This makes the integrated path match the engine path.

## Testing

`chainRW` (`ChainReaderWriterEth1`) is a concrete struct, not an interface, so a direct-path unit test would require introducing a mock seam. The BAL-extraction logic is identical to `ExecutionClientEngine`'s request builder, which is unit-tested (`TestBuildExecutionPayload_BlockAccessListGloasOnly`), and the persistence path is exercised by the execmodule insert tests. Builds and `make lint` clean for the changed file.
