### PR TITLE
cl/rpc: reject Gloas schema-slot mismatches at the RPC boundary

### DIFF
--- a/cl/rpc/rpc.go
+++ b/cl/rpc/rpc.go
@@ -46,6 +46,8 @@ import (
 
 const maxMessageLength = 18 * datasize.MB
 
+var errBlockForkSchemaSlotMismatch = errors.New("block schema fork disagrees with the fork implied by its slot")
+
 // blobSidecarRawBytes is the fixed SSZ size of a BlobSidecar (the blob dominates; fork-independent).
 func blobSidecarRawBytes() int { return (&cltypes.BlobSidecar{}).EncodingSizeSSZ() }
 
@@ -103,6 +105,10 @@ func (b *BeaconRpcP2P) sendBlocksRequest(ctx context.Context, topic string, reqD
 		responseChunk := cltypes.NewSignedBeaconBlock(b.beaconConfig, data.version)
 		if err := responseChunk.DecodeSSZ(data.raw, int(data.version)); err != nil {
 			return nil, pid, err
+		}
+		if !b.beaconConfig.ForkSchemaMatchesSlot(responseChunk.Block.Slot, responseChunk.Version()) {
+			b.BanPeer(pid)
+			return nil, pid, fmt.Errorf("%w: slot %d, decoded version %s", errBlockForkSchemaSlotMismatch, responseChunk.Block.Slot, responseChunk.Version())
 		}
 		responsePacket = append(responsePacket, responseChunk)
 	}

--- a/cl/rpc/rpc_test.go
+++ b/cl/rpc/rpc_test.go
@@ -1,13 +1,38 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
+	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
 )
+
+type blockResponseSentinel struct {
+	sentinelproto.SentinelClient
+	response   []byte
+	bannedPeer string
+}
+
+func (s *blockResponseSentinel) SendRequest(context.Context, *sentinelproto.RequestData, ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	return &sentinelproto.ResponseData{
+		Data: s.response,
+		Peer: &sentinelproto.Peer{Pid: "malicious-peer"},
+	}, nil
+}
+
+func (s *blockResponseSentinel) BanPeer(_ context.Context, peer *sentinelproto.Peer, _ ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
+	s.bannedPeer = peer.Pid
+	return &sentinelproto.EmptyMessage{}, nil
+}
 
 func TestExecutionPayloadEnvelopeRequestsRejectOverLimit(t *testing.T) {
 	cfg := clparams.MainnetBeaconConfig
@@ -34,4 +59,34 @@ func TestMaxRequestPayloadsFallback(t *testing.T) {
 
 	_, _, err = rpc.SendExecutionPayloadEnvelopesByRootReq(context.Background(), make([][32]byte, 18))
 	require.ErrorContains(t, err, "17")
+}
+
+func TestSendBeaconBlocksByRangeReqRejectsForkSchemaSlotMismatch(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	clock := eth_clock.NewEthereumClock(0, common.Hash{}, &cfg)
+
+	gloasDigest, err := clock.ComputeForkDigest(cfg.GloasForkEpoch)
+	require.NoError(t, err)
+
+	slot := (cfg.FuluForkEpoch + 1) * cfg.SlotsPerEpoch
+	block := cltypes.NewSignedBeaconBlock(&cfg, clparams.GloasVersion)
+	block.Block.Slot = slot
+
+	var response bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&response, block, gloasDigest[:]...))
+
+	sentinel := &blockResponseSentinel{response: response.Bytes()}
+	client := &BeaconRpcP2P{
+		ctx:          context.Background(),
+		sentinel:     sentinel,
+		beaconConfig: &cfg,
+		ethClock:     clock,
+	}
+
+	blocks, pid, err := client.SendBeaconBlocksByRangeReq(context.Background(), slot, 1)
+	require.ErrorIs(t, err, errBlockForkSchemaSlotMismatch)
+	require.Nil(t, blocks)
+	require.Equal(t, "malicious-peer", pid)
+	require.Equal(t, "malicious-peer", sentinel.bannedPeer)
 }


### PR DESCRIPTION
## Problem

For beacon block request/response traffic, the peer-provided fork-context digest selects the SSZ schema independently of the slot embedded in the decoded block. Across the Gloas boundary, those inputs can disagree: a block decoded with the Gloas schema can claim a pre-Gloas slot, leaving fields expected by slot-derived processing unset.

The reported BlocksByRange case produced a recovered ChainTipSync panic. It did not terminate Caplin, but repeated invalid responses can waste sync attempts while the serving peer remains eligible for selection.

Report: https://github.com/ethereum-bounty/erigon/issues/22
PoC: https://github.com/ethereum-bounty/erigon/pull/21

## Fix

Validate every decoded block in the shared sendBlocksRequest path with BeaconChainConfig.ForkSchemaMatchesSlot before returning it to a caller. On a mismatch, the RPC client:

- discards the response;
- returns the mismatch error and serving peer ID;
- requests the standard Sentinel peer ban.

The shared path covers BlocksByRange and BlocksByRoot responses. ForkChoiceStore.OnBlock independently enforces the same invariant for blocks received through other paths.

Sentinel retains peers when the active peer count is below its grace threshold. This change follows that existing policy: it always rejects the malformed response at the RPC boundary, but it does not override low-peer retention.

## Tests

TestSendBeaconBlocksByRangeReqRejectsForkSchemaSlotMismatch sends a Gloas-digest block claiming a Fulu slot through the request/response decoder and verifies that no block is returned, the mismatch error and peer ID are preserved, and a peer ban is requested.

- go test ./cl/rpc -count=1
- go test ./cl/phase1/forkchoice -run ^TestOnBlockRejectsForkSchemaSlotMismatch$ -count=1
- make lint
- make erigon integration

The full PR CI suite passes, including Caplin, race, benchmark, and cross-platform jobs.

## Credit

Reported by @bshastry through the Ethereum bug bounty program.

Fixes https://github.com/ethereum-bounty/erigon/issues/22