### PR TITLE
[r3.6] cl: reject sidecars and blocks with inconsistent fork schema

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -814,6 +814,15 @@ func (b *BeaconChainConfig) GetCurrentStateVersion(epoch uint64) StateVersion {
 	return stateVersion
 }
 
+// ForkSchemaMatchesSlot reports whether an object decoded with decodedVersion is
+// consistent with the fork implied by slot. A peer picks the response fork digest,
+// so the two are independent inputs; Gloas changed which fields BeaconBody and
+// DataColumnSidecar carry, so a disagreement reaches a field left unset.
+func (b *BeaconChainConfig) ForkSchemaMatchesSlot(slot uint64, decodedVersion StateVersion) bool {
+	slotIsGloas := b.GetCurrentStateVersion(slot/b.SlotsPerEpoch) >= GloasVersion
+	return slotIsGloas == (decodedVersion >= GloasVersion)
+}
+
 // AttestationDueMs returns the attestation deadline in milliseconds from slot start.
 func (b *BeaconChainConfig) AttestationDueMs(gloas bool) uint64 {
 	if b == nil || b.SecondsPerSlot == 0 {

--- a/cl/clparams/config_test.go
+++ b/cl/clparams/config_test.go
@@ -218,3 +218,47 @@ func TestMaxBlobsPerBlockUpperBound(t *testing.T) {
 	noSchedule := &BeaconChainConfig{MaxBlobsPerBlock: 6, MaxBlobsPerBlockElectra: 9}
 	require.EqualValues(t, 9, noSchedule.MaxBlobsPerBlockUpperBound())
 }
+
+func TestForkSchemaMatchesSlot(t *testing.T) {
+	cfg := MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 1
+	cfg.GloasForkEpoch = 2
+	cfg.InitializeForkSchedule()
+	spe := cfg.SlotsPerEpoch
+
+	for _, tc := range []struct {
+		name           string
+		slot           uint64
+		decodedVersion StateVersion
+		want           bool
+	}{
+		// Schemas diverge only across the Gloas boundary, so a disagreement
+		// below it is not a mismatch.
+		{"both pre-Gloas", spe, DenebVersion, true},
+		{"both Gloas", 2 * spe, GloasVersion, true},
+		{"Gloas schema at a pre-Gloas slot", spe, GloasVersion, false},
+		{"pre-Gloas schema at a Gloas slot", 2 * spe, FuluVersion, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, cfg.ForkSchemaMatchesSlot(tc.slot, tc.decodedVersion))
+		})
+	}
+}
+
+// Mainnet keeps Gloas at FAR_FUTURE_EPOCH, so no slot maps to it and every
+// Gloas-schema object is inconsistent whatever slot it claims.
+func TestForkSchemaMatchesSlotFarFutureGloas(t *testing.T) {
+	cfg := MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	require.Equal(t, uint64(math.MaxUint64), cfg.GloasForkEpoch)
+
+	fuluSlot := cfg.FuluForkEpoch * cfg.SlotsPerEpoch
+	require.True(t, cfg.ForkSchemaMatchesSlot(fuluSlot, FuluVersion))
+	require.False(t, cfg.ForkSchemaMatchesSlot(fuluSlot, GloasVersion))
+	require.False(t, cfg.ForkSchemaMatchesSlot(math.MaxUint64/cfg.SlotsPerEpoch, GloasVersion))
+}

