### PR TITLE
[r3.6] execution: withhold created-empty versioned writes

### DIFF
--- a/execution/bal/rederive.go
+++ b/execution/bal/rederive.go
@@ -60,15 +60,18 @@ func RederiveBlockAccessList(
 	balIO := &state.VersionedIO{}
 	noopWriter := state.NewNoopWriter()
 	ibs.SetTxContext(blockNum, -1)
+	hashFn := protocol.GetHashFn(header, getHeader)
+	blockContext := protocol.NewEVMBlockContext(header, hashFn, engine, accounts.NilAddress, cfg)
+	blockRules := blockContext.Rules(cfg)
 	err := protocol.InitializeBlockExecution(engine, chainReader, header, cfg, ibs, noopWriter, logger, nil)
 	if err != nil {
 		return nil, fmt.Errorf("bal.RederiveBlockAccessList: initialize block %d: %w", blockNum, err)
 	}
-	ibs.MergeTxIOInto(balIO)
+	initWrites := ibs.FinalizedWrites(blockRules, false)
+	ibs.MergeTxIOInto(balIO, initWrites)
 	ibs.ResetVersionedIO()
 	gasUsed := new(protocol.GasUsed)
 	gp := new(protocol.GasPool).AddGas(header.GasLimit).AddBlobGas(cfg.GetMaxBlobGasPerBlock(header.Time))
-	hashFn := protocol.GetHashFn(header, getHeader)
 	vmCfg := vm.Config{}
 	receipts := make(types.Receipts, 0, len(txns))
 	for i, txn := range txns {
@@ -89,7 +92,8 @@ func RederiveBlockAccessList(
 		if evm.Cancelled() {
 			return nil, fmt.Errorf("bal.RederiveBlockAccessList: execution aborted replaying tx %d of block %d: %w", i, blockNum, ctx.Err())
 		}
-		ibs.MergeTxIOInto(balIO)
+		txWrites := ibs.FinalizedWrites(blockRules, false)
+		ibs.MergeTxIOInto(balIO, txWrites)
 		ibs.ResetVersionedIO()
 		receipts = append(receipts, receipt)
 	}
@@ -104,6 +108,7 @@ func RederiveBlockAccessList(
 	if err != nil {
 		return nil, fmt.Errorf("bal.RederiveBlockAccessList: finalize block %d: %w", blockNum, err)
 	}
-	ibs.MergeTxIOInto(balIO)
+	finalWrites := ibs.FinalizedWrites(blockRules, false)
+	ibs.MergeTxIOInto(balIO, finalWrites)
 	return balIO.AsBlockAccessList(), nil
 }

--- a/execution/engineapi/engine_api_builder_test.go
+++ b/execution/engineapi/engine_api_builder_test.go
@@ -17,6 +17,7 @@
 package engineapi_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"encoding/binary"
@@ -35,16 +36,173 @@ import (
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/execution/abi/bind"
 	enginetypes "github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/engineapi/engineapitester"
 	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/state/contracts"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/node/ethconfig"
 	"github.com/erigontech/erigon/rpc"
 )
+
+func signAuthorization(t *testing.T, key *ecdsa.PrivateKey, chainID *uint256.Int, target common.Address, nonce uint64) types.Authorization {
+	t.Helper()
+	var buf [33]byte
+	data := bytes.NewBuffer(nil)
+
+	authLen := rlp.Uint256Len(*chainID)
+	authLen += 1 + length.Addr
+	authLen += rlp.U64Len(nonce)
+	require.NoError(t, rlp.EncodeListPrefix(authLen, data, buf[:]))
+	require.NoError(t, rlp.EncodeUint256(*chainID, data, buf[:]))
+	require.NoError(t, types.EncodeOptionalAddress(&target, data, buf[:]))
+	require.NoError(t, rlp.EncodeU64(nonce, data, buf[:]))
+
+	hash := crypto.Keccak256Hash(append([]byte{params.SetCodeMagicPrefix}, data.Bytes()...))
+	sig, err := crypto.Sign(hash[:], key)
+	require.NoError(t, err)
+
+	auth := types.Authorization{
+		ChainID: *chainID,
+		Address: target,
+		Nonce:   nonce,
+		YParity: sig[64],
+		R:       *uint256.NewInt(0).SetBytes(sig[:32]),
+		S:       *uint256.NewInt(0).SetBytes(sig[32:64]),
+	}
+	recovered, err := auth.RecoverSigner(bytes.NewBuffer(nil), buf[:])
+	require.NoError(t, err)
+	require.Equal(t, crypto.PubkeyToAddress(key.PublicKey), *recovered)
+	return auth
+}
+
+func TestEngineApiClearsFreshTouchedEmptyAccount(t *testing.T) {
+	tests := []struct {
+		name            string
+		experimentalBAL bool
+	}{
+		{name: "serial builder"},
+		{name: "experimental BAL builder", experimentalBAL: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testEngineApiClearsFreshTouchedEmptyAccount(t, test.experimentalBAL)
+		})
+	}
+}
+
+func testEngineApiClearsFreshTouchedEmptyAccount(t *testing.T, experimentalBAL bool) {
+	parallel := dbg.Exec3Parallel
+	dbg.Exec3Parallel = true
+	t.Cleanup(func() { dbg.Exec3Parallel = parallel })
+
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlError)
+	genesis, coinbaseKey, err := engineapitester.DefaultEngineApiTesterGenesis()
+	require.NoError(t, err)
+	genesis.Config.AmsterdamTime = nil
+
+	senderKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	senderAddr := crypto.PubkeyToAddress(senderKey.PublicKey)
+	genesis.Alloc[senderAddr] = types.GenesisAccount{
+		Balance: new(big.Int).Exp(big.NewInt(10), big.NewInt(20), nil),
+	}
+
+	emptyKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	emptyAddr := crypto.PubkeyToAddress(emptyKey.PublicKey)
+
+	eat, err := engineapitester.InitialiseEngineApiTester(ctx, engineapitester.EngineApiTesterInitArgs{
+		Logger: logger, DataDir: t.TempDir(), Genesis: genesis, CoinbaseKey: coinbaseKey,
+		EthConfigTweaker: func(cfg *ethconfig.Config) {
+			cfg.ExperimentalBAL = experimentalBAL
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		chainID := eat.ChainId()
+		signer := types.LatestSignerForChainID(chainID)
+		rpcClient := eat.Transactor.RpcClient()
+		feeCap := uint256.NewInt(1_000_000_000)
+
+		send := func(txn types.Transaction) {
+			signed, err := types.SignTx(txn, *signer, senderKey)
+			require.NoError(t, err)
+			_, err = rpcClient.SendTransaction(signed)
+			require.NoError(t, err)
+		}
+
+		// Deploy runtime code that pushes emptyAddr and executes SELFDESTRUCT.
+		initCode := append([]byte{0x75, 0x73}, emptyAddr[:]...)
+		initCode = append(initCode, 0xff, 0x60, 0x00, 0x52, 0x60, 0x16, 0x60, 0x0a, 0xf3)
+		send(&types.DynamicFeeTransaction{
+			CommonTx: types.CommonTx{Nonce: 0, GasLimit: 200_000, Data: initCode},
+			ChainID:  *chainID, TipCap: *feeCap, FeeCap: *feeCap,
+		})
+		_, err = eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+
+		selfDestructor := types.CreateAddress(senderAddr, 0)
+		send(&types.DynamicFeeTransaction{
+			CommonTx: types.CommonTx{Nonce: 1, GasLimit: 200_000, To: &selfDestructor},
+			ChainID:  *chainID, TipCap: *feeCap, FeeCap: *feeCap,
+		})
+		send(&types.SetCodeTransaction{
+			DynamicFeeTransaction: types.DynamicFeeTransaction{
+				CommonTx: types.CommonTx{Nonce: 2, GasLimit: 500_000, To: &senderAddr},
+				ChainID:  *chainID, TipCap: *feeCap, FeeCap: *feeCap,
+			},
+			Authorizations: []types.Authorization{
+				signAuthorization(t, emptyKey, chainID, common.Address{0xaa}, 0),
+			},
+		})
+
+		payload, err := eat.MockCl.BuildCanonicalBlock(ctx)
+		require.NoError(t, err)
+		const gasUsedWithoutAuthorityExistenceRefund = uint64(74_603)
+		require.Equal(t, gasUsedWithoutAuthorityExistenceRefund, uint64(payload.ExecutionPayload.GasUsed))
+	})
+}
+
+func TestEngineApiClearsFreshZeroAmountWithdrawal(t *testing.T) {
+	parallel := dbg.Exec3Parallel
+	dbg.Exec3Parallel = true
+	t.Cleanup(func() { dbg.Exec3Parallel = parallel })
+
+	ctx := t.Context()
+	logger := testlog.Logger(t, log.LvlError)
+	genesis, coinbaseKey, err := engineapitester.DefaultEngineApiTesterGenesis()
+	require.NoError(t, err)
+
+	eat, err := engineapitester.InitialiseEngineApiTester(ctx, engineapitester.EngineApiTesterInitArgs{
+		Logger: logger, DataDir: t.TempDir(), Genesis: genesis, CoinbaseKey: coinbaseKey,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, eat.Close()) })
+
+	eat.Run(t, func(ctx context.Context, t *testing.T, eat engineapitester.EngineApiTester) {
+		fresh := common.Address{0xbe, 0xef}
+		withdrawals := []*types.Withdrawal{{Index: 1, Validator: 1, Address: fresh, Amount: 0}}
+		payload, err := eat.MockCl.BuildCanonicalBlock(ctx, engineapitester.WithWithdrawals(withdrawals))
+		require.NoError(t, err)
+
+		bal := decodeAndValidateBAL(t, payload)
+		changes := findAccountChanges(bal, accounts.InternAddress(fresh))
+		require.NotNilf(t, changes, "zero-amount withdrawal recipient must remain an access-only BAL entry\n%s", bal.DebugString())
+		require.Empty(t, changes.StorageChanges)
+		require.Empty(t, changes.StorageReads)
+		require.Empty(t, changes.BalanceChanges)
+		require.Empty(t, changes.NonceChanges)
+		require.Empty(t, changes.CodeChanges)
+	})
+}
 
 func TestEngineApiBuiltBlockStateMatchesValidation(t *testing.T) {
 	ctx := t.Context()

--- a/execution/exec/block_assembler.go
+++ b/execution/exec/block_assembler.go
@@ -101,6 +101,7 @@ type BlockAssembler struct {
 	*AssembledBlock
 	cfg         AssemblerCfg
 	balIO       *state.VersionedIO
+	blockRules  *chain.Rules
 	stateWriter state.StateWriter // optional: if set, domain writes go here instead of NoopWriter
 	gasUsed     protocol.GasUsed  // EIP-8037: cumulative per-dimension gas across AddTransactions calls
 }
@@ -108,16 +109,15 @@ type BlockAssembler struct {
 func (ba *BlockAssembler) CumulativeGasUsed() protocol.GasUsed { return ba.gasUsed }
 
 func NewBlockAssembler(cfg AssemblerCfg, block *AssembledBlock) *BlockAssembler {
-	var balIO *state.VersionedIO
-
+	ba := &BlockAssembler{AssembledBlock: block, cfg: cfg}
 	if cfg.ChainConfig.IsAmsterdam(block.Header.Time) || cfg.ExperimentalBAL {
-		balIO = &state.VersionedIO{}
+		ba.balIO = &state.VersionedIO{}
+		blockContext := protocol.NewEVMBlockContext(
+			block.Header, protocol.GetHashFn(block.Header, nil), cfg.Engine, accounts.NilAddress, cfg.ChainConfig,
+		)
+		ba.blockRules = blockContext.Rules(cfg.ChainConfig)
 	}
-	return &BlockAssembler{
-		AssembledBlock: block,
-		cfg:            cfg,
-		balIO:          balIO,
-	}
+	return ba
 }
 
 func (ba *BlockAssembler) HasBAL() bool {
@@ -155,7 +155,8 @@ func (ba *BlockAssembler) Initialize(ibs *state.IntraBlockState, tx kv.TemporalT
 		return err
 	}
 	if ba.HasBAL() {
-		ibs.MergeTxIOInto(ba.balIO)
+		writes := ibs.FinalizedWrites(ba.blockRules, false)
+		ibs.MergeTxIOInto(ba.balIO, writes)
 		ibs.ResetVersionedIO()
 	}
 	return nil
@@ -206,7 +207,8 @@ func (ba *BlockAssembler) AddTransactions(
 	writer := state.NewNoopWriter()
 	recordTxIO := func() {
 		if ba.HasBAL() {
-			ibs.MergeTxIOInto(ba.balIO)
+			writes := ibs.FinalizedWrites(ba.blockRules, false)
+			ibs.MergeTxIOInto(ba.balIO, writes)
 		}
 		ibs.ResetVersionedIO()
 	}
@@ -397,8 +399,9 @@ func (ba *BlockAssembler) AssembleBlock(stateReader state.StateReader, ibs *stat
 	// so we must modify the block's header directly, not ba.Header.
 	header := block.HeaderNoCopy()
 	if ba.HasBAL() {
+		writes := ibs.FinalizedWrites(ba.blockRules, false)
 		// Record finalize system call I/O (EIP-7002, EIP-7251, etc.)
-		ibs.MergeTxIOInto(ba.balIO)
+		ibs.MergeTxIOInto(ba.balIO, writes)
 		ibs.ResetVersionedIO()
 		ba.BlockAccessList = ba.balIO.AsBlockAccessList()
 		// Only embed the BAL hash in the header for Amsterdam+ chains.

--- a/execution/exec/txtask.go
+++ b/execution/exec/txtask.go
@@ -615,7 +615,7 @@ func (txTask *TxTask) Execute(evm *vm.EVM,
 
 		result.AccessedAddresses = ibs.AccessedAddresses()
 		result.TxIn = txTask.VersionedReads(ibs)
-		result.TxOut = txTask.VersionedWrites(ibs)
+		result.TxOut = ibs.FinalizedWrites(rules, false)
 	}
 
 	return &result

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -344,6 +344,10 @@ func FinalizeBlockExecution(
 		return ret, err
 	}
 
+	if ibs.IsVersioned() {
+		ibs.StartAccessRecording()
+	}
+
 	if isMining {
 		newBlock, retRequests, err = engine.FinalizeAndAssemble(cc, header, ibs, txs, uncles, receipts, withdrawals, chainReader, syscall, nil, logger)
 	} else {

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1880,10 +1880,7 @@ func (result *execResult) finalizeSystemTx(
 	if err := ibs.FinalizeTx(rules, stateWriter); err != nil {
 		return nil, state.ReadSet{}, nil, err
 	}
-	// Use checkDirty=false because FinalizeTx clears the journal (dirties map).
-	// With checkDirty=true, all writes would be deleted from the versionMap
-	// since no address appears dirty after the journal reset.
-	return nil, ibs.VersionedReads(), ibs.VersionedWrites(false), nil
+	return nil, ibs.VersionedReads(), ibs.FinalizedWrites(rules, false), nil
 }
 
 func (result *execResult) calcFees(
@@ -3023,6 +3020,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			localVersionMap := state.NewVersionMap(nil)
 			ibs.SetVersionMap(localVersionMap)
 			ibs.SetTxContext(finalVersion.BlockNum, finalVersion.TxIndex)
+			ibs.StartAccessRecording()
 
 			if tt, ok := lastResult.Task.(*taskVersion).Task.(*exec.TxTask); ok {
 				// Syscalls share the main ibs so their writes (EIP-7002/7251
@@ -3057,17 +3055,13 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 					return be.invalidBlockResult(fmt.Errorf("%w: can't finalize block %d: %v", rules.ErrInvalidBlock, be.blockNum, err)), nil
 				}
 
-				// syscallIBS == ibs unconditionally now; no separate write
-				// propagation needed — syscall writes flow through
-				// ibs.MakeWriteSet into finalizeWrites below.
-
 				be.blockIO.RecordReads(finalVersion, ibs.VersionedReads())
 				be.blockIO.RecordAccesses(finalVersion, ibs.AccessedAddresses())
 
-				ivw := ibs.VersionedWrites(true)
-				if !ivw.IsEmpty() {
-					be.blockIO.RecordWrites(finalVersion, ivw)
-					be.versionMap.FlushVersionedWrites(ivw, true, "")
+				writes := ibs.FinalizedWrites(lastResult.Rules(), true)
+				if !writes.IsEmpty() {
+					be.blockIO.RecordWrites(finalVersion, writes)
+					be.versionMap.FlushVersionedWrites(writes, true, "")
 				}
 
 				collector := state.NewVersionedWriteCollector(pe.rs)

--- a/execution/state/created_empty_versioned_test.go
+++ b/execution/state/created_empty_versioned_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+func TestFinalizedWritesWithholdCreatedEmptyAccount(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xe1})
+	vm := NewVersionMap(nil)
+	ibs := NewWithVersionMap(&minimalStateReader{}, vm)
+	t.Cleanup(func() { ibs.Release(false) })
+	ibs.SetTxContext(1, 0)
+
+	require.NoError(t, ibs.TouchAccount(addr))
+
+	writes := ibs.FinalizedWrites(&chain.Rules{IsSpuriousDragon: true}, false)
+	_, hasAddress := writes.GetAddress(addr)
+	require.False(t, hasAddress)
+	_, hasBalance := writes.GetBalance(addr)
+	require.False(t, hasBalance)
+	_, hasDelete := writes.GetSelfDestruct(addr)
+	require.False(t, hasDelete)
+
+	vm.FlushVersionedWrites(writes, true, "")
+	next := NewWithVersionMap(&minimalStateReader{}, vm)
+	t.Cleanup(func() { next.Release(false) })
+	next.SetTxContext(1, 1)
+	exists, err := next.Exist(addr)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestFinalizedWritesLeavesVersionMapForApplyLoop(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xe1})
+	vm := NewVersionMap(nil)
+	ibs := NewWithVersionMap(&minimalStateReader{}, vm)
+	t.Cleanup(func() { ibs.Release(false) })
+	ibs.SetTxContext(1, 0)
+
+	require.NoError(t, ibs.TouchAccount(addr))
+	vm.FlushVersionedWrites(ibs.VersionedWrites(false), false, "")
+
+	writes := ibs.FinalizedWrites(&chain.Rules{IsSpuriousDragon: true}, false)
+	_, hasAddress := writes.GetAddress(addr)
+	require.False(t, hasAddress)
+
+	_, result, ok := vm.ReadAddress(addr, 1)
+	require.True(t, ok)
+	require.Equal(t, MVReadResultDependency, result.Status())
+	require.Equal(t, 0, result.DepIdx())
+}
+
+func TestCreatedEmptyRequiresNoOtherWrites(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xe1})
+	newWrites := func() *WriteSet {
+		account := accounts.NewAccount()
+		writes := &WriteSet{}
+		writes.SetAddress(addr, &VersionedWrite[*accounts.Account]{Val: &account})
+		return writes
+	}
+	tests := []struct {
+		name string
+		add  func(*WriteSet)
+	}{
+		{
+			name: "balance",
+			add: func(writes *WriteSet) {
+				writes.SetBalance(addr, &VersionedWrite[uint256.Int]{Val: *uint256.NewInt(1)})
+			},
+		},
+		{
+			name: "nonce",
+			add: func(writes *WriteSet) {
+				writes.SetNonce(addr, &VersionedWrite[uint64]{Val: 1})
+			},
+		},
+		{
+			name: "code hash",
+			add: func(writes *WriteSet) {
+				writes.SetCodeHash(addr, &VersionedWrite[accounts.CodeHash]{Val: accounts.InternCodeHash(common.Hash{1})})
+			},
+		},
+		{
+			name: "code",
+			add: func(writes *WriteSet) {
+				writes.SetCode(addr, &VersionedWrite[accounts.Code]{})
+			},
+		},
+		{
+			name: "code size",
+			add: func(writes *WriteSet) {
+				writes.SetCodeSize(addr, &VersionedWrite[int]{})
+			},
+		},
+		{
+			name: "storage",
+			add: func(writes *WriteSet) {
+				writes.SetStorage(addr, accounts.InternKey([32]byte{1}), &VersionedWrite[uint256.Int]{})
+			},
+		},
+		{
+			name: "self-destruct",
+			add: func(writes *WriteSet) {
+				writes.SetSelfDestruct(addr, &VersionedWrite[bool]{})
+			},
+		},
+		{
+			name: "contract creation",
+			add: func(writes *WriteSet) {
+				writes.SetCreateContract(addr, &VersionedWrite[bool]{})
+			},
+		},
+		{
+			name: "incarnation",
+			add: func(writes *WriteSet) {
+				writes.SetIncarnation(addr, &VersionedWrite[uint64]{})
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writes := newWrites()
+			require.True(t, writes.createdEmpty(addr))
+			test.add(writes)
+			require.False(t, writes.createdEmpty(addr))
+		})
+	}
+}
+
+func TestFinalizedWritesKeepCreatedEmptyBeforeEIP161(t *testing.T) {
+	ibs := NewWithVersionMap(&minimalStateReader{}, NewVersionMap(nil))
+	t.Cleanup(func() { ibs.Release(false) })
+	ibs.SetTxContext(1, 0)
+
+	addr := accounts.InternAddress([20]byte{0xe1})
+	require.NoError(t, ibs.TouchAccount(addr))
+
+	writes := ibs.FinalizedWrites(&chain.Rules{}, false)
+	_, ok := writes.GetAddress(addr)
+	require.True(t, ok)
+}
+
+func TestFinalizedWritesKeepCreatedEmptyAtGenesis(t *testing.T) {
+	ibs := NewWithVersionMap(&minimalStateReader{}, NewVersionMap(nil))
+	t.Cleanup(func() { ibs.Release(false) })
+	ibs.SetTxContext(0, 0)
+
+	addr := accounts.InternAddress([20]byte{0xe1})
+	require.NoError(t, ibs.TouchAccount(addr))
+
+	writes := ibs.FinalizedWrites(&chain.Rules{IsSpuriousDragon: true}, false)
+	_, ok := writes.GetAddress(addr)
+	require.True(t, ok)
+}
+
+func TestFinalizedWritesKeepCreatedEmptyAuraSystemAccount(t *testing.T) {
+	ibs := NewWithVersionMap(&minimalStateReader{}, NewVersionMap(nil))
+	t.Cleanup(func() { ibs.Release(false) })
+	ibs.SetTxContext(1, 0)
+
+	require.NoError(t, ibs.TouchAccount(params.SystemAddress))
+
+	writes := ibs.FinalizedWrites(&chain.Rules{
+		IsSpuriousDragon: true,
+		IsAura:           true,
+	}, false)
+	_, ok := writes.GetAddress(params.SystemAddress)
+	require.True(t, ok)
+}

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2291,12 +2291,33 @@ func (sdb *IntraBlockState) MakeWriteSet(chainRules *chain.Rules, stateWriter St
 	return nil
 }
 
-// MergeTxIOInto folds the current transaction's recorded reads, writes and
-// accesses into io at the current tx index, without building an intermediate
-// VersionedIO.
-func (sdb *IntraBlockState) MergeTxIOInto(io *VersionedIO) {
+// MergeTxIOInto folds the current transaction's reads, accesses, and supplied writes into io.
+func (sdb *IntraBlockState) MergeTxIOInto(io *VersionedIO, writes *WriteSet) {
 	version := Version{BlockNum: sdb.blockNum, TxIndex: sdb.txIndex, Incarnation: sdb.version}
-	io.mergeTx(version, sdb.versionedReads, sdb.VersionedWrites(false), sdb.addressAccess)
+	io.mergeTx(version, sdb.versionedReads, writes, sdb.addressAccess)
+}
+
+// FinalizedWrites returns committable versioned writes after EIP-161 filtering.
+func (sdb *IntraBlockState) FinalizedWrites(chainRules *chain.Rules, checkDirty bool) *WriteSet {
+	writes := sdb.VersionedWrites(checkDirty)
+	sdb.withholdCreatedEmptyAccounts(chainRules, writes)
+	return writes
+}
+
+func (sdb *IntraBlockState) withholdCreatedEmptyAccounts(chainRules *chain.Rules, writes *WriteSet) {
+	if sdb.blockNum == 0 || chainRules == nil {
+		return
+	}
+	for addr := range writes.address {
+		if !EIP161EmptyRemoval(chainRules.IsEIP161Enabled(), chainRules.IsAura, addr) {
+			continue
+		}
+		read, ok := sdb.versionedReads.GetAddress(addr)
+		if !ok || (read.Val != nil && !read.Val.IsNil()) || !writes.createdEmpty(addr) {
+			continue
+		}
+		writes.deleteAddr(addr)
+	}
 }
 
 func (sdb *IntraBlockState) Print(chainRules chain.Rules, all bool) {
@@ -2473,6 +2494,14 @@ func (sdb *IntraBlockState) MarkAddressAccess(addr accounts.Address, revertable 
 	} else {
 		sdb.addressAccess[addr] = &accessOptions{revertable}
 	}
+}
+
+// StartAccessRecording enables versioned access tracking until ResetVersionedIO.
+func (sdb *IntraBlockState) StartAccessRecording() {
+	if sdb.addressAccess == nil {
+		sdb.addressAccess = make(map[accounts.Address]*accessOptions)
+	}
+	sdb.recordAccess = true
 }
 
 // MarkReadsInternal marks all versioned reads for addr as internal.

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -2785,3 +2785,29 @@ func GetDep(deps *VersionedIO) map[int]map[int]bool {
 
 	return newDependencies
 }
+
+func (s *WriteSet) createdEmpty(addr accounts.Address) bool {
+	created, ok := s.address[addr]
+	if !ok || created.Val == nil {
+		return false
+	}
+	account := *created.Val
+	if written, ok := s.balance[addr]; ok {
+		account.Balance = written.Val
+	}
+	if written, ok := s.nonce[addr]; ok {
+		account.Nonce = written.Val
+	}
+	if written, ok := s.codeHash[addr]; ok {
+		account.CodeHash = written.Val
+	}
+	if !account.Empty() {
+		return false
+	}
+	_, hasCode := s.code[addr]
+	_, hasIncarnation := s.incarnation[addr]
+	_, destroyed := s.selfDestruct[addr]
+	_, createdContract := s.createContract[addr]
+	_, hasCodeSize := s.codeSize[addr]
+	return !hasCode && !hasIncarnation && !destroyed && !createdContract && !hasCodeSize && len(s.storage[addr]) == 0
+}

--- a/execution/tests/blockgen/chain_makers.go
+++ b/execution/tests/blockgen/chain_makers.go
@@ -147,7 +147,7 @@ func (b *BlockGen) AddTxWithChain(getHeader func(hash common.Hash, number uint64
 	}
 
 	if b.ibs.IsVersioned() {
-		writes := b.ibs.VersionedWrites(false)
+		writes := b.ibs.FinalizedWrites(b.blockRules(), false)
 		if b.blockIO != nil {
 			b.blockIO.RecordReads(txVersion, b.ibs.VersionedReads())
 			b.blockIO.RecordAccesses(txVersion, b.ibs.AccessedAddresses())
@@ -159,6 +159,13 @@ func (b *BlockGen) AddTxWithChain(getHeader func(hash common.Hash, number uint64
 
 	b.txs = append(b.txs, txn)
 	b.receipts = append(b.receipts, receipt)
+}
+
+func (b *BlockGen) blockRules() *chain.Rules {
+	blockContext := protocol.NewEVMBlockContext(
+		b.header, protocol.GetHashFn(b.header, nil), b.engine, accounts.NilAddress, b.config,
+	)
+	return blockContext.Rules(b.config)
 }
 
 func (b *BlockGen) AddFailedTxWithChain(getHeader func(hash common.Hash, number uint64) (*types.Header, error), engine rules.Engine, txn types.Transaction) {
@@ -577,7 +584,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine rules.Engin
 			// Record system call I/O into blockIO for BAL computation
 			if ibs.IsVersioned() && b.blockIO != nil {
 				initVersion := state.Version{BlockNum: b.header.Number.Uint64(), TxIndex: -1}
-				writes := ibs.VersionedWrites(false)
+				writes := ibs.FinalizedWrites(b.blockRules(), false)
 				b.blockIO.RecordReads(initVersion, ibs.VersionedReads())
 				b.blockIO.RecordAccesses(initVersion, ibs.AccessedAddresses())
 				b.blockIO.RecordWrites(initVersion, writes)
@@ -604,6 +611,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine rules.Engin
 			// Reset versioned I/O before finalize to capture system call I/O cleanly
 			if ibs.IsVersioned() {
 				ibs.ResetVersionedIO()
+				ibs.StartAccessRecording()
 			}
 			// Finalize and seal the block
 			syscall := func(contract accounts.Address, data []byte) ([]byte, error) {
@@ -617,7 +625,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine rules.Engin
 			// Record finalize system call I/O into blockIO for BAL computation
 			if ibs.IsVersioned() && b.blockIO != nil {
 				finalizeVersion := state.Version{BlockNum: b.header.Number.Uint64(), TxIndex: len(b.txs)}
-				writes := ibs.VersionedWrites(false)
+				writes := ibs.FinalizedWrites(b.blockRules(), false)
 				b.blockIO.RecordReads(finalizeVersion, ibs.VersionedReads())
 				b.blockIO.RecordAccesses(finalizeVersion, ibs.AccessedAddresses())
 				b.blockIO.RecordWrites(finalizeVersion, writes)

--- a/execution/vm/runtime/runtime_test.go
+++ b/execution/vm/runtime/runtime_test.go
@@ -990,7 +990,7 @@ func TestSystemCallZeroValueSkipsTransferChecks(t *testing.T) {
 	// The call-level BAL must not include SYSTEM_ADDRESS when the syscall only
 	// performs the sender-side touch and no actual account access.
 	var io state.VersionedIO
-	statedb.MergeTxIOInto(&io)
+	statedb.MergeTxIOInto(&io, statedb.VersionedWrites(false))
 	bal := io.AsBlockAccessList()
 	for _, accountChanges := range bal {
 		require.NotEqual(t, systemAddr, accountChanges.Address,


### PR DESCRIPTION
Cherry-pick of #22768 to release/3.6.

## r3.6-specific adaptations

- Retains the materialized IntraBlockState and VersionedWrites(checkDirty) path used on release/3.6.
- Preserves the release branch BAL access records while filtering finalized writes.