### PR TITLE
"Handshake transport error" log demote to trace level

### DIFF
--- a/cl/sentinel/discovery.go
+++ b/cl/sentinel/discovery.go
@@ -583,7 +583,7 @@ func (s *Sentinel) onConnection(_ network.Network, conn network.Conn) {
 		if err != nil {
 			// Handshake transport error (stream reset, timeout, etc.) — keep the peer.
 			// The peer may still work for gossip even if status exchange failed.
-			log.Debug("[Sentinel] Handshake transport error (keeping connection)", "peer", peerId, "err", err)
+			log.Trace("[Sentinel] Handshake transport error (keeping connection)", "peer", peerId, "err", err)
 		}
 
 		if !valid && err == nil {


### PR DESCRIPTION
now in logs: 
```
[DBUG] [08-03|05:52:46.505] [Sentinel] Handshake transport error (keeping connection) peer=16Uiu2HAmLqJUYPkMg2tcoBryQZXTZTekwa1JaYNtbfD89FqnXGFM err="hand shake error: , can't Connect to Peer: connection failed\n"
```
- it's meaningless (user or me can't know what peer is it)
- it's not actionable (unclear do we need to take any actions to fix this errors or not)
- maybe we need filter-out only `connection failed` and keep other errors (i don't know)
- `\n` is wrong formatting in logs

