### PR TITLE
db/snapshotsync: publish caplin visible files as one atomic generation

### DIFF
--- a/db/snapshotsync/caplin_state_generation_test.go
+++ b/db/snapshotsync/caplin_state_generation_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package snapshotsync
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+)
+
+// A View reports the generation it pinned, not whatever is current. Serving the live
+// set instead would hand back segments whose files the View's RoTxs never pinned, so
+// a concurrent recalc could unlink them under the reader.
+func TestCaplinStateViewServesPinnedGeneration(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.BlockRoot
+
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 100_000, logger)
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+
+	view := s.View()
+	defer view.Close()
+	require.Len(t, view.VisibleSegments(table), 1)
+
+	// Publish a second generation while the view is alive.
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 200_000, logger)
+	require.NoError(t, s.OpenFolder())
+	require.Len(t, s.visible.Load().segments[table], 2, "recalc must publish the new generation")
+
+	require.Len(t, view.VisibleSegments(table), 1, "view must keep serving the generation it pinned")
+	_, served := view.VisibleSegment(150_000, table)
+	require.False(t, served, "a slot only in the newer generation must not be served by an older view")
+}
+
+// idxMax must travel with the generation it was computed from: a reader that observes
+// the new segment set must never pair it with the previous set's height.
+func TestCaplinStateIdxMaxMatchesItsGeneration(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.BlockRoot
+
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 100_000, logger)
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.Equal(t, uint64(100_000), s.IndicesMax())
+
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 200_000, logger)
+	require.NoError(t, s.OpenFolder())
+
+	v := s.visible.Load()
+	require.Equal(t, uint64(200_000), v.idxMax)
+	require.Equal(t, caplinStateIdxAvailability(v.segments), v.idxMax)
+}
+
+// Readers run lock-free against recalc, so every read path must go through one
+// pointer load. Under -race this fails on any unguarded field read.
+func TestCaplinStateConcurrentRecalcAndReaders(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.BlockRoot
+
+	writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 100_000, logger)
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+
+	const rounds = 200
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for range rounds {
+			s.recalcVisibleFiles()
+		}
+	})
+	wg.Go(func() {
+		for range rounds {
+			view := s.View()
+			require.Len(t, view.VisibleSegments(table), 1)
+			view.Close()
+		}
+	})
+	wg.Go(func() {
+		for range rounds {
+			require.Equal(t, uint64(100_000), s.IndicesMax())
+			require.NotEmpty(t, s.coveredRangesForType(table))
+			s.BlocksAvailable()
+		}
+	})
+	wg.Wait()
+}

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -148,29 +148,29 @@ type CaplinStateSnapshots struct {
 
 	Salt uint32
 
-	dirtySegmentsLock   sync.RWMutex
-	visibleSegmentsLock sync.RWMutex
+	dirtySegmentsLock sync.RWMutex                            // guards `dirty` field
+	dirty             map[string]*btree.BTreeG[*DirtySegment] // ordered map `type name` -> DirtySegments
 
-	// BeaconBlocks *segments
-	// BlobSidecars *segments
-	// Segments      map[string]*segments
-	dirtyLock sync.RWMutex                            // guards `dirty` field
-	dirty     map[string]*btree.BTreeG[*DirtySegment] // ordered map `type.Enum()` -> DirtySegments
-
-	visibleLock sync.RWMutex // guards  `visible` field
-	visible     sync.Map
-	//visible     map[string]VisibleSegments // ordered map `type.Enum()` -> VisbileSegments
+	visible atomic.Pointer[caplinStateVisible]
 
 	snapshotTypes SnapshotTypes
 
 	dir         string
 	tmpdir      string
 	segmentsMax atomic.Uint64 // all types of .seg files are available - up to this number
-	idxMax      atomic.Uint64 // all types of .idx files are available - up to this number
 	cfg         ethconfig.BlocksFreezing
 	logger      log.Logger
 	// chain cfg
 	beaconCfg *clparams.BeaconChainConfig
+}
+
+// caplinStateVisible is one immutable generation of visible files plus the heights
+// derived from it, published as a single pointer so a reader can never mix segments
+// from two generations or pair them with another generation's idxMax. The map is
+// never mutated after Store.
+type caplinStateVisible struct {
+	segments map[string]VisibleSegments // ordered map `type name` -> VisibleSegments
+	idxMax   uint64                     // all types of .idx files are available - up to this number
 }
 
 type KeyValueGetter func(numId uint64) ([]byte, []byte, error)
