### PR TITLE
execution/stagedsync: log fork-validation wrong trie root at Warn

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -416,6 +416,16 @@ type txExecutor struct {
 	enableChaosMonkey bool
 }
 
+// A wrong root under fork validation means a payload the CL offered was rejected,
+// which is the answer the CL asked for, not a fault of this node.
+func (te *txExecutor) logWrongTrieRoot(msg string) {
+	if te.isForkValidation {
+		te.logger.Warn(msg)
+		return
+	}
+	te.logger.Error(msg)
+}
+
 func (te *txExecutor) readState() *state.StateV3Buffered {
 	return te.rs
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -462,7 +462,7 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 				if !errors.Is(cr.err, ErrWrongTrieRoot) {
 					return fmt.Errorf("[%s] commitment: %w", pe.logPrefix, cr.err)
 				}
-				pe.logger.Error(fmt.Sprintf("[%s] Wrong trie root of block %d: %x (%v)",
+				pe.logWrongTrieRoot(fmt.Sprintf("[%s] Wrong trie root of block %d: %x (%v)",
 					pe.logPrefix, cr.blockNum, cr.rootHash, cr.err))
 				return fmt.Errorf("%w, block=%d", ErrWrongTrieRoot, cr.blockNum)
 			}

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -201,7 +201,7 @@ func (se *serialExecutor) exec(ctx context.Context, execStage *StageState, u Unw
 			se.doms.SetChangesetAccumulator(nil)
 
 			if !bytes.Equal(rh, header.Root[:]) {
-				se.logger.Error(fmt.Sprintf("[%s] Wrong trie root of block %d: %x, expected (from header): %x. Block hash: %x", se.logPrefix, header.Number.Uint64(), rh, header.Root[:], header.Hash()))
+				se.logWrongTrieRoot(fmt.Sprintf("[%s] Wrong trie root of block %d: %x, expected (from header): %x. Block hash: %x", se.logPrefix, header.Number.Uint64(), rh, header.Root[:], header.Hash()))
 				return b.HeaderNoCopy(), rwTx, fmt.Errorf("%w, block=%d", ErrWrongTrieRoot, blockNum)
 			}
 		}

--- a/execution/stagedsync/exec3_wrong_root_log_test.go
+++ b/execution/stagedsync/exec3_wrong_root_log_test.go
@@ -1,0 +1,44 @@
+package stagedsync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+type levelRecorder struct{ levels []log.Lvl }
+
+func (h *levelRecorder) Log(r *log.Record) error               { h.levels = append(h.levels, r.Lvl); return nil }
+func (h *levelRecorder) Enabled(context.Context, log.Lvl) bool { return true }
+
+func newRecordingExecutor(isForkValidation bool) (*txExecutor, *levelRecorder) {
+	rec := &levelRecorder{}
+	logger := log.New()
+	logger.SetHandler(rec)
+	return &txExecutor{logger: logger, logPrefix: "5/5 Execution", isForkValidation: isForkValidation}, rec
+}
+
+// A payload rejected during fork validation is an expected outcome — the CL asked
+// "is this block valid?" and got an answer. Reporting it at Error makes a normal
+// gossip rejection indistinguishable from a node fault, and aborts QA sync runs
+// that treat any [EROR] line as a failure.
+func TestWrongTrieRootIsNotAnErrorDuringForkValidation(t *testing.T) {
+	te, rec := newRecordingExecutor(true)
+
+	te.logWrongTrieRoot("[5/5 Execution] Wrong trie root of block 25661334")
+
+	require.Len(t, rec.levels, 1)
+	require.Greater(t, rec.levels[0], log.LvlError, "fork-validation wrong root must log below Error")
+}
+
+func TestWrongTrieRootStaysAnErrorDuringNormalExecution(t *testing.T) {
+	te, rec := newRecordingExecutor(false)
+
+	te.logWrongTrieRoot("[5/5 Execution] Wrong trie root of block 25661334")
+
+	require.Len(t, rec.levels, 1)
+	require.Equal(t, log.LvlError, rec.levels[0], "a wrong root while applying blocks is a real node error")
+}


### PR DESCRIPTION
A wrong trie root found while validating a payload the CL offered is the answer the CL asked for, not a fault of this node. It was logged at `Error`, and the QA sync drivers abort a run on any `[EROR]` line — so one malformed payload at the mainnet tip ends a multi-hour run.

That happened on 2026-08-01, killing the mainnet job in two workflows at the same instant:

| run | workflow | job |
|---|---|---|
| [30690063394](https://github.com/erigontech/erigon/actions/runs/30690063394) | QA - Sync from scratch (full node) | `mainnet` |
| [30645661555](https://github.com/erigontech/erigon/actions/runs/30645661555) | QA - Sync from scratch | `mainnet` |

Both reported the same `result-mainnet.json` verdict:

```json
{ "outcome": "Unexpected error",
  "reason": "Erigon in ERROR: Errored line: [EROR] [08-01|18:50:36.568] [5/5 Execution] Wrong trie root of block 25661334 ..." }
```

```
[DBUG] [08-01|18:50:36.378] [execmodule] validating chain  number=25661334 hash=0xb7176513…
[EROR] [08-01|18:50:36.471] [5/5 Execution] Wrong trie root of block 25661334: ee55bb86…
       (… expected 0000000000000000000000000000000000000000000000000000000000000000)
[INFO] [08-01|18:50:36.476] [5/5 Execution] parallel executed … isForkValidation=true
```

Stack: `validation.go` → `on_block.go` → `execution_client_direct.go` → `exec_module.go` → `fork_validator.go` → `exec3_parallel.go`.

<details><summary>Why the rejection itself was correct</summary>

The payload came from beacon block `0x4d0a1141…` at slot 14898251, which is a **missed slot** on mainnet — the beacon API 404s both [by root](https://ethereum-beacon-api.publicnode.com/eth/v2/beacon/blocks/0x4d0a1141b081d217c1b88bd82d4f722c370c67d34a14c07040db460e7290aa06) and [by slot](https://ethereum-beacon-api.publicnode.com/eth/v2/beacon/blocks/14898251). Canonical block 25661334 came from slot 14898252 (`0x1f61f55b…`, 307 txs, stateRoot `0xdba70cb0…`); the payload erigon was handed had 304 txs and 24.21M gas.

The `expected 0000…0` is not a plumbing bug. [`Eth1Block.RlpHeader`](https://github.com/erigontech/erigon/blob/main/cl/cltypes/eth1_block.go#L461) sets `Root: b.StateRoot` and then refuses to return a header whose hash does not match `payload.block_hash`:

```go
if header.Hash() != b.BlockHash {
    return nil, fmt.Errorf("cannot derive rlp header: mismatching hash: …")
}
```

It did not refuse, so the gossiped payload declared `state_root = 0x0` with a self-consistent block hash. Every client rejected it, which is why that slot is empty. Erigon's verdict was right — only its log level was wrong.
</details>

<details><summary>Exposure</summary>

The three wrong-root sites disagreed on level: `exec3.go:823` already used `Warn`, while `exec3_serial.go:204` and `exec3_parallel.go:465` used `Error`. Sync-from-scratch tracks the tip for 8–16 h so it catches these; tip-tracking's 2 h window has stayed green.
</details>

Both executors now go through `txExecutor.logWrongTrieRoot`, which keeps `Error` while applying blocks and drops to `Warn` under fork validation. The error returned to the caller is unchanged, so the block is still rejected and the payload still reported invalid.

Driven by two tests in `exec3_wrong_root_log_test.go` — red before the change (`"eror" is not greater than "eror"`), green after; the second pins that a wrong root during normal execution stays at `Error`.
