### PR TITLE
engineapi: add missing custodyColumns parameter in engine_forkchoiceUpdatedV4

### DIFF
--- a/cl/phase1/execution_client/engine_api_rpc_client.go
+++ b/cl/phase1/execution_client/engine_api_rpc_client.go
@@ -120,9 +120,9 @@ func (c *EngineAPIRPCClient) ForkchoiceUpdatedV3(ctx context.Context, forkChoice
 	return result, nil
 }
 
-func (c *EngineAPIRPCClient) ForkchoiceUpdatedV4(ctx context.Context, forkChoiceState *engine_types.ForkChoiceState, payloadAttributes *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error) {
+func (c *EngineAPIRPCClient) ForkchoiceUpdatedV4(ctx context.Context, forkChoiceState *engine_types.ForkChoiceState, payloadAttributes *engine_types.PayloadAttributes, custodyColumns *engine_types.CustodyColumns) (*engine_types.ForkChoiceUpdatedResponse, error) {
 	result := &engine_types.ForkChoiceUpdatedResponse{}
-	if err := c.client.CallContext(ctx, result, rpc_helper.ForkChoiceUpdatedV4, forkChoiceState, payloadAttributes); err != nil {
+	if err := c.client.CallContext(ctx, result, rpc_helper.ForkChoiceUpdatedV4, forkChoiceState, payloadAttributes, custodyColumns); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -241,7 +241,7 @@ func (cc *ExecutionClientEngine) ForkChoiceUpdate(
 		// V3 is valid for Cancun (Deneb) and Prague (Electra/Fulu)
 		resp, err = cc.engine.ForkchoiceUpdatedV3(ctx, forkChoiceState, attributes)
 	default: // Gloas+ (Amsterdam)
-		resp, err = cc.engine.ForkchoiceUpdatedV4(ctx, forkChoiceState, attributes)
+		resp, err = cc.engine.ForkchoiceUpdatedV4(ctx, forkChoiceState, attributes, nil)
 	}
 	if err != nil {
 		if err.Error() == errContextExceeded {

--- a/execution/engineapi/engine_api_custody_columns_test.go
+++ b/execution/engineapi/engine_api_custody_columns_test.go
@@ -1,0 +1,160 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engineapi_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/testlog"
+
+	enginetypes "github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/engineapi/engineapitester"
+)
+
+// TestForkchoiceUpdatedV4_NullCustodyColumns verifies that ForkchoiceUpdatedV4
+// accepts a null custodyColumns (third parameter) via the Go-typed client.
+// This is the primary regression test: before the fix, the RPC framework
+// rejected 3-parameter requests with "too many arguments, want at most 2".
+func TestForkchoiceUpdatedV4_NullCustodyColumns(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlDebug)
+	eat, err := engineapitester.DefaultEngineApiTester(ctx, logger, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		if eat.ChainConfig.AmsterdamTime == nil {
+			t.Skip("test requires Amsterdam-enabled chain config")
+		}
+
+		fcu := enginetypes.ForkChoiceState{
+			HeadHash:           eat.GenesisBlock.Hash(),
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+		r, err := eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcu, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, r.PayloadStatus.Status)
+	})
+}
+
+// TestForkchoiceUpdatedV4_WithCustodyColumns verifies that ForkchoiceUpdatedV4
+// accepts a non-null 16-byte custodyColumns value. The value is accepted but
+// currently unused by the forkchoice logic.
+func TestForkchoiceUpdatedV4_WithCustodyColumns(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlDebug)
+	eat, err := engineapitester.DefaultEngineApiTester(ctx, logger, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		if eat.ChainConfig.AmsterdamTime == nil {
+			t.Skip("test requires Amsterdam-enabled chain config")
+		}
+
+		cc := enginetypes.CustodyColumns{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+
+		fcu := enginetypes.ForkChoiceState{
+			HeadHash:           eat.GenesisBlock.Hash(),
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+		r, err := eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcu, nil, &cc)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, r.PayloadStatus.Status)
+	})
+}
+
+// TestForkchoiceUpdatedV4_BackwardCompat_TwoParams verifies that
+// ForkchoiceUpdatedV4 still works when custodyColumns is omitted (nil pointer
+// in the Go client, which the RPC framework auto-fills as nil).
+func TestForkchoiceUpdatedV4_BackwardCompat_TwoParams(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlDebug)
+	eat, err := engineapitester.DefaultEngineApiTester(ctx, logger, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		if eat.ChainConfig.AmsterdamTime == nil {
+			t.Skip("test requires Amsterdam-enabled chain config")
+		}
+
+		fcu := enginetypes.ForkChoiceState{
+			HeadHash:           eat.GenesisBlock.Hash(),
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+		// Call with nil custodyColumns — simulates a legacy V4 caller sending only 2 params
+		r, err := eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcu, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, r.PayloadStatus.Status)
+	})
+}
+
+// TestForkchoiceUpdatedV3_Unaffected verifies that V3 behaviour is preserved —
+// V3 still accepts exactly 2 parameters and returns VALID.
+func TestForkchoiceUpdatedV3_Unaffected(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlDebug)
+	eat, err := engineapitester.DefaultEngineApiTester(ctx, logger, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		_ = big.NewInt(0) // suppress unused import if needed
+		fcu := enginetypes.ForkChoiceState{
+			HeadHash:           eat.GenesisBlock.Hash(),
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+		r, err := eat.EngineApiClient.ForkchoiceUpdatedV3(ctx, &fcu, nil)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, r.PayloadStatus.Status)
+	})
+}
+
+// TestForkchoiceUpdatedV4_NullPayloadAttributes_WithCustodyColumns verifies
+// the edge case of null payloadAttributes with non-null custodyColumns.
+func TestForkchoiceUpdatedV4_NullPayloadAttributes_WithCustodyColumns(t *testing.T) {
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlDebug)
+	eat, err := engineapitester.DefaultEngineApiTester(ctx, logger, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		if eat.ChainConfig.AmsterdamTime == nil {
+			t.Skip("test requires Amsterdam-enabled chain config")
+		}
+
+		cc := enginetypes.CustodyColumns{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+		fcu := enginetypes.ForkChoiceState{
+			HeadHash:           eat.GenesisBlock.Hash(),
+			SafeBlockHash:      eat.GenesisBlock.Hash(),
+			FinalizedBlockHash: eat.GenesisBlock.Hash(),
+		}
+		// null payloadAttributes but non-null custodyColumns
+		r, err := eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcu, nil, &cc)
+		require.NoError(t, err)
+		require.Equal(t, enginetypes.ValidStatus, r.PayloadStatus.Status)
+	})
+}

