### PR TITLE
rpc: prestateTracer must skip faulted opcodes

### DIFF
--- a/execution/tracing/tracers/native/prestate.go
+++ b/execution/tracing/tracers/native/prestate.go
@@ -141,6 +141,12 @@ func (t *prestateTracer) OnExit(depth int, output []byte, gasUsed uint64, err er
 
 // OnOpcode implements the EVMLogger interface to trace a single step of VM execution.
 func (t *prestateTracer) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+	// A faulted opcode (e.g. out-of-gas at the opcode itself) never performs its
+	// account/storage access in consensus terms, so it must not contribute to the
+	// prestate. Mirrors go-ethereum (PR #26848).
+	if err != nil {
+		return
+	}
 	// Skip if tracing was interrupted
 	if t.interrupt.Load() {
 		return

--- a/execution/tracing/tracers/native/prestate_test.go
+++ b/execution/tracing/tracers/native/prestate_test.go
@@ -70,14 +70,14 @@ type fakeOpContext struct {
 	addr  accounts.Address
 }
 
-func (c *fakeOpContext) MemoryData() []byte            { return nil }
-func (c *fakeOpContext) StackData() []uint256.Int      { return c.stack }
-func (c *fakeOpContext) Caller() accounts.Address      { return c.addr }
-func (c *fakeOpContext) Address() accounts.Address     { return c.addr }
-func (c *fakeOpContext) CallValue() uint256.Int        { return uint256.Int{} }
-func (c *fakeOpContext) CallInput() []byte             { return nil }
-func (c *fakeOpContext) Code() []byte                  { return nil }
-func (c *fakeOpContext) CodeHash() accounts.CodeHash   { return accounts.EmptyCodeHash }
+func (c *fakeOpContext) MemoryData() []byte          { return nil }
+func (c *fakeOpContext) StackData() []uint256.Int    { return c.stack }
+func (c *fakeOpContext) Caller() accounts.Address    { return c.addr }
+func (c *fakeOpContext) Address() accounts.Address   { return c.addr }
+func (c *fakeOpContext) CallValue() uint256.Int      { return uint256.Int{} }
+func (c *fakeOpContext) CallInput() []byte           { return nil }
+func (c *fakeOpContext) Code() []byte                { return nil }
+func (c *fakeOpContext) CodeHash() accounts.CodeHash { return accounts.EmptyCodeHash }
 
 // TestPrestateTracerOnOpcodeFaultedSkipsLookup verifies that an opcode invoked
 // with a non-nil err (fault path, e.g. out-of-gas at the opcode itself) does not

--- a/execution/tracing/tracers/native/prestate_test.go
+++ b/execution/tracing/tracers/native/prestate_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
 )
 
 var _ tracing.IntraBlockState = (*postTxIBS)(nil)
@@ -60,6 +61,55 @@ func newTestPrestateTracer(cfg prestateTracerConfig) *prestateTracer {
 		created: make(map[accounts.Address]bool),
 		deleted: make(map[accounts.Address]bool),
 	}
+}
+
+// fakeOpContext is a minimal tracing.OpContext carrying only a stack and the
+// executing contract address, as seen by OnOpcode.
+type fakeOpContext struct {
+	stack []uint256.Int
+	addr  accounts.Address
+}
+
+func (c *fakeOpContext) MemoryData() []byte            { return nil }
+func (c *fakeOpContext) StackData() []uint256.Int      { return c.stack }
+func (c *fakeOpContext) Caller() accounts.Address      { return c.addr }
+func (c *fakeOpContext) Address() accounts.Address     { return c.addr }
+func (c *fakeOpContext) CallValue() uint256.Int        { return uint256.Int{} }
+func (c *fakeOpContext) CallInput() []byte             { return nil }
+func (c *fakeOpContext) Code() []byte                  { return nil }
+func (c *fakeOpContext) CodeHash() accounts.CodeHash   { return accounts.EmptyCodeHash }
+
+// TestPrestateTracerOnOpcodeFaultedSkipsLookup verifies that an opcode invoked
+// with a non-nil err (fault path, e.g. out-of-gas at the opcode itself) does not
+// record any touched account or storage slot: in consensus terms the access never
+// happened (no EIP-2929 warm-up), and go-ethereum skips it since PR #26848.
+func TestPrestateTracerOnOpcodeFaultedSkipsLookup(t *testing.T) {
+	caller := accounts.InternAddress(common.HexToAddress("0x0000000000000000000000000000000000001111"))
+	target := accounts.InternAddress(common.HexToAddress("0x0000000000000000000000000000000000002222"))
+
+	tr := newTestPrestateTracer(prestateTracerConfig{})
+	tr.env = &tracing.VMContext{
+		IntraBlockState: &postTxIBS{},
+	}
+	tr.lookupAccount(caller)
+
+	// EXTCODESIZE faulting with the target address as operand
+	// (real-world case: mainnet tx 0x84357b59..., block 25634962, OOG at EXTCODESIZE).
+	targetAddr := target.Value()
+	stack := []uint256.Int{*new(uint256.Int).SetBytes(targetAddr[:])}
+	tr.OnOpcode(0, byte(vm.EXTCODESIZE), 1724, 2600, &fakeOpContext{stack: stack, addr: caller}, nil, 2, vm.ErrOutOfGas)
+
+	_, ok := tr.pre[target]
+	require.False(t, ok, "account referenced by a faulted EXTCODESIZE must not be recorded in the prestate")
+
+	// SLOAD faulting with the slot key as operand
+	// (real-world case: mainnet tx 0xa4b924b4..., block 25638021, OOG at SLOAD).
+	slot := common.HexToHash("0xbaaed5f3d2bc4b0bc4f1758fde25c1522c4254f5b2fbfa513449670cff246a98")
+	stack = []uint256.Int{*new(uint256.Int).SetBytes(slot[:])}
+	tr.OnOpcode(0, byte(vm.SLOAD), 1577, 2100, &fakeOpContext{stack: stack, addr: caller}, nil, 1, vm.ErrOutOfGas)
+
+	require.NotContains(t, tr.pre[caller].Storage, slot,
+		"storage slot referenced by a faulted SLOAD must not be recorded in the prestate")
 }
 
 // TestPrestateTracerDiffModeDeletedAccount verifies that an account deleted during