--- a/cl/das/peer_das.go
+++ b/cl/das/peer_das.go
@@ -832,28 +832,13 @@ mainloop:
 			var wg sync.WaitGroup
 			for _, sidecar := range result.sidecars {
 				wg.Go(func() {
-					// [Modified in Gloas:EIP7732] Get slot first, then use epoch-based version detection
-					var slot uint64
-					if sidecar.SignedBlockHeader != nil && sidecar.SignedBlockHeader.Header != nil {
-						slot = sidecar.SignedBlockHeader.Header.Slot
-					} else {
-						slot = sidecar.Slot
+					slot, blockRoot, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+					if !ok {
+						log.Debug("rejecting malformed or schema-inconsistent column sidecar", "pid", result.pid)
+						d.rpc.BanPeer(result.pid)
+						return
 					}
-					epoch := slot / d.beaconConfig.SlotsPerEpoch
-					isGloasSidecar := d.beaconConfig.GetCurrentStateVersion(epoch) >= clparams.GloasVersion
-
-					var blockRoot common.Hash
-					if isGloasSidecar {
-						blockRoot = sidecar.BeaconBlockRoot
-					} else {
-						var err error
-						blockRoot, err = sidecar.SignedBlockHeader.Header.HashSSZ()
-						if err != nil {
-							log.Debug("failed to get block root", "err", err)
-							d.rpc.BanPeer(result.pid)
-							return
-						}
-					}
+					isGloasSidecar := sidecar.Version() >= clparams.GloasVersion
 					defer func() {
 						// check if need to schedule recover whenever we download a column sidecar
 						if needToRecoverBlobs &&
@@ -936,6 +921,31 @@ mainloop:
 	}
 
 	return nil
+}
+
+// resolveColumnSidecarSlotAndRoot reads a received column sidecar's slot and
+// block root from the fields populated by the schema it was decoded with. ok is
+// false for a malformed sidecar, or one whose slot disagrees with that schema —
+// see BeaconChainConfig.ForkSchemaMatchesSlot.
+func (d *peerdas) resolveColumnSidecarSlotAndRoot(sidecar *cltypes.DataColumnSidecar) (slot uint64, blockRoot common.Hash, ok bool) {
+	if sidecar.Version() >= clparams.GloasVersion {
+		if !d.beaconConfig.ForkSchemaMatchesSlot(sidecar.Slot, sidecar.Version()) {
+			return 0, common.Hash{}, false
+		}
+		return sidecar.Slot, sidecar.BeaconBlockRoot, true
+	}
+	header := sidecar.SignedBlockHeader
+	if header == nil || header.Header == nil {
+		return 0, common.Hash{}, false
+	}
+	if !d.beaconConfig.ForkSchemaMatchesSlot(header.Header.Slot, sidecar.Version()) {
+		return 0, common.Hash{}, false
+	}
+	root, err := header.Header.HashSSZ()
+	if err != nil {
+		return 0, common.Hash{}, false
+	}
+	return header.Header.Slot, root, true
 }
 
 func isExpectedColumnDownloadMiss(err error) bool {

--- a/cl/das/peer_das_download_test.go
+++ b/cl/das/peer_das_download_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package das
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/erigontech/erigon/cl/beacon/beaconevents"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	peerdasstate "github.com/erigontech/erigon/cl/das/state"
+	"github.com/erigontech/erigon/cl/persistence/blob_storage"
+	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
+	"github.com/erigontech/erigon/cl/rpc"
+	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
+	"github.com/erigontech/erigon/cl/utils/eth_clock"
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
+)
+
+// maliciousColumnSentinel stands in for a selected custody peer. It answers
+// metadata honestly so it becomes eligible for column requests, then serves a
+// fixed response to every column request.
+type maliciousColumnSentinel struct {
+	sentinelproto.SentinelClient
+	metadataResponse []byte
+	columnResponse   []byte
+
+	metadataOnce  sync.Once
+	metadataReady chan struct{}
+	banOnce       sync.Once
+	banned        chan struct{}
+}
+
+func (s *maliciousColumnSentinel) PeersInfo(context.Context, *sentinelproto.PeersInfoRequest, ...grpc.CallOption) (*sentinelproto.PeersInfoResponse, error) {
+	return &sentinelproto.PeersInfoResponse{Peers: []*sentinelproto.Peer{{Pid: "malicious-peer"}}}, nil
+}
+
+func (s *maliciousColumnSentinel) BanPeer(context.Context, *sentinelproto.Peer, ...grpc.CallOption) (*sentinelproto.EmptyMessage, error) {
+	s.banOnce.Do(func() { close(s.banned) })
+	return &sentinelproto.EmptyMessage{}, nil
+}
+
+func (s *maliciousColumnSentinel) SendPeerRequest(_ context.Context, req *sentinelproto.RequestDataWithPeer, _ ...grpc.CallOption) (*sentinelproto.ResponseData, error) {
+	peer := &sentinelproto.Peer{Pid: "malicious-peer"}
+	if strings.Contains(req.Topic, "metadata") {
+		s.metadataOnce.Do(func() { close(s.metadataReady) })
+		return &sentinelproto.ResponseData{Data: s.metadataResponse, Peer: peer}, nil
+	}
+	return &sentinelproto.ResponseData{Data: s.columnResponse, Peer: peer}, nil
+}
+
+// A peer selects the response fork digest, so it can serve a Gloas-schema
+// sidecar (no SignedBlockHeader) that claims a pre-Gloas slot. runDownload must
+// ban the peer rather than dereference the header the schema left unset; the
+// per-sidecar goroutine has no recover, so a nil deref there kills the process.
+//
+// This drives the real BeaconRpcP2P decode path, so it also pins that
+// DataColumnSidecar.Version() reflects the peer's digest choice.
+func TestRunDownloadRejectsGloasSidecarWithPreGloasSlot(t *testing.T) {
+	// Kept at mainnet's schedule: Gloas sits at FAR_FUTURE_EPOCH, so its digest is
+	// registered and resolvable even though no slot maps to Gloas.
+	cfg := clparams.MainnetBeaconConfig
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+
+	currentSlot := (cfg.FuluForkEpoch + 1) * cfg.SlotsPerEpoch
+	genesisTime := uint64(time.Now().Unix()) - currentSlot*cfg.SecondsPerSlot
+	clock := eth_clock.NewEthereumClock(genesisTime, common.Hash{}, &cfg)
+
+	gloasDigest, err := clock.ComputeForkDigest(cfg.GloasForkEpoch)
+	require.NoError(t, err)
+	decodeVersion, err := clock.StateVersionByForkDigest(gloasDigest)
+	require.NoError(t, err)
+	require.Equal(t, clparams.GloasVersion, decodeVersion, "far-future Gloas digest must resolve")
+
+	// Advertising every custody group makes this peer eligible for any column.
+	cgc := cfg.NumberOfColumns
+	syncnets := [1]byte{}
+	metadata := &cltypes.Metadata{Syncnets: &syncnets, CustodyGroupCount: &cgc}
+	var metadataWire bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&metadataWire, metadata))
+
+	sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+	sidecar.Slot = 0
+	sidecar.BeaconBlockRoot = common.HexToHash("0x1234")
+	require.Nil(t, sidecar.SignedBlockHeader, "Gloas schema must leave SignedBlockHeader unset")
+	var columnWire bytes.Buffer
+	require.NoError(t, ssz_snappy.EncodeAndWrite(&columnWire, sidecar, gloasDigest[:]...))
+
+	sentinel := &maliciousColumnSentinel{
+		metadataResponse: metadataWire.Bytes(),
+		columnResponse:   columnWire.Bytes(),
+		metadataReady:    make(chan struct{}),
+		banned:           make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rpcClient := rpc.NewBeaconRpcP2P(ctx, sentinel, &cfg, clock, nil)
+
+	select {
+	case <-sentinel.metadataReady:
+	case <-time.After(30 * time.Second):
+		t.Fatal("malicious peer was not added to the custody-peer queue")
+	}
+
+	// gloasDataCache is populated so that a sidecar wrongly accepted as Gloas
+	// fails this test's ban assertion rather than nil-panicking downstream.
+	gloasDataCache, err := lru.New[common.Hash, *gloasBlockData]("gloasDataCacheTest", 8)
+	require.NoError(t, err)
+	d := &peerdas{
+		rpc:            rpcClient,
+		beaconConfig:   &cfg,
+		state:          peerdasstate.NewPeerDasState(&cfg, &clparams.NetworkConfig{}),
+		columnStorage:  blob_storage.NewDataColumnStore(afero.NewMemMapFs(), 0, &cfg, clock, beaconevents.NewEventEmitter()),
+		gloasDataCache: gloasDataCache,
+	}
+	req := &downloadRequest{
+		beaconConfig: &cfg,
+		downloadTable: map[downloadTableEntry]map[uint64]bool{
+			{blockRoot: common.HexToHash("0xbeef"), slot: currentSlot}: {0: true},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- d.runDownload(ctx, req, false) }()
+
+	select {
+	case <-sentinel.banned:
+	case <-time.After(30 * time.Second):
+		t.Fatal("malicious sidecar was never rejected")
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runDownload did not return after cancellation")
+	}
+
+	// Nothing may be stored: the sidecar is rejected before any write.
+	saved, err := d.columnStorage.GetSavedColumnIndex(context.Background(), currentSlot, common.HexToHash("0xbeef"))
+	require.NoError(t, err)
+	require.Empty(t, saved)
+}

--- a/cl/das/peer_das_test.go
+++ b/cl/das/peer_das_test.go
@@ -23,8 +23,21 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/sentinel/httpreqresp"
+	"github.com/erigontech/erigon/common"
 )
+
+// initTestBeaconConfig installs cfg as the global config if no test has done so
+// yet. InitGlobalStaticConfig panics on a second call, so tests in this package
+// must agree on every global-only field; they may differ only in fork epochs,
+// which each test reads from its own local config.
+func initTestBeaconConfig(cfg *clparams.BeaconChainConfig) {
+	if clparams.GetBeaconConfig() == nil {
+		clparams.InitGlobalStaticConfig(cfg, &clparams.CaplinConfig{})
+	}
+}
 
 func TestIsExpectedColumnDownloadMiss(t *testing.T) {
 	require.False(t, isExpectedColumnDownloadMiss(nil))
@@ -43,4 +56,59 @@ func TestIsExpectedColumnDownloadMiss(t *testing.T) {
 		Body:       "Read Code: EOF",
 	}))
 	require.False(t, isExpectedColumnDownloadMiss(errors.New("peer error code: 2 (server error). Error message: broken")))
+}
+
+func TestResolveColumnSidecarSlotAndRoot(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 1
+	cfg.GloasForkEpoch = 2
+	cfg.InitializeForkSchedule()
+	initTestBeaconConfig(&cfg)
+	d := &peerdas{beaconConfig: &cfg}
+	spe := cfg.SlotsPerEpoch
+
+	t.Run("rejects Gloas schema carrying a pre-Gloas slot", func(t *testing.T) {
+		// A peer selects the Gloas decode schema (no SignedBlockHeader) via the
+		// response fork-digest, then claims slot 0, which maps to a pre-Gloas
+		// fork. The pre-Gloas branch must not dereference the absent header.
+		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+		sidecar.Slot = 0
+		require.Nil(t, sidecar.SignedBlockHeader)
+		_, _, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+		require.False(t, ok)
+	})
+
+	t.Run("rejects pre-Gloas schema with nil signed block header", func(t *testing.T) {
+		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+		sidecar.SignedBlockHeader = nil
+		_, _, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+		require.False(t, ok)
+	})
+
+	t.Run("accepts a consistent Fulu sidecar", func(t *testing.T) {
+		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.FuluVersion)
+		require.NotNil(t, sidecar.SignedBlockHeader)
+		sidecar.SignedBlockHeader.Header.Slot = spe // epoch 1 => Fulu
+		slot, blockRoot, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+		require.True(t, ok)
+		require.Equal(t, spe, slot)
+		want, err := sidecar.SignedBlockHeader.Header.HashSSZ()
+		require.NoError(t, err)
+		require.Equal(t, common.Hash(want), blockRoot)
+	})
+
+	t.Run("accepts a consistent Gloas sidecar", func(t *testing.T) {
+		sidecar := cltypes.NewDataColumnSidecarWithVersion(clparams.GloasVersion)
+		sidecar.Slot = 2 * spe // epoch 2 => Gloas
+		sidecar.BeaconBlockRoot = common.HexToHash("0xabc")
+		slot, blockRoot, ok := d.resolveColumnSidecarSlotAndRoot(sidecar)
+		require.True(t, ok)
+		require.Equal(t, 2*spe, slot)
+		require.Equal(t, common.HexToHash("0xabc"), blockRoot)
+	})
 }

