### PR TITLE
execution: optimise bn254ScalarMul for infinity point

### DIFF
--- a/execution/vm/contracts.go
+++ b/execution/vm/contracts.go
@@ -701,6 +701,9 @@ func runBn254ScalarMul(input []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if x.IsInfinity() {
+		return make([]byte, 64), nil
+	}
 	return libbn254.MarshalCurvePointG1(x.ScalarMultiplication(&x, new(big.Int).SetBytes(getData(input, 64, 32)))), nil
 }
 

--- a/execution/vm/contracts_test.go
+++ b/execution/vm/contracts_test.go
@@ -327,7 +327,19 @@ func TestPrecompiledModExpInputEip7823(t *testing.T) {
 // Tests the sample inputs from the elliptic curve scalar multiplication EIP 213.
 func TestPrecompiledBn254ScalarMul(t *testing.T)      { testJson("bn254ScalarMul", "07", t) }
 func BenchmarkPrecompiledBn254ScalarMul(b *testing.B) { benchJson("bn254ScalarMul", "07", b) }
-func TestPrecompiledBn254ScalarMulFail(t *testing.T)  { testJsonFail("bn254ScalarMul", "07", t) }
+func BenchmarkPrecompiledBn254ScalarMulInfinity(b *testing.B) {
+	input := make([]byte, 96)
+	copy(input[64:], bytes.Repeat([]byte{0xff}, 32))
+	benchmarkPrecompiled(b, "07", precompiledTest{
+		Input:    common.Bytes2Hex(input),
+		Expected: common.Bytes2Hex(make([]byte, 64)),
+		Name:     "infinity-large-scalar",
+	})
+}
+
+func TestPrecompiledBn254ScalarMulFail(t *testing.T) {
+	testJsonFail("bn254ScalarMul", "07", t)
+}
 
 // Tests the sample inputs from the elliptic curve pairing check EIP 197.
 func TestPrecompiledBn254Pairing(t *testing.T)      { testJson("bn254Pairing", "08", t) }

--- a/execution/vm/contracts_test.go
+++ b/execution/vm/contracts_test.go
@@ -327,6 +327,7 @@ func TestPrecompiledModExpInputEip7823(t *testing.T) {
 // Tests the sample inputs from the elliptic curve scalar multiplication EIP 213.
 func TestPrecompiledBn254ScalarMul(t *testing.T)      { testJson("bn254ScalarMul", "07", t) }
 func BenchmarkPrecompiledBn254ScalarMul(b *testing.B) { benchJson("bn254ScalarMul", "07", b) }
+
 func BenchmarkPrecompiledBn254ScalarMulInfinity(b *testing.B) {
 	input := make([]byte, 96)
 	copy(input[64:], bytes.Repeat([]byte{0xff}, 32))


### PR DESCRIPTION
for https://github.com/erigontech/erigon/issues/14522

## Summary

- Skip BN254 scalar multiplication when the input point is infinity.
- Return the canonical 64-byte zero encoding directly, since multiplying infinity by any scalar always produces infinity.
- Add a benchmark covering an infinity point with a large 32-byte scalar.

## Performance

Same-main microbenchmark:

| | Before | After |
|---|---:|---:|
| Time | 24,741 ns/op | 29.54 ns/op |
| Allocations | 15 | 1 |
| Speedup | | ~838x |

The 11 corresponding Benchmarkoor compute fixtures improved by 16.1x-23.7x, with a median speedup of 19x. All fixtures passed with no parallel-execution aborts or invalid executions.
