### PR TITLE
recsplit: bounds checks elimination in hot loops

### DIFF
--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -52,6 +52,12 @@ const RecSplitLogPrefix = "recsplit"
 
 const MaxLeafSize = 24
 
+// maxFanout bounds splitParams' fanout for every leafSize <= MaxLeafSize (the real
+// maximum is 9, see TestSplitParamsFanoutBound). findSplit counts into fixed-size
+// arrays of this length, so masking a partition index with maxFanout-1 is a no-op
+// that lets the compiler drop the bounds check.
+const maxFanout = 16
+
 // ExistenceFilterVersion selects the existence-filter format written for new index files.
 //
 //	0 = byte-array of first-bytes (legacy, no FuseFilter)
@@ -84,7 +90,7 @@ func remix(z uint64) uint64 {
 
 // recsplitScratch holds per-execution scratch buffers and configuration (shared by sequential and worker paths).
 type recsplitScratch struct {
-	count              []uint16 // Size = secondaryAggrBound (for findSplit 8-way)
+	count              []uint16 // Partition offsets used to redistribute a bucket after findSplit
 	buffer             []uint64
 	offsetBuffer       []uint64
 	unaryBuf           []uint64 // reused across buckets to avoid allocation
@@ -356,13 +362,24 @@ func (sc *recsplitScratch) preAlloc(n int) {
 // the Golomb parameter for m. Each scratch owns its own slice, so this is safe
 // to call concurrently from different workers without any locking.
 func (sc *recsplitScratch) golombParam(m uint16) int {
+	if table := sc.golombRice; int(m) < len(table) {
+		return int(table[m] >> 27)
+	}
+	return sc.golombParamSlow(m)
+}
+
+// golombParamSlow extends the table up to m, then returns the parameter for m.
+// Kept out of golombParam so the common already-computed case stays inlinable.
+func (sc *recsplitScratch) golombParamSlow(m uint16) int {
 	for s := uint16(len(sc.golombRice)); m >= s; s++ {
-		sc.golombRice = append(sc.golombRice, 0)
-		if s == 0 {
-			sc.golombRice[0] = (bijMemo[0] << 27) | bijMemo[0]
-		} else if s <= sc.leafSize {
-			sc.golombRice[s] = (bijMemo[s] << 27) | (uint32(1) << 16) | bijMemo[s]
-		} else {
+		switch {
+		case s == 0:
+			sc.golombRice = append(sc.golombRice, (bijMemo[0]<<27)|bijMemo[0])
+		case s <= sc.leafSize:
+			bij := bijMemo[s]
+			sc.golombRice = append(sc.golombRice, (bij<<27)|(uint32(1)<<16)|bij)
+		default:
+			sc.golombRice = append(sc.golombRice, 0)
 			computeGolombRice(s, sc.golombRice, sc.leafSize, sc.primaryAggrBound, sc.secondaryAggrBound)
 		}
 	}
@@ -652,43 +669,37 @@ func (rs *RecSplit) recsplitCurrentBucket() error {
 
 // findSplit finds a salt value such that keys in bucket are evenly distributed
 // into fanout partitions of size unit each (based on remap16(remix(key+salt), m) / unit).
-// Uses 8-way salt parallelism with 8 independent count arrays carved from the
-// count slice (which must have len >= 8*fanout).
-func findSplit(bucket []uint64, salt uint64, fanout, unit uint16, count []uint16) uint64 {
+// Uses 8-way salt parallelism with 8 independent count arrays.
+func findSplit(bucket []uint64, salt uint64, fanout, unit uint16) uint64 {
+	if fanout > maxFanout {
+		panic(fmt.Sprintf("fanout %d exceeds maxFanout %d", fanout, maxFanout))
+	}
 	m := uint16(len(bucket))
-	c0 := count[0*fanout : 1*fanout : 1*fanout]
-	c1 := count[1*fanout : 2*fanout : 2*fanout]
-	c2 := count[2*fanout : 3*fanout : 3*fanout]
-	c3 := count[3*fanout : 4*fanout : 4*fanout]
-	c4 := count[4*fanout : 5*fanout : 5*fanout]
-	c5 := count[5*fanout : 6*fanout : 6*fanout]
-	c6 := count[6*fanout : 7*fanout : 7*fanout]
-	c7 := count[7*fanout : 8*fanout : 8*fanout]
 	for {
-		clear(count[:8*fanout])
-		for i := range m {
-			key := bucket[i]
-			c0[remap16(remix(key+salt), m)/unit]++
-			c1[remap16(remix(key+salt+1), m)/unit]++
-			c2[remap16(remix(key+salt+2), m)/unit]++
-			c3[remap16(remix(key+salt+3), m)/unit]++
-			c4[remap16(remix(key+salt+4), m)/unit]++
-			c5[remap16(remix(key+salt+5), m)/unit]++
-			c6[remap16(remix(key+salt+6), m)/unit]++
-			c7[remap16(remix(key+salt+7), m)/unit]++
+		var c [8][maxFanout]uint16
+		for _, key := range bucket {
+			c[0][(remap16(remix(key+salt), m)/unit)&(maxFanout-1)]++
+			c[1][(remap16(remix(key+salt+1), m)/unit)&(maxFanout-1)]++
+			c[2][(remap16(remix(key+salt+2), m)/unit)&(maxFanout-1)]++
+			c[3][(remap16(remix(key+salt+3), m)/unit)&(maxFanout-1)]++
+			c[4][(remap16(remix(key+salt+4), m)/unit)&(maxFanout-1)]++
+			c[5][(remap16(remix(key+salt+5), m)/unit)&(maxFanout-1)]++
+			c[6][(remap16(remix(key+salt+6), m)/unit)&(maxFanout-1)]++
+			c[7][(remap16(remix(key+salt+7), m)/unit)&(maxFanout-1)]++
 		}
 		// Branchless validation: XOR each count with expected value,
 		// OR-accumulate to detect any mismatch.
 		var bad0, bad1, bad2, bad3, bad4, bad5, bad6, bad7 uint16
-		for i := uint16(0); i < fanout-1; i++ {
-			bad0 |= c0[i] ^ unit
-			bad1 |= c1[i] ^ unit
-			bad2 |= c2[i] ^ unit
-			bad3 |= c3[i] ^ unit
-			bad4 |= c4[i] ^ unit
-			bad5 |= c5[i] ^ unit
-			bad6 |= c6[i] ^ unit
-			bad7 |= c7[i] ^ unit
+		for i := range fanout - 1 {
+			j := i & (maxFanout - 1)
+			bad0 |= c[0][j] ^ unit
+			bad1 |= c[1][j] ^ unit
+			bad2 |= c[2][j] ^ unit
+			bad3 |= c[3][j] ^ unit
+			bad4 |= c[4][j] ^ unit
+			bad5 |= c[5][j] ^ unit
+			bad6 |= c[6][j] ^ unit
+			bad7 |= c[7][j] ^ unit
 		}
 		if bad0 == 0 {
 			return salt
@@ -727,8 +738,7 @@ func findBijection(bucket []uint64, salt uint64) uint64 {
 	fullMask := uint32((1 << m) - 1)
 	for {
 		var mask0, mask1, mask2, mask3, mask4, mask5, mask6, mask7 uint32
-		for i := range m {
-			key := bucket[i]
+		for _, key := range bucket {
 			// adding `& 31` - it doesn't have runtime overhead, but it tells for compiler that shift can't overflow
 			// and compiler generating less assembly checks: ~10% perf.
 			// it's safe because: len(bucket) <= leafSize <= 24
@@ -798,7 +808,7 @@ func recsplit(level int, bucket []uint64, offsets []uint64, unary []uint64, rs *
 	} else {
 		fanout, unit := splitParams(m, rs.leafSize, rs.primaryAggrBound, rs.secondaryAggrBound)
 		count := rs.count
-		salt = findSplit(bucket, salt, fanout, unit, count)
+		salt = findSplit(bucket, salt, fanout, unit)
 		for i, c := uint16(0), uint16(0); i < fanout; i++ {
 			count[i] = c
 			c += unit

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -362,8 +362,8 @@ func (sc *recsplitScratch) preAlloc(n int) {
 // the Golomb parameter for m. Each scratch owns its own slice, so this is safe
 // to call concurrently from different workers without any locking.
 func (sc *recsplitScratch) golombParam(m uint16) int {
-	if table := sc.golombRice; int(m) < len(table) {
-		return int(table[m] >> 27)
+	if i, table := int(m), sc.golombRice; i < len(table) {
+		return int(table[i] >> 27)
 	}
 	return sc.golombParamSlow(m)
 }

--- a/db/recsplit/recsplit_test.go
+++ b/db/recsplit/recsplit_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -215,6 +216,24 @@ func TestFindBijectionSmallBuckets(t *testing.T) {
 	}
 }
 
+// findSplit masks partition indexes with maxFanout-1 instead of bounds-checking them.
+// That is only correct while every reachable (leafSize, m) keeps fanout - and the
+// largest index a key can land in - below maxFanout.
+func TestSplitParamsFanoutBound(t *testing.T) {
+	for leafSize := uint16(1); leafSize <= MaxLeafSize; leafSize++ {
+		primaryAggrBound := leafSize * uint16(math.Max(2, math.Ceil(0.35*float64(leafSize)+1./2.)))
+		secondaryAggrBound := primaryAggrBound * 2
+		if leafSize >= 7 {
+			secondaryAggrBound = primaryAggrBound * uint16(math.Ceil(0.21*float64(leafSize)+9./10.))
+		}
+		for m := leafSize + 1; m <= 4000; m++ {
+			fanout, unit := splitParams(m, leafSize, primaryAggrBound, secondaryAggrBound)
+			require.LessOrEqual(t, fanout, uint16(maxFanout), "leafSize=%d m=%d", leafSize, m)
+			require.Less(t, (m-1)/unit, fanout, "leafSize=%d m=%d unit=%d", leafSize, m, unit)
+		}
+	}
+}
+
 func TestFindSplit(t *testing.T) {
 	const (
 		leafSize           = uint16(8)
@@ -232,9 +251,8 @@ func TestFindSplit(t *testing.T) {
 	}
 
 	fanout, unit := splitParams(m, leafSize, primaryAggrBound, secondaryAggrBound)
-	count := make([]uint16, secondaryAggrBound)
 
-	salt := findSplit(bucket, 0, fanout, unit, count)
+	salt := findSplit(bucket, 0, fanout, unit)
 
 	// Verify: each partition gets exactly 'unit' keys (except possibly the last)
 	partitionCounts := make([]uint16, fanout)
@@ -267,9 +285,8 @@ func TestFindSplitSecondaryAggr(t *testing.T) {
 	}
 
 	fanout, unit := splitParams(m, leafSize, primaryAggrBound, secondaryAggrBound)
-	count := make([]uint16, secondaryAggrBound)
 
-	salt := findSplit(bucket, 0, fanout, unit, count)
+	salt := findSplit(bucket, 0, fanout, unit)
 
 	partitionCounts := make([]uint16, fanout)
 	for _, key := range bucket {
@@ -308,11 +325,10 @@ func BenchmarkFindSplit(b *testing.B) {
 	}
 	fanout, unit := splitParams(m, leafSize, primaryAggrBound, secondaryAggrBound)
 	salt := uint64(0x6453cec3f7376937) // startSeed[1]
-	count := make([]uint16, secondaryAggrBound)
 
 	for b.Loop() {
 		for i := range buckets {
-			findSplit(buckets[i][:], salt, fanout, unit, count)
+			findSplit(buckets[i][:], salt, fanout, unit)
 		}
 	}
 }

--- a/db/recsplit/recsplit_test.go
+++ b/db/recsplit/recsplit_test.go
@@ -226,10 +226,16 @@ func TestSplitParamsFanoutBound(t *testing.T) {
 		if leafSize >= 7 {
 			secondaryAggrBound = primaryAggrBound * uint16(math.Ceil(0.21*float64(leafSize)+9./10.))
 		}
-		for m := leafSize + 1; m <= 4000; m++ {
+		// m == MaxUint16 is excluded: splitParams computes m+1, which wraps to 0 and
+		// yields unit 0. Unreachable for real bucket sizes and unrelated to the mask.
+		for m := leafSize + 1; m < math.MaxUint16; m++ {
 			fanout, unit := splitParams(m, leafSize, primaryAggrBound, secondaryAggrBound)
-			require.LessOrEqual(t, fanout, uint16(maxFanout), "leafSize=%d m=%d", leafSize, m)
-			require.Less(t, (m-1)/unit, fanout, "leafSize=%d m=%d unit=%d", leafSize, m, unit)
+			if fanout > maxFanout {
+				t.Fatalf("fanout %d > maxFanout %d at leafSize=%d m=%d", fanout, maxFanout, leafSize, m)
+			}
+			if j := (m - 1) / unit; j >= fanout {
+				t.Fatalf("index %d >= fanout %d at leafSize=%d m=%d unit=%d", j, fanout, leafSize, m, unit)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Removes 31 array bounds checks from the recsplit build path: `findBijection`, `findSplit` and `golombParam` all index slices the compiler's prove pass cannot bound, so each key paid a check per salt lane. Index files are byte-identical before and after.

| bench (M4 Max) | main | this PR | Δ |
|---|---|---|---|
| FindSplit | 5.672m | 4.944m | -12.84% |
| FindBijection | 2.037m | 1.955m | -4.04% |
| Build (1M keys) | 740.8m | 678.9m | -8.35% |
| BuildParallel/workers=1 | 737.7m | 671.3m | -9.01% |
| BuildParallel/workers=2 | 546.0m | 510.4m | -6.53% |
| BuildParallel/workers=4 | 360.2m | 344.9m | -4.25% |
| BuildParallel/workers=8 | 267.6m | 260.7m | -2.60% |
| geomean | 491.8m | 461.4m | -6.18% |

<details>
<summary>What blocked each check</summary>

- **findBijection** — `m := uint16(len(bucket)); for i := range m` puts the loop bound on a truncation of `len`, which prove cannot relate back to the slice. `for _, key := range bucket` is the same iteration with no check.
- **findSplit** — the index is `remap16(...)/unit`. prove has no range information for a multiply-shift, so all 8 lanes plus the validation loop were checked. Counting into `[8][maxFanout]uint16` and masking the index with `maxFanout-1` makes it a constant-bounded array access. Clamping inside `remap16` instead would pay a compare at every call site, including `findBijection` where the result feeds a shift, not an index.
- **golombParam** — the table is grown lazily, so the trailing `sc.golombRice[m]` was unprovable. Returning inside the `int(m) < len(table)` guard fixes the common case; a phi merging the cold grow path would have brought the check back, hence the split into `golombParamSlow`. Side effect: the fast path now inlines (cost 80).

`maxFanout` is 16 and `TestSplitParamsFanoutBound` pins the real bound — over every `leafSize <= MaxLeafSize` and `m <= 4000`, fanout stays <= 9 and the largest partition index a key can reach is 8.
</details>

<details>
<summary>Correctness</summary>

Built 50k-key indexes with `leafSize` 8 and 16, workers 1 and 4, on main and on this branch: sha256 identical in all four cases. The search order is untouched, so the same salts are chosen.

Dropping the `count` parameter from `findSplit` also removes a latent panic: `rs.count` is sized `secondaryAggrBound`, but the old 8-way carve needed `8*fanout`, which is undersized for `leafSize < 7` (e.g. `leafSize=3` needs 16, has 12). `rs.count` is now only the redistribution prefix-sum array.
</details>

<details>
<summary>Remaining checks in this package</summary>

Not addressed here: `recsplit()` itself keeps 5 checks per key in the redistribution loop and 3 in the leaf loop, and `golomb_rice.go` has 16 more in `appendFixed`/`appendUnaryAll`.
</details>
