### PR TITLE
ci: split legacy Cancun race shards by fork

### DIFF
--- a/.claude/skills/erigon-test-all/SKILL.md
+++ b/.claude/skills/erigon-test-all/SKILL.md
@@ -33,9 +33,9 @@ make eest-spec-blocktests-legacy-constantinople-sequential
                                              # ...-race-other-forks
 make eest-spec-blocktests-legacy-cancun-sequential
                                              # Hive legacy-cancun selection;
-                                             # -parallel plus two race partitions:
-                                             # ...-race-berlin-shanghai-cancun and
-                                             # ...-race-other-forks
+                                             # -parallel plus six race partitions:
+                                             # ...-race-{berlin,shanghai,cancun,
+                                             # london,paris,other-forks}
 make eest-spec-enginextests-benchmark-1m-sequential
                                              # engine-x benchmark fixtures @ 1M gas target
                                              # (with per-test --time stats);

--- a/.claude/skills/erigon-test-race/SKILL.md
+++ b/.claude/skills/erigon-test-race/SKILL.md
@@ -11,14 +11,24 @@ Runs the full test suite with Go's `-race` flag. Catches concurrency bugs that n
 
 `make test-all-race` no longer downloads any fixture tarballs. EEST spec tests (state/blockchain/engine-x) moved out of `go test ./...` and into the dedicated `eest-spec-*` Makefile targets driven by the **EEST spec tests** workflow (`test-eest-spec.yml`); the consensus spec test (`cl/spectest`) is skipped here via `ERIGON_SKIP_CL_SPECTEST=true` (set automatically by the Makefile) and runs only in `test-integration-caplin.yml`.
 
-If you want race coverage on the EEST blocktests, use the dedicated race shards — `make eest-spec-blocktests-stable-race-{pre-cancun,cancun,prague,osaka}-{sequential,parallel}` and `make eest-spec-blocktests-devnet-race-amsterdam`. These build a race-instrumented `evm.race` binary automatically (see `EEST_SPEC_RACE_SHARDS` in the root `Makefile`); the `-sequential` / `-parallel` split pins `ERIGON_EXEC3_PARALLEL` so race coverage hits both modes. For the consensus spec suite or other Go packages, pass `GOFLAGS='-race'` or invoke `go test -race` against the relevant package directly.
+Use the dedicated EEST blocktest race shards:
+
+```bash
+make eest-spec-blocktests-stable-race-{pre-cancun,cancun,prague,osaka}-{sequential,parallel}
+make eest-spec-blocktests-devnet-race-amsterdam
+make eest-spec-blocktests-legacy-consensus-race
+make eest-spec-blocktests-legacy-constantinople-race-{constantinople,constantinople-fix,other-forks}
+make eest-spec-blocktests-legacy-cancun-race-{berlin,shanghai,cancun,london,paris,other-forks}
+```
+
+These targets build a race-instrumented `evm.race` binary automatically (see `EEST_SPEC_RACE_SHARDS` in the root `Makefile`). The stable `-sequential` / `-parallel` pairs pin both execution modes; the devnet and legacy race shards pin parallel execution to match their fixture topology. For the consensus spec suite or other Go packages, pass `GOFLAGS='-race'` or invoke `go test -race` against the relevant package directly.
 
 **Pitfall: stale `evm.race` binary.** `make eest-spec-<race-shard>` lists `evm.race` as a prereq and `go build` is cache-aware, so a stale binary gets rebuilt. Calling `bash tools/run-eest-spec-test.sh <shard>` directly with `EVM_BIN=build/bin/evm.race` **bypasses** the rebuild and silently runs an old race-instrumented binary against current fixtures — race reports against code that no longer exists, missed races against code that does. After pulling or switching branches: `rm -f build/bin/evm.race && make evm.race` before re-running.
 
 One side prerequisite still applies for tests `make test-all-race` does run:
 
 ```bash
-git submodule update --init --recursive --force            # only for legacy-tests (TestLegacyCancunState)
+git submodule update --init --recursive --force            # legacy RLP, transaction, and difficulty fixtures
 ```
 
 The CI workflow handles this in `setup-erigon`; locally you must do it yourself.
@@ -89,9 +99,4 @@ Areas historically susceptible to races in Erigon:
 
 ## CI Equivalent
 
-There is no dedicated race CI workflow — the "All tests" workflow does not run with `-race` by default. This is a local-only check.
-
-To run a subset with race via CI, consider running locally or using:
-```bash
-go test -race --timeout 60m ./execution/exec3/... ./execution/stagedsync/...
-```
+The **All tests (with -race)** workflow (`test-all-erigon-race.yml`) runs Go package race checks, while **EEST spec tests** (`test-eest-spec.yml`) runs the `evm.race` fixture shards above. Both are part of the CI gate.

--- a/tools/eest-spec-shards.yml
+++ b/tools/eest-spec-shards.yml
@@ -135,24 +135,57 @@
   exec3-parallel: true
   exclude:
     - '/\.meta/'
-- shard: blocktests-legacy-cancun-race-berlin-shanghai-cancun
+- shard: blocktests-legacy-cancun-race-berlin
   workers: 12
   # PoW fork-choice and total-difficulty support: https://github.com/erigontech/erigon/issues/22061
   max-allowed-failures: 7
