### PR TITLE
readme: drop the Coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Twitter](https://img.shields.io/twitter/follow/ErigonEth?style=social)](https://x.com/ErigonEth)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat&logo=discord&logoColor=white)](https://dsc.gg/erigon)
 [![Build status](https://github.com/erigontech/erigon/actions/workflows/ci.yml/badge.svg)](https://github.com/erigontech/erigon/actions/workflows/ci.yml)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=erigontech_erigon&metric=coverage)](https://sonarcloud.io/summary/new_code?id=erigontech_erigon)
 
 Erigon is an implementation of Ethereum (execution layer with embeddable consensus layer), on the efficiency
 frontier.


### PR DESCRIPTION
Requested by @AskAlexSharov.

The SonarCloud coverage percentage is not a signal README readers act on, and it renders as a live third-party request on every page view of the repo landing page.

The **Build status** badge stays — that one tells a visitor whether the branch is currently green, which is actionable.

The **Docs** and **Blog** badges were reviewed at the same time and are correct as they stand (`docs-up` → docs.erigon.tech, `blog-up` → erigon.tech/blog), so they are deliberately left untouched.

Split out from #22973 (Polygon disk tab) because that PR had already entered the merge queue and its branch was frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