--- a/execution/engineapi/engine_api_jsonrpc_client.go
+++ b/execution/engineapi/engine_api_jsonrpc_client.go
@@ -265,10 +265,11 @@ func (c *JsonRpcClient) ForkchoiceUpdatedV4(
 	ctx context.Context,
 	forkChoiceState *enginetypes.ForkChoiceState,
 	payloadAttributes *enginetypes.PayloadAttributes,
+	custodyColumns *enginetypes.CustodyColumns,
 ) (*enginetypes.ForkChoiceUpdatedResponse, error) {
 	return backoff.RetryWithData(func() (*enginetypes.ForkChoiceUpdatedResponse, error) {
 		var result enginetypes.ForkChoiceUpdatedResponse
-		err := c.rpcClient.CallContext(ctx, &result, "engine_forkchoiceUpdatedV4", forkChoiceState, payloadAttributes)
+		err := c.rpcClient.CallContext(ctx, &result, "engine_forkchoiceUpdatedV4", forkChoiceState, payloadAttributes, custodyColumns)
 		if err != nil {
 			return nil, c.maybeMakePermanent(err)
 		}

--- a/execution/engineapi/engine_api_methods.go
+++ b/execution/engineapi/engine_api_methods.go
@@ -185,7 +185,7 @@ func (e *EngineServer) ForkchoiceUpdatedV3(ctx context.Context, forkChoiceState 
 
 // Successor of [ForkchoiceUpdatedV3] post Amsterdam, with stricter check on params
 // See https://github.com/ethereum/execution-apis/blob/main/src/engine/amsterdam.md#engine_forkchoiceupdatedv4
-func (e *EngineServer) ForkchoiceUpdatedV4(ctx context.Context, forkChoiceState *engine_types.ForkChoiceState, payloadAttributes *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error) {
+func (e *EngineServer) ForkchoiceUpdatedV4(ctx context.Context, forkChoiceState *engine_types.ForkChoiceState, payloadAttributes *engine_types.PayloadAttributes, custodyColumns *engine_types.CustodyColumns) (*engine_types.ForkChoiceUpdatedResponse, error) {
 	return e.forkchoiceUpdated(ctx, forkChoiceState, payloadAttributes, clparams.GloasVersion)
 }
 

--- a/execution/engineapi/engine_api_reorg_test.go
+++ b/execution/engineapi/engine_api_reorg_test.go
@@ -467,7 +467,7 @@ func TestEngineApiForkchoiceToGenesisRewindsHead(t *testing.T) {
 		}
 		var r *enginetypes.ForkChoiceUpdatedResponse
 		if eat.ChainConfig.AmsterdamTime != nil {
-			r, err = eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcu, nil)
+			r, err = eat.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcu, nil, nil)
 		} else {
 			r, err = eat.EngineApiClient.ForkchoiceUpdatedV3(ctx, &fcu, nil)
 		}

--- a/execution/engineapi/engine_types/custody_columns.go
+++ b/execution/engineapi/engine_types/custody_columns.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engine_types
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// CustodyColumnsSize is the byte-length of the custody columns bitarray (CELLS_PER_EXT_BLOB / 8 = 128 / 8 = 16).
+const CustodyColumnsSize = 16
+
+// CustodyColumns is a 16-byte bitarray where bit i indicates custody of blob column i.
+// Defined by the Amsterdam Engine API specification for engine_forkchoiceUpdatedV4.
+type CustodyColumns [CustodyColumnsSize]byte
+
+func (c CustodyColumns) MarshalJSON() ([]byte, error) {
+	return json.Marshal("0x" + hex.EncodeToString(c[:]))
+}
+
+func (c *CustodyColumns) UnmarshalJSON(input []byte) error {
+	var s string
+	if err := json.Unmarshal(input, &s); err != nil {
+		return err
+	}
+	s = strings.TrimPrefix(s, "0x")
+	s = strings.TrimPrefix(s, "0X")
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return fmt.Errorf("invalid custodyColumns hex: %w", err)
+	}
+	if len(b) != CustodyColumnsSize {
+		return fmt.Errorf("invalid custodyColumns length: got %d bytes, want %d", len(b), CustodyColumnsSize)
+	}
+	copy(c[:], b)
+	return nil
+}

--- a/execution/engineapi/engine_types/custody_columns_test.go
+++ b/execution/engineapi/engine_types/custody_columns_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package engine_types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustodyColumnsMarshalJSON(t *testing.T) {
+	cc := CustodyColumns{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	data, err := json.Marshal(cc)
+	require.NoError(t, err)
+	require.Equal(t, `"0x0102030405060708090a0b0c0d0e0f10"`, string(data))
+}
+
+func TestCustodyColumnsUnmarshalJSON(t *testing.T) {
+	input := `"0x0102030405060708090a0b0c0d0e0f10"`
+	var cc CustodyColumns
+	err := json.Unmarshal([]byte(input), &cc)
+	require.NoError(t, err)
+	require.Equal(t, CustodyColumns{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}, cc)
+}
+
+func TestCustodyColumnsUnmarshalJSON_WrongLength(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"too short", `"0xabcd"`},
+		{"too long", `"0x0102030405060708090a0b0c0d0e0f1011"`},
+		{"empty", `"0x"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cc CustodyColumns
+			err := json.Unmarshal([]byte(tt.input), &cc)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid custodyColumns length")
+		})
+	}
+}
+
+func TestCustodyColumnsNullPointer(t *testing.T) {
+	type wrapper struct {
+		CC *CustodyColumns `json:"custodyColumns"`
+	}
+	var w wrapper
+	err := json.Unmarshal([]byte(`{"custodyColumns":null}`), &w)
+	require.NoError(t, err)
+	require.Nil(t, w.CC)
+}
+
+func TestCustodyColumnsRoundTrip(t *testing.T) {
+	original := CustodyColumns{0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00,
+		0xff, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded CustodyColumns
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, original, decoded)
+}

--- a/execution/engineapi/engineapitester/engine_x_test_runner.go
+++ b/execution/engineapi/engineapitester/engine_x_test_runner.go
@@ -475,7 +475,7 @@ func processFcu(ctx context.Context, tester EngineApiTester, head common.Hash, v
 			case "3":
 				r, err = tester.EngineApiClient.ForkchoiceUpdatedV3(ctx, &fcu, nil)
 			case "4":
-				r, err = tester.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcu, nil)
+				r, err = tester.EngineApiClient.ForkchoiceUpdatedV4(ctx, &fcu, nil, nil)
 			default:
 				return nil, "", fmt.Errorf("unsupported fcu version: %s", version)
 			}

--- a/execution/engineapi/engineapitester/mock_cl.go
+++ b/execution/engineapi/engineapitester/mock_cl.go
@@ -147,7 +147,7 @@ func (cl *MockCl) StartBuilding(ctx context.Context, opts ...BlockBuildingOption
 			var r *enginetypes.ForkChoiceUpdatedResponse
 			var err error
 			if cl.chainConfig.AmsterdamTime != nil {
-				r, err = cl.engineApiClient.ForkchoiceUpdatedV4(ctx, &forkChoiceState, &payloadAttributes)
+				r, err = cl.engineApiClient.ForkchoiceUpdatedV4(ctx, &forkChoiceState, &payloadAttributes, nil)
 			} else {
 				r, err = cl.engineApiClient.ForkchoiceUpdatedV3(ctx, &forkChoiceState, &payloadAttributes)
 			}
@@ -243,7 +243,7 @@ func (cl *MockCl) UpdateForkChoice(ctx context.Context, p *MockClPayload) error 
 			var r *enginetypes.ForkChoiceUpdatedResponse
 			var err error
 			if cl.chainConfig.AmsterdamTime != nil {
-				r, err = cl.engineApiClient.ForkchoiceUpdatedV4(ctx, &forkChoiceState, nil)
+				r, err = cl.engineApiClient.ForkchoiceUpdatedV4(ctx, &forkChoiceState, nil, nil)
 			} else {
 				r, err = cl.engineApiClient.ForkchoiceUpdatedV3(ctx, &forkChoiceState, nil)
 			}

--- a/execution/engineapi/interface.go
+++ b/execution/engineapi/interface.go
@@ -34,7 +34,7 @@ type EngineAPI interface {
 	ForkchoiceUpdatedV1(ctx context.Context, forkChoiceState *engine_types.ForkChoiceState, payloadAttributes *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error)
 	ForkchoiceUpdatedV2(ctx context.Context, forkChoiceState *engine_types.ForkChoiceState, payloadAttributes *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error)
 	ForkchoiceUpdatedV3(ctx context.Context, forkChoiceState *engine_types.ForkChoiceState, payloadAttributes *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error)
-	ForkchoiceUpdatedV4(ctx context.Context, forkChoiceState *engine_types.ForkChoiceState, payloadAttributes *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error)
+	ForkchoiceUpdatedV4(ctx context.Context, forkChoiceState *engine_types.ForkChoiceState, payloadAttributes *engine_types.PayloadAttributes, custodyColumns *engine_types.CustodyColumns) (*engine_types.ForkChoiceUpdatedResponse, error)
 	GetPayloadV1(ctx context.Context, payloadID hexutil.Bytes) (*engine_types.ExecutionPayload, error)
 	GetPayloadV2(ctx context.Context, payloadID hexutil.Bytes) (*engine_types.GetPayloadResponse, error)
 	GetPayloadV3(ctx context.Context, payloadID hexutil.Bytes) (*engine_types.GetPayloadResponse, error)

--- a/execution/engineapi/sszrest_handler.go
+++ b/execution/engineapi/sszrest_handler.go
@@ -301,7 +301,7 @@ func (e *EngineServer) handleSSZForkchoice(w http.ResponseWriter, r *http.Reques
 	case 3:
 		resp, err = e.ForkchoiceUpdatedV3(r.Context(), &state, attrs)
 	case 4:
-		resp, err = e.ForkchoiceUpdatedV4(r.Context(), &state, attrs)
+		resp, err = e.ForkchoiceUpdatedV4(r.Context(), &state, attrs, nil)
 	}
 	if err != nil {
 		writeEngineError(w, err)


### PR DESCRIPTION
### What is changed?

Updated `engine_forkchoiceUpdatedV4` to accept 3 parameters by adding `custodyColumns` as the 3rd argument, strictly following the [Amsterdam Engine API specification](https://github.com/ethereum/execution-apis/blob/main/src/engine/amsterdam.md#engine_forkchoiceupdatedv4).

### Why this change?

Right now, `engine_forkchoiceUpdatedV4` in Erigon takes only 2 arguments. When an Amsterdam-compatible consensus client sends 3 parameters (`forkchoiceState`, `payloadAttributes`, `custodyColumns`), Erigon's RPC decoder rejects the call with `"too many arguments, want at most 2"`.

This PR defines `CustodyColumns` (`[16]byte`) and updates `engine_forkchoiceUpdatedV4` across the interface, server, clients, and test mocks. This allows 3-parameter requests to work properly while fully preserving backward compatibility for 2-parameter requests.

### Testing

- Added unit tests for `CustodyColumns` hex parsing, length validation (must be 16 bytes), and null handling.
- Added regression tests for 3-parameter calls, `null` custody columns, non-null custody columns, and 2-parameter backward compatibility.

fixes #22896