### PR TITLE
cl/pool: prune finalized operations asynchronously

### DIFF
--- a/cl/beacon/handler/pool.go
+++ b/cl/beacon/handler/pool.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/gossip"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/network/services"
 	"github.com/erigontech/erigon/cl/phase1/network/subnets"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -268,7 +269,6 @@ func (a *ApiHandler) PostEthV1BeaconPoolVoluntaryExits(w http.ResponseWriter, r 
 		beaconhttp.NewEndpointError(http.StatusBadRequest, err).WriteTo(w)
 		return
 	}
-	a.operationsPool.VoluntaryExitsPool.Insert(req.VoluntaryExit.ValidatorIndex, &req)
 	if err := a.gossipManager.Publish(r.Context(), gossip.TopicNameVoluntaryExit, encodedSSZ); err != nil {
 		a.logger.Debug("[Beacon REST] failed to publish voluntary exit to gossip", "err", err)
 	}
@@ -284,7 +284,7 @@ func (a *ApiHandler) PostEthV1BeaconPoolAttesterSlashings(w http.ResponseWriter,
 		beaconhttp.NewEndpointError(http.StatusBadRequest, err).WriteTo(w)
 		return
 	}
-	if err := a.forkchoiceStore.OnAttesterSlashing(req, false); err != nil {
+	if err := a.forkchoiceStore.OnAttesterSlashing(req, false); err != nil && !errors.Is(err, forkchoice.ErrIgnore) {
 		beaconhttp.NewEndpointError(http.StatusBadRequest, err).WriteTo(w)
 		return
 	}

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -162,6 +162,10 @@ type ForkChoiceStore struct {
 	queuedEmits           []func()
 	queuedPrunes          []uint64
 	queuedOperationPrunes []common.Hash
+	operationPruneMu      sync.Mutex
+	operationPruneRoot    common.Hash
+	operationPrunePending bool
+	operationPruneRunning bool
 	synced                atomic.Bool
 
 	ethClock                eth_clock.EthereumClock

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -161,9 +161,9 @@ type ForkChoiceStore struct {
 	// event sends queued under f.mu, emitted after release (see queueEmit)
 	queuedEmits           []func()
 	queuedPrunes          []uint64
-	queuedOperationPrunes []common.Hash
+	queuedOperationPrunes []solid.Checkpoint
 	operationPruneMu      sync.Mutex
-	operationPruneRoot    common.Hash
+	operationPruneTarget  solid.Checkpoint
 	operationPrunePending bool
 	operationPruneRunning bool
 	synced                atomic.Bool

--- a/cl/phase1/forkchoice/forkchoice.go
+++ b/cl/phase1/forkchoice/forkchoice.go
@@ -159,9 +159,10 @@ type ForkChoiceStore struct {
 
 	emitters *beaconevents.EventEmitter
 	// event sends queued under f.mu, emitted after release (see queueEmit)
-	queuedEmits  []func()
-	queuedPrunes []uint64
-	synced       atomic.Bool
+	queuedEmits           []func()
+	queuedPrunes          []uint64
+	queuedOperationPrunes []common.Hash
+	synced                atomic.Bool
 
 	ethClock                eth_clock.EthereumClock
 	optimisticStore         optimistic.OptimisticStore

--- a/cl/phase1/forkchoice/forkchoice_test.go
+++ b/cl/phase1/forkchoice/forkchoice_test.go
@@ -212,6 +212,25 @@ func TestAttesterSlashingSeenCheckPrecedesValidation(t *testing.T) {
 	require.ErrorIs(t, err, ErrIgnore)
 }
 
+func TestAttesterSlashingSeenCheckHandlesUnsortedIndices(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	store := &ForkChoiceStore{
+		equivocatingIndicies: []byte{0b00000010},
+	}
+	slashing := &cltypes.AttesterSlashing{
+		Attestation_1: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(2048, []uint64{2, 1}),
+		},
+		Attestation_2: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(2048, []uint64{1}),
+		},
+	}
+
+	err := store.onProcessAttesterSlashing(slashing, state.New(&cfg), false)
+
+	require.ErrorIs(t, err, ErrIgnore)
+}
+
 func TestOnAttesterSlashingRejectsIncompleteOperation(t *testing.T) {
 	cfg := clparams.MainnetBeaconConfig
 	store := &ForkChoiceStore{

--- a/cl/phase1/forkchoice/forkchoice_test.go
+++ b/cl/phase1/forkchoice/forkchoice_test.go
@@ -18,7 +18,10 @@ package forkchoice
 
 import (
 	"errors"
+	"slices"
+	"sync"
 	"testing"
+	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/require"
@@ -138,6 +141,8 @@ func TestUpdateCheckpointsPrunesOperationsWithExactFinalizedState(t *testing.T) 
 		states: map[common.Hash]*state.CachingBeaconState{
 			finalizedRoot: finalizedState,
 		},
+		getStateStarted: make(chan common.Hash, 1),
+		getStateRelease: make(chan struct{}),
 	}
 	store := &ForkChoiceStore{
 		forkGraph:      graph,
@@ -152,13 +157,30 @@ func TestUpdateCheckpointsPrunesOperationsWithExactFinalizedState(t *testing.T) 
 		solid.Checkpoint{},
 		solid.Checkpoint{Epoch: 2, Root: finalizedRoot},
 	)
-	require.Empty(t, graph.getStateRoots)
+	require.Empty(t, graph.stateRoots())
 
-	store.drainQueuedWork()
+	drained := make(chan struct{})
+	go func() {
+		store.drainQueuedWork()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(100 * time.Millisecond):
+		close(graph.getStateRelease)
+		<-drained
+		t.Fatal("drainQueuedWork waited for finalized operation pruning")
+	}
 
-	require.Equal(t, []common.Hash{finalizedRoot}, graph.getStateRoots)
-	require.Equal(t, []bool{true}, graph.getStateAlwaysCopy)
-	require.False(t, operationsPool.VoluntaryExitsPool.Has(0))
+	require.Equal(t, finalizedRoot, waitForStateLoad(t, graph.getStateStarted))
+	require.True(t, operationsPool.VoluntaryExitsPool.Has(0))
+	close(graph.getStateRelease)
+	require.Eventually(t, func() bool {
+		return !operationsPool.VoluntaryExitsPool.Has(0)
+	}, time.Second, time.Millisecond)
+	require.Equal(t, []common.Hash{finalizedRoot}, graph.stateRoots())
+	require.Equal(t, []bool{true}, graph.stateCopyModes())
+	requireOperationPrunerIdle(t, store)
 }
 
 func TestAllAttesterSlashingIndicesSeen(t *testing.T) {
@@ -186,15 +208,73 @@ func TestDrainQueuedWorkRetainsOperationsWhenFinalizedStateIsUnavailable(t *test
 
 	store.drainQueuedWork()
 
+	requireOperationPrunerIdle(t, store)
 	require.True(t, operationsPool.VoluntaryExitsPool.Has(0))
+}
+
+func TestOperationPrunerCoalescesPendingFinalizedRoots(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	firstRoot := common.Hash{1}
+	skippedRoot := common.Hash{2}
+	latestRoot := common.Hash{3}
+	graph := &getFinalizedExecutionHashForkGraph{
+		states: map[common.Hash]*state.CachingBeaconState{
+			firstRoot:  state.New(&cfg),
+			latestRoot: state.New(&cfg),
+		},
+		getStateStarted: make(chan common.Hash, 3),
+		getStateRelease: make(chan struct{}),
+	}
+	store := &ForkChoiceStore{
+		forkGraph:      graph,
+		operationsPool: pool.NewOperationsPool(&cfg),
+	}
+
+	store.queueOperationPrune(firstRoot)
+	store.drainQueuedWork()
+	require.Equal(t, firstRoot, waitForStateLoad(t, graph.getStateStarted))
+
+	store.queueOperationPrune(skippedRoot)
+	store.queueOperationPrune(latestRoot)
+	store.drainQueuedWork()
+	close(graph.getStateRelease)
+	require.Equal(t, latestRoot, waitForStateLoad(t, graph.getStateStarted))
+	require.Eventually(t, func() bool {
+		return len(graph.stateRoots()) == 2
+	}, time.Second, time.Millisecond)
+	require.Equal(t, []common.Hash{firstRoot, latestRoot}, graph.stateRoots())
+	requireOperationPrunerIdle(t, store)
+}
+
+func requireOperationPrunerIdle(t *testing.T, store *ForkChoiceStore) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		store.operationPruneMu.Lock()
+		defer store.operationPruneMu.Unlock()
+		return !store.operationPruneRunning && !store.operationPrunePending
+	}, time.Second, time.Millisecond)
+}
+
+func waitForStateLoad(t *testing.T, started <-chan common.Hash) common.Hash {
+	t.Helper()
+	select {
+	case root := <-started:
+		return root
+	case <-time.After(time.Second):
+		t.Fatal("finalized state load did not start")
+		return common.Hash{}
+	}
 }
 
 type getFinalizedExecutionHashForkGraph struct {
 	blocks                map[common.Hash]*cltypes.SignedBeaconBlock
 	headers               map[common.Hash]*cltypes.BeaconBlockHeader
 	states                map[common.Hash]*state.CachingBeaconState
+	getStateMu            sync.Mutex
 	getStateRoots         []common.Hash
 	getStateAlwaysCopy    []bool
+	getStateStarted       chan common.Hash
+	getStateRelease       chan struct{}
 	beforeUpdate          *cltypes.LightClientUpdate
 	afterUpdate           *cltypes.LightClientUpdate
 	addChainSegmentStatus fork_graph.ChainSegmentInsertionResult
@@ -218,10 +298,30 @@ func (g *getFinalizedExecutionHashForkGraph) GetBlock(blockRoot common.Hash) (*c
 }
 
 func (g *getFinalizedExecutionHashForkGraph) GetState(blockRoot common.Hash, alwaysCopy bool) (*state.CachingBeaconState, error) {
+	g.getStateMu.Lock()
 	g.getStateRoots = append(g.getStateRoots, blockRoot)
 	g.getStateAlwaysCopy = append(g.getStateAlwaysCopy, alwaysCopy)
+	g.getStateMu.Unlock()
+	if g.getStateStarted != nil {
+		g.getStateStarted <- blockRoot
+	}
+	if g.getStateRelease != nil {
+		<-g.getStateRelease
+	}
 	state := g.states[blockRoot]
 	return state, nil
+}
+
+func (g *getFinalizedExecutionHashForkGraph) stateRoots() []common.Hash {
+	g.getStateMu.Lock()
+	defer g.getStateMu.Unlock()
+	return slices.Clone(g.getStateRoots)
+}
+
+func (g *getFinalizedExecutionHashForkGraph) stateCopyModes() []bool {
+	g.getStateMu.Lock()
+	defer g.getStateMu.Unlock()
+	return slices.Clone(g.getStateAlwaysCopy)
 }
 
 func (g *getFinalizedExecutionHashForkGraph) GetCurrentJustifiedCheckpoint(common.Hash) (solid.Checkpoint, bool) {

--- a/cl/phase1/forkchoice/forkchoice_test.go
+++ b/cl/phase1/forkchoice/forkchoice_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice/fork_graph"
+	"github.com/erigontech/erigon/cl/pool"
 	"github.com/erigontech/erigon/cl/transition/impl/eth2"
 	"github.com/erigontech/erigon/common"
 )
@@ -108,8 +109,92 @@ func TestAddChainSegmentQueuesLightClientEventsOnSuccess(t *testing.T) {
 	require.Len(t, store.queuedEmits, 1)
 }
 
+func TestUpdateCheckpointsPrunesOperationsWithExactFinalizedState(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	finalizedRoot := common.Hash{0x42}
+	finalizedState := state.New(&cfg)
+	finalizedState.SetSlot(2 * cfg.SlotsPerEpoch)
+	validator := solid.NewValidatorFromParameters(
+		common.Bytes48{},
+		common.Hash{},
+		cfg.MaxEffectiveBalance,
+		false,
+		0,
+		0,
+		3,
+		cfg.FarFutureEpoch,
+	)
+	finalizedState.AddValidator(validator, cfg.MaxEffectiveBalance)
+
+	operationsPool := pool.NewOperationsPool(&cfg)
+	exit := &cltypes.SignedVoluntaryExit{
+		VoluntaryExit: &cltypes.VoluntaryExit{ValidatorIndex: 0},
+	}
+	operationsPool.VoluntaryExitsPool.Insert(0, exit)
+	graph := &getFinalizedExecutionHashForkGraph{
+		headers: map[common.Hash]*cltypes.BeaconBlockHeader{
+			finalizedRoot: {},
+		},
+		states: map[common.Hash]*state.CachingBeaconState{
+			finalizedRoot: finalizedState,
+		},
+	}
+	store := &ForkChoiceStore{
+		forkGraph:      graph,
+		operationsPool: operationsPool,
+		beaconCfg:      &cfg,
+		emitters:       beaconevents.NewEventEmitter(),
+	}
+	store.justifiedCheckpoint.Store(solid.Checkpoint{})
+	store.finalizedCheckpoint.Store(solid.Checkpoint{})
+
+	store.updateCheckpoints(
+		solid.Checkpoint{},
+		solid.Checkpoint{Epoch: 2, Root: finalizedRoot},
+	)
+	require.Empty(t, graph.getStateRoots)
+
+	store.drainQueuedWork()
+
+	require.Equal(t, []common.Hash{finalizedRoot}, graph.getStateRoots)
+	require.Equal(t, []bool{true}, graph.getStateAlwaysCopy)
+	require.False(t, operationsPool.VoluntaryExitsPool.Has(0))
+}
+
+func TestAllAttesterSlashingIndicesSeen(t *testing.T) {
+	store := &ForkChoiceStore{
+		equivocatingIndicies: []byte{0b00000110},
+	}
+
+	require.True(t, store.allAttesterSlashingIndicesSeen([]uint64{1, 2}))
+	require.False(t, store.allAttesterSlashingIndicesSeen([]uint64{1, 3}))
+	require.False(t, store.allAttesterSlashingIndicesSeen(nil))
+}
+
+func TestDrainQueuedWorkRetainsOperationsWhenFinalizedStateIsUnavailable(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	operationsPool := pool.NewOperationsPool(&cfg)
+	exit := &cltypes.SignedVoluntaryExit{
+		VoluntaryExit: &cltypes.VoluntaryExit{ValidatorIndex: 0},
+	}
+	operationsPool.VoluntaryExitsPool.Insert(0, exit)
+	store := &ForkChoiceStore{
+		forkGraph:      &getFinalizedExecutionHashForkGraph{},
+		operationsPool: operationsPool,
+	}
+	store.queueOperationPrune(common.Hash{1})
+
+	store.drainQueuedWork()
+
+	require.True(t, operationsPool.VoluntaryExitsPool.Has(0))
+}
+
 type getFinalizedExecutionHashForkGraph struct {
 	blocks                map[common.Hash]*cltypes.SignedBeaconBlock
+	headers               map[common.Hash]*cltypes.BeaconBlockHeader
+	states                map[common.Hash]*state.CachingBeaconState
+	getStateRoots         []common.Hash
+	getStateAlwaysCopy    []bool
 	beforeUpdate          *cltypes.LightClientUpdate
 	afterUpdate           *cltypes.LightClientUpdate
 	addChainSegmentStatus fork_graph.ChainSegmentInsertionResult
@@ -122,8 +207,9 @@ func (g *getFinalizedExecutionHashForkGraph) AddChainSegment(*cltypes.SignedBeac
 	return nil, g.addChainSegmentStatus, g.addChainSegmentErr
 }
 
-func (g *getFinalizedExecutionHashForkGraph) GetHeader(common.Hash) (*cltypes.BeaconBlockHeader, bool) {
-	panic("not used")
+func (g *getFinalizedExecutionHashForkGraph) GetHeader(blockRoot common.Hash) (*cltypes.BeaconBlockHeader, bool) {
+	header := g.headers[blockRoot]
+	return header, header != nil
 }
 
 func (g *getFinalizedExecutionHashForkGraph) GetBlock(blockRoot common.Hash) (*cltypes.SignedBeaconBlock, bool) {
@@ -131,8 +217,11 @@ func (g *getFinalizedExecutionHashForkGraph) GetBlock(blockRoot common.Hash) (*c
 	return block, block != nil
 }
 
-func (g *getFinalizedExecutionHashForkGraph) GetState(common.Hash, bool) (*state.CachingBeaconState, error) {
-	panic("not used")
+func (g *getFinalizedExecutionHashForkGraph) GetState(blockRoot common.Hash, alwaysCopy bool) (*state.CachingBeaconState, error) {
+	g.getStateRoots = append(g.getStateRoots, blockRoot)
+	g.getStateAlwaysCopy = append(g.getStateAlwaysCopy, alwaysCopy)
+	state := g.states[blockRoot]
+	return state, nil
 }
 
 func (g *getFinalizedExecutionHashForkGraph) GetCurrentJustifiedCheckpoint(common.Hash) (solid.Checkpoint, bool) {

--- a/cl/phase1/forkchoice/forkchoice_test.go
+++ b/cl/phase1/forkchoice/forkchoice_test.go
@@ -231,6 +231,26 @@ func TestAttesterSlashingSeenCheckHandlesUnsortedIndices(t *testing.T) {
 	require.ErrorIs(t, err, ErrIgnore)
 }
 
+func TestAttesterSlashingRejectsIndicesOverLimitBeforeSeenCheck(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	store := &ForkChoiceStore{
+		equivocatingIndicies: []byte{0b00000010},
+	}
+	slashing := &cltypes.AttesterSlashing{
+		Attestation_1: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(1, []uint64{2, 1}),
+		},
+		Attestation_2: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(1, []uint64{1}),
+		},
+	}
+
+	err := store.onProcessAttesterSlashing(slashing, state.New(&cfg), false)
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrIgnore)
+}
+
 func TestOnAttesterSlashingRejectsIncompleteOperation(t *testing.T) {
 	cfg := clparams.MainnetBeaconConfig
 	store := &ForkChoiceStore{

--- a/cl/phase1/forkchoice/forkchoice_test.go
+++ b/cl/phase1/forkchoice/forkchoice_test.go
@@ -190,7 +190,24 @@ func TestAllAttesterSlashingIndicesSeen(t *testing.T) {
 
 	require.True(t, store.allAttesterSlashingIndicesSeen([]uint64{1, 2}))
 	require.False(t, store.allAttesterSlashingIndicesSeen([]uint64{1, 3}))
-	require.False(t, store.allAttesterSlashingIndicesSeen(nil))
+	require.True(t, store.allAttesterSlashingIndicesSeen(nil))
+}
+
+func TestAttesterSlashingIgnoresDisjointIndices(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	store := &ForkChoiceStore{}
+	slashing := &cltypes.AttesterSlashing{
+		Attestation_1: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(2048, []uint64{1}),
+		},
+		Attestation_2: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(2048, []uint64{2}),
+		},
+	}
+
+	err := store.onProcessAttesterSlashing(slashing, state.New(&cfg), false)
+
+	require.ErrorIs(t, err, ErrIgnore)
 }
 
 func TestAttesterSlashingSeenCheckPrecedesValidation(t *testing.T) {

--- a/cl/phase1/forkchoice/forkchoice_test.go
+++ b/cl/phase1/forkchoice/forkchoice_test.go
@@ -166,7 +166,7 @@ func TestUpdateCheckpointsPrunesOperationsWithExactFinalizedState(t *testing.T) 
 	}()
 	select {
 	case <-drained:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		close(graph.getStateRelease)
 		<-drained
 		t.Fatal("drainQueuedWork waited for finalized operation pruning")
@@ -193,6 +193,36 @@ func TestAllAttesterSlashingIndicesSeen(t *testing.T) {
 	require.False(t, store.allAttesterSlashingIndicesSeen(nil))
 }
 
+func TestAttesterSlashingSeenCheckPrecedesValidation(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	store := &ForkChoiceStore{
+		equivocatingIndicies: []byte{0b00000010},
+	}
+	slashing := &cltypes.AttesterSlashing{
+		Attestation_1: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(2048, []uint64{1}),
+		},
+		Attestation_2: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(2048, []uint64{1}),
+		},
+	}
+
+	err := store.onProcessAttesterSlashing(slashing, state.New(&cfg), false)
+
+	require.ErrorIs(t, err, ErrIgnore)
+}
+
+func TestOnAttesterSlashingRejectsIncompleteOperation(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	store := &ForkChoiceStore{
+		operationsPool: pool.NewOperationsPool(&cfg),
+	}
+
+	require.NotPanics(t, func() {
+		require.Error(t, store.OnAttesterSlashing(&cltypes.AttesterSlashing{}, false))
+	})
+}
+
 func TestDrainQueuedWorkRetainsOperationsWhenFinalizedStateIsUnavailable(t *testing.T) {
 	cfg := clparams.MainnetBeaconConfig
 	operationsPool := pool.NewOperationsPool(&cfg)
@@ -204,12 +234,29 @@ func TestDrainQueuedWorkRetainsOperationsWhenFinalizedStateIsUnavailable(t *test
 		forkGraph:      &getFinalizedExecutionHashForkGraph{},
 		operationsPool: operationsPool,
 	}
-	store.queueOperationPrune(common.Hash{1})
+	store.queueOperationPrune(solid.Checkpoint{Epoch: 1, Root: common.Hash{1}})
 
 	store.drainQueuedWork()
 
 	requireOperationPrunerIdle(t, store)
 	require.True(t, operationsPool.VoluntaryExitsPool.Has(0))
+}
+
+func TestDrainQueuedWorkSkipsOperationStateLoadWithoutPrunableOperations(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	graph := &getFinalizedExecutionHashForkGraph{}
+	operationsPool := pool.NewOperationsPool(&cfg)
+	operationsPool.AttestationsPool.Insert(common.Bytes96{1}, &solid.Attestation{})
+	store := &ForkChoiceStore{
+		forkGraph:      graph,
+		operationsPool: operationsPool,
+	}
+	store.queueOperationPrune(solid.Checkpoint{Epoch: 1, Root: common.Hash{1}})
+
+	store.drainQueuedWork()
+
+	requireOperationPrunerIdle(t, store)
+	require.Empty(t, graph.stateRoots())
 }
 
 func TestOperationPrunerCoalescesPendingFinalizedRoots(t *testing.T) {
@@ -225,17 +272,22 @@ func TestOperationPrunerCoalescesPendingFinalizedRoots(t *testing.T) {
 		getStateStarted: make(chan common.Hash, 3),
 		getStateRelease: make(chan struct{}),
 	}
+	operationsPool := pool.NewOperationsPool(&cfg)
+	operationsPool.VoluntaryExitsPool.Insert(0, &cltypes.SignedVoluntaryExit{
+		VoluntaryExit: &cltypes.VoluntaryExit{ValidatorIndex: 0},
+	})
 	store := &ForkChoiceStore{
 		forkGraph:      graph,
-		operationsPool: pool.NewOperationsPool(&cfg),
+		operationsPool: operationsPool,
 	}
 
-	store.queueOperationPrune(firstRoot)
+	store.queueOperationPrune(solid.Checkpoint{Epoch: 1, Root: firstRoot})
 	store.drainQueuedWork()
 	require.Equal(t, firstRoot, waitForStateLoad(t, graph.getStateStarted))
 
-	store.queueOperationPrune(skippedRoot)
-	store.queueOperationPrune(latestRoot)
+	store.queueOperationPrune(solid.Checkpoint{Epoch: 3, Root: latestRoot})
+	store.drainQueuedWork()
+	store.queueOperationPrune(solid.Checkpoint{Epoch: 2, Root: skippedRoot})
 	store.drainQueuedWork()
 	close(graph.getStateRelease)
 	require.Equal(t, latestRoot, waitForStateLoad(t, graph.getStateStarted))

--- a/cl/phase1/forkchoice/on_attester_slashing.go
+++ b/cl/phase1/forkchoice/on_attester_slashing.go
@@ -30,8 +30,15 @@ import (
 )
 
 func (f *ForkChoiceStore) OnAttesterSlashing(attesterSlashing *cltypes.AttesterSlashing, test bool) error {
+	if attesterSlashing == nil ||
+		attesterSlashing.Attestation_1 == nil ||
+		attesterSlashing.Attestation_2 == nil ||
+		attesterSlashing.Attestation_1.AttestingIndices == nil ||
+		attesterSlashing.Attestation_2.AttestingIndices == nil {
+		return errors.New("invalid attester slashing")
+	}
 	if f.operationsPool.AttesterSlashingsPool.Has(pool.ComputeKeyForAttesterSlashing(attesterSlashing)) {
-		return nil
+		return ErrIgnore
 	}
 	f.mu.Lock()
 	defer f.drainQueuedWork()
@@ -58,6 +65,13 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 	// Check if this attestation is even slashable.
 	attestation1 := attesterSlashing.Attestation_1
 	attestation2 := attesterSlashing.Attestation_2
+	intersection := solid.IntersectionOfSortedSets(attestation1.AttestingIndices, attestation2.AttestingIndices)
+	if f.allAttesterSlashingIndicesSeen(intersection) {
+		return ErrIgnore
+	}
+	if attestation1.Data == nil || attestation2.Data == nil {
+		return errors.New("invalid attester slashing data")
+	}
 	if !cltypes.IsSlashableAttestationData(attestation1.Data, attestation2.Data) {
 		return errors.New("attestation data is not slashable")
 	}
@@ -68,10 +82,6 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 	attestation2PublicKeys, err := getIndexedAttestationPublicKeys(s, attestation2)
 	if err != nil {
 		return err
-	}
-	intersection := solid.IntersectionOfSortedSets(attestation1.AttestingIndices, attestation2.AttestingIndices)
-	if f.allAttesterSlashingIndicesSeen(intersection) {
-		return nil
 	}
 	domain1, err := s.GetDomain(s.BeaconConfig().DomainBeaconAttester, attestation1.Data.Target.Epoch)
 	if err != nil {

--- a/cl/phase1/forkchoice/on_attester_slashing.go
+++ b/cl/phase1/forkchoice/on_attester_slashing.go
@@ -69,6 +69,10 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 	if err != nil {
 		return err
 	}
+	intersection := solid.IntersectionOfSortedSets(attestation1.AttestingIndices, attestation2.AttestingIndices)
+	if f.allAttesterSlashingIndicesSeen(intersection) {
+		return nil
+	}
 	domain1, err := s.GetDomain(s.BeaconConfig().DomainBeaconAttester, attestation1.Data.Target.Epoch)
 	if err != nil {
 		return fmt.Errorf("unable to get the domain: %v", err)
@@ -108,7 +112,7 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 	}
 
 	var anySlashed bool
-	for _, index := range solid.IntersectionOfSortedSets(attestation1.AttestingIndices, attestation2.AttestingIndices) {
+	for _, index := range intersection {
 		f.setUnequivocating(index)
 		if !anySlashed {
 			v, err := s.ValidatorForValidatorIndex(int(index))
@@ -125,6 +129,18 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 		f.queueEmit(func() { f.emitters.Operation().SendAttesterSlashing(attesterSlashing) })
 	}
 	return nil
+}
+
+func (f *ForkChoiceStore) allAttesterSlashingIndicesSeen(indices []uint64) bool {
+	if len(indices) == 0 {
+		return false
+	}
+	for _, index := range indices {
+		if !f.isUnequivocating(index) {
+			return false
+		}
+	}
+	return true
 }
 
 func getIndexedAttestationPublicKeys(b *state.CachingBeaconState, att *cltypes.IndexedAttestation) ([][]byte, error) {

--- a/cl/phase1/forkchoice/on_attester_slashing.go
+++ b/cl/phase1/forkchoice/on_attester_slashing.go
@@ -65,7 +65,7 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 	// Check if this attestation is even slashable.
 	attestation1 := attesterSlashing.Attestation_1
 	attestation2 := attesterSlashing.Attestation_2
-	intersection := solid.IntersectionOfSortedSets(attestation1.AttestingIndices, attestation2.AttestingIndices)
+	intersection := intersectAttestingIndices(attestation1.AttestingIndices, attestation2.AttestingIndices)
 	if f.allAttesterSlashingIndicesSeen(intersection) {
 		return ErrIgnore
 	}
@@ -83,6 +83,7 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 	if err != nil {
 		return err
 	}
+	intersection = solid.IntersectionOfSortedSets(attestation1.AttestingIndices, attestation2.AttestingIndices)
 	domain1, err := s.GetDomain(s.BeaconConfig().DomainBeaconAttester, attestation1.Data.Target.Epoch)
 	if err != nil {
 		return fmt.Errorf("unable to get the domain: %v", err)
@@ -139,6 +140,22 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 		f.queueEmit(func() { f.emitters.Operation().SendAttesterSlashing(attesterSlashing) })
 	}
 	return nil
+}
+
+func intersectAttestingIndices(left, right solid.IterableSSZ[uint64]) []uint64 {
+	leftIndices := make(map[uint64]struct{}, left.Length())
+	for i := 0; i < left.Length(); i++ {
+		leftIndices[left.Get(i)] = struct{}{}
+	}
+	intersection := make([]uint64, 0, min(left.Length(), right.Length()))
+	for i := 0; i < right.Length(); i++ {
+		index := right.Get(i)
+		if _, ok := leftIndices[index]; ok {
+			intersection = append(intersection, index)
+			delete(leftIndices, index)
+		}
+	}
+	return intersection
 }
 
 func (f *ForkChoiceStore) allAttesterSlashingIndicesSeen(indices []uint64) bool {

--- a/cl/phase1/forkchoice/on_attester_slashing.go
+++ b/cl/phase1/forkchoice/on_attester_slashing.go
@@ -65,6 +65,10 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 	// Check if this attestation is even slashable.
 	attestation1 := attesterSlashing.Attestation_1
 	attestation2 := attesterSlashing.Attestation_2
+	if attestation1.AttestingIndices.Length() > attestation1.AttestingIndices.Cap() ||
+		attestation2.AttestingIndices.Length() > attestation2.AttestingIndices.Cap() {
+		return errors.New("attesting indices exceed limit")
+	}
 	intersection := intersectAttestingIndices(attestation1.AttestingIndices, attestation2.AttestingIndices)
 	if f.allAttesterSlashingIndicesSeen(intersection) {
 		return ErrIgnore
@@ -143,6 +147,9 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 }
 
 func intersectAttestingIndices(left, right solid.IterableSSZ[uint64]) []uint64 {
+	if left.Length() > right.Length() {
+		left, right = right, left
+	}
 	leftIndices := make(map[uint64]struct{}, left.Length())
 	for i := 0; i < left.Length(); i++ {
 		leftIndices[left.Get(i)] = struct{}{}

--- a/cl/phase1/forkchoice/on_attester_slashing.go
+++ b/cl/phase1/forkchoice/on_attester_slashing.go
@@ -87,7 +87,6 @@ func (f *ForkChoiceStore) onProcessAttesterSlashing(attesterSlashing *cltypes.At
 	if err != nil {
 		return err
 	}
-	intersection = solid.IntersectionOfSortedSets(attestation1.AttestingIndices, attestation2.AttestingIndices)
 	domain1, err := s.GetDomain(s.BeaconConfig().DomainBeaconAttester, attestation1.Data.Target.Epoch)
 	if err != nil {
 		return fmt.Errorf("unable to get the domain: %v", err)
@@ -166,9 +165,6 @@ func intersectAttestingIndices(left, right solid.IterableSSZ[uint64]) []uint64 {
 }
 
 func (f *ForkChoiceStore) allAttesterSlashingIndicesSeen(indices []uint64) bool {
-	if len(indices) == 0 {
-		return false
-	}
 	for _, index := range indices {
 		if !f.isUnequivocating(index) {
 			return false

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -426,8 +426,6 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 		stateFinalized              = lastProcessedState.FinalizedCheckpoint()
 		justificationBits           = lastProcessedState.JustificationBits().Copy()
 	)
-	f.operationsPool.NotifyBlock(block.Block)
-
 	// Eagerly compute unrealized justification and finality (spec: compute_pulled_up_tip)
 	if err := statechange.ProcessJustificationBitsAndFinality(lastProcessedState, nil); err != nil {
 		return err

--- a/cl/phase1/forkchoice/on_tick_test.go
+++ b/cl/phase1/forkchoice/on_tick_test.go
@@ -82,6 +82,7 @@ func TestFinalizedCheckpointEmittedOutsideLock(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("OnTick did not finish")
 	}
+	requireOperationPrunerIdle(t, f)
 }
 
 type blockingPruneForkGraph struct {
@@ -151,4 +152,5 @@ func TestForkGraphPruneRunsOutsideLock(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("OnTick did not finish")
 	}
+	requireOperationPrunerIdle(t, f)
 }

--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -45,14 +45,28 @@ func (f *ForkChoiceStore) queuePrune(slot uint64) {
 	f.queuedPrunes = append(f.queuedPrunes, slot)
 }
 
+func (f *ForkChoiceStore) queueOperationPrune(root common.Hash) {
+	f.queuedOperationPrunes = append(f.queuedOperationPrunes, root)
+}
+
 // drainQueuedWork runs queued event sends and prunes. Call after releasing f.mu.
 func (f *ForkChoiceStore) drainQueuedWork() {
 	f.mu.Lock()
 	emits := f.queuedEmits
 	prunes := f.queuedPrunes
+	operationPrunes := f.queuedOperationPrunes
 	f.queuedEmits = nil
 	f.queuedPrunes = nil
+	f.queuedOperationPrunes = nil
 	f.mu.Unlock()
+	for _, root := range operationPrunes {
+		finalizedState, err := f.forkGraph.GetState(root, true)
+		if err != nil || finalizedState == nil {
+			log.Warn("Failed to load finalized state for operation pruning", "root", root, "err", err)
+			continue
+		}
+		f.operationsPool.PruneFinalized(finalizedState)
+	}
 	for _, emit := range emits {
 		emit()
 	}
@@ -69,6 +83,7 @@ func (f *ForkChoiceStore) updateCheckpoints(justifiedCheckpoint, finalizedCheckp
 		f.justifiedCheckpoint.Store(justifiedCheckpoint)
 	}
 	if finalizedCheckpoint.Epoch > f.finalizedCheckpoint.Load().(solid.Checkpoint).Epoch {
+		f.queueOperationPrune(finalizedCheckpoint.Root)
 		f.onNewFinalized(finalizedCheckpoint)
 		f.finalizedCheckpoint.Store(finalizedCheckpoint)
 

--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -45,8 +45,8 @@ func (f *ForkChoiceStore) queuePrune(slot uint64) {
 	f.queuedPrunes = append(f.queuedPrunes, slot)
 }
 
-func (f *ForkChoiceStore) queueOperationPrune(root common.Hash) {
-	f.queuedOperationPrunes = append(f.queuedOperationPrunes, root)
+func (f *ForkChoiceStore) queueOperationPrune(checkpoint solid.Checkpoint) {
+	f.queuedOperationPrunes = append(f.queuedOperationPrunes, checkpoint)
 }
 
 // drainQueuedWork runs queued event sends and prunes. Call after releasing f.mu.
@@ -59,7 +59,7 @@ func (f *ForkChoiceStore) drainQueuedWork() {
 	f.queuedPrunes = nil
 	f.queuedOperationPrunes = nil
 	f.mu.Unlock()
-	if len(operationPrunes) > 0 {
+	if len(operationPrunes) > 0 && f.operationsPool.HasPrunableOperations() {
 		f.scheduleOperationPrune(operationPrunes[len(operationPrunes)-1])
 	}
 	for _, emit := range emits {
@@ -72,9 +72,13 @@ func (f *ForkChoiceStore) drainQueuedWork() {
 	}
 }
 
-func (f *ForkChoiceStore) scheduleOperationPrune(root common.Hash) {
+func (f *ForkChoiceStore) scheduleOperationPrune(checkpoint solid.Checkpoint) {
 	f.operationPruneMu.Lock()
-	f.operationPruneRoot = root
+	if checkpoint.Epoch <= f.operationPruneTarget.Epoch {
+		f.operationPruneMu.Unlock()
+		return
+	}
+	f.operationPruneTarget = checkpoint
 	f.operationPrunePending = true
 	if f.operationPruneRunning {
 		f.operationPruneMu.Unlock()
@@ -93,16 +97,19 @@ func (f *ForkChoiceStore) runOperationPruner() {
 			f.operationPruneMu.Unlock()
 			return
 		}
-		root := f.operationPruneRoot
+		checkpoint := f.operationPruneTarget
 		f.operationPrunePending = false
 		f.operationPruneMu.Unlock()
 
-		finalizedState, err := f.forkGraph.GetState(root, true)
-		if err != nil || finalizedState == nil {
-			log.Warn("Failed to load finalized state for operation pruning", "root", root, "err", err)
+		if !f.operationsPool.HasPrunableOperations() {
 			continue
 		}
-		f.operationsPool.PruneFinalized(finalizedState)
+		finalizedState, err := f.forkGraph.GetState(checkpoint.Root, true)
+		if err != nil || finalizedState == nil {
+			log.Warn("Failed to load finalized state for operation pruning", "root", checkpoint.Root, "err", err)
+			continue
+		}
+		f.operationsPool.PruneFinalized(finalizedState, checkpoint.Epoch)
 	}
 }
 
@@ -112,7 +119,7 @@ func (f *ForkChoiceStore) updateCheckpoints(justifiedCheckpoint, finalizedCheckp
 		f.justifiedCheckpoint.Store(justifiedCheckpoint)
 	}
 	if finalizedCheckpoint.Epoch > f.finalizedCheckpoint.Load().(solid.Checkpoint).Epoch {
-		f.queueOperationPrune(finalizedCheckpoint.Root)
+		f.queueOperationPrune(finalizedCheckpoint)
 		f.onNewFinalized(finalizedCheckpoint)
 		f.finalizedCheckpoint.Store(finalizedCheckpoint)
 

--- a/cl/phase1/forkchoice/utils.go
+++ b/cl/phase1/forkchoice/utils.go
@@ -59,13 +59,8 @@ func (f *ForkChoiceStore) drainQueuedWork() {
 	f.queuedPrunes = nil
 	f.queuedOperationPrunes = nil
 	f.mu.Unlock()
-	for _, root := range operationPrunes {
-		finalizedState, err := f.forkGraph.GetState(root, true)
-		if err != nil || finalizedState == nil {
-			log.Warn("Failed to load finalized state for operation pruning", "root", root, "err", err)
-			continue
-		}
-		f.operationsPool.PruneFinalized(finalizedState)
+	if len(operationPrunes) > 0 {
+		f.scheduleOperationPrune(operationPrunes[len(operationPrunes)-1])
 	}
 	for _, emit := range emits {
 		emit()
@@ -74,6 +69,40 @@ func (f *ForkChoiceStore) drainQueuedWork() {
 		if err := f.forkGraph.Prune(pruneSlot); err != nil {
 			log.Warn("Failed to prune fork graph", "pruneSlot", pruneSlot, "err", err)
 		}
+	}
+}
+
+func (f *ForkChoiceStore) scheduleOperationPrune(root common.Hash) {
+	f.operationPruneMu.Lock()
+	f.operationPruneRoot = root
+	f.operationPrunePending = true
+	if f.operationPruneRunning {
+		f.operationPruneMu.Unlock()
+		return
+	}
+	f.operationPruneRunning = true
+	f.operationPruneMu.Unlock()
+	go f.runOperationPruner()
+}
+
+func (f *ForkChoiceStore) runOperationPruner() {
+	for {
+		f.operationPruneMu.Lock()
+		if !f.operationPrunePending {
+			f.operationPruneRunning = false
+			f.operationPruneMu.Unlock()
+			return
+		}
+		root := f.operationPruneRoot
+		f.operationPrunePending = false
+		f.operationPruneMu.Unlock()
+
+		finalizedState, err := f.forkGraph.GetState(root, true)
+		if err != nil || finalizedState == nil {
+			log.Warn("Failed to load finalized state for operation pruning", "root", root, "err", err)
+			continue
+		}
+		f.operationsPool.PruneFinalized(finalizedState)
 	}
 }
 

--- a/cl/phase1/network/services/block_service.go
+++ b/cl/phase1/network/services/block_service.go
@@ -312,7 +312,7 @@ func (b *blockService) importBlockOperations(block *cltypes.SignedBeaconBlock) {
 		return true
 	})
 	block.Block.Body.AttesterSlashings.Range(func(idx int, a *cltypes.AttesterSlashing, total int) bool {
-		if err := b.forkchoiceStore.OnAttesterSlashing(a, false); err != nil {
+		if err := b.forkchoiceStore.OnAttesterSlashing(a, false); err != nil && !errors.Is(err, forkchoice.ErrIgnore) {
 			log.Debug("bad attester slashing received", "err", err)
 		}
 		return true

--- a/cl/phase1/network/services/block_service_test.go
+++ b/cl/phase1/network/services/block_service_test.go
@@ -17,7 +17,9 @@
 package services
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,11 +30,22 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
 	"github.com/erigontech/erigon/db/kv/memdb"
 )
+
+type attesterSlashingErrorStore struct {
+	forkchoice.ForkChoiceStorage
+	err error
+}
+
+func (s attesterSlashingErrorStore) OnAttesterSlashing(*cltypes.AttesterSlashing, bool) error {
+	return s.err
+}
 
 func setupBlockService(t *testing.T, ctrl *gomock.Controller) (BlockService, *synced_data.SyncedDataManager, *eth_clock.MockEthereumClock, *mock_services.ForkChoiceStorageMock) {
 	db := memdb.NewTestDB(t, dbcfg.ChainDB)
@@ -151,6 +164,35 @@ func TestBlockServiceSuccess(t *testing.T) {
 	blocks[1].Block.Body.BlobKzgCommitments = solid.NewStaticListSSZ[*cltypes.KZGCommitment](100, 48)
 
 	require.NoError(t, blockService.ProcessMessage(context.Background(), nil, blocks[1]))
+}
+
+func TestImportBlockOperationsAttesterSlashingLogging(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantLogged bool
+	}{
+		{name: "ignored", err: forkchoice.ErrIgnore},
+		{name: "rejected", err: errors.New("invalid attester slashing"), wantLogged: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var output bytes.Buffer
+			logger := log.Root()
+			previousHandler := logger.GetHandler()
+			logger.SetHandler(log.StreamHandler(&output, log.LogfmtFormat()))
+			t.Cleanup(func() { logger.SetHandler(previousHandler) })
+
+			block := cltypes.NewSignedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.Phase0Version)
+			block.Block.Body.AttesterSlashings.Append(&cltypes.AttesterSlashing{})
+			service := blockService{forkchoiceStore: attesterSlashingErrorStore{err: tc.err}}
+
+			service.importBlockOperations(block)
+
+			require.Equal(t, tc.wantLogged, bytes.Contains(output.Bytes(), []byte("bad attester slashing received")))
+		})
+	}
 }
 
 // ==================== GLOAS (EIP-7732/ePBS) Tests ====================

--- a/cl/phase1/network/services/bls_to_execution_change_service.go
+++ b/cl/phase1/network/services/bls_to_execution_change_service.go
@@ -104,10 +104,10 @@ func (s *blsToExecutionChangeService) ProcessMessage(ctx context.Context, subnet
 	// for the validator with index signed_bls_to_execution_change.message.validator_index.
 	change := msg.SignedBLSToExecutionChange.Message
 	if _, ok := s.seen.Get(change.ValidatorIndex); ok {
-		return nil
+		return ErrIgnore
 	}
 	if s.operationsPool.BLSToExecutionChangesPool.Has(msg.SignedBLSToExecutionChange.Signature) {
-		return nil
+		return ErrIgnore
 	}
 
 	var wc, genesisValidatorRoot common.Hash
@@ -159,9 +159,7 @@ func (s *blsToExecutionChangeService) ProcessMessage(ctx context.Context, subnet
 		Pks:         [][]byte{change.From[:]},
 		SendingPeer: msg.Receiver,
 		F: func() {
-			s.seen.Add(change.ValidatorIndex, struct{}{})
-			s.emitters.Operation().SendBlsToExecution(msg.SignedBLSToExecutionChange)
-			s.operationsPool.BLSToExecutionChangesPool.Insert(msg.SignedBLSToExecutionChange.Signature, msg.SignedBLSToExecutionChange)
+			s.storeVerifiedChange(msg.SignedBLSToExecutionChange)
 		},
 	}
 
@@ -177,4 +175,12 @@ func (s *blsToExecutionChangeService) ProcessMessage(ctx context.Context, subnet
 	// in BatchSignatureVerifier service. After validating signatures, if they are valid we will publish the
 	// gossip ourselves or ban the peer which sent that particular invalid signature.
 	return nil
+}
+
+func (s *blsToExecutionChangeService) storeVerifiedChange(change *cltypes.SignedBLSToExecutionChange) {
+	if seen, _ := s.seen.ContainsOrAdd(change.Message.ValidatorIndex, struct{}{}); seen {
+		return
+	}
+	s.emitters.Operation().SendBlsToExecution(change)
+	s.operationsPool.BLSToExecutionChangesPool.Insert(change.Signature, change)
 }

--- a/cl/phase1/network/services/bls_to_execution_change_service.go
+++ b/cl/phase1/network/services/bls_to_execution_change_service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erigontech/erigon/cl/fork"
 	"github.com/erigontech/erigon/cl/gossip"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/pool"
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
@@ -51,6 +52,7 @@ type blsToExecutionChangeService struct {
 	syncedDataManager      synced_data.SyncedData
 	beaconCfg              *clparams.BeaconChainConfig
 	batchSignatureVerifier *BatchSignatureVerifier
+	seen                   *lru.Cache[uint64, struct{}]
 }
 
 func NewBLSToExecutionChangeService(
@@ -60,12 +62,17 @@ func NewBLSToExecutionChangeService(
 	beaconCfg *clparams.BeaconChainConfig,
 	batchSignatureVerifier *BatchSignatureVerifier,
 ) BLSToExecutionChangeService {
+	seen, err := lru.New[uint64, struct{}]("bls_to_execution_change_seen", operationSeenCacheSize)
+	if err != nil {
+		panic(err)
+	}
 	return &blsToExecutionChangeService{
 		operationsPool:         operationsPool,
 		emitters:               emitters,
 		syncedDataManager:      syncedDataManager,
 		beaconCfg:              beaconCfg,
 		batchSignatureVerifier: batchSignatureVerifier,
+		seen:                   seen,
 	}
 }
 
@@ -89,13 +96,19 @@ func (s *blsToExecutionChangeService) DecodeGossipMessage(pid peer.ID, data []by
 }
 
 func (s *blsToExecutionChangeService) ProcessMessage(ctx context.Context, subnet *uint64, msg *SignedBLSToExecutionChangeForGossip) error {
+	if msg == nil || msg.SignedBLSToExecutionChange == nil || msg.SignedBLSToExecutionChange.Message == nil {
+		return errors.New("invalid BLS to execution change")
+	}
 	// https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/p2p-interface.md#bls_to_execution_change
 	// [IGNORE] The signed_bls_to_execution_change is the first valid signed bls to execution change received
 	// for the validator with index signed_bls_to_execution_change.message.validator_index.
+	change := msg.SignedBLSToExecutionChange.Message
+	if _, ok := s.seen.Get(change.ValidatorIndex); ok {
+		return nil
+	}
 	if s.operationsPool.BLSToExecutionChangesPool.Has(msg.SignedBLSToExecutionChange.Signature) {
 		return nil
 	}
-	change := msg.SignedBLSToExecutionChange.Message
 
 	var wc, genesisValidatorRoot common.Hash
 	if err := s.syncedDataManager.ViewHeadState(func(stateReader *state.CachingBeaconState) error {
@@ -146,6 +159,7 @@ func (s *blsToExecutionChangeService) ProcessMessage(ctx context.Context, subnet
 		Pks:         [][]byte{change.From[:]},
 		SendingPeer: msg.Receiver,
 		F: func() {
+			s.seen.Add(change.ValidatorIndex, struct{}{})
 			s.emitters.Operation().SendBlsToExecution(msg.SignedBLSToExecutionChange)
 			s.operationsPool.BLSToExecutionChangesPool.Insert(msg.SignedBLSToExecutionChange.Signature, msg.SignedBLSToExecutionChange)
 		},

--- a/cl/phase1/network/services/bls_to_execution_change_service_test.go
+++ b/cl/phase1/network/services/bls_to_execution_change_service_test.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -127,6 +128,7 @@ func TestBlsToExecutionChangeProcessMessage(t *testing.T) {
 			prepare: func(t *testing.T, testCtx *blsToExecutionChangeTestContext, _ *state.CachingBeaconState, msg *SignedBLSToExecutionChangeForGossip) {
 				testCtx.operationsPool.BLSToExecutionChangesPool.Insert(msg.SignedBLSToExecutionChange.Signature, msg.SignedBLSToExecutionChange)
 			},
+			wantErr:    ErrIgnore,
 			wantInPool: true,
 		},
 		{
@@ -235,8 +237,26 @@ func TestBlsToExecutionChangeIgnoresSeenValidatorAfterPoolPrune(t *testing.T) {
 	st.ValidatorSet().SetWithdrawalCredentialForValidatorAtIndex(int(validatorIndex), credentials)
 	syncHeadState(t, testCtx.syncedData, st)
 
-	require.NoError(t, testCtx.service.ProcessMessage(context.Background(), nil, msg))
+	require.ErrorIs(t, testCtx.service.ProcessMessage(context.Background(), nil, msg), ErrIgnore)
 	require.True(t, testCtx.gomockCtrl.Satisfied())
+}
+
+func TestBlsToExecutionChangeStoresOneVerifiedChangePerValidator(t *testing.T) {
+	const validatorIndex = uint64(1)
+	testCtx, _ := setupBLSToExecutionChangeTest(t)
+	service := testCtx.service.(*blsToExecutionChangeService)
+	const variants = 32
+	var wg sync.WaitGroup
+	for i := range variants {
+		change := newSignedBLSToExecutionChangeForGossip(validatorIndex).SignedBLSToExecutionChange
+		change.Signature[0] = byte(i + 1)
+		wg.Go(func() {
+			service.storeVerifiedChange(change)
+		})
+	}
+	wg.Wait()
+
+	require.Len(t, testCtx.operationsPool.BLSToExecutionChangesPool.Raw(), 1)
 }
 
 func TestBlsToExecutionChangeRejectsIncompleteMessage(t *testing.T) {

--- a/cl/phase1/network/services/bls_to_execution_change_service_test.go
+++ b/cl/phase1/network/services/bls_to_execution_change_service_test.go
@@ -204,3 +204,50 @@ func TestBlsToExecutionChangeProcessMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestBlsToExecutionChangeIgnoresSeenValidatorAfterPoolPrune(t *testing.T) {
+	const validatorIndex = uint64(1)
+	testCtx, st := setupBLSToExecutionChangeTest(t)
+	msg := newSignedBLSToExecutionChangeForGossip(validatorIndex)
+	st.ValidatorSet().SetWithdrawalCredentialForValidatorAtIndex(
+		int(validatorIndex),
+		matchingWithdrawalCredentials(testCtx.beaconCfg, msg.SignedBLSToExecutionChange.Message.From),
+	)
+	syncHeadState(t, testCtx.syncedData, st)
+	testCtx.gomockCtrl.RecordCall(
+		testCtx.mockFuncs,
+		"ComputeSigningRoot",
+		msg.SignedBLSToExecutionChange.Message,
+		gomock.Any(),
+	).Return([32]byte{}, nil).Times(1)
+	testCtx.gomockCtrl.RecordCall(
+		testCtx.mockFuncs,
+		"BlsVerifyMultipleSignatures",
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(true, nil).Times(1)
+
+	require.NoError(t, testCtx.service.ProcessMessage(context.Background(), nil, msg))
+	require.True(t, testCtx.operationsPool.BLSToExecutionChangesPool.DeleteIfExist(msg.SignedBLSToExecutionChange.Signature))
+	credentials := matchingWithdrawalCredentials(testCtx.beaconCfg, msg.SignedBLSToExecutionChange.Message.From)
+	credentials[0] = byte(testCtx.beaconCfg.ETH1AddressWithdrawalPrefixByte)
+	st.ValidatorSet().SetWithdrawalCredentialForValidatorAtIndex(int(validatorIndex), credentials)
+	syncHeadState(t, testCtx.syncedData, st)
+
+	require.NoError(t, testCtx.service.ProcessMessage(context.Background(), nil, msg))
+	require.True(t, testCtx.gomockCtrl.Satisfied())
+}
+
+func TestBlsToExecutionChangeRejectsIncompleteMessage(t *testing.T) {
+	testCtx, _ := setupBLSToExecutionChangeTest(t)
+	for _, msg := range []*SignedBLSToExecutionChangeForGossip{
+		nil,
+		{},
+		{SignedBLSToExecutionChange: &cltypes.SignedBLSToExecutionChange{}},
+	} {
+		require.NotPanics(t, func() {
+			require.Error(t, testCtx.service.ProcessMessage(context.Background(), nil, msg))
+		})
+	}
+}

--- a/cl/phase1/network/services/constants.go
+++ b/cl/phase1/network/services/constants.go
@@ -27,6 +27,7 @@ import (
 const (
 	validatorAttestationCacheSize = 100_000
 	proposerSlashingCacheSize     = 100
+	operationSeenCacheSize        = 16_384
 	seenBlockCacheSize            = 1000 // SeenBlockCacheSize is the size of the cache for seen blocks.
 	blockJobsIntervalTick         = 50 * time.Millisecond
 	blobJobsIntervalTick          = 5 * time.Millisecond

--- a/cl/phase1/network/services/voluntary_exit_service.go
+++ b/cl/phase1/network/services/voluntary_exit_service.go
@@ -105,10 +105,10 @@ func (s *voluntaryExitService) ProcessMessage(ctx context.Context, subnet *uint6
 
 	// [IGNORE] The voluntary exit is the first valid voluntary exit received for the validator with index signed_voluntary_exit.message.validator_index.
 	if _, ok := s.seen.Get(voluntaryExit.ValidatorIndex); ok {
-		return nil
+		return ErrIgnore
 	}
 	if s.operationsPool.VoluntaryExitsPool.Has(voluntaryExit.ValidatorIndex) {
-		return nil
+		return ErrIgnore
 	}
 
 	var (
@@ -180,9 +180,7 @@ func (s *voluntaryExitService) ProcessMessage(ctx context.Context, subnet *uint6
 		Pks:         [][]byte{pk[:]},
 		SendingPeer: msg.Receiver,
 		F: func() {
-			s.seen.Add(voluntaryExit.ValidatorIndex, struct{}{})
-			s.operationsPool.VoluntaryExitsPool.Insert(voluntaryExit.ValidatorIndex, msg.SignedVoluntaryExit)
-			s.emitters.Operation().SendVoluntaryExit(msg.SignedVoluntaryExit)
+			s.storeVerifiedExit(msg.SignedVoluntaryExit)
 		},
 	}
 
@@ -198,4 +196,12 @@ func (s *voluntaryExitService) ProcessMessage(ctx context.Context, subnet *uint6
 	// in BatchSignatureVerifier service. After validating signatures, if they are valid we will publish the
 	// gossip ourselves or ban the peer which sent that particular invalid signature.
 	return nil
+}
+
+func (s *voluntaryExitService) storeVerifiedExit(exit *cltypes.SignedVoluntaryExit) {
+	if seen, _ := s.seen.ContainsOrAdd(exit.VoluntaryExit.ValidatorIndex, struct{}{}); seen {
+		return
+	}
+	s.operationsPool.VoluntaryExitsPool.Insert(exit.VoluntaryExit.ValidatorIndex, exit)
+	s.emitters.Operation().SendVoluntaryExit(exit)
 }

--- a/cl/phase1/network/services/voluntary_exit_service.go
+++ b/cl/phase1/network/services/voluntary_exit_service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erigontech/erigon/cl/fork"
 	"github.com/erigontech/erigon/cl/gossip"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/pool"
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
@@ -43,6 +44,7 @@ type voluntaryExitService struct {
 	beaconCfg              *clparams.BeaconChainConfig
 	ethClock               eth_clock.EthereumClock
 	batchSignatureVerifier *BatchSignatureVerifier
+	seen                   *lru.Cache[uint64, struct{}]
 }
 
 // SignedVoluntaryExitForGossip type represents SignedVoluntaryExit with the gossip data where it's coming from.
@@ -60,6 +62,10 @@ func NewVoluntaryExitService(
 	ethClock eth_clock.EthereumClock,
 	batchSignatureVerifier *BatchSignatureVerifier,
 ) VoluntaryExitService {
+	seen, err := lru.New[uint64, struct{}]("voluntary_exit_seen", operationSeenCacheSize)
+	if err != nil {
+		panic(err)
+	}
 	return &voluntaryExitService{
 		operationsPool:         operationsPool,
 		emitters:               emitters,
@@ -67,6 +73,7 @@ func NewVoluntaryExitService(
 		beaconCfg:              beaconCfg,
 		ethClock:               ethClock,
 		batchSignatureVerifier: batchSignatureVerifier,
+		seen:                   seen,
 	}
 }
 
@@ -90,10 +97,16 @@ func (s *voluntaryExitService) DecodeGossipMessage(pid peer.ID, data []byte, ver
 }
 
 func (s *voluntaryExitService) ProcessMessage(ctx context.Context, subnet *uint64, msg *SignedVoluntaryExitForGossip) error {
+	if msg == nil || msg.SignedVoluntaryExit == nil || msg.SignedVoluntaryExit.VoluntaryExit == nil {
+		return errors.New("invalid voluntary exit")
+	}
 	// ref: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#voluntary_exit
 	voluntaryExit := msg.SignedVoluntaryExit.VoluntaryExit
 
 	// [IGNORE] The voluntary exit is the first valid voluntary exit received for the validator with index signed_voluntary_exit.message.validator_index.
+	if _, ok := s.seen.Get(voluntaryExit.ValidatorIndex); ok {
+		return nil
+	}
 	if s.operationsPool.VoluntaryExitsPool.Has(voluntaryExit.ValidatorIndex) {
 		return nil
 	}
@@ -167,6 +180,7 @@ func (s *voluntaryExitService) ProcessMessage(ctx context.Context, subnet *uint6
 		Pks:         [][]byte{pk[:]},
 		SendingPeer: msg.Receiver,
 		F: func() {
+			s.seen.Add(voluntaryExit.ValidatorIndex, struct{}{})
 			s.operationsPool.VoluntaryExitsPool.Insert(voluntaryExit.ValidatorIndex, msg.SignedVoluntaryExit)
 			s.emitters.Operation().SendVoluntaryExit(msg.SignedVoluntaryExit)
 		},

--- a/cl/phase1/network/services/voluntary_exit_service_test.go
+++ b/cl/phase1/network/services/voluntary_exit_service_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/pool"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/ssz"
 )
 
@@ -247,6 +248,65 @@ func (t *voluntaryExitTestSuite) TestProcessMessage() {
 		} else {
 			t.Require().NoError(err)
 		}
+	}
+}
+
+func (t *voluntaryExitTestSuite) TestSeenValidatorIsIgnoredAfterPoolPrune() {
+	const (
+		currentEpoch   = uint64(100)
+		validatorIndex = uint64(10)
+	)
+	msg := &SignedVoluntaryExitForGossip{
+		SignedVoluntaryExit: &cltypes.SignedVoluntaryExit{
+			VoluntaryExit: &cltypes.VoluntaryExit{
+				Epoch:          1,
+				ValidatorIndex: validatorIndex,
+			},
+		},
+		ImmediateVerification: true,
+	}
+	_, st, _ := tests.GetBellatrixRandom()
+	validator := solid.NewValidatorFromParameters(
+		common.Bytes48{},
+		common.Hash{},
+		0,
+		false,
+		0,
+		0,
+		currentEpoch+1,
+		0,
+	)
+	st.ValidatorSet().Set(int(validatorIndex), validator)
+	t.Require().NoError(t.syncedData.OnHeadState(st))
+	t.ethClock.EXPECT().GetCurrentEpoch().Return(currentEpoch).Times(1)
+	t.beaconCfg.FarFutureEpoch = validator.ExitEpoch()
+	t.gomockCtrl.RecordCall(
+		t.mockFuncs,
+		"BlsVerifyMultipleSignatures",
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(true, nil).Times(1)
+
+	t.Require().NoError(t.voluntaryExitService.ProcessMessage(context.Background(), nil, msg))
+	t.Require().True(t.operationsPool.VoluntaryExitsPool.DeleteIfExist(validatorIndex))
+	validator.SetExitEpoch(0)
+	st.ValidatorSet().Set(int(validatorIndex), validator)
+	t.Require().NoError(t.syncedData.OnHeadState(st))
+
+	t.Require().NoError(t.voluntaryExitService.ProcessMessage(context.Background(), nil, msg))
+	t.Require().True(t.gomockCtrl.Satisfied())
+}
+
+func (t *voluntaryExitTestSuite) TestIncompleteMessageReturnsError() {
+	for _, msg := range []*SignedVoluntaryExitForGossip{
+		nil,
+		{},
+		{SignedVoluntaryExit: &cltypes.SignedVoluntaryExit{}},
+	} {
+		t.Require().NotPanics(func() {
+			t.Require().Error(t.voluntaryExitService.ProcessMessage(context.Background(), nil, msg))
+		})
 	}
 }
 

--- a/cl/phase1/network/services/voluntary_exit_service_test.go
+++ b/cl/phase1/network/services/voluntary_exit_service_test.go
@@ -117,7 +117,8 @@ func (t *voluntaryExitTestSuite) TestProcessMessage() {
 				t.operationsPool.VoluntaryExitsPool.Insert(mockValidatorIndex, mockMsg.SignedVoluntaryExit)
 			},
 			msg:     mockMsg,
-			wantErr: false, // Silent ignore: returns nil when already in pool
+			wantErr: true,
+			err:     ErrIgnore,
 		},
 		{
 			name: "state is nil",
@@ -294,7 +295,7 @@ func (t *voluntaryExitTestSuite) TestSeenValidatorIsIgnoredAfterPoolPrune() {
 	st.ValidatorSet().Set(int(validatorIndex), validator)
 	t.Require().NoError(t.syncedData.OnHeadState(st))
 
-	t.Require().NoError(t.voluntaryExitService.ProcessMessage(context.Background(), nil, msg))
+	t.Require().ErrorIs(t.voluntaryExitService.ProcessMessage(context.Background(), nil, msg), ErrIgnore)
 	t.Require().True(t.gomockCtrl.Satisfied())
 }
 

--- a/cl/pool/operation_pool.go
+++ b/cl/pool/operation_pool.go
@@ -71,6 +71,10 @@ func (o *OperationPool[K, T]) Raw() []T {
 	return o.pool.Values()
 }
 
+func (o *OperationPool[K, T]) Len() int {
+	return o.pool.Len()
+}
+
 func (o *OperationPool[K, T]) Get(k K) (T, bool) {
 	return o.pool.Get(k)
 }

--- a/cl/pool/operations_pool.go
+++ b/cl/pool/operations_pool.go
@@ -112,6 +112,7 @@ func (o *OperationsPool) PruneFinalized(finalizedState abstract.BeaconState, fin
 			continue
 		}
 		validatorIndex := exit.VoluntaryExit.ValidatorIndex
+		// Builder indices are reusable, so finalized validator state cannot prove a builder exit terminal.
 		if validatorIndex&clparams.BuilderIndexFlag != 0 {
 			continue
 		}

--- a/cl/pool/operations_pool.go
+++ b/cl/pool/operations_pool.go
@@ -78,11 +78,17 @@ func NewOperationsPool(beaconCfg *clparams.BeaconChainConfig) OperationsPool {
 	}
 }
 
-func (o *OperationsPool) PruneFinalized(finalizedState abstract.BeaconState) {
+func (o *OperationsPool) HasPrunableOperations() bool {
+	return o.AttesterSlashingsPool.Len() > 0 ||
+		o.ProposerSlashingsPool.Len() > 0 ||
+		o.BLSToExecutionChangesPool.Len() > 0 ||
+		o.VoluntaryExitsPool.Len() > 0
+}
+
+func (o *OperationsPool) PruneFinalized(finalizedState abstract.BeaconState, finalizedEpoch uint64) {
 	if finalizedState == nil {
 		return
 	}
-	finalizedEpoch := finalizedState.Slot() / finalizedState.BeaconConfig().SlotsPerEpoch
 
 	for _, slashing := range o.ProposerSlashingsPool.Raw() {
 		if slashing == nil || slashing.Header1 == nil || slashing.Header1.Header == nil || slashing.Header2 == nil {

--- a/cl/pool/operations_pool.go
+++ b/cl/pool/operations_pool.go
@@ -17,6 +17,7 @@
 package pool
 
 import (
+	"github.com/erigontech/erigon/cl/abstract"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
@@ -24,22 +25,18 @@ import (
 	"github.com/erigontech/erigon/common/crypto/blake2b"
 )
 
-// Pool capacities are gossip retention windows, not per-block bounds: the pools are drained
-// only by eviction, and a proposer packs from operations gathered over many slots.
+// Pool capacities are gossip retention windows bounded by finalized-state pruning and eviction.
 const (
 	// Aggregates are retained for this many slots. A deeper window offers the proposer more
 	// partial aggregates to merge, but block production is linear in pool occupancy and
 	// quadratic within one data root, with a BLS aggregation per merge, so widening it is a
 	// latency trade and needs measuring first.
 	attestationRetentionSlots = 10
-	// Has() on these pools is the only cheap gate in front of full BLS verification of a
-	// re-gossiped slashing, so keep them deep: eviction is not recoverable for lifeSpan.
 	attesterSlashingsCapacity = 10240
 	proposerSlashingsCapacity = 10240
-	// Keyed by validator index, so the pool self-dedupes. Sized for a mass-exit queue
-	// arriving faster than it drains at MaxVoluntaryExits per block.
+	// Voluntary exits are keyed by validator index and sized for a mass-exit queue.
 	voluntaryExitsCapacity = 16384
-	// Purged on every imported block, so this only ever holds one slot of arrivals.
+	// BLS changes remain available through reorgs until their credential changes are finalized.
 	blsToExecutionChangesCapacity = 10240
 )
 
@@ -81,22 +78,83 @@ func NewOperationsPool(beaconCfg *clparams.BeaconChainConfig) OperationsPool {
 	}
 }
 
-func (o *OperationsPool) NotifyBlock(blk *cltypes.BeaconBlock) {
-	blk.Body.VoluntaryExits.Range(func(_ int, exit *cltypes.SignedVoluntaryExit, _ int) bool {
-		o.VoluntaryExitsPool.DeleteIfExist(exit.VoluntaryExit.ValidatorIndex)
-		return true
-	})
-	blk.Body.AttesterSlashings.Range(func(_ int, att *cltypes.AttesterSlashing, _ int) bool {
-		o.AttesterSlashingsPool.DeleteIfExist(ComputeKeyForAttesterSlashing(att))
-		return true
-	})
-	blk.Body.ProposerSlashings.Range(func(_ int, ps *cltypes.ProposerSlashing, _ int) bool {
-		o.ProposerSlashingsPool.DeleteIfExist(ComputeKeyForProposerSlashing(ps))
-		return true
-	})
-	blk.Body.ExecutionChanges.Range(func(_ int, c *cltypes.SignedBLSToExecutionChange, _ int) bool {
-		o.BLSToExecutionChangesPool.DeleteIfExist(c.Signature)
-		return true
-	})
-	o.BLSToExecutionChangesPool.pool.Purge()
+func (o *OperationsPool) PruneFinalized(finalizedState abstract.BeaconState) {
+	if finalizedState == nil {
+		return
+	}
+	finalizedEpoch := finalizedState.Slot() / finalizedState.BeaconConfig().SlotsPerEpoch
+
+	for _, slashing := range o.ProposerSlashingsPool.Raw() {
+		if slashing == nil || slashing.Header1 == nil || slashing.Header1.Header == nil || slashing.Header2 == nil {
+			continue
+		}
+		validator, ok := validatorFromState(finalizedState, slashing.Header1.Header.ProposerIndex)
+		if ok && slashingTerminal(validator, finalizedEpoch) {
+			o.ProposerSlashingsPool.DeleteIfExist(ComputeKeyForProposerSlashing(slashing))
+		}
+	}
+
+	for _, slashing := range o.AttesterSlashingsPool.Raw() {
+		if !attesterSlashingTerminal(finalizedState, slashing, finalizedEpoch) {
+			continue
+		}
+		o.AttesterSlashingsPool.DeleteIfExist(ComputeKeyForAttesterSlashing(slashing))
+	}
+
+	for _, exit := range o.VoluntaryExitsPool.Raw() {
+		if exit == nil || exit.VoluntaryExit == nil {
+			continue
+		}
+		validatorIndex := exit.VoluntaryExit.ValidatorIndex
+		if validatorIndex&clparams.BuilderIndexFlag != 0 {
+			continue
+		}
+		validator, ok := validatorFromState(finalizedState, validatorIndex)
+		if ok && validator.ExitEpoch() != finalizedState.BeaconConfig().FarFutureEpoch {
+			o.VoluntaryExitsPool.DeleteIfExist(validatorIndex)
+		}
+	}
+
+	for _, change := range o.BLSToExecutionChangesPool.Raw() {
+		if change == nil || change.Message == nil {
+			continue
+		}
+		validator, ok := validatorFromState(finalizedState, change.Message.ValidatorIndex)
+		if ok && validator.WithdrawalCredentials()[0] != byte(finalizedState.BeaconConfig().BLSWithdrawalPrefixByte) {
+			o.BLSToExecutionChangesPool.DeleteIfExist(change.Signature)
+		}
+	}
+}
+
+func validatorFromState(finalizedState abstract.BeaconState, validatorIndex uint64) (solid.Validator, bool) {
+	if validatorIndex >= uint64(finalizedState.ValidatorLength()) {
+		return nil, false
+	}
+	validator, err := finalizedState.ValidatorForValidatorIndex(int(validatorIndex))
+	return validator, err == nil && validator != nil
+}
+
+func slashingTerminal(validator solid.Validator, finalizedEpoch uint64) bool {
+	return validator.Slashed() || validator.WithdrawableEpoch() <= finalizedEpoch
+}
+
+func attesterSlashingTerminal(finalizedState abstract.BeaconState, slashing *cltypes.AttesterSlashing, finalizedEpoch uint64) bool {
+	if slashing == nil || slashing.Attestation_1 == nil || slashing.Attestation_2 == nil ||
+		slashing.Attestation_1.AttestingIndices == nil || slashing.Attestation_2.AttestingIndices == nil {
+		return false
+	}
+	intersection := solid.IntersectionOfSortedSets(
+		slashing.Attestation_1.AttestingIndices,
+		slashing.Attestation_2.AttestingIndices,
+	)
+	if len(intersection) == 0 {
+		return false
+	}
+	for _, validatorIndex := range intersection {
+		validator, ok := validatorFromState(finalizedState, validatorIndex)
+		if !ok || !slashingTerminal(validator, finalizedEpoch) {
+			return false
+		}
+	}
+	return true
 }

--- a/cl/pool/operations_pool_test.go
+++ b/cl/pool/operations_pool_test.go
@@ -18,6 +18,7 @@ package pool
 
 import (
 	"encoding/binary"
+	"sync"
 	"testing"
 
 	"github.com/erigontech/erigon/cl/clparams"
@@ -184,7 +185,7 @@ func TestOperationsPoolPruneFinalized(t *testing.T) {
 		require.NoError(t, finalizedState.SetValidatorSlashed(1, true))
 		require.NoError(t, finalizedState.SetWithdrawableEpochForValidatorAtIndex(2, 3))
 
-		pools.PruneFinalized(finalizedState)
+		pools.PruneFinalized(finalizedState, 3)
 
 		require.True(t, pools.ProposerSlashingsPool.Has(ComputeKeyForProposerSlashing(keep)))
 		require.False(t, pools.ProposerSlashingsPool.Has(ComputeKeyForProposerSlashing(removeSlashed)))
@@ -199,7 +200,7 @@ func TestOperationsPoolPruneFinalized(t *testing.T) {
 		pools.AttesterSlashingsPool.Insert(ComputeKeyForAttesterSlashing(partial), partial)
 		pools.AttesterSlashingsPool.Insert(ComputeKeyForAttesterSlashing(terminal), terminal)
 
-		pools.PruneFinalized(finalizedState)
+		pools.PruneFinalized(finalizedState, 3)
 
 		require.True(t, pools.AttesterSlashingsPool.Has(ComputeKeyForAttesterSlashing(partial)))
 		require.False(t, pools.AttesterSlashingsPool.Has(ComputeKeyForAttesterSlashing(terminal)))
@@ -212,7 +213,7 @@ func TestOperationsPoolPruneFinalized(t *testing.T) {
 		pools.VoluntaryExitsPool.Insert(10, voluntaryExit(10))
 		finalizedState.SetExitEpochForValidatorAtIndex(2, 4)
 
-		pools.PruneFinalized(finalizedState)
+		pools.PruneFinalized(finalizedState, 3)
 
 		require.True(t, pools.VoluntaryExitsPool.Has(0))
 		require.False(t, pools.VoluntaryExitsPool.Has(2))
@@ -230,7 +231,7 @@ func TestOperationsPoolPruneFinalized(t *testing.T) {
 		credentials := common.Hash{byte(cfg.ETH1AddressWithdrawalPrefixByte)}
 		finalizedState.SetWithdrawalCredentialForValidatorAtIndex(2, credentials)
 
-		pools.PruneFinalized(finalizedState)
+		pools.PruneFinalized(finalizedState, 3)
 
 		require.True(t, pools.BLSToExecutionChangesPool.Has(keep.Signature))
 		require.False(t, pools.BLSToExecutionChangesPool.Has(remove.Signature))
@@ -253,7 +254,7 @@ func TestOperationsPoolPruneFinalized(t *testing.T) {
 		pools.VoluntaryExitsPool.Insert(keepIndex, voluntaryExit(keepIndex))
 		pools.VoluntaryExitsPool.Insert(removeIndex, voluntaryExit(removeIndex))
 
-		pools.PruneFinalized(gloasState)
+		pools.PruneFinalized(gloasState, 0)
 
 		require.True(t, pools.VoluntaryExitsPool.Has(keepIndex))
 		require.True(t, pools.VoluntaryExitsPool.Has(removeIndex))
@@ -264,7 +265,7 @@ func TestOperationsPoolPruneFinalized(t *testing.T) {
 		key := common.Bytes96{1}
 		pools.AttestationsPool.Insert(key, &solid.Attestation{})
 
-		pools.PruneFinalized(finalizedState)
+		pools.PruneFinalized(finalizedState, 3)
 
 		require.True(t, pools.AttestationsPool.Has(key))
 	})
@@ -288,12 +289,76 @@ func TestOperationsPoolPruneFinalizedIgnoresIncompleteEntries(t *testing.T) {
 	pools.BLSToExecutionChangesPool.Insert(common.Bytes96{3}, nil)
 
 	require.NotPanics(t, func() {
-		pools.PruneFinalized(finalizedState)
+		pools.PruneFinalized(finalizedState, 0)
 	})
 	require.Len(t, pools.ProposerSlashingsPool.Raw(), 2)
 	require.Len(t, pools.AttesterSlashingsPool.Raw(), 1)
 	require.Len(t, pools.VoluntaryExitsPool.Raw(), 1)
 	require.Len(t, pools.BLSToExecutionChangesPool.Raw(), 1)
+}
+
+func TestOperationsPoolPruneFinalizedUsesCheckpointEpoch(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	finalizedState := state.New(&cfg)
+	finalizedState.SetSlot(2 * cfg.SlotsPerEpoch)
+	validator := solid.NewValidatorFromParameters(
+		common.Bytes48{},
+		common.Hash{},
+		cfg.MaxEffectiveBalance,
+		false,
+		0,
+		0,
+		cfg.FarFutureEpoch,
+		3,
+	)
+	finalizedState.AddValidator(validator, cfg.MaxEffectiveBalance)
+	slashing := proposerSlashing(0, 1)
+
+	t.Run("before boundary", func(t *testing.T) {
+		pools := NewOperationsPool(&cfg)
+		pools.ProposerSlashingsPool.Insert(ComputeKeyForProposerSlashing(slashing), slashing)
+
+		pools.PruneFinalized(finalizedState, 2)
+
+		require.True(t, pools.ProposerSlashingsPool.Has(ComputeKeyForProposerSlashing(slashing)))
+	})
+
+	t.Run("at skipped-slot checkpoint boundary", func(t *testing.T) {
+		pools := NewOperationsPool(&cfg)
+		pools.ProposerSlashingsPool.Insert(ComputeKeyForProposerSlashing(slashing), slashing)
+
+		pools.PruneFinalized(finalizedState, 3)
+
+		require.False(t, pools.ProposerSlashingsPool.Has(ComputeKeyForProposerSlashing(slashing)))
+	})
+}
+
+func TestOperationsPoolPruneFinalizedConcurrentInsert(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	finalizedState := state.New(&cfg)
+	validator := solid.NewValidator()
+	validator.SetExitEpoch(1)
+	finalizedState.AddValidator(validator, 0)
+	pools := NewOperationsPool(&cfg)
+	pools.VoluntaryExitsPool.Insert(0, voluntaryExit(0))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			pools.PruneFinalized(finalizedState, 1)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := uint64(1); i <= 100; i++ {
+			pools.VoluntaryExitsPool.Insert(i, voluntaryExit(i))
+		}
+	}()
+	wg.Wait()
+
+	require.False(t, pools.VoluntaryExitsPool.Has(0))
 }
 
 func proposerSlashing(validatorIndex uint64, signatureByte byte) *cltypes.ProposerSlashing {

--- a/cl/pool/operations_pool_test.go
+++ b/cl/pool/operations_pool_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/common"
 	"github.com/stretchr/testify/require"
 )
@@ -151,6 +152,187 @@ func TestOperationsPool(t *testing.T) {
 	require.Len(t, pools.BLSToExecutionChangesPool.Raw(), 1)
 
 	require.Len(t, pools.ProposerSlashingsPool.Raw(), 1)
+}
+
+func TestOperationsPoolPruneFinalized(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	finalizedState := state.New(&cfg)
+	finalizedState.SetSlot(3 * cfg.SlotsPerEpoch)
+	for i := range 3 {
+		finalizedState.AddValidator(solid.NewValidatorFromParameters(
+			common.Bytes48{byte(i)},
+			common.Hash{},
+			cfg.MaxEffectiveBalance,
+			false,
+			0,
+			0,
+			cfg.FarFutureEpoch,
+			cfg.FarFutureEpoch,
+		), cfg.MaxEffectiveBalance)
+	}
+
+	t.Run("proposer slashings", func(t *testing.T) {
+		pools := NewOperationsPool(&cfg)
+		keep := proposerSlashing(0, 1)
+		removeSlashed := proposerSlashing(1, 3)
+		removeWithdrawable := proposerSlashing(2, 5)
+		missing := proposerSlashing(10, 7)
+		pools.ProposerSlashingsPool.Insert(ComputeKeyForProposerSlashing(keep), keep)
+		pools.ProposerSlashingsPool.Insert(ComputeKeyForProposerSlashing(removeSlashed), removeSlashed)
+		pools.ProposerSlashingsPool.Insert(ComputeKeyForProposerSlashing(removeWithdrawable), removeWithdrawable)
+		pools.ProposerSlashingsPool.Insert(ComputeKeyForProposerSlashing(missing), missing)
+		require.NoError(t, finalizedState.SetValidatorSlashed(1, true))
+		require.NoError(t, finalizedState.SetWithdrawableEpochForValidatorAtIndex(2, 3))
+
+		pools.PruneFinalized(finalizedState)
+
+		require.True(t, pools.ProposerSlashingsPool.Has(ComputeKeyForProposerSlashing(keep)))
+		require.False(t, pools.ProposerSlashingsPool.Has(ComputeKeyForProposerSlashing(removeSlashed)))
+		require.False(t, pools.ProposerSlashingsPool.Has(ComputeKeyForProposerSlashing(removeWithdrawable)))
+		require.True(t, pools.ProposerSlashingsPool.Has(ComputeKeyForProposerSlashing(missing)))
+	})
+
+	t.Run("attester slashings retain a slashable intersection member", func(t *testing.T) {
+		pools := NewOperationsPool(&cfg)
+		partial := attesterSlashing([]uint64{0, 1}, []uint64{0, 1}, 4)
+		terminal := attesterSlashing([]uint64{1}, []uint64{1}, 5)
+		pools.AttesterSlashingsPool.Insert(ComputeKeyForAttesterSlashing(partial), partial)
+		pools.AttesterSlashingsPool.Insert(ComputeKeyForAttesterSlashing(terminal), terminal)
+
+		pools.PruneFinalized(finalizedState)
+
+		require.True(t, pools.AttesterSlashingsPool.Has(ComputeKeyForAttesterSlashing(partial)))
+		require.False(t, pools.AttesterSlashingsPool.Has(ComputeKeyForAttesterSlashing(terminal)))
+	})
+
+	t.Run("voluntary exits", func(t *testing.T) {
+		pools := NewOperationsPool(&cfg)
+		pools.VoluntaryExitsPool.Insert(0, voluntaryExit(0))
+		pools.VoluntaryExitsPool.Insert(2, voluntaryExit(2))
+		pools.VoluntaryExitsPool.Insert(10, voluntaryExit(10))
+		finalizedState.SetExitEpochForValidatorAtIndex(2, 4)
+
+		pools.PruneFinalized(finalizedState)
+
+		require.True(t, pools.VoluntaryExitsPool.Has(0))
+		require.False(t, pools.VoluntaryExitsPool.Has(2))
+		require.True(t, pools.VoluntaryExitsPool.Has(10))
+	})
+
+	t.Run("bls to execution changes", func(t *testing.T) {
+		pools := NewOperationsPool(&cfg)
+		keep := blsChange(0, 6)
+		remove := blsChange(2, 7)
+		missing := blsChange(10, 8)
+		pools.BLSToExecutionChangesPool.Insert(keep.Signature, keep)
+		pools.BLSToExecutionChangesPool.Insert(remove.Signature, remove)
+		pools.BLSToExecutionChangesPool.Insert(missing.Signature, missing)
+		credentials := common.Hash{byte(cfg.ETH1AddressWithdrawalPrefixByte)}
+		finalizedState.SetWithdrawalCredentialForValidatorAtIndex(2, credentials)
+
+		pools.PruneFinalized(finalizedState)
+
+		require.True(t, pools.BLSToExecutionChangesPool.Has(keep.Signature))
+		require.False(t, pools.BLSToExecutionChangesPool.Has(remove.Signature))
+		require.True(t, pools.BLSToExecutionChangesPool.Has(missing.Signature))
+	})
+
+	t.Run("gloas builder exits are retained across reusable indices", func(t *testing.T) {
+		gloasState := state.New(&cfg)
+		gloasState.SetVersion(clparams.GloasVersion)
+		builders := solid.NewStaticListSSZ[*cltypes.Builder](
+			int(cfg.BuilderRegistryLimit),
+			new(cltypes.Builder).EncodingSizeSSZ(),
+		)
+		builders.Append(&cltypes.Builder{WithdrawableEpoch: cfg.FarFutureEpoch})
+		builders.Append(&cltypes.Builder{WithdrawableEpoch: 4})
+		gloasState.SetBuilders(builders)
+		keepIndex := state.ConvertBuilderIndexToValidatorIndex(0)
+		removeIndex := state.ConvertBuilderIndexToValidatorIndex(1)
+		pools := NewOperationsPool(&cfg)
+		pools.VoluntaryExitsPool.Insert(keepIndex, voluntaryExit(keepIndex))
+		pools.VoluntaryExitsPool.Insert(removeIndex, voluntaryExit(removeIndex))
+
+		pools.PruneFinalized(gloasState)
+
+		require.True(t, pools.VoluntaryExitsPool.Has(keepIndex))
+		require.True(t, pools.VoluntaryExitsPool.Has(removeIndex))
+	})
+
+	t.Run("attestations are not finalized-state pruned", func(t *testing.T) {
+		pools := NewOperationsPool(&cfg)
+		key := common.Bytes96{1}
+		pools.AttestationsPool.Insert(key, &solid.Attestation{})
+
+		pools.PruneFinalized(finalizedState)
+
+		require.True(t, pools.AttestationsPool.Has(key))
+	})
+}
+
+func TestOperationsPoolPruneFinalizedIgnoresIncompleteEntries(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	finalizedState := state.New(&cfg)
+	validator := solid.NewValidator()
+	validator.SetSlashed(true)
+	finalizedState.AddValidator(validator, 0)
+	pools := NewOperationsPool(&cfg)
+	pools.ProposerSlashingsPool.Insert(common.Bytes96{1}, nil)
+	pools.ProposerSlashingsPool.Insert(common.Bytes96{4}, &cltypes.ProposerSlashing{
+		Header1: &cltypes.SignedBeaconBlockHeader{
+			Header: &cltypes.BeaconBlockHeader{ProposerIndex: 0},
+		},
+	})
+	pools.AttesterSlashingsPool.Insert(common.Bytes96{2}, nil)
+	pools.VoluntaryExitsPool.Insert(0, nil)
+	pools.BLSToExecutionChangesPool.Insert(common.Bytes96{3}, nil)
+
+	require.NotPanics(t, func() {
+		pools.PruneFinalized(finalizedState)
+	})
+	require.Len(t, pools.ProposerSlashingsPool.Raw(), 2)
+	require.Len(t, pools.AttesterSlashingsPool.Raw(), 1)
+	require.Len(t, pools.VoluntaryExitsPool.Raw(), 1)
+	require.Len(t, pools.BLSToExecutionChangesPool.Raw(), 1)
+}
+
+func proposerSlashing(validatorIndex uint64, signatureByte byte) *cltypes.ProposerSlashing {
+	return &cltypes.ProposerSlashing{
+		Header1: &cltypes.SignedBeaconBlockHeader{
+			Header:    &cltypes.BeaconBlockHeader{ProposerIndex: validatorIndex},
+			Signature: common.Bytes96{signatureByte},
+		},
+		Header2: &cltypes.SignedBeaconBlockHeader{
+			Header:    &cltypes.BeaconBlockHeader{ProposerIndex: validatorIndex},
+			Signature: common.Bytes96{signatureByte + 1},
+		},
+	}
+}
+
+func attesterSlashing(one, two []uint64, signatureByte byte) *cltypes.AttesterSlashing {
+	return &cltypes.AttesterSlashing{
+		Attestation_1: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(2048, one),
+			Signature:        common.Bytes96{signatureByte},
+		},
+		Attestation_2: &cltypes.IndexedAttestation{
+			AttestingIndices: solid.NewRawUint64List(2048, two),
+			Signature:        common.Bytes96{signatureByte + 1},
+		},
+	}
+}
+
+func voluntaryExit(validatorIndex uint64) *cltypes.SignedVoluntaryExit {
+	return &cltypes.SignedVoluntaryExit{
+		VoluntaryExit: &cltypes.VoluntaryExit{ValidatorIndex: validatorIndex},
+	}
+}
+
+func blsChange(validatorIndex uint64, signatureByte byte) *cltypes.SignedBLSToExecutionChange {
+	return &cltypes.SignedBLSToExecutionChange{
+		Message:   &cltypes.BLSToExecutionChange{ValidatorIndex: validatorIndex},
+		Signature: common.Bytes96{signatureByte},
+	}
 }
 
 func TestEpbsPoolGetPreferenceExactLookup(t *testing.T) {


### PR DESCRIPTION
## Summary

- retain slashings, voluntary exits, and BLS-to-execution changes across non-finalized block imports
- prune only operations that are terminal in the finalized beacon state
- run finalized-state loading and pool scans in a bounded background worker outside the forkchoice mutex
- preserve gossip first-valid semantics with validator-based seen caches and explicit `IGNORE` handling

## Related issue

Related to #22790.

#22790 identified that operation-pool capacities should be chosen deliberately instead of ignoring the beacon-chain configuration. #22823 addressed that capacity sizing. This PR is a follow-up that adds the missing operation lifecycle: reorg-safe retention and finalized-state pruning. It does not change the capacity formula introduced by #22823.

## Why

The operation pools previously removed operations as soon as they appeared in an imported block, and the BLS-to-execution pool was purged wholesale. That can discard still-useful operations when the block is reorged out. Finalized-state pruning gives these operations a reorg-safe lifecycle while fixed capacities continue to bound memory.

## Implementation

- proposer and attester slashings are removed once all relevant validators are terminal at the finalized checkpoint
- voluntary exits are removed after the validator has a non-far-future exit epoch
- BLS changes are removed after finalized withdrawal credentials no longer use the BLS prefix
- attestation retention remains slot-based and is not part of finalized pruning
- finality updates coalesce to one worker plus the latest pending checkpoint; empty pools skip finalized-state loading
- duplicate BLS changes and voluntary exits are atomically deduplicated by validator
- the REST voluntary-exit path relies on immediate verification for its single pool insertion, avoiding a pre-verification bypass of seen-cache deduplication
- attester-slashing early `IGNORE` checks use order-independent, capacity-bounded set semantics before normal sorted-index validation
- imported-block processing suppresses expected attester-slashing `ErrIgnore` logs while retaining logs for rejected operations

## Validation

- `go test ./cl/pool ./cl/phase1/forkchoice ./cl/phase1/network/services -count=1`
- `go test -race --timeout 10m ./cl/pool ./cl/phase1/forkchoice ./cl/phase1/network/services -count=1`
- `go test ./cl/beacon/handler -count=1`
- `make lint` (repeated clean runs)
- `make erigon integration`

The final branch also completed adversarial review rounds covering consensus-spec behavior, concurrency/performance, and test/scope coverage, with no remaining actionable Critical, High, or Medium findings.
