### PR TITLE
[r3.6] common/hexutil: improve performance of EncodeBig

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -19,7 +19,6 @@ package hexutil
 import (
 	"encoding/binary"
 	"encoding/hex"
-	"fmt"
 	"math/big"
 	"strconv"
 )
@@ -123,13 +122,14 @@ func MustDecodeBig(input string) *big.Int {
 }
 
 // EncodeBig encodes bigint as a hex string with 0x prefix.
-// The sign of the integer is ignored.
 func EncodeBig(bigint *big.Int) string {
-	nbits := bigint.BitLen()
-	if nbits == 0 {
+	if sign := bigint.Sign(); sign == 0 {
 		return "0x0"
+	} else if sign > 0 {
+		return "0x" + bigint.Text(16)
+	} else {
+		return "-0x" + bigint.Text(16)[1:]
 	}
-	return fmt.Sprintf("%#x", bigint)
 }
 
 func has0xPrefix(input string) bool {

--- a/common/hexutil/hexutil_test.go
+++ b/common/hexutil/hexutil_test.go
@@ -190,6 +190,19 @@ func TestEncodeBig(t *testing.T) {
 	}
 }
 
+func BenchmarkEncodeBig(b *testing.B) {
+	inputs := make([]*big.Int, len(encodeBigTests))
+	for i, test := range encodeBigTests {
+		inputs[i] = test.input.(*big.Int)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		for _, bigint := range inputs {
+			EncodeBig(bigint)
+		}
+	}
+}
+
 func TestDecodeBig(t *testing.T) {
 	for idx, test := range decodeBigTests {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of #22778 to release/3.6.

## r3.6-specific adaptations

Dropped the `json.go` hunk: it only retouches a comment inside `Big.AppendText`, which was added by #22695 and is not on release/3.6.