### PR TITLE
[r3.6] db/downloader: allow seeding caplin state snapshots with nil global type

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -746,7 +746,9 @@ func (d *Downloader) VerifyData(
 func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error {
 	ff, isStateFile, ok := snaptype.ParseFileName("", name)
 	if ok {
-		if !isStateFile && ff.Type == nil {
+		// Caplin beacon-state snapshots have no registered global snaptype, so
+		// ParseFileName leaves ff.Type nil for them; they are still seedable by name.
+		if !isStateFile && ff.Type == nil && !snaptype.IsCaplin("", name) {
 			return fmt.Errorf("nil ptr after parsing file: %s", name)
 		}
 	}

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -128,6 +128,17 @@ func TestAddNewSeedableFileConcurrentWithAllActiveSnapshots(t *testing.T) {
 	}
 }
 
+// Caplin beacon-state snapshots (e.g. NextSyncCommittee) have no registered global
+// snaptype, so ParseFileName returns a nil Type for them. They are still seedable by
+// name, so AddNewSeedableFile must not reject them as malformed.
+func TestAddNewSeedableFileCaplinStateType(t *testing.T) {
+	test := newDownloaderTest(t)
+	name := filepath.Join("caplin", "v1.1-000000-007150-NextSyncCommittee.seg")
+	require.NoError(t, os.MkdirAll(filepath.Join(test.dirs.Snap, "caplin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(test.dirs.Snap, name), nil, 0o644))
+	require.NoError(t, test.downloader.AddNewSeedableFile(t.Context(), name))
+}
+
 func TestChangeInfoHashOfSameFile(t *testing.T) {
 	ctx := t.Context()
 	require := require.New(t)


### PR DESCRIPTION
Cherry-pick of #22911 to release/3.6.

Silences the `[Antiquary] Failed to add items to bittorent ... nil ptr after parsing file: caplin/...-NextSyncCommittee.seg` warning seen after an in-place 3.4→3.5/3.6 upgrade. Caplin beacon-state snapshot types have no registered global snaptype (so `ParseFileName` returns a nil `Type`), but are seedable by name; `AddNewSeedableFile` now lets caplin files through the nil-Type guard. Cosmetic (no functional impact — caplin state snapshots have no P2P download path today), but the guard also silently defeated the `Seed` call's intent.

TDD: `TestAddNewSeedableFileCaplinStateType` reproduces (red) and passes (green) with the guard relaxed. Clean cherry-pick, no adaptations.