### PR TITLE
execution/state: reject non-delegation code by size before materializing it

### DIFF
--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -404,6 +404,17 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			code = c.Bytes
 		}
 		if len(code) == 0 && stateReader != nil {
+			// Reject on size before materializing: only a designator can be
+			// recovered, and every storage-dirty contract in the block reaches
+			// this loop with a filled-in codeHash, so reading the bytes would
+			// decompress whole contracts just to fail ParseDelegation below.
+			size, err := stateReader.ReadAccountCodeSize(addr)
+			if err != nil {
+				return nil, err
+			}
+			if size != types.DelegateDesignationCodeSize {
+				continue
+			}
 			c, err := stateReader.ReadAccountCode(addr)
 			if err != nil {
 				return nil, err

--- a/execution/state/writeset_normalize_test.go
+++ b/execution/state/writeset_normalize_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
@@ -137,4 +139,69 @@ func TestNormalize_SelfDestructBalanceRetention_EIP8246(t *testing.T) {
 	post, _ := build().Normalize(vm, 1, 0, &minimalStateReader{}, nil, false, false, true /*eip8246*/)
 	_, postBal := post.GetBalance(addr)
 	require.True(t, postBal, "EIP-8246 SD retains the balance write")
+}
+
+// codeCountingReader records how often Normalize materializes code bytes vs
+// asks only for the size.
+type codeCountingReader struct {
+	minimalStateReader
+	code      []byte
+	codeReads int
+	sizeReads int
+}
+
+func (r *codeCountingReader) ReadAccountCode(addr accounts.Address) ([]byte, error) {
+	r.codeReads++
+	return r.code, nil
+}
+
+func (r *codeCountingReader) ReadAccountCodeSize(addr accounts.Address) (int, error) {
+	r.sizeReads++
+	return len(r.code), nil
+}
+
+// codeHashWriteSet is a tx that emitted a codeHash without code bytes — the
+// shape Normalize tries to repair by recovering the code.
+func codeHashWriteSet(addr accounts.Address, hash accounts.CodeHash) *WriteSet {
+	ws := &WriteSet{}
+	ws.SetCodeHash(addr, &VersionedWrite[accounts.CodeHash]{
+		WriteHeader: WriteHeader{Address: addr, Path: CodeHashPath, Version: Version{TxIndex: 0}},
+		Val:         hash,
+	})
+	return ws
+}
+
+// Only an EIP-7702 designator can be recovered, so committed code of any other
+// length must be rejected on its size — reading the bytes decompresses a whole
+// contract just to throw it away, and every storage-dirty contract in a block
+// reaches this loop.
+func TestNormalize_CodeRecoveryRejectsNonDelegationBySize(t *testing.T) {
+	t.Parallel()
+	addr := accounts.InternAddress(common.HexToAddress("0xC0DE"))
+	code := accounts.NewCode(bytes.Repeat([]byte{0x60}, 64))
+	reader := &codeCountingReader{code: code.Bytes}
+
+	out, err := codeHashWriteSet(addr, code.Hash).Normalize(NewVersionMap(nil), 0, 0, reader, nil, false, false, false)
+	require.NoError(t, err)
+
+	_, hasCode := out.GetCode(addr)
+	require.False(t, hasCode, "non-designator code must not be re-emitted")
+	require.Zero(t, reader.codeReads, "ordinary contract code must not be materialized to be rejected")
+}
+
+// The size gate must not cost the repair its reason for existing: a designator
+// still gets its CodePath back.
+func TestNormalize_CodeRecoveryKeepsDelegation(t *testing.T) {
+	t.Parallel()
+	addr := accounts.InternAddress(common.HexToAddress("0xA0"))
+	delegate := accounts.InternAddress(common.HexToAddress("0xB0"))
+	code := accounts.NewCode(types.AddressToDelegation(delegate))
+	reader := &codeCountingReader{code: code.Bytes}
+
+	out, err := codeHashWriteSet(addr, code.Hash).Normalize(NewVersionMap(nil), 0, 0, reader, nil, false, false, false)
+	require.NoError(t, err)
+
+	got, hasCode := out.GetCode(addr)
+	require.True(t, hasCode, "a delegation designator must still be recovered")
+	require.Equal(t, code.Bytes, got.Val.Bytes)
 }


### PR DESCRIPTION
> **Depends on #22858.** `GetCodeSize`'s cold path is today the same `sd.GetLatest(kv.CodeDomain, ...)` as the code read, so on its own this change swaps one full read for another and saves nothing. Profiling the call site shows it is 100% cold path — `ReadAccountCode -> temporalGetter.GetCode -> SharedDomains.GetCode -> GetLatest`, 0.42s, no content-addressed cache hits. #22858 gives `GetCodeSize` a size-only read that skips decompression; this PR is what turns that into a saving on the exec path. Draft until it lands.

`WriteSet.Normalize` repairs the codeHash-no-code case: a tx that emitted a `CodeHashPath` without a `CodePath` gets its code recovered and re-emitted, so an account can never be persisted with a codeHash whose bytes are missing. The repair only applies to EIP-7702 designators — `ParseDelegation` gates it — but the code was fetched first and rejected afterwards:

```go
c, err := stateReader.ReadAccountCode(addr)   // full bytes, decompressed
...
if _, ok := types.ParseDelegation(code); !ok { continue }   // rejects on len != 23
```

The loop runs for every address in the normalized set that has a non-empty codeHash and no code write — which includes every storage-dirty contract, because Normalize itself fills in the missing account fields (balance, nonce, incarnation, codeHash) from committed state for any address the tx only wrote storage to. So an ordinary contract's code is read out of `CodeDomain` and decompressed once per block it is touched in, purely to fail a length check.

A designator is exactly `DelegateDesignationCodeSize` (23) bytes, so the size decides it. `ReadAccountCodeSize` takes a size-only fast path when the getter offers one (`GetCodeSize`: codeHash from the account cache, size from the size cache, no bytes loaded). When both those caches miss it falls through to the same `GetLatest` the code read does — which is exactly what the profile below is hitting — so the saving arrives with #22858's size-only read path. Designators pay one extra read on readers without a size-only path; rare enough to be a good trade.

Behaviour is unchanged: same reader, same txNum, and the bytes are still read (and still hash-checked against the emitted codeHash) for anything of designator size.

## Why it showed up

30s CPU profile of a syncing node, parallel executor:

```
processResults                        9.21s   (100% blockExecutor.nextResult)
  WriteSet.Normalize                  3.48s   37.8% of nextResult
    Normalize.AllHeaders loop body    1.53s   44.0% of Normalize
    CachedReaderV3.ReadAccountData    0.58s   16.7%
    CachedReaderV3.ReadAccountCode    0.42s   12.1%   <- this
    SetAccountFieldFromAccount        0.22s    6.3%
```

`nextResult` runs on the exec loop's single goroutine, so this is serial time on the block-completion path.

## Tests

`TestNormalize_CodeRecoveryRejectsNonDelegationBySize` counts code materializations through the state reader: it is 1 before the change and 0 after, for a 64-byte contract. `TestNormalize_CodeRecoveryKeepsDelegation` pins that a designator is still recovered.

## Rejected alternative

Skipping the repair entirely for codeHash entries Normalize synthesized from committed state — the reasoning being that committed code is already in `CodeDomain`, so only codeHashes a tx actually wrote can be missing bytes. `TestNormalizeWriteSet_CodePathRecoveredFromStateReader` pins the opposite: an already-committed 7702 authority whose re-delegating tx writes only a nonce bump gets its codeHash filled from committed state and *must* have `CodePath` recovered through the stateReader. So the filled entries are exactly what the repair is for, and the size gate — which keeps that case, since a designator passes the size check — is the right shape.

