### PR TITLE
docs: migrate README-only operator content to the site

### DIFF
--- a/docs/site/docs/fundamentals/caplin.md
+++ b/docs/site/docs/fundamentals/caplin.md
@@ -49,3 +49,9 @@ When Caplin is running, it exposes a Beacon API that external tools can query. T
 | `--beacon.api.read.timeout` | `5` | HTTP server read timeout, in seconds |
 | `--beacon.api.write.timeout` | `31536000` | HTTP server write timeout, in seconds (~1 year) |
 | `--beacon.api.idle.timeout` | `25` | HTTP server idle timeout, in seconds |
+
+The API is not served until you enable it with `--beacon.api=<namespaces>`; see [Caplin for staking](../staking/caplin) for the full namespace list.
+
+:::note
+Enabling the Beacon API increases RAM usage by roughly **6 GB**. Account for it when sizing your host — see [Hardware Requirements](../get-started/hardware-requirements).
+:::

--- a/docs/site/docs/fundamentals/database.md
+++ b/docs/site/docs/fundamentals/database.md
@@ -93,7 +93,7 @@ Deleting `chaindata/` is **recoverable but not free**: it discards the latest mu
 
 ## Tuning knobs
 
-- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM.
+- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM. Larger batches also leave more data in `chaindata/` between snapshot builds, so keep it at or below `1G` if you want to cap how far MDBX grows.
 - **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
 - **`--db.read.concurrency`** — number of concurrent MDBX read transactions. Increase when you run a high-throughput RPC Daemon against the same datadir.
 - **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.

--- a/docs/site/docs/fundamentals/logs.md
+++ b/docs/site/docs/fundamentals/logs.md
@@ -31,6 +31,10 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 * `--log.dir.verbosity`: Set file log level (default: `dbug`)
 * `--log.delays`: Enable block delay logging
 
+**Downloader (torrent) logs**
+
+The torrent client inside the Downloader keeps its own JSON-formatted file, `logs/torrent.log`. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
+
 **Log Levels**
 
 The logging system defines six distinct log levels in hierarchical order:

--- a/docs/site/docs/fundamentals/security.md
+++ b/docs/site/docs/fundamentals/security.md
@@ -20,6 +20,10 @@ Based on best practices for execution clients, your local machine's firewall set
 | 8545     | TCP          | JSON-RPC (Public API)         | Block all traffic _except_ from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
 | 9090     | TCP          | Private API Communication     | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node).                            |
 
