### PR TITLE
docs(readme): drop content duplicated by docs.erigon.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ Log flags, log levels and log files: [Logs](https://docs.erigon.tech/fundamental
 
 #### Torrent client logging
 
-The torrent client in the Downloader logs to `logs/torrent.log` at the level specified by `torrent.verbosity` or WARN, whichever is lower. Logs at `torrent.verbosity` or higher are also passed through to the top level Erigon dir and console loggers (which must have their own levels set low enough to log the messages in their respective handlers).
+The torrent client in the Downloader keeps its own file, `logs/torrent.log`. It is written at whichever is **more
+verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity.
+Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which
+emit them only if `--log.dir.verbosity` and `--verbosity` are themselves verbose enough.
 
 ### Block Production (PoS Validator)
 
@@ -102,6 +105,10 @@ Binaries land in `./build/bin`. Use `-j<n>` to parallelise the build. Packaged b
 per-platform install steps are on the
 [installation](https://docs.erigon.tech/get-started/installation) page; to build a specific release rather than `main`,
 check out its tag.
+
+On Windows, build natively (Chocolatey, MinGW, and the MinGW anti-virus false-positive workaround) or under WSL2:
+[Native compilation](https://docs.erigon.tech/get-started/installation/#install-native) and
+[WSL](https://docs.erigon.tech/get-started/installation/#install-wsl).
 
 ### Executables
 
@@ -166,29 +173,8 @@ Every default port, the flags that change them, and firewalling guidance:
 
 #### Hetzner expecting strict firewall rules
 
-```
-0.0.0.0/8             "This" Network             RFC 1122, Section 3.2.1.3
-10.0.0.0/8            Private-Use Networks       RFC 1918
-100.64.0.0/10         Carrier-Grade NAT (CGN)    RFC 6598, Section 7
-127.16.0.0/12         Private-Use Networks       RFC 1918
-169.254.0.0/16        Link Local                 RFC 3927
-172.16.0.0/12         Private-Use Networks       RFC 1918
-192.0.0.0/24          IETF Protocol Assignments  RFC 5736
-192.0.2.0/24          TEST-NET-1                 RFC 5737
-192.88.99.0/24        6to4 Relay Anycast         RFC 3068
-192.168.0.0/16        Private-Use Networks       RFC 1918
-198.18.0.0/15         Network Interconnect
-Device Benchmark Testing   RFC 2544
-198.51.100.0/24       TEST-NET-2                 RFC 5737
-203.0.113.0/24        TEST-NET-3                 RFC 5737
-224.0.0.0/4           Multicast                  RFC 3171
-240.0.0.0/4           Reserved for Future Use    RFC 1112, Section 4
-255.255.255.255/32    Limited Broadcast          RFC 919, Section 7
-RFC 922, Section 7
-```
-
-Same
-in [IpTables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068)
+Ports to open and the reserved IPv4 ranges to block:
+[Hetzner firewall note](https://docs.erigon.tech/help-center/troubleshooting#hetzner-cloud--dedicated-server-firewall-note).
 
 ### Run as a separate user - `systemd` example
 
@@ -214,44 +200,6 @@ make DIST=/opt/erigon install
 ### How to change db pagesize
 
 [post](https://github.com/erigontech/erigon/blob/main/cmd/integration/Readme.md#copy-data-to-another-db)
-
-### Windows
-
-Windows users may run erigon in 3 possible ways:
-
-* Build executable binaries natively for Windows using `make`. Example: `make erigon` builds the erigon
-  executable. All binaries are placed in `.\build\bin\` subfolder. There are some requirements for a successful native
-  build on windows :
-    * [Git](https://git-scm.com/downloads) for Windows must be installed (provides bash and MSYS2 environment). If
-      you're cloning this repository is very likely you already have it
-  * [GO Programming Language](https://golang.org/dl/) must be installed. Minimum required version is 1.25
-    * [Chocolatey package manager](https://chocolatey.org/) for Windows must be installed. Then install the required
-      build tools: `choco install cmake make mingw` (provides GNU CC Compiler >= 13, GNU Make, and CMake). Make sure
-      Windows System "Path" variable has:
-      C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin
-
-  **Important note about Anti-Viruses**
-  During MinGW's compiler detection phase some temporary executables are generated to test compiler capabilities. It's
-  been reported some anti-virus programs detect those files as possibly infected by `Win64/Kryptic.CIS` trojan horse (or
-  a variant of it). Although those are false positives we have no control over 100+ vendors of security products for
-  Windows and their respective detection algorithms and we understand this might make your experience with Windows
-  builds uncomfortable. To workaround the issue you might either set exclusions for your antivirus specifically
-  for `build\bin\mdbx\CMakeFiles` sub-folder of the cloned repo or you can run erigon using the following other two
-  options
-
-* Use Docker :  see [docker-compose.yml](./docker-compose.yml)
-
-* Use WSL (Windows Subsystem for Linux) **strictly on version 2**. Under this option you can build Erigon just as you
-  would on a regular Linux distribution. You can point your data also to any of the mounted Windows partitions (
-  eg. `/mnt/c/[...]`, `/mnt/d/[...]` etc) but in such case be advised performance is impacted: this is due to the fact
-  those mount points use `DrvFS` which is
-  a [network file system](https://docs.erigon.tech/help-center/known-issues#cloud-network-drives)
-  and, additionally, MDBX locks the db for exclusive access which implies only one process at a time can access data.
-  This has consequences on the running of `rpcdaemon` which has to be configured as [Remote DB](#json-rpc-daemon) even if
-  it is executed on the very same computer. If instead your data is hosted on the native Linux filesystem non
-  limitations apply.
-  **Please also note the default WSL2 environment has its own IP address which does not match the one of the network
-  interface of Windows host: take this into account when configuring NAT for port 30303 on your router.**
 
 Getting in touch
 ================

--- a/README.md
+++ b/README.md
@@ -10,60 +10,26 @@
 Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer), on the efficiency
 frontier.
 
-- [Erigon](#erigon)
-- [System Requirements](#system-requirements)
-- [Sync Times](#sync-times)
-- [Usage](#usage)
-    - [Getting Started](#getting-started)
-    - [Datadir structure](#datadir-structure)
-    - [History on cheap disk](#history-on-cheap-disk)
-    - [Erigon3 datadir size](#erigon3-datadir-size)
-    - [Erigon3 changes from Erigon2](#erigon3-changes-from-erigon2)
-    - [Logging](#logging)
-    - [Modularity](#modularity)
-    - [Embedded Consensus Layer](#embedded-consensus-layer)
-    - [Testnets](#testnets)
-    - [Block Production (PoS Validator)](#block-production-pos-validator)
-    - [Config Files TOML](#config-files-toml)
-    - [Beacon Chain (Consensus Layer)](#beacon-chain-consensus-layer)
-    - [Caplin](#caplin)
-        - [Caplin's Usage](#caplins-usage)
-    - [Multiple Instances / One Machine](#multiple-instances--one-machine)
-    - [Dev Chain](#dev-chain)
-- [Key features](#key-features)
-    - [Faster Initial Sync](#faster-initial-sync)
-    - [More Efficient State Storage](#more-efficient-state-storage)
-    - [JSON-RPC daemon](#json-rpc-daemon)
-    - [Grafana dashboard](#grafana-dashboard)
-- [FAQ](#faq)
-    - [Use as library](#use-as-library)
-    - [Default Ports and Firewalls](#default-ports-and-firewalls)
-        - [`erigon` ports](#erigon-ports)
-        - [`caplin` ports](#caplin-ports)
-        - [`beaconAPI` ports](#beaconapi-ports)
-        - [`shared` ports](#shared-ports)
-        - [`other` ports](#other-ports)
-        - [Hetzner expecting strict firewall rules](#hetzner-expecting-strict-firewall-rules)
-    - [Run as a separate user - `systemd` example](#run-as-a-separate-user---systemd-example)
-    - [Grab diagnostic for bug report](#grab-diagnostic-for-bug-report)
-    - [Run local devnet](#run-local-devnet)
-    - [Docker permissions error](#docker-permissions-error)
-    - [Public RPC](#public-rpc)
-    - [RaspberryPI](#raspberrypi)
-    - [Run all components by docker-compose](#run-all-components-by-docker-compose)
-        - [Optional: Setup dedicated user](#optional-setup-dedicated-user)
-        - [Environment Variables](#environment-variables)
-        - [Run](#run)
-    - [How to change db pagesize](#how-to-change-db-pagesize)
-    - [Erigon3 perf tricks](#erigon3-perf-tricks)
-    - [Windows](#windows)
-- [Getting in touch](#getting-in-touch)
-    - [Reporting security issues/concerns](#reporting-security-issuesconcerns)
+**[Download](https://github.com/erigontech/erigon/releases)**
+| [Documentation](https://docs.erigon.tech/)
+| [Blog](https://erigon.tech/blog/)
 
-<!--te-->
+This README is for people working on the repository. Everything about operating a node — install methods,
+flags, pruning modes, ports, monitoring, staking — is on the documentation site.
 
-**Important defaults**: Erigon 3 is a Full Node by default. (Erigon 2 was an [Archive Node](https://ethereum.org/en/developers/docs/nodes-and-clients/archive-nodes/#what-is-an-archive-node) by default.)
-Set `--prune.mode` to "archive" if you need an archive node or to "minimal" if you run a validator on a small disk (not allowed to change after first start).
+Documentation
+=============
+
+The [Erigon documentation](https://docs.erigon.tech/) answers most questions. Useful starting points:
+
+* [Installation](https://docs.erigon.tech/get-started/installation) — binaries, Docker, Linux/macOS, Windows, ARM
+* [Hardware requirements](https://docs.erigon.tech/get-started/hardware-requirements) — disk, RAM, CPU, bandwidth
+* [Pruning modes](https://docs.erigon.tech/fundamentals/pruning-modes) — `archive`, `full`, `blocks`, `minimal`
+* [CLI reference](https://docs.erigon.tech/fundamentals/configuring-erigon) — every flag, config files, env vars
+* [Default ports](https://docs.erigon.tech/fundamentals/default-ports) and [Security](https://docs.erigon.tech/fundamentals/security)
+* [Interacting with Erigon](https://docs.erigon.tech/interacting-with-erigon) — JSON-RPC, GraphQL, gRPC namespaces
+* [Creating a dashboard](https://docs.erigon.tech/fundamentals/creating-a-dashboard) — Prometheus and Grafana
+* [Upgrading](https://docs.erigon.tech/get-started/installation/upgrading) — versions and snapshot formats
 
 <code>In-depth links are marked by the microscope sign (🔬) </code>
 
@@ -132,15 +98,6 @@ Erigon (https://docs.gnosischain.com/category/step--3---run-consensus-client).
 
 Running `make help` will list and describe the convenience commands available in the [Makefile](./Makefile).
 
-### Upgrading from 3.0 to 3.1
-
-1. Backup your datadir.
-2. Upgrade your Erigon binary.
-3. OPTIONAL: Upgrade snapshot files.
-   1. Update snapshot file names. To do this either run Erigon 3.1 until the sync stage completes, or run `erigon snapshots update-to-new-ver-format --datadir /your/datadir`.
-   2. Reset your datadir so that Erigon will sync to a newer snapshot. `erigon snapshots reset --datadir /your/datadir`. See [Resetting snapshots](#Resetting-snapshots) for more details.
-4. Run Erigon 3.1. Your snapshots file names will be migrated automatically if you didn't do this manually. If you reset your datadir, Erigon will sync to the latest remote snapshots.
-
 ### Datadir structure
 
 ```sh
@@ -160,28 +117,6 @@ datadir
 ```
 
 See the [lib](db/downloader/README.md) and [cmd](cmd/downloader/README.md) READMEs for more information.
-
-### History on cheap disk
-
-If you can afford to store the datadir on a single NVMe RAID — great. If you can't, it's possible to store history on a cheaper drive.
-
-```sh
-# place (or ln -s) `datadir` on slow disk. link some sub-folders to fast (low-latency) disk.
-# Example: what need link to fast disk to speedup execution
-datadir        
-    chaindata   # link to fast disk
-    snapshots   
-        domain    # link to fast disk
-        history   
-        idx       
-        accessor 
-    temp # buffers to sort data >> RAM. sequential-buffered IO - is slow-disk-friendly   
-
-# Example: how to speedup history access: 
-#   - go step-by-step - first try store `accessor` on fast disk
-#   - if speed is not good enough: `idx`
-#   - if still not enough: `history` 
-```
 
 ### Erigon3 datadir size
 
@@ -231,122 +166,22 @@ chain db that every node with the embedded Consensus Layer keeps anyway. Blob si
 
 ### Logging
 
-_Flags:_
-
-- `verbosity`
-- `log.console.verbosity` (overriding alias for `verbosity`)
-- `log.json`
-- `log.console.json` (alias for `log.json`)
-- `log.dir.path`
-- `log.dir.prefix`
-- `log.dir.verbosity`
-- `log.dir.json`
-- `torrent.verbosity`
-
-In order to log only to the stdout/stderr the `--verbosity` (or `log.console.verbosity`) flag can be used to supply an
-int value specifying the highest output log level:
-
-```
-  LvlCrit = 0
-  LvlError = 1
-  LvlWarn = 2
-  LvlInfo = 3
-  LvlDebug = 4
-  LvlTrace = 5
-```
-
-To set an output dir for logs to be collected on disk, please set `--log.dir.path` If you want to change the filename
-produced from `erigon` you should also set the `--log.dir.prefix` flag to an alternate name. The
-flag `--log.dir.verbosity` is
-also available to control the verbosity of this logging, with the same int value as above, or the string value e.g. '
-debug' or 'info'. Default verbosity is 'debug' (4), for disk logging.
-
-Log format can be set to json by the use of the boolean flags `log.json` or `log.console.json`, or for the disk
-output `--log.dir.json`.
+Log flags, log levels and log files: [Logs](https://docs.erigon.tech/fundamentals/logs) and the
+[CLI reference](https://docs.erigon.tech/fundamentals/configuring-erigon).
 
 #### Torrent client logging
 
 The torrent client in the Downloader logs to `logs/torrent.log` at the level specified by `torrent.verbosity` or WARN, whichever is lower. Logs at `torrent.verbosity` or higher are also passed through to the top level Erigon dir and console loggers (which must have their own levels set low enough to log the messages in their respective handlers).
 
-### Resetting snapshots
-
-Erigon 3.1 adds the command `erigon snapshots reset`. This modifies your datadir so that Erigon will sync to the latest remote snapshots on next run. You must pass `--datadir`. If the chain cannot be inferred from the chaindata, you must pass `--chain`. `--local=false` will prevent locally generated snapshots from also being removed. Pass `--dry-run` and/or `--verbosity=5` for more information.
-
-### Modularity
-
-Erigon by default is "all in one binary" solution, but it's possible start TxPool as separated processes.
-Same true about: JSON RPC layer (RPCDaemon), p2p layer (Sentry), history download layer (Downloader), consensus.
-Don't start services as separate processes unless you have a clear reason to do so: resource limiting, scaling, replacing with
-your own implementation, or security.
-How to start Erigon's services as separated processes, see in [docker-compose.yml](./docker-compose.yml).
-Each service has own `./cmd/*/README.md` file.
-[Erigon Blog](https://erigon.tech/blog/).
-
-### Embedded Consensus Layer
-
-Built-in consensus for Ethereum Mainnet, Sepolia, Hoodi, Gnosis, Chiado.
-To use external Consensus Layer: `--externalcl`.
-
-### Testnets
-
-If you would like to give Erigon a try: a good option is to start syncing one of the public testnets, Hoodi (or Chiado).
-It syncs much quicker, and does not take so much disk space:
-
-```sh
-git clone https://github.com/erigontech/erigon.git
-cd erigon
-make erigon
-./build/bin/erigon --datadir=<your_datadir> --chain=hoodi --prune.mode=full
-```
-
-Please note the `--datadir` option that allows you to store Erigon files in a non-default location. Name of the
-directory `--datadir` does not have to match the name of the chain in `--chain`.
-
 ### Block Production (PoS Validator)
 
 Block production is fully supported for Ethereum & Gnosis Chain.
 
-### Config Files TOML
-
-You can set Erigon flags through a TOML configuration file with the flag `--config`. The flags set in the
-configuration file can be overwritten by writing the flags directly on Erigon command line
-
-`./build/bin/erigon --config ./config.toml --chain=sepolia`
-
-Assuming we have `chain : "mainnet"` in our configuration file, by adding `--chain=sepolia` allows the overwrite of the
-flag inside of the toml configuration file and sets the chain to sepolia
-
-```toml
-datadir = 'your datadir'
-port = 1111
-chain = "mainnet"
-http = true
-"private.api.addr"="localhost:9090"
-
-"http.api" = ["eth","debug","net"]
-```
-
 ### Beacon Chain (Consensus Layer)
 
-Erigon can be used as an Execution Layer (EL) for Consensus Layer clients (CL). Default configuration is OK.
-
-If your CL client is on a different device, add `--authrpc.addr 0.0.0.0` ([Engine API] listens on localhost by default)
-as well as `--authrpc.vhosts <CL host>` where `<CL host>` is your source host or `any`.
-
-[Engine API]: https://github.com/ethereum/execution-apis/blob/main/src/engine
-
-In order to establish a secure connection between the Consensus Layer and the Execution Layer, a JWT secret key is
-automatically generated.
-
-The JWT secret key will be present in the datadir by default under the name of `jwt.hex` and its path can be specified
-with the flag `--authrpc.jwtsecret`.
-
-This piece of info needs to be specified in the Consensus Layer as well in order to establish connection successfully.
-More information can be found [here](https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md).
-
-Once Erigon is running, you need to point your CL client to `<erigon address>:8551`,
-where `<erigon address>` is either `localhost` or the IP address of the device running Erigon, and also point to the JWT
-secret path created by Erigon.
+Erigon can be used as an Execution Layer for external Consensus Layer clients. See
+[JWT secret](https://docs.erigon.tech/fundamentals/jwt) and
+[Ethereum with an external CL](https://docs.erigon.tech/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl).
 
 ### Caplin
 
@@ -376,75 +211,41 @@ In order to enable the caplin's Beacon API, the flag `--beacon.api=<namespaces>`
 e.g: `--beacon.api=beacon,builder,config,debug,node,validator,lighthouse` will enable all endpoints. 
 Note: enabling the Beacon API will lead to a 6 GB higher RAM usage
 
-### Multiple Instances / One Machine
-
-Define 7 flags to avoid conflicts:
-`--datadir --port --http.port --authrpc.port --torrent.port --private.api.addr --mcp.port`.
-Example of multiple chains on the same machine:
-
-```
-# mainnet
-./build/bin/erigon --datadir="<your_mainnet_data_path>" --chain=mainnet --port=30303 --http.port=8545 --authrpc.port=8551 --torrent.port=42069 --private.api.addr=127.0.0.1:9090 --mcp.port=8553 --http --ws --http.api=eth,debug,net,trace,web3,erigon
-
-
-# sepolia
-./build/bin/erigon --datadir="<your_sepolia_data_path>" --chain=sepolia --port=30304 --http.port=8546 --authrpc.port=8552 --torrent.port=42068 --private.api.addr=127.0.0.1:9091 --mcp.port=8554 --http --ws --http.api=eth,debug,net,trace,web3,erigon
-```
-
-Quote your path if it has spaces.
-
 ### Dev Chain
 
 <code> 🔬 Detailed explanation is [DEV_CHAIN](/docs/DEV_CHAIN.md).</code>
 
-Key features
-============
+For developers
+==============
 
-### Faster Initial Sync
+### Executables
 
-On a good network connection, an Ethereum Mainnet Full Node syncs in 3
-hours: [OtterSync](https://erigon.substack.com/p/erigon-3-alpha-2-introducing-blazingly) can sync
+`make erigon` builds the node; `make all` builds the full suite into `./build/bin`. `make help` lists every target.
 
-### More Efficient State Storage
+| Command      | Description                                                                                      |
+|--------------|--------------------------------------------------------------------------------------------------|
+| `erigon`     | The node: execution layer with the embedded consensus layer (Caplin)                             |
+| `rpcdaemon`  | JSON-RPC server; runs in-process or standalone against a local or remote Erigon                  |
+| `sentry`     | The p2p layer as an independent process                                                          |
+| `txpool`     | The transaction pool as an independent process                                                   |
+| `downloader` | Snapshot downloader, and verification of webseed metainfos against the preverified set            |
+| `integration`| Sync-stage and datadir maintenance tool — see [cmd/integration/Readme.md](./cmd/integration/Readme.md) |
+| `evm`        | Standalone EVM for running bytecode, disassembling and full trace logs                            |
+| `mcp`        | Standalone MCP server for Erigon                                                                  |
 
-**Flat KV storage.** Erigon uses a key-value database and stores accounts and storage in a straightforward way.
+`caplin`, `capcli`, `snapshots`, `rpctest` and `pics` are also built by `make all`.
 
-**Preprocessing**. For some operations, Erigon uses temporary files to preprocess data before inserting it into the main
-DB. That reduces write amplification and DB inserts are orders of magnitude quicker.
-
-<code> 🔬 See our detailed ETL explanation [here](https://github.com/erigontech/erigon/blob/main/db/etl/README.md).</code>
-
-**Plain state**
-
-**Single accounts/state trie**. Erigon uses a single Merkle trie for both accounts and the storage.
-
-<code> 🔬 [Staged Sync Readme](/docs/readthedocs/source/stagedsync.rst)</code>
-
-### JSON-RPC daemon
-
-Most of Erigon's components (txpool, rpcdaemon, snapshots downloader, sentry, ...) can run inside Erigon or as
-independent processes on the same server (or a separate server). Example:
+### Testing
 
 ```sh
-make erigon rpcdaemon
-./build/bin/erigon --datadir=/my --http=false
-# To run RPCDaemon as separated process: use same `--datadir` as Erigon
-./build/bin/rpcdaemon --datadir=/my --http.api=eth,erigon,web3,net,debug,trace,txpool --ws
+make test-short           # fast unit tests
+make test-all             # full test suite
+make test-fixtures-cl     # consensus-spec fixtures (also: test-fixtures-eest, test-fixtures-zkevm)
+make lint                 # run before opening or updating a PR
 ```
 
-- Supported JSON-RPC
-  calls: [eth](./rpc/jsonrpc/eth_api.go), [debug](./rpc/jsonrpc/debug_api.go), [net](./rpc/jsonrpc/net_api.go), [web3](./rpc/jsonrpc/web3_api.go)
-- increase throughput by: `--rpc.batch.concurrency`, `--rpc.batch.limit`, `--db.read.concurrency`
-- increase throughput by disabling: `--http.compression`, `--ws.compression`
-
-<code>🔬 See [RPC-Daemon docs](./cmd/rpcdaemon/README.md)</code>
-
-### Grafana dashboard
-
-`docker compose up prometheus grafana`, [detailed docs](./cmd/prometheus/Readme.md).
-
-FAQ
-================
+[docs/TESTING.md](./docs/TESTING.md) covers the release-time incremental-sync verification, which is a separate
+exercise from the test suite above.
 
 ### Use as library
 
@@ -454,61 +255,28 @@ go get github.com/erigontech/erigon@main
 go mod tidy
 ```
 
+### Repository docs
+
+- [docs/DEV_CHAIN.md](./docs/DEV_CHAIN.md) — dev chain / local devnet
+- [docker-compose.yml](./docker-compose.yml) — how the services are wired when run as separate processes
+- [db/etl/README.md](./db/etl/README.md) — the ETL framework used to preprocess data before DB inserts
+- [db/downloader/README.md](./db/downloader/README.md) — snapshot downloader internals
+- [cmd/rpcdaemon/README.md](./cmd/rpcdaemon/README.md) — RPC daemon, including running it remotely
+- [cmd/prometheus/Readme.md](./cmd/prometheus/Readme.md) — metrics and dashboards
+- [CI-GUIDELINES.md](./CI-GUIDELINES.md) — read before changing workflows
+
+### JSON-RPC daemon
+
+Most of Erigon's components (txpool, rpcdaemon, snapshots downloader, sentry, ...) can run inside Erigon or as
+independent processes. Deployment modes, flags and remote (Remote DB) setup:
+[RPC Daemon](https://docs.erigon.tech/fundamentals/modules/rpc-daemon) and
+[cmd/rpcdaemon/README.md](./cmd/rpcdaemon/README.md).
+
 ### Default Ports and Firewalls
 
-#### `erigon` ports
-
-| Component | Port  | Protocol  | Purpose                     | Should Expose |
-|-----------|-------|-----------|-----------------------------|---------------|
-| engine    | 9090  | TCP       | gRPC Server                 | Private       |
-| engine    | 42069 | TCP & UDP | Snap sync (Bittorrent)      | Public        |
-| engine    | 8551  | TCP       | Engine API (JWT auth)       | Private       |
-| sentry    | 30303 | TCP & UDP | eth peering (all versions)  | Public        |
-| sentry    | 9091  | TCP       | incoming gRPC Connections   | Private       |
-| rpcdaemon | 8545  | TCP       | HTTP & WebSockets & GraphQL | Private       |
-| mcp       | 8553  | TCP       | MCP server (AI assistants)  | Private       |
-| shutter   | 23102 | TCP       | Peering                     | Public        |
-
-Typically, 30303 is exposed to the internet to allow incoming peering connections. 9090 is exposed only
-internally for rpcdaemon or other connections, (e.g. rpcdaemon -> erigon).
-Port 8551 (JWT authenticated) is exposed only internally for [Engine API] JSON-RPC queries from the Consensus Layer
-node.
-Port 8553 is the embedded MCP server for AI-assistant integration; it binds to localhost only and should never be
-exposed publicly. To disable it entirely, pass `--mcp.disable`.
-
-#### `caplin` ports
-
-| Component | Port | Protocol | Purpose | Should Expose |
-|-----------|------|----------|---------|---------------|
-| sentinel  | 4000 | UDP      | Peering | Public        |
-| sentinel  | 4001 | TCP      | Peering | Public        |
-
-In order to configure the ports, use:
-
-```
-   --caplin.discovery.addr value                                                    Address for Caplin DISCV5 protocol (default: "127.0.0.1")
-   --caplin.discovery.port value                                                    Port for Caplin DISCV5 protocol (default: 4000)
-   --caplin.discovery.tcpport value                                                 TCP Port for Caplin DISCV5 protocol (default: 4001)
-```
-
-#### `beaconAPI` ports
-
-| Component | Port | Protocol | Purpose | Should Expose |
-|-----------|------|----------|---------|---------------|
-| REST      | 5555 | TCP      | REST    | Public        |
-
-#### `shared` ports
-
-| Component | Port | Protocol | Purpose | Should Expose |
-|-----------|------|----------|---------|---------------|
-| all       | 6060 | TCP      | pprof   | Private       |
-| all       | 6061 | TCP      | metrics | Private       |
-
-Optional flags can be enabled that enable pprof or metrics (or both). Use `--help` with the binary for more info.
-
-#### `other` ports
-
-Reserved for future use: **gRPC ports**: `9092` consensus engine, `9093` snapshot downloader, `9094` TxPool
+Every default port, the flags that change them, and firewalling guidance:
+[Default ports](https://docs.erigon.tech/fundamentals/default-ports) and
+[Security](https://docs.erigon.tech/fundamentals/security).
 
 #### Hetzner expecting strict firewall rules
 
@@ -557,134 +325,9 @@ make DIST=/opt/erigon install
 
 <code> 🔬 Detailed explanation is [here](/docs/DEV_CHAIN.md).</code>
 
-### Docker permissions error
-
-Docker uses user erigon with UID/GID 1000 (for security reasons). You can see this user being created in the Dockerfile.
-Can fix by giving a host's user ownership of the folder, where the host's user UID/GID is the same as the docker's user
-UID/GID (1000).
-More details
-in [post](https://www.fullstaq.com/knowledge-hub/blogs/docker-and-the-host-filesystem-owner-matching-problem)
-
-### Public RPC
-
-- `--txpool.nolocals=true`
-- don't add `admin` in `--http.api` list
-- `--http.corsdomain="*"` is bad-practice: set exact hostname or IP
-- protect from DOS by reducing: `--rpc.batch.concurrency`, `--rpc.batch.limit`
-
-### Why doesn't my full node have earlier blocks data?
-
-- `prune.mode=full` no longer downloads pre-merge blocks (see [partial history expiry](https://blog.ethereum.org/2025/07/08/partial-history-exp)).
-   Now it only stores post-merge blocks data (i.e. blocks and transactions)
-- To include pre-merge blocks data, use `--prune.mode=blocks` (all blocks data + only recent state data) or `--prune.mode=archive` (all data)
-
-### RaspberryPI
-
-https://github.com/mathMakesArt/Erigon-on-RPi-4
-
-### Run all components by docker-compose
-
-Docker allows for building and running Erigon via containers. This alleviates the need for installing build dependencies
-onto the host OS.
-
-#### Optional: Setup dedicated user
-
-User UID/GID need to be synchronized between the host OS and container so files are written with correct permission.
-
-You may wish to setup a dedicated user/group on the host OS, in which case the following `make` targets are available.
-
-```sh
-# create "erigon" user
-make user_linux
-# or
-make user_macos
-```
-
-#### Environment Variables
-
-There is a `.env.example` file in the root of the repo.
-
-* `DOCKER_UID` - The UID of the docker user
-* `DOCKER_GID` - The GID of the docker user
-* `XDG_DATA_HOME` - The data directory which will be mounted to the docker containers
-
-If not specified, the UID/GID will use the current user.
-
-A good choice for `XDG_DATA_HOME` is to use the `~erigon/.ethereum` directory created by helper
-targets `make user_linux` or `make user_macos`.
-
-#### Run
-
-Check permissions: In all cases, `XDG_DATA_HOME` (specified or default) must be writable by the user UID/GID in docker,
-which will be determined by the `DOCKER_UID` and `DOCKER_GID` at build time. If a build or service startup is failing
-due to permissions, check that all the directories, UID, and GID controlled by these environment variables are correct.
-
-Next command starts: Erigon on port 30303, rpcdaemon on port 8545, prometheus on port 9090, and grafana on port 3000.
-
-```sh
-#
-# Will mount ~/.local/share/erigon to /home/erigon/.local/share/erigon inside container
-#
-make docker-compose
-
-#
-# or
-#
-# if you want to use a custom data directory
-# or, if you want to use different uid/gid for a dedicated user
-#
-# To solve this, pass in the uid/gid parameters into the container.
-#
-# DOCKER_UID: the user id
-# DOCKER_GID: the group id
-# XDG_DATA_HOME: the data directory (default: ~/.local/share)
-#
-# Note: /preferred/data/folder must be read/writeable on host OS by user with UID/GID given
-#       if you followed above instructions
-#
-# Note: uid/gid syntax below will automatically use uid/gid of running user so this syntax
-#       is intended to be run via the dedicated user setup earlier
-#
-DOCKER_UID=$(id -u) DOCKER_GID=$(id -g) XDG_DATA_HOME=/preferred/data/folder DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 make docker-compose
-
-#
-# if you want to run the docker, but you are not logged in as the $ERIGON_USER
-# then you'll need to adjust the syntax above to grab the correct uid/gid
-#
-# To run the command via another user, use
-#
-ERIGON_USER=erigon
-sudo -u ${ERIGON_USER} DOCKER_UID=$(id -u ${ERIGON_USER}) DOCKER_GID=$(id -g ${ERIGON_USER}) XDG_DATA_HOME=~${ERIGON_USER}/.ethereum DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 make docker-compose
-```
-
-Makefile creates the initial directories for erigon, prometheus and grafana. The PID namespace is shared between erigon
-and rpcdaemon which is required to open Erigon's DB from another process (RPCDaemon local-mode).
-See: https://github.com/erigontech/erigon/pull/2392/files
-
-If your docker installation requires the docker daemon to run as root (which is by default), you will need to prefix
-the command above with `sudo`. However, it is sometimes recommended running docker (and therefore its containers) as a
-non-root user for security reasons. For more information about how to do this, refer to
-[this article](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
-
 ### How to change db pagesize
 
 [post](https://github.com/erigontech/erigon/blob/main/cmd/integration/Readme.md#copy-data-to-another-db)
-
-### Erigon3 perf tricks
-
-- on BorMainnet may help: `--sync.loop.block.limit=10_000`
-- on cloud-drives (good throughput, bad latency) - can enable OS's brain to pre-fetch: `SNAPSHOT_MADV_RND=false`
-- can lock latest state in RAM - to prevent from eviction (node may face high historical RPC traffic without impacting
-  Chain-Tip perf):
-
-```
-vmtouch -vdlw /mnt/erigon/snapshots/domain/*bt
-ls /mnt/erigon/snapshots/domain/*.kv | parallel vmtouch -vdlw
-
-# if it failing with "can't allocate memory", try: 
-sync && sudo sysctl vm.drop_caches=3
-echo 1 > /proc/sys/vm/compact_memory
-```
 
 ### Windows
 
@@ -730,3 +373,15 @@ Getting in touch
 ### Reporting security issues/concerns
 
 Send an email to `security [at] torquem.ch`.
+
+### Getting help
+
+* [Discord](https://dsc.gg/erigon) for community support and development chat
+* [GitHub Issues](https://github.com/erigontech/erigon/issues) to report a bug — see
+  [Grab diagnostic for bug report](#grab-diagnostic-for-bug-report) first
+* [Release notes](https://github.com/erigontech/erigon/releases) for what changed in each version
+
+License
+=======
+
+Erigon is licensed under the [GNU Lesser General Public License v3.0](./COPYING).

--- a/README.md
+++ b/README.md
@@ -33,119 +33,8 @@ The [Erigon documentation](https://docs.erigon.tech/) answers most questions. Us
 
 <code>In-depth links are marked by the microscope sign (🔬) </code>
 
-System Requirements
-===================
-
-RAM: >=32GB, [Golang >= 1.25](https://golang.org/doc/install); GCC 10+ or Clang; On Linux: kernel > v4. 64-bit
-architecture.
-
-Disk space, July 2026:
-
-| Chain            | Archive | Full   | Minimal |
-|------------------|---------|--------|---------|
-| Ethereum Mainnet | 2TB     | 420GB  | 380GB   |
-| Gnosis           | 675GB   | 220GB  | 205GB   |
-| Sepolia          | 1.1TB   | -      | -       |
-| Hoodi            | 134GB   | -      | -       |
-| Chiado           | 30GB    | -      | -       |
-
-Sizes grow with the chain. Archive figures are measured on Erigon 3.6 nodes running `--prune.mode=archive` with default
-pruning options; enabling receipts or commitment history adds a lot on top — see [Erigon3 datadir size](#erigon3-datadir-size).
-The same figures are published, with more detail, on the
-[hardware requirements](https://docs.erigon.tech/get-started/hardware-requirements) page.
-
-SSD or NVMe. We do not recommend HDD — on HDD, Erigon will always stay a few blocks behind the chain tip but will not fall further behind.
-Bear in mind that SSD performance deteriorates when close to capacity. CloudDrives (like
-gp3): Blocks Execution is slow
-on [cloud-network-drives](https://docs.erigon.tech/help-center/known-issues#cloud-network-drives)
-
-🔬 More details on [Erigon3 datadir size](#erigon3-datadir-size)
-
-🔬 More details on what type of data stored [here](https://ledgerwatch.github.io/turbo_geth_release.html#Disk-space)
-
-Sync Times
-==========
-
-These are the approximate sync times for syncing from scratch to the tip of the chain (results may vary depending on hardware and bandwidth).
-
-
-| Chain      | Archive         | Full           | Minimal        |
-|------------|-----------------|----------------|----------------|
-| Ethereum   | 7 Hours, 55 Minutes | 4 Hours, 23 Minutes | 1 Hour, 41 Minutes |
-| Gnosis     | 2 Hours, 10 Minutes | 1 Hour, 5 Minutes  | 33 Minutes      |
-
 Usage
 =====
-
-### Getting Started
-
-[Release Notes and Binaries](https://github.com/erigontech/erigon/releases)
-
-Build latest release (this will be suitable for most users just wanting to run a node):
-
-```sh
-git clone --branch release/<x.xx> --single-branch https://github.com/erigontech/erigon.git
-cd erigon
-make erigon
-./build/bin/erigon
-```
-
-Use `--datadir` to choose where to store data.
-
-Use `--chain=gnosis` for [Gnosis Chain](https://www.gnosis.io/).
-For Gnosis Chain you need a [Consensus Layer](#beacon-chain-consensus-layer) client alongside
-Erigon (https://docs.gnosischain.com/category/step--3---run-consensus-client).
-
-Running `make help` will list and describe the convenience commands available in the [Makefile](./Makefile).
-
-### Datadir structure
-
-```sh
-datadir        
-    chaindata     # "Recently-updated Latest State", "Recent History", "Recent Blocks"
-    snapshots     # contains `.seg` files - it's old blocks
-        domain    # Latest State
-        history   # Historical values 
-        idx       # InvertedIndices: can search/filtering/union/intersect them - to find historical data. like eth_getLogs or trace_transaction
-        accessor # Additional (generated) indices of history - have "random-touch" read-pattern. They can serve only `Get` requests (no search/filters).
-    caplin        # embedded Consensus Layer: beacon chain db and its snapshots
-    txpool        # pending transactions. safe to remove.
-    nodes         # p2p peers. safe to remove.
-    temp          # used to sort data bigger than RAM. can grow to ~100gb. cleaned at startup.
-   
-# There are 6 domains: account, storage, code, commitment, receipt, rcache. Last one only with `--prune.include-receipts`.
-```
-
-See the [lib](db/downloader/README.md) and [cmd](cmd/downloader/README.md) READMEs for more information.
-
-### Erigon3 datadir size
-
-Measured on Erigon 3.6 `--prune.mode=archive` nodes, July 2026. The `snapshots/*.seg` row is only the block files —
-headers, bodies and transactions — that sit directly in `snapshots/`; the rows below it are its sub-folders. Each
-column is one node, so totals can differ a few percent from the table above, which is measured on freshly synced
-nodes.
-
-| Path                 | eth-mainnet | gnosis    | sepolia   | hoodi     | chiado   |
-|----------------------|-------------|-----------|-----------|-----------|----------|
-| `chaindata`          | 22.75 GB    | 9.63 GB   | 12.87 GB  | 6.78 GB   | 2.40 GB  |
-| `snapshots/*.seg`    | 996.40 GB   | 284.82 GB | 614.90 GB | 33.38 GB  | 12.91 GB |
-| `snapshots/domain`   | 417.66 GB   | 227.03 GB | 237.26 GB | 52.39 GB  | 7.17 GB  |
-| `snapshots/idx`      | 332.72 GB   | 136.67 GB | 115.95 GB | 25.47 GB  | 3.44 GB  |
-| `snapshots/history`  | 255.60 GB   | 39.28 GB  | 68.93 GB  | 8.00 GB   | 2.33 GB  |
-| `snapshots/accessor` | 141.61 GB   | 33.73 GB  | 45.85 GB  | 7.70 GB   | 1.39 GB  |
-| total                | 2.17 TB     | 731.16 GB | 1.10 TB   | 133.73 GB | 29.64 GB |
-
-Data that is off by default, measured on the same nodes:
-
-| Flag                                 | eth-mainnet | gnosis     | sepolia    | hoodi      | chiado    |
-|--------------------------------------|-------------|------------|------------|------------|-----------|
-| `--prune.include-receipts`           | +441.42 GB  | +246.74 GB | +135.15 GB | +11.31 GB  | +3.38 GB  |
-| `--prune.include-commitment-history` | +4.40 TB    | -          | +1.09 TB   | +182.27 GB | +57.35 GB |
-| `--caplin.blocks-archive`, `--caplin.blobs-archive`, `--caplin.states-archive` | +2.48 TB | +501.00 GB | +1.40 TB | +135.28 GB | - |
-
-Caplin numbers are the backfilled beacon blocks, blob sidecars and beacon state snapshots. They exclude the beacon
-chain db that every node with the embedded Consensus Layer keeps anyway. Blob sidecars dominate: on mainnet they are
-2.17 TB of the 2.48 TB total.
 
 ### Erigon3 changes from Erigon2
 
@@ -185,31 +74,12 @@ Erigon can be used as an Execution Layer for external Consensus Layer clients. S
 
 ### Caplin
 
-Caplin is a full-fledged validating Consensus Client like Prysm, Lighthouse, Teku, Nimbus and Lodestar. Its goal is:
+Caplin is Erigon's embedded Consensus Layer, enabled by default. Flags, archival modes and Beacon API configuration:
+[Caplin](https://docs.erigon.tech/fundamentals/caplin) and [Caplin for staking](https://docs.erigon.tech/staking/caplin).
 
-* provide better stability
-* Validation of the chain
-* Stay in sync
-* keep the execution of blocks on chain tip
-* serve the Beacon API using a fast and compact data model alongside low CPU and memory usage.
-
-The main reason we developed a new Consensus Layer is to explore the potential benefits it can bring.
-For example, The Engine API does not work well with Erigon. The Engine API sends data one block at a time, which does
-not suit how Erigon works. Erigon is designed to handle many blocks simultaneously and needs to sort and process data
-efficiently. Therefore, it would be better for Erigon to handle the blocks independently instead of relying on the
-Engine API.
-
-#### Caplin's Usage
-
-Caplin is enabled by default. To disable it and use the Engine API instead, use the `--externalcl` flag. From that point
-on, an external Consensus Layer will no longer be needed.
-
-Caplin also has an archival mode for historical blocks, blobs and states, enabled through `--caplin.blocks-archive`,
-`--caplin.blobs-archive` and `--caplin.states-archive` (the latter turns on block archival as well). All three are off
-by default and cost a lot of disk — see [Erigon3 datadir size](#erigon3-datadir-size).
-In order to enable the caplin's Beacon API, the flag `--beacon.api=<namespaces>` must be added.
-e.g: `--beacon.api=beacon,builder,config,debug,node,validator,lighthouse` will enable all endpoints. 
-Note: enabling the Beacon API will lead to a 6 GB higher RAM usage
+Why a new Consensus Layer rather than the Engine API: the Engine API delivers blocks one at a time, which does not suit
+Erigon's bulk model — Erigon is built to handle many blocks simultaneously and to sort and process data in batches.
+Owning the consensus layer lets Erigon drive block handling on its own terms instead of being paced by the Engine API.
 
 ### Dev Chain
 
@@ -217,6 +87,21 @@ Note: enabling the Beacon API will lead to a 6 GB higher RAM usage
 
 For developers
 ==============
+
+### Building
+
+Toolchain: [Go >= 1.25](https://golang.org/doc/install), GCC 10+ or Clang, 64-bit architecture. On Linux, kernel > v4.
+
+```sh
+git clone https://github.com/erigontech/erigon.git
+cd erigon
+make erigon
+```
+
+Binaries land in `./build/bin`. Use `-j<n>` to parallelise the build. Packaged binaries, Docker images and the
+per-platform install steps are on the
+[installation](https://docs.erigon.tech/get-started/installation) page; to build a specific release rather than `main`,
+check out its tag.
 
 ### Executables
 
@@ -261,6 +146,7 @@ go mod tidy
 - [docker-compose.yml](./docker-compose.yml) — how the services are wired when run as separate processes
 - [db/etl/README.md](./db/etl/README.md) — the ETL framework used to preprocess data before DB inserts
 - [db/downloader/README.md](./db/downloader/README.md) — snapshot downloader internals
+- [cmd/downloader/readme.md](./cmd/downloader/readme.md) — snapshots overview: what they are, when they are created and pulled
 - [cmd/rpcdaemon/README.md](./cmd/rpcdaemon/README.md) — RPC daemon, including running it remotely
 - [cmd/prometheus/Readme.md](./cmd/prometheus/Readme.md) — metrics and dashboards
 - [CI-GUIDELINES.md](./CI-GUIDELINES.md) — read before changing workflows


### PR DESCRIPTION
## What

The root `README.md` had grown into a second, slower-moving copy of the documentation site. This cuts it down to what only the repository can answer, and points everything else at the page that owns it.

`README.md`: **731 → 220 lines** (+99 / −610).

Three commits, each reviewable on its own:

1. Move operator content to the site and add the developer sections that were missing.
2. Drop the sections the site already covers.
3. Link out Hetzner and Windows; fix the torrent-log wording.

## What moved out, and where it was verified

Every section below was read against the page that owns it before being removed — not assumed.

| Removed from README | Verified against |
| --- | --- |
| System Requirements | `get-started/hardware-requirements` — disk figures for all five networks, per-mode RAM, kernel > v4, SSD/NVMe-over-HDD and the capacity-degradation caveat |
| Sync Times | `get-started/hardware-requirements`, where the table now sits with a bandwidth caveat the README lacked |
| Usage / Getting Started | `get-started/installation` — clone, tag checkout, `make erigon`, `make -j<n>`, `./build/bin/erigon` |
| Datadir structure | `fundamentals/database` → "The datadir at a glance" — same tree, clearer per-directory comments |
| Erigon3 datadir size | `fundamentals/database` → "What does it cost on disk?" — **identical** measured figures for all five networks |
| Caplin / Caplin's Usage | `fundamentals/caplin` + `staking/caplin`; `--externalcl` in `fundamentals/architecture` and `staking/external-consensus-client-as-validator` |
| Hetzner strict-firewall list | `help-center/troubleshooting` → Hetzner firewall note |
| Windows | `get-started/installation` — native compilation (Chocolatey, MinGW, the `Win64/Kryptic.CIS` anti-virus false positive), Docker, and WSL2 |

The earlier scope note in this PR — that it avoided everything #22866 and #22867 touched — no longer applies: both are merged to `main`, so the disk-size and network content they rewrote is settled and safe to defer to.

## What is deliberately kept

- **Why Caplin exists instead of the Engine API.** The site does not have this. `fundamentals/architecture` only notes that the Engine-API path matches Geth/Besu/Reth; it does not explain that one-block-at-a-time delivery is what conflicts with Erigon's bulk model. Condensed to two sentences.
- **Build prerequisites**, moved out of the operator preamble into a new **Building** section under *For developers* — where a repository README should state its own toolchain. Trimmed to the toolchain plus a pointer to the installation page.
- Everything a checkout can answer but the site cannot: executables table, testing, `go get` as a library, repository-doc index, devnet, diagnostics.

## Two corrections, not just deletions

- **The Hetzner list was corrupted.** It carried `127.16.0.0/12  "Private-Use Networks RFC 1918"` — a mangling of loopback and RFC 1918, with `172.16.0.0/12` already listed separately — plus a Network Interconnect row and a Limited Broadcast row each split across two lines by the code fence. The linked version is correct.
- **The torrent-log level read backwards.** The README said `logs/torrent.log` is written at whichever is *lower* of `--torrent.verbosity` and `WARN`. `erigonToSlogLevel` is `12 - 4*lvl` ([`slogger.go:13`](https://github.com/erigontech/erigon/blob/main/db/downloader/downloadercfg/slogger.go#L13)), so a higher Erigon verbosity maps to a numerically *lower* `slog.Level`, and the `min(erigonToSlogLevel(verbosity), slog.LevelWarn)` at [`downloadercfg.go:249`](https://github.com/erigontech/erigon/blob/main/db/downloader/downloadercfg/downloadercfg.go#L249) selects the **more verbose** threshold. Reworded to match the behaviour operators actually see.

## Ordering

Two of these cuts land content that reaches readers only once #22962 deploys — the Sync Times table and the corrected Hetzner blocklist are added to the site there, against `release/3.5` (the branch `docs-deploy.yml` publishes from). **Merge this after #22962 has deployed**, otherwise those two links point at pages that do not yet carry the content.

## Known gaps, for a follow-up docs PR against `release/3.5`

Three details existed only in the README and are not on the site. They are not blockers for the cut, but they should be added:

- `caplin/` is missing from the datadir tree in `fundamentals/database`.
- The six domains are named in the README (`account`, `storage`, `code`, `commitment`, `receipt`, `rcache`); `database.md` only counts them as "4 state domains + 2 receipt domains".
- The off-by-default size table had per-network columns for `--prune.include-receipts`, `--prune.include-commitment-history` and the Caplin archive; `database.md` gives mainnet only, as prose.

## Verification

- Every relative repo link resolves. This also fixes one that was already broken on `main`: `cmd/downloader/README.md` does not exist — the file is `cmd/downloader/readme.md`, now listed under Repository docs.
- Both remaining internal anchors resolve; no dangling anchors left by the removed sections, and nothing in the repo or on the docs site links to any removed README anchor.
- Every docs.erigon.tech target checked to exist in `docs/site/`, including the anchors `#install-native`, `#install-wsl` and the Hetzner firewall note.
- `docs/site`: `npm ci && npm run build` clean; `generate-llms.py --check` OK (4 files, 74 pages).
- Markdown only; no Go changed.
