### PR TITLE
.github/actions: move Windows Go caches to D drive

### DIFF
--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -72,14 +72,18 @@ runs:
         fi
         df -h
 
-    - name: "Use D: drive for temp files on Windows"
+    - name: "Use D: drive for caches and temp files on Windows"
       if: ${{ runner.os == 'Windows' }}
       shell: bash
       run: |
-        mkdir -p D:/tmp
-        echo "TEMP=D:/tmp" >> "$GITHUB_ENV"
-        echo "TMP=D:/tmp" >> "$GITHUB_ENV"
-        echo "TMPDIR=D:/tmp" >> "$GITHUB_ENV"
+        mkdir -p D:/tmp D:/go-build D:/go/pkg/mod
+        {
+          echo "TEMP=D:/tmp"
+          echo "TMP=D:/tmp"
+          echo "TMPDIR=D:/tmp"
+          echo "GOCACHE=D:/go-build"
+          echo "GOMODCACHE=D:/go/pkg/mod"
+        } >> "$GITHUB_ENV"
 
     - name: Enable long paths on Windows
       if: ${{ runner.os == 'Windows' }}
@@ -249,6 +253,9 @@ runs:
         echo "build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "modcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
         workflow="${CACHE_NAMESPACE:-$(basename "${GITHUB_WORKFLOW_REF%%@*}" .yml)}"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          workflow="${workflow}-windows-d-drive-v1"
+        fi
         echo "workflow=$workflow" >> "$GITHUB_OUTPUT"
         echo "ERIGON_CI_GOCACHE_PATH=$(go env GOCACHE)" >> "$GITHUB_ENV"
         echo "ERIGON_CI_MODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -253,9 +253,6 @@ runs:
         echo "build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "modcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
         workflow="${CACHE_NAMESPACE:-$(basename "${GITHUB_WORKFLOW_REF%%@*}" .yml)}"
-        if [ "$RUNNER_OS" = "Windows" ]; then
-          workflow="${workflow}-windows-d-drive-v1"
-        fi
         echo "workflow=$workflow" >> "$GITHUB_OUTPUT"
         echo "ERIGON_CI_GOCACHE_PATH=$(go env GOCACHE)" >> "$GITHUB_ENV"
         echo "ERIGON_CI_MODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

- move Windows `GOCACHE` and `GOMODCACHE` from `C:` to the runner's spacious `D:` drive
- keep the existing cache keys; `actions/cache` includes the configured path in its internal cache version
- keep cache warming and CI gate jobs aligned through the shared setup action

## Root cause

The Windows parallel job in [merge-queue run 30642000041](https://github.com/erigontech/erigon/actions/runs/30642000041/job/91194055093) completed `make test-all`, then the Actions worker failed during cleanup because `C:` was full.

The setup action already placed the workspace and temporary files on `D:`, but Go kept `GOCACHE` and `GOMODCACHE` under `C:\Users\runneradmin`. In the successful rerun, restoring those caches reduced free space on `C:` from 34 GB to 13 GB before tests started. Cache growth during tests could therefore exhaust the same drive used by the Actions worker logs.

Changing the cache paths is sufficient to prevent old `C:` entries from matching because [`actions/cache` versions caches by path](https://github.com/actions/cache#cache-version).

## Validation

- `actionlint -shellcheck '' --ignore '"workspace" is not defined in object type' --ignore 'unexpected key "queue" for "concurrency" section'`
- `make lint` (repeated clean passes)
- `make erigon integration`
- focused configuration assertion: both Windows Go caches use `D:` without a custom workflow namespace