### PR TITLE
db/seg, db/state, execution/vm: check errors flagged by errcheck

### DIFF
--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -315,8 +315,8 @@ func (c *Compressor) Compress() error {
 		return err
 	}
 	tmpFileName := cf.Name()
-	defer dir.RemoveFile(tmpFileName)
-	defer cf.Close()
+	defer dir.RemoveFile(tmpFileName) //nolint:errcheck
+	defer cf.Close()                  //nolint:errcheck
 
 	if c.version == FileCompressionFormatV1 {
 		if _, err := cf.Write([]byte{c.version, byte(c.featureFlagBitmask)}); err != nil {
@@ -960,8 +960,8 @@ func (f *RawWordsFile) Flush() error {
 }
 func (f *RawWordsFile) Close() {
 	if f.w != nil {
-		f.w.Flush()
-		f.f.Close()
+		f.w.Flush() //nolint:errcheck
+		f.f.Close() //nolint:errcheck
 		bufiopool.PutWriter(f.w)
 		f.w = nil
 		f.f = nil
@@ -969,7 +969,7 @@ func (f *RawWordsFile) Close() {
 }
 func (f *RawWordsFile) CloseAndRemove() {
 	f.Close()
-	dir2.RemoveFile(f.filePath)
+	dir2.RemoveFile(f.filePath) //nolint:errcheck
 }
 func (f *RawWordsFile) Append(v []byte) error {
 	f.count++

--- a/db/seg/parallel_compress.go
+++ b/db/seg/parallel_compress.go
@@ -396,8 +396,8 @@ func compressWithPatternCandidates(ctx context.Context, trace bool, cfg Cfg, log
 		return fmt.Errorf("create intermediate file: %w", err)
 	}
 	intermediatePath := intermediateFile.Name()
-	defer dir.RemoveFile(intermediatePath)
-	defer intermediateFile.Close()
+	defer dir.RemoveFile(intermediatePath) //nolint:errcheck
+	defer intermediateFile.Close()         //nolint:errcheck
 	intermediateW := bufiopool.Writer(intermediateFile)
 	defer bufiopool.PutWriter(intermediateW)
 
@@ -1179,7 +1179,7 @@ func PersistDictionary(fileName string, db *DictionaryBuilder) error {
 	}
 	w := bufiopool.Writer(df)
 	defer bufiopool.PutWriter(w)
-	db.ForEach(func(score uint64, word []byte) { fmt.Fprintf(w, "%d %x\n", score, word) })
+	db.ForEach(func(score uint64, word []byte) { fmt.Fprintf(w, "%d %x\n", score, word) }) //nolint:errcheck
 	if err := w.Flush(); err != nil {
 		return err
 	}
@@ -1196,7 +1196,7 @@ func ReadSimpleFile(fileName string, walker func(v []byte) error) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 	r := bufiopool.Reader(f)
 	defer bufiopool.PutReader(r)
 	buf := make([]byte, 4096)

--- a/db/seg/seg_auto_rw.go
+++ b/db/seg/seg_auto_rw.go
@@ -241,10 +241,13 @@ func Decompressor2bufio(d *Decompressor) (*bufio.Reader, func()) {
 				return
 			}
 		}
-		wr.Flush()
-		pw.Close()
+		if err := wr.Flush(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		pw.Close() //nolint:errcheck
 	}()
-	return bufio.NewReaderSize(pr, int(128*datasize.MB)), func() { pr.Close() }
+	return bufio.NewReaderSize(pr, int(128*datasize.MB)), func() { _ = pr.Close() }
 }
 
 // Bufio2compressor reads uvarint-length-prefixed words from src and writes them to a Writer.

--- a/db/seg/seg_paged_rw_test.go
+++ b/db/seg/seg_paged_rw_test.go
@@ -459,7 +459,7 @@ func BenchmarkName(b *testing.B) {
 	buf := &multyBytesWriter{pageSize: 16}
 	w := NewPagedWriter(b.Context(), buf, false, 1)
 	for i := range 16 {
-		w.Add([]byte{byte(i)}, []byte{10 + byte(i)})
+		w.Add([]byte{byte(i)}, []byte{10 + byte(i)}) //nolint:errcheck
 	}
 	bts := buf.Bytes()[0]
 

--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -101,7 +101,7 @@ func queueKeys(ctx context.Context, seed, ofSize uint64) <-chan []byte {
 				break
 			}
 			bb := make([]byte, ofSize)
-			rnd.Read(bb)
+			_, _ = rnd.Read(bb)
 
 			keys <- bb
 		}
@@ -120,7 +120,7 @@ func Benchmark_BtreeIndex_Search(b *testing.B) {
 	logger := log.New()
 	rnd := newRnd(uint64(time.Now().UnixNano()))
 	tmp := b.TempDir()
-	defer dir.RemoveAll(tmp)
+	defer dir.RemoveAll(tmp) //nolint:errcheck
 
 	indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bti")
 	comp := seg.CompressKeys | seg.CompressVals
@@ -156,7 +156,7 @@ func benchInitBtreeIndex(b *testing.B, params bTreeParameters, compression seg.F
 
 	logger := log.New()
 	tmp := b.TempDir()
-	b.Cleanup(func() { dir.RemoveAll(tmp) })
+	b.Cleanup(func() { _ = dir.RemoveAll(tmp) })
 
 	dataPath := generateKV(b, tmp, params.KeySize, params.ValueSize, params.KeyCount, logger, compression)
 	indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bt")
@@ -416,7 +416,7 @@ func Benchmark_Recsplit_Find_ExternalFile(b *testing.B) {
 	rnd := newRnd(uint64(time.Now().UnixNano()))
 	tmp := b.TempDir()
 
-	defer dir.RemoveAll(tmp)
+	defer dir.RemoveAll(tmp) //nolint:errcheck
 
 	indexPath := dataPath + "i"
 	idx, err := recsplit.OpenIndex(indexPath)

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -368,7 +368,7 @@ func TestReceiptFilesVersionAdjust(t *testing.T) {
 		fullpath := filepath.Join(dirs.SnapDomain, file)
 		ofile, err := os.Create(fullpath)
 		require.NoError(t, err)
-		ofile.Close()
+		require.NoError(t, ofile.Close())
 	}
 
 	t.Run("v1.0 files", func(t *testing.T) {

--- a/db/state/archive_test.go
+++ b/db/state/archive_test.go
@@ -147,11 +147,11 @@ func TestArchiveWriter(t *testing.T) {
 func TestPrunableProgress(t *testing.T) {
 	t.Parallel()
 	_, tx := memdb.NewTestTx(t)
-	SaveExecV3PrunableProgress(tx, []byte("test"), 100)
+	require.NoError(t, SaveExecV3PrunableProgress(tx, []byte("test"), 100))
 	s, err := GetExecV3PrunableProgress(tx, []byte("test"))
 	require.NoError(t, err)
 	require.EqualValues(t, 100, s)
-	SaveExecV3PrunableProgress(tx, []byte("test"), 120)
+	require.NoError(t, SaveExecV3PrunableProgress(tx, []byte("test"), 120))
 	s, err = GetExecV3PrunableProgress(tx, []byte("test"))
 	require.NoError(t, err)
 	require.EqualValues(t, 120, s)

--- a/db/state/commitment_convert.go
+++ b/db/state/commitment_convert.go
@@ -968,11 +968,11 @@ func writeRestoreManifestAtomic(path string, entries []string) error {
 		return err
 	}
 	if _, err := f.Write([]byte(strings.Join(entries, "\n"))); err != nil {
-		f.Close()
+		_ = f.Close()
 		return err
 	}
 	if err := f.Sync(); err != nil {
-		f.Close()
+		_ = f.Close()
 		return err
 	}
 	if err := f.Close(); err != nil {
@@ -998,7 +998,7 @@ func fsyncDir(path string) error {
 		return err
 	}
 	if err := d.Sync(); err != nil {
-		d.Close()
+		_ = d.Close()
 		return err
 	}
 	return d.Close()

--- a/db/state/commitment_convert_blackbox_test.go
+++ b/db/state/commitment_convert_blackbox_test.go
@@ -86,7 +86,7 @@ func readFileBytes(t *testing.T, path string) []byte {
 	t.Helper()
 	f, err := os.Open(path)
 	require.NoError(t, err)
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 	b, err := io.ReadAll(f)
 	require.NoError(t, err)
 	return b

--- a/db/state/dirty_files_test.go
+++ b/db/state/dirty_files_test.go
@@ -90,13 +90,13 @@ func TestFileItemWithMissedAccessor(t *testing.T) {
 
 	// create accesssor files for f1, f2
 	for _, fname := range accessorFor(f1.StepRange(aggStep)) {
-		os.WriteFile(fname, []byte("test"), 0644)
-		defer dir.RemoveFile(fname)
+		require.NoError(t, os.WriteFile(fname, []byte("test"), 0644))
+		defer dir.RemoveFile(fname) //nolint:errcheck
 	}
 
 	for _, fname := range accessorFor(f2.StepRange(aggStep)) {
-		os.WriteFile(fname, []byte("test"), 0644)
-		defer dir.RemoveFile(fname)
+		require.NoError(t, os.WriteFile(fname, []byte("test"), 0644))
+		defer dir.RemoveFile(fname) //nolint:errcheck
 	}
 
 	fileItems := fileItemsWithMissedAccessors(df.Items(), aggStep, accessorFor)

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -925,7 +925,7 @@ func TestDomainRoTx_CursorParentCheck(t *testing.T) {
 	defer writer.Close()
 
 	val := []byte("value1")
-	writer.addValue([]byte("key1"), val, kv.Step(1/d.stepSize))
+	require.NoError(writer.addValue([]byte("key1"), val, kv.Step(1/d.stepSize)))
 
 	err = writer.Flush(ctx, tx)
 	require.NoError(err)
@@ -1768,7 +1768,7 @@ func generateRandomKey(r *rndGen, size uint64) string {
 
 func generateRandomKeyBytes(r *rndGen, size uint64) []byte {
 	key := make([]byte, size)
-	r.Read(key)
+	_, _ = r.Read(key)
 	return key
 }
 
@@ -1782,7 +1782,7 @@ func generateUpdates(r *rndGen, totalTx, keyTxsLimit uint64) []upd {
 
 		if r.Rand.IntN(100) < 85 || i == keyTxsLimit-1 { // 15% rate for delete, last tx is never a deletion
 			up.value = make([]byte, 10)
-			r.Read(up.value)
+			_, _ = r.Read(up.value)
 		}
 
 		updates = append(updates, up)
@@ -1838,7 +1838,7 @@ func TestDomain_GetAfterAggregation(t *testing.T) {
 			if i > 0 {
 				pv = updates[i-1].value
 			}
-			writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, pv)
+			require.NoError(writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, pv))
 		}
 	}
 
@@ -2027,7 +2027,7 @@ func TestDomain_CanScanPruneAfterAggregation(t *testing.T) {
 	for key, updates := range data {
 		p := []byte{}
 		for i := range updates {
-			writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, p)
+			require.NoError(t, writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, p))
 			p = bytes.Clone(updates[i].value)
 		}
 	}
@@ -2128,7 +2128,7 @@ func TestDomain_PruneAfterAggregation(t *testing.T) {
 	for key, updates := range data {
 		p := []byte{}
 		for i := range updates {
-			writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, p)
+			require.NoError(t, writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, p))
 			p = bytes.Clone(updates[i].value)
 		}
 	}
@@ -2560,7 +2560,7 @@ func TestDomain_Unwind(t *testing.T) {
 		currTx = unwindTo
 		require.NoError(t, err)
 		domainRoTx.Close()
-		tx.Commit()
+		require.NoError(t, tx.Commit())
 
 		t.Log("=====write expected data===== \n\n")
 		tmpDb, expected := testDbAndDomain(t, log.New())
@@ -2914,7 +2914,7 @@ func TestDomainContext_findShortenedKey(t *testing.T) {
 	for key, updates := range data {
 		p := []byte{}
 		for i := range updates {
-			writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, p)
+			require.NoError(t, writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, p))
 			p = bytes.Clone(updates[i].value)
 		}
 	}

--- a/db/state/history_stream.go
+++ b/db/state/history_stream.go
@@ -860,8 +860,11 @@ func (ht *HistoryTraceKeyFiles) Next() (uint64, []byte, error) {
 	default:
 	}
 
-	defer ht.advance()
-	return ht.txNum, ht.v, nil
+	txNum, v := ht.txNum, ht.v
+	if err := ht.advance(); err != nil {
+		return 0, nil, err
+	}
+	return txNum, v, nil
 }
 
 type HistoryTraceKeyDB struct {

--- a/db/state/merge_test.go
+++ b/db/state/merge_test.go
@@ -1085,7 +1085,7 @@ func TestCommitmentValTransformDomainPanicsWithNeedMergeFalse(t *testing.T) {
 	defer dc.Close()
 
 	require.Panics(t, func() {
-		dc.commitmentValTransformDomain(MergeRange{needMerge: false}, dc, dc, nil, nil, false)
+		_, _ = dc.commitmentValTransformDomain(MergeRange{needMerge: false}, dc, dc, nil, nil, false)
 	})
 }
 
@@ -1379,7 +1379,7 @@ func TestHistoryAndIIAlignment(t *testing.T) {
 	agg := NewTest(dirs).Logger(logger).StepSize(1).MustOpen(t.Context(), db)
 	t.Cleanup(agg.Close)
 	setup := func() (account *Domain) {
-		agg.RegisterDomain(statecfg.Schema.GetDomainCfg(kv.AccountsDomain), nil, dirs, logger)
+		require.NoError(t, agg.RegisterDomain(statecfg.Schema.GetDomainCfg(kv.AccountsDomain), nil, dirs, logger))
 		domain := agg.d[kv.AccountsDomain]
 		domain.History.InvertedIndex.Accessors = 0
 		domain.History.Accessors = 0

--- a/db/state/snap_creation_fragility_test.go
+++ b/db/state/snap_creation_fragility_test.go
@@ -715,7 +715,7 @@ func TestOpenFolder_UnrelatedFilesIgnored(t *testing.T) {
 	for _, f := range garbageFiles {
 		// Create zero-byte placeholder
 		if fp, err := os.Create(f); err == nil {
-			fp.Close()
+			require.NoError(t, fp.Close())
 		}
 	}
 
@@ -782,7 +782,7 @@ func TestOpenFolder_CorruptedDataFile(t *testing.T) {
 	corruptPath, _ := repo.schema.DataFile(version.V1_0, RootNum(repo.stepSize), RootNum(2*repo.stepSize))
 	f, err := os.Create(corruptPath)
 	require.NoError(t, err)
-	f.Close()
+	require.NoError(t, f.Close())
 
 	// OpenFolder must not crash on corrupted file
 	err = repo.OpenFolder()

--- a/db/state/snap_repo_test.go
+++ b/db/state/snap_repo_test.go
@@ -288,7 +288,7 @@ func TestMergeRangeSnapRepo(t *testing.T) {
 	execTestCase := func(ranges []testFileRange, vfCount int, needMerge bool, mergeFromStep, mergeToStep uint64) {
 		testFn(ranges, vfCount, needMerge, mergeFromStep, mergeToStep)
 		// Clean up temporary files created by compressors/decompressors in dirs.Tmp
-		filepath.WalkDir(dirs.Tmp, func(path string, d os.DirEntry, err error) error {
+		require.NoError(t, filepath.WalkDir(dirs.Tmp, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				if os.IsNotExist(err) {
 					return nil
@@ -300,7 +300,7 @@ func TestMergeRangeSnapRepo(t *testing.T) {
 			}
 			_ = dir.RemoveFile(path)
 			return nil
-		})
+		}))
 	}
 
 	// 0-1, 1-2 => 0-2
@@ -549,7 +549,7 @@ func cleanupFiles(t *testing.T, repo *SnapshotRepo, dirs datadir.Dirs) {
 	repo.Close()
 	repo.RecalcVisibleFiles(0)
 
-	filepath.WalkDir(dirs.DataDir, func(path string, d os.DirEntry, err error) error {
+	require.NoError(t, filepath.WalkDir(dirs.DataDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) { //skip magically disappeared files
 				return nil
@@ -564,7 +564,7 @@ func cleanupFiles(t *testing.T, repo *SnapshotRepo, dirs datadir.Dirs) {
 			panic(err)
 		}
 		return nil
-	})
+	}))
 }
 
 func stepToRootNum(t *testing.T, step uint64, repo *SnapshotRepo) RootNum {
@@ -701,7 +701,7 @@ func populateFiles(t *testing.T, dirs datadir.Dirs, schema SnapNameSchema, allFi
 			seg3, err := seg.NewDecompressor(sampleFile)
 			require.NoError(t, err)
 			defer seg3.Close()
-			defer dir.RemoveFile(sampleFile)
+			defer dir.RemoveFile(sampleFile) //nolint:errcheck
 
 			r := seg.NewReader(seg3.MakeGetter(), seg.CompressNone)
 			kveiFile := strings.TrimSuffix(filename, ".bt") + ".kvei"

--- a/db/state/snap_schema_test.go
+++ b/db/state/snap_schema_test.go
@@ -86,11 +86,11 @@ func TestE2SnapSchema(t *testing.T) {
 	require.Equal(t, "v1.0-000005-000020-transactions-to-block.idx", fName)
 
 	require.Panics(t, func() {
-		p.BtIdxFile(version.V1_0, stepFrom, stepTo)
+		_, _ = p.BtIdxFile(version.V1_0, stepFrom, stepTo)
 	})
 
 	require.Panics(t, func() {
-		p.ExistenceFile(version.V1_0, stepFrom, stepTo)
+		_, _ = p.ExistenceFile(version.V1_0, stepFrom, stepTo)
 	})
 
 	require.True(t, p.AccessorIdxFileMetadata().Supported())
@@ -154,7 +154,7 @@ func TestE3SnapSchemaForDomain1(t *testing.T) {
 	require.Equal(t, "v1.0-accounts.288-296.bt", fName)
 
 	require.Panics(t, func() {
-		p.AccessorIdxFile(version.V1_0, stepFrom, stepTo, 0)
+		_, _ = p.AccessorIdxFile(version.V1_0, stepFrom, stepTo, 0)
 	})
 
 	exFull, _ := p.ExistenceFile(ver.Current, stepFrom, stepTo)
@@ -203,10 +203,10 @@ func TestE3SnapSchemaForCommitmentDomain(t *testing.T) {
 	require.Equal(t, "v1.0-commitments.288-296.kvi", fName)
 
 	require.Panics(t, func() {
-		p.BtIdxFile(version.V1_0, stepFrom, stepTo)
+		_, _ = p.BtIdxFile(version.V1_0, stepFrom, stepTo)
 	})
 	require.Panics(t, func() {
-		p.ExistenceFile(version.V1_0, stepFrom, stepTo)
+		_, _ = p.ExistenceFile(version.V1_0, stepFrom, stepTo)
 	})
 
 	require.True(t, p.indexFileMetadata.supported)
@@ -253,11 +253,11 @@ func TestE3SnapSchemaForHistory(t *testing.T) {
 	require.Equal(t, "v1.0-accounts.192-256.vi", fName)
 
 	require.Panics(t, func() {
-		p.BtIdxFile(version.V1_0, stepFrom, stepTo)
+		_, _ = p.BtIdxFile(version.V1_0, stepFrom, stepTo)
 	})
 
 	require.Panics(t, func() {
-		p.ExistenceFile(version.V1_0, stepFrom, stepTo)
+		_, _ = p.ExistenceFile(version.V1_0, stepFrom, stepTo)
 	})
 
 	require.True(t, p.indexFileMetadata.supported)
@@ -307,11 +307,11 @@ func TestE3SnapSchemaForII(t *testing.T) {
 	require.Equal(t, "v1.0-logaddrs.128-192.efi", fName)
 
 	require.Panics(t, func() {
-		p.BtIdxFile(version.V1_0, stepFrom, stepTo)
+		_, _ = p.BtIdxFile(version.V1_0, stepFrom, stepTo)
 	})
 
 	require.Panics(t, func() {
-		p.ExistenceFile(version.V1_0, stepFrom, stepTo)
+		_, _ = p.ExistenceFile(version.V1_0, stepFrom, stepTo)
 	})
 
 	require.True(t, p.indexFileMetadata.supported)

--- a/execution/vm/asm/compiler.go
+++ b/execution/vm/asm/compiler.go
@@ -181,8 +181,9 @@ func (c *Compiler) compileElement(element token) error {
 		rvalue := c.next()
 		switch rvalue.typ {
 		case number:
-			// TODO figure out how to return the error properly
-			c.compileNumber(rvalue)
+			if _, err := c.compileNumber(rvalue); err != nil {
+				return err
+			}
 		case stringValue:
 			// strings are quoted, remove them.
 			c.pushBin(rvalue.text[1 : len(rvalue.text)-2])

--- a/execution/vm/benchmark/bench_call_chain_test.go
+++ b/execution/vm/benchmark/bench_call_chain_test.go
@@ -32,7 +32,7 @@ func BenchmarkNestedStaticCalls(b *testing.B) {
 
 			// Deploy depth chain: addr[0] → addr[1] → ... → addr[depth-1]
 			addrs := makeAddrs(depth)
-			deployCallChain(statedb, addrs) // staticcall chain
+			deployCallChain(b, statedb, addrs) // staticcall chain
 
 			// Entry point loops: JUMPDEST, STATICCALL(addr[0]), POP, JUMP
 			entry, lbl := program.New().Jumpdest()
@@ -40,7 +40,7 @@ func BenchmarkNestedStaticCalls(b *testing.B) {
 				StaticCall(nil, addrs[0].raw, 0, 0, 0, 0).
 				Op(vm.POP).
 				Jump(lbl).Bytes()
-			deployContract(statedb, addrContract, entryCode)
+			deployContract(b, statedb, addrContract, entryCode)
 
 			callOOG(b, vmenv, addrContract)
 			for b.Loop() {
@@ -59,7 +59,7 @@ func BenchmarkDelegateCallProxy(b *testing.B) {
 			statedb := vmenv.IntraBlockState()
 
 			addrs := makeAddrs(layers)
-			deployDelegateChain(statedb, addrs)
+			deployDelegateChain(b, statedb, addrs)
 
 			// Entry: loop calling first proxy
 			entry, lbl := program.New().Jumpdest()
@@ -67,7 +67,7 @@ func BenchmarkDelegateCallProxy(b *testing.B) {
 				DelegateCall(nil, addrs[0].raw, 0, 0, 0, 0).
 				Op(vm.POP).
 				Jump(lbl).Bytes()
-			deployContract(statedb, addrContract, entryCode)
+			deployContract(b, statedb, addrContract, entryCode)
 
 			callOOG(b, vmenv, addrContract)
 			for b.Loop() {
@@ -87,11 +87,11 @@ func BenchmarkCallWithValue(b *testing.B) {
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
 
-		deployContract(statedb, addrPair, targetCode)
+		deployContract(b, statedb, addrPair, targetCode)
 		// Caller loops: CALL with value=0
 		p, lbl := program.New().Jumpdest()
 		code := p.Call(nil, rawPair, 0, 0, 0, 0, 0).Op(vm.POP).Jump(lbl).Bytes()
-		deployContract(statedb, addrContract, code)
+		deployContract(b, statedb, addrContract, code)
 
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
@@ -104,11 +104,11 @@ func BenchmarkCallWithValue(b *testing.B) {
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
 
-		deployContract(statedb, addrPair, targetCode)
+		deployContract(b, statedb, addrPair, targetCode)
 		// Caller loops: CALL with value=1 wei
 		p, lbl := program.New().Jumpdest()
 		code := p.Call(nil, rawPair, 1, 0, 0, 0, 0).Op(vm.POP).Jump(lbl).Bytes()
-		deployContractWithBalance(statedb, addrContract, code, uint256.NewInt(1_000_000_000))
+		deployContractWithBalance(b, statedb, addrContract, code, uint256.NewInt(1_000_000_000))
 
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
@@ -125,7 +125,7 @@ func BenchmarkDeFiSwapChain(b *testing.B) {
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
 
-		deployDeFiContracts(statedb)
+		deployDeFiContracts(b, statedb)
 
 		// Entry contract loops: CALL router
 		entry, lbl := program.New().Jumpdest()
@@ -133,7 +133,7 @@ func BenchmarkDeFiSwapChain(b *testing.B) {
 			Call(nil, rawRouter, 0, 0, 0, 0, 0).
 			Op(vm.POP).
 			Jump(lbl).Bytes()
-		deployContract(statedb, addrContract, entryCode)
+		deployContract(b, statedb, addrContract, entryCode)
 
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
@@ -164,31 +164,31 @@ func makeAddrs(n int) []chainAddr {
 
 // deployCallChain deploys a chain where each contract STATICCALLs the next.
 // The last contract just does PUSH+POP+STOP.
-func deployCallChain(statedb *state.IntraBlockState, addrs []chainAddr) {
+func deployCallChain(b testing.TB, statedb *state.IntraBlockState, addrs []chainAddr) {
 	for i, a := range addrs {
 		if i == len(addrs)-1 {
 			// Leaf: minimal work
 			code := program.New().Push(42).Op(vm.POP, vm.STOP).Bytes()
-			deployContract(statedb, a.interned, code)
+			deployContract(b, statedb, a.interned, code)
 		} else {
 			// Intermediate: STATICCALL next, POP result, STOP
 			p := program.New()
 			code := p.StaticCall(nil, addrs[i+1].raw, 0, 0, 0, 0).Op(vm.POP, vm.STOP).Bytes()
-			deployContract(statedb, a.interned, code)
+			deployContract(b, statedb, a.interned, code)
 		}
 	}
 }
 
 // deployDelegateChain deploys a chain where each contract DELEGATECALLs the next.
-func deployDelegateChain(statedb *state.IntraBlockState, addrs []chainAddr) {
+func deployDelegateChain(b testing.TB, statedb *state.IntraBlockState, addrs []chainAddr) {
 	for i, a := range addrs {
 		if i == len(addrs)-1 {
 			code := program.New().Push(42).Op(vm.POP, vm.STOP).Bytes()
-			deployContract(statedb, a.interned, code)
+			deployContract(b, statedb, a.interned, code)
 		} else {
 			p := program.New()
 			code := p.DelegateCall(nil, addrs[i+1].raw, 0, 0, 0, 0).Op(vm.POP, vm.STOP).Bytes()
-			deployContract(statedb, a.interned, code)
+			deployContract(b, statedb, a.interned, code)
 		}
 	}
 }
@@ -198,15 +198,15 @@ func deployDelegateChain(statedb *state.IntraBlockState, addrs []chainAddr) {
 //	Router: STATICCALL Pair (getReserves), CALL TokenA.transfer, CALL TokenB.transfer
 //	Pair: SLOAD reserve0, SLOAD reserve1, RETURN (simplified getReserves)
 //	TokenA/B: SLOAD balance(from), SLOAD balance(to), SSTORE×2, LOG3 (transfer)
-func deployDeFiContracts(statedb *state.IntraBlockState) {
+func deployDeFiContracts(b testing.TB, statedb *state.IntraBlockState) {
 	// Pair contract: load 2 reserves, return them
 	pairCode := program.New().
 		Push(0).Op(vm.SLOAD). // reserve0
 		Push(1).Op(vm.SLOAD). // reserve1
 		Op(vm.POP, vm.POP, vm.STOP).
 		Bytes()
-	deployContract(statedb, addrPair, pairCode)
-	setStorage(statedb, addrPair, map[uint256.Int]uint256.Int{
+	deployContract(b, statedb, addrPair, pairCode)
+	setStorage(b, statedb, addrPair, map[uint256.Int]uint256.Int{
 		*uint256.NewInt(0): *uint256.NewInt(1_000_000), // reserve0
 		*uint256.NewInt(1): *uint256.NewInt(2_000_000), // reserve1
 	})
@@ -226,8 +226,8 @@ func deployDeFiContracts(statedb *state.IntraBlockState) {
 		Op(vm.STOP).Bytes()
 
 	for _, addr := range []accounts.Address{addrTokenA, addrTokenB} {
-		deployContract(statedb, addr, tokenCode)
-		setStorage(statedb, addr, map[uint256.Int]uint256.Int{
+		deployContract(b, statedb, addr, tokenCode)
+		setStorage(b, statedb, addr, map[uint256.Int]uint256.Int{
 			*uint256.NewInt(0): *uint256.NewInt(1_000_000_000),
 			*uint256.NewInt(1): *uint256.NewInt(1_000_000_000),
 		})
@@ -239,5 +239,5 @@ func deployDeFiContracts(statedb *state.IntraBlockState) {
 		Call(nil, rawTokenA, 0, 0, 0, 0, 0).Op(vm.POP).
 		Call(nil, rawTokenB, 0, 0, 0, 0, 0).Op(vm.POP).
 		Op(vm.STOP).Bytes()
-	deployContract(statedb, addrRouter, routerCode)
+	deployContract(b, statedb, addrRouter, routerCode)
 }

--- a/execution/vm/benchmark/bench_interpreter_test.go
+++ b/execution/vm/benchmark/bench_interpreter_test.go
@@ -22,7 +22,7 @@ func BenchmarkPureArithmetic(b *testing.B) {
 			b.ReportAllocs()
 			vmenv := benchConfig(b, gas)
 			statedb := vmenv.IntraBlockState()
-			deployContract(statedb, addrContract, code)
+			deployContract(b, statedb, addrContract, code)
 			// Warmup
 			callOOG(b, vmenv, addrContract)
 			for b.Loop() {
@@ -38,7 +38,7 @@ func BenchmarkPureArithmetic(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, mulCode)
+		deployContract(b, statedb, addrContract, mulCode)
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
 			callOOG(b, vmenv, addrContract)
@@ -60,7 +60,7 @@ func BenchmarkStackOps(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, code)
+		deployContract(b, statedb, addrContract, code)
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
 			callOOG(b, vmenv, addrContract)
@@ -80,7 +80,7 @@ func BenchmarkMemoryOps(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, code)
+		deployContract(b, statedb, addrContract, code)
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
 			callOOG(b, vmenv, addrContract)
@@ -104,7 +104,7 @@ func BenchmarkMemoryOps(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, 10_000_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, growCode)
+		deployContract(b, statedb, addrContract, growCode)
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
 			callOOG(b, vmenv, addrContract)
@@ -123,7 +123,7 @@ func BenchmarkKeccak256(b *testing.B) {
 			b.ReportAllocs()
 			vmenv := benchConfig(b, 100_000_000)
 			statedb := vmenv.IntraBlockState()
-			deployContract(statedb, addrContract, code)
+			deployContract(b, statedb, addrContract, code)
 			callOOG(b, vmenv, addrContract)
 			for b.Loop() {
 				callOOG(b, vmenv, addrContract)
@@ -153,7 +153,7 @@ func BenchmarkMixedCompute(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, code)
+		deployContract(b, statedb, addrContract, code)
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
 			callOOG(b, vmenv, addrContract)

--- a/execution/vm/benchmark/bench_snailtracer_test.go
+++ b/execution/vm/benchmark/bench_snailtracer_test.go
@@ -25,7 +25,7 @@ func BenchmarkSnailtracer(b *testing.B) {
 
 	vmenv := benchConfig(b, 1_000_000_000)
 	statedb := vmenv.IntraBlockState()
-	deployContract(statedb, addrContract, code)
+	deployContract(b, statedb, addrContract, code)
 
 	// callComplete checks the call did work; only this benchmark also has a
 	// rendered frame to check.
@@ -48,7 +48,7 @@ func TestSnailtracerPathsAgree(t *testing.T) {
 
 	render := func(noMaterialize bool) []byte {
 		vmenv := newBenchEnv(t, 1_000_000_000, noMaterialize)
-		deployContract(vmenv.IntraBlockState(), addrContract, code)
+		deployContract(t, vmenv.IntraBlockState(), addrContract, code)
 		ret, _, err := prepareAndCall(vmenv, addrContract, input)
 		require.NoError(t, err)
 		require.NotEmpty(t, ret)

--- a/execution/vm/benchmark/bench_storage_test.go
+++ b/execution/vm/benchmark/bench_storage_test.go
@@ -31,8 +31,8 @@ func BenchmarkSLOADCold(b *testing.B) {
 			// Gas: 2100 per cold SLOAD + overhead
 			vmenv := benchConfig(b, uint64(n)*2200+100_000)
 			statedb := vmenv.IntraBlockState()
-			deployContract(statedb, addrContract, code)
-			setStorage(statedb, addrContract, slots)
+			deployContract(b, statedb, addrContract, code)
+			setStorage(b, statedb, addrContract, slots)
 			callComplete(b, vmenv, addrContract, nil)
 			for b.Loop() {
 				callComplete(b, vmenv, addrContract, nil)
@@ -59,8 +59,8 @@ func BenchmarkSLOADWarm(b *testing.B) {
 			b.ReportAllocs()
 			vmenv := benchConfig(b, 100_000_000)
 			statedb := vmenv.IntraBlockState()
-			deployContract(statedb, addrContract, code)
-			setStorage(statedb, addrContract, slots)
+			deployContract(b, statedb, addrContract, code)
+			setStorage(b, statedb, addrContract, slots)
 			callOOG(b, vmenv, addrContract)
 			for b.Loop() {
 				callOOG(b, vmenv, addrContract)
@@ -86,7 +86,7 @@ func BenchmarkSSTORE(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, uint64(n)*22_100+100_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, code)
+		deployContract(b, statedb, addrContract, code)
 		callComplete(b, vmenv, addrContract, nil)
 		for b.Loop() {
 			callComplete(b, vmenv, addrContract, nil)
@@ -108,8 +108,8 @@ func BenchmarkSSTORE(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, uint64(n)*5200+100_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, code)
-		setStorage(statedb, addrContract, slots)
+		deployContract(b, statedb, addrContract, code)
+		setStorage(b, statedb, addrContract, slots)
 		callComplete(b, vmenv, addrContract, nil)
 		for b.Loop() {
 			callComplete(b, vmenv, addrContract, nil)
@@ -131,8 +131,8 @@ func BenchmarkSSTORE(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, uint64(n)*5200+100_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, code)
-		setStorage(statedb, addrContract, slots)
+		deployContract(b, statedb, addrContract, code)
+		setStorage(b, statedb, addrContract, slots)
 		callComplete(b, vmenv, addrContract, nil)
 		for b.Loop() {
 			callComplete(b, vmenv, addrContract, nil)
@@ -157,7 +157,7 @@ func BenchmarkTransientStorage(b *testing.B) {
 			b.ReportAllocs()
 			vmenv := benchConfig(b, 100_000_000)
 			statedb := vmenv.IntraBlockState()
-			deployContract(statedb, addrContract, code)
+			deployContract(b, statedb, addrContract, code)
 			callOOG(b, vmenv, addrContract)
 			for b.Loop() {
 				callOOG(b, vmenv, addrContract)
@@ -184,8 +184,8 @@ func BenchmarkStorageDiversity(b *testing.B) {
 			b.ReportAllocs()
 			vmenv := benchConfig(b, uint64(n)*2200+100_000)
 			statedb := vmenv.IntraBlockState()
-			deployContract(statedb, addrContract, code)
-			setStorage(statedb, addrContract, slots)
+			deployContract(b, statedb, addrContract, code)
+			setStorage(b, statedb, addrContract, slots)
 			callComplete(b, vmenv, addrContract, nil)
 			for b.Loop() {
 				callComplete(b, vmenv, addrContract, nil)

--- a/execution/vm/benchmark/bench_token_transfer_test.go
+++ b/execution/vm/benchmark/bench_token_transfer_test.go
@@ -62,8 +62,8 @@ func BenchmarkERC20Transfer(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, code)
-		setStorage(statedb, addrContract, slots)
+		deployContract(b, statedb, addrContract, code)
+		setStorage(b, statedb, addrContract, slots)
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
 			callOOG(b, vmenv, addrContract)
@@ -105,8 +105,8 @@ func BenchmarkERC20TransferFrom(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, code)
-		setStorage(statedb, addrContract, slots)
+		deployContract(b, statedb, addrContract, code)
+		setStorage(b, statedb, addrContract, slots)
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
 			callOOG(b, vmenv, addrContract)
@@ -130,8 +130,8 @@ func BenchmarkERC20BalanceOf(b *testing.B) {
 		b.ReportAllocs()
 		vmenv := benchConfig(b, 100_000_000)
 		statedb := vmenv.IntraBlockState()
-		deployContract(statedb, addrContract, code)
-		setStorage(statedb, addrContract, slots)
+		deployContract(b, statedb, addrContract, code)
+		setStorage(b, statedb, addrContract, slots)
 		callOOG(b, vmenv, addrContract)
 		for b.Loop() {
 			callOOG(b, vmenv, addrContract)
@@ -168,8 +168,8 @@ func BenchmarkERC20BatchTransfers(b *testing.B) {
 			gas := uint64(n)*30_000 + 100_000
 			vmenv := benchConfig(b, gas)
 			statedb := vmenv.IntraBlockState()
-			deployContract(statedb, addrContract, code)
-			setStorage(statedb, addrContract, slots)
+			deployContract(b, statedb, addrContract, code)
+			setStorage(b, statedb, addrContract, slots)
 			callComplete(b, vmenv, addrContract, nil)
 			for b.Loop() {
 				callComplete(b, vmenv, addrContract, nil)

--- a/execution/vm/benchmark/helpers.go
+++ b/execution/vm/benchmark/helpers.go
@@ -93,23 +93,25 @@ func newBenchEnv(t testing.TB, gasLimit uint64, noMaterialize bool) *vm.EVM {
 }
 
 // deployContract deploys code at the given address in the state.
-func deployContract(statedb *state.IntraBlockState, addr accounts.Address, code []byte) {
-	statedb.CreateAccount(addr, true)
-	statedb.SetCode(addr, code, tracing.CodeChangeUnspecified)
+func deployContract(tb testing.TB, statedb *state.IntraBlockState, addr accounts.Address, code []byte) {
+	tb.Helper()
+	require.NoError(tb, statedb.CreateAccount(addr, true))
+	require.NoError(tb, statedb.SetCode(addr, code, tracing.CodeChangeUnspecified))
 }
 
 // deployContractWithBalance deploys code and sets an ETH balance.
-func deployContractWithBalance(statedb *state.IntraBlockState, addr accounts.Address, code []byte, balance *uint256.Int) {
-	statedb.CreateAccount(addr, true)
-	statedb.SetCode(addr, code, tracing.CodeChangeUnspecified)
-	statedb.SetBalance(addr, *balance, 0)
+func deployContractWithBalance(tb testing.TB, statedb *state.IntraBlockState, addr accounts.Address, code []byte, balance *uint256.Int) {
+	tb.Helper()
+	deployContract(tb, statedb, addr, code)
+	require.NoError(tb, statedb.SetBalance(addr, *balance, 0))
 }
 
 // setStorage pre-populates storage slots for a contract address.
-func setStorage(statedb *state.IntraBlockState, addr accounts.Address, slots map[uint256.Int]uint256.Int) {
+func setStorage(tb testing.TB, statedb *state.IntraBlockState, addr accounts.Address, slots map[uint256.Int]uint256.Int) {
+	tb.Helper()
 	for k, v := range slots {
 		key := accounts.InternKey(k.Bytes32())
-		statedb.SetState(addr, key, v)
+		require.NoError(tb, statedb.SetState(addr, key, v))
 	}
 }
 

--- a/execution/vm/contracts_fuzz_test.go
+++ b/execution/vm/contracts_fuzz_test.go
@@ -36,7 +36,9 @@ func FuzzPrecompiledContracts(f *testing.F) {
 			return
 		}
 		inWant := string(input)
-		RunPrecompiledContract(p, input, gas, nil)
+		// Fuzzed input is expected to fail; the assertion below is about
+		// the precompile not mutating the caller's buffer.
+		_, _, _ = RunPrecompiledContract(p, input, gas, nil)
 		if inHave := string(input); inWant != inHave {
 			t.Errorf("Precompiled %v modified input data", a)
 		}

--- a/execution/vm/evm.go
+++ b/execution/vm/evm.go
@@ -332,7 +332,9 @@ func (evm *EVM) call(typ OpCode, caller accounts.Address, callerAddress accounts
 			if !isPrecompile && evm.chainRules.IsEIP161Enabled() && value.IsZero() {
 				return nil, gasRemaining, mdgas.MdGasUsage{}, nil
 			}
-			evm.intraBlockState.CreateAccount(addr, false)
+			if err := evm.intraBlockState.CreateAccount(addr, false); err != nil {
+				return nil, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+			}
 		}
 		// System calls use TouchAccount instead of Transfer to avoid
 		// spurious balance reads on the caller that would pollute the
@@ -505,8 +507,8 @@ func (evm *EVM) prepareCreate(caller accounts.Address, address accounts.Address,
 		}
 		if nested {
 			preparation.incrementCallerNonce = true
-		} else {
-			evm.intraBlockState.SetNonce(caller, preparation.callerNonce+1, tracing.NonceChangeContractCreator)
+		} else if err := evm.intraBlockState.SetNonce(caller, preparation.callerNonce+1, tracing.NonceChangeContractCreator); err != nil {
+			return preparation, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
 		}
 	}
 	if evm.chainRules.IsBerlin {
@@ -591,7 +593,11 @@ func (evm *EVM) createWithPreparation(caller accounts.Address, codeAndHash *code
 		preparation = &prepared
 	}
 	if preparation.incrementCallerNonce {
-		evm.intraBlockState.SetNonce(caller, preparation.callerNonce+1, tracing.NonceChangeContractCreator)
+		if err = evm.intraBlockState.SetNonce(caller, preparation.callerNonce+1, tracing.NonceChangeContractCreator); err != nil {
+			gasRemaining = mdgas.MdGas{}
+			err = fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+			return
+		}
 	}
 	var collision bool
 	collision, err = evm.hasCreateCollision(address)
@@ -611,9 +617,13 @@ func (evm *EVM) createWithPreparation(caller accounts.Address, codeAndHash *code
 	snapshot := evm.intraBlockState.PushSnapshot()
 	defer evm.intraBlockState.PopSnapshot(snapshot)
 
-	evm.intraBlockState.CreateAccount(address, true)
+	if err := evm.intraBlockState.CreateAccount(address, true); err != nil {
+		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+	}
 	if evm.chainRules.IsEIP161Enabled() {
-		evm.intraBlockState.SetNonce(address, 1, tracing.NonceChangeNewContract)
+		if err := evm.intraBlockState.SetNonce(address, 1, tracing.NonceChangeNewContract); err != nil {
+			return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+		}
 	}
 	if err := evm.Context.Transfer(evm.intraBlockState, caller, address, value, bailout, evm.chainRules); err != nil {
 		return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
@@ -675,7 +685,9 @@ func (evm *EVM) createWithPreparation(caller accounts.Address, codeAndHash *code
 		}
 
 		if stateGasOk && executionGasOk {
-			evm.intraBlockState.SetCode(address, ret, tracing.CodeChangeContractCreation)
+			if err := evm.intraBlockState.SetCode(address, ret, tracing.CodeChangeContractCreation); err != nil {
+				return nil, accounts.NilAddress, mdgas.MdGas{}, mdgas.MdGasUsage{}, fmt.Errorf("%w: %w", ErrIntraBlockStateFailed, err)
+			}
 			// EIP-8037: post-Run code-deposit state charge counts toward this
 			// frame's state-gas usage; its spilled portion propagates so an
 			// ancestor revert refills it from the right pool.

--- a/execution/vm/gas_table.go
+++ b/execution/vm/gas_table.go
@@ -179,7 +179,9 @@ func gasSStore(evm *EVM, callContext *CallContext, availableGas mdgas.MdGas, mem
 	}
 	if !original.IsZero() {
 		if current.IsZero() { // recreate slot (2.2.1.1)
-			evm.IntraBlockState().SubRefund(params.NetSstoreClearRefund)
+			if err := evm.IntraBlockState().SubRefund(params.NetSstoreClearRefund); err != nil {
+				return mdgas.MdGas{}, err
+			}
 		} else if value.IsZero() { // delete slot (2.2.1.2)
 			evm.IntraBlockState().AddRefund(params.NetSstoreClearRefund)
 		}
@@ -237,7 +239,9 @@ func gasSStoreEIP2200(evm *EVM, callContext *CallContext, availableGas mdgas.MdG
 	}
 	if !original.IsZero() {
 		if current.IsZero() { // recreate slot (2.2.1.1)
-			evm.IntraBlockState().SubRefund(params.SstoreClearsScheduleRefundEIP2200)
+			if err := evm.IntraBlockState().SubRefund(params.SstoreClearsScheduleRefundEIP2200); err != nil {
+				return mdgas.MdGas{}, err
+			}
 		} else if value.IsZero() { // delete slot (2.2.1.2)
 			evm.IntraBlockState().AddRefund(params.SstoreClearsScheduleRefundEIP2200)
 		}

--- a/execution/vm/gas_table_test.go
+++ b/execution/vm/gas_table_test.go
@@ -132,9 +132,9 @@ func TestEIP2200(t *testing.T) {
 			defer s.Close()
 
 			address := accounts.InternAddress(common.BytesToAddress([]byte("contract")))
-			s.CreateAccount(address, true)
-			s.SetCode(address, hexutil.MustDecode(tt.input), tracing.CodeChangeUnspecified)
-			s.SetState(address, accounts.ZeroKey, *uint256.NewInt(uint64(tt.original)))
+			require.NoError(t, s.CreateAccount(address, true))
+			require.NoError(t, s.SetCode(address, hexutil.MustDecode(tt.input), tracing.CodeChangeUnspecified))
+			require.NoError(t, s.SetState(address, accounts.ZeroKey, *uint256.NewInt(uint64(tt.original))))
 
 			vmctx := evmtypes.BlockContext{
 				CanTransfer: func(evmtypes.IntraBlockState, accounts.Address, uint256.Int) (bool, error) { return true, nil },
@@ -233,9 +233,9 @@ func TestEIP8038SStore(t *testing.T) {
 			s := state.New(r)
 			defer s.Close()
 			address := accounts.InternAddress(common.BytesToAddress([]byte("contract")))
-			s.CreateAccount(address, true)
-			s.SetCode(address, hexutil.MustDecode(tt.input), tracing.CodeChangeUnspecified)
-			s.SetState(address, accounts.ZeroKey, *uint256.NewInt(uint64(tt.original)))
+			require.NoError(t, s.CreateAccount(address, true))
+			require.NoError(t, s.SetCode(address, hexutil.MustDecode(tt.input), tracing.CodeChangeUnspecified))
+			require.NoError(t, s.SetState(address, accounts.ZeroKey, *uint256.NewInt(uint64(tt.original))))
 			vmctx := evmtypes.BlockContext{
 				CanTransfer: func(evmtypes.IntraBlockState, accounts.Address, uint256.Int) (bool, error) { return true, nil },
 				Transfer: func(evmtypes.IntraBlockState, accounts.Address, accounts.Address, uint256.Int, bool, *chain.Rules) error {
@@ -276,7 +276,7 @@ func TestEIP7928SStoreReadRequiresAffordableAccess(t *testing.T) {
 			statedb.SetTxContext(1, 0)
 			contract := accounts.InternAddress(common.HexToAddress("0x1000"))
 			slot := accounts.InternKey(common.HexToHash("0x01"))
-			statedb.CreateAccount(contract, true)
+			require.NoError(t, statedb.CreateAccount(contract, true))
 			require.NoError(t, statedb.SetCode(contract, hexutil.MustDecode("0x6001600155"), tracing.CodeChangeUnspecified))
 			statedb.ResetVersionedReads()
 			blockCtx := evmtypes.BlockContext{
@@ -388,8 +388,8 @@ func TestCallNewAccountSpillBefore63of64(t *testing.T) {
 			s := state.New(r)
 			defer s.Close()
 			caller := accounts.InternAddress(common.BytesToAddress([]byte("contract")))
-			s.CreateAccount(caller, true)
-			s.SetCode(caller, hexutil.MustDecode(callerCode), tracing.CodeChangeUnspecified)
+			require.NoError(t, s.CreateAccount(caller, true))
+			require.NoError(t, s.SetCode(caller, hexutil.MustDecode(callerCode), tracing.CodeChangeUnspecified))
 			vmctx := evmtypes.BlockContext{
 				CanTransfer: func(evmtypes.IntraBlockState, accounts.Address, uint256.Int) (bool, error) { return true, nil },
 				Transfer: func(evmtypes.IntraBlockState, accounts.Address, accounts.Address, uint256.Int, bool, *chain.Rules) error {
@@ -425,10 +425,10 @@ func TestCreate2OntoExistingAccountSkipsNewAccountCharge(t *testing.T) {
 	factory := accounts.InternAddress(factoryAddress)
 	target := accounts.InternAddress(types.CreateAddress2(factoryAddress, salt.Bytes32(), accounts.InternCodeHash(crypto.Keccak256Hash(initCode))))
 	factoryCode := program.New().Create2(initCode, salt).Push(0).Op(vm.MSTORE).Return(0, 32).Bytes()
-	s.CreateAccount(factory, true)
-	s.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified)
-	s.CreateAccount(target, false)
-	s.AddBalance(target, *uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+	require.NoError(t, s.CreateAccount(factory, true))
+	require.NoError(t, s.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified))
+	require.NoError(t, s.CreateAccount(target, false))
+	require.NoError(t, s.AddBalance(target, *uint256.NewInt(1), tracing.BalanceChangeUnspecified))
 	vmctx := evmtypes.BlockContext{
 		CanTransfer: func(evmtypes.IntraBlockState, accounts.Address, uint256.Int) (bool, error) { return true, nil },
 		Transfer: func(evmtypes.IntraBlockState, accounts.Address, accounts.Address, uint256.Int, bool, *chain.Rules) error {
@@ -491,8 +491,8 @@ func TestCreate2OntoStorageOnlyAccountChargesBeforeCollision(t *testing.T) {
 				factory := accounts.InternAddress(factoryAddress)
 				target := accounts.InternAddress(types.CreateAddress2(factoryAddress, salt.Bytes32(), accounts.InternCodeHash(crypto.Keccak256Hash(initCode))))
 				factoryCode := program.New().Create2(initCode, salt).Push(0).Op(vm.MSTORE).Return(0, 32).Bytes()
-				s.CreateAccount(factory, true)
-				s.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified)
+				require.NoError(t, s.CreateAccount(factory, true))
+				require.NoError(t, s.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified))
 				vmctx := evmtypes.BlockContext{
 					CanTransfer: func(evmtypes.IntraBlockState, accounts.Address, uint256.Int) (bool, error) { return true, nil },
 					Transfer: func(evmtypes.IntraBlockState, accounts.Address, accounts.Address, uint256.Int, bool, *chain.Rules) error {
@@ -500,7 +500,7 @@ func TestCreate2OntoStorageOnlyAccountChargesBeforeCollision(t *testing.T) {
 					},
 				}
 				_ = s.CommitBlock(vmctx.Rules(chain.AllProtocolChanges), w)
-				s.CreateAccount(target, true)
+				require.NoError(t, s.CreateAccount(target, true))
 				require.NoError(t, s.SetState(target, accounts.ZeroKey, *uint256.NewInt(1)))
 				empty, err := s.Empty(target)
 				require.NoError(t, err)
@@ -560,8 +560,8 @@ func TestCreateTraceOnEarlyFailure(t *testing.T) {
 				salt := uint256.NewInt(0)
 				factory := accounts.InternAddress(common.HexToAddress("0xfac0"))
 				factoryCode := program.New().Mstore(initCode, 0).Push(salt).Push(len(initCode)).Push(0).Push(1).Op(vm.CREATE2).Bytes()
-				s.CreateAccount(factory, true)
-				s.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified)
+				require.NoError(t, s.CreateAccount(factory, true))
+				require.NoError(t, s.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified))
 				vmctx := evmtypes.BlockContext{
 					CanTransfer: func(_ evmtypes.IntraBlockState, _ accounts.Address, value uint256.Int) (bool, error) {
 						return value.IsZero(), nil
@@ -618,8 +618,8 @@ func TestCreatePropagatesAmsterdamPreparationError(t *testing.T) {
 	factory := accounts.InternAddress(common.HexToAddress("0xfac0"))
 	initCode := []byte{byte(vm.STOP)}
 	factoryCode := program.New().Create2(initCode, uint256.NewInt(0)).Bytes()
-	statedb.CreateAccount(factory, true)
-	statedb.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified)
+	require.NoError(t, statedb.CreateAccount(factory, true))
+	require.NoError(t, statedb.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified))
 	vmctx := evmtypes.BlockContext{
 		CanTransfer: func(evmtypes.IntraBlockState, accounts.Address, uint256.Int) (bool, error) {
 			return false, backendErr
@@ -658,8 +658,8 @@ func TestNestedCreateCollisionSeesOnEnterState(t *testing.T) {
 				factory := accounts.InternAddress(factoryAddress)
 				target := accounts.InternAddress(types.CreateAddress2(factoryAddress, salt.Bytes32(), accounts.InternCodeHash(crypto.Keccak256Hash(initCode))))
 				factoryCode := program.New().Create2(initCode, salt).Push(0).Op(vm.MSTORE).Return(0, 32).Bytes()
-				s.CreateAccount(factory, true)
-				s.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified)
+				require.NoError(t, s.CreateAccount(factory, true))
+				require.NoError(t, s.SetCode(factory, factoryCode, tracing.CodeChangeUnspecified))
 				vmctx := evmtypes.BlockContext{
 					CanTransfer: func(evmtypes.IntraBlockState, accounts.Address, uint256.Int) (bool, error) { return true, nil },
 					Transfer: func(evmtypes.IntraBlockState, accounts.Address, accounts.Address, uint256.Int, bool, *chain.Rules) error {
@@ -740,8 +740,8 @@ func TestCreateGas(t *testing.T) {
 
 		s := state.New(stateReader)
 		defer s.Close()
-		s.CreateAccount(address, true)
-		s.SetCode(address, hexutil.MustDecode(tt.code), tracing.CodeChangeUnspecified)
+		require.NoError(t, s.CreateAccount(address, true))
+		require.NoError(t, s.SetCode(address, hexutil.MustDecode(tt.code), tracing.CodeChangeUnspecified))
 
 		vmctx := evmtypes.BlockContext{
 			CanTransfer: func(evmtypes.IntraBlockState, accounts.Address, uint256.Int) (bool, error) { return true, nil },

--- a/execution/vm/operations_acl.go
+++ b/execution/vm/operations_acl.go
@@ -92,7 +92,9 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		}
 		if !original.IsZero() {
 			if current.IsZero() { // recreate slot (2.2.1.1)
-				evm.IntraBlockState().SubRefund(clearRefund)
+				if err := evm.IntraBlockState().SubRefund(clearRefund); err != nil {
+					return mdgas.MdGas{}, err
+				}
 			} else if value.IsZero() { // delete slot (2.2.1.2)
 				evm.IntraBlockState().AddRefund(clearRefund)
 			}

--- a/execution/vm/runtime/runtime.go
+++ b/execution/vm/runtime/runtime.go
@@ -145,9 +145,13 @@ func Execute(code, input []byte, cfg *Config, tempdir string) ([]byte, *state.In
 		rules   = vmenv.ChainRules()
 	)
 	cfg.State.Prepare(rules, cfg.Origin, cfg.Coinbase, address, vm.ActivePrecompiles(rules), nil)
-	cfg.State.CreateAccount(address, true)
+	if err := cfg.State.CreateAccount(address, true); err != nil {
+		return nil, nil, err
+	}
 	// set the receiver's (the executing contract) code for execution.
-	cfg.State.SetCode(address, code, tracing.CodeChangeUnspecified)
+	if err := cfg.State.SetCode(address, code, tracing.CodeChangeUnspecified); err != nil {
+		return nil, nil, err
+	}
 	// Call the code with the given configuration.
 	if cfg.EVMConfig.Tracer != nil && cfg.EVMConfig.Tracer.OnTxStart != nil {
 		cfg.EVMConfig.Tracer.OnTxStart(&tracing.VMContext{IntraBlockState: cfg.State}, nil, accounts.ZeroAddress)
@@ -180,7 +184,7 @@ func Create(input []byte, cfg *Config, blockNr uint64) ([]byte, common.Address, 
 		if err != nil {
 			return nil, [20]byte{}, mdgas.MdGas{}, err
 		}
-		defer dir.RemoveAll(tmp)
+		defer dir.RemoveAll(tmp) //nolint:errcheck
 
 		dirs := datadir.New(tmp)
 		db := temporaltest.NewTestDB(nil, dirs)
@@ -238,7 +242,9 @@ func Create(input []byte, cfg *Config, blockNr uint64) ([]byte, common.Address, 
 		code, createdAddress, leftOverGas, _, err = vmenv.Create(sender, input, leftOverGas, cfg.Value, nil, false)
 		protocol.RefillTopLevelGas(&leftOverGas, &topLevelGasUsed, cfg.EVMConfig.RestoreState, err)
 	} else if errors.Is(err, vm.ErrRuntimeOutOfGas) {
-		cfg.State.SetNonce(sender, nonce+1, tracing.NonceChangeContractCreator)
+		if nonceErr := cfg.State.SetNonce(sender, nonce+1, tracing.NonceChangeContractCreator); nonceErr != nil {
+			return nil, common.Address{}, mdgas.MdGas{}, nonceErr
+		}
 		leftOverGas = mdgas.MdGas{State: gas.State}
 		protocol.TraceTopLevelFailure(vmenv, vm.CREATE, sender, address, input, gas, leftOverGas, cfg.Value, err)
 	}

--- a/execution/vm/runtime/runtime_fuzz_test.go
+++ b/execution/vm/runtime/runtime_fuzz_test.go
@@ -25,7 +25,8 @@ import (
 
 func FuzzVmRuntime(f *testing.F) {
 	f.Fuzz(func(t *testing.T, code, input []byte) {
-		Execute(code, input, &Config{
+		// Fuzzed bytecode is expected to fail; this target looks for panics.
+		_, _, _ = Execute(code, input, &Config{
 			GasLimit: 12000000,
 		}, t.TempDir())
 	})

--- a/execution/vm/runtime/runtime_test.go
+++ b/execution/vm/runtime/runtime_test.go
@@ -118,14 +118,14 @@ func TestCall(t *testing.T) {
 	state := state.New(state.NewReaderV3(domains.AsGetter(tx)))
 	defer state.Close()
 	address := accounts.InternAddress(common.HexToAddress("0xaa"))
-	state.SetCode(address, []byte{
+	require.NoError(t, state.SetCode(address, []byte{
 		byte(vm.PUSH1), 10,
 		byte(vm.PUSH1), 0,
 		byte(vm.MSTORE),
 		byte(vm.PUSH1), 32,
 		byte(vm.PUSH1), 0,
 		byte(vm.RETURN),
-	}, tracing.CodeChangeUnspecified)
+	}, tracing.CodeChangeUnspecified))
 
 	ret, _, err := Call(address, nil, &Config{State: state})
 	if err != nil {
@@ -394,8 +394,8 @@ func benchmarkEVM_Create(b *testing.B, code string) {
 	)
 	defer statedb.Close()
 
-	statedb.CreateAccount(sender, true)
-	statedb.SetCode(receiver, common.FromHex(code), tracing.CodeChangeUnspecified)
+	require.NoError(b, statedb.CreateAccount(sender, true))
+	require.NoError(b, statedb.SetCode(receiver, common.FromHex(code), tracing.CodeChangeUnspecified))
 	runtimeConfig := Config{
 		Origin:      sender,
 		State:       statedb,
@@ -469,7 +469,7 @@ func BenchmarkEVM_RETURN(b *testing.B) {
 			b.ReportAllocs()
 
 			contractCode := returnContract(n)
-			statedb.SetCode(contractAddr, contractCode, tracing.CodeChangeUnspecified)
+			require.NoError(b, statedb.SetCode(contractAddr, contractCode, tracing.CodeChangeUnspecified))
 
 			cfg := Config{State: statedb}
 			setDefaults(&cfg)
@@ -671,25 +671,25 @@ func benchmarkNonModifyingCode(gas mdgas.MdGas, code []byte, name string, tracer
 		vmenv       = NewEnv(cfg)
 		sender      = cfg.Origin
 	)
-	cfg.State.CreateAccount(destination, true)
+	require.NoError(b, cfg.State.CreateAccount(destination, true))
 	eoa := accounts.InternAddress(common.HexToAddress("E0"))
 	{
-		cfg.State.CreateAccount(eoa, true)
-		cfg.State.SetNonce(eoa, 100, tracing.NonceChangeUnspecified)
+		require.NoError(b, cfg.State.CreateAccount(eoa, true))
+		require.NoError(b, cfg.State.SetNonce(eoa, 100, tracing.NonceChangeUnspecified))
 	}
 	reverting := accounts.InternAddress(common.HexToAddress("EE"))
 	{
-		cfg.State.CreateAccount(reverting, true)
-		cfg.State.SetCode(reverting, []byte{
+		require.NoError(b, cfg.State.CreateAccount(reverting, true))
+		require.NoError(b, cfg.State.SetCode(reverting, []byte{
 			byte(vm.PUSH1), 0x00,
 			byte(vm.PUSH1), 0x00,
 			byte(vm.REVERT),
-		}, tracing.CodeChangeUnspecified)
+		}, tracing.CodeChangeUnspecified))
 	}
 
 	//cfg.State.CreateAccount(cfg.Origin)
 	// set the receiver's (the executing contract) code for execution.
-	cfg.State.SetCode(destination, code, tracing.CodeChangeUnspecified)
+	require.NoError(b, cfg.State.SetCode(destination, code, tracing.CodeChangeUnspecified))
 	_, warmLeft, _, warmErr := vmenv.Call(sender, destination, nil, gas, cfg.Value, false /* bailout */)
 	mustOOG(b, warmLeft, warmErr)
 
@@ -920,7 +920,7 @@ func BenchmarkEVM_SWAP1(b *testing.B) {
 
 	b.Run("10k", func(b *testing.B) {
 		contractCode := swapContract(10_000)
-		state.SetCode(contractAddr, contractCode, tracing.CodeChangeUnspecified)
+		require.NoError(b, state.SetCode(contractAddr, contractCode, tracing.CodeChangeUnspecified))
 
 		cfg := Config{State: state}
 		setDefaults(&cfg)
@@ -949,8 +949,8 @@ func TestCreate2CollisionWithEIP7702Delegation(t *testing.T) {
 	defer statedb.Close()
 
 	sender := accounts.InternAddress(common.HexToAddress("0x1234"))
-	statedb.CreateAccount(sender, true)
-	statedb.AddBalance(sender, *uint256.NewInt(1e18), tracing.BalanceChangeUnspecified)
+	require.NoError(t, statedb.CreateAccount(sender, true))
+	require.NoError(t, statedb.AddBalance(sender, *uint256.NewInt(1e18), tracing.BalanceChangeUnspecified))
 
 	// Initcode that just returns empty runtime code (PUSH1 0, PUSH1 0, RETURN).
 	initcode := []byte{byte(vm.PUSH1), 0, byte(vm.PUSH1), 0, byte(vm.RETURN)}
@@ -964,8 +964,8 @@ func TestCreate2CollisionWithEIP7702Delegation(t *testing.T) {
 	// Set an EIP-7702 delegation on the target address (points to some arbitrary empty account).
 	delegationTarget := common.HexToAddress("0xdead")
 	delegationCode := types.AddressToDelegation(accounts.InternAddress(delegationTarget))
-	statedb.CreateAccount(delegatedAddr, true)
-	statedb.SetCode(delegatedAddr, delegationCode, tracing.CodeChangeUnspecified)
+	require.NoError(t, statedb.CreateAccount(delegatedAddr, true))
+	require.NoError(t, statedb.SetCode(delegatedAddr, delegationCode, tracing.CodeChangeUnspecified))
 
 	// Build a factory contract that executes CREATE2 with the initcode and salt=0.
 	// The factory is placed at factoryAddr.
@@ -974,8 +974,8 @@ func TestCreate2CollisionWithEIP7702Delegation(t *testing.T) {
 	// Push the result to storage slot 0 for inspection.
 	factory.Push(0).Op(vm.SSTORE)
 
-	statedb.CreateAccount(accounts.InternAddress(factoryAddr), true)
-	statedb.SetCode(accounts.InternAddress(factoryAddr), factory.Bytes(), tracing.CodeChangeUnspecified)
+	require.NoError(t, statedb.CreateAccount(accounts.InternAddress(factoryAddr), true))
+	require.NoError(t, statedb.SetCode(accounts.InternAddress(factoryAddr), factory.Bytes(), tracing.CodeChangeUnspecified))
 
 	cfg := &Config{
 		State:  statedb,
@@ -1008,8 +1008,8 @@ func TestCreateCollisionWithEIP7702Delegation(t *testing.T) {
 	defer statedb.Close()
 
 	sender := accounts.InternAddress(common.HexToAddress("0x1234"))
-	statedb.CreateAccount(sender, true)
-	statedb.AddBalance(sender, *uint256.NewInt(1e18), tracing.BalanceChangeUnspecified)
+	require.NoError(t, statedb.CreateAccount(sender, true))
+	require.NoError(t, statedb.AddBalance(sender, *uint256.NewInt(1e18), tracing.BalanceChangeUnspecified))
 
 	// Initcode that returns empty runtime code.
 	initcode := []byte{byte(vm.PUSH1), 0, byte(vm.PUSH1), 0, byte(vm.RETURN)}
@@ -1034,8 +1034,8 @@ func TestCreateCollisionWithEIP7702Delegation(t *testing.T) {
 	// Set an EIP-7702 delegation on the target address.
 	delegationTarget := common.HexToAddress("0xdead")
 	delegationCode := types.AddressToDelegation(accounts.InternAddress(delegationTarget))
-	statedb.CreateAccount(delegatedAddr, true)
-	statedb.SetCode(delegatedAddr, delegationCode, tracing.CodeChangeUnspecified)
+	require.NoError(t, statedb.CreateAccount(delegatedAddr, true))
+	require.NoError(t, statedb.SetCode(delegatedAddr, delegationCode, tracing.CodeChangeUnspecified))
 
 	// Build a factory that executes CREATE with the initcode.
 	factory := program.New()
@@ -1046,8 +1046,8 @@ func TestCreateCollisionWithEIP7702Delegation(t *testing.T) {
 					Op(vm.CREATE)
 	factory.Push(0).Op(vm.SSTORE) // store result in slot 0
 
-	statedb.CreateAccount(factoryAcct, true)
-	statedb.SetCode(factoryAcct, factory.Bytes(), tracing.CodeChangeUnspecified)
+	require.NoError(t, statedb.CreateAccount(factoryAcct, true))
+	require.NoError(t, statedb.SetCode(factoryAcct, factory.Bytes(), tracing.CodeChangeUnspecified))
 
 	cfg := &Config{
 		State:  statedb,
@@ -1144,15 +1144,15 @@ func TestSystemCallZeroValueSkipsTransferChecks(t *testing.T) {
 	target := accounts.InternAddress(common.HexToAddress("0xbeef"))
 
 	// Deploy a trivial contract at the target that returns 0x42.
-	statedb.CreateAccount(target, true)
-	statedb.SetCode(target, []byte{
+	require.NoError(t, statedb.CreateAccount(target, true))
+	require.NoError(t, statedb.SetCode(target, []byte{
 		byte(vm.PUSH1), 0x42,
 		byte(vm.PUSH1), 0,
 		byte(vm.MSTORE),
 		byte(vm.PUSH1), 32,
 		byte(vm.PUSH1), 0,
 		byte(vm.RETURN),
-	}, tracing.CodeChangeUnspecified)
+	}, tracing.CodeChangeUnspecified))
 
 	// Track balance-change events on SYSTEM_ADDRESS.
 	type balChange struct {


### PR DESCRIPTION
Makes `golangci-lint run --no-config --enable-only=errcheck` clean for `./execution/vm/...` (51 findings), `./db/state/...` (40) and `./db/seg/...` (13).

Three are real defects:

- `HistoryTraceKeyFiles.Next` dropped the error from `advance()` via a bare `defer`, so a read failure while positioning the iterator surfaced as a silent end-of-stream. Its sibling `HistoryTraceKeyDB.Next` in the same file already returns it; the two now match.
- `Decompressor2bufio` dropped the final `wr.Flush()` error and then called `pw.Close()`, signalling a clean EOF to the reader instead of the failure — a short read would look like a complete one. Every other write error in that goroutine already goes through `pw.CloseWithError`.
- `asm.compileElement` dropped `compileNumber`'s error — the `// TODO figure out how to return the error properly` next to it is now resolved and removed.

The rest propagate `IntraBlockState` errors in the CREATE/SSTORE paths (using the existing `ErrIntraBlockStateFailed` wrapping idiom), or assert them in tests. Fuzz targets discard explicitly: arbitrary fuzz input is expected to error, and those targets assert no-panic / input-not-mutated instead. Cleanup defers and error-less `Close` methods carry `//nolint:errcheck`.

`execution/vm/benchmark` helpers (`deployContract`, `setStorage`, …) now take `testing.TB` so a failed fixture setup fails the benchmark instead of silently measuring nothing.

Two things left alone on purpose, both wider than a lint pass:

- `.golangci.yml` excludes errcheck repo-wide via a `text: not checked` rule — errcheck's message template always contains that substring, so the rule mutes the linter everywhere and none of this was visible to `make lint`.
- `RawWordsFile.Close` swallows its final `w.Flush()` error because it has no error return. Surfacing it means changing the signature and its callers.