--- a/cl/phase1/forkchoice/on_block.go
+++ b/cl/phase1/forkchoice/on_block.go
@@ -53,6 +53,7 @@ var (
 	ErrMissingSegment                = errors.New("missing segment: parent state not available")
 	ErrParentEnvelopePending         = errors.New("parent execution payload envelope not yet available")
 	ErrNotFinalizedDescendant        = errors.New("block is not a descendant of the finalized checkpoint")
+	ErrForkSchemaSlotMismatch        = errors.New("block schema fork disagrees with the fork implied by its slot")
 )
 
 func verifyKzgCommitmentsAgainstTransactions(cfg *clparams.BeaconChainConfig, block *cltypes.BeaconBlock) error {
@@ -129,6 +130,10 @@ func (f *ForkChoiceStore) OnBlock(ctx context.Context, block *cltypes.SignedBeac
 		return ErrNotFinalizedDescendant
 	}
 	currentSlotOnEntry := f.ethClock.GetCurrentSlot()
+
+	if !f.beaconCfg.ForkSchemaMatchesSlot(block.Block.Slot, block.Version()) {
+		return ErrForkSchemaSlotMismatch
+	}
 
 	// Validate parent payload status path early (before expensive operations)
 	blockEpoch := f.computeEpochAtSlot(block.Block.Slot)

--- a/cl/phase1/forkchoice/on_block_fork_consistency_test.go
+++ b/cl/phase1/forkchoice/on_block_fork_consistency_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package forkchoice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/utils"
+)
+
+// A response's decoded schema comes from the peer-chosen fork digest, so it is
+// independent of the slot the block claims. Gloas removed ExecutionPayload and
+// BlobKzgCommitments from BeaconBody, so a Gloas-decoded block whose slot maps
+// to a pre-Gloas fork must be rejected before the pre-Gloas branch reads them.
+func TestOnBlockRejectsForkSchemaSlotMismatch(t *testing.T) {
+	cfg := &clparams.MainnetBeaconConfig
+	store := buildExAnteStore(t)
+
+	// Borrow slot/parent from a block the store already accepted, so the block
+	// clears the early ancestry and timing checks and reaches version dispatch.
+	ref := cltypes.NewSignedBeaconBlock(cfg, clparams.DenebVersion)
+	require.NoError(t, utils.DecodeSSZSnappy(ref, diffBlock3aEnc, int(clparams.AltairVersion)))
+
+	mismatched := cltypes.NewSignedBeaconBlock(cfg, clparams.GloasVersion)
+	mismatched.Block.Slot = ref.Block.Slot
+	mismatched.Block.ProposerIndex = ref.Block.ProposerIndex
+	mismatched.Block.ParentRoot = ref.Block.ParentRoot
+	mismatched.Block.StateRoot = ref.Block.StateRoot
+
+	require.Equal(t, clparams.GloasVersion, mismatched.Version(), "decoded schema must be Gloas")
+	require.Nil(t, mismatched.Block.Body.BlobKzgCommitments, "Gloas schema leaves BlobKzgCommitments unset")
+	require.Nil(t, mismatched.Block.Body.ExecutionPayload, "Gloas schema leaves ExecutionPayload unset")
+	require.Less(t, cfg.GetCurrentStateVersion(mismatched.Block.Slot/cfg.SlotsPerEpoch), clparams.GloasVersion,
+		"slot must map to a pre-Gloas fork for the mismatch to exist")
+
+	err := store.OnBlock(context.Background(), mismatched, false, true, true)
+	require.ErrorIs(t, err, ErrForkSchemaSlotMismatch)
+}


### PR DESCRIPTION
Cherry-pick of #22797 to release/3.6. Applies without conflicts.

Worth backporting rather than leaving to 3.7: `release/3.6` is live-vulnerable. Mainnet is post-Fulu, Caplin runs by default, and the far-future Gloas digest is registered, so a peer can serve a Gloas-schema data-column sidecar claiming a pre-Gloas slot and the pre-Gloas branch dereferences the absent `SignedBlockHeader`. That runs in a per-sidecar goroutine with no `recover`, so it exits the process. Ported onto this branch unchanged, `TestRunDownloadRejectsGloasSidecarWithPreGloasSlot` panics at `cl/das/peer_das.go:850`; with the cherry-pick it passes.

Verified here: `make lint` clean, `make erigon integration` builds, and all five regression tests pass in `cl/das`, `cl/clparams` and `cl/phase1/forkchoice`.

`release/3.5` needs the same fix and does not cherry-pick cleanly (the download loop predates `wg.Go` and there is no `cl/das/peer_das_test.go`), so it will be a separate PR. `release/3.4` is unaffected — it has no Gloas and a single data-column sidecar schema.
