### PR TITLE
db/seg: async io for domain kv files (experimental & off by default)

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -49,6 +49,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	libkzg "github.com/erigontech/erigon/common/crypto/kzg"
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/iouring"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/config3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -2036,6 +2037,14 @@ func SetEthConfig(nodeCtx context.Context, ctx *cli.Command, nodeConfig *nodecfg
 	if ctx.IsSet(ExecSerialFlag.Name) && ctx.Bool(ExecSerialFlag.Name) {
 		dbg.SetExec3Workers(1)
 		cfg.ExecWorkerCount = 1
+	}
+	// If FILES_ASYNC_IO is set but io_uring is unavailable (old kernel, or blocked
+	// by a seccomp sandbox such as Docker's default profile), disable the gate at
+	// startup so it doesn't pay the per-read residency-probe cost for warms that
+	// would never run. Warming is an optimization; reads just use ordinary faults.
+	if dbg.FilesAsyncIO && runtime.GOOS == "linux" && !iouring.Available() {
+		log.Warn("FILES_ASYNC_IO is set but io_uring is unavailable (unsupported kernel, or blocked by a seccomp sandbox such as Docker's default profile); disabling it — reads will use ordinary blocking faults")
+		dbg.FilesAsyncIO = false
 	}
 	if c := ctx.Int(DBReadConcurrencyFlag.Name); c > 0 {
 		if limit := httpcfg.RoTxsLimit(c, cfg.ExecWorkerCount); int64(c) < limit {

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -136,6 +136,14 @@ var (
 	DisableAdaptivePin   = EnvBool("DISABLE_ADAPTIVE_PIN", false)
 	AssertStateCache     = EnvBool("ASSERT_STATE_CACHE", false)
 	ReadAhead            = EnvBool("READ_AHEAD", true)
+	// FilesAsyncIO warms cold state .kv pages via io_uring before the mmap read, so
+	// a would-be blocking page fault becomes a non-blocking read that releases the
+	// goroutine's P. Linux + io_uring only; self-disables (reads use ordinary faults)
+	// if io_uring is unavailable. Not free when on: each gated .kv file runs a
+	// background goroutine that mincore-rescans it every RESIDENCY_REFRESH_SEC
+	// (default 120s) — a real page-table-walk cost across a full datadir. Experimental,
+	// off by default.
+	FilesAsyncIO = EnvBool("FILES_ASYNC_IO", false)
 
 	BorValidateHeaderTime = EnvBool("BOR_VALIDATE_HEADER_TIME", true)
 	TraceDeletion         = EnvBool("TRACE_DELETION", false)

--- a/common/iouring/iouring_linux.go
+++ b/common/iouring/iouring_linux.go
@@ -1,0 +1,215 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+// Package iouring is a minimal hand-rolled io_uring facility for file reads at a
+// controlled queue depth — enough to warm the page cache without blocking the
+// goroutine's P (io_uring_enter goes through the syscall path, so a slow read
+// hands the P off). Not a general async reactor: BatchReadWarm submits a batch
+// and waits for all of it.
+package iouring
+
+import (
+	"fmt"
+	"sync/atomic"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	opRead                 = 22 // IORING_OP_READ
+	enterGetevents         = 1  // IORING_ENTER_GETEVENTS
+	offSQRing      uintptr = 0
+	offCQRing      uintptr = 0x8000000
+	offSQEs        uintptr = 0x10000000
+
+	sqeSize = 64
+	cqeSize = 16
+)
+
+// io_uring_params layout (Linux). Only the fields we read are named precisely.
+type params struct {
+	sqEntries    uint32
+	cqEntries    uint32
+	flags        uint32
+	sqThreadCPU  uint32
+	sqThreadIdle uint32
+	features     uint32
+	wqFD         uint32
+	resv         [3]uint32
+	sqOff        sqringOffsets
+	cqOff        cqringOffsets
+}
+
+type sqringOffsets struct {
+	head, tail, ringMask, ringEntries, flags, dropped, array, resv1 uint32
+	resv2                                                           uint64
+}
+type cqringOffsets struct {
+	head, tail, ringMask, ringEntries, overflow, cqes, flags, resv1 uint32
+	resv2                                                           uint64
+}
+
+type Ring struct {
+	fd      int
+	entries uint32
+
+	sqRing []byte
+	cqRing []byte
+	sqes   []byte
+
+	// pointers into sqRing/cqRing
+	sqHead, sqTail *uint32
+	sqMask         uint32
+	sqArray        []uint32
+	cqHead, cqTail *uint32
+}
+
+func p32(b []byte, off uint32) *uint32 { return (*uint32)(unsafe.Pointer(&b[off])) }
+
+// New sets up a ring sized for `entries` in-flight requests (rounded up to pow2 by kernel).
+func New(entries uint32) (*Ring, error) {
+	var pp params
+	r1, _, errno := unix.Syscall(unix.SYS_IO_URING_SETUP, uintptr(entries), uintptr(unsafe.Pointer(&pp)), 0)
+	if errno != 0 {
+		return nil, fmt.Errorf("io_uring_setup: %w", errno)
+	}
+	ring := &Ring{fd: int(r1), entries: pp.sqEntries}
+
+	sqRingSize := pp.sqOff.array + pp.sqEntries*4
+	cqRingSize := pp.cqOff.cqes + pp.cqEntries*cqeSize
+
+	// On any mmap error, Close() unmaps whatever succeeded (it tolerates nil
+	// slices) and closes the fd — closing the fd alone does not unmap the rings.
+	var err error
+	ring.sqRing, err = unix.Mmap(ring.fd, int64(offSQRing), int(sqRingSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED|unix.MAP_POPULATE)
+	if err != nil {
+		ring.Close()
+		return nil, fmt.Errorf("mmap sq: %w", err)
+	}
+	ring.cqRing, err = unix.Mmap(ring.fd, int64(offCQRing), int(cqRingSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED|unix.MAP_POPULATE)
+	if err != nil {
+		ring.Close()
+		return nil, fmt.Errorf("mmap cq: %w", err)
+	}
+	ring.sqes, err = unix.Mmap(ring.fd, int64(offSQEs), int(pp.sqEntries*sqeSize), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED|unix.MAP_POPULATE)
+	if err != nil {
+		ring.Close()
+		return nil, fmt.Errorf("mmap sqes: %w", err)
+	}
+
+	ring.sqHead = p32(ring.sqRing, pp.sqOff.head)
+	ring.sqTail = p32(ring.sqRing, pp.sqOff.tail)
+	ring.sqMask = *p32(ring.sqRing, pp.sqOff.ringMask)
+	arrayPtr := unsafe.Pointer(&ring.sqRing[pp.sqOff.array])
+	ring.sqArray = unsafe.Slice((*uint32)(arrayPtr), pp.sqEntries)
+
+	ring.cqHead = p32(ring.cqRing, pp.cqOff.head)
+	ring.cqTail = p32(ring.cqRing, pp.cqOff.tail)
+
+	return ring, nil
+}
+
+// reset resyncs the cached indices to the kernel's, discarding any half-submitted
+// SQE or pending CQE left by a failed io_uring_enter so the ring is reusable. Safe
+// for warming: a dropped completion just means a page isn't pre-warmed and takes an
+// ordinary fault.
+func (r *Ring) reset() {
+	atomic.StoreUint32(r.sqTail, atomic.LoadUint32(r.sqHead))
+	atomic.StoreUint32(r.cqHead, atomic.LoadUint32(r.cqTail))
+}
+
+func (r *Ring) Close() {
+	if r.sqRing != nil {
+		unix.Munmap(r.sqRing)
+	}
+	if r.cqRing != nil {
+		unix.Munmap(r.cqRing)
+	}
+	if r.sqes != nil {
+		unix.Munmap(r.sqes)
+	}
+	unix.Close(r.fd)
+}
+
+func (r *Ring) fillSQE(idx uint32, fd int, off uint64, buf []byte, userData uint64) {
+	base := unsafe.Pointer(&r.sqes[idx*sqeSize])
+	s := unsafe.Slice((*byte)(base), sqeSize)
+	for i := range s {
+		s[i] = 0
+	}
+	*(*uint8)(base) = opRead                                                    // opcode @0
+	*(*int32)(unsafe.Add(base, 4)) = int32(fd)                                  // fd @4
+	*(*uint64)(unsafe.Add(base, 8)) = off                                       // off @8
+	*(*uint64)(unsafe.Add(base, 16)) = uint64(uintptr(unsafe.Pointer(&buf[0]))) // addr @16
+	*(*uint32)(unsafe.Add(base, 24)) = uint32(len(buf))                         // len @24
+	*(*uint64)(unsafe.Add(base, 32)) = userData                                 // user_data @32
+}
+
+// BatchReadWarm reads each (offset,len) request into scratch buffers using
+// io_uring, keeping up to the ring size in flight. Returns after all complete.
+// The reads populate the page cache; buffer contents are discarded.
+func (r *Ring) BatchReadWarm(fd int, offsets []int64, lens []int, scratch [][]byte) error {
+	n := len(offsets)
+	done := 0
+	for done < n {
+		// Submit a wave up to ring capacity.
+		tail := atomic.LoadUint32(r.sqTail)
+		head := atomic.LoadUint32(r.sqHead)
+		space := r.entries - (tail - head)
+		wave := 0
+		for wave < int(space) && done+wave < n {
+			i := done + wave
+			slot := tail & r.sqMask
+			r.fillSQE(slot, fd, uint64(offsets[i]), scratch[wave][:lens[i]], uint64(i))
+			r.sqArray[slot] = slot
+			tail++
+			wave++
+		}
+		// Release-store the tail so the SQE bodies and sqArray writes above are
+		// visible to the kernel before it observes the advanced tail.
+		atomic.StoreUint32(r.sqTail, tail)
+
+		_, _, errno := unix.Syscall6(unix.SYS_IO_URING_ENTER, uintptr(r.fd), uintptr(wave), uintptr(wave), enterGetevents, 0, 0)
+		if errno != 0 {
+			return fmt.Errorf("io_uring_enter: %w", errno)
+		}
+
+		// Reap `wave` completions.
+		reaped := 0
+		for reaped < wave {
+			ch := atomic.LoadUint32(r.cqHead)
+			ct := atomic.LoadUint32(r.cqTail)
+			// A CQE result (res @8) is discarded: a failed warm just means the
+			// following mmap access takes an ordinary fault. Only the count matters.
+			for ch != ct {
+				ch++
+				reaped++
+			}
+			atomic.StoreUint32(r.cqHead, ch)
+			if reaped < wave {
+				_, _, errno := unix.Syscall6(unix.SYS_IO_URING_ENTER, uintptr(r.fd), 0, uintptr(wave-reaped), enterGetevents, 0, 0)
+				if errno != 0 {
+					return fmt.Errorf("io_uring_enter(wait): %w", errno)
+				}
+			}
+		}
+		done += wave
+	}
+	return nil
+}

--- a/common/iouring/warmone_linux.go
+++ b/common/iouring/warmone_linux.go
@@ -1,0 +1,112 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package iouring
+
+import (
+	"os"
+	"runtime"
+	"sync"
+
+	"github.com/erigontech/erigon/common/dbg"
+)
+
+// Pool of small rings for per-access warming: each goroutine borrows a ring,
+// does a single-read submit+wait (which releases the P via io_uring_enter),
+// and returns it. Sized to the expected number of concurrent cold readers.
+
+// WarmBufSize is the largest region one WarmOne can pull in. Sized in pages so it
+// always covers the residency gate's max window (8 pages) on any page size — the
+// gate must cap its window at WarmBufSize so it never marks unwarmed pages resident.
+var WarmBufSize = 8 * os.Getpagesize()
+
+// poolSize bounds concurrent warms at ~2*GOMAXPROCS: a blocking fault holds a P,
+// and an io_uring read frees it for one more, so beyond that rings sit idle. The
+// cap also keeps the per-process io_uring memory footprint small (each instance
+// pins kernel memory; hundreds of rings can exhaust it).
+func poolSize() int {
+	if n := dbg.EnvInt("RESIDENCY_IOURING_RINGS", 0); n > 0 {
+		return n
+	}
+	return min(2*runtime.GOMAXPROCS(0), 64)
+}
+
+type pooledRing struct {
+	r   *Ring
+	buf []byte
+	// reusable single-read argument slots, so a warm allocates nothing per call
+	offs [1]int64
+	lens [1]int
+	bufs [1][]byte
+}
+
+var (
+	// ringPool is nil when io_uring is unavailable — WarmOne then no-ops and reads
+	// fall back to ordinary blocking mmap faults. There is no crash: warming is an
+	// optimization, and skipping it is always safe.
+	ringPool     chan *pooledRing
+	ringPoolOnce sync.Once
+)
+
+func initPool() {
+	n := poolSize()
+	pool := make(chan *pooledRing, n)
+	for range n {
+		r, err := New(8)
+		if err != nil { // io_uring unavailable: leave ringPool nil, close any partial pool
+			close(pool)
+			for pr := range pool {
+				pr.r.Close()
+			}
+			return
+		}
+		pool <- &pooledRing{r: r, buf: make([]byte, WarmBufSize)}
+	}
+	ringPool = pool
+}
+
+// WarmOne reads [off, off+length) via a pooled io_uring ring to populate the page
+// cache. It blocks for a free ring when the pool is drained (parking the goroutine,
+// freeing its P). A no-op if io_uring is unavailable — the caller's mmap read then
+// takes an ordinary blocking fault.
+func WarmOne(fd int, off int64, length int) {
+	ringPoolOnce.Do(initPool)
+	if ringPool == nil {
+		return
+	}
+	if length > WarmBufSize {
+		length = WarmBufSize
+	}
+	pr := <-ringPool
+	pr.offs[0], pr.lens[0], pr.bufs[0] = off, length, pr.buf
+	if err := pr.r.BatchReadWarm(fd, pr.offs[:], pr.lens[:], pr.bufs[:]); err != nil {
+		pr.r.reset() // resync after a failed enter; the lost warm is a harmless extra fault
+	}
+	ringPool <- pr
+}
+
+// Available reports whether io_uring can be set up in this process (kernel support,
+// not blocked by seccomp). Used to warn at startup and to skip io_uring tests.
+func Available() bool {
+	r, err := New(1)
+	if err != nil {
+		return false
+	}
+	r.Close()
+	return true
+}

--- a/common/iouring/warmone_other.go
+++ b/common/iouring/warmone_other.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !linux
+
+package iouring
+
+// WarmOne is unreachable off Linux: the residency probe (mmap.Resident) is a
+// no-op there, so the gate never warms. It panics rather than silently no-op
+// because there is no fallback path — io_uring is Linux-only.
+func WarmOne(fd int, off int64, length int) {
+	panic("iouring: io_uring warming is only available on linux")
+}
+
+// Available reports io_uring support: always false off Linux.
+func Available() bool { return false }

--- a/common/mmap/residency_linux.go
+++ b/common/mmap/residency_linux.go
@@ -1,0 +1,50 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package mmap
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Resident reports whether every page spanned by m is present in this process's
+// page tables (i.e. touching it will not take a major fault). m must start on a
+// page boundary. It never triggers I/O.
+func Resident(m []byte) (bool, error) {
+	if len(m) == 0 {
+		return true, nil
+	}
+	pageSize := os.Getpagesize()
+	vec := make([]byte, (len(m)+pageSize-1)/pageSize)
+	_, _, errno := unix.Syscall(unix.SYS_MINCORE,
+		uintptr(unsafe.Pointer(&m[0])),
+		uintptr(len(m)),
+		uintptr(unsafe.Pointer(&vec[0])))
+	if errno != 0 {
+		return false, errno
+	}
+	for _, v := range vec {
+		if v&1 == 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/common/mmap/residency_linux_test.go
+++ b/common/mmap/residency_linux_test.go
@@ -1,0 +1,68 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package mmap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// residencySink defeats dead-code elimination of the page-touching loop.
+var residencySink int
+
+func TestResidencyProbe(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f")
+	pg := os.Getpagesize()
+	data := make([]byte, pg*8)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	require.NoError(t, os.WriteFile(p, data, 0o644))
+
+	f, err := os.Open(p)
+	require.NoError(t, err)
+	defer f.Close()
+
+	// Flush to disk and drop the file's clean pages from the page cache so the
+	// mapping starts cold.
+	require.NoError(t, f.Sync())
+	require.NoError(t, unix.Fadvise(int(f.Fd()), 0, int64(len(data)), unix.FADV_DONTNEED))
+
+	m, h2, err := Mmap(f, len(data))
+	require.NoError(t, err)
+	defer Munmap(m, h2)
+
+	res, err := Resident(m)
+	require.NoError(t, err)
+	require.False(t, res, "pages should be cold right after a page-cache drop")
+
+	// Touch every page to fault them all in from disk.
+	for i := 0; i < len(m); i += pg {
+		residencySink += int(m[i])
+	}
+
+	res, err = Resident(m)
+	require.NoError(t, err)
+	require.True(t, res, "all pages should be resident after touching them")
+}

--- a/common/mmap/residency_other.go
+++ b/common/mmap/residency_other.go
@@ -1,0 +1,23 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !linux
+
+package mmap
+
+// Resident is a no-op on platforms without mincore: it reports pages as
+// resident so callers skip the residency gate and fall back to plain mmap.
+func Resident(m []byte) (bool, error) { return true, nil }

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -193,6 +194,9 @@ type Decompressor struct {
 	filePath, fileName string
 
 	readAheadRefcnt atomic.Int32 // ref-counter: allow enable/disable read-ahead from goroutines. only when refcnt=0 - disable read-ahead once
+
+	residency     atomic.Pointer[residencyBitmap] // page-residency bitmap for the async-io gate; nil unless enabled
+	residencyOnce sync.Once
 }
 
 const (
@@ -570,6 +574,10 @@ func (d *Decompressor) Close() {
 		return
 	}
 	d.checkFileLenChange()
+	if rb := d.residency.Load(); rb != nil {
+		rb.stop() // join the refresh goroutine before munmap so no mincore touches freed memory
+		d.residency.Store(nil)
+	}
 	if err := mmap.Munmap(d.mmapHandle1, d.mmapHandle2); err != nil {
 		log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", d.FileName(), "stack", dbg.Stack())
 	}
@@ -780,11 +788,12 @@ type Getter struct {
 	posEntries []posEntry // cached d.posDict.entries, avoids pointer chain on hot path
 	data       []byte
 	//less hot fields
-	posTables   []posTable // posArena.tables; only used for the subtable path
-	patternDict *patternTable
-	d           *Decompressor
-	fName       string
-	trace       bool
+	posTables     []posTable // posArena.tables; only used for the subtable path
+	patternDict   *patternTable
+	d             *Decompressor
+	fName         string
+	trace         bool
+	residencyGate bool
 }
 
 func (g *Getter) MadvNormal() MadvDisabler {
@@ -935,6 +944,9 @@ func (g *Getter) DataLen() int {
 func (g *Getter) Reset(offset uint64) {
 	g.dataP = offset
 	g.dataBit = 0
+	if g.residencyGate {
+		g.ensureResident(offset)
+	}
 }
 
 func (g *Getter) HasNext() bool {

--- a/db/seg/residency_gate_linux.go
+++ b/db/seg/residency_gate_linux.go
@@ -93,9 +93,9 @@ func (g *Getter) residencyBitmap() *residencyBitmap {
 	return g.d.residency.Load()
 }
 
-// warm pulls the byte range into the page cache so the following mmap access is a
-// minor fault. There is no fallback: if io_uring is unavailable the process exits
-// on the first warm (see iouring.WarmOne).
+// warm pulls the byte range into the page cache via io_uring so the following
+// mmap access is a minor fault. If io_uring is unavailable, WarmOne no-ops —
+// the range is simply left cold, not warmed.
 func (g *Getter) warm(fileOffset int64, n int) {
 	iouring.WarmOne(int(g.d.f.Fd()), fileOffset, n)
 }

--- a/db/seg/residency_gate_linux.go
+++ b/db/seg/residency_gate_linux.go
@@ -1,0 +1,204 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package seg
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/common/iouring"
+)
+
+var pageSize = os.Getpagesize()
+
+// residencyWindow is how many bytes from the reset offset the gate ensures are
+// resident. State reads are scattered, so warming beyond the page holding the
+// read is pure read-amplification; the default of one page covers the read
+// itself and nothing more. Capped at one io_uring warm (WarmBufSize) so the gate
+// never marks a page resident that WarmOne truncated away — holds on any page size.
+var residencyWindow = min(dbg.EnvInt("RESIDENCY_WINDOW_PAGES", 1)*pageSize, iouring.WarmBufSize)
+
+// residencyRefresh is how often the cached residency bitmap is rebuilt from a
+// fresh mincore scan, correcting bits the OS changed under us (evictions clear,
+// readahead sets). Between refreshes the gate never calls mincore on the hot path.
+var residencyRefresh = time.Duration(dbg.EnvInt("RESIDENCY_REFRESH_SEC", 120)) * time.Second
+
+// EnableResidencyGate turns a would-be blocking mmap fault on a cold .kv page into
+// a non-blocking io_uring read that releases the goroutine's P before the value is
+// decompressed off the mapping. For random-access readers over state .kv files.
+func (g *Getter) EnableResidencyGate() { g.residencyGate = true }
+
+// residencyRegion returns the page-aligned mmap slice covering the word extent
+// at offset, along with its file offset. Returns nil when out of range.
+func (g *Getter) residencyRegion(offset uint64) (region []byte, fileOffset int64) {
+	full := g.d.mmapHandle1
+	if len(full) == 0 || len(g.data) == 0 {
+		return nil, 0
+	}
+	base := int(uintptr(unsafe.Pointer(&g.data[0])) - uintptr(unsafe.Pointer(&full[0])))
+	absStart := base + int(offset)
+	if absStart < 0 || absStart >= len(full) {
+		return nil, 0
+	}
+	aligned := absStart &^ (pageSize - 1)
+	end := min(aligned+residencyWindow, len(full))
+	return full[aligned:end], int64(aligned)
+}
+
+func (g *Getter) ensureResident(offset uint64) {
+	if residencyWindow <= 0 { // RESIDENCY_WINDOW_PAGES=0 disables the gate
+		return
+	}
+	region, fileOffset := g.residencyRegion(offset)
+	if region == nil {
+		return
+	}
+	rb := g.residencyBitmap()
+	first := int(fileOffset) / pageSize
+	last := first + (len(region)-1)/pageSize
+	if rb.residentRange(first, last) {
+		return // believed resident — go straight to the mapping (a stale bit just faults)
+	}
+	g.warm(fileOffset, len(region))
+	rb.markRange(first, last)
+}
+
+func (g *Getter) residencyBitmap() *residencyBitmap {
+	if rb := g.d.residency.Load(); rb != nil {
+		return rb
+	}
+	g.d.residencyOnce.Do(func() {
+		g.d.residency.Store(newResidencyBitmap(g.d.mmapHandle1, int(g.d.f.Fd())))
+	})
+	return g.d.residency.Load()
+}
+
+// warm pulls the byte range into the page cache so the following mmap access is a
+// minor fault. There is no fallback: if io_uring is unavailable the process exits
+// on the first warm (see iouring.WarmOne).
+func (g *Getter) warm(fileOffset int64, n int) {
+	iouring.WarmOne(int(g.d.f.Fd()), fileOffset, n)
+}
+
+// residencyBitmap caches page-cache residency, one bit per mapped page, so the
+// hot path is a single atomic load instead of a per-read mincore syscall. The bit
+// is a hint, kept honest by a periodic mincore rescan: a stale set bit costs one
+// mmap fault, a stale clear bit one cheap cache-hit io_uring read — both harmless.
+type residencyBitmap struct {
+	mmap   []byte
+	fd     int
+	nPages int
+	words  []uint64
+	done   chan struct{}
+
+	mu      sync.Mutex // serializes refresh scans against stop() so no mincore runs after munmap
+	stopped bool
+}
+
+func newResidencyBitmap(m []byte, fd int) *residencyBitmap {
+	nPages := (len(m) + pageSize - 1) / pageSize
+	rb := &residencyBitmap{
+		mmap:   m,
+		fd:     fd,
+		nPages: nPages,
+		words:  make([]uint64, (nPages+63)/64),
+		done:   make(chan struct{}),
+	}
+	// Seed happens on the refresh goroutine's first tick, not here: a synchronous
+	// mincore of a multi-GB file would stall the exec worker that triggered init.
+	// Until the seed lands the bitmap reads all-cold, so early reads warm via
+	// io_uring (cache hits, cheap) rather than faulting.
+	go rb.refreshLoop()
+	return rb
+}
+
+func (rb *residencyBitmap) residentRange(first, last int) bool {
+	for p := first; p <= last; p++ {
+		w := atomic.LoadUint64(&rb.words[p>>6])
+		if w&(1<<uint(p&63)) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (rb *residencyBitmap) markRange(first, last int) {
+	for p := first; p <= last; p++ {
+		atomic.OrUint64(&rb.words[p>>6], 1<<uint(p&63))
+	}
+}
+
+func (rb *residencyBitmap) refreshLoop() {
+	rb.refresh() // seed
+	t := time.NewTicker(residencyRefresh)
+	defer t.Stop()
+	for {
+		select {
+		case <-rb.done:
+			return
+		case <-t.C:
+			rb.refresh()
+		}
+	}
+}
+
+// refresh rebuilds the whole bitmap from a chunked mincore scan of the mapping.
+// It replaces words wholesale; a concurrent markRange that gets clobbered is a
+// harmless false-negative (one extra io_uring next time).
+func (rb *residencyBitmap) refresh() {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	if rb.stopped {
+		return
+	}
+	const chunkPages = 1 << 18 // 1GB per mincore call (256KB scratch), word-aligned
+	vec := make([]byte, chunkPages)
+	for p := 0; p < rb.nPages; p += chunkPages {
+		n := min(chunkPages, rb.nPages-p)
+		lenBytes := min(n*pageSize, len(rb.mmap)-p*pageSize)
+		_, _, errno := unix.Syscall(unix.SYS_MINCORE,
+			uintptr(unsafe.Pointer(&rb.mmap[p*pageSize])),
+			uintptr(lenBytes),
+			uintptr(unsafe.Pointer(&vec[0])))
+		if errno != 0 {
+			return
+		}
+		for wp := 0; wp < n; wp += 64 {
+			var word uint64
+			bits := min(64, n-wp)
+			for b := range bits {
+				if vec[wp+b]&1 != 0 {
+					word |= 1 << uint(b)
+				}
+			}
+			atomic.StoreUint64(&rb.words[(p+wp)>>6], word)
+		}
+	}
+}
+
+func (rb *residencyBitmap) stop() {
+	rb.mu.Lock()
+	rb.stopped = true
+	rb.mu.Unlock()
+	close(rb.done)
+}

--- a/db/seg/residency_gate_other.go
+++ b/db/seg/residency_gate_other.go
@@ -1,0 +1,32 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !linux
+
+package seg
+
+// The async-io residency gate relies on mincore + io_uring and is Linux-only.
+// Off Linux these are no-ops so the cross-platform read path still compiles;
+// EnableResidencyGate is never called (dbg.FilesAsyncIO stays off), and even if
+// it were, ensureResident does nothing.
+
+type residencyBitmap struct{}
+
+func (*residencyBitmap) stop() {}
+
+func (*Getter) EnableResidencyGate() {}
+
+func (*Getter) ensureResident(uint64) {}

--- a/db/seg/residency_gate_test.go
+++ b/db/seg/residency_gate_test.go
@@ -47,7 +47,7 @@ func regionAround(g *Getter, offset uint64, window int) []byte {
 
 func TestResidencyGateWarmsOnReset(t *testing.T) {
 	if !iouring.Available() {
-		t.Skip("io_uring unavailable; the gate's warm path would exit the process")
+		t.Skip("io_uring unavailable; the gate's warm path no-ops, so the warmed-page assertion below would fail")
 	}
 	tmp := t.TempDir()
 	file := filepath.Join(tmp, "test.kv")

--- a/db/seg/residency_gate_test.go
+++ b/db/seg/residency_gate_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package seg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/erigontech/erigon/common/iouring"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/mmap"
+)
+
+// regionAround returns the page-aligned mmap slice covering [offset, offset+window)
+// within the getter's data, mirroring what the residency gate probes.
+func regionAround(g *Getter, offset uint64, window int) []byte {
+	full := g.d.mmapHandle1
+	base := int(uintptr(unsafe.Pointer(&g.data[0])) - uintptr(unsafe.Pointer(&full[0])))
+	absStart := base + int(offset)
+	pg := os.Getpagesize()
+	aligned := absStart &^ (pg - 1)
+	end := min(aligned+window, len(full))
+	return full[aligned:end]
+}
+
+func TestResidencyGateWarmsOnReset(t *testing.T) {
+	if !iouring.Available() {
+		t.Skip("io_uring unavailable; the gate's warm path would exit the process")
+	}
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "test.kv")
+	cfg := DefaultCfg
+	cfg.MinPatternScore = 1
+	c, err := NewCompressor(t.Context(), "t", file, tmp, cfg, log.LvlDebug, log.New())
+	require.NoError(t, err)
+	const n = 40000
+	for i := range n {
+		require.NoError(t, c.AddWord(fmt.Appendf(nil, "residency-word-%d-padding-aaaaaaaaaaaaaaaaaaaa", i)))
+	}
+	require.NoError(t, c.Compress())
+	c.Close()
+
+	d, err := NewDecompressor(file)
+	require.NoError(t, err)
+	defer d.Close()
+
+	// Collect (offset, word) pairs; iterating warms the whole file.
+	type ent struct {
+		off uint64
+		w   []byte
+	}
+	var ents []ent
+	gi := d.MakeGetter()
+	for gi.HasNext() {
+		off := gi.dataP
+		w, _ := gi.Next(nil)
+		ents = append(ents, ent{off, append([]byte(nil), w...)})
+	}
+	require.Greater(t, len(ents), n/2)
+	pick := ents[len(ents)*3/4]
+
+	// Probe just the word's start page; the gate warms at least this,
+	// independent of the configured window size.
+	window := os.Getpagesize()
+	evict := func() {
+		require.NoError(t, unix.Madvise(d.mmapHandle1, unix.MADV_DONTNEED))
+		require.NoError(t, d.f.Sync())
+		require.NoError(t, unix.Fadvise(int(d.f.Fd()), 0, int64(len(d.mmapHandle1)), unix.FADV_DONTNEED))
+	}
+	isResident := func(g *Getter) bool {
+		r, err := mmap.Resident(regionAround(g, pick.off, window))
+		require.NoError(t, err)
+		return r
+	}
+
+	// Ungated getter: Reset must not warm anything.
+	evict()
+	gu := d.MakeGetter()
+	require.False(t, isResident(gu), "region must be cold right after eviction")
+	gu.Reset(pick.off)
+	require.False(t, isResident(gu), "ungated Reset must not warm the page")
+
+	// Gated getter: Reset warms the word's pages before the mmap touch.
+	evict()
+	gg := d.MakeGetter()
+	gg.EnableResidencyGate()
+	require.False(t, isResident(gg), "region must be cold right after eviction")
+	gg.Reset(pick.off)
+	require.True(t, isResident(gg), "gated Reset should warm the word's pages")
+
+	w, _ := gg.Next(nil)
+	require.Equal(t, pick.w, w, "gated read must still return the correct word")
+}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1575,7 +1575,11 @@ func (d *Domain) dataReader(f *seg.Decompressor) *seg.Reader {
 	if !strings.Contains(f.FileName(), ".kv") {
 		panic("assert: miss-use " + f.FileName())
 	}
-	return seg.NewReader(f.MakeGetter(), d.Compression)
+	g := f.MakeGetter()
+	if dbg.FilesAsyncIO {
+		g.EnableResidencyGate()
+	}
+	return seg.NewReader(g, d.Compression)
 }
 func (d *Domain) dataWriter(f *seg.Compressor, forceNoCompress bool) *seg.Writer {
 	if !strings.Contains(f.FileName(), ".kv") {


### PR DESCRIPTION
## What

Adds an **opt-in** async-I/O path for reading cold state `.kv` snapshot pages. When enabled, a cold read is served by an `io_uring` read that pulls the page into the page cache *before* the value is touched through the mmap — so a read that would otherwise take a blocking major page fault becomes a non-blocking one.

Off by default. Enable with the env var `FILES_ASYNC_IO=true`.

## Why

State `.kv` files are read through `mmap`. A cold read takes a **major page fault**, and the Go runtime can't see a page fault the way it sees a syscall — the faulting thread keeps its P (scheduler slot) parked in the kernel until the disk read returns. Under parallel execution that caps how many cold reads can be in flight at the number of Ps, even when the disk has plenty of spare queue depth.

An `io_uring` read goes through the normal syscall path, so it releases the P for the duration of the read. That lets more cold reads overlap.

## How it works

- On each `Getter.Reset`, the gate checks whether the target page is resident via a **cached bitmap** (one bit per page, ~`file_size / 32768` bytes — a few MB for the whole state). The check is a single atomic load, not a syscall.
- If the page looks cold, it's warmed with a small pooled `io_uring` read, then the normal mmap read proceeds (now a cheap minor fault).
- A background goroutine (one per gated `.kv` file) rebuilds the bitmap from a real `mincore` scan every `RESIDENCY_REFRESH_SEC` (default 120s), so bits the OS changed underneath us (evictions, readahead) get corrected. The bit is only a hint: a stale "resident" costs one ordinary fault, a stale "cold" costs one cheap cache-hit read — neither affects correctness, only warmth.

The `io_uring` ring is hand-rolled (no external dependency; just the raw `io_uring_setup`/`enter` syscalls via `x/sys/unix`). It's Linux-only; the non-Linux build is a stub, and the gate is never enabled off Linux.

## Scope / guardrails

- **Default off.** With `FILES_ASYNC_IO` unset, the gate is never enabled and none of this code runs — zero change to the default read path.
- Only domain `.kv` reads are gated (wired at `Domain.dataReader`); `.seg` block files and everything else are untouched.
- **Graceful fallback:** if the flag is on but `io_uring` is unavailable (old kernel, or blocked by a seccomp sandbox like Docker's default profile), the gate self-disables — probed once at startup in `SetEthConfig`, with a warning — and reads use ordinary blocking faults. No crash: warming is an optimization, and skipping it is always safe. (A rare mid-run ring error resyncs and drops that one warm, same principle.)
- **Not free when on:** each gated `.kv` file runs the background `mincore`-rescan goroutine above — a real page-table-walk cost across a full datadir. Fine for an experiment flag; noted so nobody flips it on expecting zero cost.

## Notes

This is intentionally a small, self-contained, opt-in change. Benchmarking so far suggests the win is modest for the current parallel-execution workload (it's often limited upstream of the read path rather than by read concurrency), so it ships behind a flag for further measurement rather than on by default.