### PR TITLE
claude: update benchmarkoor skill with state actor

### DIFF
--- a/.claude/skills/benchmarkoor/SKILL.md
+++ b/.claude/skills/benchmarkoor/SKILL.md
@@ -1,355 +1,449 @@
 ---
 name: benchmarkoor
-description: Run benchmarkoor performance benchmarks against a locally-built Erigon binary and produce per-test MGas/s comparison tables. Covers image build, dataset reset, run invocation, result parsing, and before/after comparisons.
-allowed-tools: Bash, Read, Write, Edit, Glob, Monitor
+description: Build pristine State Actor datadirs and run repeatable benchmarkoor performance benchmarks against a locally built Erigon image using protected native Linux OverlayFS. Use for first-time benchmarkoor setup, Glamsterdam compute or stateful repricing suites, local client image overrides, pristine-state protection, result extraction, before/after MGas/s comparisons, and cross-client ranking tables.
 ---
 
-# Benchmarkoor: per-test throughput benchmarks
+# Benchmarkoor
 
-Benchmarkoor (`ethpandaops/benchmarkoor`) drives an execution client through the Engine API and measures `engine_newPayloadV<N>` throughput in MGas/s per test (the `V<N>` payload version depends on the dataset's hardfork — V5 for Amsterdam, V4 for Prague, etc.). This skill teaches you to run it against a locally-built Erigon, parse results, and compare two runs.
+Run benchmarkoor on Linux with native OverlayFS without mutating the pristine State Actor datadir.
+Put a kernel-enforced read-only bind mount in front of the pristine directory and keep all writable
+overlay data in a disposable external directory.
 
-The skill assumes the host already has the benchmarkoor binary, a config YAML, a snapshot/working datadir pair, and Docker installed — it focuses on the agent workflow, not first-time setup.
+## Read current upstream material
 
-## References
+Consult these sources before adapting a current suite:
 
-(All `$VAR` placeholders used below — `$BENCH_DIR`, `$CONFIG`, `$INSTANCE_ID`, etc. — are defined in the next section, "Adapt to the user's environment first".)
+- [Local benchmarking guideline](https://hackmd.io/@QmVpC8TxQ8a1nTCW46EsEQ/SygwzXUrMl)
+- [benchmarkoor configuration reference](https://github.com/ethpandaops/benchmarkoor/blob/master/docs/configuration.md)
+- [benchmarkoor-tests configs](https://github.com/ethpandaops/benchmarkoor-tests)
 
-When something in this skill is ambiguous, or for newer/unfamiliar config options, consult these upstream sources before guessing:
+Record the benchmarkoor, benchmarkoor-tests, Erigon, and State Actor image revisions. Do not assume
+rolling branches, fixture URLs, or image tags still identify the same code.
 
-- **Skylenet's BAL benchmark runs notes**: <https://notes.ethereum.org/@skylenet/bal-benchmark-runs> — narrative writeup of how the BAL devnet benchmarks were set up; useful for the *intent* behind the suite (which precompiles, why 120M gas, etc.) and for the dataset preparation steps that aren't visible from the YAML alone.
-- **Benchmarkoor docs**: <https://github.com/ethpandaops/benchmarkoor/tree/master/docs> — authoritative reference for config schema, CLI flags, and the datadir-method matrix.
-- **Example configs**: <https://github.com/ethpandaops/benchmarkoor/tree/master/examples/configuration> — working YAML samples covering different clients, network configs, and datadir methods. When the user wants a config knob you haven't seen before, find the closest example here and adapt rather than guessing.
+## Preserve these invariants
 
-If you change anything in `$CONFIG` that isn't already in this skill, cross-check it against the docs or examples links above before running.
+- Obey the repository's `AGENTS.md`. For Erigon work, build from a dedicated Git worktree rather
+  than the primary checkout.
+- Give the completed State Actor directory a name containing `pristine` and never use it as a
+  `direct` runner datadir.
+- Use `method: overlayfs` for these Linux benchmark hosts.
+- Configure `source_dir` to a verified read-only bind mount of the pristine datadir, never to the
+  original writable path.
+- Keep OverlayFS `upperdir`, `workdir`, and `merged` paths outside the pristine and lower trees.
+- Verify the lower mount is `ro` before startup and remains `ro` throughout the run.
+- Treat every other datadir method as an alternative that requires an explicit user request; never
+  inherit an upstream datadir default silently.
+- Do not stop unrelated workloads merely to improve benchmark isolation. Report contention and
+  ask before changing out-of-scope processes.
 
-## Adapt to the user's environment first
+## Discover paths and pin revisions
 
-Before running anything, identify the host-specific values. Don't hard-code these — different hosts and different datasets use different names. Ask the user if anything below is ambiguous.
-
-| Placeholder | What it is | How to discover |
-|---|---|---|
-| `$BENCH_DIR` | benchmarkoor host root (contains the binary, config, snapshot dirs) | The binary usually isn't in `$PATH`. Find it with `find ~ /opt /srv -maxdepth 4 -name benchmarkoor -type f -executable 2>/dev/null` and take the parent dir, or ask the user. Common pattern: `~/<dataset-name>/` |
-| `$CONFIG` | YAML config file passed to `benchmarkoor run --config <…>` | `ls $BENCH_DIR/*.yaml` — there may be more than one (one per network/dataset). Ask which to use. |
-| `$INSTANCE_ID` | The `instances[].id` to benchmark | `grep -E '^\s*-\s+id:' $CONFIG` |
-| `$IMAGE_TAG` | Docker image tag the Erigon instance references | Look at `instances[].image` for the chosen `$INSTANCE_ID` (e.g. `erigon-local:traced`) |
-| `$SNAPSHOT_DIR` | Read-only pristine dataset; never mutated | Look at `client.datadirs.erigon.source_dir` in the config, or the `PRISTINE=...` line in the reset script |
-| `$WORKING_DIR` | Writable copy that benchmarkoor mutates | The `--datadir` benchmarkoor's docker mount uses; see `HYBRID=...` in the reset script or the `source_dir` for `method: direct` datadirs |
-| `$RESET_SCRIPT` | Script that re-syncs $SNAPSHOT_DIR → $WORKING_DIR | Typically `reset-hybrid.sh` or `reset-<dataset>.sh` in `$BENCH_DIR`. May not exist if the snapshot/working dirs are the same (then state simply persists across runs). |
-
-Concrete example for one host (perf-devnet-3):
-```
-$BENCH_DIR     = /home/erigon/perf-devnet-3-erigon-snapshot
-$CONFIG        = benchmarkoor.interop.bal.yaml
-$INSTANCE_ID   = erigon-bal-full
-$IMAGE_TAG     = erigon-local:traced
-$SNAPSHOT_DIR  = /home/erigon/perf-devnet-3-erigon-snapshot/erigon_snapshot
-$WORKING_DIR   = /home/erigon/perf-devnet-3-erigon-snapshot/erigon_hybrid
-$RESET_SCRIPT  = reset-hybrid.sh
-```
-
-Don't assume these names elsewhere — discover them per session.
-
-## Datadir setup approaches
-
-Benchmarkoor's source tree (`pkg/datadir/`) exposes five `client.datadirs.<client>.method` values: `copy`, `overlayfs`, `fuse-overlayfs`, `zfs`, `direct`. Only the first four are listed in upstream's `docs/configuration.md`; `direct` is present in the code (`pkg/datadir/direct.go`) but documented in its source as *"not suitable for normal benchmarking … intended for inspection / resume workflows."* Choose based on host filesystem and how clean you need isolation between runs.
-
-### 1. "Hybrid" (= `method: direct` + external reset script) — what we use today
-
-Strictly speaking this is `method: direct` pointing at a pre-prepared writable copy (`erigon_hybrid/`) of a read-only pristine snapshot (`erigon_snapshot/`). A user-owned script (`reset-hybrid.sh`) rsyncs snapshot → working copy between runs, and the read-only `snapshots/` subdir is bind-mounted from the pristine source to avoid duplicating immutable segment files.
-
-- **Pros:** works on any filesystem; no kernel/ZFS features needed; no per-test copy-up cost during execution; full reset is one rsync (~tens of seconds).
-- **Cons:** user-managed, not built into benchmarkoor; requires sudo for the reset (containers leave root-owned files in the working dir).
-- **Use when:** the host has no ZFS, and you want fast, repeatable, isolated runs without paying overlayfs copy-up at runtime.
-
-Config side: `method: direct` pointing at `$WORKING_DIR`. Reset side: external script before each run.
-
-### 2. `method: overlayfs` — **doesn't work for our Erigon dataset**
-
-Native Linux overlayfs with `$SNAPSHOT_DIR` as the read-only lower layer and a `/tmp/benchmarkoor-overlay-*` upper. Mount itself is instant. The problem is that MDBX's open path touches enough chaindata pages during recovery/steady-sync that the kernel copies up substantial parts of the file to the upper layer, taking minutes. Benchmarkoor's RPC-readiness probe (observed at ~2 minutes; check `pkg/runner/` for the current value) trips, and Erigon gets killed mid-open with `Got interrupt, shutting down...`.
-
-Past evidence in our results dir: runs `1779001673_b1eeb60b_…` and `1779002095_ae096a8b_…` (May 17) — both timed out around the `Opening Database` step.
-
-- **Use when:** working with clients whose datadirs don't trigger heavy copy-up (smaller / less-touched files). For Erigon with the current dataset size, skip it.
-- **Possible workaround if you must:** increase whatever timeout benchmarkoor exposes for RPC readiness; we didn't pursue this.
-
-### 3. `method: zfs` — promising once the host has ZFS
-
-ZFS snapshot + clone provides copy-on-write isolation that should avoid the overlayfs copy-up problem because COW is the native operation, not a degraded fallback.
-
-- **Requires:** `$SNAPSHOT_DIR` must live on a ZFS dataset; root or appropriate ZFS delegations.
-- **What benchmarkoor does:** snapshots the source dataset, clones the snapshot to a working dataset, mounts that into the container; cleans up the clone after the run.
-- **Not yet tested here:** the current host's root FS is ext4, so we never exercised it. When migrating to a ZFS host, this is the path to try first — it should subsume the "hybrid" workflow with no external reset script needed.
-
-### 4. `method: direct` (raw) — **not for benchmarking, and dangerous if pointed at the snapshot**
-
-Mounts `source_dir` directly into the container with no isolation. Whatever Erigon writes persists in `source_dir`. From benchmarkoor's own code comment: *"not suitable for normal benchmarking … intended for inspection / resume workflows."*
-
-- **⚠️ If `source_dir` is the pristine snapshot, it will be irreversibly mutated.** The snapshot is ~2 TB on this host, and re-downloading it takes many hours. There is no automatic backup. Double-check `client.datadirs.erigon.source_dir` in the YAML *before* running with `method: direct` — if it points at `$SNAPSHOT_DIR`, change it or abort.
-- **Use only when:** you specifically want to inspect / iterate on the chain state left behind by a prior run, or you're debugging.
-- The "hybrid" approach above uses `method: direct` *correctly* because it points at a disposable working copy (`$WORKING_DIR`), not the pristine snapshot. That's the safe pattern.
-
-### (Bonus) `method: copy` and `method: fuse-overlayfs`
-
-Two more methods exist but weren't explored:
-- `copy` — parallel file copy of `source_dir` to a fresh working dir each run. Universal but slow for large datadirs.
-- `fuse-overlayfs` — userspace overlayfs; documented as ~3× slower than native overlayfs. Fallback when native isn't available.
-
-## Layout convention (typical)
-
-```
-$BENCH_DIR/                                            # benchmarkoor host root
-├── benchmarkoor                                       # binary (root-owned, requires sudo)
-├── $CONFIG                                            # main config (one of possibly several)
-├── $RESET_SCRIPT                                      # resets datadir (sudo-only); may not exist
-├── $SNAPSHOT_DIR/                                     # read-only pristine dataset (never touched)
-├── $WORKING_DIR/                                      # writable copy that benchmarkoor mutates
-└── results/runs/                                      # per-run output dirs
-    ├── index.json                                     # generated run index
-    └── <unix_ts>_<short_hash>_<instance-id>/          # one dir per run
-
-# The Erigon clone (containing build/bin/erigon) typically lives elsewhere on
-# the host — sibling of $BENCH_DIR or a separate workspace — and is referenced
-# via cp/COPY in Step 1. Don't assume it's under $BENCH_DIR.
-```
-
-## Prerequisites (verify before starting)
-
-1. **Erigon binary** built at `$BENCH_DIR/erigon/build/bin/erigon` (or wherever the user's clone lives). If missing, build with `make erigon` from the erigon repo.
-2. **Docker image** `$IMAGE_TAG` exists. Confirm with `sudo -n docker images | grep <image-name>`.
-3. **Benchmarkoor binary** at `$BENCH_DIR/benchmarkoor`. Requires `sudo -n` to invoke (controls docker, cpuset, cpufreq).
-4. **Dataset snapshot** at `$SNAPSHOT_DIR` (untouched) and `$WORKING_DIR` (working copy). `$RESET_SCRIPT` rsyncs the former into the latter.
-5. **No conflicting Erigon process** using the benchmark datadir. Check with `pgrep -af "build/bin/erigon"` and stop any local node that has `$WORKING_DIR` as its `--datadir` (many setups have a `stop.sh` next to the datadir; otherwise `pkill -f "datadir.*$WORKING_DIR"`).
-6. **No stale benchmarkoor containers** — they don't always get cleaned up on aborted runs. If you see `benchmarkoor-<oldhash>-*` containers still up, run `sudo -n ./benchmarkoor cleanup` (or `sudo -n docker rm -f <container>`) before starting.
-
-## Workflow
-
-### Step 1 — Rebuild Docker image with the new binary
-
-If you've changed Erigon source since the last image was built, you need a fresh image. A full Dockerfile build is slow; use a quick overlay instead:
+Define task-specific paths after inspecting the host:
 
 ```bash
-mkdir -p /tmp/erigon-img-overlay
-cp "$BENCH_DIR/erigon/build/bin/erigon" /tmp/erigon-img-overlay/erigon
-# Unquoted EOF on purpose — $IMAGE_TAG must expand into the heredoc.
-cat > /tmp/erigon-img-overlay/Dockerfile <<EOF
-FROM $IMAGE_TAG
-COPY --chown=erigon:erigon erigon /usr/local/bin/erigon
-EOF
-cd /tmp/erigon-img-overlay && sudo -n docker build -t "$IMAGE_TAG" .
+BENCHMARKOOR_SRC=/absolute/path/to/benchmarkoor
+TESTS_DIR=/absolute/path/to/benchmarkoor-tests
+ERIGON_WT=/absolute/path/to/erigon-worktree
+STATE_ROOT=/absolute/path/to/state-actor-v1-pristine
+PRISTINE_DIR="$STATE_ROOT/erigon"
+LOWER_ROOT=/absolute/path/to/state-actor-v1-lower-ro
+OVERLAY_TMP=/absolute/path/to/overlay-runtime
+BENCHMARKOOR_BIN="$BENCHMARKOOR_SRC/bin/benchmarkoor"
+INSTANCE_ID=erigon-bal-full
+IMAGE_TAG=erigon-local:glamsterdam-devnet-7-<short-commit>
 ```
 
-This re-tags `$IMAGE_TAG` in under a second. The original Dockerfile multi-stage build is only needed if base layers (OS, deps) changed.
-
-If you've never built the base image, fall back to:
-```bash
-cd "$BENCH_DIR/erigon" && sudo -n docker build -t "$IMAGE_TAG" .
-```
-
-Caveat: the stock Erigon `Dockerfile` may not reproduce the original `$IMAGE_TAG`'s build flags (e.g. tracing builds use extra args). If the original image was built with non-default args, ask the user how it was first built before falling back.
-
-### Step 2 — Reset the working datadir
-
-`$RESET_SCRIPT` (typically) rsyncs `$SNAPSHOT_DIR/` → `$WORKING_DIR/` (excluding the read-only `snapshots/` bind mount). Requires sudo because containers leave root-owned files behind.
+Verify repository state and record commits:
 
 ```bash
-sudo -n bash "$BENCH_DIR/$RESET_SCRIPT"
+git -C "$BENCHMARKOOR_SRC" status --short --branch
+git -C "$BENCHMARKOOR_SRC" rev-parse HEAD
+git -C "$TESTS_DIR" status --short --branch
+git -C "$TESTS_DIR" rev-parse HEAD
+git -C "$ERIGON_WT" status --short --branch
+git -C "$ERIGON_WT" rev-parse HEAD
 ```
 
-**Always run this before every benchmark run.** Skipping it means leftover state from the previous run pollutes results.
+Fetch the authoritative Erigon and benchmarkoor-tests branches immediately before creating the
+worktree and resolving the suite, then record both commits. Re-fetch after a long run. If a remote
+tip advanced, report both hashes and describe the intervening changes; call the result "latest at
+launch," not the current tip. For benchmarkoor-tests, also compare the selected runner-config blob
+and fixture URL because the repository can advance without changing the suite that ran. Do not
+silently move the worktree or relabel an already-produced result.
 
-If no reset script exists for this dataset, the user has chosen a setup where state persists across runs — in that case ask whether they want a manual rsync from `$SNAPSHOT_DIR` to `$WORKING_DIR` before starting, or to deliberately run on the prior state.
+## Build benchmarkoor
 
-### Step 3 — Inspect/edit the config
+```bash
+cd "$BENCHMARKOOR_SRC"
+make build-core
+"$BENCHMARKOOR_BIN" version
+```
 
-Open `$BENCH_DIR/$CONFIG`. Don't construct YAML from scratch — read the existing file and edit it in place; the snippet below shows the *knobs* you'll likely touch, not the full schema. (Full schema in the upstream `examples/configuration/` reference.) Key knobs:
+Use the source build because datadir handling, result formats, and State Actor orchestration change
+across benchmarkoor revisions.
+
+Before a long suite whose rollback strategy is `container-recreate`, verify the selected
+benchmarkoor revision eagerly releases the previous datadir after removing its container. At
+benchmarkoor `709ad43`, cleanup stayed deferred until process teardown, so a stateful run retained
+one OverlayFS mount and upper layer per completed fixture. Local patch `ea92a86` was validated to
+release each previous mount before preparing the next; use an upstream equivalent when available.
+Do not infer safety from a successful short command alone: smoke-test the actual binary and assert
+the live overlay count never exceeds one.
+
+## Generate a separate pristine State Actor datadir
+
+Stop if `$PRISTINE_DIR` already exists and its ownership is unclear. Choose a new path rather than
+using `--force` against a valuable snapshot.
+
+Append a local override after all upstream configs:
 
 ```yaml
+global:
+  env:
+    STATE_DIR: /absolute/path/to/state-actor-v1-pristine
+
 runner:
+  container_runtime: docker
+  live_reporting:
+    enabled: false
+```
+
+Do not put `runner.client.datadirs` in this build-only override. Datadir isolation is a run-time
+concern, and the later run-only override supplies the protected OverlayFS source.
+
+From the benchmarkoor-tests repository, build only Erigon:
+
+```bash
+cd "$TESTS_DIR"
+"$BENCHMARKOOR_BIN" build \
+  --config configs/global.yaml \
+  --config configs/datadirs/state-actor/v1/global.yaml \
+  --config configs/datadirs/state-actor/v1/builder.yaml \
+  --config local-overrides.yaml \
+  --limit-state-actor-target=erigon \
+  --rebuild-on-diff
+```
+
+State Actor can exceed its final-size projection while creating `streamsort-*` intermediates and
+explicit templates. Reserve peak working headroom and trust only the completed filesystem
+measurement after temporary data is cleaned up. One completed v1 build peaked near 1,056.5 GiB and
+settled at 516.83 GiB; treat that 2.04x ratio as capacity evidence, not a bound. Wait for a successful
+exit and inspect CPU and disk activity instead of treating a quiet finalization phase or ETA as a
+failure.
+
+After success, inspect:
+
+```bash
+jq . "$PRISTINE_DIR/state-actor-manifest.json"
+jq . "$PRISTINE_DIR/.benchmarkoor-build.json"
+find "$PRISTINE_DIR" -maxdepth 1 -type f -printf '%f %s bytes\n' | sort
+```
+
+The manifest records State Actor metadata and the resolved builder-image digest; the sidecar records
+benchmarkoor's rebuild fingerprint. Do not rerun State Actor against this path after declaring it
+pristine.
+
+## Measure pristine and overlay capacity
+
+Measure allocated and apparent sizes because large database files may be sparse, then check the
+writable filesystem that will hold the overlay upper layer:
+
+```bash
+du -sx --block-size=1 "$PRISTINE_DIR"
+du -sx --apparent-size --block-size=1 "$PRISTINE_DIR"
+df -B1 --output=size,used,avail,target "$PRISTINE_DIR" "$OVERLAY_TMP"
+findmnt -T "$PRISTINE_DIR"
+findmnt -T "$OVERLAY_TMP"
+```
+
+Do not assume OverlayFS needs a second full copy for this workload, but do not assume the upper
+will stay small either. Before the first run, treat the pristine datadir's allocated size as a
+conservative copy-up budget and require operational headroom beyond it. During the run, measure the
+actual upper layer and stop before the filesystem becomes critically full. A completed 4,773-test
+compute run observed about 1.8 GiB of upper-layer data over a 516.83 GiB lower; this is evidence that
+2x was unnecessary for that run, not a future storage bound.
+
+## Build an image from the exact Erigon worktree
+
+Build the binary from the exact commit under test:
+
+```bash
+cd "$ERIGON_WT"
+make erigon
+./build/bin/erigon --version
+sha256sum ./build/bin/erigon
+```
+
+When a compatible image for the same branch already exists, a small overlay image avoids rebuilding
+the unchanged container environment. Create a dedicated build-context directory containing the
+built `erigon` binary and this Dockerfile:
+
+```dockerfile
+FROM ethpandaops/erigon:glamsterdam-devnet-7@sha256:<resolved-base-digest>
+COPY --chown=0:0 erigon /usr/local/bin/erigon
+```
+
+Build and verify that the image contains the byte-identical local binary:
+
+```bash
+docker build -t "$IMAGE_TAG" /absolute/path/to/overlay-context
+docker run --rm "$IMAGE_TAG" --version
+docker run --rm --entrypoint sha256sum "$IMAGE_TAG" /usr/local/bin/erigon
+```
+
+Resolve and pin the base-image digest. If the branch changes the container environment or is
+incompatible with that base, build the repository's complete Dockerfile instead. Do not rely on a
+rolling remote image's Erigon binary when benchmarking a local branch.
+
+## Create a run-only override
+
+Copy the complete chosen instance from the current `clients.yaml` into the last override, then
+change its image and pull policy. Viper replaces lists rather than merging list entries, so an
+override containing `runner.instances` replaces the entire upstream instance list.
+
+For Glamsterdam devnet 7, the override should have this shape:
+
+```yaml
+global:
+  env:
+    STATE_DIR: /absolute/path/to/state-actor-v1-lower-ro
+
+runner:
+  container_runtime: docker
+  live_reporting:
+    enabled: false
+  directories:
+    tmp_datadir: /absolute/path/to/overlay-runtime
   benchmark:
+    results_owner: "<invoking-uid>:<invoking-gid>"
     tests:
-      # The filter regex picks which tests run. Edit alternations to add/remove
-      # tests; edit the size suffix (e.g. 120M / 60M) to change gas budgets per test.
-      filter: 'regex:__test_(<test_name_1>|<test_name_2>|...)\[.*benchmark_<size>M\]'
-
+      metadata:
+        labels:
+          data-disk-type: overlayfs
+          erigon-commit: <full-erigon-commit>
   client:
-    config:
-      resource_limits:
-        # Prefer explicit `cpuset:` over `cpuset_count:` for reproducibility.
-        # Pin to exactly 6 distinct physical cores to match ethpandaops's upstream
-        # reference runs (which also use 6) so results are comparable.
-        # See "CPU pinning" notes below for how to pick the actual ids per host.
-        cpuset: [<6 logical CPU ids, one per distinct physical core>]
-        # cpuset_count: 6         # alternative: random 6 CPUs each run — adds variance
-        cpu_freq: "3600MHz"
-        cpu_turboboost: false
-        cpu_freq_governor: performance
-        memory: "32g"
-
-instances:
-  - id: <instance-id>
-    client: erigon
-    image: <image-tag>           # must match the image tag from Step 1
-    pull_policy: never            # critical — local image only
-    extra_args:
-      # fork overrides for the snapshot's chain state — values are dataset-specific
+    datadirs:
+      erigon:
+        source_dir: ${STATE_DIR}/erigon
+        method: overlayfs
+  instances:
+    - id: erigon-bal-full
+      client: erigon
+      image: erigon-local:glamsterdam-devnet-7-<short-commit>
+      pull_policy: never
+      metadata:
+        labels:
+          bal-mode: full
+      extra_args:
+        - --override.amsterdam=1
+        - --fcu.background.commit=false
+        - --exec.no-merge=true
+        - --exec.no-prune=true
+        - --exec.no-background-maintenance
+        - --experimental.parallel-commitment
+      bootstrap_fcu:
+        enabled: true
+        max_retries: 120
+        backoff: 30s
 ```
 
-### CPU pinning
+Re-copy the instance when upstream `clients.yaml` changes; do not let this example silently erase
+new required flags. Check every copied `extra_args` option against `docker run --rm "$IMAGE_TAG"
+--help` before starting the long suite.
 
-`cpuset:` (explicit logical-CPU list) and `cpuset_count:` (random N CPUs each run) are mutually exclusive. **Prefer `cpuset:`** — it's deterministic across runs and lets you pick topology-aware values. `cpuset_count` picks N logical CPUs *at random* each run, which on SMT hosts produces different physical-core counts each time (the random selection often double-books some physical cores via their SMT siblings), baking noise into A/B comparisons.
+For current Erigon, `--experimental.parallel-commitment` is the CLI equivalent of
+`COMMITMENT_PARALLEL=true`: it sets `ExperimentalParallelCommitment` and selects the parallel hex
+Patricia/`ParallelPatriciaHashed` commitment variant. Recheck that mapping in the exact source under
+test and confirm the persisted container command includes the flag.
 
-**Pin to exactly 6 logical CPUs**, one per distinct physical core, avoiding SMT sibling pairs. The "6" matches what ethpandaops's upstream reference runs use (e.g. `cpuset: [6,7,8,9,10,11]` at <https://benchmarkoor.core.ethpandaops.io/runs/>), so any A/B against published reference numbers is core-count-comparable. If the host has more than 6 physical cores, leave the extras unpinned so the docker daemon, benchmarkoor itself, and the host kernel don't compete with the bench workload. If the host has fewer than 6 physical cores, that's a deeper problem — note it and ask the user.
-
-Discover the host's topology:
+Verify the configured CPU IDs map to the intended number of distinct physical cores:
 
 ```bash
-lscpu | grep -E "^CPU|^Thread|^Core|^Socket|Model name"
-for c in $(seq 0 $(($(nproc)-1))); do
-  printf 'cpu%s: core=%s siblings=%s\n' \
-    "$c" \
-    "$(cat /sys/devices/system/cpu/cpu$c/topology/core_id)" \
-    "$(cat /sys/devices/system/cpu/cpu$c/topology/thread_siblings_list)"
-done
+lscpu -e=CPU,CORE,SOCKET,NODE,ONLINE
 ```
 
-Read off **6 logical CPUs whose `core_id`s are distinct** (i.e. skip SMT siblings). On a typical Linux topology where logical CPUs 0..N-1 are physical and N..2N-1 are SMT siblings of cores 0..N-1, pick any 6 from the lower half.
+Do not infer topology from consecutive CPU numbers or from a config comment.
 
-The literal cpuset numbers in the reference run (`6,7,8,9,10,11`) are specific to *that* host — don't copy them; replicate the *intent* (deterministic + physical-only + count=6).
+## Protect the pristine datadir with OverlayFS
 
-### Sanity-check the filter
-
-To know how many tests will actually run, dry-run the filter against the extracted test fixtures. Strip the `regex:` prefix from the YAML filter value and feed the rest to `grep -E`:
-```bash
-# e.g. for filter 'regex:__test_(blake2f_benchmark|ecrecover)\[.*benchmark_120M\]'
-ls "$BENCH_DIR"/.cache/opcode-archive-extract-*/eest_bal/testing/ 2>/dev/null \
-  | grep -cE '__test_(blake2f_benchmark|ecrecover)\[.*benchmark_120M\]'
-```
-
-### Step 4 — Run benchmarkoor
+Put a kernel-enforced read-only bind mount in front of the pristine datadir rather than configuring
+the original path directly:
 
 ```bash
-cd "$BENCH_DIR" && sudo -n ./benchmarkoor run \
-  --config "$CONFIG" \
-  --limit-instance-id "$INSTANCE_ID" \
-  2>&1 | tee /tmp/benchmarkoor.log
+sudo mkdir -p "$LOWER_ROOT/erigon" "$OVERLAY_TMP"
+sudo mount --bind "$PRISTINE_DIR" "$LOWER_ROOT/erigon"
+sudo mount -o remount,bind,ro "$LOWER_ROOT/erigon"
+findmnt -n -o SOURCE,OPTIONS "$LOWER_ROOT/erigon"
 ```
 
-Notes:
-- `benchmarkoor run --help` shows both `--limit-instance-id` (specific instance ids; what we use) and `--limit-instance-client` (any instance for a given client name). They coexist; pick the one matching how you've keyed your instances. Without either flag, benchmarkoor runs every instance in the config.
-- Each test runs as its own freshly-recreated container; the suite wall-clock scales linearly with `<number of tests matched by the filter>`. Pre-test orchestration (container start, gas-bump, funding) dominates over the actual test on this setup, so expect tens of seconds per test even for tiny test payloads.
-- Run in background and watch progress: either tail+grep `tail -F /tmp/benchmarkoor.log | grep -E "index=[0-9]+/|Error|FAIL|panic"`, or use the `Monitor` tool with the same filter to get notifications.
-- While running, `sudo -n docker ps` shows the active container (`benchmarkoor-<runid>-<instance>-<index>`).
-
-### Step 5 — Locate results
+Require `ro` as a distinct mount option before continuing. Record allocated/apparent size, critical
+file hashes, and a metadata fingerprint that covers every path's type, size, mtime, ctime, mode,
+owner, group, and symlink target:
 
 ```bash
-ls -t "$BENCH_DIR"/results/runs/ | head -3
+pristine_fingerprint() {
+  find "$PRISTINE_DIR" -xdev \
+    -printf '%P\0%y\0%s\0%T@\0%C@\0%m\0%u\0%g\0%l\0' |
+    LC_ALL=C sort -z |
+    sha256sum
+}
+
+du -sx --block-size=1 "$PRISTINE_DIR"
+du -sx --apparent-size --block-size=1 "$PRISTINE_DIR"
+sha256sum \
+  "$PRISTINE_DIR/state-actor-manifest.json" \
+  "$PRISTINE_DIR/.benchmarkoor-build.json" \
+  "$PRISTINE_DIR/chainspec.json" \
+  "$PRISTINE_DIR/genesis.json" \
+  "$PRISTINE_DIR/nodekey"
+pristine_fingerprint
 ```
 
-Most recent dir matches `<unix_timestamp>_<short_hash>_<instance-id>/`. Inside, each test has its own dir:
+Before the real run, manually mount a small probe overlay with this read-only bind as `lowerdir`.
+Create a canary through the merged path and require it to appear in `upperdir` but never in either
+the bind mount or pristine directory:
 
-```
-$BENCH_DIR/results/runs/<run-id>/
-├── config.json                                        # snapshot of the YAML
-├── result.json                                        # aggregated run-level stats
-├── benchmarkoor.log
-├── test_<name>.py__test_<func>[<params>].txt/
-│   ├── setup.result-aggregated.json
-│   ├── setup.result-details.json
-│   ├── test.result-aggregated.json                    # ← per-test MGas/s lives here
-│   └── test.result-details.json
-└── ...                                                # one dir per test that ran
-```
-
-To confirm the run completed all matched tests, check `result.json`'s `tests_total` / `tests_passed` (or grep `Run result written ... tests_count=<N>` in `benchmarkoor.log`).
-
-The MGas/s value for each test is at:
-```
-.method_stats.mgas_s.engine_newPayloadV<N>.last
-```
-
-The `V<N>` suffix depends on the dataset's hardfork (V5 for Amsterdam, V4 for Prague, V3 for Cancun, etc. — matching line at top of skill). **Don't guess the key — inspect one `test.result-aggregated.json` first**, e.g.:
 ```bash
-jq -r '.method_stats.mgas_s | keys[]' \
-  "$BENCH_DIR"/results/runs/<run-id>/test_*/test.result-aggregated.json | sort -u | head
+PROBE_ROOT=$(mktemp -d "$OVERLAY_TMP/benchmarkoor-overlay-probe.XXXXXX")
+CANARY=.benchmarkoor-overlay-canary
+mkdir "$PROBE_ROOT/upper" "$PROBE_ROOT/work" "$PROBE_ROOT/merged"
+
+(
+  set -euo pipefail
+  trap 'sudo umount "$PROBE_ROOT/merged" 2>/dev/null || true' EXIT
+  sudo mount -t overlay overlay \
+    -o "lowerdir=$LOWER_ROOT/erigon,upperdir=$PROBE_ROOT/upper,workdir=$PROBE_ROOT/work" \
+    "$PROBE_ROOT/merged"
+  sudo touch "$PROBE_ROOT/merged/$CANARY"
+  test -e "$PROBE_ROOT/upper/$CANARY"
+  test ! -e "$LOWER_ROOT/erigon/$CANARY"
+  test ! -e "$PRISTINE_DIR/$CANARY"
+  sudo umount "$PROBE_ROOT/merged"
+  trap - EXIT
+)
 ```
 
-A `.last` value (instead of `.mean`) is fine because each test runs exactly one such call against its payload. If you're A/B-comparing runs across hardforks, the keys differ — the comparator below will show `n/a` for any mismatched key.
+Inspect and remove only this verified temporary probe tree afterward. Keep `upperdir` and `workdir`
+together on the same writable filesystem.
 
-### Step 6 — Build a comparison table
+Use the run-only override above so benchmarkoor writes its disposable overlay under `OVERLAY_TMP`
+and reads from the protected bind. Keep the explicit `data-disk-type: overlayfs` label because an
+upstream runner config may otherwise misclassify published results.
 
-Use a Python one-liner that reads two run dirs and produces a per-test speedup table sorted by ratio. The script auto-handles different test counts and naming patterns:
+Run a 5-10-fixture smoke subset with the exact binary, config stack, image, and State Actor lower
+before either full suite. During smoke and production runs, periodically require the lower
+mount to remain `ro`, monitor free space, measure the current `upper` directory, and count matching
+OverlayFS mounts. Zero is valid during the handoff between fixtures; more than one means cleanup is
+lagging and the run must be stopped before mounts and copied-up data accumulate. For a long run,
+capture the exact benchmarkoor PID and use a separate free-space watchdog that sends `SIGINT` only
+when a predeclared floor is crossed. Never use a broad process match as the kill target.
 
-```python
-# Substitute <bench-dir>, <old-run-dirname>, <new-run-dirname> below before running.
-# Python does NOT expand shell variables; use literal paths or os.environ.
-import json, glob, os, re
+After benchmarkoor exits, require zero matching overlay mounts, temporary overlay directories,
+containers, and benchmarkoor processes. Eager cleanup can leave old deferred container callbacks;
+`No such container` warnings are harmless only when the run exited successfully and all of those
+postconditions pass. Compare the full-tree metadata fingerprint, sizes, and critical hashes before
+and after while the read-only guard is still mounted. Unmount only the guard after those checks
+pass. Never unmount or remove the pristine directory itself.
 
-RUNS_DIR  = '<bench-dir>/results/runs'   # or: os.environ['BENCH_DIR'] + '/results/runs'
-before_id = '<old-run-dirname>'
-after_id  = '<new-run-dirname>'
+## Choose and run compute or stateful
 
-def shorten(name):
-    m = re.search(r'test_(\w+)\.py__(test_\w+)\[(.+)\]', name)
-    if not m: return name
-    tname, params = m.group(2), m.group(3)
-    parts = [tname]
-    for label, pat in [('', r'opcode_(\w+)'), ('mod', r'mod_bits_(\d+)'),
-                       ('rounds', r'rounds_(\d+)'), ('', r'benchmark_(\d+M)')]:
-        mm = re.search(pat, params)
-        if mm: parts.append(f'{label}{mm.group(1)}')
-    return '-'.join(parts)
+Read [Compute and stateful suites](references/compute-stateful-suites.md) before selecting or
+filtering a suite. It defines how to discover the current runner files, distinguish the adjacent
+`glamsterdam-devnet-7-full` context, validate fixture provenance, assemble the ordered config stack,
+and check the completed result.
 
-def mgas(run_id):
-    """Read MGas/s from each test in a run. Auto-detects the engine_newPayloadV<N> key."""
-    out = {}
-    for f in sorted(glob.glob(os.path.join(RUNS_DIR, run_id, 'test_*/test.result-aggregated.json'))):
-        with open(f) as fp: d = json.load(fp)
-        name = os.path.basename(os.path.dirname(f)).removesuffix('.txt')
-        stats = d.get('method_stats', {}).get('mgas_s', {})
-        # Pick the first engine_newPayloadV* entry — same hardfork ⇒ same key across tests.
-        key = next((k for k in stats if k.startswith('engine_newPayloadV')), None)
-        if key and 'last' in stats[key]:
-            out[name] = stats[key]['last']
-    return out
+The essential runtime distinction is:
 
-b, a = mgas(before_id), mgas(after_id)
-rows = [(shorten(n), b.get(n), a.get(n)) for n in sorted(set(b)|set(a))]
-rows = [(n, bv, av,
-         (av / bv) if (bv is not None and av is not None and bv > 0) else None)
-        for n, bv, av in rows]
-rows.sort(key=lambda r: r[3] if r[3] is not None else 0, reverse=True)
+- Compute uses `test-source.compute.runner.yaml` and normally `rollback_strategy: none`; one
+  disposable overlay serves the run.
+- Stateful uses `test-source.stateful.runner.yaml` and normally
+  `rollback_strategy: container-recreate`; each fixture must start from the protected lower and the
+  previous container and overlay must be released before the next one.
 
-def fmt_num(x): return f'{x:>14.1f}' if x is not None else f'{"n/a":>14}'
-def fmt_sp(s):  return f'{s:>8.2f}x' if s is not None else f'{"n/a":>9}'
+Never infer the suite from `fixtures_subdir`: both can say `blockchain_tests_stateful_engine`.
+Require the selected file's `test-type`, suite name, fixture URL, and rollback strategy to agree.
+Run benchmarkoor as root or through an approved privileged wrapper because native OverlayFS needs
+mount operations; Docker-group membership alone is insufficient.
 
-print(f'{"Test":<55} {"Before":>14} {"After":>14} {"Speedup":>9}')
-for n, bv, av, sp in rows:
-    print(f'{n:<55} {fmt_num(bv)} {fmt_num(av)} {fmt_sp(sp)}')
-if b and a:
-    print(f'\navg: {sum(b.values())/len(b):.1f} → {sum(a.values())/len(a):.1f} ({sum(a.values())/sum(b.values()):.2f}x)')
+## Validate and summarize results
+
+Find the newest run and confirm counts:
+
+```bash
+find "$TESTS_DIR/results/runs" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %f\n' |
+  sort -nr | head
+RUN_DIR="$TESTS_DIR/results/runs/<run-id>"
+jq '{status, test_counts, suite_hash, instance: {
+  id: .instance.id,
+  image: .instance.image,
+  image_sha256: .instance.image_sha256,
+  datadir: .instance.datadir
+}}' "$RUN_DIR/config.json"
+jq '{
+  test_count: (.tests | length),
+  tests_with_failed_steps: ([
+    .tests | to_entries[] |
+    select(any(.value.steps[]; .aggregated.fail > 0))
+  ] | length)
+}' "$RUN_DIR/result.json"
 ```
 
-Render as a markdown table for inclusion in the response; write to `/tmp/benchmark_comparison.md` if the user wants to copy-paste. **Important**: the average is over the test set actually present in both runs. If the filter changed between runs, the averages aren't directly comparable — call that out explicitly.
+Current benchmarkoor writes run status and pass/fail totals to `config.json`; `result.json` contains
+the keyed per-test results. Looking for `tests_total` at the root of `result.json` returns nulls.
+During a run, `result.json` can briefly expose a null or shorter `.tests` object while it is being
+rewritten. Retry the read and corroborate it with the monotonically increasing `Executing test`
+index; use the stable files after process exit for final counts.
 
-## Failure modes & gotchas
+Confirm the suite source and effective resource limits from the persisted run, not just the input
+YAML:
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| `Failed to set turbo boost` warning | CPU governor not user-controllable | Harmless; ignore. |
-| `HEAD failed; using cached file` | GitHub Actions artifact HEAD requires auth | Harmless if cache is present at `$BENCH_DIR/.cache/`. |
-| `Container stopped for recreate` count = N–1 (not N) at end | Last container's "stopped" log fires after the suite completion log | Verify with `Run result written ... tests_count=<N>` in the log. |
-| Big variance between identical runs | CPU governor not pinned, or other heavy workload | Always set `cpu_freq_governor: performance`; don't run other CPU-heavy tasks (full make test-all, syncing nodes) simultaneously. |
-| Image-tag mismatch (the right `IMAGE_TAG` not used) | Docker cached an older layer | Rebuild the image (Step 1) explicitly; confirm `docker images` shows a recent `CREATED` time. |
-| Old `benchmarkoor-<hash>-*` container lingering | Previous run aborted before cleanup | `sudo -n docker rm -f <container>` + `sudo -n ./benchmarkoor cleanup`. |
-| Run "completes" instantly with 0 tests | Wrong cwd, or filter regex matches 0 tests | Confirm cwd is `$BENCH_DIR`; sanity-check the filter against `$BENCH_DIR/.cache/opcode-archive-extract-*/eest_bal/testing/*.txt`. |
+```bash
+rg 'Downloading fixtures tarball|Resource limits configured|CPU frequency info|turbo boost' \
+  "$RUN_DIR/benchmarkoor.log"
+jq '.instance | {
+  rollback_strategy,
+  resource_limits,
+  image,
+  image_sha256,
+  datadir
+}' "$RUN_DIR/config.json"
+SUITE_HASH=$(jq -r .suite_hash "$RUN_DIR/config.json")
+jq '.metadata.labels' "$TESTS_DIR/results/suites/$SUITE_HASH/summary.json"
+lscpu -e=CPU,CORE,SOCKET,NODE,ONLINE
+```
 
-## A few "what to remember" rules
+Count the configured CPU IDs and confirm that their `(socket, core)` pairs are distinct. For a
+32 GiB limit, expect `memory_bytes: 34359738368`; also confirm `swap_disabled: true` when required.
+CPU pinning and memory enforcement can be correct even when turbo control fails. Treat requested
+frequency settings as a separate check: inspect every pinned CPU's reported `scaling_min` and
+`scaling_max`, and disclose partial application.
 
-- **Discover the host-specific names per session.** Don't hard-code `erigon_snapshot`/`erigon_hybrid`/`benchmarkoor.interop.bal.yaml`/`erigon-local:traced`/`erigon-bal-full` — they vary between datasets and hosts.
-- **Always run the reset script (if it exists) before each run.** State leakage between runs is real and silently skews numbers.
-- **Always pass `--limit-instance-id`** when comparing just one client — otherwise the run also exercises every other client in the config (geth/besu/reth/nethermind/…) which adds tens of minutes and clutters `results/runs/`.
-- **The `image` tag in the YAML must match `pull_policy: never`** — benchmarkoor will refuse to pull, so a missing local image fails immediately rather than silently downloading a stale upstream one.
-- **`results/runs/index.json` is regenerated by `generate-index-file`**; don't hand-edit. After a successful run it's auto-generated when `generate_results_index: true` in the config. If it's stale or missing (e.g. an aborted previous run, or comparing against an older directory the index doesn't list), regenerate explicitly: `sudo -n ./benchmarkoor generate-index-file --config "$CONFIG"`.
-- **A run dir is keyed by suite-hash** (under `results/suites/`). Two runs with the same filter regex have the same suite hash, so comparing them is direct. A different filter ⇒ different suite hash ⇒ different test set, and shortened-name matching is the only sane cross-suite comparison — flag this to the user.
-- **For PR-style before/after testing:** stash the change, rebuild image (Step 1), reset working dir (Step 2), run baseline; unstash, rebuild image, reset, run again. Compare the two newest run dirs. Don't compare a fresh run against an old result captured before unrelated config changes — too many variables.
+Scan parallel-execution telemetry separately from benchmark pass/fail status, using only one of the
+mirrored client logs to avoid double counting:
+
+```bash
+rg 'parallel executed.*(abort=[1-9][0-9]*|invalid=[1-9][0-9]*)' \
+  "$RUN_DIR/container.log"
+```
+
+Associate each match with the latest `Executing test` line. Nonzero `abort` or `invalid` counters
+indicate speculative retry work even when the fixture passed.
+
+For local before/after, per-fixture MGas/s, website peer, or PR-style ranking comparisons, read
+[Cross-client ranking comparisons](references/ranking-comparisons.md). It defines the raw timing
+fields, full-name intersection, weighted aggregates, ranking formulas, and comparability checks.
+
+## Handoff checklist
+
+Report:
+
+- all repository commits and container image digests;
+- pristine allocated/apparent sizes and remaining filesystem space;
+- protected lower path, disposable upper location, and observed upper-layer peak;
+- exact before/after pristine fingerprint and read-only lower-mount proof;
+- selected compute/stateful runner, fixture URL, suite filter/test count, run ID, pass/fail count,
+  and results path;
+- effective datadir method and published `data-disk-type` label;
+- effective memory bytes, swap policy, CPU IDs, physical-core mapping, and frequency-control result;
+- whether an authoritative branch advanced after launch and, if so, both the run and handoff tips;
+- any host contention or fidelity caveat.

--- a/.claude/skills/benchmarkoor/references/compute-stateful-suites.md
+++ b/.claude/skills/benchmarkoor/references/compute-stateful-suites.md
@@ -1,0 +1,156 @@
+# Compute and stateful suites
+
+Use this reference when locating, selecting, filtering, running, or validating a Benchmarkoor
+compute or stateful suite.
+
+## Contents
+
+- Discover the current files
+- Distinguish the suites
+- Validate the selection
+- Run the selected suite
+- Validate the result
+- Recover from interruption
+
+## Discover the current files
+
+Search the checked-out `benchmarkoor-tests` revision instead of assuming an old path still exists:
+
+```bash
+CONTEXTS_DIR="$TESTS_DIR/configs/contexts/repricing/v1"
+rg --files "$CONTEXTS_DIR" |
+  rg '/test-source\.(compute|stateful)\.runner\.ya?ml$' |
+  sort
+
+rg -l --glob 'test-source.*.runner.yaml' \
+  'name:\s*state-actor-glamsterdam-devnet-7-(compute|stateful)\s*$' \
+  "$CONTEXTS_DIR"
+```
+
+For the non-`full` Glamsterdam devnet 7 suites, resolve and require these files:
+
+```bash
+CONTEXT_DIR="$CONTEXTS_DIR/glamsterdam-devnet-7"
+COMPUTE_CONFIG="$CONTEXT_DIR/test-source.compute.runner.yaml"
+STATEFUL_CONFIG="$CONTEXT_DIR/test-source.stateful.runner.yaml"
+
+test -f "$COMPUTE_CONFIG"
+test -f "$STATEFUL_CONFIG"
+test -f "$CONTEXT_DIR/global.yaml"
+test -f "$CONTEXT_DIR/clients.yaml"
+```
+
+The sibling `glamsterdam-devnet-7-full` directory is a different fixture set. Select it only when
+the user explicitly requests the `full` suite. Files ending in `.builder.yaml` build fixture
+archives; use `.runner.yaml` to run downloaded fixtures locally.
+
+## Distinguish the suites
+
+| Property | Compute | Stateful |
+|---|---|---|
+| Runner file | `test-source.compute.runner.yaml` | `test-source.stateful.runner.yaml` |
+| `test-type` label | `compute` | `stateful` |
+| Fixture URL | contains `-compute-` | contains `-stateful-` |
+| Expected rollback | `none` | `container-recreate` |
+| Typical test path | `benchmark/compute/...` | `benchmark/stateful/bloatnet/...` |
+| Datadir lifetime | one disposable overlay for the run | fresh container and overlay per fixture |
+
+At `benchmarkoor-tests` commit `b9ddbab85b44fd8327940bcba9a8370798e064df`, successful local
+runs produced these checkpoints:
+
+| Suite | Tests | Suite hash |
+|---|---:|---|
+| Compute | 4,773 | `3c6dc791050b116d` |
+| Stateful | 1,461 | `3f6a0898955dff4f` |
+
+Treat those counts and hashes as revision-specific evidence, not permanent constants.
+
+## Validate the selection
+
+Inspect the resolved runner file before starting:
+
+```bash
+SUITE_KIND=${SUITE_KIND:?set to compute or stateful}
+case "$SUITE_KIND" in compute|stateful) ;; *) exit 2 ;; esac
+SUITE_RUNNER_CONFIG="$CONTEXT_DIR/test-source.$SUITE_KIND.runner.yaml"
+
+rg -n 'name:|test-type:|fixtures_url:|fixtures_subdir:|rollback_strategy:' \
+  "$SUITE_RUNNER_CONFIG"
+git -C "$TESTS_DIR" rev-parse HEAD
+git -C "$TESTS_DIR" status --short --branch
+```
+
+Require all five fields to describe the requested suite. The shared
+`blockchain_tests_stateful_engine` fixtures subdirectory does not distinguish compute from
+stateful. If the fixture archive is cached, the run log may omit a download line; retain the
+selected YAML blob and URL as provenance.
+
+For a subset, put `runner.benchmark.tests.filter` in the last local override. EEST names can carry
+a leading `tests/` while filtering even though persisted result keys omit it, so anchor local
+regular expressions with `^(tests/)?benchmark/...`, not only `^benchmark/...`. A filter changes the
+derived suite hash. Record the parent runner config and full-suite hash alongside the filtered run,
+and reject a smoke run that resolves to zero tests.
+
+## Run the selected suite
+
+Check the read-only lower, image, free space, and residual state first:
+
+```bash
+findmnt -n -o SOURCE,OPTIONS "$LOWER_ROOT/erigon"
+findmnt -rn -t overlay | rg "$OVERLAY_TMP|benchmarkoor-overlay" || true
+docker image inspect "$IMAGE_TAG"
+docker ps --format '{{.Names}} {{.Image}} {{.Status}}'
+df -h "$OVERLAY_TMP"
+```
+
+Require `ro` in the lower mount options and no unexplained overlay or client container. Preserve
+this config order and keep the local override last:
+
+```bash
+cd "$TESTS_DIR"
+sudo -n "$BENCHMARKOOR_BIN" run \
+  --config configs/global.yaml \
+  --config configs/resource-limits-eip-7870-fullnode.yaml \
+  --config configs/datadirs/state-actor/v1/global.yaml \
+  --config configs/datadirs/state-actor/v1/runner.yaml \
+  --config "$CONTEXT_DIR/global.yaml" \
+  --config "$SUITE_RUNNER_CONFIG" \
+  --config "$CONTEXT_DIR/clients.yaml" \
+  --config local-run-overrides.yaml \
+  --limit-instance-client=erigon \
+  --limit-instance-id=erigon-bal-full
+```
+
+For stateful, confirm the Benchmarkoor revision eagerly removes each previous container and
+OverlayFS datadir before preparing the next. During a smoke run, require at most one live matching
+overlay mount. Compute does not recreate per fixture, but its single upper layer is still disposable
+and must never be the pristine directory.
+
+## Validate the result
+
+After exit, validate the persisted result rather than trusting the input variables:
+
+```bash
+jq '{suite_hash,status,test_counts,instance:{
+  id:.instance.id,
+  rollback_strategy:.instance.rollback_strategy,
+  resource_limits:.instance.resource_limits,
+  datadir:.instance.datadir
+}}' "$RUN_DIR/config.json"
+
+jq -r '.tests | keys[0:5][]' "$RUN_DIR/result.json"
+rg 'Downloading fixtures tarball|Suite output created|Running tests with' \
+  "$RUN_DIR/benchmarkoor.log"
+```
+
+Require compute result keys and rollback behavior to match compute, or stateful keys and rollback
+behavior to match stateful. Confirm the resolved test count is nonzero, pass/fail totals are final,
+the datadir method is `overlayfs`, the lower remained read-only, and no overlay mounts or benchmark
+containers remain.
+
+## Recover from interruption
+
+First confirm the benchmark process and client container stopped. Run `benchmarkoor cleanup
+--force` with the identical config stack, then require zero matching OverlayFS mounts and temporary
+directories. Never unmount an overlay while its client is running, and never target the pristine
+directory during cleanup.

--- a/.claude/skills/benchmarkoor/references/ranking-comparisons.md
+++ b/.claude/skills/benchmarkoor/references/ranking-comparisons.md
@@ -1,0 +1,136 @@
+# Cross-client ranking comparisons
+
+Use this workflow to combine a target client's local Benchmarkoor result with peer runs from the
+[Benchmarkoor website](https://benchmarkoor.core.ethpandaops.io/) and produce tables like the
+[Erigon PR #22409 performance table](https://github.com/erigontech/erigon/pull/22409#issue-4868249288).
+
+## Contents
+
+- Preserve provenance and secrets
+- Select comparable runs
+- Extract normalized fixture data
+- Calculate rankings and summaries
+- Present and qualify the results
+
+## Preserve provenance and secrets
+
+- Obtain an API key from the user or environment and keep it only in
+  `BENCHMARKOOR_API_KEY`. Never put a key in this skill, a script, a command literal, a result file,
+  a commit, or the final report. Disable shell tracing before authenticated requests.
+- Record the suite page, suite hash, local result path and run ID, every selected peer run ID, and
+  the retrieval time. Do not substitute a website run for a local target run when the user asks to
+  rank a particular local build.
+- Record each run's Benchmarkoor version, image and digest, client version, instance ID, command,
+  resource limits, host CPU, datadir method, cache-drop policy, rollback strategy, State Actor
+  manifest, and pass/fail counts. Fetch `config.json` through `/api/v1/files/*` when the run query
+  does not expose these fields; follow the returned presigned URL when the response contains `url`.
+- Treat matching suite hashes as fixture identity, not proof of experimental equivalence. Prefer a
+  contemporaneous peer batch from one host with matching CPU, memory, frequency, cache, storage,
+  and runner settings. Disclose every mismatch. In particular, label local OverlayFS versus remote
+  Schelk or different-host comparisons as directional rather than controlled measurements.
+
+## Select comparable runs
+
+Use the indexed API rather than scraping rendered tables. Pass the API key as a bearer token from
+the environment. The query endpoints use `column=operator.value`, support `order`, `limit`, and
+`offset`, and return rows in `.data`:
+
+```bash
+API_BASE=https://benchmarkoor.core.ethpandaops.io/api/v1
+SUITE_HASH=<suite-hash>
+CLIENT=reth
+set +x
+curl -fsS --config - --get "$API_BASE/index/query/runs" \
+  --data-urlencode "suite_hash=eq.$SUITE_HASH" \
+  --data-urlencode "client=eq.$CLIENT" \
+  --data-urlencode "status=eq.completed" \
+  --data-urlencode "has_result=eq.true" \
+  --data-urlencode "order=timestamp.desc" \
+  --data-urlencode "limit=100" <<EOF
+header = "Authorization: Bearer ${BENCHMARKOOR_API_KEY:?set BENCHMARKOOR_API_KEY}"
+EOF
+```
+
+Inspect candidates instead of blindly taking the newest run. Require the exact suite hash, intended
+full-suite instance such as `<client>-bal-full`, completed status, a result, zero failed tests, and
+the expected fixture count. Select one consistent snapshot across peers and explain any exception.
+Keep the selected metadata as an auditable manifest.
+
+Fetch each selected run's fixture rows from `/index/query/test_stats` with filters for both
+`suite_hash` and `run_id`. Select at least `client,run_id,test_name,test_gas_used,test_time_ns,
+test_mgas_s`. Paginate with `limit` and `offset` until no rows remain; never assume the first page is
+complete. Reject duplicate `test_name` rows within one run.
+
+## Extract normalized fixture data
+
+Extract the local target's successful test-step gas and payload-processing duration from
+`result.json`:
+
+```bash
+jq -r '
+  .tests | to_entries[] |
+  select((.value.steps.test.aggregated.fail // 0) == 0) |
+  [
+    .key,
+    .value.steps.test.aggregated.gas_used_total,
+    .value.steps.test.aggregated.gas_used_time_total
+  ] | @tsv
+' "$RUN_DIR/result.json"
+```
+
+Use full `test_name` values as join keys. Shorten names only when rendering a table. Build the exact
+intersection across the local target and every selected peer, and report each source count plus the
+intersection count. Do not impute or silently drop missing or failed fixtures. Verify that gas is
+positive and identical across clients for every joined fixture; investigate or explicitly exclude
+any mismatch.
+
+Calculate each unrounded fixture rate from raw fields:
+
+```text
+rate_mgas_s(client, fixture) = gas_used * 1000 / time_ns
+```
+
+Use `gas_used_time_total` locally and `test_time_ns` remotely. Do not use total step duration because
+it includes non-payload work. Treat the API's `test_mgas_s` as a cross-check, not a separate metric.
+
+## Calculate rankings and summaries
+
+For every fixture in the common intersection:
+
+- Sort unrounded rates descending. Set the target rank to one plus the number of clients with a
+  strictly higher rate; exact ties share a rank. Never derive ranks from rounded display values.
+- Set `gap to 1st` to `fastest peer rate / target rate` and `gap to 2nd` to
+  `second-fastest peer rate / target rate`. Choose both from peer clients, excluding the target. A
+  ratio below `1.0x` means the target is faster than that peer.
+- Define the target's "worst fixtures" by descending `gap to 1st`, not by raw target MGas/s or rank
+  alone. Use target rank descending and full fixture name ascending as deterministic tie-breakers.
+- For a before/after target comparison, calculate `improvement = after / before`, calculate both
+  ranks against the same fixed peer snapshot, and set `rank delta = rank_before - rank_after`, so a
+  positive delta means improvement.
+
+Calculate an overall or grouped throughput only over the same fixture set for every client:
+
+```text
+aggregate_mgas_s = sum(gas_used) * 1000 / sum(time_ns)
+```
+
+Never average per-fixture MGas/s values. Group by the full test module path before `::` when module
+summaries are useful. Define a 100M subset from the raw gas value `100000000`, not from a name match.
+Optionally report target-versus-peer wins, losses, and exact ties, plus the target's fixture-rank
+distribution.
+
+## Present and qualify the results
+
+Start with a provenance and comparability block, then report:
+
+- coverage counts and exclusions;
+- weighted overall and, when requested, 100M or module summaries;
+- a PR-style fixture table with target, peer rates, target rank, gaps to the two fastest peers, and
+  optional baseline improvement and rank movement;
+- the requested top-N worst fixtures sorted by `gap to 1st`;
+- head-to-head and rank-distribution summaries when they help diagnose broad behavior.
+
+Round only for display and retain raw values for calculations. State that cross-host or mixed
+datadir-method rankings measure the observed environments as a whole and cannot isolate client-code
+performance. Preserve the selected-run manifest and derived machine-readable data so later tables
+use the same snapshot instead of silently fetching newer peers.


### PR DESCRIPTION
## Summary

- Replace the legacy direct/rsync workflow and obsolete “OverlayFS does not work” guidance with the validated State Actor v1 workflow using a read-only bind mount and disposable native Linux OverlayFS layers.
- Document revision pinning, disk-capacity checks, pristine-state fingerprinting, local Erigon image construction, resource validation, and parallel Patricia commitment.
- Add instructions for discovering and validating the current compute and stateful runner configs, including:
  - Standard versus `-full` contexts.
  - Compute `rollback_strategy: none`.
  - Stateful `rollback_strategy: container-recreate`.
  - Fixture URL and test-type validation.
  - Subset-filter prefixes, derived suite hashes, cleanup, and result checks.
- Add a cross-client comparison workflow covering API run selection, exact fixture intersections, gas-weighted MGas/s, rankings, provenance, and cross-host caveats.
