### PR TITLE
execution/engineapi: validate getPayload fork boundaries and blob bundle counts

### DIFF
--- a/execution/engineapi/engine_api_methods.go
+++ b/execution/engineapi/engine_api_methods.go
@@ -130,7 +130,7 @@ func (e *EngineServer) GetPayloadV3(ctx context.Context, payloadID hexutil.Bytes
 	return e.getPayload(ctx, decodedPayloadId, clparams.DenebVersion)
 }
 
-// Same as [GetPayloadV3], but returning ExecutionPayloadV4 (= ExecutionPayloadV3 + requests)
+// Same as [GetPayloadV3], with executionRequests added to the response.
 // See https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#engine_getpayloadv4
 func (e *EngineServer) GetPayloadV4(ctx context.Context, payloadID hexutil.Bytes) (*engine_types.GetPayloadResponse, error) {
 	decodedPayloadId, err := decodePayloadID(payloadID)
@@ -152,7 +152,7 @@ func (e *EngineServer) GetPayloadV5(ctx context.Context, payloadID hexutil.Bytes
 	return e.getPayload(ctx, decodedPayloadId, clparams.FuluVersion)
 }
 
-// Same as [GetPayloadV5], but returning ExecutionPayloadV6
+// Same as [GetPayloadV5], but returning ExecutionPayloadV4.
 // See https://github.com/ethereum/execution-apis/blob/main/src/engine/amsterdam.md#engine_getpayloadv6
 func (e *EngineServer) GetPayloadV6(ctx context.Context, payloadID hexutil.Bytes) (*engine_types.GetPayloadResponse, error) {
 	decodedPayloadId, err := decodePayloadID(payloadID)

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -699,8 +699,7 @@ func (s *EngineServer) getPayload(ctx context.Context, payloadId uint64, version
 	}
 
 	ts := header.Time
-	if (!s.config.IsShanghai(ts) && version >= clparams.CapellaVersion) ||
-		(s.config.IsShanghai(ts) && version < clparams.CapellaVersion) ||
+	if (s.config.IsShanghai(ts) && version < clparams.CapellaVersion) ||
 		(!s.config.IsCancun(ts) && version >= clparams.DenebVersion) ||
 		(s.config.IsCancun(ts) && version < clparams.DenebVersion) ||
 		(!s.config.IsPrague(ts) && version >= clparams.ElectraVersion) ||

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -699,7 +699,9 @@ func (s *EngineServer) getPayload(ctx context.Context, payloadId uint64, version
 	}
 
 	ts := header.Time
-	if (!s.config.IsCancun(ts) && version >= clparams.DenebVersion) ||
+	if (!s.config.IsShanghai(ts) && version >= clparams.CapellaVersion) ||
+		(s.config.IsShanghai(ts) && version < clparams.CapellaVersion) ||
+		(!s.config.IsCancun(ts) && version >= clparams.DenebVersion) ||
 		(s.config.IsCancun(ts) && version < clparams.DenebVersion) ||
 		(!s.config.IsPrague(ts) && version >= clparams.ElectraVersion) ||
 		(s.config.IsPrague(ts) && version < clparams.ElectraVersion) ||

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -715,7 +715,7 @@ func (s *EngineServer) getPayload(ctx context.Context, payloadId uint64, version
 		return nil, err
 	}
 
-	if version == clparams.FuluVersion {
+	if version >= clparams.FuluVersion {
 		if payload.BlobsBundle == nil {
 			payload.BlobsBundle = &engine_types.BlobsBundle{
 				Commitments: make([]hexutil.Bytes, 0),

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -717,13 +717,6 @@ func (s *EngineServer) getPayload(ctx context.Context, payloadId uint64, version
 	}
 
 	if version >= clparams.FuluVersion {
-		if payload.BlobsBundle == nil {
-			payload.BlobsBundle = &engine_types.BlobsBundle{
-				Commitments: make([]hexutil.Bytes, 0),
-				Blobs:       make([]hexutil.Bytes, 0),
-				Proofs:      make([]hexutil.Bytes, 0),
-			}
-		}
 		if len(payload.BlobsBundle.Commitments) != len(payload.BlobsBundle.Blobs) || len(payload.BlobsBundle.Proofs) != len(payload.BlobsBundle.Blobs)*int(params.CellsPerExtBlob) {
 			return nil, fmt.Errorf("built invalid blobsBundle len(blobs)=%d len(commitments)=%d len(proofs)=%d", len(payload.BlobsBundle.Blobs), len(payload.BlobsBundle.Commitments), len(payload.BlobsBundle.Proofs))
 		}

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -718,8 +718,12 @@ func (s *EngineServer) getPayload(ctx context.Context, payloadId uint64, version
 		return nil, err
 	}
 
-	if version >= clparams.FuluVersion {
-		if len(payload.BlobsBundle.Commitments) != len(payload.BlobsBundle.Blobs) || len(payload.BlobsBundle.Proofs) != len(payload.BlobsBundle.Blobs)*int(params.CellsPerExtBlob) {
+	if version >= clparams.DenebVersion {
+		proofsPerBlob := 1
+		if version >= clparams.FuluVersion {
+			proofsPerBlob = int(params.CellsPerExtBlob)
+		}
+		if len(payload.BlobsBundle.Commitments) != len(payload.BlobsBundle.Blobs) || len(payload.BlobsBundle.Proofs) != len(payload.BlobsBundle.Blobs)*proofsPerBlob {
 			return nil, fmt.Errorf("built invalid blobsBundle len(blobs)=%d len(commitments)=%d len(proofs)=%d", len(payload.BlobsBundle.Blobs), len(payload.BlobsBundle.Commitments), len(payload.BlobsBundle.Proofs))
 		}
 	}

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -699,6 +699,8 @@ func (s *EngineServer) getPayload(ctx context.Context, payloadId uint64, version
 	}
 
 	ts := header.Time
+	// Unlike later forks, Shanghai does not require an exact version match:
+	// engine_getPayloadV2 serves both Paris and Shanghai payloads.
 	if (s.config.IsShanghai(ts) && version < clparams.CapellaVersion) ||
 		(!s.config.IsCancun(ts) && version >= clparams.DenebVersion) ||
 		(s.config.IsCancun(ts) && version < clparams.DenebVersion) ||

--- a/execution/engineapi/engine_server_getpayload_test.go
+++ b/execution/engineapi/engine_server_getpayload_test.go
@@ -44,7 +44,7 @@ func TestGetPayloadV4RejectsNilRequests(t *testing.T) {
 		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
 			require.Equal(t, payloadID, id)
 			return execmodule.AssembledBlockResult{
-				Block: minimalPragueBlock(1, nil /* nil Requests */),
+				Block: minimalPayloadBlock(1, nil /* nil Requests */),
 			}, nil
 		},
 	}
@@ -64,7 +64,7 @@ func TestGetPayloadV4AcceptsEmptyRequestsBundle(t *testing.T) {
 		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
 			require.Equal(t, payloadID, id)
 			return execmodule.AssembledBlockResult{
-				Block: minimalPragueBlock(1, make(types.FlatRequests, 0)),
+				Block: minimalPayloadBlock(1, make(types.FlatRequests, 0)),
 			}, nil
 		},
 	}
@@ -78,16 +78,18 @@ func TestGetPayloadV4AcceptsEmptyRequestsBundle(t *testing.T) {
 	require.Len(t, resp.ExecutionRequests, 0)
 }
 
-func TestGetPayloadRejectsInvalidAmsterdamBlobsBundle(t *testing.T) {
+func TestGetPayloadV6RejectsInvalidBlobsBundle(t *testing.T) {
+	t.Parallel()
+
 	const payloadID uint64 = 44
 	cfg := allForksChainConfig()
 	to := common.Address{0x01}
-	wrappedTxn := &types.BlobTxWrapper{}
+	wrappedTxn := &types.BlobTxWrapper{WrapperVersion: 1}
 	wrappedTxn.Tx.To = &to
 	wrappedTxn.Tx.ChainID = *cfg.ChainID
-	wrappedTxn.Tx.BlobVersionedHashes = []common.Hash{{0x01}, {0x01}}
-	wrappedTxn.Commitments = make(types.BlobKzgs, 2)
-	wrappedTxn.Blobs = make(types.Blobs, 2)
+	wrappedTxn.Tx.BlobVersionedHashes = []common.Hash{{0x01}}
+	wrappedTxn.Commitments = make(types.BlobKzgs, 1)
+	wrappedTxn.Blobs = make(types.Blobs, 1)
 	wrappedTxn.Proofs = make(types.KZGProofs, 1)
 
 	header := &types.Header{
@@ -109,9 +111,9 @@ func TestGetPayloadRejectsInvalidAmsterdamBlobsBundle(t *testing.T) {
 			}, nil
 		},
 	}
-	srv := NewEngineServer(log.New(), cfg, stub, nil, false, false, true, true, nil, nil, 0, 0)
+	srv := newProposingEngineServerWithConfig(cfg, stub)
 
-	resp, err := srv.getPayload(context.Background(), payloadID, clparams.GloasVersion)
+	resp, err := srv.GetPayloadV6(context.Background(), payloadIDBytes(payloadID))
 
 	require.ErrorContains(t, err, "built invalid blobsBundle")
 	require.Nil(t, resp)
@@ -125,7 +127,7 @@ func TestGetPayloadV1RejectsShanghaiPayload(t *testing.T) {
 		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
 			require.Equal(t, payloadID, id)
 			return execmodule.AssembledBlockResult{
-				Block:      minimalPragueBlock(100, nil),
+				Block:      minimalPayloadBlock(100, nil),
 				BlockValue: uint256.NewInt(0),
 			}, nil
 		},
@@ -147,7 +149,7 @@ func TestGetPayloadV2AcceptsParisPayload(t *testing.T) {
 		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
 			require.Equal(t, payloadID, id)
 			return execmodule.AssembledBlockResult{
-				Block:      minimalPragueBlock(99, nil),
+				Block:      minimalPayloadBlock(99, nil),
 				BlockValue: uint256.NewInt(0),
 			}, nil
 		},
@@ -221,9 +223,8 @@ func parisShanghaiChainConfig() *chain.Config {
 	return cfg
 }
 
-// minimalPragueBlock builds the smallest possible BlockWithReceipts for Prague
-// (timestamp=1, BaseFee set, no transactions) with the given requests slice.
-func minimalPragueBlock(timestamp uint64, requests types.FlatRequests) *types.BlockWithReceipts {
+// minimalPayloadBlock builds a transaction-free payload block with the given timestamp and execution requests.
+func minimalPayloadBlock(timestamp uint64, requests types.FlatRequests) *types.BlockWithReceipts {
 	baseFee := uint256.NewInt(1_000_000_000)
 	header := &types.Header{
 		Number:   *uint256.NewInt(101),

--- a/execution/engineapi/engine_server_getpayload_test.go
+++ b/execution/engineapi/engine_server_getpayload_test.go
@@ -78,7 +78,7 @@ func TestGetPayloadV4AcceptsEmptyRequestsBundle(t *testing.T) {
 	require.Len(t, resp.ExecutionRequests, 0)
 }
 
-func TestGetPayloadV4AcceptsValidBlobsBundle(t *testing.T) {
+func TestGetPayloadV4AcceptsMatchingBlobsBundleCounts(t *testing.T) {
 	t.Parallel()
 
 	const payloadID uint64 = 48
@@ -102,7 +102,7 @@ func TestGetPayloadV4AcceptsValidBlobsBundle(t *testing.T) {
 	require.Len(t, resp.BlobsBundle.Proofs, 1)
 }
 
-func TestGetPayloadV3RejectsInvalidBlobsBundle(t *testing.T) {
+func TestGetPayloadV3RejectsMismatchedBlobsBundleCounts(t *testing.T) {
 	t.Parallel()
 
 	const payloadID uint64 = 47
@@ -124,7 +124,7 @@ func TestGetPayloadV3RejectsInvalidBlobsBundle(t *testing.T) {
 	require.Nil(t, resp)
 }
 
-func TestGetPayloadV6RejectsInvalidBlobsBundle(t *testing.T) {
+func TestGetPayloadV6RejectsMismatchedBlobsBundleCounts(t *testing.T) {
 	t.Parallel()
 
 	const payloadID uint64 = 44
@@ -286,7 +286,6 @@ func parisShanghaiChainConfig() *chain.Config {
 	return cfg
 }
 
-// minimalPayloadBlock builds a transaction-free payload block with the given timestamp and execution requests.
 func minimalPayloadBlock(timestamp uint64, requests types.FlatRequests) *types.BlockWithReceipts {
 	baseFee := uint256.NewInt(1_000_000_000)
 	header := &types.Header{
@@ -302,8 +301,6 @@ func minimalPayloadBlock(timestamp uint64, requests types.FlatRequests) *types.B
 	}
 }
 
-// blobPayloadBlock builds a payload block containing a single blob transaction
-// with the given wrapper version and commitment/blob/proof counts.
 func blobPayloadBlock(chainID *uint256.Int, wrapperVersion byte, commitments, blobs, proofs int) *types.BlockWithReceipts {
 	to := common.Address{0x01}
 	wrappedTxn := &types.BlobTxWrapper{WrapperVersion: wrapperVersion}

--- a/execution/engineapi/engine_server_getpayload_test.go
+++ b/execution/engineapi/engine_server_getpayload_test.go
@@ -76,6 +76,45 @@ func TestGetPayloadV4AcceptsEmptyRequestsBundle(t *testing.T) {
 	require.Len(t, resp.ExecutionRequests, 0)
 }
 
+func TestGetPayloadRejectsInvalidAmsterdamBlobsBundle(t *testing.T) {
+	const payloadID uint64 = 44
+	cfg := allForksChainConfig()
+	to := common.Address{0x01}
+	wrappedTxn := &types.BlobTxWrapper{}
+	wrappedTxn.Tx.To = &to
+	wrappedTxn.Tx.ChainID = *cfg.ChainID
+	wrappedTxn.Tx.BlobVersionedHashes = []common.Hash{{0x01}, {0x01}}
+	wrappedTxn.Commitments = make(types.BlobKzgs, 2)
+	wrappedTxn.Blobs = make(types.Blobs, 2)
+	wrappedTxn.Proofs = make(types.KZGProofs, 1)
+
+	header := &types.Header{
+		Number:   *uint256.NewInt(101),
+		Time:     1,
+		BaseFee:  uint256.NewInt(1_000_000_000),
+		GasLimit: 30_000_000,
+	}
+	block := types.NewBlock(header, []types.Transaction{wrappedTxn}, nil, nil, nil)
+	stub := &getPayloadStubModule{
+		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
+			require.Equal(t, payloadID, id)
+			return execmodule.AssembledBlockResult{
+				Block: &types.BlockWithReceipts{
+					Block:    block,
+					Requests: make(types.FlatRequests, 0),
+				},
+				BlockValue: uint256.NewInt(0),
+			}, nil
+		},
+	}
+	srv := NewEngineServer(log.New(), cfg, stub, nil, false, false, true, true, nil, nil, 0, 0)
+
+	resp, err := srv.getPayload(context.Background(), payloadID, clparams.GloasVersion)
+
+	require.ErrorContains(t, err, "built invalid blobsBundle")
+	require.Nil(t, resp)
+}
+
 func TestAssembledBlockToPayloadResponseIncludesCanonicalEmptyBAL(t *testing.T) {
 	t.Parallel()
 

--- a/execution/engineapi/engine_server_getpayload_test.go
+++ b/execution/engineapi/engine_server_getpayload_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/builder"
+	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/rpc"
 )
 
 func TestGetPayloadV4RejectsNilRequests(t *testing.T) {
@@ -115,6 +117,40 @@ func TestGetPayloadRejectsInvalidAmsterdamBlobsBundle(t *testing.T) {
 	require.Nil(t, resp)
 }
 
+func TestGetPayloadRejectsParisShanghaiMismatch(t *testing.T) {
+	t.Parallel()
+
+	const payloadID uint64 = 44
+	for _, tc := range []struct {
+		name      string
+		timestamp uint64
+		version   clparams.StateVersion
+	}{
+		{"Shanghai payload with Paris schema", 100, clparams.BellatrixVersion},
+		{"Paris payload with Shanghai schema", 99, clparams.CapellaVersion},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stub := &getPayloadStubModule{
+				getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
+					require.Equal(t, payloadID, id)
+					return execmodule.AssembledBlockResult{
+						Block:      minimalPragueBlock(tc.timestamp, nil),
+						BlockValue: uint256.NewInt(0),
+					}, nil
+				},
+			}
+			srv := newProposingEngineServerWithConfig(parisShanghaiChainConfig(), stub)
+
+			resp, err := srv.getPayload(context.Background(), payloadID, tc.version)
+
+			require.Nil(t, resp)
+			var unsupported *rpc.UnsupportedForkError
+			require.ErrorAs(t, err, &unsupported)
+		})
+	}
+}
+
 func TestAssembledBlockToPayloadResponseIncludesCanonicalEmptyBAL(t *testing.T) {
 	t.Parallel()
 
@@ -145,6 +181,10 @@ func newProposingEngineServerForGetPayloadTests(stub execmodule.ExecutionModule)
 	cfg.OsakaTime = nil
 	cfg.AmsterdamTime = nil
 
+	return newProposingEngineServerWithConfig(cfg, stub)
+}
+
+func newProposingEngineServerWithConfig(cfg *chain.Config, stub execmodule.ExecutionModule) *EngineServer {
 	return NewEngineServer(
 		log.New(),
 		cfg,
@@ -159,6 +199,16 @@ func newProposingEngineServerForGetPayloadTests(stub execmodule.ExecutionModule)
 		0,     // fcuTimeout
 		0,     // maxReorgDepth
 	)
+}
+
+func parisShanghaiChainConfig() *chain.Config {
+	cfg := allForksChainConfig()
+	cfg.ShanghaiTime = common.NewUint64(100)
+	cfg.CancunTime = nil
+	cfg.PragueTime = nil
+	cfg.OsakaTime = nil
+	cfg.AmsterdamTime = nil
+	return cfg
 }
 
 // minimalPragueBlock builds the smallest possible BlockWithReceipts for Prague

--- a/execution/engineapi/engine_server_getpayload_test.go
+++ b/execution/engineapi/engine_server_getpayload_test.go
@@ -117,38 +117,48 @@ func TestGetPayloadRejectsInvalidAmsterdamBlobsBundle(t *testing.T) {
 	require.Nil(t, resp)
 }
 
-func TestGetPayloadRejectsParisShanghaiMismatch(t *testing.T) {
+func TestGetPayloadV1RejectsShanghaiPayload(t *testing.T) {
 	t.Parallel()
 
 	const payloadID uint64 = 44
-	for _, tc := range []struct {
-		name      string
-		timestamp uint64
-		version   clparams.StateVersion
-	}{
-		{"Shanghai payload with Paris schema", 100, clparams.BellatrixVersion},
-		{"Paris payload with Shanghai schema", 99, clparams.CapellaVersion},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			stub := &getPayloadStubModule{
-				getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
-					require.Equal(t, payloadID, id)
-					return execmodule.AssembledBlockResult{
-						Block:      minimalPragueBlock(tc.timestamp, nil),
-						BlockValue: uint256.NewInt(0),
-					}, nil
-				},
-			}
-			srv := newProposingEngineServerWithConfig(parisShanghaiChainConfig(), stub)
-
-			resp, err := srv.getPayload(context.Background(), payloadID, tc.version)
-
-			require.Nil(t, resp)
-			var unsupported *rpc.UnsupportedForkError
-			require.ErrorAs(t, err, &unsupported)
-		})
+	stub := &getPayloadStubModule{
+		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
+			require.Equal(t, payloadID, id)
+			return execmodule.AssembledBlockResult{
+				Block:      minimalPragueBlock(100, nil),
+				BlockValue: uint256.NewInt(0),
+			}, nil
+		},
 	}
+	srv := newProposingEngineServerWithConfig(parisShanghaiChainConfig(), stub)
+
+	resp, err := srv.GetPayloadV1(context.Background(), payloadIDBytes(payloadID))
+
+	require.Nil(t, resp)
+	var unsupported *rpc.UnsupportedForkError
+	require.ErrorAs(t, err, &unsupported)
+}
+
+func TestGetPayloadV2AcceptsParisPayload(t *testing.T) {
+	t.Parallel()
+
+	const payloadID uint64 = 45
+	stub := &getPayloadStubModule{
+		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
+			require.Equal(t, payloadID, id)
+			return execmodule.AssembledBlockResult{
+				Block:      minimalPragueBlock(99, nil),
+				BlockValue: uint256.NewInt(0),
+			}, nil
+		},
+	}
+	srv := newProposingEngineServerWithConfig(parisShanghaiChainConfig(), stub)
+
+	resp, err := srv.GetPayloadV2(context.Background(), payloadIDBytes(payloadID))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.ExecutionPayload.Withdrawals)
 }
 
 func TestAssembledBlockToPayloadResponseIncludesCanonicalEmptyBAL(t *testing.T) {

--- a/execution/engineapi/engine_server_getpayload_test.go
+++ b/execution/engineapi/engine_server_getpayload_test.go
@@ -146,6 +146,28 @@ func TestGetPayloadV6RejectsInvalidBlobsBundle(t *testing.T) {
 	require.Nil(t, resp)
 }
 
+func TestGetPayloadV1AcceptsParisPayload(t *testing.T) {
+	t.Parallel()
+
+	const payloadID uint64 = 49
+	stub := &getPayloadStubModule{
+		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
+			require.Equal(t, payloadID, id)
+			return execmodule.AssembledBlockResult{
+				Block:      minimalPayloadBlock(99, nil),
+				BlockValue: uint256.NewInt(0),
+			}, nil
+		},
+	}
+	srv := newProposingEngineServerWithConfig(parisShanghaiChainConfig(), stub)
+
+	resp, err := srv.GetPayloadV1(context.Background(), payloadIDBytes(payloadID))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.Withdrawals)
+}
+
 func TestGetPayloadV1RejectsShanghaiPayload(t *testing.T) {
 	t.Parallel()
 

--- a/execution/engineapi/engine_server_getpayload_test.go
+++ b/execution/engineapi/engine_server_getpayload_test.go
@@ -163,6 +163,27 @@ func TestGetPayloadV2AcceptsParisPayload(t *testing.T) {
 	require.Nil(t, resp.ExecutionPayload.Withdrawals)
 }
 
+func TestGetPayloadV2AcceptsShanghaiPayload(t *testing.T) {
+	t.Parallel()
+
+	const payloadID uint64 = 46
+	stub := &getPayloadStubModule{
+		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
+			require.Equal(t, payloadID, id)
+			return execmodule.AssembledBlockResult{
+				Block:      minimalPayloadBlock(100, nil),
+				BlockValue: uint256.NewInt(0),
+			}, nil
+		},
+	}
+	srv := newProposingEngineServerWithConfig(parisShanghaiChainConfig(), stub)
+
+	resp, err := srv.GetPayloadV2(context.Background(), payloadIDBytes(payloadID))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
 func TestAssembledBlockToPayloadResponseIncludesCanonicalEmptyBAL(t *testing.T) {
 	t.Parallel()
 
@@ -214,12 +235,8 @@ func newProposingEngineServerWithConfig(cfg *chain.Config, stub execmodule.Execu
 }
 
 func parisShanghaiChainConfig() *chain.Config {
-	cfg := allForksChainConfig()
+	cfg := preCancunChainConfig()
 	cfg.ShanghaiTime = common.NewUint64(100)
-	cfg.CancunTime = nil
-	cfg.PragueTime = nil
-	cfg.OsakaTime = nil
-	cfg.AmsterdamTime = nil
 	return cfg
 }
 

--- a/execution/engineapi/engine_server_getpayload_test.go
+++ b/execution/engineapi/engine_server_getpayload_test.go
@@ -78,35 +78,62 @@ func TestGetPayloadV4AcceptsEmptyRequestsBundle(t *testing.T) {
 	require.Len(t, resp.ExecutionRequests, 0)
 }
 
+func TestGetPayloadV4AcceptsValidBlobsBundle(t *testing.T) {
+	t.Parallel()
+
+	const payloadID uint64 = 48
+	cfg := preOsakaChainConfig()
+	stub := &getPayloadStubModule{
+		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
+			require.Equal(t, payloadID, id)
+			return execmodule.AssembledBlockResult{
+				Block:      blobPayloadBlock(cfg.ChainID, 0 /* wrapperVersion */, 1 /* commitments */, 1 /* blobs */, 1 /* proofs */),
+				BlockValue: uint256.NewInt(0),
+			}, nil
+		},
+	}
+	srv := newProposingEngineServerWithConfig(cfg, stub)
+
+	resp, err := srv.GetPayloadV4(context.Background(), payloadIDBytes(payloadID))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.BlobsBundle.Blobs, 1)
+	require.Len(t, resp.BlobsBundle.Proofs, 1)
+}
+
+func TestGetPayloadV3RejectsInvalidBlobsBundle(t *testing.T) {
+	t.Parallel()
+
+	const payloadID uint64 = 47
+	cfg := prePragueChainConfig()
+	stub := &getPayloadStubModule{
+		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
+			require.Equal(t, payloadID, id)
+			return execmodule.AssembledBlockResult{
+				Block:      blobPayloadBlock(cfg.ChainID, 0 /* wrapperVersion */, 1 /* commitments */, 1 /* blobs */, 2 /* proofs */),
+				BlockValue: uint256.NewInt(0),
+			}, nil
+		},
+	}
+	srv := newProposingEngineServerWithConfig(cfg, stub)
+
+	resp, err := srv.GetPayloadV3(context.Background(), payloadIDBytes(payloadID))
+
+	require.ErrorContains(t, err, "built invalid blobsBundle")
+	require.Nil(t, resp)
+}
+
 func TestGetPayloadV6RejectsInvalidBlobsBundle(t *testing.T) {
 	t.Parallel()
 
 	const payloadID uint64 = 44
 	cfg := allForksChainConfig()
-	to := common.Address{0x01}
-	wrappedTxn := &types.BlobTxWrapper{WrapperVersion: 1}
-	wrappedTxn.Tx.To = &to
-	wrappedTxn.Tx.ChainID = *cfg.ChainID
-	wrappedTxn.Tx.BlobVersionedHashes = []common.Hash{{0x01}}
-	wrappedTxn.Commitments = make(types.BlobKzgs, 1)
-	wrappedTxn.Blobs = make(types.Blobs, 1)
-	wrappedTxn.Proofs = make(types.KZGProofs, 1)
-
-	header := &types.Header{
-		Number:   *uint256.NewInt(101),
-		Time:     1,
-		BaseFee:  uint256.NewInt(1_000_000_000),
-		GasLimit: 30_000_000,
-	}
-	block := types.NewBlock(header, []types.Transaction{wrappedTxn}, nil, nil, nil)
 	stub := &getPayloadStubModule{
 		getAssembledBlockFunc: func(_ context.Context, id uint64) (execmodule.AssembledBlockResult, error) {
 			require.Equal(t, payloadID, id)
 			return execmodule.AssembledBlockResult{
-				Block: &types.BlockWithReceipts{
-					Block:    block,
-					Requests: make(types.FlatRequests, 0),
-				},
+				Block:      blobPayloadBlock(cfg.ChainID, 1 /* wrapperVersion */, 1 /* commitments */, 1 /* blobs */, 1 /* proofs */),
 				BlockValue: uint256.NewInt(0),
 			}, nil
 		},
@@ -208,13 +235,10 @@ func TestAssembledBlockToPayloadResponseIncludesCanonicalEmptyBAL(t *testing.T) 
 	require.Equal(t, hexutil.Bytes(emptyBAL), *resp.ExecutionPayload.BlockAccessList)
 }
 
+// newProposingEngineServerForGetPayloadTests returns a server on a Prague-window
+// config: GetPayloadV4 is valid on Prague but invalid once Osaka activates.
 func newProposingEngineServerForGetPayloadTests(stub execmodule.ExecutionModule) *EngineServer {
-	cfg := allForksChainConfig()
-	// GetPayloadV4 is valid on Prague but invalid once Osaka activates.
-	cfg.OsakaTime = nil
-	cfg.AmsterdamTime = nil
-
-	return newProposingEngineServerWithConfig(cfg, stub)
+	return newProposingEngineServerWithConfig(preOsakaChainConfig(), stub)
 }
 
 func newProposingEngineServerWithConfig(cfg *chain.Config, stub execmodule.ExecutionModule) *EngineServer {
@@ -253,6 +277,31 @@ func minimalPayloadBlock(timestamp uint64, requests types.FlatRequests) *types.B
 	return &types.BlockWithReceipts{
 		Block:    block,
 		Requests: requests,
+	}
+}
+
+// blobPayloadBlock builds a payload block containing a single blob transaction
+// with the given wrapper version and commitment/blob/proof counts.
+func blobPayloadBlock(chainID *uint256.Int, wrapperVersion byte, commitments, blobs, proofs int) *types.BlockWithReceipts {
+	to := common.Address{0x01}
+	wrappedTxn := &types.BlobTxWrapper{WrapperVersion: wrapperVersion}
+	wrappedTxn.Tx.To = &to
+	wrappedTxn.Tx.ChainID = *chainID
+	wrappedTxn.Tx.BlobVersionedHashes = []common.Hash{{0x01}}
+	wrappedTxn.Commitments = make(types.BlobKzgs, commitments)
+	wrappedTxn.Blobs = make(types.Blobs, blobs)
+	wrappedTxn.Proofs = make(types.KZGProofs, proofs)
+
+	header := &types.Header{
+		Number:   *uint256.NewInt(101),
+		Time:     1,
+		BaseFee:  uint256.NewInt(1_000_000_000),
+		GasLimit: 30_000_000,
+	}
+	block := types.NewBlock(header, []types.Transaction{wrappedTxn}, nil, nil, nil)
+	return &types.BlockWithReceipts{
+		Block:    block,
+		Requests: make(types.FlatRequests, 0),
 	}
 }
 

--- a/execution/engineapi/testing_api_test.go
+++ b/execution/engineapi/testing_api_test.go
@@ -209,6 +209,25 @@ func preCancunChainConfig() *chain.Config {
 	return cfg
 }
 
+// prePragueChainConfig returns a chain config where Cancun is active but
+// Prague and later forks are NOT activated.
+func prePragueChainConfig() *chain.Config {
+	cfg := allForksChainConfig()
+	cfg.PragueTime = nil
+	cfg.OsakaTime = nil
+	cfg.AmsterdamTime = nil
+	return cfg
+}
+
+// preOsakaChainConfig returns a chain config where Prague is active but
+// Osaka and later forks are NOT activated.
+func preOsakaChainConfig() *chain.Config {
+	cfg := allForksChainConfig()
+	cfg.OsakaTime = nil
+	cfg.AmsterdamTime = nil
+	return cfg
+}
+
 // preAmsterdamChainConfig returns a chain config where Osaka is active but
 // Amsterdam (Glamsterdam) is NOT activated.
 func preAmsterdamChainConfig() *chain.Config {


### PR DESCRIPTION
## Summary

- reject `engine_getPayloadV1` for Shanghai-and-later payloads while keeping `engine_getPayloadV2` valid on both sides of the Shanghai boundary
- validate blob bundle counts on every bundle-bearing endpoint:
  - `BlobsBundleV1` from `engine_getPayloadV3`/`V4` (Cancun/Prague) has equal commitment, blob, and proof counts
  - `BlobsBundleV2` from `engine_getPayloadV5`/`V6` (Osaka/Amsterdam) has equal commitment/blob counts and `CELLS_PER_EXT_BLOB` cell proofs per blob
- rely on bundle construction's non-nil initialized result instead of an unreachable nil fallback
- correct the `GetPayloadV4` and `GetPayloadV6` comments to match the response structures defined by the specifications

## Why

Erigon payload IDs are monotonically allocated identifiers; they do not encode the Engine API version used to start the build. `getPayload` must therefore validate the built payload's timestamp against the requested endpoint. V2 intentionally spans Paris and Shanghai, whereas V1 and V3–V6 must stay within their respective fork windows.

Every response that carries a blob bundle must satisfy the count invariant of its bundle version. `BlobsBundleV1` requires equal commitment, blob, and proof counts. `BlobsBundleV2` requires equal commitment/blob counts and `CELLS_PER_EXT_BLOB` proofs per blob. `BlobsBundleFromTransactions` always returns a non-nil bundle with initialized slices, including for an empty bundle.

## Testing

- `go test ./execution/engineapi/... -count=1`
- `make lint` (repeated)
- `make erigon integration`
