### PR TITLE
docs(hardware): drop the Polygon disk tab, unsupported since 3.1

### DIFF
--- a/docs/site/docs/get-started/hardware-requirements.mdx
+++ b/docs/site/docs/get-started/hardware-requirements.mdx
@@ -67,17 +67,6 @@ _Current Disk Usage measured as of {/* ds-date:hoodi */}2026-07-29{/* ds:end */}
 
 _Current Disk Usage measured as of {/* ds-date:chiado */}2026-07-29{/* ds:end */}; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
 </TabItem>
-<TabItem value="polygon" label="Polygon">
-:::warning
-The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases). Disk usage figures below are from September 2025 and are no longer automatically updated.
-:::
-
-| **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
-| -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | 4.85 TB                | 8 TB                        | 64 GB              | 128 GB                |
-| Full (Default) | 3.3 TB                 | 4 TB                        | 32 GB              | 64 GB                 |
-| Minimal        | 1.2 TB                 | 2 TB                        | 32 GB              | 64 GB                 |
-</TabItem>
 </Tabs>
 
 :::tip

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -101,16 +101,6 @@ _Current Disk Usage measured as of 2026-07-29; usage grows over time as the chai
 
 _Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
 
-:::warning
-The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases). Disk usage figures below are from September 2025 and are no longer automatically updated.
-:::
-
-| **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
-| -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | 4.85 TB                | 8 TB                        | 64 GB              | 128 GB                |
-| Full (Default) | 3.3 TB                 | 4 TB                        | 32 GB              | 64 GB                 |
-| Minimal        | 1.2 TB                 | 2 TB                        | 32 GB              | 64 GB                 |
-
 :::tip
 See also how you can [optimize storage](../fundamentals/optimizing-storage).
 :::

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -101,16 +101,6 @@ _Current Disk Usage measured as of 2026-07-29; usage grows over time as the chai
 
 _Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only — full and minimal modes are not measured for this network._
 
-:::warning
-The final release series of Erigon that officially supports Polygon is 3.1.\*. For the software supported by Polygon, please refer to the link: [https://github.com/0xPolygon/erigon/releases](https://github.com/0xPolygon/erigon/releases). Disk usage figures below are from September 2025 and are no longer automatically updated.
-:::
-
-| **Pruning Mode**  | **Current Disk Usage** | **Disk Size (Recommended)** | **RAM (Required)** | **RAM (Recommended)** |
-| -------------- | ---------------------- | --------------------------- | ------------------ | --------------------- |
-| Archive        | 4.85 TB                | 8 TB                        | 64 GB              | 128 GB                |
-| Full (Default) | 3.3 TB                 | 4 TB                        | 32 GB              | 64 GB                 |
-| Minimal        | 1.2 TB                 | 2 TB                        | 32 GB              | 64 GB                 |
-
 :::tip
 See also how you can [optimize storage](../fundamentals/optimizing-storage).
 :::


### PR DESCRIPTION
Docs-only. Found while auditing the `release/3.6` docs backlog in #22970 — the same stale content is on `main`.

## The Polygon tab documents a network this binary cannot sync

`hardware-requirements.mdx` carried a Polygon tab with September 2025 disk sizes, behind a warning that the last Polygon-supporting series is 3.1.\* and that the figures are no longer updated.

On `main`, `bor-mainnet` has **zero occurrences** in `cmd/utils/flags.go` — there is no Polygon chain config left. So those were recommended disk sizes and RAM for a network the binary has no way to run.

Removed. Nothing else is lost:

- The support statement itself lives in [Supported Networks](https://docs.erigon.tech/fundamentals/supported-networks) and in the "How to run a Polygon node" guide — neither is touched.
- The frozen `v3.4` and `v3.3` versioned snapshots keep their Polygon tab, which is correct: those series did support it.

`release/3.5` already handles this via #22919, and #22970 does the same for `release/3.6`. This closes the last branch still publishing the figures.

## Unrelated finding on this branch, not fixed here

While comparing `main` against `release/3.6`, `configuring-erigon.mdx` on this branch documents:

```
* `--witness.cache.blocks value` *(New in v3.6)*: ...
```

That flag does **not exist on `release/3.6`** — `witness.cache.blocks` has no occurrences in that branch's Go code, along with `--witness.cache.head-capture`, `--witness.cache.maxmb` and `--caplin.resume-max-staleness-epochs`. They are all `main`-only.

So either the flags missed the 3.6 branch cut, or the label should name the next series. I have deliberately **not** guessed a version — someone who knows the release plan should decide whether to correct the label or backport the flags. Flagging it rather than silently editing.

## Verification

- `npm ci && npm run build` in `docs/site` — clean. `onBrokenLinks`, `onBrokenMarkdownLinks` and `onBrokenAnchors` are all `throw`, so a passing build proves no link or anchor depended on the removed tab.
- `python3 docs/site/scripts/render-disk-sizes.py --check` — page still matches `disk-sizes.json` (the tab held hardcoded values, not `ds:` markers, so the record is unaffected).
- `python3 docs/site/scripts/generate-llms.py --check` — 4 llms artifacts match, 74 pages.
- `python3 -m unittest discover docs/site/scripts` — 78 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
