### PR TITLE
[r3.6] common/dbg: disable adaptive trunk-pin by default

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -129,7 +129,7 @@ var (
 	UseTxDependencies    = EnvBool("USE_TX_DEPENDENCIES", false)
 	UseStateCache        = EnvBool("USE_STATE_CACHE", true)
 	UseCodeStore         = EnvBool("USE_CODE_STORE", true)
-	DisableAdaptivePin   = EnvBool("DISABLE_ADAPTIVE_PIN", false)
+	DisableAdaptivePin   = EnvBool("DISABLE_ADAPTIVE_PIN", true)
 	AssertStateCache     = EnvBool("ASSERT_STATE_CACHE", false)
 	ReadAhead            = EnvBool("READ_AHEAD", true)
 


### PR DESCRIPTION
Flips `DISABLE_ADAPTIVE_PIN` to default `true` on release/3.6, so `Aggregator.openFolder` no longer builds the `AdaptivePinController` and no trunk preload runs.

The controller's promote/extend preloads run inline from `SharedDomains.Commit` — under the controller mutex and inside the still-open write tx — so their cost (per-contract `TblCommitmentVals` cursor scan into a Go map, per-wave frontier sort, sequential `GetLatest` per key) lands on the block-commit critical path.

`DISABLE_ADAPTIVE_PIN=false` re-enables it.