### PR TITLE
qa-tests: add file retirement test for minimal node 

### DIFF
--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -30,6 +30,8 @@ jobs:
       TRACKING_TIME_SECONDS: 7200 # 2 hours
       TOTAL_TIME_SECONDS: 43200 # 18 hours
       CHAIN: ${{ matrix.chain }}
+      RETIREMENT_PRUNE_DISTANCE: 20000 # narrowed state-history window, in blocks
+      RETIREMENT_TIMEOUT_SECONDS: 1800 # 30 minutes to observe the first retirement
 
     steps:
       - name: Check out repository
@@ -141,6 +143,67 @@ jobs:
         with:
           name: disk-usage-${{ env.CHAIN }}-minimal
           path: ${{ github.workspace }}/disk-usage-${{ env.CHAIN }}-minimal.txt
+
+      # Restart Erigon on the datadir just synced, with a state-history window
+      # narrower than the one it was synced with. That moves the retirement
+      # cutoff past whole snapshot-file boundaries, so aged history files become
+      # deletable within minutes instead of the days the default minimal window
+      # would need at tip. Gnosis is excluded until its step density is measured:
+      # 20000 blocks is a mainnet-calibrated value.
+      - name: Test old state-history file retirement (minimal node)
+        id: retirement_step
+        if: ${{ success() && env.CHAIN == 'mainnet' }}
+        run: |
+          set +e # Disable exit on error
+
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/file-retirement/run_and_check_file_retirement.py \
+            ${{ github.workspace }}/build/bin $ERIGON_DATA_DIR \
+            --chain $CHAIN \
+            --distance $RETIREMENT_PRUNE_DISTANCE \
+            --timeout $RETIREMENT_TIMEOUT_SECONDS \
+            --result-file "$GITHUB_WORKSPACE/result-retirement-$CHAIN.json"
+
+          # Capture the check script exit status
+          test_exit_status=$?
+
+          # Save the subsection reached status
+          echo "test_executed=true" >> "$GITHUB_OUTPUT"
+
+          # Check the check script exit status
+          if [ $test_exit_status -eq 0 ]; then
+            echo "File retirement test completed successfully"
+            echo "::notice::File retirement test completed successfully"
+            echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "Error detected during file retirement test"
+            echo "::error::Error detected during file retirement test"
+            echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Save file retirement test results
+        if: ${{ always() && steps.retirement_step.outputs.test_executed == 'true' }}
+        env:
+          TEST_RESULT: ${{ steps.retirement_step.outputs.TEST_RESULT }}
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+            --repo erigon \
+            --commit $(git rev-parse HEAD) \
+            --branch "$GITHUB_REF_NAME" \
+            --test_name minimal-node-file-retirement \
+            --chain $CHAIN \
+            --runner "$RUNNER_NAME" \
+            --outcome $TEST_RESULT \
+            --result_file "$GITHUB_WORKSPACE/result-retirement-$CHAIN.json"
+
+      - name: Upload file retirement test results
+        if: ${{ always() && steps.retirement_step.outputs.test_executed == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: file-retirement-results-${{ env.CHAIN }}
+          path: |
+            ${{ github.workspace }}/result-retirement-${{ env.CHAIN }}.json
+            ${{ github.workspace }}/erigon_data/logs/
 
       - name: Clean up Erigon data directory
         if: always()


### PR DESCRIPTION
Add 3 steps to the Sync-from-scratch test to test "snapshot retirement" in a minimal node configuration.

Waiting for a "normal" snapshot retirement event is too long for the test, so we use this algorithm:

1. run a normal sync-from-scratch test and wait for Erigon to reach the tip 
2. stop Erigon and restart it with `--prune.distance=20000` (see [here](https://github.com/erigontech/erigon-qa/blob/0062e243c897324577f828db8bdcebee7d1e6fd1/test_system/qa-tests/file-retirement/run_and_check_file_retirement.py#L497))
3. check snapshot pruning

