### PR TITLE
[r3.6] db/downloader: detect caplin state snapshots via CaplinTypeString

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -747,8 +747,9 @@ func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error 
 	ff, isStateFile, ok := snaptype.ParseFileName("", name)
 	if ok {
 		// Caplin beacon-state snapshots have no registered global snaptype, so
-		// ParseFileName leaves ff.Type nil for them; they are still seedable by name.
-		if !isStateFile && ff.Type == nil && !snaptype.IsCaplin("", name) {
+		// ParseFileName leaves ff.Type nil but populates CaplinTypeString; they are
+		// still seedable by name.
+		if !isStateFile && ff.Type == nil && ff.CaplinTypeString == "" {
 			return fmt.Errorf("nil ptr after parsing file: %s", name)
 		}
 	}


### PR DESCRIPTION
Cherry-pick of #22971 to release/3.6.

Follow-up to the already-merged #22921: replaces the `!snaptype.IsCaplin("", name)` discriminator in the `AddNewSeedableFile` guard with the parse-based `ff.CaplinTypeString == ""`, addressing @sudeepdino008's review. `ParseFileName` leaves `Type` nil for caplin state snapshots but always populates `CaplinTypeString`, so this is the more robust check. Behavior unchanged for the real seed path; existing `TestAddNewSeedableFileCaplinStateType` stays green.

Clean cherry-pick, no adaptations.