--- a/execution/tracing/tracers/native/prestate_test.go
+++ b/execution/tracing/tracers/native/prestate_test.go
@@ -96,7 +96,9 @@ func TestPrestateTracerOnOpcodeFaultedSkipsLookup(t *testing.T) {
 	// EXTCODESIZE faulting with the target address as operand
 	// (real-world case: mainnet tx 0x84357b59..., block 25634962, OOG at EXTCODESIZE).
 	targetAddr := target.Value()
-	stack := []uint256.Int{*new(uint256.Int).SetBytes(targetAddr[:])}
+	var operand uint256.Int
+	operand.SetBytes(targetAddr[:])
+	stack := []uint256.Int{operand}
 	tr.OnOpcode(0, byte(vm.EXTCODESIZE), 1724, 2600, &fakeOpContext{stack: stack, addr: caller}, nil, 2, vm.ErrOutOfGas)
 
 	_, ok := tr.pre[target]
@@ -105,7 +107,8 @@ func TestPrestateTracerOnOpcodeFaultedSkipsLookup(t *testing.T) {
 	// SLOAD faulting with the slot key as operand
 	// (real-world case: mainnet tx 0xa4b924b4..., block 25638021, OOG at SLOAD).
 	slot := common.HexToHash("0xbaaed5f3d2bc4b0bc4f1758fde25c1522c4254f5b2fbfa513449670cff246a98")
-	stack = []uint256.Int{*new(uint256.Int).SetBytes(slot[:])}
+	operand.SetBytes(slot[:])
+	stack = []uint256.Int{operand}
 	tr.OnOpcode(0, byte(vm.SLOAD), 1577, 2100, &fakeOpContext{stack: stack, addr: caller}, nil, 1, vm.ErrOutOfGas)
 
 	require.NotContains(t, tr.pre[caller].Storage, slot,


### PR DESCRIPTION
`prestateTracer` records accounts and storage slots referenced by **faulted** opcodes (e.g.
  out-of-gas at the opcode itself). A faulted opcode never performs its access in consensus
  terms, so nothing should be recorded — go-ethereum skips them since
  [ethereum/go-ethereum#26848](https://github.com/ethereum/go-ethereum/pull/26848) (v1.12.0+).

  Root cause of the recurring `debug_traceBlockByNumber/test_43.json` QA failures vs the Geth
  reference. Fixes #22888.

  ## Root cause

  The interpreter invokes `OnOpcode` with a non-nil `err` on the fault path, stack still
  intact; the tracer had no `err` check, so it recorded phantom accounts (faulted
  `EXTCODESIZE`/`BALANCE`/`CALL*`) and phantom storage slots (faulted `SLOAD`/`SSTORE`).
  Both variants were hit in QA (#22888): block 25634962 tx `0x84357b59…` (extra account,
  faulted `EXTCODESIZE`) and block 25638021 tx `0xa4b924b4…` (extra slot, faulted `SLOAD`).

  ## Fix

  Bail out at the top of `OnOpcode` when `err != nil`, mirroring go-ethereum.

  ## Tests

  - `TestPrestateTracerOnOpcodeFaultedSkipsLookup` models both real-world cases (RED before,
    GREEN after); existing prestate tests unchanged and passing.
  - Re-traced both QA transactions on a local node: the fix removes exactly the diffs in
    
#22888 — responses now byte-identical to the Geth reference.

Fixes #22888
