### PR TITLE
cl/utils/eth_clock: ENR next_fork_version must not use an unscheduled fork

### DIFF
--- a/cl/utils/eth_clock/ethereum_clock.go
+++ b/cl/utils/eth_clock/ethereum_clock.go
@@ -180,8 +180,13 @@ func (t *ethereumClockImpl) ForkId() ([]byte, error) {
 		currentEpoch = 0
 	}
 
+	// A fork parked at FAR_FUTURE_EPOCH is not scheduled, so it must not become
+	// next_fork_version: the spec wants the current version when nothing follows.
 	var nextForkVersion [4]byte
 	for _, fork := range forkList(t.beaconCfg.ForkVersionSchedule) {
+		if fork.epoch == t.beaconCfg.FarFutureEpoch || fork.epoch == math.MaxUint64 {
+			continue
+		}
 		if currentEpoch < fork.epoch {
 			nextForkVersion = fork.version
 			break

--- a/cl/utils/eth_clock/fork_id_test.go
+++ b/cl/utils/eth_clock/fork_id_test.go
@@ -1,0 +1,43 @@
+package eth_clock
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/utils"
+	"github.com/erigontech/erigon/common"
+	chainspec "github.com/erigontech/erigon/execution/chain/spec"
+)
+
+// ENR eth2 field: with no future fork scheduled the spec requires
+// next_fork_version == current_fork_version, so a fork left at FAR_FUTURE_EPOCH
+// must not contribute its version.
+func TestForkIdNextForkVersionWithoutScheduledFork(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		chainID        clparams.NetworkType
+		currentVersion uint32
+	}{
+		{"chiado", chainspec.ChiadoChainID, 0x0600006f},
+		{"gnosis", chainspec.GnosisChainID, 0x06000064},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, beaconCfg := clparams.GetConfigsByNetwork(tc.chainID)
+			clock := NewEthereumClock(beaconCfg.MinGenesisTime, common.Hash{}, beaconCfg)
+
+			forkID, err := clock.ForkId()
+			require.NoError(t, err)
+			require.Len(t, forkID, 16)
+
+			nextForkEpoch := binary.BigEndian.Uint64(forkID[8:])
+			require.Equal(t, beaconCfg.FarFutureEpoch, nextForkEpoch,
+				"precondition: no fork is scheduled after the current one")
+
+			require.Equal(t, common.Bytes4(utils.Uint32ToBytes4(tc.currentVersion)), common.Bytes4(forkID[4:8]),
+				"next_fork_version must fall back to the current fork version")
+		})
+	}
+}


### PR DESCRIPTION
`ForkId()` picked `next_fork_version` from the first fork-schedule entry above the current epoch, including forks parked at `FAR_FUTURE_EPOCH`. The `next_fork_epoch` half of the same 16-byte field already normalises those away (`NextForkEpochIncludeBPO`), so the two halves disagreed.

Decoded from the `eth2` ENR field of two live nodes (QA sync-from-scratch, 2026-08-01):

| network | fork_digest | next_fork_version | next_fork_epoch |
|---|---|---|---|
| chiado | `0x25f9148e` | `0x07000000` | FAR_FUTURE |
| gnosis | `0x3237dab6` | `0x07000000` | FAR_FUTURE |

`0x07000000` is **mainnet's** `GLOAS_FORK_VERSION`. Neither `gnosisConfig()` nor `chiadoConfig()` overrides `GloasForkVersion`, so both inherit it from `MainnetBeaconConfig` and advertise a foreign chain's fork version. The [p2p-interface spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#eth2-field) requires:

> `next_fork_version` is the fork version corresponding to the next planned hard fork at a future epoch. If no future fork is planned, set `next_fork_version = current_fork_version` to signal this fact.

After the fix chiado advertises `0x0600006f` and gnosis `0x06000064` — their own current (Fulu) versions. Mainnet moves from `0x07000000` to `0x06000000` for the same reason.

**The fork digest is unchanged**, so this cannot affect gossip topics or existing peering — only the advertised `next_fork_version`.

<details><summary>How this surfaced</summary>

Found while investigating why `chiado` fails `QA - Sync from scratch` on nearly every run (e.g. [30698597994](https://github.com/erigontech/erigon/actions/runs/30698597994), [30645661555](https://github.com/erigontech/erigon/actions/runs/30645661555)) with `outcome: "Unexpected error", reason: "Deadline reached"` — Caplin sits in `DownloadHistoricalBlocks` for the whole window with `peerCount=0`.

This PR is **not** claimed as the fix for that. Erigon's chiado fork digest is correct: `0x25f9148e` reproduces as `sha256(pad32(0x0600006f) || GVR)[:4] XOR sha256(le64(948224) || le64(2))[:4]`, the EIP-7892 Fulu XOR using the Electra fallback `GetBlobParameters` returns for an empty `BlobSchedule`, and [upstream chiado config.yaml](https://github.com/gnosischain/configs/blob/main/chiado/config.yaml) confirms the inputs (`ELECTRA_FORK_EPOCH: 948224`, `MAX_BLOBS_PER_BLOCK_ELECTRA: 2`, `FULU_FORK_VERSION: 0x0600006f`). The same code path on gnosis produces the digest that node held 127 peers with.

chiado's real problem is discovery: its bootnodes are largely gone (5 of the 7 in `ChiadoBootstrapNodes` do not answer on port 9000, and all 7 ENRs are Bellatrix-era, `next_fork_version 0x0200006f`). Refreshing them from upstream does not help — the 3 entries upstream has that we lack are dead too. That needs a separate decision.
</details>

Driven by `TestForkIdNextForkVersionWithoutScheduledFork`, which asserts the precondition (`next_fork_epoch == FAR_FUTURE_EPOCH`) and then the version fallback for chiado and gnosis. Red before the change with `actual: 0x07000000` on both.