-  expected-tests: 56564
+  expected-tests: 14026
   exec3-parallel: true
-  run: '(_(Berlin|Shanghai|Cancun)$|fork_(Berlin|Shanghai|Cancun)-)'
+  run: '(_Berlin$|fork_Berlin-)'
+  exclude:
+    - '/\.meta/'
+- shard: blocktests-legacy-cancun-race-shanghai
+  workers: 12
+  max-allowed-failures: 0
+  expected-tests: 20689
+  exec3-parallel: true
+  run: '(_Shanghai$|fork_Shanghai-)'
+  exclude:
+    - '/\.meta/'
+- shard: blocktests-legacy-cancun-race-cancun
+  workers: 12
+  max-allowed-failures: 0
+  expected-tests: 21849
+  exec3-parallel: true
+  run: '(_Cancun$|fork_Cancun-)'
+  exclude:
+    - '/\.meta/'
+- shard: blocktests-legacy-cancun-race-london
+  workers: 12
+  # PoW fork-choice and total-difficulty support: https://github.com/erigontech/erigon/issues/22061
+  max-allowed-failures: 7
+  expected-tests: 20337
+  exec3-parallel: true
+  run: '(_London$|fork_London-)'
+  exclude:
+    - '/\.meta/'
+- shard: blocktests-legacy-cancun-race-paris
+  workers: 12
+  max-allowed-failures: 0
+  expected-tests: 20369
+  exec3-parallel: true
+  run: '(_Paris$|fork_Paris-)'
   exclude:
     - '/\.meta/'
 - shard: blocktests-legacy-cancun-race-other-forks
   workers: 12
   # PoW fork-choice and total-difficulty support: https://github.com/erigontech/erigon/issues/22061
-  max-allowed-failures: 19
-  expected-tests: 55419
+  max-allowed-failures: 12
+  expected-tests: 14713
   exec3-parallel: true
   exclude:
     - '/\.meta/'
-    - '::.*(_(Berlin|Shanghai|Cancun)$|fork_(Berlin|Shanghai|Cancun)-)'
+    - '::.*(_(Berlin|Shanghai|Cancun|London|Paris)$|fork_(Berlin|Shanghai|Cancun|London|Paris)-)'
 - shard: enginextests-stable-sequential
   workers: 8
   max-allowed-failures: 0

--- a/tools/run-eest-spec-test.sh
+++ b/tools/run-eest-spec-test.sh
@@ -19,7 +19,7 @@
 #                                              Hive legacy suite
 #   blocktests-legacy-cancun-{sequential,parallel}
 #                                              Hive legacy-cancun suite
-#   blocktests-legacy-cancun-race-{berlin-shanghai-cancun,other-forks}
+#   blocktests-legacy-cancun-race-{berlin,shanghai,cancun,london,paris,other-forks}
 #                                              race-detector partition of the
 #                                              Hive legacy-cancun suite
 #   enginextests-stable-sequential             engine-x tests vs. eest_stable


### PR DESCRIPTION
fixes https://github.com/erigontech/erigon/issues/22881

## Before

| Race shard | Tests | CI time |
|---|---:|---:|
| Berlin + Shanghai + Cancun | 56,564 | [58m10s](https://github.com/erigontech/erigon/actions/runs/30453226635/job/90580288692) |
| Other forks | 55,419 | [48m52s](https://github.com/erigontech/erigon/actions/runs/30453226635/job/90580288653) |
| **Total** | **111,983** | **58m10s longest** |

## After

| Race shard | Tests | Failures | Local time |
|---|---:|---:|---:|
| Berlin | 14,026 | 7 | ~6m18s |
| Shanghai | 20,689 | 0 | ~6m18s |
| Cancun | 21,849 | 0 | ≤8m54s |
| Paris | 20,369 | 0 | ≤8m54s |
| London | 20,337 | 7 | ≤8m04s |
| Other forks | 14,713 | 12 | ≤8m04s |
| **Total** | **111,983** | **26** | — |

The new shards were validated locally in concurrent pairs: Berlin/Shanghai, Cancun/Paris, and London/other-forks. Each displayed time is the wall time by which both members of that pair completed, so it is an upper bound for an individual shard rather than isolated CI timing. The before timings are from isolated GitHub Actions jobs and are not directly comparable to the local measurements.

## Summary

Split the two long-running legacy Cancun blocktest race jobs into six fork-based shards:

- Berlin
- Shanghai
- Cancun
- London
- Paris
- all remaining forks

The largest new shard contains 21,849 tests, down from 56,564 in the previous largest shard. All six jobs can run independently in the existing EEST matrix, reducing the critical path through horizontal scaling while preserving the complete 111,983-test corpus.

## Changes

- Replace `blocktests-legacy-cancun-race-berlin-shanghai-cancun` with separate Berlin, Shanghai, and Cancun shards.
- Split London and Paris out of `blocktests-legacy-cancun-race-other-forks`.
- Keep a complement shard for every remaining fork.
- Set exact `expected-tests` values and distribute the 26 known failure budget across the shards that contain those failures.
- Update the local runner documentation and the `erigon-test-all` / `erigon-test-race` skills with the new Make targets.

No workflow or Makefile changes are needed: both derive their job/target lists from `tools/eest-spec-shards.yml`.
