### PR TITLE
denser btree index for domains

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -721,7 +721,7 @@ func checkCommitmentFileHasRoot(filePath string) (hasState, broken bool, label s
 		log.Warn("[dbg] no accessor found, assuming file may have state", "file", filePath)
 		return true, false, "", nil
 	}
-	rd, bti, err := btindex.OpenBtreeIndexAndDataFile(bt, filePath, btindex.DefaultBtreeM, statecfg.Schema.CommitmentDomain.Compression, false)
+	rd, bti, err := btindex.OpenBtreeIndexAndDataFile(bt, filePath, statecfg.Schema.CommitmentDomain.Compression, false)
 	if err != nil {
 		return false, false, "", err
 	}
@@ -1442,7 +1442,7 @@ func doBtSearch(ctx context.Context, cliCtx *cli.Command) error {
 	dbg.ReadMemStats(&m)
 	logger.Info("before open", "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
 	compress := seg.CompressKeys | seg.CompressVals
-	kv, idx, err := btindex.OpenBtreeIndexAndDataFile(srcF, dataFilePath, btindex.DefaultBtreeM, compress, false)
+	kv, idx, err := btindex.OpenBtreeIndexAndDataFile(srcF, dataFilePath, compress, false)
 	if err != nil {
 		return err
 	}
@@ -2810,7 +2810,7 @@ func doMeta(ctx context.Context, cliCtx *cli.Command) error {
 			panic(err)
 		}
 		defer src.Close()
-		bt, err := btindex.OpenBtreeIndexWithDecompressor(fname, btindex.DefaultBtreeM, seg.NewReader(src.MakeGetter(), seg.CompressNone))
+		bt, err := btindex.OpenBtreeIndexWithDecompressor(fname, seg.NewReader(src.MakeGetter(), seg.CompressNone))
 		if err != nil {
 			return err
 		}

--- a/db/datastruct/btindex/bpstree_bench_test.go
+++ b/db/datastruct/btindex/bpstree_bench_test.go
@@ -20,11 +20,11 @@ import (
 func BenchmarkBpsTreeSeek(t *testing.B) {
 	tmp := t.TempDir()
 	logger := log.New()
-	keyCount, M := 12_000_000, 256
+	keyCount := 12_000_000
 	if testing.Short() {
 		keyCount = 10_000
 	}
-	t.Logf("N: %d, M: %d skip since shard <= %d", keyCount, M, DefaultBtreeStartSkip)
+	t.Logf("N: %d, M: %d skip since shard <= %d", keyCount, DefaultBtreeM, DefaultBtreeStartSkip)
 	compressFlags := seg.CompressKeys | seg.CompressVals
 
 	dataPath := generateKV(t, tmp, 52, 180, keyCount, logger, 0)
@@ -32,7 +32,7 @@ func BenchmarkBpsTreeSeek(t *testing.B) {
 	indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bti")
 	buildBtreeIndex(t, dataPath, indexPath, compressFlags, 1, logger, true)
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, uint64(M), compressFlags, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, compressFlags, false)
 	require.NoError(t, err)
 	require.EqualValues(t, bt.KeyCount(), keyCount)
 	defer bt.Close()
@@ -62,14 +62,14 @@ func BenchmarkBpsTreeSeek(t *testing.B) {
 func BenchmarkBpsTreeGet(t *testing.B) {
 	tmp := t.TempDir()
 	logger := log.New()
-	keyCount, M := 100_000, 256
+	keyCount := 100_000
 	compressFlags := seg.CompressKeys | seg.CompressVals
 
 	dataPath := generateKV(t, tmp, 52, 180, keyCount, logger, 0)
 	indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bti")
 	buildBtreeIndex(t, dataPath, indexPath, compressFlags, 1, logger, true)
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, uint64(M), compressFlags, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, compressFlags, false)
 	require.NoError(t, err)
 	require.EqualValues(t, bt.KeyCount(), keyCount)
 	defer bt.Close()
@@ -164,7 +164,7 @@ func BenchmarkBpsTreeGetReal(t *testing.B) {
 	t.Logf("compression: %d", compressFlags)
 
 	getter := seg.NewReader(d.MakeGetter(), compressFlags)
-	bt, err := OpenBtreeIndexWithDecompressor(btPath, 256, getter)
+	bt, err := OpenBtreeIndexWithDecompressor(btPath, getter)
 	require.NoError(t, err)
 	defer bt.Close()
 

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -44,7 +44,9 @@ const BtreeLogPrefix = "btree"
 
 // DefaultBtreeM - amount of keys on leaf of BTree
 // It will do log2(M) co-located-reads from data file - for binary-search inside leaf
-var DefaultBtreeM = uint64(dbg.EnvInt("BT_M", 256))
+var DefaultBtreeM = uint64(dbg.EnvInt("BT_M", 64))
+
+const DefaultBtreeMLegacy = uint64(256) // for legacy format (determined first byte), we created the files with m=256
 
 const DefaultBtreeStartSkip = uint64(4) // defines smallest shard available for scan instead of binsearch
 
@@ -375,18 +377,18 @@ type BtIndex struct {
 	pool     sync.Pool
 }
 
-// Decompressor should be managed by caller (could be closed after index is built). When index is built, external getter should be passed to seekInFiles function
-func CreateBtreeIndexWithDecompressor(indexPath string, existenceFilterPath string, m uint64, decompressor *seg.Reader, seed uint32, ps *background.ProgressSet, tmpdir string, logger log.Logger, noFsync bool, accessors statecfg.Accessors) (*BtIndex, error) {
+// CreateBtreeIndexWithDecompressor Decompressor should be managed by caller (could be closed after index is built). When index is built, external getter should be passed to seekInFiles function
+func CreateBtreeIndexWithDecompressor(indexPath string, existenceFilterPath string, decompressor *seg.Reader, seed uint32, ps *background.ProgressSet, tmpdir string, logger log.Logger, noFsync bool, accessors statecfg.Accessors) (*BtIndex, error) {
 	err := BuildBtreeIndexWithDecompressor(indexPath, existenceFilterPath, decompressor, ps, tmpdir, seed, logger, noFsync, accessors)
 	if err != nil {
 		return nil, err
 	}
-	return OpenBtreeIndexWithDecompressor(indexPath, m, decompressor)
+	return OpenBtreeIndexWithDecompressor(indexPath, decompressor)
 }
 
 // OpenBtreeIndexAndDataFile opens btree index file and data file and returns it along with BtIndex instance
 // Mostly useful for testing
-func OpenBtreeIndexAndDataFile(indexPath, dataPath string, m uint64, compressed seg.FileCompression, trace bool) (_ *seg.Decompressor, _ *BtIndex, err error) {
+func OpenBtreeIndexAndDataFile(indexPath, dataPath string, compressed seg.FileCompression, trace bool) (_ *seg.Decompressor, _ *BtIndex, err error) {
 	d, err := seg.NewDecompressor(dataPath)
 	if err != nil {
 		return nil, nil, err
@@ -397,7 +399,7 @@ func OpenBtreeIndexAndDataFile(indexPath, dataPath string, m uint64, compressed 
 		}
 	}()
 	kv := seg.NewReader(d.MakeGetter(), compressed)
-	bt, err := OpenBtreeIndexWithDecompressor(indexPath, m, kv)
+	bt, err := OpenBtreeIndexWithDecompressor(indexPath, kv)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -470,10 +472,9 @@ func BuildBtreeIndexWithDecompressor(indexPath string, existenceFilterPath strin
 	return nil
 }
 
-func OpenBtreeIndexWithDecompressor(indexPath string, m uint64, kvGetter *seg.Reader) (bt *BtIndex, err error) {
+func OpenBtreeIndexWithDecompressor(indexPath string, kvGetter *seg.Reader) (bt *BtIndex, err error) {
 	idx := &BtIndex{
 		filePath: indexPath,
-		indexM:   m,
 	}
 
 	var validationPassed bool
@@ -513,6 +514,7 @@ func OpenBtreeIndexWithDecompressor(indexPath string, m uint64, kvGetter *seg.Re
 	var nodeOfftEF *eliasfano32.EliasFano
 	var keysBlob []byte
 	var nodeStride uint64
+	m := DefaultBtreeMLegacy // newer format ("use footer") carry m in the file itself
 	switch idx.data[0] {
 	case btFirstByteLegacy: // legacy [EF][nodesCount][di-nodes]
 		var pos int

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -43,7 +43,7 @@ func Test_BtreeIndex_Init(t *testing.T) {
 	logger := log.New()
 	tmp := t.TempDir()
 
-	keyCount, M := 100, uint64(4)
+	keyCount := 100
 	compPath := generateKV(t, tmp, 52, 300, keyCount, logger, 0)
 	decomp, err := seg.NewDecompressor(compPath)
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func Test_BtreeIndex_Init(t *testing.T) {
 	err = BuildBtreeIndexWithDecompressor(filepath.Join(tmp, "a.bt"), filepath.Join(tmp, "a.kvei"), r, background.NewProgressSet(), tmp, 1, logger, true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 	require.NoError(t, err)
 
-	bt, err := OpenBtreeIndexWithDecompressor(filepath.Join(tmp, "a.bt"), M, r)
+	bt, err := OpenBtreeIndexWithDecompressor(filepath.Join(tmp, "a.bt"), r)
 	require.NoError(t, err)
 	require.EqualValues(t, bt.KeyCount(), keyCount)
 	bt.Close()
@@ -64,7 +64,7 @@ func Test_BtreeIndex_Seek(t *testing.T) {
 
 	tmp := t.TempDir()
 	logger := log.New()
-	keyCount, M := 120, 30
+	keyCount := 120
 	compressFlags := seg.CompressKeys | seg.CompressVals
 
 	t.Run("empty index", func(t *testing.T) {
@@ -72,7 +72,7 @@ func Test_BtreeIndex_Seek(t *testing.T) {
 		indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bti")
 		buildBtreeIndex(t, dataPath, indexPath, compressFlags, 1, logger, true)
 
-		kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, uint64(M), compressFlags, false)
+		kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, compressFlags, false)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, bt.KeyCount())
 		bt.Close()
@@ -83,7 +83,7 @@ func Test_BtreeIndex_Seek(t *testing.T) {
 	indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bti")
 	buildBtreeIndex(t, dataPath, indexPath, compressFlags, 1, logger, true)
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, uint64(M), compressFlags, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, compressFlags, false)
 	require.NoError(t, err)
 	require.EqualValues(t, bt.KeyCount(), keyCount)
 	defer bt.Close()
@@ -151,7 +151,7 @@ func Test_BtreeIndex_Build(t *testing.T) {
 
 	tmp := t.TempDir()
 	logger := log.New()
-	keyCount, M := 20000, 510
+	keyCount := 20000
 
 	compressFlags := seg.CompressKeys | seg.CompressVals
 	dataPath := generateKV(t, tmp, 52, 48, keyCount, logger, compressFlags)
@@ -162,7 +162,7 @@ func Test_BtreeIndex_Build(t *testing.T) {
 	buildBtreeIndex(t, dataPath, indexPath, compressFlags, 1, logger, true)
 	require.NoError(t, err)
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, uint64(M), compressFlags, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, compressFlags, false)
 	require.NoError(t, err)
 	require.EqualValues(t, bt.KeyCount(), keyCount)
 	defer bt.Close()
@@ -266,7 +266,7 @@ func Test_BtreeIndex_V0_V2_Read(t *testing.T) {
 
 	for _, tc := range []struct{ name, path string }{{"v0", v0Path}, {"v2", v2Path}} {
 		t.Run(tc.name, func(t *testing.T) {
-			kv, bt, err := OpenBtreeIndexAndDataFile(tc.path, dataPath, M, compressFlags, false)
+			kv, bt, err := OpenBtreeIndexAndDataFile(tc.path, dataPath, compressFlags, false)
 			require.NoError(t, err)
 			defer bt.Close()
 			defer kv.Close()
@@ -297,7 +297,7 @@ func Test_BtreeIndex_V0_M_Mismatch(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	logger := log.New()
-	const writeM, openM = uint64(32), uint64(256)
+	const writeM = uint64(32)
 	keyCount := 500
 	compressFlags := seg.CompressKeys | seg.CompressVals
 
@@ -308,7 +308,7 @@ func Test_BtreeIndex_V0_M_Mismatch(t *testing.T) {
 	v0Path := filepath.Join(tmp, "v0.bt")
 	writeV0Index(t, dataPath, v0Path, compressFlags, writeM)
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(v0Path, dataPath, openM, compressFlags, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(v0Path, dataPath, compressFlags, false)
 	require.NoError(t, err)
 	defer bt.Close()
 	defer kv.Close()
@@ -338,26 +338,9 @@ func TestBtIndex_SeekBeyondLast(t *testing.T) {
 	require.NoError(t, err)
 
 	indexPath := strings.TrimSuffix(kvPath, ".kv") + "_m8.bt"
-	func() {
-		decomp, err := seg.NewDecompressor(kvPath)
-		require.NoError(t, err)
-		defer decomp.Close()
-		iw, err := NewBtIndexWriter(BtIndexWriterArgs{IndexFile: indexPath, TmpDir: tmp, M: M, KeyCount: uint64(decomp.Count() / 2), MaxOffset: uint64(decomp.Size())}, logger)
-		require.NoError(t, err)
-		defer iw.Close()
-		r := seg.NewReader(decomp.MakeGetter(), compress)
-		r.Reset(0)
-		var pos uint64
-		for r.HasNext() {
-			key, _ := r.Next(nil)
-			require.NoError(t, iw.AddKey(key, pos))
-			pos, _ = r.Skip()
-		}
-		iw.DisableFsync()
-		require.NoError(t, iw.Build())
-	}()
+	buildBtreeIndexWithM(t, kvPath, indexPath, compress, M, logger)
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, M, compress, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, compress, false)
 	require.NoError(t, err)
 	defer bt.Close()
 	defer kv.Close()
@@ -420,7 +403,7 @@ func TestFooter_ZeroKeyCount(t *testing.T) {
 	// Use a 1-key KV as the reader — it won't be consulted because Open will
 	// fail before building the BpsTree.
 	dataPath := generateKV(t, tmp, 8, 8, 1, log.New(), seg.CompressNone)
-	_, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, 256, seg.CompressNone, false)
+	_, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, seg.CompressNone, false)
 	if err == nil {
 		defer bt.Close()
 		require.True(t, bt.Empty())
@@ -463,6 +446,29 @@ func Test_BtreeIndex_V2_EfOffset(t *testing.T) {
 }
 
 // Opens .kv at dataPath and generates index over it to file 'indexPath'
+// buildBtreeIndexWithM writes an index with an explicit M, bypassing DefaultBtreeM.
+func buildBtreeIndexWithM(tb testing.TB, dataPath, indexPath string, compressed seg.FileCompression, m uint64, logger log.Logger) {
+	tb.Helper()
+	decomp, err := seg.NewDecompressor(dataPath)
+	require.NoError(tb, err)
+	defer decomp.Close()
+
+	iw, err := NewBtIndexWriter(BtIndexWriterArgs{IndexFile: indexPath, TmpDir: tb.TempDir(), M: m, KeyCount: uint64(decomp.Count() / 2), MaxOffset: uint64(decomp.Size())}, logger)
+	require.NoError(tb, err)
+	defer iw.Close()
+
+	r := seg.NewReader(decomp.MakeGetter(), compressed)
+	r.Reset(0)
+	var pos uint64
+	for r.HasNext() {
+		key, _ := r.Next(nil)
+		require.NoError(tb, iw.AddKey(key, pos))
+		pos, _ = r.Skip()
+	}
+	iw.DisableFsync()
+	require.NoError(tb, iw.Build())
+}
+
 func buildBtreeIndex(tb testing.TB, dataPath, indexPath string, compressed seg.FileCompression, seed uint32, logger log.Logger, noFsync bool) {
 	tb.Helper()
 	decomp, err := seg.NewDecompressor(dataPath)
@@ -488,7 +494,7 @@ func Test_BtreeIndex_Seek2(t *testing.T) {
 	indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bti")
 	buildBtreeIndex(t, dataPath, indexPath, compressFlags, 1, logger, true)
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, uint64(M), compressFlags, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, compressFlags, false)
 	require.NoError(t, err)
 	require.EqualValues(t, bt.KeyCount(), keyCount)
 	defer bt.Close()
@@ -668,7 +674,7 @@ func TestNewBtIndex(t *testing.T) {
 
 	indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, DefaultBtreeM, seg.CompressNone, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, seg.CompressNone, false)
 	require.NoError(t, err)
 	defer bt.Close()
 	defer kv.Close()
@@ -692,31 +698,17 @@ func TestBtIndex_MStoredInFile(t *testing.T) {
 	logger := log.New()
 	kvPath := generateKV(t, tmp, 20, 10, 1000, logger, seg.CompressNone)
 
+	indexPath := strings.TrimSuffix(kvPath, ".kv") + "_m8.bt"
+	buildBtreeIndexWithM(t, kvPath, indexPath, seg.CompressNone, wantM, logger)
+
 	decomp, err := seg.NewDecompressor(kvPath)
 	require.NoError(t, err)
 	defer decomp.Close()
 
-	indexPath := strings.TrimSuffix(kvPath, ".kv") + "_m8.bt"
-	iw, err := NewBtIndexWriter(BtIndexWriterArgs{IndexFile: indexPath, TmpDir: tmp, M: wantM, KeyCount: uint64(decomp.Count() / 2), MaxOffset: uint64(decomp.Size())}, logger)
-	require.NoError(t, err)
-	defer iw.Close()
-
-	r := seg.NewReader(decomp.MakeGetter(), seg.CompressNone)
-	r.Reset(0)
-	var pos uint64
-	for r.HasNext() {
-		key, _ := r.Next(nil)
-		require.NoError(t, iw.AddKey(key, pos))
-		pos, _ = r.Skip()
-	}
-	iw.DisableFsync()
-	require.NoError(t, iw.Build())
-
-	r2 := seg.NewReader(decomp.MakeGetter(), seg.CompressNone)
-	bt, err := OpenBtreeIndexWithDecompressor(indexPath, 1, r2) // pass wrong M — file M should win
+	bt, err := OpenBtreeIndexWithDecompressor(indexPath, seg.NewReader(decomp.MakeGetter(), seg.CompressNone))
 	require.NoError(t, err)
 	defer bt.Close()
-	require.Equal(t, wantM, bt.M())
+	require.Equal(t, wantM, bt.M(), "M must come from the file, not from DefaultBtreeM")
 }
 
 func BenchmarkBtIndex_Get(b *testing.B) {
@@ -727,14 +719,16 @@ func BenchmarkBtIndex_Get(b *testing.B) {
 	compress := seg.CompressKeys
 
 	for _, M := range []uint64{256, 128, 64, 32} {
-		kvPath := generateKV(b, b.TempDir(), 20, 10, keyCount, log.New(), compress)
+		tmp := b.TempDir()
+		kvPath := generateKV(b, tmp, 20, 10, keyCount, log.New(), compress)
 		keys, err := pivotKeysFromKV(kvPath)
 		require.NoError(b, err)
 
-		indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
+		indexPath := filepath.Join(tmp, fmt.Sprintf("m%d.bt", M))
+		buildBtreeIndexWithM(b, kvPath, indexPath, compress, M, log.New())
 
 		b.Run(fmt.Sprintf("M%d", M), func(b *testing.B) {
-			decomp, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, M, compress, false)
+			decomp, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, compress, false)
 			require.NoError(b, err)
 			defer bt.Close()
 			defer decomp.Close()

--- a/db/datastruct/btindex/interp_search_test.go
+++ b/db/datastruct/btindex/interp_search_test.go
@@ -23,7 +23,7 @@ func TestInterpEquivBinary(t *testing.T) {
 	indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
 	buildBtreeIndex(t, kvPath, indexPath, compress, 1, log.New(), true)
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, DefaultBtreeM, compress, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, compress, false)
 	require.NoError(t, err)
 	defer bt.Close()
 	defer kv.Close()

--- a/db/datastruct/btindex/interp_varlen_test.go
+++ b/db/datastruct/btindex/interp_varlen_test.go
@@ -80,7 +80,7 @@ func TestInterpEquivBinaryVarLen(t *testing.T) {
 	kvPath := generateVarLenKV(t, t.TempDir(), keyCount, log.New(), compress)
 	indexPath := strings.TrimSuffix(kvPath, ".kv") + ".bt"
 
-	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, DefaultBtreeM, compress, false)
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, kvPath, compress, false)
 	require.NoError(t, err)
 	defer bt.Close()
 	defer kv.Close()

--- a/db/datastruct/btindex/nodeofft_ef_test.go
+++ b/db/datastruct/btindex/nodeofft_ef_test.go
@@ -51,7 +51,7 @@ func Test_BtreeIndex_NodeOfftEF_V0_V2(t *testing.T) {
 
 	for _, tc := range []struct{ name, path string }{{"v0", v0Path}, {"v2", v2Path}} {
 		t.Run(tc.name, func(t *testing.T) {
-			kv, bt, err := OpenBtreeIndexAndDataFile(tc.path, dataPath, M, compressFlags, false)
+			kv, bt, err := OpenBtreeIndexAndDataFile(tc.path, dataPath, compressFlags, false)
 			require.NoError(t, err)
 			defer bt.Close()
 			defer kv.Close()

--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -124,8 +124,7 @@ func Benchmark_BtreeIndex_Search(b *testing.B) {
 	comp := seg.CompressKeys | seg.CompressVals
 	buildBtreeIndex(b, dataPath, indexPath, comp, 1, logger, true)
 
-	M := 1024
-	kv, bt, err := btindex.OpenBtreeIndexAndDataFile(indexPath, dataPath, uint64(M), comp, false)
+	kv, bt, err := btindex.OpenBtreeIndexAndDataFile(indexPath, dataPath, comp, false)
 	require.NoError(b, err)
 	defer bt.Close()
 	defer kv.Close()
@@ -145,7 +144,6 @@ func Benchmark_BtreeIndex_Search(b *testing.B) {
 }
 
 type bTreeParameters struct {
-	M         uint64
 	KeySize   int // bytes
 	ValueSize int // bytes
 	KeyCount  int
@@ -163,7 +161,7 @@ func benchInitBtreeIndex(b *testing.B, params bTreeParameters, compression seg.F
 
 	buildBtreeIndex(b, dataPath, indexPath, compression, 1, logger, true)
 
-	kv, bt, err := btindex.OpenBtreeIndexAndDataFile(indexPath, dataPath, params.M, compression, false)
+	kv, bt, err := btindex.OpenBtreeIndexAndDataFile(indexPath, dataPath, compression, false)
 	require.NoError(b, err)
 	b.Cleanup(func() { bt.Close() })
 	b.Cleanup(func() { kv.Close() })
@@ -180,7 +178,6 @@ func Benchmark_BTree_SeekVsGetCompressedV(b *testing.B) {
 		keyCount = 10_000
 	}
 	kv, bt, keys, _ := benchInitBtreeIndex(b, bTreeParameters{
-		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
 		KeyCount:  keyCount,
@@ -226,7 +223,6 @@ func Benchmark_BTree_SeekVsGetCompressedK(b *testing.B) {
 		keyCount = 10_000
 	}
 	kv, bt, keys, _ := benchInitBtreeIndex(b, bTreeParameters{
-		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
 		KeyCount:  keyCount,
@@ -272,7 +268,6 @@ func Benchmark_BTree_SeekVsGetCompressedKV(b *testing.B) {
 		keyCount = 10_000
 	}
 	kv, bt, keys, _ := benchInitBtreeIndex(b, bTreeParameters{
-		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
 		KeyCount:  keyCount,
@@ -318,7 +313,6 @@ func Benchmark_BTree_SeekVsGetUncompressed(b *testing.B) {
 		keyCount = 10_000
 	}
 	kv, bt, keys, _ := benchInitBtreeIndex(b, bTreeParameters{
-		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
 		KeyCount:  keyCount,
@@ -364,7 +358,6 @@ func Benchmark_BTree_SeekThenNext(b *testing.B) {
 		keyCount = 10_000
 	}
 	kv, bt, keys, _ := benchInitBtreeIndex(b, bTreeParameters{
-		M:         1024,
 		KeySize:   64,
 		ValueSize: 1024,
 		KeyCount:  keyCount,

--- a/db/state/dirty_files.go
+++ b/db/state/dirty_files.go
@@ -438,7 +438,7 @@ func (d *Domain) openDirtyFiles(ctx context.Context, dirEntries []string) (err e
 			if ok {
 				fName := filepath.Base(fPath)
 				d.FileVersion.AccessorBT.MustSupport(fileVer, fName)
-				if item.bindex, err = btindex.OpenBtreeIndexWithDecompressor(fPath, btindex.DefaultBtreeM, d.dataReader(item.decompressor)); err != nil {
+				if item.bindex, err = btindex.OpenBtreeIndexWithDecompressor(fPath, d.dataReader(item.decompressor)); err != nil {
 					d.logger.Debug("[agg] Domain.openDirtyFiles", "err", err, "f", fName)
 					// don't interrupt on error. other files may be good
 				}

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -998,7 +998,7 @@ func (d *Domain) buildFileRange(ctx context.Context, stepFrom, stepTo kv.Step, c
 	if d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := d.kvBtAccessorNewFilePathIn(dstDir, stepFrom, stepTo)
 		kveiPath := d.kvExistenceIdxNewFilePathIn(dstDir, stepFrom, stepTo)
-		bt, err = btindex.CreateBtreeIndexWithDecompressor(btPath, kveiPath, btindex.DefaultBtreeM, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
+		bt, err = btindex.CreateBtreeIndexWithDecompressor(btPath, kveiPath, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
 		if err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s .bt idx: %w", d.FilenameBase, err)
 		}
@@ -1101,7 +1101,7 @@ func (d *Domain) buildFiles(ctx context.Context, step kv.Step, collation Collati
 	if d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := d.kvBtAccessorNewFilePath(step, step+1)
 		kveiPath := d.kvExistenceIdxNewFilePath(step, step+1)
-		bt, err = btindex.CreateBtreeIndexWithDecompressor(btPath, kveiPath, btindex.DefaultBtreeM, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
+		bt, err = btindex.CreateBtreeIndexWithDecompressor(btPath, kveiPath, d.dataReader(valuesDecomp), *d.salt.Load(), ps, d.dirs.Tmp, d.logger, d.noFsync, d.Accessors)
 		if err != nil {
 			return StaticFiles{}, fmt.Errorf("build %s .bt idx: %w", d.FilenameBase, err)
 		}

--- a/db/state/merge.go
+++ b/db/state/merge.go
@@ -555,11 +555,7 @@ func (dt *DomainRoTx) mergeFiles(ctx context.Context, domainFiles, indexFiles, h
 	if dt.d.Accessors.Has(statecfg.AccessorBTree) {
 		btPath := dt.d.kvBtAccessorNewFilePath(fromStep, toStep)
 		kveiPath := dt.d.kvExistenceIdxNewFilePath(fromStep, toStep)
-		btM := btindex.DefaultBtreeM
-		if toStep == 0 && dt.d.FilenameBase == "commitment" {
-			btM = 128
-		}
-		valuesIn.bindex, err = btindex.CreateBtreeIndexWithDecompressor(btPath, kveiPath, btM, dt.dataReader(valuesIn.decompressor), *dt.salt, ps, dt.d.dirs.Tmp, dt.d.logger, dt.d.noFsync, dt.d.Accessors)
+		valuesIn.bindex, err = btindex.CreateBtreeIndexWithDecompressor(btPath, kveiPath, dt.dataReader(valuesIn.decompressor), *dt.salt, ps, dt.d.dirs.Tmp, dt.d.logger, dt.d.noFsync, dt.d.Accessors)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("merge %s btindex [%d-%d]: %w", dt.d.FilenameBase, r.values.from, r.values.to, err)
 		}

--- a/db/state/snap_repo.go
+++ b/db/state/snap_repo.go
@@ -390,7 +390,7 @@ func (f *SnapshotRepo) openDirtyFiles(dirEntries []string) error {
 				f.logger.Error("SnapshotRepo.openDirtyFiles btindex path", "err", err, "f", fPath)
 			} else {
 				r := seg.NewReader(item.decompressor.MakeGetter(), p.DataFileCompression())
-				if item.bindex, err = btindex.OpenBtreeIndexWithDecompressor(fPath, btindex.DefaultBtreeM, r); err != nil {
+				if item.bindex, err = btindex.OpenBtreeIndexWithDecompressor(fPath, r); err != nil {
 					_, fName := filepath.Split(fPath)
 					f.logger.Error("SnapshotRepo.openDirtyFiles", "err", err, "f", fName)
 					// don't interrupt on error. other files maybe good

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -705,7 +705,7 @@ func populateFiles(t *testing.T, dirs datadir.Dirs, schema SnapNameSchema, allFi
 
 			r := seg.NewReader(seg3.MakeGetter(), seg.CompressNone)
 			kveiFile := strings.TrimSuffix(filename, ".bt") + ".kvei"
-			bti, err := btindex.CreateBtreeIndexWithDecompressor(filename, kveiFile, 128, r, uint32(1), background.NewProgressSet(), dirs.Tmp, log.New(), true, statecfg.AccessorBTree|statecfg.AccessorExistence)
+			bti, err := btindex.CreateBtreeIndexWithDecompressor(filename, kveiFile, r, uint32(1), background.NewProgressSet(), dirs.Tmp, log.New(), true, statecfg.AccessorBTree|statecfg.AccessorExistence)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
- updated the default M value from 256 to 64
- reason: with bloatnet/jochemnet/ef benchmarks etc. we're moving into a performance regime. Moving from 256 to 64 does provide good cold access latencies (https://github.com/erigontech/erigon/issues/21692#issue-4620962561) **which drops by about 35%**.
- **bt index sizes**: decreasing M increases size by 60%. But bt is small - e.g in mainnet, storage domain still fits well under 3GB.
- btree is mostly mmap'ed on page cache; so not much increase in heap usage.
- backwards compatibility: this **is** a backwards compatible change. Legacy formats open with m=256; while the new footer based format stores M in the file itself and uses that.
- no file version upgrade needed

extra:
- removed special handling for commitment file domain - it doesn't use bt but kvi
