### PR TITLE
exec: drop eager formatting from hot paths

### DIFF
--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -83,6 +83,22 @@ func (e ErrExecAbortError) IsError() bool {
 	return e.OriginError != nil
 }
 
+// nonceError formats lazily: under parallel execution a nonce mismatch is a
+// re-execution signal whose text is discarded, so eager formatting would
+// hex-encode the sender on every speculative miss.
+type nonceError struct {
+	err        error // ErrNonceTooHigh or ErrNonceTooLow
+	from       accounts.Address
+	txNonce    uint64
+	stateNonce uint64
+}
+
+func (e *nonceError) Error() string {
+	return fmt.Sprintf("%s: address %v, tx: %d state: %d", e.err, e.from, e.txNonce, e.stateNonce)
+}
+
+func (e *nonceError) Unwrap() error { return e.err }
+
 type TxnExecutor struct {
 	gp                    *GasPool
 	msg                   Message
@@ -319,11 +335,9 @@ func (st *TxnExecutor) preCheck(gasBailout bool, intrinsicGasResult mdgas.Intrin
 			return fmt.Errorf("%w: %w", ErrTxnExecutionFailed, err)
 		}
 		if msgNonce := st.msg.Nonce(); stNonce < msgNonce {
-			return fmt.Errorf("%w: address %v, tx: %d state: %d", ErrNonceTooHigh,
-				from, msgNonce, stNonce)
+			return &nonceError{ErrNonceTooHigh, from, msgNonce, stNonce}
 		} else if stNonce > msgNonce {
-			return fmt.Errorf("%w: address %v, tx: %d state: %d", ErrNonceTooLow,
-				from, msgNonce, stNonce)
+			return &nonceError{ErrNonceTooLow, from, msgNonce, stNonce}
 		} else if stNonce+1 < stNonce {
 			return fmt.Errorf("%w: address %v, nonce: %d", ErrNonceMax,
 				from, stNonce)

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -84,8 +84,7 @@ func (e ErrExecAbortError) IsError() bool {
 }
 
 // nonceError formats lazily: under parallel execution a nonce mismatch is a
-// re-execution signal whose text is discarded, so eager formatting would
-// hex-encode the sender on every speculative miss.
+// routine re-execution signal whose text is discarded.
 type nonceError struct {
 	err        error // ErrNonceTooHigh or ErrNonceTooLow
 	from       accounts.Address

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -335,9 +335,9 @@ func (st *TxnExecutor) preCheck(gasBailout bool, intrinsicGasResult mdgas.Intrin
 			return fmt.Errorf("%w: %w", ErrTxnExecutionFailed, err)
 		}
 		if msgNonce := st.msg.Nonce(); stNonce < msgNonce {
-			return &nonceError{ErrNonceTooHigh, from, msgNonce, stNonce}
+			return &nonceError{err: ErrNonceTooHigh, from: from, txNonce: msgNonce, stateNonce: stNonce}
 		} else if stNonce > msgNonce {
-			return &nonceError{ErrNonceTooLow, from, msgNonce, stNonce}
+			return &nonceError{err: ErrNonceTooLow, from: from, txNonce: msgNonce, stateNonce: stNonce}
 		} else if stNonce+1 < stNonce {
 			return fmt.Errorf("%w: address %v, nonce: %d", ErrNonceMax,
 				from, stNonce)

--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -461,7 +461,7 @@ func (st *TxnExecutor) ApplyFrame() (*evmtypes.ExecutionResult, error) {
 		runtimeSnapshot = st.state.PushSnapshot()
 		defer st.state.PopSnapshot(runtimeSnapshot)
 	}
-	st.gasRemaining, _, err = st.verifyAuthorities(auths, contractCreation, rules.ChainID.String(), st.gasRemaining)
+	st.gasRemaining, _, err = st.verifyAuthorities(auths, contractCreation, rules.ChainID, st.gasRemaining)
 	if err == nil && !contractCreation {
 		st.gasRemaining, gasUsed.topLevel, err = st.prepareTopLevelCall(st.gasRemaining)
 	}
@@ -638,7 +638,7 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 		runtimeSnapshot = st.state.PushSnapshot()
 		defer st.state.PopSnapshot(runtimeSnapshot)
 	}
-	st.gasRemaining, gasUsed.auth, vmerr = st.verifyAuthorities(auths, contractCreation, rules.ChainID.String(), st.gasRemaining)
+	st.gasRemaining, gasUsed.auth, vmerr = st.verifyAuthorities(auths, contractCreation, rules.ChainID, st.gasRemaining)
 	if vmerr == nil {
 		if contractCreation {
 			createNonce, vmerr = st.state.GetNonce(sender)
@@ -814,7 +814,7 @@ func (st *TxnExecutor) prepareTopLevelCreate(destination accounts.Address, gasRe
 	return gasRemaining, gasUsed, err
 }
 
-func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCreation bool, chainID string, gasRemaining mdgas.MdGas) (mdgas.MdGas, mdgas.MdGasUsage, error) {
+func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCreation bool, chainID *uint256.Int, gasRemaining mdgas.MdGas) (mdgas.MdGas, mdgas.MdGasUsage, error) {
 	var gasUsed mdgas.MdGasUsage
 	if auths == nil {
 		return gasRemaining, gasUsed, nil
@@ -842,7 +842,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 		data.Reset()
 
 		// 1. chainId check
-		if !auth.ChainID.IsZero() && chainID != auth.ChainID.String() {
+		if !auth.ChainID.IsZero() && !auth.ChainID.Eq(chainID) {
 			log.Debug("invalid chainID, skipping", "chainId", auth.ChainID, "authIndex", i)
 			continue
 		}

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -958,11 +958,12 @@ func TestBuyGas_NilMaxFeePerBlobGasWithBlobs(t *testing.T) {
 }
 
 // TestPreCheckNonceMismatchError pins the message text and the errors.Is
-// identity: the parallel executor matches the sentinel, RPC surfaces the text.
+// identity that block assembly and eth_simulate match on. The sender address
+// carries letters so the pinned text also covers EIP-55 casing.
 func TestPreCheckNonceMismatchError(t *testing.T) {
 	t.Parallel()
 
-	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	sender := accounts.InternAddress(common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"))
 	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
 
 	preCheckWithNonce := func(t *testing.T, stateNonce, msgNonce uint64) error {
@@ -991,7 +992,7 @@ func TestPreCheckNonceMismatchError(t *testing.T) {
 		require.ErrorIs(t, err, ErrNonceTooHigh)
 		require.NotErrorIs(t, err, ErrNonceTooLow)
 		require.Equal(t,
-			"nonce too high: address 0x1111111111111111111111111111111111111111, tx: 7 state: 3",
+			"nonce too high: address 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF, tx: 7 state: 3",
 			err.Error())
 	})
 
@@ -1000,7 +1001,7 @@ func TestPreCheckNonceMismatchError(t *testing.T) {
 		require.ErrorIs(t, err, ErrNonceTooLow)
 		require.NotErrorIs(t, err, ErrNonceTooHigh)
 		require.Equal(t,
-			"nonce too low: address 0x1111111111111111111111111111111111111111, tx: 3 state: 7",
+			"nonce too low: address 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF, tx: 3 state: 7",
 			err.Error())
 	})
 

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -956,3 +956,57 @@ func TestBuyGas_NilMaxFeePerBlobGasWithBlobs(t *testing.T) {
 	require.NotPanics(t, func() { err = st.buyGas(false) })
 	require.NoError(t, err)
 }
+
+// TestPreCheckNonceMismatchError pins the wire format and the errors.Is
+// identity of the nonce-mismatch errors. The parallel executor matches on the
+// sentinel and RPC surfaces the text, so both must survive changes to how the
+// error is built.
+func TestPreCheckNonceMismatchError(t *testing.T) {
+	t.Parallel()
+
+	sender := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	preCheckWithNonce := func(t *testing.T, stateNonce, msgNonce uint64) error {
+		t.Helper()
+		ibs := state.New(state.NewNoopReader())
+		defer ibs.Close()
+		require.NoError(t, ibs.SetNonce(sender, stateNonce, tracing.NonceChangeGenesis))
+
+		evm := newTestEVM(ibs, chain.TestChainOsakaConfig, 30_000_000)
+		msg := types.NewMessage(
+			sender, recipient, msgNonce, uint256.NewInt(0), 100_000,
+			uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0),
+			nil, nil,
+			true,  // checkNonce
+			false, // checkTransaction
+			false, // checkGas
+			false, // isFree
+			nil,   // maxFeePerBlobGas
+		)
+		st := NewTxnExecutor(evm, msg, new(GasPool).AddGas(30_000_000))
+		return st.preCheck(false, mdgas.IntrinsicGasCalcResult{})
+	}
+
+	t.Run("nonce too high", func(t *testing.T) {
+		err := preCheckWithNonce(t, 3, 7)
+		require.ErrorIs(t, err, ErrNonceTooHigh)
+		require.NotErrorIs(t, err, ErrNonceTooLow)
+		require.Equal(t,
+			"nonce too high: address 0x1111111111111111111111111111111111111111, tx: 7 state: 3",
+			err.Error())
+	})
+
+	t.Run("nonce too low", func(t *testing.T) {
+		err := preCheckWithNonce(t, 7, 3)
+		require.ErrorIs(t, err, ErrNonceTooLow)
+		require.NotErrorIs(t, err, ErrNonceTooHigh)
+		require.Equal(t,
+			"nonce too low: address 0x1111111111111111111111111111111111111111, tx: 3 state: 7",
+			err.Error())
+	})
+
+	t.Run("matching nonce passes", func(t *testing.T) {
+		require.NoError(t, preCheckWithNonce(t, 5, 5))
+	})
+}

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -957,10 +957,8 @@ func TestBuyGas_NilMaxFeePerBlobGasWithBlobs(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestPreCheckNonceMismatchError pins the wire format and the errors.Is
-// identity of the nonce-mismatch errors. The parallel executor matches on the
-// sentinel and RPC surfaces the text, so both must survive changes to how the
-// error is built.
+// TestPreCheckNonceMismatchError pins the message text and the errors.Is
+// identity: the parallel executor matches the sentinel, RPC surfaces the text.
 func TestPreCheckNonceMismatchError(t *testing.T) {
 	t.Parallel()
 

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2598,10 +2598,8 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			}
 		}
 
-		tracePrefix := fmt.Sprintf("%d (%d.%d)", be.blockNum, txVersion.TxIndex, txVersion.Incarnation)
-
-		var trace bool
-		if trace = dbg.TraceTransactionIO && dbg.TraceTx(be.blockNum, txVersion.TxIndex); trace {
+		if dbg.TraceTransactionIO && dbg.TraceTx(be.blockNum, txVersion.TxIndex) {
+			tracePrefix := fmt.Sprintf("%d (%d.%d)", be.blockNum, txVersion.TxIndex, txVersion.Incarnation)
 			fmt.Println(tracePrefix, "RD", be.blockIO.ReadSet(txVersion.TxIndex).Len(), "WRT", be.blockIO.WriteSet(txVersion.TxIndex).Count())
 			be.blockIO.ReadSet(txVersion.TxIndex).TraceReads(tracePrefix)
 			for h := range be.blockIO.WriteSet(txVersion.TxIndex).AllHeaders() {


### PR DESCRIPTION
Three `fmt`/string calls run on every iteration of a hot loop and their output is thrown away.

**`blockExecutor.nextResult`** built `tracePrefix` with `fmt.Sprintf` for every successful tx result, then used it only inside the `dbg.TraceTransactionIO` branch. Moved into the branch. The sibling site a few lines below (the validate loop) already did it this way.

**`TxnExecutor.preCheck`** built the nonce-mismatch error with `fmt.Errorf`. Under parallel execution this is not an exceptional path: a tx dispatched ahead of its predecessor reads a stale sender nonce, `preCheck` returns `ErrNonceTooHigh`, `TxTask.Execute` wraps it in `ErrExecAbortError` and `nextResult` re-queues the tx. The message is never read. `accounts.Address` has a `Format` method, so `%v` boxes it and hex-encodes 42 chars per speculative miss. Replaced with a `nonceError` that stores the fields and formats in `Error()`.

**`TxnExecutor.verifyAuthorities`** took the chain ID as a decimal string, so every transaction built `rules.ChainID.String()` before the call — including the overwhelming majority that carry no authorization list and never enter the loop that reads it. Inside the loop the string was only used for an equality test, which `uint256.Eq` does directly.

## Numbers

From `cpu.pprof` (300s, 1103.40s samples, parallel exec on mainnet):

| site | cum | share |
|---|---|---|
| `fmt.Sprintf` under `nextResult` | 0.75s | 94% of all `fmt.Sprintf` samples |
| `fmt.Errorf` under `preCheck` | 0.28s | 93% of all `fmt.Errorf` samples; 5.8% of `preCheck` |
| `uint256.Int.String` under `Execute` | 0.10s | — |

Micro-benchmarks:

```
trace prefix   fmt.Sprintf   67.5 ns/op   16 B/op   1 alloc/op   -> not built at all
nonce error    fmt.Errorf   305.0 ns/op  176 B/op   3 allocs/op
               nonceError    13.9 ns/op   48 B/op   1 alloc/op   (-95.4% ns, -72.7% B)
chain id       String()       2.1 ns/op
               Eq()          0.55 ns/op
```

## Behaviour

Unchanged. `nonceError.Unwrap` keeps `errors.Is(err, ErrNonceTooHigh)` / `ErrNonceTooLow` working for the two consumers that match the sentinels (`block_assembler.go`, `eth_simulation.go`), and `Error()` reproduces the previous string byte for byte. The parallel executor never matches them — it handles the wrapped `ErrExecAbortError` opaquely, keying dispatch on `IsError()` plus version validation.

`ErrNonceMax` keeps `fmt.Errorf` — it needs `stNonce+1 < stNonce`, so it is unreachable outside `MaxUint64` and not worth a second type.

`uint256` decimal strings are canonical, so string equality and `Eq` agree on every input. `verifyAuthorities` has no other callers.

The new test is a characterization test, added before the refactor and green on both sides: it pins the exact message text and the `errors.Is` identity for both directions. The sender address carries hex letters, so the pinned text also covers EIP-55 casing. Per CLAUDE.md this is the pure-refactor case, so it is a safety net rather than a Red->Green cycle.
