### PR TITLE
[r3.5] db/downloader: allow seeding caplin state snapshots (nil global type)

### DIFF
--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -751,8 +751,9 @@ func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error 
 	ff, isStateFile, ok := snaptype.ParseFileName("", name)
 	if ok {
 		// Caplin beacon-state snapshots have no registered global snaptype, so
-		// ParseFileName leaves ff.Type nil for them; they are still seedable by name.
-		if !isStateFile && ff.Type == nil && !snaptype.IsCaplin("", name) {
+		// ParseFileName leaves ff.Type nil but populates CaplinTypeString; they are
+		// still seedable by name.
+		if !isStateFile && ff.Type == nil && ff.CaplinTypeString == "" {
 			return fmt.Errorf("nil ptr after parsing file: %s", name)
 		}
 	}

--- a/db/downloader/downloader.go
+++ b/db/downloader/downloader.go
@@ -750,7 +750,9 @@ func (d *Downloader) VerifyData(
 func (d *Downloader) AddNewSeedableFile(ctx context.Context, name string) error {
 	ff, isStateFile, ok := snaptype.ParseFileName("", name)
 	if ok {
-		if !isStateFile && ff.Type == nil {
+		// Caplin beacon-state snapshots have no registered global snaptype, so
+		// ParseFileName leaves ff.Type nil for them; they are still seedable by name.
+		if !isStateFile && ff.Type == nil && !snaptype.IsCaplin("", name) {
 			return fmt.Errorf("nil ptr after parsing file: %s", name)
 		}
 	}

--- a/db/downloader/downloader_test.go
+++ b/db/downloader/downloader_test.go
@@ -132,6 +132,17 @@ func TestAddNewSeedableFileConcurrentWithAllActiveSnapshots(t *testing.T) {
 	}
 }
 
+// Caplin beacon-state snapshots (e.g. NextSyncCommittee) have no registered global
+// snaptype, so ParseFileName returns a nil Type for them. They are still seedable by
+// name, so AddNewSeedableFile must not reject them as malformed.
+func TestAddNewSeedableFileCaplinStateType(t *testing.T) {
+	test := newDownloaderTest(t)
+	name := filepath.Join("caplin", "v1.1-000000-007150-NextSyncCommittee.seg")
+	require.NoError(t, os.MkdirAll(filepath.Join(test.dirs.Snap, "caplin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(test.dirs.Snap, name), nil, 0o644))
+	require.NoError(t, test.downloader.AddNewSeedableFile(t.Context(), name))
+}
+
 func TestChangeInfoHashOfSameFile(t *testing.T) {
 	ctx := t.Context()
 	require := require.New(t)


### PR DESCRIPTION
Cherry-picks of #22911 and #22971 to release/3.5.

Silences the `[Antiquary] Failed to add items to bittorent ... nil ptr after parsing file: caplin/...-NextSyncCommittee.seg` warning. Caplin beacon-state snapshot types have no registered global snaptype, so `ParseFileName` returns a nil `Type`; they are still seedable by name, so `AddNewSeedableFile` must not reject them.

## r3.5-specific note

The base fix #22911 was never cherry-picked to release/3.5 (it went to main + release/3.6 only), so this PR bundles **both** commits to bring 3.5 to the final form:
- #22911 — the original guard relax + `TestAddNewSeedableFileCaplinStateType`
- #22971 — the follow-up refining the discriminator to `ff.CaplinTypeString == ""` (per @sudeepdino008's review)

Both applied cleanly (auto-merge). End state matches main and release/3.6.