### PR TITLE
use MADV_SEQUENTIAL for btree index build scan

### DIFF
--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -411,7 +411,7 @@ func BuildBtreeIndexWithDecompressor(indexPath string, existenceFilterPath strin
 	p := ps.AddNew(indexFileName, uint64(kv.Count()/2))
 	defer ps.Delete(p)
 
-	defer kv.MadvNormal().DisableReadAhead()
+	defer kv.MadvSequential().DisableReadAhead()
 
 	var existenceFilter *existence.Filter
 	if accessors.Has(statecfg.AccessorExistence) {

--- a/db/seg/seg_auto_rw.go
+++ b/db/seg/seg_auto_rw.go
@@ -89,6 +89,10 @@ func (g *Reader) MadvNormal() MadvDisabler {
 	g.d.MadvNormal()
 	return g
 }
+func (g *Reader) MadvSequential() MadvDisabler {
+	g.d.MadvSequential()
+	return g
+}
 func (g *Reader) DisableReadAhead() { g.d.DisableReadAhead() }
 func (g *Reader) FileName() string  { return g.Getter.FileName() }
 func (g *Reader) Next(buf []byte) ([]byte, uint64) {


### PR DESCRIPTION
`BuildBtreeIndexWithDecompressor` walks the `.kv` strictly forward — `kv.Reset(0)` then `Next`/`Skip` to EOF — so `MADV_SEQUENTIAL` fits better than `MADV_NORMAL`, whose mmap readahead window is centered on the current access (`ra->start = pgoff - ra_pages/2`), spending half of it on pages the walk has already passed.

Also adds `MadvSequential()` to `*seg.Reader`, which previously only exposed `MadvNormal()`.

Safe on the shared mmap here: `checkForVisibility` rejects a domain file that requires `AccessorBTree` while `item.bindex == nil`, and this is the code that produces that missing `.bt` — so there are no concurrent random readers during the scan.