+:::note
+Some hosting providers impose additional firewall requirements on top of these. If you run on Hetzner Cloud or a Hetzner dedicated server, see the [Hetzner firewall note](/help-center/troubleshooting#hetzner-cloud--dedicated-server-firewall-note) for the ports to open and the reserved ranges to block.
+:::
+
 #### CORS Protection
 
 When exposing public RPC endpoints (like those on port 8545), use the following practice to mitigate cross-origin attacks:

--- a/docs/site/docs/get-started/hardware-requirements.mdx
+++ b/docs/site/docs/get-started/hardware-requirements.mdx
@@ -110,3 +110,16 @@ Your internet bandwidth is also an important factor, particularly for sync speed
 | -------------- | -------------------- | ----------------------- |
 | Staking/Mining | 10 Mbps              | 50 Mbps                 |
 | Non-Staking    | 5 Mbps               | 25 Mbps                 |
+
+## Sync Times
+
+Approximate times to sync from scratch to the tip of the chain.
+
+| Chain    | Archive | Full (Default) | Minimal |
+| -------- | ------- | -------------- | ------- |
+| Ethereum | ~8 h    | ~4–6 h         | ~2 h    |
+| Gnosis   | ~2 h    | ~1–2 h         | ~30 m   |
+
+:::info
+These figures are indicative and are **not measured by CI** — read them as an order of magnitude, not a target. Most of the elapsed time is snapshot download rather than block execution, so your available [bandwidth](#bandwidth-requirements) influences the result more than CPU does: expect proportionally faster syncs on a well-connected host and slower ones on a constrained link.
+:::

--- a/docs/site/docs/get-started/installation/index.mdx
+++ b/docs/site/docs/get-started/installation/index.mdx
@@ -357,6 +357,16 @@ make -j<n> erigon
 
 The resulting executable binary will be created in the `./build/bin/erigon` path.
 
+**2.4 Installing Outside the Build Tree (Optional)**
+
+Running Erigon as a [dedicated system user](/fundamentals/security) — for example under `systemd` — is easiest when the binaries live outside your source checkout, where that user can reach them. Pass a destination to `make install`:
+
+```sh
+make DIST=/opt/erigon install
+```
+
+`$HOME/erigon` works equally well. `make install` copies whatever is currently in `build/bin`, so build every component you intend to deploy before running it.
+
 **3. Running Erigon**
 
 After installation, you can run Erigon from your terminal:

--- a/docs/site/help-center/troubleshooting.md
+++ b/docs/site/help-center/troubleshooting.md
@@ -44,6 +44,8 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
+If the node is wedged and you are ready to lose the running instance, `kill -6 $(pidof erigon)` (`SIGABRT`) dumps the stacks and terminates the process in one step.
+
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 
 ```bash
@@ -69,4 +71,27 @@ Hetzner applies a stateless firewall at the network edge. Ensure the following p
 | P2P (Caplin)   | 9000  | TCP+UDP  |
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure the firewall in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`.
+
+An Erigon node should also never attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is good practice on any host and worth doing explicitly on Hetzner, whose stricter filtering is what prompted this note. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are the ones commonly blocked for an Ethereum node (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
+
+```text
+0.0.0.0/8             "This" Network                                RFC 1122, Section 3.2.1.3
+10.0.0.0/8            Private-Use Networks                          RFC 1918
+100.64.0.0/10         Carrier-Grade NAT (CGN)                       RFC 6598, Section 7
+127.0.0.0/8           Loopback                                      RFC 1122, Section 3.2.1.3
+169.254.0.0/16        Link Local                                    RFC 3927
+172.16.0.0/12         Private-Use Networks                          RFC 1918
+192.0.0.0/24          IETF Protocol Assignments                     RFC 5736
+192.0.2.0/24          TEST-NET-1                                    RFC 5737
+192.88.99.0/24        6to4 Relay Anycast                            RFC 3068
+192.168.0.0/16        Private-Use Networks                          RFC 1918
+198.18.0.0/15         Network Interconnect Device Benchmark Testing RFC 2544
+198.51.100.0/24       TEST-NET-2                                    RFC 5737
+203.0.113.0/24        TEST-NET-3                                    RFC 5737
+224.0.0.0/4           Multicast                                     RFC 3171
+240.0.0.0/4           Reserved for Future Use                       RFC 1112, Section 4
+255.255.255.255/32    Limited Broadcast                             RFC 919 and RFC 922, Section 7
+```
+
+The same list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068).
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -143,6 +143,19 @@ Your internet bandwidth is also an important factor, particularly for sync speed
 | Staking/Mining | 10 Mbps              | 50 Mbps                 |
 | Non-Staking    | 5 Mbps               | 25 Mbps                 |
 
+## Sync Times
+
+Approximate times to sync from scratch to the tip of the chain.
+
+| Chain    | Archive | Full (Default) | Minimal |
+| -------- | ------- | -------------- | ------- |
+| Ethereum | ~8 h    | ~4–6 h         | ~2 h    |
+| Gnosis   | ~2 h    | ~1–2 h         | ~30 m   |
+
+:::info
+These figures are indicative and are **not measured by CI** — read them as an order of magnitude, not a target. Most of the elapsed time is snapshot download rather than block execution, so your available [bandwidth](#bandwidth-requirements) influences the result more than CPU does: expect proportionally faster syncs on a well-connected host and slower ones on a constrained link.
+:::
+
 ---
 
 # Migrating from Geth
@@ -584,6 +597,16 @@ make -j<n> erigon
 ```
 
 The resulting executable binary will be created in the `./build/bin/erigon` path.
+
+**2.4 Installing Outside the Build Tree (Optional)**
+
+Running Erigon as a [dedicated system user](/fundamentals/security) — for example under `systemd` — is easiest when the binaries live outside your source checkout, where that user can reach them. Pass a destination to `make install`:
+
+```sh
+make DIST=/opt/erigon install
+```
+
+`$HOME/erigon` works equally well. `make install` copies whatever is currently in `build/bin`, so build every component you intend to deploy before running it.
 
 **3. Running Erigon**
 
@@ -1661,7 +1684,7 @@ Deleting `chaindata/` is **recoverable but not free**: it discards the latest mu
 
 ## Tuning knobs
 
-- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM.
+- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM. Larger batches also leave more data in `chaindata/` between snapshot builds, so keep it at or below `1G` if you want to cap how far MDBX grows.
 - **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
 - **`--db.read.concurrency`** — number of concurrent MDBX read transactions. Increase when you run a high-throughput RPC Daemon against the same datadir.
 - **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.
@@ -1925,6 +1948,12 @@ When Caplin is running, it exposes a Beacon API that external tools can query. T
 | `--beacon.api.read.timeout` | `5` | HTTP server read timeout, in seconds |
 | `--beacon.api.write.timeout` | `31536000` | HTTP server write timeout, in seconds (~1 year) |
 | `--beacon.api.idle.timeout` | `25` | HTTP server idle timeout, in seconds |
+
+The API is not served until you enable it with `--beacon.api=<namespaces>`; see [Caplin for staking](../staking/caplin) for the full namespace list.
+
+:::note
+Enabling the Beacon API increases RAM usage by roughly **6 GB**. Account for it when sizing your host — see [Hardware Requirements](../get-started/hardware-requirements).
+:::
 
 ---
 
@@ -3197,6 +3226,10 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 * `--log.dir.verbosity`: Set file log level (default: `dbug`)
 * `--log.delays`: Enable block delay logging
 
+**Downloader (torrent) logs**
+
+The torrent client inside the Downloader keeps its own JSON-formatted file, `logs/torrent.log`. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
+
 **Log Levels**
 
 The logging system defines six distinct log levels in hierarchical order:
@@ -3277,6 +3310,10 @@ Based on best practices for execution clients, your local machine's firewall set
 | 30303    | TCP & UDP    | Peer-to-Peer (P2P) Networking | Allow inbound and outbound traffic to enable peer discovery and connections.                                                             |
 | 8545     | TCP          | JSON-RPC (Public API)         | Block all traffic _except_ from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
 | 9090     | TCP          | Private API Communication     | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node).                            |
+
+:::note
+Some hosting providers impose additional firewall requirements on top of these. If you run on Hetzner Cloud or a Hetzner dedicated server, see the [Hetzner firewall note](/help-center/troubleshooting#hetzner-cloud--dedicated-server-firewall-note) for the ports to open and the reserved ranges to block.
+:::
 
 #### CORS Protection
 
@@ -7837,6 +7874,8 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
+If the node is wedged and you are ready to lose the running instance, `kill -6 $(pidof erigon)` (`SIGABRT`) dumps the stacks and terminates the process in one step.
+
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 
 ```bash
@@ -7862,6 +7901,29 @@ Hetzner applies a stateless firewall at the network edge. Ensure the following p
 | P2P (Caplin)   | 9000  | TCP+UDP  |
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure the firewall in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`.
+
+An Erigon node should also never attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is good practice on any host and worth doing explicitly on Hetzner, whose stricter filtering is what prompted this note. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are the ones commonly blocked for an Ethereum node (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
+
+```text
+0.0.0.0/8             "This" Network                                RFC 1122, Section 3.2.1.3
+10.0.0.0/8            Private-Use Networks                          RFC 1918
+100.64.0.0/10         Carrier-Grade NAT (CGN)                       RFC 6598, Section 7
+127.0.0.0/8           Loopback                                      RFC 1122, Section 3.2.1.3
+169.254.0.0/16        Link Local                                    RFC 3927
+172.16.0.0/12         Private-Use Networks                          RFC 1918
+192.0.0.0/24          IETF Protocol Assignments                     RFC 5736
+192.0.2.0/24          TEST-NET-1                                    RFC 5737
+192.88.99.0/24        6to4 Relay Anycast                            RFC 3068
+192.168.0.0/16        Private-Use Networks                          RFC 1918
+198.18.0.0/15         Network Interconnect Device Benchmark Testing RFC 2544
+198.51.100.0/24       TEST-NET-2                                    RFC 5737
+203.0.113.0/24        TEST-NET-3                                    RFC 5737
+224.0.0.0/4           Multicast                                     RFC 3171
+240.0.0.0/4           Reserved for Future Use                       RFC 1112, Section 4
+255.255.255.255/32    Limited Broadcast                             RFC 919 and RFC 922, Section 7
+```
+
+The same list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068).
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -143,6 +143,19 @@ Your internet bandwidth is also an important factor, particularly for sync speed
 | Staking/Mining | 10 Mbps              | 50 Mbps                 |
 | Non-Staking    | 5 Mbps               | 25 Mbps                 |
 
+## Sync Times
+
+Approximate times to sync from scratch to the tip of the chain.
+
+| Chain    | Archive | Full (Default) | Minimal |
+| -------- | ------- | -------------- | ------- |
+| Ethereum | ~8 h    | ~4–6 h         | ~2 h    |
+| Gnosis   | ~2 h    | ~1–2 h         | ~30 m   |
+
+:::info
+These figures are indicative and are **not measured by CI** — read them as an order of magnitude, not a target. Most of the elapsed time is snapshot download rather than block execution, so your available [bandwidth](#bandwidth-requirements) influences the result more than CPU does: expect proportionally faster syncs on a well-connected host and slower ones on a constrained link.
+:::
+
 ---
 
 # Migrating from Geth
@@ -584,6 +597,16 @@ make -j<n> erigon
 ```
 
 The resulting executable binary will be created in the `./build/bin/erigon` path.
+
+**2.4 Installing Outside the Build Tree (Optional)**
+
+Running Erigon as a [dedicated system user](/fundamentals/security) — for example under `systemd` — is easiest when the binaries live outside your source checkout, where that user can reach them. Pass a destination to `make install`:
+
+```sh
+make DIST=/opt/erigon install
+```
+
+`$HOME/erigon` works equally well. `make install` copies whatever is currently in `build/bin`, so build every component you intend to deploy before running it.
 
 **3. Running Erigon**
 
@@ -1661,7 +1684,7 @@ Deleting `chaindata/` is **recoverable but not free**: it discards the latest mu
 
 ## Tuning knobs
 
-- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM.
+- **`--batchSize`** — size of the Execution stage's in-memory buffer before it is flushed to MDBX. Default: `512M`. Raising it (for example `--batchSize 1G` or higher) can speed up execution-heavy sync at the cost of more RAM. Larger batches also leave more data in `chaindata/` between snapshot builds, so keep it at or below `1G` if you want to cap how far MDBX grows.
 - **`--db.size.limit`** — caps the MDBX file size. Useful when running multiple Erigon instances on one disk to prevent one from starving the others.
 - **`--db.read.concurrency`** — number of concurrent MDBX read transactions. Increase when you run a high-throughput RPC Daemon against the same datadir.
 - **Symlinks for tiered storage.** Place `chaindata/` and `snapshots/domain/` on fast NVMe, leave `snapshots/idx/` and `snapshots/history/` on cheaper SATA. See [Optimizing Storage](optimizing-storage) for the recipe.
@@ -1925,6 +1948,12 @@ When Caplin is running, it exposes a Beacon API that external tools can query. T
 | `--beacon.api.read.timeout` | `5` | HTTP server read timeout, in seconds |
 | `--beacon.api.write.timeout` | `31536000` | HTTP server write timeout, in seconds (~1 year) |
 | `--beacon.api.idle.timeout` | `25` | HTTP server idle timeout, in seconds |
+
+The API is not served until you enable it with `--beacon.api=<namespaces>`; see [Caplin for staking](../staking/caplin) for the full namespace list.
+
+:::note
+Enabling the Beacon API increases RAM usage by roughly **6 GB**. Account for it when sizing your host — see [Hardware Requirements](../get-started/hardware-requirements).
+:::
 
 ---
 
@@ -3197,6 +3226,10 @@ Erigon provides extensive logging configuration through command-line flags. Key 
 * `--log.dir.verbosity`: Set file log level (default: `dbug`)
 * `--log.delays`: Enable block delay logging
 
+**Downloader (torrent) logs**
+
+The torrent client inside the Downloader keeps its own JSON-formatted file, `logs/torrent.log`. It is written at whichever is **more verbose** of `--torrent.verbosity` and `WARN`, so warnings and errors always reach it even at the default verbosity. Messages at `--torrent.verbosity` or above are additionally forwarded to Erigon's own file and console loggers, which emit them only if `--log.dir.verbosity` and `--verbosity` are themselves set to a verbose enough level.
+
 **Log Levels**
 
 The logging system defines six distinct log levels in hierarchical order:
@@ -3277,6 +3310,10 @@ Based on best practices for execution clients, your local machine's firewall set
 | 30303    | TCP & UDP    | Peer-to-Peer (P2P) Networking | Allow inbound and outbound traffic to enable peer discovery and connections.                                                             |
 | 8545     | TCP          | JSON-RPC (Public API)         | Block all traffic _except_ from explicitly defined trusted machines. This port should never be publicly exposed without strict controls. |
 | 9090     | TCP          | Private API Communication     | Block all traffic except for communication between your internal components (e.g., RPC Daemon and core node).                            |
+
+:::note
+Some hosting providers impose additional firewall requirements on top of these. If you run on Hetzner Cloud or a Hetzner dedicated server, see the [Hetzner firewall note](/help-center/troubleshooting#hetzner-cloud--dedicated-server-firewall-note) for the ports to open and the reserved ranges to block.
+:::
 
 #### CORS Protection
 
@@ -7837,6 +7874,8 @@ kill -SIGUSR1 $(pidof erigon)
 # Stack traces are printed to the erigon log / stdout
 ```
 
+If the node is wedged and you are ready to lose the running instance, `kill -6 $(pidof erigon)` (`SIGABRT`) dumps the stacks and terminates the process in one step.
+
 **Capture a CPU or heap profile via pprof** (requires `--pprof` flag at startup — default address `localhost:6060`; override with `--pprof.addr` and `--pprof.port`):
 
 ```bash
@@ -7862,6 +7901,29 @@ Hetzner applies a stateless firewall at the network edge. Ensure the following p
 | P2P (Caplin)   | 9000  | TCP+UDP  |
 
 Without these, the node may appear to have peers (via the cloud dashboard) but will suffer poor block propagation. Configure the firewall in the Hetzner Cloud Console under **Firewalls** or via `hcloud firewall`.
+
+An Erigon node should also never attempt to peer with IPv4 ranges that are reserved for special use. Blocking them is good practice on any host and worth doing explicitly on Hetzner, whose stricter filtering is what prompted this note. The authoritative list is the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) ([RFC 6890](https://datatracker.ietf.org/doc/html/rfc6890)); the ranges below are the ones commonly blocked for an Ethereum node (`100.64.0.0/10` comes from [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598), and `192.88.99.0/24` has since been deprecated by [RFC 7526](https://datatracker.ietf.org/doc/html/rfc7526) — blocking it remains correct):
+
+```text
+0.0.0.0/8             "This" Network                                RFC 1122, Section 3.2.1.3
+10.0.0.0/8            Private-Use Networks                          RFC 1918
+100.64.0.0/10         Carrier-Grade NAT (CGN)                       RFC 6598, Section 7
+127.0.0.0/8           Loopback                                      RFC 1122, Section 3.2.1.3
+169.254.0.0/16        Link Local                                    RFC 3927
+172.16.0.0/12         Private-Use Networks                          RFC 1918
+192.0.0.0/24          IETF Protocol Assignments                     RFC 5736
+192.0.2.0/24          TEST-NET-1                                    RFC 5737
+192.88.99.0/24        6to4 Relay Anycast                            RFC 3068
+192.168.0.0/16        Private-Use Networks                          RFC 1918
+198.18.0.0/15         Network Interconnect Device Benchmark Testing RFC 2544
+198.51.100.0/24       TEST-NET-2                                    RFC 5737
+203.0.113.0/24        TEST-NET-3                                    RFC 5737
+224.0.0.0/4           Multicast                                     RFC 3171
+240.0.0.0/4           Reserved for Future Use                       RFC 1112, Section 4
+255.255.255.255/32    Limited Broadcast                             RFC 919 and RFC 922, Section 7
+```
+
+The same list expressed in [iptables syntax](https://ethereum.stackexchange.com/questions/6386/how-to-prevent-being-blacklisted-for-running-an-ethereum-client/13068#13068).
 
 ---
 


### PR DESCRIPTION
Docs-only. Stacked on #22919 — it targets that PR's branch so the diff here is the single commit; GitHub will retarget this to `release/3.5` once #22919 merges. Review #22919 first.

This is the preparatory half of the README cleanup. #22915 drops the duplicated content from `README.md` on `main`; that deletion is only safe once the content that lives **nowhere else** has a home on the site. This PR gives it one. Nothing is deleted here.

## What moves, and where

Six items existed only in `README.md`:

| Content | Now lives in |
| --- | --- |
| Sync-times table | `get-started/hardware-requirements` |
| Hetzner reserved-range blocklist | `help-center/troubleshooting`, linked from the Network Security section of `fundamentals/security` |
| Downloader torrent-log behaviour | `fundamentals/logs` |
| `make DIST=<path> install` | `get-started/installation` |
| Beacon API RAM cost + the `--beacon.api` enabling flag | `fundamentals/caplin` |
| `--batchSize` guard against chaindata growth | `fundamentals/database` |

## What is deliberately not moved

Four README items are already documented on the site in better form, so they are dropped rather than duplicated:

- **SIGUSR1/pprof diagnostics** — `help-center/troubleshooting` also documents `--pprof.addr` and uses `curl` instead of requiring a Go toolchain.
- **Chaindata deletion** — `fundamentals/database` states the consequences the README omitted.
- **WSL caveats** — `get-started/installation` covers DrvFS, the remote-DB rpcdaemon requirement and the WSL2 NAT address.
- **`--sync.loop.block.limit` default of 5000** — already in the CLI reference.

The README's "MDBX locks the db for exclusive access" rationale is also not carried over: it contradicts the single-writer/many-reader model documented in `fundamentals/database`.

## Three corrections made while moving

**The Hetzner blocklist had a corrupted row.** It listed `127.16.0.0/12` as "Private-Use Networks RFC 1918" — a mangling of two separate entries, since `172.16.0.0/12` was already listed on its own line. Restored to `127.0.0.0/8  Loopback`. The list is now attributed to the [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml) rather than RFC 5735, which does not contain `100.64.0.0/10` (that is RFC 6598, 2012) and is itself obsoleted by RFC 6890.

**The torrent-log level read backwards.** The README said `logs/torrent.log` is written at whichever is *lower* of `--torrent.verbosity` and `WARN`. In this codebase `erigonToSlogLevel` is `12 - 4*lvl` ([`db/downloader/downloadercfg/slogger.go:13`](https://github.com/erigontech/erigon/blob/main/db/downloader/downloadercfg/slogger.go#L13)), so a higher Erigon verbosity maps to a numerically *lower* `slog.Level`. The `min(erigonToSlogLevel(verbosity), slog.LevelWarn)` at [`downloadercfg.go:249`](https://github.com/erigontech/erigon/blob/main/db/downloader/downloadercfg/downloadercfg.go#L249) therefore selects the **more verbose** threshold. Reworded accordingly, which is also the behaviour operators actually observe: warnings and errors reach the file even at default verbosity.

**The sync-times table loses its to-the-minute precision.** The README published cells like `4h 23m` with no stated provenance, and nothing on this branch measures them: there is no `qa-sync-from-scratch-*` workflow and no `in-sync-delay` measurement anywhere in `.github/`. Where CI observations did exist they ran well above the published values — Ethereum full **5h06–5h48** across four runs against **4h23**, Gnosis full **1h55–2h07** against **1h05**.

Replaced with coarse ranges chosen to span both the published values and those observations, and labelled **not measured by CI**:

| Chain | Archive | Full (Default) | Minimal |
| --- | --- | --- | --- |
| Ethereum | ~8 h | ~4–6 h | ~2 h |
| Gnosis | ~2 h | ~1–2 h | ~30 m |

The figures are worth keeping in some form — they are the only sync-time guidance published anywhere, and #22915 removes the README copy on the strength of this page — but not at a precision nothing backs. If a sync-from-scratch job lands on the publishing branch, this table should be driven by it.

## Verification

- `npm ci && npm run build` in `docs/site` — clean. The site sets `onBrokenLinks`, `onBrokenMarkdownLinks` and `onBrokenAnchors` all to `throw`, so a passing build proves every link and anchor added here resolves.
- `python3 docs/site/scripts/generate-llms.py --check` — OK, 4 llms files match regenerated content (74 pages).
- `python3 docs/site/scripts/render-disk-sizes.py --check` — page still matches `disk-sizes.json`.
- Served the built site and checked each migrated block rendered as intended.
- Claims checked against source rather than assumed: `make DIST=<path> install` against `Makefile:626-633` (it copies from `build/bin` via `GOBIN`); `--beacon.api` against `cmd/utils/flags.go:975` — a `StringSliceFlag` with no default, so the "not served until you enable it" wording is accurate.

The Beacon API "~6 GB RAM" figure is core-dev sourced and is not verifiable in-repo. It is kept, hedged, as the only guidance available on that cost.
