### PR TITLE
execution/state: cut allocations in WriteSet.Normalize and Apply

### DIFF
--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -83,12 +83,18 @@ func (rs *StateV3) SetTxNum(txNum uint64) {
 //     original.Incarnation > account.Incarnation (followed by account fields)
 func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx, blockNum, txNum uint64, balanceIncreases map[accounts.Address]uint256.Int, rules *chain.Rules, blockCache *BlockStateCache, trace bool) error {
 	if writes != nil && !writes.IsEmpty() {
+		// Field presence is tracked with has-flags rather than pointers: the
+		// pointer form heap-escapes one allocation per field per address.
 		type addrState struct {
-			balance        *uint256.Int
-			nonce          *uint64
-			incarnation    *uint64
-			codeHash       *accounts.CodeHash
+			balance        uint256.Int
+			nonce          uint64
+			incarnation    uint64
+			codeHash       accounts.CodeHash
 			code           []byte
+			hasBalance     bool
+			hasNonce       bool
+			hasIncarnation bool
+			hasCodeHash    bool
 			codeWritten    bool
 			selfDestruct   bool
 			createContract bool
@@ -107,22 +113,26 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 		// Range the typed collections directly rather than AllHeaders()+GetX —
 		// the header walk plus a second per-value map probe is strictly more work.
 		for a, vw := range writes.Balances() {
-			v := vw.Val
-			ensure(a).balance = &v
+			d := ensure(a)
+			d.balance = vw.Val
+			d.hasBalance = true
 		}
 		for a, vw := range writes.Nonces() {
-			v := vw.Val
-			ensure(a).nonce = &v
+			d := ensure(a)
+			d.nonce = vw.Val
+			d.hasNonce = true
 		}
 		for a, vw := range writes.Incarnations() {
-			v := vw.Val
-			ensure(a).incarnation = &v
+			d := ensure(a)
+			d.incarnation = vw.Val
+			d.hasIncarnation = true
 		}
 		// CodeHashes before Codes: an explicit CodeHashPath write wins; a code
 		// write only supplies the hash when no explicit one was recorded.
 		for a, vw := range writes.CodeHashes() {
-			v := vw.Val
-			ensure(a).codeHash = &v
+			d := ensure(a)
+			d.codeHash = vw.Val
+			d.hasCodeHash = true
 		}
 		for a, vw := range writes.Codes() {
 			d := ensure(a)
@@ -164,8 +174,8 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 				}
 				// An EIP-8246 self-destruct keeps its balance write; the record
 				// survives only when a non-zero balance is left to preserve.
-				sdPreservedBalance := d.balance != nil && !d.balance.IsZero()
-				pureDelete := !sdPreservedBalance && d.nonce == nil && d.incarnation == nil && d.codeHash == nil
+				sdPreservedBalance := d.hasBalance && !d.balance.IsZero()
+				pureDelete := !sdPreservedBalance && !d.hasNonce && !d.hasIncarnation && !d.hasCodeHash
 				if blockCache != nil {
 					// Route the account+code delete and storage-prefix wipe through
 					// the cache so they're recorded in writeLog order. A later
@@ -213,7 +223,7 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 				}
 			}
 
-			if d.balance != nil || d.nonce != nil || d.incarnation != nil || d.codeHash != nil || d.codeWritten {
+			if d.hasBalance || d.hasNonce || d.hasIncarnation || d.hasCodeHash || d.codeWritten {
 				// A WriteSet may contain only the changed account fields, so
 				// overlay it on the current state. Self-destruct is the exception:
 				// its base stays empty so cleared fields cannot be resurrected.
@@ -229,17 +239,17 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 						_ = accounts.DeserialiseV3(&acc, enc0)
 					}
 				}
-				if d.balance != nil {
-					acc.Balance = *d.balance
+				if d.hasBalance {
+					acc.Balance = d.balance
 				}
-				if d.nonce != nil {
-					acc.Nonce = *d.nonce
+				if d.hasNonce {
+					acc.Nonce = d.nonce
 				}
-				if d.incarnation != nil {
-					acc.Incarnation = *d.incarnation
+				if d.hasIncarnation {
+					acc.Incarnation = d.incarnation
 				}
-				if d.codeHash != nil {
-					acc.CodeHash = *d.codeHash
+				if d.hasCodeHash {
+					acc.CodeHash = d.codeHash
 				} else if d.codeWritten {
 					acc.CodeHash = accounts.NewCode(d.code).Hash
 				}

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -75,11 +75,12 @@ func (rs *StateV3) SetTxNum(txNum uint64) {
 // the parallel executor and block production. trace gates the dbg.TraceApply
 // logging StateV3 used to read from its own flag.
 //
-// Writes carry complete account state (all fields emitted by UpdateAccountData),
-// so no domain reads are needed to reconstruct the full serialised account. A
-// self-destructed address carries at most the balance EIP-8246 preserves, plus
-// its storage-delete cascade: Normalize drops the nonce, incarnation and code
-// hash, and assertSelfDestructNormalized pins that.
+// A write set may carry only the account fields that changed, so Apply overlays
+// it on the current account, read from the block cache or AccountsDomain. A
+// self-destructed address is the exception: its base stays empty so cleared
+// fields cannot be resurrected, and it carries at most the balance EIP-8246
+// preserves plus its storage-delete cascade — Normalize drops the nonce,
+// incarnation and code hash, and assertSelfDestructNormalized pins that.
 func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx, blockNum, txNum uint64, balanceIncreases map[accounts.Address]uint256.Int, rules *chain.Rules, blockCache *BlockStateCache, trace bool) error {
 	if writes != nil && !writes.IsEmpty() {
 		if dbg.AssertEnabled {

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -83,6 +83,9 @@ func (rs *StateV3) SetTxNum(txNum uint64) {
 //     original.Incarnation > account.Incarnation (followed by account fields)
 func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx, blockNum, txNum uint64, balanceIncreases map[accounts.Address]uint256.Int, rules *chain.Rules, blockCache *BlockStateCache, trace bool) error {
 	if writes != nil && !writes.IsEmpty() {
+		if dbg.AssertEnabled {
+			writes.assertSelfDestructNormalized()
+		}
 		// Field presence is tracked with has-flags rather than pointers: the
 		// pointer form heap-escapes one allocation per field per address.
 		type addrState struct {

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -76,11 +76,10 @@ func (rs *StateV3) SetTxNum(txNum uint64) {
 // logging StateV3 used to read from its own flag.
 //
 // Writes carry complete account state (all fields emitted by UpdateAccountData),
-// so no domain reads are needed to reconstruct the full serialised account.
-// SelfDestructPath=true signals either:
-//   - pure account deletion (no account fields follow) — from DeleteAccount
-//   - code+storage cleanup before recreation — from UpdateAccountData when
-//     original.Incarnation > account.Incarnation (followed by account fields)
+// so no domain reads are needed to reconstruct the full serialised account. A
+// self-destructed address carries at most the balance EIP-8246 preserves, plus
+// its storage-delete cascade: Normalize drops the nonce, incarnation and code
+// hash, and assertSelfDestructNormalized pins that.
 func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx, blockNum, txNum uint64, balanceIncreases map[accounts.Address]uint256.Int, rules *chain.Rules, blockCache *BlockStateCache, trace bool) error {
 	if writes != nil && !writes.IsEmpty() {
 		if dbg.AssertEnabled {
@@ -214,8 +213,8 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 						continue
 					}
 				}
-				// Otherwise: cleanup code+storage before recreating account
-				// (originalIncarnation > account.Incarnation case).
+				// Otherwise an EIP-8246 balance survives: code and storage are
+				// gone, and the account is written back from an empty base below.
 			}
 
 			// Contract creation: clear stale storage before writing new account.

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1000,8 +1000,6 @@ func (s *WriteSet) restoreCreateFields(addr accounts.Address, snap *createWriteS
 	}
 }
 
-// DeleteAccountFields removes the Balance/Nonce/Incarnation/CodeHash writes for
-// addr, leaving storage/code/self-destruct intact.
 // assertSelfDestructNormalized panics if a self-destructed address still carries
 // the account fields Normalize is required to drop. Any of them makes Apply
 // compute pureDelete=false and take the cleanup-before-recreate branch, which
@@ -1028,6 +1026,8 @@ func (s *WriteSet) assertSelfDestructNormalized() {
 	}
 }
 
+// DeleteAccountFields removes the Balance/Nonce/Incarnation/CodeHash writes for
+// addr, leaving storage/code/self-destruct intact.
 func (s *WriteSet) DeleteAccountFields(addr accounts.Address) {
 	delete(s.balance, addr)
 	delete(s.nonce, addr)

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1140,6 +1140,15 @@ func (s *WriteSet) forEachAddr(f func(accounts.Address)) {
 	for a := range s.address {
 		f(a)
 	}
+	s.forEachFieldAddr(f)
+}
+
+// forEachFieldAddr is forEachAddr restricted to field-level writes: it skips the
+// record-level AddressPath map, whose entries carry no field of their own.
+func (s *WriteSet) forEachFieldAddr(f func(accounts.Address)) {
+	if s == nil {
+		return
+	}
 	for a := range s.balance {
 		f(a)
 	}

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1002,6 +1002,32 @@ func (s *WriteSet) restoreCreateFields(addr accounts.Address, snap *createWriteS
 
 // DeleteAccountFields removes the Balance/Nonce/Incarnation/CodeHash writes for
 // addr, leaving storage/code/self-destruct intact.
+// assertSelfDestructNormalized panics if a self-destructed address still carries
+// the account fields Normalize is required to drop. Any of them makes Apply
+// compute pureDelete=false and take the cleanup-before-recreate branch, which
+// writes the account back with a live incarnation instead of deleting it — a
+// phantom account that breaks a later CREATE2 at the same address. Balance
+// (retained under EIP-8246) and the storage-delete cascade are legal.
+func (s *WriteSet) assertSelfDestructNormalized() {
+	for addr, sdw := range s.selfDestruct {
+		if !sdw.Val {
+			continue
+		}
+		var field string
+		switch {
+		case s.nonce[addr] != nil:
+			field = "nonce"
+		case s.incarnation[addr] != nil:
+			field = "incarnation"
+		case s.codeHash[addr] != nil:
+			field = "codeHash"
+		default:
+			continue
+		}
+		panic(fmt.Sprintf("write set not normalized: self-destructed %x keeps its %s write", addr.Value(), field))
+	}
+}
+
 func (s *WriteSet) DeleteAccountFields(addr accounts.Address) {
 	delete(s.balance, addr)
 	delete(s.nonce, addr)

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -57,6 +57,9 @@ import (
 // isn't silent.
 var codePathRecoveryHashMismatch = metrics.GetOrCreateCounter("exec3_codepath_recovery_hash_mismatch")
 
+// Bit i of the addrFields mask below corresponds to normalizeAccountPaths[i].
+var normalizeAccountPaths = [4]AccountPath{BalancePath, NoncePath, IncarnationPath, CodeHashPath}
+
 func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, stateReader StateReader, domainStorageKeys func(addr accounts.Address) []accounts.StorageKey, emptyRemoval bool, isAura bool, eip8246 bool) (*WriteSet, error) {
 	filtered := &WriteSet{}
 	if writes == nil {
@@ -112,39 +115,35 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	//      already uses last-write-wins for d.selfDestruct, so this keeps the two
 	//      in agreement. (EIP-6780 narrows this pattern post-Cancun but doesn't
 	//      eliminate it; mainnet-rare, but cheap to get right.)
-	sdSet := make(map[accounts.Address]bool)
-	for addr, vw := range writes.SelfDestructs() {
+	// A nil sdSet reads as all-false; allocated only when the tx self-destructed.
+	var sdSet map[accounts.Address]bool
+	for addr, vw := range writes.selfDestruct {
 		if vw.Version.Incarnation == incarnation && vw.Val {
+			if sdSet == nil {
+				sdSet = make(map[accounts.Address]bool)
+			}
 			sdSet[addr] = true
 		}
 	}
 
-	for h := range writes.AllHeaders() {
-		// Drop account-field writes for SD'd addresses so applyVersionedWrites
-		// takes the pure-delete branch instead of cleanup-before-recreate; drop
-		// raw StoragePath writes too (the SelfDestructPath case re-emits an
-		// explicit StoragePath=0 delete for every slot via sdStorageSlots).
-		if sdSet[h.Address] {
-			switch h.Path {
-			case NoncePath, IncarnationPath, CodeHashPath, CodePath, StoragePath:
-				continue
-			case BalancePath:
-				// EIP-8246 keeps the post-SD balance so the calculator can
-				// preserve a balance-only account (or delete it when zero);
-				// pre-8246 drops it so the account is purely deleted.
-				if !eip8246 {
-					continue
-				}
-			}
+	// The filter walks the typed maps directly rather than AllHeaders(): every
+	// range-over-func pass allocates its iterator closures, and the header walk
+	// would need a second per-value map probe anyway. Per-entry decisions are
+	// order-independent, so per-path loops are equivalent.
+	//
+	// SD'd addresses drop their account-field/storage writes so
+	// applyVersionedWrites takes the pure-delete branch instead of
+	// cleanup-before-recreate; the SelfDestructPath case re-emits an explicit
+	// StoragePath=0 delete for every slot via sdStorageSlots. EIP-8246 keeps
+	// the post-SD balance so the calculator can preserve a balance-only
+	// account; pre-8246 drops it so the account is purely deleted.
+	for addr, inner := range writes.storage {
+		if sdSet[addr] {
+			continue
 		}
-		switch h.Path {
-		case StoragePath:
+		for key, sw := range inner {
 			// Only include writes from the current (validated) incarnation.
-			if h.Version.Incarnation != incarnation {
-				continue
-			}
-			sw, ok := writes.GetStorage(h.Address, h.Key)
-			if !ok {
+			if sw.Version.Incarnation != incarnation {
 				continue
 			}
 			writeVal := sw.Val
@@ -157,13 +156,13 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			// that re-writes a slot to its pre-SD value is wrongly dropped as a
 			// no-op (TestDeleteRecreateSlotsAcrossManyBlocks).
 			sdTxIdx, sdOk := -1, false
-			if v, sd, _ := vm.ReadSelfDestruct(h.Address, txIndex); sd.Status() == MVReadResultDone && v {
+			if v, sd, _ := vm.ReadSelfDestruct(addr, txIndex); sd.Status() == MVReadResultDone && v {
 				sdTxIdx, sdOk = sd.Version().TxIndex, true
 			}
 			// No-op filter: compare against origin (what this TX would have read).
 			// First check versionMap floor (prior TX's write in this block).
 			// Then fall back to stateReader (pre-block value from domain).
-			originVal, origin, originOK := vm.ReadStorage(h.Address, h.Key, txIndex)
+			originVal, origin, originOK := vm.ReadStorage(addr, key, txIndex)
 			originValid := originOK && origin.Status() == MVReadResultDone &&
 				!(sdOk && sdTxIdx > origin.Version().TxIndex)
 			if originValid {
@@ -183,12 +182,12 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 				// misses it. Narrower than an IncarnationPath probe: pure
 				// CREATE (no prior SD=true) doesn't wipe pre-existing storage,
 				// so its same-value SSTOREs still no-op against pre-block.
-				if vm.AnyDoneSelfDestructEquals(h.Address, txIndex-1, true) {
+				if vm.AnyDoneSelfDestructEquals(addr, txIndex-1, true) {
 					if writeVal.IsZero() {
 						continue
 					}
 				} else {
-					preVal, found, err := stateReader.ReadAccountStorage(h.Address, h.Key)
+					preVal, found, err := stateReader.ReadAccountStorage(addr, key)
 					if err != nil {
 						return nil, err
 					}
@@ -200,74 +199,80 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 					}
 				}
 			}
-			filtered.SetStorage(h.Address, h.Key, sw)
-		case BalancePath, NoncePath, IncarnationPath, CodeHashPath:
-			// Account fields: prefer the versionMap's accumulated value; fall
-			// back to the raw write when the map has none.
-			if !SetAccountFieldFromMap(filtered, vm, h.Address, h.Path, h.Version, txIndex+1) {
-				switch h.Path {
-				case BalancePath:
-					if vw, ok := writes.GetBalance(h.Address); ok {
-						filtered.SetBalance(h.Address, vw)
-					}
-				case NoncePath:
-					if vw, ok := writes.GetNonce(h.Address); ok {
-						filtered.SetNonce(h.Address, vw)
-					}
-				case IncarnationPath:
-					if vw, ok := writes.GetIncarnation(h.Address); ok {
-						filtered.SetIncarnation(h.Address, vw)
-					}
-				case CodeHashPath:
-					if vw, ok := writes.GetCodeHash(h.Address); ok {
-						filtered.SetCodeHash(h.Address, vw)
-					}
-				}
-			}
-		case CodePath:
-			if h.Version.Incarnation != incarnation {
-				continue
-			}
-			if vw, ok := writes.GetCode(h.Address); ok {
-				filtered.SetCode(h.Address, vw)
-			}
-		case CreateContractPath:
-			if h.Version.Incarnation != incarnation {
-				continue
-			}
-			if vw, ok := writes.GetCreateContract(h.Address); ok {
-				filtered.SetCreateContract(h.Address, vw)
-			}
-		case SelfDestructPath:
-			if h.Version.Incarnation != incarnation {
-				continue
-			}
-			// Only emit storage DELETE entries when the account was actually
-			// self-destructed (val=true).
-			sdw, ok := writes.GetSelfDestruct(h.Address)
-			if !ok || !sdw.Val {
-				continue
-			}
-			filtered.SetSelfDestruct(h.Address, sdw)
-			for _, slot := range sdStorageSlots(h.Address) {
-				filtered.SetStorage(h.Address, slot, &VersionedWrite[uint256.Int]{
-					WriteHeader: WriteHeader{
-						Address: h.Address,
-						Path:    StoragePath,
-						Key:     slot,
-						Version: h.Version,
-					},
-				})
-			}
-		case AddressPath:
-			// AddressPath is record-level — skip for field-level consumers.
-		case CodeSizePath:
-			// Code size is derived from the code bytes and isn't a domain field,
-			// so it's intentionally not carried into the calc/apply write set (as
-			// on serial). Cross-tx ReadCodeSize is served from the versionMap,
-			// which the worker populates directly — independent of this pass.
+			filtered.SetStorage(addr, key, sw)
 		}
 	}
+	// Account fields: prefer the versionMap's accumulated value; fall back to
+	// the raw write when the map has none.
+	for addr, vw := range writes.balance {
+		if sdSet[addr] && !eip8246 {
+			continue
+		}
+		if !SetAccountFieldFromMap(filtered, vm, addr, BalancePath, vw.Version, txIndex+1) {
+			filtered.SetBalance(addr, vw)
+		}
+	}
+	for addr, vw := range writes.nonce {
+		if sdSet[addr] {
+			continue
+		}
+		if !SetAccountFieldFromMap(filtered, vm, addr, NoncePath, vw.Version, txIndex+1) {
+			filtered.SetNonce(addr, vw)
+		}
+	}
+	for addr, vw := range writes.incarnation {
+		if sdSet[addr] {
+			continue
+		}
+		if !SetAccountFieldFromMap(filtered, vm, addr, IncarnationPath, vw.Version, txIndex+1) {
+			filtered.SetIncarnation(addr, vw)
+		}
+	}
+	for addr, vw := range writes.codeHash {
+		if sdSet[addr] {
+			continue
+		}
+		if !SetAccountFieldFromMap(filtered, vm, addr, CodeHashPath, vw.Version, txIndex+1) {
+			filtered.SetCodeHash(addr, vw)
+		}
+	}
+	for addr, vw := range writes.code {
+		if sdSet[addr] || vw.Version.Incarnation != incarnation {
+			continue
+		}
+		filtered.SetCode(addr, vw)
+	}
+	for addr, vw := range writes.createContract {
+		if vw.Version.Incarnation != incarnation {
+			continue
+		}
+		filtered.SetCreateContract(addr, vw)
+	}
+	for addr, sdw := range writes.selfDestruct {
+		if sdw.Version.Incarnation != incarnation {
+			continue
+		}
+		// Only emit storage DELETE entries when the account was actually
+		// self-destructed (val=true).
+		if !sdw.Val {
+			continue
+		}
+		filtered.SetSelfDestruct(addr, sdw)
+		for _, slot := range sdStorageSlots(addr) {
+			filtered.SetStorage(addr, slot, &VersionedWrite[uint256.Int]{
+				WriteHeader: WriteHeader{
+					Address: addr,
+					Path:    StoragePath,
+					Key:     slot,
+					Version: sdw.Version,
+				},
+			})
+		}
+	}
+	// AddressPath is record-level and CodeSizePath is derived from the code
+	// bytes — neither is carried into the calc/apply write set (as on serial).
+	// Cross-tx ReadCodeSize is served from the versionMap, which the worker
+	// populates directly — independent of this pass.
 
 	// For addresses that appear in the raw WriteSet but don't have account-level
 	// writes in the output, emit account field entries. Serial's MakeWriteSet
@@ -277,24 +282,51 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	// - Addresses whose storage writes were all filtered as no-ops
 	//   (the object was still dirty in the IBS)
 	//
-	// Collect all addresses from the raw input (before filtering).
+	// Collect all addresses from the raw input (before filtering). AddressPath
+	// entries are record-level and intentionally excluded.
 	allAddresses := make(map[accounts.Address]bool)
-	for h := range writes.AllHeaders() {
-		if h.Path != AddressPath {
-			allAddresses[h.Address] = true
-		}
+	for addr := range writes.balance {
+		allAddresses[addr] = true
+	}
+	for addr := range writes.nonce {
+		allAddresses[addr] = true
+	}
+	for addr := range writes.incarnation {
+		allAddresses[addr] = true
+	}
+	for addr := range writes.selfDestruct {
+		allAddresses[addr] = true
+	}
+	for addr := range writes.createContract {
+		allAddresses[addr] = true
+	}
+	for addr := range writes.code {
+		allAddresses[addr] = true
+	}
+	for addr := range writes.codeHash {
+		allAddresses[addr] = true
+	}
+	for addr := range writes.codeSize {
+		allAddresses[addr] = true
+	}
+	for addr := range writes.storage {
+		allAddresses[addr] = true
 	}
 
-	// Track which fields each address already has in the output.
-	addrFields := make(map[accounts.Address]map[AccountPath]bool)
-	for h := range filtered.AllHeaders() {
-		switch h.Path {
-		case BalancePath, NoncePath, IncarnationPath, CodeHashPath:
-			if addrFields[h.Address] == nil {
-				addrFields[h.Address] = make(map[AccountPath]bool)
-			}
-			addrFields[h.Address][h.Path] = true
-		}
+	// Track which fields each address already has in the output, as a bitmask
+	// indexed like normalizeAccountPaths.
+	addrFields := make(map[accounts.Address]uint8)
+	for addr := range filtered.balance {
+		addrFields[addr] |= 1 << 0
+	}
+	for addr := range filtered.nonce {
+		addrFields[addr] |= 1 << 1
+	}
+	for addr := range filtered.incarnation {
+		addrFields[addr] |= 1 << 2
+	}
+	for addr := range filtered.codeHash {
+		addrFields[addr] |= 1 << 3
 	}
 
 	for addr := range allAddresses {
@@ -344,8 +376,8 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		fallbackLoaded := false
 
 		// For each missing field, try versionMap then stateReader.
-		for _, path := range []AccountPath{BalancePath, NoncePath, IncarnationPath, CodeHashPath} {
-			if fields != nil && fields[path] {
+		for i, path := range normalizeAccountPaths {
+			if fields&(1<<i) != 0 {
 				continue // already in output
 			}
 			if sdEarlier && hasCreateContract {
@@ -380,16 +412,12 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	// (versionMap, else stateReader post-state) and re-emit CodePath, bounded to
 	// 7702 designators so unchanged contract code isn't re-emitted. Forward-only:
 	// it can't repair codeHash-no-code already collated into snapshots.
-	codeInOutput := make(map[accounts.Address]bool)
-	for addr := range filtered.Codes() {
-		codeInOutput[addr] = true
-	}
-	codeHashInOutput := make(map[accounts.Address]accounts.CodeHash)
-	for addr, vw := range filtered.CodeHashes() {
-		codeHashInOutput[addr] = vw.Val
-	}
-	for addr, h := range codeHashInOutput {
-		if h.IsEmpty() || codeInOutput[addr] || sdSet[addr] {
+	for addr, hvw := range filtered.codeHash {
+		h := hvw.Val
+		if h.IsEmpty() || sdSet[addr] {
+			continue
+		}
+		if _, ok := filtered.code[addr]; ok {
 			continue
 		}
 		// Recover the code whose hash this tx emitted. Prefer the versionMap
@@ -458,29 +486,24 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		hasNonce bool
 		hasCode  bool
 	}
-	acctStates := make(map[accounts.Address]*acctState)
-	ensureAcctState := func(addr accounts.Address) *acctState {
+	acctStates := make(map[accounts.Address]acctState, len(filtered.balance))
+	for addr, vw := range filtered.balance {
 		s := acctStates[addr]
-		if s == nil {
-			s = &acctState{}
-			acctStates[addr] = s
-		}
-		return s
-	}
-	for addr, vw := range filtered.Balances() {
-		s := ensureAcctState(addr)
 		s.balance = vw.Val
 		s.hasBal = true
+		acctStates[addr] = s
 	}
-	for addr, vw := range filtered.Nonces() {
-		s := ensureAcctState(addr)
+	for addr, vw := range filtered.nonce {
+		s := acctStates[addr]
 		s.nonce = vw.Val
 		s.hasNonce = true
+		acctStates[addr] = s
 	}
-	for addr, vw := range filtered.CodeHashes() {
-		s := ensureAcctState(addr)
+	for addr, vw := range filtered.codeHash {
+		s := acctStates[addr]
 		s.codeHash = vw.Val
 		s.hasCode = true
+		acctStates[addr] = s
 	}
 
 	// Check for empty accounts and replace with Delete. Only when EIP-161
@@ -488,16 +511,16 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	// merely touched (e.g. a 0-value transfer) is created and persists, so
 	// converting it to a delete here would diverge from serial's trie root
 	// (TestEIP161AccountRemoval block 1, pre-SpuriousDragon).
-	emptyAddrs := make(map[accounts.Address]bool)
+	var emptyAddrs []accounts.Address
 	for addr, s := range acctStates {
 		if EIP161EmptyRemoval(emptyRemoval, isAura, addr) &&
 			s.hasBal && s.hasNonce && s.hasCode &&
 			s.balance.IsZero() && s.nonce == 0 && s.codeHash.IsEmpty() {
-			emptyAddrs[addr] = true
+			emptyAddrs = append(emptyAddrs, addr)
 		}
 	}
 
-	for addr := range emptyAddrs {
+	for _, addr := range emptyAddrs {
 		filtered.DeleteAccountFields(addr)
 		filtered.SetSelfDestruct(addr, &VersionedWrite[bool]{
 			WriteHeader: WriteHeader{

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -25,6 +25,14 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
+// codePathRecoveryHashMismatch counts BAL codePath recoveries skipped because
+// the recovered bytes didn't hash to the emitted codeHash; surfaced so the skip
+// isn't silent.
+var codePathRecoveryHashMismatch = metrics.GetOrCreateCounter("exec3_codepath_recovery_hash_mismatch")
+
+// The account fields Normalize fills in when a dirty address lacks them.
+var normalizeAccountPaths = [4]AccountPath{BalancePath, NoncePath, IncarnationPath, CodeHashPath}
+
 // Normalize produces a clean write set from the versionMap's WriteSet
 // for a given TX. It matches the serial IBS MakeWriteSet behaviour:
 //
@@ -52,14 +60,6 @@ import (
 // from the trie (wrong root in TestDeleteRecreateAccount / TestSelfDestructReceive
 // / TestEIP161AccountRemoval, all of which SD a contract whose storage predates
 // the block). Pass nil in unit tests that don't exercise pre-block storage.
-// codePathRecoveryHashMismatch counts BAL codePath recoveries skipped because
-// the recovered bytes didn't hash to the emitted codeHash; surfaced so the skip
-// isn't silent.
-var codePathRecoveryHashMismatch = metrics.GetOrCreateCounter("exec3_codepath_recovery_hash_mismatch")
-
-// The account fields Normalize fills in when a dirty address lacks them.
-var normalizeAccountPaths = [4]AccountPath{BalancePath, NoncePath, IncarnationPath, CodeHashPath}
-
 func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, stateReader StateReader, domainStorageKeys func(addr accounts.Address) []accounts.StorageKey, emptyRemoval bool, isAura bool, eip8246 bool) (*WriteSet, error) {
 	filtered := &WriteSet{}
 	if writes == nil {

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -57,7 +57,7 @@ import (
 // isn't silent.
 var codePathRecoveryHashMismatch = metrics.GetOrCreateCounter("exec3_codepath_recovery_hash_mismatch")
 
-// Bit i of the addrFields mask below corresponds to normalizeAccountPaths[i].
+// The account fields Normalize fills in when a dirty address lacks them.
 var normalizeAccountPaths = [4]AccountPath{BalancePath, NoncePath, IncarnationPath, CodeHashPath}
 
 func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, stateReader StateReader, domainStorageKeys func(addr accounts.Address) []accounts.StorageKey, emptyRemoval bool, isAura bool, eip8246 bool) (*WriteSet, error) {
@@ -285,49 +285,7 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	// Collect all addresses from the raw input (before filtering). AddressPath
 	// entries are record-level and intentionally excluded.
 	allAddresses := make(map[accounts.Address]bool)
-	for addr := range writes.balance {
-		allAddresses[addr] = true
-	}
-	for addr := range writes.nonce {
-		allAddresses[addr] = true
-	}
-	for addr := range writes.incarnation {
-		allAddresses[addr] = true
-	}
-	for addr := range writes.selfDestruct {
-		allAddresses[addr] = true
-	}
-	for addr := range writes.createContract {
-		allAddresses[addr] = true
-	}
-	for addr := range writes.code {
-		allAddresses[addr] = true
-	}
-	for addr := range writes.codeHash {
-		allAddresses[addr] = true
-	}
-	for addr := range writes.codeSize {
-		allAddresses[addr] = true
-	}
-	for addr := range writes.storage {
-		allAddresses[addr] = true
-	}
-
-	// Track which fields each address already has in the output, as a bitmask
-	// indexed like normalizeAccountPaths.
-	addrFields := make(map[accounts.Address]uint8)
-	for addr := range filtered.balance {
-		addrFields[addr] |= 1 << 0
-	}
-	for addr := range filtered.nonce {
-		addrFields[addr] |= 1 << 1
-	}
-	for addr := range filtered.incarnation {
-		addrFields[addr] |= 1 << 2
-	}
-	for addr := range filtered.codeHash {
-		addrFields[addr] |= 1 << 3
-	}
+	writes.forEachFieldAddr(func(addr accounts.Address) { allAddresses[addr] = true })
 
 	for addr := range allAddresses {
 		if sdSet[addr] {
@@ -340,7 +298,6 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			continue
 		}
 		ver := Version{TxIndex: txIndex, Incarnation: incarnation}
-		fields := addrFields[addr]
 
 		// If addr was self-destructed by an earlier TX in this block and this
 		// TX re-creates it (it isn't in sdSet — this TX didn't re-destruct it),
@@ -376,8 +333,8 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		fallbackLoaded := false
 
 		// For each missing field, try versionMap then stateReader.
-		for i, path := range normalizeAccountPaths {
-			if fields&(1<<i) != 0 {
+		for _, path := range normalizeAccountPaths {
+			if filtered.Has(WriteHeader{Address: addr, Path: path}) {
 				continue // already in output
 			}
 			if sdEarlier && hasCreateContract {

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -30,9 +30,6 @@ import (
 // isn't silent.
 var codePathRecoveryHashMismatch = metrics.GetOrCreateCounter("exec3_codepath_recovery_hash_mismatch")
 
-// The account fields Normalize fills in when a dirty address lacks them.
-var normalizeAccountPaths = [4]AccountPath{BalancePath, NoncePath, IncarnationPath, CodeHashPath}
-
 // Normalize produces a clean write set from the versionMap's WriteSet
 // for a given TX. It matches the serial IBS MakeWriteSet behaviour:
 //
@@ -331,7 +328,7 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		fallbackLoaded := false
 
 		// For each missing field, try versionMap then stateReader.
-		for _, path := range normalizeAccountPaths {
+		for _, path := range []AccountPath{BalancePath, NoncePath, IncarnationPath, CodeHashPath} {
 			if filtered.Has(WriteHeader{Address: addr, Path: path}) {
 				continue // already in output
 			}

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -115,7 +115,6 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	//      already uses last-write-wins for d.selfDestruct, so this keeps the two
 	//      in agreement. (EIP-6780 narrows this pattern post-Cancun but doesn't
 	//      eliminate it; mainnet-rare, but cheap to get right.)
-	// A nil sdSet reads as all-false; allocated only when the tx self-destructed.
 	var sdSet map[accounts.Address]bool
 	for addr, vw := range writes.selfDestruct {
 		if vw.Version.Incarnation == incarnation && vw.Val {
@@ -126,10 +125,11 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		}
 	}
 
-	// The filter walks the typed maps directly rather than AllHeaders(): every
-	// range-over-func pass allocates its iterator closures, and the header walk
-	// would need a second per-value map probe anyway. Per-entry decisions are
-	// order-independent, so per-path loops are equivalent.
+	// Per-entry decisions are order-independent, so the per-path loops below are
+	// equivalent to one pass over the merged header stream. There is no loop for
+	// AddressPath (record-level) or CodeSizePath (derived from the code bytes,
+	// not a domain field): neither is carried into the calc/apply write set, as
+	// on serial.
 	//
 	// SD'd addresses drop their account-field/storage writes so
 	// applyVersionedWrites takes the pure-delete branch instead of
@@ -269,11 +269,6 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			})
 		}
 	}
-	// AddressPath is record-level and CodeSizePath is derived from the code
-	// bytes — neither is carried into the calc/apply write set (as on serial).
-	// Cross-tx ReadCodeSize is served from the versionMap, which the worker
-	// populates directly — independent of this pass.
-
 	// For addresses that appear in the raw WriteSet but don't have account-level
 	// writes in the output, emit account field entries. Serial's MakeWriteSet
 	// always calls UpdateAccountData for every dirty object — the commitment
@@ -281,9 +276,6 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	// - Addresses with only storage writes (no balance/nonce changes)
 	// - Addresses whose storage writes were all filtered as no-ops
 	//   (the object was still dirty in the IBS)
-	//
-	// Collect all addresses from the raw input (before filtering). AddressPath
-	// entries are record-level and intentionally excluded.
 	allAddresses := make(map[accounts.Address]bool)
 	writes.forEachFieldAddr(func(addr accounts.Address) { allAddresses[addr] = true })
 

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -125,25 +125,32 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		}
 	}
 
-	// Per-entry decisions are order-independent, so the per-path loops below are
-	// equivalent to one pass over the merged header stream. There is no loop for
-	// AddressPath (record-level) or CodeSizePath (derived from the code bytes,
-	// not a domain field): neither is carried into the calc/apply write set, as
-	// on serial.
-	//
-	// SD'd addresses drop their account-field/storage writes so
-	// applyVersionedWrites takes the pure-delete branch instead of
-	// cleanup-before-recreate; the SelfDestructPath case re-emits an explicit
-	// StoragePath=0 delete for every slot via sdStorageSlots. EIP-8246 keeps
-	// the post-SD balance so the calculator can preserve a balance-only
-	// account; pre-8246 drops it so the account is purely deleted.
-	for addr, inner := range writes.storage {
-		if sdSet[addr] {
-			continue
+	for h := range writes.AllHeaders() {
+		// Drop account-field writes for SD'd addresses so applyVersionedWrites
+		// takes the pure-delete branch instead of cleanup-before-recreate; drop
+		// raw StoragePath writes too (the SelfDestructPath case re-emits an
+		// explicit StoragePath=0 delete for every slot via sdStorageSlots).
+		if sdSet[h.Address] {
+			switch h.Path {
+			case NoncePath, IncarnationPath, CodeHashPath, CodePath, StoragePath:
+				continue
+			case BalancePath:
+				// EIP-8246 keeps the post-SD balance so the calculator can
+				// preserve a balance-only account (or delete it when zero);
+				// pre-8246 drops it so the account is purely deleted.
+				if !eip8246 {
+					continue
+				}
+			}
 		}
-		for key, sw := range inner {
+		switch h.Path {
+		case StoragePath:
 			// Only include writes from the current (validated) incarnation.
-			if sw.Version.Incarnation != incarnation {
+			if h.Version.Incarnation != incarnation {
+				continue
+			}
+			sw, ok := writes.GetStorage(h.Address, h.Key)
+			if !ok {
 				continue
 			}
 			writeVal := sw.Val
@@ -156,13 +163,13 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			// that re-writes a slot to its pre-SD value is wrongly dropped as a
 			// no-op (TestDeleteRecreateSlotsAcrossManyBlocks).
 			sdTxIdx, sdOk := -1, false
-			if v, sd, _ := vm.ReadSelfDestruct(addr, txIndex); sd.Status() == MVReadResultDone && v {
+			if v, sd, _ := vm.ReadSelfDestruct(h.Address, txIndex); sd.Status() == MVReadResultDone && v {
 				sdTxIdx, sdOk = sd.Version().TxIndex, true
 			}
 			// No-op filter: compare against origin (what this TX would have read).
 			// First check versionMap floor (prior TX's write in this block).
 			// Then fall back to stateReader (pre-block value from domain).
-			originVal, origin, originOK := vm.ReadStorage(addr, key, txIndex)
+			originVal, origin, originOK := vm.ReadStorage(h.Address, h.Key, txIndex)
 			originValid := originOK && origin.Status() == MVReadResultDone &&
 				!(sdOk && sdTxIdx > origin.Version().TxIndex)
 			if originValid {
@@ -182,12 +189,12 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 				// misses it. Narrower than an IncarnationPath probe: pure
 				// CREATE (no prior SD=true) doesn't wipe pre-existing storage,
 				// so its same-value SSTOREs still no-op against pre-block.
-				if vm.AnyDoneSelfDestructEquals(addr, txIndex-1, true) {
+				if vm.AnyDoneSelfDestructEquals(h.Address, txIndex-1, true) {
 					if writeVal.IsZero() {
 						continue
 					}
 				} else {
-					preVal, found, err := stateReader.ReadAccountStorage(addr, key)
+					preVal, found, err := stateReader.ReadAccountStorage(h.Address, h.Key)
 					if err != nil {
 						return nil, err
 					}
@@ -199,76 +206,75 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 					}
 				}
 			}
-			filtered.SetStorage(addr, key, sw)
+			filtered.SetStorage(h.Address, h.Key, sw)
+		case BalancePath, NoncePath, IncarnationPath, CodeHashPath:
+			// Account fields: prefer the versionMap's accumulated value; fall
+			// back to the raw write when the map has none.
+			if !SetAccountFieldFromMap(filtered, vm, h.Address, h.Path, h.Version, txIndex+1) {
+				switch h.Path {
+				case BalancePath:
+					if vw, ok := writes.GetBalance(h.Address); ok {
+						filtered.SetBalance(h.Address, vw)
+					}
+				case NoncePath:
+					if vw, ok := writes.GetNonce(h.Address); ok {
+						filtered.SetNonce(h.Address, vw)
+					}
+				case IncarnationPath:
+					if vw, ok := writes.GetIncarnation(h.Address); ok {
+						filtered.SetIncarnation(h.Address, vw)
+					}
+				case CodeHashPath:
+					if vw, ok := writes.GetCodeHash(h.Address); ok {
+						filtered.SetCodeHash(h.Address, vw)
+					}
+				}
+			}
+		case CodePath:
+			if h.Version.Incarnation != incarnation {
+				continue
+			}
+			if vw, ok := writes.GetCode(h.Address); ok {
+				filtered.SetCode(h.Address, vw)
+			}
+		case CreateContractPath:
+			if h.Version.Incarnation != incarnation {
+				continue
+			}
+			if vw, ok := writes.GetCreateContract(h.Address); ok {
+				filtered.SetCreateContract(h.Address, vw)
+			}
+		case SelfDestructPath:
+			if h.Version.Incarnation != incarnation {
+				continue
+			}
+			// Only emit storage DELETE entries when the account was actually
+			// self-destructed (val=true).
+			sdw, ok := writes.GetSelfDestruct(h.Address)
+			if !ok || !sdw.Val {
+				continue
+			}
+			filtered.SetSelfDestruct(h.Address, sdw)
+			for _, slot := range sdStorageSlots(h.Address) {
+				filtered.SetStorage(h.Address, slot, &VersionedWrite[uint256.Int]{
+					WriteHeader: WriteHeader{
+						Address: h.Address,
+						Path:    StoragePath,
+						Key:     slot,
+						Version: h.Version,
+					},
+				})
+			}
+		case AddressPath:
+			// AddressPath is record-level — skip for field-level consumers.
+		case CodeSizePath:
+			// Code size is derived from the code bytes and isn't a domain field,
+			// so it's intentionally not carried into the calc/apply write set (as
+			// on serial). Cross-tx ReadCodeSize is served from the versionMap,
+			// which the worker populates directly — independent of this pass.
 		}
 	}
-	// Account fields: prefer the versionMap's accumulated value; fall back to
-	// the raw write when the map has none.
-	for addr, vw := range writes.balance {
-		if sdSet[addr] && !eip8246 {
-			continue
-		}
-		if !SetAccountFieldFromMap(filtered, vm, addr, BalancePath, vw.Version, txIndex+1) {
-			filtered.SetBalance(addr, vw)
-		}
-	}
-	for addr, vw := range writes.nonce {
-		if sdSet[addr] {
-			continue
-		}
-		if !SetAccountFieldFromMap(filtered, vm, addr, NoncePath, vw.Version, txIndex+1) {
-			filtered.SetNonce(addr, vw)
-		}
-	}
-	for addr, vw := range writes.incarnation {
-		if sdSet[addr] {
-			continue
-		}
-		if !SetAccountFieldFromMap(filtered, vm, addr, IncarnationPath, vw.Version, txIndex+1) {
-			filtered.SetIncarnation(addr, vw)
-		}
-	}
-	for addr, vw := range writes.codeHash {
-		if sdSet[addr] {
-			continue
-		}
-		if !SetAccountFieldFromMap(filtered, vm, addr, CodeHashPath, vw.Version, txIndex+1) {
-			filtered.SetCodeHash(addr, vw)
-		}
-	}
-	for addr, vw := range writes.code {
-		if sdSet[addr] || vw.Version.Incarnation != incarnation {
-			continue
-		}
-		filtered.SetCode(addr, vw)
-	}
-	for addr, vw := range writes.createContract {
-		if vw.Version.Incarnation != incarnation {
-			continue
-		}
-		filtered.SetCreateContract(addr, vw)
-	}
-	for addr, sdw := range writes.selfDestruct {
-		if sdw.Version.Incarnation != incarnation {
-			continue
-		}
-		// Only emit storage DELETE entries when the account was actually
-		// self-destructed (val=true).
-		if !sdw.Val {
-			continue
-		}
-		filtered.SetSelfDestruct(addr, sdw)
-		for _, slot := range sdStorageSlots(addr) {
-			filtered.SetStorage(addr, slot, &VersionedWrite[uint256.Int]{
-				WriteHeader: WriteHeader{
-					Address: addr,
-					Path:    StoragePath,
-					Key:     slot,
-					Version: sdw.Version,
-				},
-			})
-		}
-	}
+
 	// For addresses that appear in the raw WriteSet but don't have account-level
 	// writes in the output, emit account field entries. Serial's MakeWriteSet
 	// always calls UpdateAccountData for every dirty object — the commitment

--- a/execution/state/writeset_normalize_bench_test.go
+++ b/execution/state/writeset_normalize_bench_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+func benchAddr(i int) accounts.Address {
+	return accounts.InternAddress([20]byte{byte(i >> 8), byte(i)})
+}
+
+func benchKey(i int) accounts.StorageKey {
+	return accounts.InternKey([32]byte{byte(i >> 8), byte(i)})
+}
+
+// buildNormalizeInput models a typical tx write set: addrs accounts with
+// balance+nonce writes, each with slots storage writes, plus a few
+// storage-only addresses (they exercise the account-field fill loop).
+func buildNormalizeInput(addrs, slots int) *WriteSet {
+	ws := &WriteSet{}
+	ver := Version{TxIndex: 0, Incarnation: 0}
+	for i := range addrs {
+		a := benchAddr(i)
+		ws.SetBalance(a, &VersionedWrite[uint256.Int]{
+			WriteHeader: WriteHeader{Address: a, Path: BalancePath, Version: ver},
+			Val:         *uint256.NewInt(uint64(i + 1)),
+		})
+		ws.SetNonce(a, &VersionedWrite[uint64]{
+			WriteHeader: WriteHeader{Address: a, Path: NoncePath, Version: ver},
+			Val:         uint64(i + 1),
+		})
+		for s := range slots {
+			k := benchKey(s)
+			ws.SetStorage(a, k, &VersionedWrite[uint256.Int]{
+				WriteHeader: WriteHeader{Address: a, Path: StoragePath, Key: k, Version: ver},
+				Val:         *uint256.NewInt(uint64(s + 1)),
+			})
+		}
+	}
+	for i := range 2 {
+		a := benchAddr(addrs + i)
+		k := benchKey(i)
+		ws.SetStorage(a, k, &VersionedWrite[uint256.Int]{
+			WriteHeader: WriteHeader{Address: a, Path: StoragePath, Key: k, Version: ver},
+			Val:         *uint256.NewInt(7),
+		})
+	}
+	return ws
+}
+
+func BenchmarkWriteSetNormalize(b *testing.B) {
+	for _, size := range []struct{ addrs, slots int }{{4, 2}, {16, 8}} {
+		b.Run(fmt.Sprintf("addrs=%d/slots=%d", size.addrs, size.slots), func(b *testing.B) {
+			ws := buildNormalizeInput(size.addrs, size.slots)
+			vm := NewVersionMap(nil)
+			vm.FlushVersionedWrites(ws, true, "")
+			reader := &minimalStateReader{}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := ws.Normalize(vm, 0, 0, reader, nil, true, false, false)
+				if err != nil {
+					b.Fatal(err)
+				}
+				sinkNormalized = out
+			}
+		})
+	}
+}
+
+var sinkNormalized *WriteSet

--- a/execution/state/writeset_normalize_bench_test.go
+++ b/execution/state/writeset_normalize_bench_test.go
@@ -33,12 +33,25 @@ func benchKey(i int) accounts.StorageKey {
 	return accounts.InternKey([32]byte{byte(i >> 8), byte(i)})
 }
 
-// buildNormalizeInput models a typical tx write set: addrs accounts with
-// balance+nonce writes, each with slots storage writes, plus a few
-// storage-only addresses (they exercise the account-field fill loop).
-func buildNormalizeInput(addrs, slots int) *WriteSet {
+func countStorage(ws *WriteSet) (n int) {
+	for _, inner := range ws.storage {
+		n += len(inner)
+	}
+	return n
+}
+
+// benchStorageVal is the value a slot holds after the prior tx; a write-back of
+// the same value is what the no-op filter must drop.
+func benchStorageVal(slot int) uint256.Int { return *uint256.NewInt(uint64(slot + 1)) }
+
+// buildNormalizeInput builds one tx's write set at txIndex: addrs accounts with
+// balance+nonce writes and slots storage writes each, half of them written back
+// unchanged so the no-op filter has something to drop, plus contract code on
+// every third account and two storage-only addresses that miss all four account
+// fields and so exercise the fill loop.
+func buildNormalizeInput(addrs, slots, txIndex int) *WriteSet {
 	ws := &WriteSet{}
-	ver := Version{TxIndex: 0, Incarnation: 0}
+	ver := Version{TxIndex: txIndex, Incarnation: 0}
 	for i := range addrs {
 		a := benchAddr(i)
 		ws.SetBalance(a, &VersionedWrite[uint256.Int]{
@@ -49,11 +62,26 @@ func buildNormalizeInput(addrs, slots int) *WriteSet {
 			WriteHeader: WriteHeader{Address: a, Path: NoncePath, Version: ver},
 			Val:         uint64(i + 1),
 		})
+		if i%3 == 0 {
+			code := accounts.NewCode([]byte{0x60, byte(i), 0x60, 0x00, 0x55})
+			ws.SetCode(a, &VersionedWrite[accounts.Code]{
+				WriteHeader: WriteHeader{Address: a, Path: CodePath, Version: ver},
+				Val:         code,
+			})
+			ws.SetCodeHash(a, &VersionedWrite[accounts.CodeHash]{
+				WriteHeader: WriteHeader{Address: a, Path: CodeHashPath, Version: ver},
+				Val:         code.Hash,
+			})
+		}
 		for s := range slots {
 			k := benchKey(s)
+			val := benchStorageVal(s)
+			if s%2 == 1 {
+				val = *uint256.NewInt(uint64(s + 1000)) // changed: survives the filter
+			}
 			ws.SetStorage(a, k, &VersionedWrite[uint256.Int]{
 				WriteHeader: WriteHeader{Address: a, Path: StoragePath, Key: k, Version: ver},
-				Val:         *uint256.NewInt(uint64(s + 1)),
+				Val:         val,
 			})
 		}
 	}
@@ -68,17 +96,46 @@ func buildNormalizeInput(addrs, slots int) *WriteSet {
 	return ws
 }
 
+// seedPriorTx flushes a preceding tx's storage values into the version map, so
+// that the benchmarked tx's write-backs of those same values reach the no-op
+// filter's drop arm rather than falling through to the state reader.
+func seedPriorTx(vm *VersionMap, addrs, slots int) {
+	prior := &WriteSet{}
+	ver := Version{TxIndex: 0, Incarnation: 0}
+	for i := range addrs {
+		a := benchAddr(i)
+		for s := range slots {
+			k := benchKey(s)
+			prior.SetStorage(a, k, &VersionedWrite[uint256.Int]{
+				WriteHeader: WriteHeader{Address: a, Path: StoragePath, Key: k, Version: ver},
+				Val:         benchStorageVal(s),
+			})
+		}
+	}
+	vm.FlushVersionedWrites(prior, true, "")
+}
+
 func BenchmarkWriteSetNormalize(b *testing.B) {
+	const txIndex = 1
 	for _, size := range []struct{ addrs, slots int }{{4, 2}, {16, 8}} {
 		b.Run(fmt.Sprintf("addrs=%d/slots=%d", size.addrs, size.slots), func(b *testing.B) {
-			ws := buildNormalizeInput(size.addrs, size.slots)
+			ws := buildNormalizeInput(size.addrs, size.slots, txIndex)
 			vm := NewVersionMap(nil)
+			seedPriorTx(vm, size.addrs, size.slots)
 			vm.FlushVersionedWrites(ws, true, "")
 			reader := &minimalStateReader{}
+			// Guard the shape the numbers describe: the no-op filter must
+			// actually drop writes, else a regression in it stays invisible.
+			probe, err := ws.Normalize(vm, txIndex, 0, reader, nil, true, false, false)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if kept, in := countStorage(probe), countStorage(ws); kept >= in {
+				b.Fatalf("no-op filter dropped nothing: %d storage writes in, %d out", in, kept)
+			}
 			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				out, err := ws.Normalize(vm, 0, 0, reader, nil, true, false, false)
+			for b.Loop() {
+				out, err := ws.Normalize(vm, txIndex, 0, reader, nil, true, false, false)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/execution/state/writeset_normalize_test.go
+++ b/execution/state/writeset_normalize_test.go
@@ -195,3 +195,63 @@ func TestNormalize_SelfDestructDropsAccountFieldAndStorageWrites(t *testing.T) {
 	_, storageOK := out.GetStorage(addr, kRaw)
 	require.False(t, storageOK, "raw storage write of a self-destructed address must be dropped")
 }
+
+// The account-field writes of a self-destructed address are what make Apply
+// compute pureDelete=false and take the cleanup-before-recreate branch, leaving
+// a phantom account. Normalize drops them; this asserts the guarantee at the
+// consumer so a filter regression surfaces on the block that triggers it rather
+// than as a wrong trie root later.
+func TestAssertSelfDestructNormalized(t *testing.T) {
+	t.Parallel()
+	addr := accounts.InternAddress(common.HexToAddress("0xA55E27"))
+	ver := Version{TxIndex: 1}
+	sd := func(ws *WriteSet) *WriteSet {
+		ws.SetSelfDestruct(addr, &VersionedWrite[bool]{
+			WriteHeader: WriteHeader{Address: addr, Path: SelfDestructPath, Version: ver},
+			Val:         true,
+		})
+		return ws
+	}
+
+	require.Panics(t, func() {
+		ws := sd(&WriteSet{})
+		ws.SetNonce(addr, &VersionedWrite[uint64]{
+			WriteHeader: WriteHeader{Address: addr, Path: NoncePath, Version: ver},
+			Val:         1,
+		})
+		ws.assertSelfDestructNormalized()
+	}, "a nonce write on a self-destructed address must trip the assert")
+
+	require.Panics(t, func() {
+		ws := sd(&WriteSet{})
+		ws.SetCodeHash(addr, &VersionedWrite[accounts.CodeHash]{
+			WriteHeader: WriteHeader{Address: addr, Path: CodeHashPath, Version: ver},
+			Val:         accounts.NewCode([]byte{0x00}).Hash,
+		})
+		ws.assertSelfDestructNormalized()
+	}, "a codeHash write on a self-destructed address must trip the assert")
+
+	require.Panics(t, func() {
+		ws := sd(&WriteSet{})
+		ws.SetIncarnation(addr, &VersionedWrite[uint64]{
+			WriteHeader: WriteHeader{Address: addr, Path: IncarnationPath, Version: ver},
+			Val:         2,
+		})
+		ws.assertSelfDestructNormalized()
+	}, "an incarnation write on a self-destructed address must trip the assert")
+
+	// Balance (kept under EIP-8246) and the storage-delete cascade are the two
+	// things a normalized self-destruct legitimately carries.
+	require.NotPanics(t, func() {
+		ws := sd(&WriteSet{})
+		ws.SetBalance(addr, &VersionedWrite[uint256.Int]{
+			WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Version: ver},
+			Val:         *uint256.NewInt(9),
+		})
+		k := accounts.InternKey(common.HexToHash("0x01"))
+		ws.SetStorage(addr, k, &VersionedWrite[uint256.Int]{
+			WriteHeader: WriteHeader{Address: addr, Path: StoragePath, Key: k, Version: ver},
+		})
+		ws.assertSelfDestructNormalized()
+	}, "balance and storage deletes are legal on a self-destructed address")
+}

--- a/execution/state/writeset_normalize_test.go
+++ b/execution/state/writeset_normalize_test.go
@@ -138,3 +138,60 @@ func TestNormalize_SelfDestructBalanceRetention_EIP8246(t *testing.T) {
 	_, postBal := post.GetBalance(addr)
 	require.True(t, postBal, "EIP-8246 SD retains the balance write")
 }
+
+// A self-destructed address must keep none of its account-field or raw storage
+// writes: any survivor makes Apply see a non-empty account and take the
+// cleanup-before-recreate branch instead of the pure delete, leaving a phantom
+// account whose incarnation breaks a later CREATE2 at the same address. Only
+// SelfDestructPath (and, under EIP-8246, the balance) may remain.
+func TestNormalize_SelfDestructDropsAccountFieldAndStorageWrites(t *testing.T) {
+	t.Parallel()
+	addr := accounts.InternAddress(common.HexToAddress("0x5DEAD"))
+	kRaw := accounts.InternKey(common.HexToHash("0x03"))
+	code := accounts.NewCode([]byte{0x60, 0x00})
+	ver := Version{TxIndex: 1}
+
+	ws := &WriteSet{}
+	ws.SetSelfDestruct(addr, &VersionedWrite[bool]{
+		WriteHeader: WriteHeader{Address: addr, Path: SelfDestructPath, Version: ver},
+		Val:         true,
+	})
+	ws.SetNonce(addr, &VersionedWrite[uint64]{
+		WriteHeader: WriteHeader{Address: addr, Path: NoncePath, Version: ver},
+		Val:         7,
+	})
+	ws.SetIncarnation(addr, &VersionedWrite[uint64]{
+		WriteHeader: WriteHeader{Address: addr, Path: IncarnationPath, Version: ver},
+		Val:         3,
+	})
+	ws.SetCodeHash(addr, &VersionedWrite[accounts.CodeHash]{
+		WriteHeader: WriteHeader{Address: addr, Path: CodeHashPath, Version: ver},
+		Val:         code.Hash,
+	})
+	ws.SetCode(addr, &VersionedWrite[accounts.Code]{
+		WriteHeader: WriteHeader{Address: addr, Path: CodePath, Version: ver},
+		Val:         code,
+	})
+	// Not present in the versionMap or the domain, so the SD storage cascade
+	// cannot re-emit it — if it shows up, the raw write survived the SD filter.
+	ws.SetStorage(addr, kRaw, &VersionedWrite[uint256.Int]{
+		WriteHeader: WriteHeader{Address: addr, Path: StoragePath, Key: kRaw, Version: ver},
+		Val:         *uint256.NewInt(42),
+	})
+
+	out, err := ws.Normalize(NewVersionMap(nil), 1, 0, &minimalStateReader{}, nil, false /*emptyRemoval*/, false /*isAura*/, false /*eip8246*/)
+	require.NoError(t, err)
+
+	_, sdOK := out.GetSelfDestruct(addr)
+	require.True(t, sdOK, "the self-destruct itself must survive")
+	_, nonceOK := out.GetNonce(addr)
+	require.False(t, nonceOK, "nonce write of a self-destructed address must be dropped")
+	_, incOK := out.GetIncarnation(addr)
+	require.False(t, incOK, "incarnation write of a self-destructed address must be dropped")
+	_, codeHashOK := out.GetCodeHash(addr)
+	require.False(t, codeHashOK, "codeHash write of a self-destructed address must be dropped")
+	_, codeOK := out.GetCode(addr)
+	require.False(t, codeOK, "code write of a self-destructed address must be dropped")
+	_, storageOK := out.GetStorage(addr, kRaw)
+	require.False(t, storageOK, "raw storage write of a self-destructed address must be dropped")
+}


### PR DESCRIPTION
## Motivation

Mainnet exec heap profile (`alloc_objects`): `WriteSet.Normalize` 57M objects cum (8.8%), `ApplyStateWrites` → `WriteSet.Apply` 45M (6.9%) — together ~16% of all allocations in an exec-heavy window.

## Normalize

Only the per-call scratch structures change; the header walk and all filtering logic are untouched.

- `sdSet` is allocated lazily (nil when the tx has no self-destructs, which is almost every tx).
- The per-address field set (`map[Address]map[AccountPath]bool`) is gone — the fill loop asks `filtered.Has` directly.
- `acctStates` holds values instead of a pointer per address; `emptyAddrs` is a slice instead of a map.
- The code-recovery pass probes `filtered.code`/`filtered.codeHash` instead of building two snapshot maps.
- The address union reuses `forEachAddr`, split so callers can skip the record-level `AddressPath` map.

## Apply

Field presence was encoded as `*uint256.Int`/`*uint64`/`*CodeHash` pointers (`v := vw.Val; d.balance = &v`), heap-escaping one allocation per written field per address. Replaced with value fields plus has-flags.

## What was deliberately left out

An earlier revision also replaced Normalize's `AllHeaders` walk with per-path typed-map loops. Measured against this benchmark it saves **zero** allocations (158/op either way) — the entire win comes from the scratch structures above. It only buys time (23.4µs → 17.9µs at 16 addrs / 8 slots), while rewriting the self-destruct filtering that produces wrong trie roots when it breaks. Dropped from this PR; it can be proposed on its own now that the benchmark and the self-destruct pins exist to judge it.

## Safety

Mutation testing found five guards the existing suites did **not** pin: removing the `sdSet` skip for nonce, incarnation, codeHash, code or storage writes left every test green, although a surviving nonce or codeHash write makes `Apply` compute `pureDelete=false` and take the cleanup-before-recreate branch — the phantom-account wrong-root case. `TestNormalize_SelfDestructDropsAccountFieldAndStorageWrites` fails on each of those five mutations (verified by re-introducing them one at a time). The test asserts behavior, not structure, so it holds regardless of how the filter is implemented.

## Making the invariant self-enforcing

The deeper fragility is that `Normalize` produces the guarantee, `Apply` consumes it on trust, and nothing checks it — which is why five guards could be deleted with the suite green. `Apply` now calls `assertSelfDestructNormalized` under `ERIGON_ASSERT`: it panics if a self-destructed address still carries a nonce, incarnation or codeHash write, the three fields that make `pureDelete` false. Balance (kept under EIP-8246) and the storage-delete cascade stay legal. The QA workflows already run with `ERIGON_ASSERT: true`, so real self-destructs on real chains exercise it — stronger than any unit test, since it checks the invariant on every block rather than on hand-built inputs. Verified: `execution/state`, `stagedsync`, `tests` and `execmodule` all pass with `ERIGON_ASSERT=true`.

## Numbers

`BenchmarkWriteSetNormalize` (new), same benchmark run against `origin/main` sources and against this branch:

| shape | allocs/op | B/op | ns/op |
|---|---|---|---|
| 4 addrs / 2 slots | 87 → 53 (−39%) | 5950 → 4438 (−25%) | 6.3µs → 4.5µs (−29%) |
| 16 addrs / 8 slots | 240 → 158 (−34%) | 21784 → 18176 (−17%) | 31.6µs → 23.4µs (−26%) |

The first version of this benchmark seeded the version map at the same `txIndex` it normalized, so `readFloor` could never see the seeded writes and the storage no-op filter dropped nothing — its drop arms were dead code and the figures described the maximum-output shape. It now seeds a prior tx, writes half the slots back unchanged, includes contract code, and fails if the filter stops dropping.

`Apply` has no isolated micro-benchmark (it needs SharedDomains); that half is mechanical pointer→value, covered by the exec suites, and should show up in the next mainnet heap profile.

Behavior: no functional change intended; `execution/state`, `execution/stagedsync`, `execution/tests`, `execution/execmodule` suites green.
