### PR TITLE
db/state: align visible files of every domain and index

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -85,7 +85,11 @@ type Aggregator struct {
 	// visible is CoW field updated only by `recalcVisibleFiles`.
 	visible atomic.Pointer[aggregatorVisible]
 	// oldestVisible head of linked-list of visibleFiles objects (oldest still-have-reader object). Mutated only under dirtyFilesLock.
-	oldestVisible     *aggregatorVisible
+	oldestVisible *aggregatorVisible
+	// unaligned entities are left out of the shared visible-file ceiling while tooling
+	// regenerates them. Guarded by dirtyFilesLock.
+	unalignedDomain   [kv.DomainLen]bool
+	unalignedIdx      [kv.StandaloneIdxLen]bool
 	snapshotBuildSema *semaphore.Weighted
 
 	disableHistory      bool
@@ -497,9 +501,9 @@ func (a *Aggregator) EnableAllDependencies() {
 	if a.checker == nil {
 		return
 	}
-	a.checker.Enable()
 	a.dirtyFilesLock.Lock()
 	defer a.dirtyFilesLock.Unlock()
+	a.checker.Enable()
 	a.recalcVisibleFiles(nil)
 }
 
@@ -507,9 +511,48 @@ func (a *Aggregator) DisableAllDependencies() {
 	if a.checker == nil {
 		return
 	}
-	a.checker.Disable()
 	a.dirtyFilesLock.Lock()
 	defer a.dirtyFilesLock.Unlock()
+	a.checker.Disable()
+	a.recalcVisibleFiles(nil)
+}
+
+// Unalign leaves a domain out of the shared visible-file ceiling while tooling regenerates
+// it: it stops clamping the others and stays clamped by them, so it can lag them and never
+// lead. Not persisted - an interrupted rebuild reopens aligned.
+//
+// Accounts, storage and code hold the state a rebuild reads: unaligning one panics.
+func (a *Aggregator) Unalign(d kv.Domain) (realign func()) {
+	switch d {
+	case kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain:
+		panic(fmt.Sprintf("assert: %s holds the state a rebuild reads, it can not lag it", d))
+	}
+	a.setUnalignedDomain(d, true)
+	return func() { a.setUnalignedDomain(d, false) }
+}
+
+// UnalignIdx is Unalign for a standalone index.
+func (a *Aggregator) UnalignIdx(name kv.InvertedIdx) (realign func()) {
+	for id, ii := range a.standaloneIIs() {
+		if ii.Name == name {
+			a.setUnalignedIdx(id, true)
+			return func() { a.setUnalignedIdx(id, false) }
+		}
+	}
+	return func() {}
+}
+
+func (a *Aggregator) setUnalignedDomain(d kv.Domain, v bool) {
+	a.dirtyFilesLock.Lock()
+	defer a.dirtyFilesLock.Unlock()
+	a.unalignedDomain[d] = v
+	a.recalcVisibleFiles(nil)
+}
+
+func (a *Aggregator) setUnalignedIdx(id int, v bool) {
+	a.dirtyFilesLock.Lock()
+	defer a.dirtyFilesLock.Unlock()
+	a.unalignedIdx[id] = v
 	a.recalcVisibleFiles(nil)
 }
 
@@ -517,9 +560,9 @@ func (a *Aggregator) DisableInterDomainDependencies() {
 	if a.checker == nil {
 		return
 	}
-	a.checker.DisableInterDomain()
 	a.dirtyFilesLock.Lock()
 	defer a.dirtyFilesLock.Unlock()
+	a.checker.DisableInterDomain()
 	a.recalcVisibleFiles(nil)
 }
 
@@ -1736,26 +1779,35 @@ func (a *Aggregator) FirstTxNumOfStep(step kv.Step) uint64 { // could have some 
 	return firstTxNumOfStep(step, a.StepSize())
 }
 
+// dirtyFilesEndTxNumMinimax is the ceiling shared by all visible files: no entity is visible
+// past a range another one misses. Left out: entities with no files at all (a fresh node, or
+// optional indexes never downloaded, would otherwise see nothing) and unaligned ones.
 func (a *Aggregator) dirtyFilesEndTxNumMinimax() uint64 {
-	if a.d[kv.AccountsDomain] == nil || a.d[kv.StorageDomain] == nil || a.d[kv.CodeDomain] == nil {
+	// end == 0 means "entity has no files", it does not lower the ceiling
+	_min := func(ceiling, end uint64) uint64 {
+		if end == 0 {
+			return ceiling
+		}
+		return min(ceiling, end)
+	}
+
+	ceiling := uint64(math.MaxUint64)
+	for id, d := range a.d {
+		if d == nil || d.Disable || a.unalignedDomain[id] {
+			continue
+		}
+		ceiling = _min(ceiling, d.dirtyFilesEndTxNumMinimax())
+	}
+	for id, ii := range a.standaloneIIs() {
+		if ii == nil || ii.Disable || a.unalignedIdx[id] {
+			continue
+		}
+		ceiling = _min(ceiling, ii.dirtyFilesEndTxNumMinimax())
+	}
+	if ceiling == math.MaxUint64 {
 		return 0
 	}
-	m := min(
-		a.d[kv.AccountsDomain].dirtyFilesEndTxNumMinimax(),
-		a.d[kv.StorageDomain].dirtyFilesEndTxNumMinimax(),
-		a.d[kv.CodeDomain].dirtyFilesEndTxNumMinimax(),
-		// a.d[kv.CommitmentDomain].dirtyFilesEndTxNumMinimax(),
-	)
-	// TODO(awskii) have two different functions including commitment/without it
-	//  Usually its skipped because commitment either have MaxUint64 due to no history or equal to other domains
-
-	//log.Warn("dirtyFilesEndTxNumMinimax", "min", m,
-	//	"acc", a.d[kv.AccountsDomain].dirtyFilesEndTxNumMinimax(),
-	//	"sto", a.d[kv.StorageDomain].dirtyFilesEndTxNumMinimax(),
-	//	"cod", a.d[kv.CodeDomain].dirtyFilesEndTxNumMinimax(),
-	//	"com", a.d[kv.CommitmentDomain].dirtyFilesEndTxNumMinimax(),
-	//)
-	return m
+	return ceiling
 }
 
 // aggregatorVisible immutable visible-for-application files (no gaps, no overlaps, indexed)

--- a/db/state/aggregator_align_test.go
+++ b/db/state/aggregator_align_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+)
+
+// generateStandaloneIIFile writes files with a hardcoded step size of 10.
+const alignStepSize = 10
+
+func generateStateFiles(t *testing.T, dirs datadir.Dirs, ranges []testFileRange) {
+	t.Helper()
+	generateAccountsFile(t, dirs, ranges)
+	generateStorageFile(t, dirs, ranges)
+	generateCodeFile(t, dirs, ranges)
+}
+
+func generateStandaloneIIFiles(t *testing.T, dirs datadir.Dirs, ranges []testFileRange) {
+	t.Helper()
+	for _, name := range []kv.InvertedIdx{kv.LogAddrIdx, kv.LogTopicIdx, kv.TracesFromIdx, kv.TracesToIdx} {
+		generateStandaloneIIFile(t, name, dirs, ranges)
+	}
+}
+
+func requireVisibleEnd(t *testing.T, agg *Aggregator, end uint64) {
+	t.Helper()
+	at := agg.BeginFilesRo()
+	defer at.Close()
+	for _, d := range kv.StateDomains {
+		require.EqualValues(t, end, at.d[d].files.EndTxNum(), "domain %s", d)
+	}
+	for _, ii := range at.standaloneIIs() {
+		require.EqualValues(t, end, ii.files.EndTxNum(), "index %s", ii.name)
+	}
+}
+
+// state visible past commitment's files = state no commitment covers
+func TestVisibleFilesAligned_LaggingCommitmentClampsEveryone(t *testing.T) {
+	t.Parallel()
+	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+
+	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	generateStandaloneIIFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}})
+	require.NoError(t, agg.OpenFolder())
+
+	requireVisibleEnd(t, agg, alignStepSize)
+}
+
+// domains visible past the log/trace indexes answer eth_getLogs from blocks no index saw
+func TestVisibleFilesAligned_LaggingStandaloneIdxClampsEveryone(t *testing.T) {
+	t.Parallel()
+	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+
+	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	for _, name := range []kv.InvertedIdx{kv.LogTopicIdx, kv.TracesFromIdx, kv.TracesToIdx} {
+		generateStandaloneIIFile(t, name, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	}
+	generateStandaloneIIFile(t, kv.LogAddrIdx, agg.Dirs(), []testFileRange{{0, 1}})
+	require.NoError(t, agg.OpenFolder())
+
+	requireVisibleEnd(t, agg, alignStepSize)
+}
+
+// no files at all = nothing to be misaligned with, so the domains stay visible
+func TestVisibleFilesAligned_EntityWithoutFilesDoesNotClamp(t *testing.T) {
+	t.Parallel()
+	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+
+	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	require.NoError(t, agg.OpenFolder())
+
+	at := agg.BeginFilesRo()
+	defer at.Close()
+	for _, d := range kv.StateDomains {
+		require.EqualValues(t, 2*alignStepSize, at.d[d].files.EndTxNum(), "domain %s", d)
+	}
+}
+
+// stage_custom_trace re-executes blocks to rebuild receipts, and reads the state while
+// doing it
+func TestUnalign_KeepsStateVisibleWhileReceiptsLag(t *testing.T) {
+	t.Parallel()
+	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+
+	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	generateStandaloneIIFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	generateDomainFiles(t, "receipt", agg.Dirs(), []testFileRange{{0, 1}})
+	require.NoError(t, agg.OpenFolder())
+
+	requireVisibleEnd(t, agg, alignStepSize)
+
+	realign := agg.Unalign(kv.ReceiptDomain)
+	at := agg.BeginFilesRo()
+	for _, d := range kv.StateDomains {
+		require.EqualValues(t, 2*alignStepSize, at.d[d].files.EndTxNum(), "domain %s", d)
+	}
+	at.Close()
+
+	realign()
+	requireVisibleEnd(t, agg, alignStepSize)
+}
+
+// commitment rebuild reads accounts and storage while commitment covers only what it
+// rebuilt so far
+func TestUnalign_KeepsStateVisibleWhileCommitmentLags(t *testing.T) {
+	t.Parallel()
+	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+
+	generateStateFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	generateStandaloneIIFiles(t, agg.Dirs(), []testFileRange{{0, 1}, {1, 2}})
+	generateCommitmentFile(t, agg.Dirs(), []testFileRange{{0, 1}})
+	require.NoError(t, agg.OpenFolder())
+
+	agg.DisableAllDependencies() // what the rebuild does about file ranges
+	realign := agg.Unalign(kv.CommitmentDomain)
+
+	at := agg.BeginFilesRo()
+	for _, d := range []kv.Domain{kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain} {
+		require.EqualValues(t, 2*alignStepSize, at.d[d].files.EndTxNum(), "domain %s", d)
+	}
+	// it may lag what it is rebuilt from, never lead it
+	require.EqualValues(t, alignStepSize, at.d[kv.CommitmentDomain].files.EndTxNum())
+	at.Close()
+
+	realign()
+	requireVisibleEnd(t, agg, alignStepSize)
+}
+
+// the state domains can not lag: every rebuild reads them
+func TestUnalign_RejectsStateDomain(t *testing.T) {
+	t.Parallel()
+	_, agg := testDbAndAggregatorv3(t, alignStepSize)
+
+	for _, d := range []kv.Domain{kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain} {
+		require.Panics(t, func() { agg.Unalign(d) }, "domain %s", d)
+	}
+}

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -493,6 +493,7 @@ func RebuildCommitmentFilesWithHistory(ctx context.Context, rwDb kv.TemporalRwDB
 	a := rwDb.(HasAgg).Agg().(*Aggregator)
 	defer rwDb.Debug().EnableReadAhead().DisableReadAhead()
 	a.DisableInterDomainDependencies()
+	defer a.Unalign(kv.CommitmentDomain)()
 
 	// Capture the resolved flag before we temporarily flip it off for the rebuild loop;
 	// the squeeze gate below uses the captured value, not process-global schema state.
@@ -879,6 +880,7 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 	// disable hard alignment; allowing commitment and storage/account to have
 	// different visibleFiles
 	a.DisableAllDependencies()
+	defer a.Unalign(kv.CommitmentDomain)()
 
 	// Capture the resolved flag before we temporarily flip it off for the rebuild loop;
 	// the squeeze gate below uses the captured value, not process-global schema state.

--- a/execution/stagedsync/stage_custom_trace.go
+++ b/execution/stagedsync/stage_custom_trace.go
@@ -105,6 +105,33 @@ func StageCustomTraceCfg(produce []string, db kv.TemporalRwDB, dirs datadir.Dirs
 	}
 }
 
+func unalignProduced(agg *dbstate.Aggregator, produce Produce) (realign func()) {
+	var undo []func()
+	if produce.ReceiptDomain {
+		undo = append(undo, agg.Unalign(kv.ReceiptDomain))
+	}
+	if produce.RCacheDomain {
+		undo = append(undo, agg.Unalign(kv.RCacheDomain))
+	}
+	if produce.LogAddr {
+		undo = append(undo, agg.UnalignIdx(kv.LogAddrIdx))
+	}
+	if produce.LogTopic {
+		undo = append(undo, agg.UnalignIdx(kv.LogTopicIdx))
+	}
+	if produce.TraceFrom {
+		undo = append(undo, agg.UnalignIdx(kv.TracesFromIdx))
+	}
+	if produce.TraceTo {
+		undo = append(undo, agg.UnalignIdx(kv.TracesToIdx))
+	}
+	return func() {
+		for _, f := range undo {
+			f()
+		}
+	}
+}
+
 func SpawnCustomTrace(cfg CustomTraceCfg, ctx context.Context, logger log.Logger) error {
 	if cfg.Produce.RCacheDomain {
 		if err := cfg.db.View(context.Background(), func(tx kv.Tx) error {
@@ -116,6 +143,10 @@ func SpawnCustomTrace(cfg CustomTraceCfg, ctx context.Context, logger log.Logger
 
 	log.Info("[stage_custom_trace] start params", "produce", cfg.Produce)
 	txNumsReader := cfg.ExecArgs.BlockReader.TxnumReader()
+
+	// what this re-derives lags the state until it finishes, and must not clamp the files it
+	// re-executes from
+	defer unalignProduced(cfg.db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator), cfg.Produce)()
 
 	//agg := cfg.db.(dbstate.HasAgg).Agg().(*dbstate.Aggregator)
 	//stepSize := agg.StepSize()


### PR DESCRIPTION
For https://github.com/erigontech/erigon/issues/22905

- I decided strait-forward implementation (array on Agg object) instead of touching `checker` object - because wanna apply it to `release/3.6`

in follow-up in `main`. Maybe we will need clear separation of concerns: "depenency of files exestence" (can't start creation of `commitment.kv` before `storage.kv` is done), "dependency in files visibility / alignment" (`commitment.kv` not visible yet -> then `storage.kv` not visible). 
Now in code we call 2 this things "dependency" and it confusing.
(both things can be inside 1 `check` - but they must be completely separate and unambiguous)

FllowUp: 
- seems RebuildCommitment/stageCustomTrace - needs only "unalign" of some Domains. Doesn't need complete disable of dependencies. (maybe i'm wrong).
-  dependencies of files-creation - seem need only for `deref commitment` - which we disabled.
- same logic will need propagate to block files (where we also did suffer much from "in only-one specific case - we need to have only header.seg files, without transaction.seg. but by default alignment is good")


