### PR TITLE
docs/site: bump js-yaml and brace-expansion to clear Dependabot alerts

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -7170,9 +7170,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11682,9 +11682,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -56,7 +56,8 @@
     "fast-uri": "^3.1.4",
     "http-proxy-middleware": "^2.0.10",
     "joi": "^17.13.4",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
+    "brace-expansion": "^1.1.17",
     "gray-matter": {
       "js-yaml": "3.14.2"
     },


### PR DESCRIPTION
## What

Clears the three open Dependabot alerts on `docs/site/package-lock.json`:

| Alert | Package | Fix |
|---|---|---|
| CVE-2026-59869 (GHSA-52cp-r559-cp3m) | js-yaml `4.2.0` → `4.3.1` | quadratic CPU via YAML merge-key chains |
| CVE-2026-13149 (GHSA-3jxr-9vmj-r5cp) | brace-expansion `1.1.14` → `1.1.18` | exponential-time expansion of `{}` groups |
| CVE-2026-14257 (GHSA-mh99-v99m-4gvg) | brace-expansion `1.1.14` → `1.1.18` | unbounded expansion → OOM |

Done via `overrides` in `package.json` (`js-yaml` `^4.2.0` → `^4.3.0`, added
`brace-expansion` `^1.1.17`) and a regenerated lockfile.

## Impact assessment

All three are **build-time-only, DoS-class** issues. `docs/site` is the
Docusaurus static-site generator for docs.erigon.tech:

- `js-yaml` is pulled by `@docusaurus/*`, `@11ty/gray-matter`, and `cosmiconfig`
  to parse our own YAML frontmatter/config.
- `brace-expansion` is pulled by `minimatch` (glob) to expand our own build-config
  glob patterns.

They parse trusted in-repo content at build time and are never shipped to the
published static site, so there was no exposure to site visitors. The only
theoretical vector is a crafted string in untrusted PR content slowing the
`docs-site-build` CI job (bounded by its 60-min timeout). Bumping regardless to
keep Dependabot green.

## Testing

- `npm install` re-resolves the tree with **0 vulnerabilities**; lockfile diff is
  limited to the two packages' `version`/`resolved`/`integrity` fields.
- `npm ci` + `npm run build` complete successfully (only pre-existing
  `onBrokenMarkdownLinks` deprecation warnings, unrelated to this change).

Patch/minor bumps within the same major — no API changes.
