### PR TITLE
db/downloader: detect caplin state snapshots via CaplinTypeString

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -747,8 +747,9 @@ func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error 
 	ff, isStateFile, ok := snaptype.ParseFileName("", name)
 	if ok {
 		// Caplin beacon-state snapshots have no registered global snaptype, so
-		// ParseFileName leaves ff.Type nil for them; they are still seedable by name.
-		if !isStateFile && ff.Type == nil && !snaptype.IsCaplin("", name) {
+		// ParseFileName leaves ff.Type nil but populates CaplinTypeString; they are
+		// still seedable by name.
+		if !isStateFile && ff.Type == nil && ff.CaplinTypeString == "" {
 			return fmt.Errorf("nil ptr after parsing file: %s", name)
 		}
 	}


### PR DESCRIPTION
Follow-up to #22911, addressing @sudeepdino008's post-merge review comment.

#22911 let caplin state snapshots (nil global `Type`) through the `AddNewSeedableFile` guard using `!snaptype.IsCaplin("", name)`. As sudeep pointed out, the better discriminator is `ff.CaplinTypeString`: `ParseFileName` leaves `Type` nil for caplin state snapshots but always populates `CaplinTypeString` (files.go:205). Unlike `IsCaplin`, which relies on the literal `caplin` substring in the path, `CaplinTypeString` is derived from the parse, so it stays correct even for a bare basename.

Behavior is unchanged for the real seed path (full `caplin/...` paths), so the existing `TestAddNewSeedableFileCaplinStateType` stays green — this is a refactor of the guard condition to the more robust, parse-based check.

Cherry-pick to release/3.6 to follow (coordinated with the still-open cherry-pick #22921).