### PR TITLE
db/etl, tools: draw pooled ETL buffers lazily to cut race-shard memory

### DIFF
--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -79,10 +79,11 @@ func writeSortedEntries(w io.Writer, entries []sortableBufferEntry) error {
 
 var BufferOptimalSize = dbg.EnvDataSize("ETL_OPTIMAL", 256*datasize.MB) /*  var because we want to sometimes change it from tests or command-line flags */
 
-// Pooled buffers start empty and grow with the data they actually see: a
-// pooled buffer keeps its grown capacity across reuse (Reset preserves cap),
-// so hot collectors amortize growth while collectors with tiny working sets
-// never pay a megabyte-scale prealloc.
+// etlSmallBufRAM (BufferOptimalSize/8) bounds the flush threshold so a full
+// set of domain/history/index flush collectors (~17 per batch writer) stays
+// around 512 MB when all run full. Pooled buffers start empty and grow with
+// the data they actually see; grown capacity survives reuse (Reset preserves
+// cap), so hot collectors amortize growth while never-full ones stay small.
 var etlSmallBufRAM = dbg.EnvDataSize("ETL_SMALL", BufferOptimalSize/8)
 var SmallSortableBuffers = NewAllocator(&sync.Pool{
 	New: func() any {

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -79,17 +79,20 @@ func writeSortedEntries(w io.Writer, entries []sortableBufferEntry) error {
 
 var BufferOptimalSize = dbg.EnvDataSize("ETL_OPTIMAL", 256*datasize.MB) /*  var because we want to sometimes change it from tests or command-line flags */
 
-// 3_domains * 2 + 3_history * 1 + 4_indices * 2 = 17 etl collectors, 17*(256Mb/8) = 512Mb - for all collectros
+// Pooled buffers start empty and grow with the data they actually see: a
+// pooled buffer keeps its grown capacity across reuse (Reset preserves cap),
+// so hot collectors amortize growth while collectors with tiny working sets
+// never pay a megabyte-scale prealloc.
 var etlSmallBufRAM = dbg.EnvDataSize("ETL_SMALL", BufferOptimalSize/8)
 var SmallSortableBuffers = NewAllocator(&sync.Pool{
 	New: func() any {
-		return NewSortableBuffer(etlSmallBufRAM).Prealloc(1_024, int(etlSmallBufRAM/32))
+		return NewSortableBuffer(etlSmallBufRAM)
 	},
 })
 var etlLargeBufRAM = BufferOptimalSize
 var LargeSortableBuffers = NewAllocator(&sync.Pool{
 	New: func() any {
-		return NewSortableBuffer(etlLargeBufRAM).Prealloc(1_024, int(etlLargeBufRAM/32))
+		return NewSortableBuffer(etlLargeBufRAM)
 	},
 })
 

--- a/db/etl/collector.go
+++ b/db/etl/collector.go
@@ -77,8 +77,12 @@ type Collector struct {
 	allocator *Allocator
 }
 
+// NewCollectorWithAllocator builds a collector that draws its buffer from the
+// allocator's pool lazily, on the first Collect — a collector that never
+// receives a write never takes a buffer. Batch writers built upfront for every
+// domain rely on this to make unused writers cost nothing.
 func NewCollectorWithAllocator(logPrefix, tmpdir string, allocator *Allocator, logger log.Logger) *Collector {
-	c := NewCollector(logPrefix, tmpdir, allocator.Get(), logger)
+	c := &Collector{logPrefix: logPrefix, tmpdir: tmpdir, logLvl: log.LvlInfo, logger: logger}
 	c.Allocator(allocator)
 	return c
 }
@@ -94,6 +98,7 @@ func (c *Collector) SortAndFlushInBackground(v bool) *Collector {
 func (c *Collector) extractNextFunc(originalK, k []byte, v []byte) error {
 	if c.buf == nil && c.allocator != nil {
 		c.buf = c.allocator.Get()
+		c.bufType = getTypeByBuffer(c.buf)
 	}
 	c.buf.Put(k, v)
 	if !c.buf.CheckFlushSize() {
@@ -117,7 +122,7 @@ func (c *Collector) Allocator(a *Allocator) *Collector {
 }
 
 func (c *Collector) flushBuffer(canStoreInRam bool) error {
-	if c.buf.Len() == 0 {
+	if c.buf == nil || c.buf.Len() == 0 {
 		return nil
 	}
 
@@ -143,7 +148,7 @@ func (c *Collector) flushBuffer(canStoreInRam bool) error {
 
 	fullBuf := c.buf // can't `.Reset()` because this `buf` will move to another goroutine
 	if c.allocator != nil {
-		c.buf = c.allocator.Get()
+		c.buf = nil // drawn again lazily on the next Collect; a flush is often the collector's last write event
 	} else {
 		prevLen, prevSize := fullBuf.Len(), fullBuf.SizeLimit()
 		c.buf = getBufferByType(c.bufType, datasize.ByteSize(fullBuf.SizeLimit()))
@@ -170,9 +175,6 @@ func (c *Collector) Flush() error {
 }
 
 func (c *Collector) Load(db kv.RwTx, toBucket string, loadFunc LoadFunc, args TransformArgs) error {
-	if c.buf == nil && c.allocator != nil {
-		c.buf = c.allocator.Get()
-	}
 	args.BufferType = c.bufType
 
 	if !c.allFlushed {
@@ -253,7 +255,7 @@ func (c *Collector) Load(db kv.RwTx, toBucket string, loadFunc LoadFunc, args Tr
 	simpleLoad := func(k, v []byte) error {
 		return loadFunc(k, v, currentTable, loadNextFunc)
 	}
-	if err := mergeSortFiles(c.logPrefix, c.dataProviders, simpleLoad, args, c.buf); err != nil {
+	if err := mergeSortFiles(c.logPrefix, c.dataProviders, simpleLoad, args); err != nil {
 		return fmt.Errorf("loadIntoTable %s: %w", toBucket, err)
 	}
 	//logger.Trace(fmt.Sprintf("[%s] ETL Load done", c.logPrefix), "bucket", bucket, "records", i)
@@ -285,7 +287,7 @@ func (c *Collector) Close() {
 // for the next item, which is then added back to the heap.
 // The subsequent iterations pop the heap again and load up the provider associated with it to get the next element after processing LoadFunc.
 // this continues until all providers have reached their EOF.
-func mergeSortFiles(logPrefix string, providers []dataProvider, loadFunc simpleLoadFunc, args TransformArgs, buf Buffer) (err error) {
+func mergeSortFiles(logPrefix string, providers []dataProvider, loadFunc simpleLoadFunc, args TransformArgs) (err error) {
 	for _, provider := range providers {
 		if err := provider.Wait(); err != nil {
 			return err

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -29,6 +29,8 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -659,7 +661,7 @@ func TestAppendAcrossMemProviders(t *testing.T) {
 	}
 
 	err = mergeSortFiles("test", providers, loadFunc,
-		TransformArgs{BufferType: SortableAppendBuffer}, NewAppendBuffer(1))
+		TransformArgs{BufferType: SortableAppendBuffer})
 	require.NoError(t, err)
 
 	require.Len(t, results, 4)
@@ -835,7 +837,7 @@ func TestMixedProvidersMergeSortFiles(t *testing.T) {
 		return nil
 	}
 
-	err = mergeSortFiles("test", providers, loadFunc, TransformArgs{}, NewSortableBuffer(1))
+	err = mergeSortFiles("test", providers, loadFunc, TransformArgs{})
 	require.NoError(t, err)
 
 	// Should have all 10 entries in sorted order
@@ -893,7 +895,7 @@ func TestMixedProvidersInterleavedKeys(t *testing.T) {
 		return nil
 	}
 
-	err = mergeSortFiles("test", providers, loadFunc, TransformArgs{}, NewSortableBuffer(1))
+	err = mergeSortFiles("test", providers, loadFunc, TransformArgs{})
 	require.NoError(t, err)
 
 	require.Len(t, keys, 10)
@@ -946,7 +948,7 @@ func TestMixedProvidersZeroCopyIntegrity(t *testing.T) {
 		return nil
 	}
 
-	err = mergeSortFiles("test", providers, loadFunc, TransformArgs{}, NewSortableBuffer(1))
+	err = mergeSortFiles("test", providers, loadFunc, TransformArgs{})
 	require.NoError(t, err)
 
 	require.Len(t, entries, 4)
@@ -1535,4 +1537,38 @@ func TestVmtouchMmap(t *testing.T) {
 		}
 	}
 	vmtouch("AFTER full scan")
+}
+
+// TestCollectorWithAllocatorDrawsBufferLazily pins the lazy-draw contract:
+// an allocator-backed collector must not take a pooled buffer until the
+// first Collect, so never-written collectors (common when a batch writer
+// set is built upfront) cost no buffer at all.
+func TestCollectorWithAllocatorDrawsBufferLazily(t *testing.T) {
+	logger := log.New()
+	_, tx := memdb.NewTestTx(t)
+	require := require.New(t)
+	table := kv.ChaindataTables[0]
+
+	var draws atomic.Int64
+	pool := &sync.Pool{New: func() any {
+		draws.Add(1)
+		return NewSortableBuffer(BufferOptimalSize)
+	}}
+	allocator := NewAllocator(pool)
+
+	empty := NewCollectorWithAllocator(t.Name()+"-empty", "", allocator, logger)
+	defer empty.Close()
+	require.NoError(empty.Flush())
+	require.NoError(empty.Load(tx, table, IdentityLoadFunc, TransformArgs{}))
+	empty.Close()
+	require.Zero(draws.Load(), "empty collector must not draw from the pool")
+
+	c := NewCollectorWithAllocator(t.Name(), "", allocator, logger)
+	defer c.Close()
+	require.NoError(c.Collect([]byte{1}, []byte{1}))
+	require.EqualValues(1, draws.Load(), "first Collect draws exactly one pooled buffer")
+	require.NoError(c.Load(tx, table, IdentityLoadFunc, TransformArgs{}))
+	v, err := tx.GetOne(table, []byte{1})
+	require.NoError(err)
+	require.Equal([]byte{1}, v)
 }

--- a/tools/run-eest-spec-test.sh
+++ b/tools/run-eest-spec-test.sh
@@ -184,6 +184,13 @@ workers="${EEST_SPEC_WORKERS:-$default_workers}"
 max="${EEST_SPEC_MAX_FAILURES:-$default_max}"
 evm_bin="${EVM_BIN:-build/bin/evm}"
 
+# Race-instrumented shards multiply RSS several-fold over the Go heap (TSAN
+# shadow + history). Bound the heap so allocation bursts trigger GC early
+# instead of growing the process into the CI runner's OOM range.
+if [[ "$shard" == *-race* ]]; then
+	export GOMEMLIMIT="${GOMEMLIMIT:-4GiB}"
+fi
+
 if [[ ! -x "$evm_bin" ]]; then
 	echo "$evm_bin not found or not executable; run 'make evm' first" >&2
 	exit 2


### PR DESCRIPTION
## Problem

Race-instrumented EEST spec shards have been OOM-killing 16 GB GitHub-hosted runners, failing merge-queue runs (context: #22885, #22895 and the investigation linked there; the same failure dequeued #22902 from the release/3.6 merge queue on 2026-07-31). Shard splitting treats the symptom, so I profiled the `blocktests-devnet-race-amsterdam` shard to find the source.

## Root cause (profiled)

**88% of all allocated bytes came from `etl.(*sortableBuffer).Prealloc`** (1,426 GB of the run's 1,612 GB total). The chain: each blocktest builds a full node-in-a-box; every block insertion creates a `SharedDomains`, whose `NewTemporalMemBatch` eagerly constructs flush writers for all domains, histories and indices (~17–26 ETL collectors), and `NewCollectorWithAllocator` drew a pooled buffer carrying a 1 MB prealloc at construction — even for writers that never receive a single `Put`. At ~200 `SharedDomains`/s the process allocated ~4 GB/s, forcing 7–10 GCs/s — which also cleared the `sync.Pool`s on every cycle, so pooling amortized nothing. Under `-race`, this churn multiplies into TSAN shadow/history; on the slower 4-core CI runners the run stretches to ~30 min and RSS crosses the 16 GB budget.

## Fix

- `NewCollectorWithAllocator` no longer draws a buffer at construction; the draw happens on the first `Collect` (a path the collector already supported), so never-written writers cost nothing. The background-flush path stops eagerly re-drawing, and `Load` no longer draws at all — `mergeSortFiles` never used its `buf` parameter, so it is dropped.
- The two global buffer pools no longer `Prealloc` 1 MB / 8 MB per fresh buffer. Pooled buffers keep their grown capacity across reuse (`Reset` preserves cap), so warm-pool behaviour in the live node is unchanged.
- `run-eest-spec-test.sh` sets `GOMEMLIMIT=4GiB` (overridable) for `-race` shards, so the Go heap pacer defends the runner's memory budget instead of discovering it via OOM-kill.

The lazy-draw contract is pinned by a new test (written first, red against the old eager draw).

## Measurements

Full `blocktests-devnet-race-amsterdam` shard (23,770 tests, 12 workers, race binary), identical runs before/after on a 12-core machine. Allocation totals are from end-of-run heap profiles; peak Go memory is `runtime.MemStats` `Sys`.

| Metric | Before | After |
|---|---|---|
| Tests | 23,770 / 0 failed | 23,770 / 0 failed |
| Wall time | 392 s | 391 s |
| Total allocated | 1.61 TB | 183 GB |
| GC cycles | 2,842 | 824 |
| Peak Go mem (`Sys`) | 2.61 GiB | 1.48 GiB |
| Peak process RSS | 7.61 GiB | 6.76 GiB |

Local peak RSS moves less than the Go numbers because ~5.3 GiB is TSAN meta/history, which grows with sync objects rather than allocation volume. What matters for CI: allocation bursts are structurally gone, GC pressure dropped 3.4×, and `GOMEMLIMIT` bounds the heap side outright.

## Verification

- `make lint`, `make erigon integration`
- Package tests: `db/etl`, `db/state` (short), `db/recsplit`, `db/kv/prune`, `db/seg`, senders stage
- Full amsterdam race shard locally, before and after (table above)

## Notes

- If a heavier race shard's live heap ever approaches the 4 GiB limit, the symptom is GC thrash (slow shard, high GC CPU), not an OOM — bump `GOMEMLIMIT` via env for that shard rather than removing the guard.
- Textual overlap with #22846 (rewrites `mergeSortFiles` internals): semantically orthogonal, but whichever merges second needs a trivial rebase for the dropped unused parameter.
- After merge I propose cherry-picking to `release/3.6` — its merge queue runs the same shards and hit this failure on #22902.
- The commit message quotes an earlier extrapolated total ("2.5 TB"); the measured end-of-run figure is 1.61 TB as above.