@@ -208,14 +208,16 @@ func NewCaplinStateSnapshots(cfg ethconfig.BlocksFreezing, beaconCfg *clparams.B
 	}
 
 	c := &CaplinStateSnapshots{snapshotTypes: snapshotTypes, dir: dirs.SnapCaplin, tmpdir: dirs.Tmp, cfg: cfg, dirty: dirty, logger: logger, beaconCfg: beaconCfg}
+	empty := &caplinStateVisible{segments: make(map[string]VisibleSegments, len(snapshotTypes.KeyValueGetters))}
 	for k := range snapshotTypes.KeyValueGetters {
-		c.visible.Store(k, make(VisibleSegments, 0))
+		empty.segments[k] = make(VisibleSegments, 0)
 	}
+	c.visible.Store(empty)
 	c.recalcVisibleFiles()
 	return c
 }
 
-func (s *CaplinStateSnapshots) IndicesMax() uint64  { return s.idxMax.Load() }
+func (s *CaplinStateSnapshots) IndicesMax() uint64  { return s.visible.Load().idxMax }
 func (s *CaplinStateSnapshots) SegmentsMax() uint64 { return s.segmentsMax.Load() }
 
 func (s *CaplinStateSnapshots) LogStat(str string) {
@@ -265,7 +267,7 @@ func (s *CaplinStateSnapshots) SegFileNames(from, to uint64) []string {
 }
 
 func (s *CaplinStateSnapshots) BlocksAvailable() uint64 {
-	return min(s.segmentsMax.Load(), s.idxMax.Load())
+	return min(s.segmentsMax.Load(), s.visible.Load().idxMax)
 }
 
 func (s *CaplinStateSnapshots) TypeNames() []string {
@@ -278,14 +280,7 @@ func (s *CaplinStateSnapshots) TypeNames() []string {
 }
 
 func (s *CaplinStateSnapshots) coveredRangesForType(name string) []Range {
-	s.visibleLock.RLock()
-	defer s.visibleLock.RUnlock()
-
-	v, ok := s.visible.Load(name)
-	if !ok {
-		return nil
-	}
-	segs, ok := v.(VisibleSegments)
+	segs, ok := s.visible.Load().segments[name]
 	if !ok {
 		return nil
 	}
@@ -319,7 +314,6 @@ func (s *CaplinStateSnapshots) Close() {
 	}
 	s.dirtySegmentsLock.Lock()
 	defer s.dirtySegmentsLock.Unlock()
-
 	s.closeWhatNotInList(nil)
 }
 
@@ -450,14 +444,10 @@ func isIndexed(s *DirtySegment) bool {
 	return true
 }
 
+// recalcVisibleFiles publishes a fresh generation; only new readers see it, alive
+// readers keep the previous one.
 func (s *CaplinStateSnapshots) recalcVisibleFiles() {
-	defer func() {
-		s.idxMax.Store(s.idxAvailability())
-		s.indicesReady.Store(true)
-	}()
-
-	s.visibleLock.Lock()
-	defer s.visibleLock.Unlock()
+	defer s.indicesReady.Store(true)
 
 	getNewVisibleSegments := func(dirtySegments *btree.BTreeG[*DirtySegment]) VisibleSegments {
 		newVisibleSegments := make(VisibleSegments, 0, dirtySegments.Len())
@@ -487,13 +477,14 @@ func (s *CaplinStateSnapshots) recalcVisibleFiles() {
 		return newVisibleSegments
 	}
 
-	// for k := range s.visible {
-	// 	s.visible[k] = getNewVisibleSegments(s.dirty[k])
-	// }
-	s.visible.Range(func(k, v any) bool {
-		s.visible.Store(k, getNewVisibleSegments(s.dirty[k.(string)]))
-		return true
-	})
+	s.dirtySegmentsLock.RLock()
+	segments := make(map[string]VisibleSegments, len(s.dirty))
+	for k, dirtySegments := range s.dirty {
+		segments[k] = getNewVisibleSegments(dirtySegments)
+	}
+	s.dirtySegmentsLock.RUnlock()
+
+	s.visible.Store(&caplinStateVisible{segments: segments, idxMax: caplinStateIdxAvailability(segments)})
 }
 
 // RemoveOverlaps deletes state segment files that are fully covered by a larger
@@ -548,34 +539,22 @@ func (s *CaplinStateSnapshots) RemoveOverlaps() error {
 	return nil
 }
 
-func (s *CaplinStateSnapshots) idxAvailability() uint64 {
-	s.visibleLock.RLock()
-	defer s.visibleLock.RUnlock()
-
-	min := uint64(math.MaxUint64)
-	// for _, segs := range s.visible {
-	// 	if len(segs) == 0 {
-	// 		return 0
-	// 	}
-	// 	if segs[len(segs)-1].to < min {
-	// 		min = segs[len(segs)-1].to
-	// 	}
-	// }
-	s.visible.Range(func(_, v any) bool {
-		segs := v.(VisibleSegments)
+// caplinStateIdxAvailability is the height every type has indexed files up to, so a
+// single un-indexed type holds the whole set back.
+func caplinStateIdxAvailability(segments map[string]VisibleSegments) uint64 {
+	minTo := uint64(math.MaxUint64)
+	for _, segs := range segments {
 		if len(segs) == 0 {
-			min = 0
-			return false
+			return 0
 		}
-		if segs[len(segs)-1].to < min {
-			min = segs[len(segs)-1].to
+		if segs[len(segs)-1].to < minTo {
+			minTo = segs[len(segs)-1].to
 		}
-		return true
-	})
-	if min == math.MaxUint64 {
+	}
+	if minTo == math.MaxUint64 {
 		return 0
 	}
-	return min
+	return minTo
 }
 
 func listAllSegFilesInDir(dir string) []string {
@@ -627,21 +606,16 @@ func (s *CaplinStateSnapshots) View() *CaplinStateView {
 	if s == nil {
 		return nil
 	}
-	s.visibleSegmentsLock.RLock()
-	defer s.visibleSegmentsLock.RUnlock()
+	segments := s.visible.Load().segments
 
-	v := &CaplinStateView{s: s, roTxs: make(map[string]*RoTx)}
+	v := &CaplinStateView{s: s, roTxs: make(map[string]*RoTx, len(segments))}
 	// BeginRo increments refcount - which is contended
 	s.dirtySegmentsLock.RLock()
 	defer s.dirtySegmentsLock.RUnlock()
 
-	// for k, segments := range s.visible {
-	// 	v.roTxs[k] = segments.BeginRo()
-	// }
-	s.visible.Range(func(k, val any) bool {
-		v.roTxs[k.(string)] = val.(VisibleSegments).BeginRo()
-		return true
-	})
+	for k, segs := range segments {
+		v.roTxs[k] = segs.BeginRo()
+	}
 	return v
 }
 
@@ -659,16 +633,14 @@ func (v *CaplinStateView) Close() {
 	v.closed = true
 }
 
+// VisibleSegments returns the segments this view pinned, not the live generation, so
+// a recalc mid-view cannot hand back files the view's RoTxs do not hold open.
 func (v *CaplinStateView) VisibleSegments(tbl string) VisibleSegments {
-	// if v.s == nil || v.s.visible[tbl] == nil {
-	// 	return nil
-	// }
-	// return v.s.visible[tbl]
-	if v.s == nil {
+	if v == nil || v.closed {
 		return nil
 	}
-	if val, ok := v.s.visible.Load(tbl); ok {
-		return val.(VisibleSegments)
+	if roTx, ok := v.roTxs[tbl]; ok {
+		return roTx.Segments
 	}
 	return nil
 }

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -62,17 +62,23 @@ type CaplinSnapshots struct {
 	dirtyLock sync.RWMutex            // guards `dirty` field
 	dirty     snapshotsync.DirtyFiles // ordered map `type.Enum()` -> DirtySegments
 
-	visibleLock sync.RWMutex                   // guards  `visible` field
-	visible     []snapshotsync.VisibleSegments // ordered map `type.Enum()` -> VisbileSegments
+	visible atomic.Pointer[caplinVisible]
 
 	dir         string
 	tmpdir      string
 	segmentsMax atomic.Uint64 // all types of .seg files are available - up to this number
-	idxMax      atomic.Uint64 // all types of .idx files are available - up to this number
 	cfg         ethconfig.BlocksFreezing
 	logger      log.Logger
 	// chain cfg
 	beaconCfg *clparams.BeaconChainConfig
+}
+
+// caplinVisible is one immutable generation of visible files plus the heights
+// derived from it, published as a single pointer so a reader can never mix
+// segments from two generations or pair them with another generation's idxMax.
+type caplinVisible struct {
+	segments []snapshotsync.VisibleSegments // ordered map `type.Enum()` -> VisibleSegments
+	idxMax   uint64                         // all types of .idx files are available - up to this number
 }
 
 // NewCaplinSnapshots - opens all snapshots. But to simplify everything:
@@ -85,16 +91,16 @@ func NewCaplinSnapshots(cfg ethconfig.BlocksFreezing, beaconCfg *clparams.Beacon
 		log.Debug("[dbg] NewCaplinSnapshots created with empty ChainName", "stack", dbg.Stack())
 	}
 	c := &CaplinSnapshots{dir: dirs.Snap, tmpdir: dirs.Tmp, cfg: cfg, logger: logger, beaconCfg: beaconCfg,
-		dirty:   make(snapshotsync.DirtyFiles, snaptype.MaxEnum),
-		visible: make([]snapshotsync.VisibleSegments, snaptype.MaxEnum),
+		dirty: make(snapshotsync.DirtyFiles, snaptype.MaxEnum),
 	}
+	c.visible.Store(&caplinVisible{segments: make([]snapshotsync.VisibleSegments, snaptype.MaxEnum)})
 	c.dirty[snaptype.BeaconBlocks.Enum()] = btree.NewBTreeGOptions[*snapshotsync.DirtySegment](snapshotsync.DirtySegmentLess, btree.Options{Degree: 128, NoLocks: false})
 	c.dirty[snaptype.BlobSidecars.Enum()] = btree.NewBTreeGOptions[*snapshotsync.DirtySegment](snapshotsync.DirtySegmentLess, btree.Options{Degree: 128, NoLocks: false})
 	c.recalcVisibleFiles()
 	return c
 }
 
-func (s *CaplinSnapshots) IndicesMax() uint64  { return s.idxMax.Load() }
+func (s *CaplinSnapshots) IndicesMax() uint64  { return s.visible.Load().idxMax }
 func (s *CaplinSnapshots) SegmentsMax() uint64 { return s.segmentsMax.Load() }
 
 func (s *CaplinSnapshots) LogStat(str string) {
@@ -146,7 +152,7 @@ func (s *CaplinSnapshots) SegFileNames(from, to uint64) []string {
 }
 
 func (s *CaplinSnapshots) BlocksAvailable() uint64 {
-	return min(s.segmentsMax.Load(), s.idxMax.Load())
+	return min(s.segmentsMax.Load(), s.visible.Load().idxMax)
 }
 
 func (s *CaplinSnapshots) Close() {
@@ -232,25 +238,24 @@ func (s *CaplinSnapshots) OpenList(fileNames []string, optimistic bool) error {
 	return nil
 }
 
+// recalcVisibleFiles publishes a fresh generation; only new readers see it, alive
+// readers keep the previous one.
 func (s *CaplinSnapshots) recalcVisibleFiles() {
-	defer func() {
-		s.idxMax.Store(s.idxAvailability())
-	}()
+	s.dirtyLock.RLock()
+	segments := make([]snapshotsync.VisibleSegments, snaptype.MaxEnum)
+	segments[snaptype.BeaconBlocks.Enum()] = snapshotsync.RecalcVisibleSegments(s.dirty[snaptype.BeaconBlocks.Enum()])
+	segments[snaptype.BlobSidecars.Enum()] = snapshotsync.RecalcVisibleSegments(s.dirty[snaptype.BlobSidecars.Enum()])
+	s.dirtyLock.RUnlock()
 
-	s.visibleLock.Lock()
-	defer s.visibleLock.Unlock()
-	s.visible = make([]snapshotsync.VisibleSegments, snaptype.MaxEnum) // create new pointer - only new readers will see it. old-alive readers will continue use previous pointer
-	s.visible[snaptype.BeaconBlocks.Enum()] = snapshotsync.RecalcVisibleSegments(s.dirty[snaptype.BeaconBlocks.Enum()])
-	s.visible[snaptype.BlobSidecars.Enum()] = snapshotsync.RecalcVisibleSegments(s.dirty[snaptype.BlobSidecars.Enum()])
+	s.visible.Store(&caplinVisible{segments: segments, idxMax: caplinIdxAvailability(segments)})
 }
 
-func (s *CaplinSnapshots) idxAvailability() uint64 {
-	s.visibleLock.RLock()
-	defer s.visibleLock.RUnlock()
-	if len(s.visible[snaptype.BeaconBlocks.Enum()]) == 0 {
+func caplinIdxAvailability(segments []snapshotsync.VisibleSegments) uint64 {
+	beaconBlocks := segments[snaptype.BeaconBlocks.Enum()]
+	if len(beaconBlocks) == 0 {
 		return 0
 	}
-	return s.visible[snaptype.BeaconBlocks.Enum()][len(s.visible[snaptype.BeaconBlocks.Enum()])-1].To()
+	return beaconBlocks[len(beaconBlocks)-1].To()
 }
 
 func (s *CaplinSnapshots) OpenFolder() error {
@@ -284,15 +289,14 @@ type CaplinView struct {
 }
 
 func (s *CaplinSnapshots) View() *CaplinView {
-	s.visibleLock.RLock()
-	defer s.visibleLock.RUnlock()
+	segments := s.visible.Load().segments
 
 	v := &CaplinView{s: s}
-	if s.visible[snaptype.BeaconBlocks.Enum()] != nil {
-		v.BeaconBlockRotx = s.visible[snaptype.BeaconBlocks.Enum()].BeginRo()
+	if segments[snaptype.BeaconBlocks.Enum()] != nil {
+		v.BeaconBlockRotx = segments[snaptype.BeaconBlocks.Enum()].BeginRo()
 	}
-	if s.visible[snaptype.BlobSidecars.Enum()] != nil {
-		v.BlobSidecarRotx = s.visible[snaptype.BlobSidecars.Enum()].BeginRo()
+	if segments[snaptype.BlobSidecars.Enum()] != nil {
+		v.BlobSidecarRotx = segments[snaptype.BlobSidecars.Enum()].BeginRo()
 	}
 	return v
 }
@@ -695,7 +699,7 @@ func (s *CaplinSnapshots) FrozenBlobs() uint64 {
 		return 0
 	}
 	ret := uint64(0)
-	for _, seg := range s.visible[snaptype.BlobSidecars.Enum()] {
+	for _, seg := range s.visible.Load().segments[snaptype.BlobSidecars.Enum()] {
 		ret = max(ret, seg.To())
 	}
 

--- a/db/snapshotsync/freezeblocks/caplin_snapshots_generation_test.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots_generation_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package freezeblocks
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/snaptype"
+	"github.com/erigontech/erigon/execution/chain/networkname"
+	"github.com/erigontech/erigon/node/ethconfig"
+)
+
+// Every read path must reach the visible set through one pointer load, so readers can
+// run lock-free against a concurrent recalc. Under -race this fails on any unguarded
+// field read — FrozenBlobs took none before the generation was published atomically.
+func TestCaplinSnapshotsConcurrentRecalcAndReaders(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+	// DenebForkEpoch must be set, else FrozenBlobs returns before touching the set.
+	beaconCfg := &clparams.BeaconChainConfig{DenebForkEpoch: 0}
+	s := NewCaplinSnapshots(ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}, beaconCfg, dirs, log.New())
+	defer s.Close()
+	require.NoError(t, s.OpenFolder())
+
+	const rounds = 200
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for range rounds {
+			s.recalcVisibleFiles()
+		}
+	})
+	wg.Go(func() {
+		for range rounds {
+			require.Zero(t, s.FrozenBlobs())
+			require.Zero(t, s.IndicesMax())
+			s.BlocksAvailable()
+		}
+	})
+	wg.Go(func() {
+		for range rounds {
+			view := s.View()
+			require.Empty(t, view.BeaconBlocks())
+			view.Close()
+		}
+	})
+	wg.Wait()
+}
+
+// idxMax must travel with the generation it was computed from, so a reader that sees
+// the new segment set never pairs it with the previous set's height.
+func TestCaplinSnapshotsIdxMaxMatchesItsGeneration(t *testing.T) {
+	dirs := datadir.New(t.TempDir())
+	s := NewCaplinSnapshots(ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}, &clparams.BeaconChainConfig{}, dirs, log.New())
+	defer s.Close()
+	require.NoError(t, s.OpenFolder())
+
+	v := s.visible.Load()
+	require.Len(t, v.segments, int(snaptype.MaxEnum))
+	require.Equal(t, caplinIdxAvailability(v.segments), v.idxMax)
+	require.Equal(t, v.idxMax, s.IndicesMax())
+}


### PR DESCRIPTION
Finishes the visible-files migration that `BaseRoSnapshots` already did (`visible atomic.Pointer[snapshotVisible]`, `db/snapshotsync/snapshots.go`) but which was never copied to the two caplin holders.

## What changes

`CaplinSnapshots` and `CaplinStateSnapshots` publish their visible files as one immutable generation behind `atomic.Pointer`, with `idxMax` folded in so a reader cannot pair one generation's segments with another generation's height. `visibleLock`, `visibleSegmentsLock`, the dead `dirtyLock` field, and the `sync.Map` + `any` type asserts go away.

Both `recalcVisibleFiles` already built a replacement set and swapped it wholesale — the old comment said *"create new pointer - only new readers will see it. old-alive readers will continue use previous pointer"*, which is `atomic.Pointer` semantics. A slice header and a `sync.Map` cannot deliver them, so the lock had to stay.

## Defects fixed

- **`CaplinSnapshots.FrozenBlobs` read `s.visible` with no lock at all**, racing `recalcVisibleFiles`. Reproduced with `-race` on the parent commit: `WARNING: DATA RACE` between `caplin_snapshots.go:242` (write) and `caplin_snapshots.go:698` (read).
- **`CaplinStateSnapshots.View` pinned under `visibleSegmentsLock` while `recalcVisibleFiles` wrote under `visibleLock`** — two different mutexes for one field, so they never excluded each other and a view could pin a mix of generations across types.
- **`CaplinStateView.VisibleSegments` served the live set**, not the set the view's `RoTxs` pinned, so a recalc mid-view handed back segments the view did not hold open. Now it returns `roTx.Segments`.

## Scope

Refcount-based reclamation (`acquireVisible`/`releaseVisible`/`retired`) is deliberately not ported — caplin has no retired-file reclamation to hang it off. `segmentsMax` stays a separate atomic in both types: it is derived from parsed file names in `OpenList`, not from the visible set.

`recalcVisibleFiles` now takes the dirty lock for read while it walks the dirty trees; it previously read them unguarded (it runs after `OpenList` releases the write lock, via defer ordering).

## Testing

- `go test ./db/snapshotsync/... -count=1`
- `go test -race ./db/snapshotsync/... -run 'TestCaplin' -count=5`
- `TestCaplinStateViewServesPinnedGeneration` verified red on the live-read semantics, green after
- `go test ./cl/antiquary/...`
- `make lint` clean on `./db/snapshotsync/...`
- `make erigon integration`

`cmd/utils/app` has two unrelated failures (`TestImportReorgUnwindToGenesis`, `TestImportClosesChaindataOnInitError`) that reproduce on the parent commit.
