### PR TITLE
cmd/evm, execution/tests, execution/tracing: stop rebuilding a database per state test, cheapen the trace writer

### DIFF
--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -24,9 +24,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/urfave/cli/v3"
 
 	"github.com/erigontech/erigon/common"
@@ -86,17 +88,20 @@ func stateTestCmd(_ context.Context, ctx *cli.Command) error {
 		DisableStorage:   ctx.Bool(DisableStorageFlag.Name),
 		EnableReturnData: !ctx.Bool(DisableReturnDataFlag.Name),
 	}
-	cfg := vm.Config{}
-	if machineFriendlyOutput {
-		cfg.Tracer = logger.NewJSONLogger(config, os.Stderr).Tracer().Hooks
-	} else if ctx.Bool(DebugFlag.Name) {
-		cfg.Tracer = logger.NewStructLogger(config).Tracer().Hooks
-	}
-
 	workers := ctx.Uint64(WorkersFlag.Name)
 	if workers == 0 {
 		return fmt.Errorf("--%s must be >= 1", WorkersFlag.Name)
 	}
+
+	cfg := vm.Config{}
+	traceOut := newTraceSink(workers)
+	defer traceOut.flush()
+	if machineFriendlyOutput {
+		cfg.Tracer = logger.NewJSONLogger(config, traceOut).Tracer().Hooks
+	} else if ctx.Bool(DebugFlag.Name) {
+		cfg.Tracer = logger.NewStructLogger(config).Tracer().Hooks
+	}
+
 	filter, err := compileTestFilter(ctx.String(RunFlag.Name), ctx.StringSlice(ExcludeFlag.Name))
 	if err != nil {
 		return err
@@ -105,7 +110,7 @@ func stateTestCmd(_ context.Context, ctx *cli.Command) error {
 	path := ctx.Args().First()
 	if len(path) != 0 {
 		collected := filter.filterFiles(collectFiles(path))
-		results, err := runStateTestsParallel(ctx, cfg, collected, workers, filter)
+		results, err := runStateTestsParallel(ctx, cfg, traceOut, collected, workers, filter)
 		if err != nil {
 			return err
 		}
@@ -124,13 +129,41 @@ func stateTestCmd(_ context.Context, ctx *cli.Command) error {
 		if len(fname) == 0 {
 			return nil
 		}
-		results, err := runStateTest(ctx, cfg, env, fname, filter)
+		results, err := runStateTest(ctx, cfg, traceOut, env, fname, filter)
 		if err != nil {
 			return err
 		}
 		report(ctx, results)
 	}
 	return scanner.Err()
+}
+
+// traceSink receives the --json opcode trace and the per-test stateRoot line.
+// The tracer emits one line per opcode, so unbuffered stderr costs a write(2)
+// each; buffering is only safe while tests run sequentially, since with
+// workers > 1 every goroutine shares this writer.
+type traceSink struct {
+	io.Writer
+	buffered *bufio.Writer
+}
+
+func newTraceSink(workers uint64) *traceSink {
+	if workers > 1 {
+		return &traceSink{Writer: os.Stderr}
+	}
+	bw := bufio.NewWriterSize(os.Stderr, int(64*datasize.KB))
+	return &traceSink{Writer: bw, buffered: bw}
+}
+
+// flush is called once per subtest, so a consumer streaming stderr still sees
+// whole tests, in order, without waiting for the run to end.
+func (s *traceSink) flush() {
+	if s.buffered == nil {
+		return
+	}
+	if err := s.buffered.Flush(); err != nil {
+		log.Warn("Failed to flush stderr", "err", err)
+	}
 }
 
 // stateTestEnv is the scratch database the tests run against. Building one
@@ -154,7 +187,7 @@ func (e *stateTestEnv) Close() {
 	dir.RemoveAll(e.tmpDir)
 }
 
-func runStateTestsParallel(ctx *cli.Command, cfg vm.Config, files []string, workers uint64, filter testFilter) ([]testResult, error) {
+func runStateTestsParallel(ctx *cli.Command, cfg vm.Config, traceOut *traceSink, files []string, workers uint64, filter testFilter) ([]testResult, error) {
 	if workers == 1 {
 		env, err := newStateTestEnv()
 		if err != nil {
@@ -163,7 +196,7 @@ func runStateTestsParallel(ctx *cli.Command, cfg vm.Config, files []string, work
 		defer env.Close()
 		results := make([]testResult, 0, len(files)*4) // pre-allocate
 		for _, fname := range files {
-			r, err := runStateTest(ctx, cfg, env, fname, filter)
+			r, err := runStateTest(ctx, cfg, traceOut, env, fname, filter)
 			if err != nil {
 				return nil, err
 			}
@@ -199,7 +232,7 @@ func runStateTestsParallel(ctx *cli.Command, cfg vm.Config, files []string, work
 			}
 			defer env.Close()
 			for item := range fileCh {
-				r, err := runStateTest(ctx, cfg, env, item.fname, filter)
+				r, err := runStateTest(ctx, cfg, traceOut, env, item.fname, filter)
 				resultCh <- fileResult{index: item.index, results: r, err: err}
 			}
 		})
@@ -229,7 +262,7 @@ func runStateTestsParallel(ctx *cli.Command, cfg vm.Config, files []string, work
 }
 
 // runStateTest loads the state-test given by fname, and executes the test.
-func runStateTest(ctx *cli.Command, cfg vm.Config, env *stateTestEnv, fname string, filter testFilter) ([]testResult, error) {
+func runStateTest(ctx *cli.Command, cfg vm.Config, traceOut *traceSink, env *stateTestEnv, fname string, filter testFilter) ([]testResult, error) {
 	src, err := os.ReadFile(fname)
 	if err != nil {
 		return nil, err
@@ -280,7 +313,7 @@ func runStateTest(ctx *cli.Command, cfg vm.Config, env *stateTestEnv, fname stri
 					h := common.Hash(root)
 					result.Root = &h
 					if emitStateRoot {
-						if _, printErr := fmt.Fprintf(os.Stderr, "{\"stateRoot\": \"%#x\"}\n", h[:]); printErr != nil {
+						if _, printErr := fmt.Fprintf(traceOut, "{\"stateRoot\": \"%#x\"}\n", h[:]); printErr != nil {
 							log.Warn("Failed to write to stderr", "err", printErr)
 						}
 					}

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -113,13 +113,18 @@ func stateTestCmd(_ context.Context, ctx *cli.Command) error {
 		return nil
 	}
 	// Otherwise, read filenames from stdin and execute back-to-back.
+	env, err := newStateTestEnv()
+	if err != nil {
+		return err
+	}
+	defer env.Close()
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		fname := scanner.Text()
 		if len(fname) == 0 {
 			return nil
 		}
-		results, err := runStateTest(ctx, cfg, fname, filter)
+		results, err := runStateTest(ctx, cfg, env, fname, filter)
 		if err != nil {
 			return err
 		}
@@ -128,11 +133,37 @@ func stateTestCmd(_ context.Context, ctx *cli.Command) error {
 	return nil
 }
 
+// stateTestEnv is the scratch database the tests run against. Building one
+// costs an MDBX env plus a datadir tree, so it is created once and reused: no
+// test ever commits, so rolling back each subtest's tx leaves it empty again.
+type stateTestEnv struct {
+	db     kv.TemporalRwDB
+	tmpDir string
+}
+
+func newStateTestEnv() (*stateTestEnv, error) {
+	tmpDir, err := os.MkdirTemp("", "erigon-statetest-*")
+	if err != nil {
+		return nil, err
+	}
+	return &stateTestEnv{db: temporaltest.NewTestDB(nil, datadir.New(tmpDir)), tmpDir: tmpDir}, nil
+}
+
+func (e *stateTestEnv) Close() {
+	e.db.Close()
+	dir.RemoveAll(e.tmpDir)
+}
+
 func runStateTestsParallel(ctx *cli.Command, cfg vm.Config, files []string, workers uint64, filter testFilter) ([]testResult, error) {
 	if workers == 1 {
+		env, err := newStateTestEnv()
+		if err != nil {
+			return nil, err
+		}
+		defer env.Close()
 		results := make([]testResult, 0, len(files)*4) // pre-allocate
 		for _, fname := range files {
-			r, err := runStateTest(ctx, cfg, fname, filter)
+			r, err := runStateTest(ctx, cfg, env, fname, filter)
 			if err != nil {
 				return nil, err
 			}
@@ -158,8 +189,17 @@ func runStateTestsParallel(ctx *cli.Command, cfg vm.Config, files []string, work
 
 	for range workers {
 		wg.Go(func() {
+			// One env per worker: a second concurrent rwtx on the same MDBX env would deadlock.
+			env, err := newStateTestEnv()
+			if err != nil {
+				for item := range fileCh {
+					resultCh <- fileResult{index: item.index, err: err}
+				}
+				return
+			}
+			defer env.Close()
 			for item := range fileCh {
-				r, err := runStateTest(ctx, cfg, item.fname, filter)
+				r, err := runStateTest(ctx, cfg, env, item.fname, filter)
 				resultCh <- fileResult{index: item.index, results: r, err: err}
 			}
 		})
@@ -189,7 +229,7 @@ func runStateTestsParallel(ctx *cli.Command, cfg vm.Config, files []string, work
 }
 
 // runStateTest loads the state-test given by fname, and executes the test.
-func runStateTest(ctx *cli.Command, cfg vm.Config, fname string, filter testFilter) ([]testResult, error) {
+func runStateTest(ctx *cli.Command, cfg vm.Config, env *stateTestEnv, fname string, filter testFilter) ([]testResult, error) {
 	src, err := os.ReadFile(fname)
 	if err != nil {
 		return nil, err
@@ -206,16 +246,7 @@ func runStateTest(ctx *cli.Command, cfg vm.Config, fname string, filter testFilt
 	// (e.g. goevmlab) that rely on per-test ordering.
 	emitStateRoot := ctx.Uint64(WorkersFlag.Name) == 1
 	results := make([]testResult, 0, len(stateTests))
-
-	// One temp datadir & DB per file; per-subtest isolation comes from tx rollback.
-	tmpDir, err := os.MkdirTemp("", "erigon-statetest-*")
-	if err != nil {
-		return nil, err
-	}
-	defer dir.RemoveAll(tmpDir)
-	dirs := datadir.New(tmpDir)
-	db := temporaltest.NewTestDB(nil, dirs)
-	defer db.Close()
+	db := env.db
 
 	for key := range stateTests {
 		if !filter.includeCase(fname, key) {
@@ -241,7 +272,7 @@ func runStateTest(ctx *cli.Command, cfg vm.Config, fname string, filter testFilt
 				}
 				defer sd.Close()
 
-				statedb, root, err := test.Run(nil, sd, tx, st, cfg, dirs)
+				statedb, root, err := test.Run(nil, sd, tx, st, cfg)
 				if err != nil {
 					result.Pass, result.Error = false, err.Error()
 				}
@@ -257,7 +288,7 @@ func runStateTest(ctx *cli.Command, cfg vm.Config, fname string, filter testFilt
 				if bench {
 					// Reuse the subtest's tx+sd: a second concurrent rwtx on the same env would deadlock.
 					_, stats, _ := timedExec(true, func() ([]byte, uint64, error) {
-						_, _, gasUsed, _ := test.RunNoVerify(nil, sd, tx, st, cfg, dirs)
+						_, _, gasUsed, _ := test.RunNoVerify(nil, sd, tx, st, cfg)
 						return nil, gasUsed, nil
 					})
 					result.Stats = &stats

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -130,7 +130,7 @@ func stateTestCmd(_ context.Context, ctx *cli.Command) error {
 		}
 		report(ctx, results)
 	}
-	return nil
+	return scanner.Err()
 }
 
 // stateTestEnv is the scratch database the tests run against. Building one

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -25,7 +25,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"slices"
 	"sync"
 
 	"github.com/c2h5oh/datasize"
@@ -281,7 +283,9 @@ func runStateTest(ctx *cli.Command, cfg vm.Config, traceOut *traceSink, env *sta
 	results := make([]testResult, 0, len(stateTests))
 	db := env.db
 
-	for key := range stateTests {
+	// Sorted, not map order: a differential-fuzzing consumer needs the same
+	// sequence of results for the same file on every run.
+	for _, key := range slices.Sorted(maps.Keys(stateTests)) {
 		if !filter.includeCase(fname, key) {
 			continue
 		}
@@ -328,6 +332,7 @@ func runStateTest(ctx *cli.Command, cfg vm.Config, traceOut *traceSink, env *sta
 				}
 			}()
 
+			traceOut.flush()
 			results = append(results, *result)
 		}
 	}

--- a/cmd/evm/staterunner_test.go
+++ b/cmd/evm/staterunner_test.go
@@ -17,9 +17,16 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 
 	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
 	"github.com/erigontech/erigon/db/state/statecfg"
@@ -54,4 +61,72 @@ func TestNewStateTestSharedDomainsUsesSelectedCommitment(t *testing.T) {
 			require.Equal(t, tc.variant, sd.GetCommitmentCtx().Trie().Variant())
 		})
 	}
+}
+
+// Batch mode reuses one scratch DB for every file on stdin, so a subtest's
+// writes must not survive into the next file: interleaving fixtures has to
+// give each of them the same result as running it alone.
+func TestStateTestBatchModeIsolatesFiles(t *testing.T) {
+	cornersDir := filepath.Join("..", "..", "execution", "tests", "test-corners", "state")
+	files := []string{
+		filepath.Join("testdata", "statetest.json"),
+		filepath.Join(cornersDir, "CallNonExistingAccount.json"),
+		filepath.Join(cornersDir, "eip2681-max-sender-nonce.json"),
+		filepath.Join(cornersDir, "SingletonStorageCell_UpdateKindPropagate_AllTheWayUpToRoot.json"),
+	}
+
+	alone := map[string][]testResult{}
+	for _, f := range files {
+		alone[f] = runStateTestBatch(t, []string{f})
+	}
+
+	interleaved := append(append([]string{}, files...), files...)
+	got := runStateTestBatch(t, interleaved)
+
+	var want []testResult
+	for _, f := range interleaved {
+		want = append(want, alone[f]...)
+	}
+	require.Equal(t, want, got)
+}
+
+// runStateTestBatch feeds files to `statetest` on stdin and decodes the
+// per-file JSON reports it writes to stdout.
+func runStateTestBatch(t *testing.T, files []string) []testResult {
+	t.Helper()
+
+	stdin, err := os.CreateTemp(t.TempDir(), "stdin")
+	require.NoError(t, err)
+	defer stdin.Close()
+	_, err = stdin.WriteString(strings.Join(files, "\n") + "\n")
+	require.NoError(t, err)
+	_, err = stdin.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	stdout, err := os.CreateTemp(t.TempDir(), "stdout")
+	require.NoError(t, err)
+	defer stdout.Close()
+
+	origIn, origOut := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = stdin, stdout
+	defer func() { os.Stdin, os.Stdout = origIn, origOut }()
+
+	cmd := &cli.Command{Commands: []*cli.Command{&stateTestCommand}}
+	require.NoError(t, cmd.Run(context.Background(), []string{"evm", "statetest", "--jsonout"}))
+
+	_, err = stdout.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	var results []testResult
+	dec := json.NewDecoder(stdout)
+	for {
+		var batch []testResult
+		if err := dec.Decode(&batch); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		results = append(results, batch...)
+	}
+	require.Len(t, results, len(files))
+	return results
 }

--- a/cmd/evm/staterunner_test.go
+++ b/cmd/evm/staterunner_test.go
@@ -117,6 +117,7 @@ func runStateTestBatch(t *testing.T, files []string) []testResult {
 	_, err = stdout.Seek(0, io.SeekStart)
 	require.NoError(t, err)
 	var results []testResult
+	batches := 0
 	dec := json.NewDecoder(stdout)
 	for {
 		var batch []testResult
@@ -125,8 +126,10 @@ func runStateTestBatch(t *testing.T, files []string) []testResult {
 		} else if err != nil {
 			t.Fatal(err)
 		}
+		batches++
 		results = append(results, batch...)
 	}
-	require.Len(t, results, len(files))
+	require.Equal(t, len(files), batches, "one JSON report per input file")
+	require.NotEmpty(t, results)
 	return results
 }

--- a/execution/tests/state_test.go
+++ b/execution/tests/state_test.go
@@ -86,7 +86,7 @@ func runStateTests(t *testing.T, st *testutil.TestMatcher, testDir string) {
 						return sdErr
 					}
 					defer sd.Close()
-					_, _, err = test.Run(t, sd, tx, subtest, vmconfig, dirs)
+					_, _, err = test.Run(t, sd, tx, subtest, vmconfig)
 					tx.Rollback()
 					if err != nil && len(test.Json.Post[subtest.Fork][subtest.Index].ExpectException) > 0 {
 						// Ignore expected errors

--- a/execution/tests/testutil/state_test_util.go
+++ b/execution/tests/testutil/state_test_util.go
@@ -38,7 +38,6 @@ import (
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/math"
-	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/snapshotsync/freezeblocks"
 	"github.com/erigontech/erigon/db/state/execctx"
@@ -250,8 +249,8 @@ func (t *StateTest) checkError(subtest StateSubtest, err error) error {
 // Run executes a specific subtest and verifies the post-state and logs.
 // sd is the caller-owned SharedDomains: discard (Close without Flush) to
 // prevent per-subtest state from polluting the long-lived branch cache.
-func (t *StateTest) Run(tb testing.TB, sd *execctx.SharedDomains, tx kv.TemporalRwTx, subtest StateSubtest, vmconfig vm.Config, dirs datadir.Dirs) (*state.IntraBlockState, common.Hash, error) {
-	st, root, _, err := t.RunNoVerify(tb, sd, tx, subtest, vmconfig, dirs)
+func (t *StateTest) Run(tb testing.TB, sd *execctx.SharedDomains, tx kv.TemporalRwTx, subtest StateSubtest, vmconfig vm.Config) (*state.IntraBlockState, common.Hash, error) {
+	st, root, _, err := t.RunNoVerify(tb, sd, tx, subtest, vmconfig)
 	return st, root, t.checkResult(subtest, st, root, err)
 }
 
@@ -278,19 +277,18 @@ func (t *StateTest) checkResult(subtest StateSubtest, st *state.IntraBlockState,
 // into it via MakePreStateInto so the per-subtest writes can be discarded by
 // closing sd without Flush — keeping ephemeral test state out of the long-lived
 // branch cache.
-func (t *StateTest) RunNoVerify(tb testing.TB, sd *execctx.SharedDomains, tx kv.TemporalRwTx, subtest StateSubtest, vmconfig vm.Config, dirs datadir.Dirs) (statedb *state.IntraBlockState, root common.Hash, gasUsed uint64, err error) {
+func (t *StateTest) RunNoVerify(tb testing.TB, sd *execctx.SharedDomains, tx kv.TemporalRwTx, subtest StateSubtest, vmconfig vm.Config) (statedb *state.IntraBlockState, root common.Hash, gasUsed uint64, err error) {
 	config, eips, err := GetChainConfig(subtest.Fork)
 	if err != nil {
 		return nil, common.Hash{}, 0, testforks.UnsupportedForkError{Name: subtest.Fork}
 	}
 	vmconfig.ExtraEips = eips
-	block, ibs, err := genesiswrite.GenesisToBlock(nil, t.genesis(config), dirs, log.Root())
-	if err != nil {
-		return nil, common.Hash{}, 0, testforks.UnsupportedForkError{Name: subtest.Fork}
-	}
-	defer ibs.Close()
+	// Only header fields feed the block context, and the genesis state root is not
+	// one of them: computing it would mean a throwaway DB plus a commitment over
+	// Pre, which MakePreStateInto redoes below anyway.
+	header, _ := genesiswrite.GenesisWithoutStateToBlock(t.genesis(config))
 
-	readBlockNr := block.NumberU64()
+	readBlockNr := header.Number.Uint64()
 	writeBlockNr := readBlockNr + 1
 
 	_, err = MakePreStateInto(&chain.Rules{}, sd, tx, t.Json.Pre, readBlockNr)
@@ -328,7 +326,6 @@ func (t *StateTest) RunNoVerify(tb testing.TB, sd *execctx.SharedDomains, tx kv.
 		}
 	}
 	post := t.Json.Post[subtest.Fork][subtest.Index]
-	header := block.HeaderNoCopy()
 
 	blockContext := protocol.NewEVMBlockContext(header, protocol.GetHashFn(header, nil), nil, accounts.InternAddress(t.Json.Env.Coinbase), config)
 	blockContext.GetHash = vmTestBlockHash
@@ -343,7 +340,7 @@ func (t *StateTest) RunNoVerify(tb testing.TB, sd *execctx.SharedDomains, tx kv.
 		blockContext.PrevRanDao = &rnd
 		blockContext.Difficulty.Clear()
 	}
-	if config.IsCancun(block.Time()) && t.Json.Env.ExcessBlobGas != nil {
+	if config.IsCancun(header.Time) && t.Json.Env.ExcessBlobGas != nil {
 		blockContext.BlobBaseFee, err = misc.GetBlobGasPrice(config, *t.Json.Env.ExcessBlobGas, header.Time)
 		if err != nil {
 			return nil, common.Hash{}, 0, err
@@ -389,7 +386,7 @@ func (t *StateTest) RunNoVerify(tb testing.TB, sd *execctx.SharedDomains, tx kv.
 	// Execute the message.
 	snapshot := statedb.PushSnapshot()
 	gaspool := new(protocol.GasPool)
-	gaspool.AddGas(block.GasLimit()).AddBlobGas(config.GetMaxBlobGasPerBlock(header.Time))
+	gaspool.AddGas(header.GasLimit).AddBlobGas(config.GetMaxBlobGasPerBlock(header.Time))
 	res, err := protocol.ApplyMessage(evm, msg, gaspool, true /* refunds */, false /* gasBailout */, nil /* engine */)
 	if res != nil {
 		gasUsed = res.ReceiptGasUsed

--- a/execution/tracing/tracers/logger/gen_structlog.go
+++ b/execution/tracing/tracers/logger/gen_structlog.go
@@ -4,12 +4,12 @@ package logger
 
 import (
 	"encoding/json"
-	"math/big"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/math"
 	"github.com/erigontech/erigon/execution/vm"
+	"github.com/holiman/uint256"
 )
 
 var _ = (*structLogMarshaling)(nil)
@@ -23,7 +23,7 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 		GasCost       math.HexOrDecimal64         `json:"gasCost"`
 		Memory        hexutil.Bytes               `json:"memory"`
 		MemorySize    int                         `json:"memSize"`
-		Stack         []*math.HexOrDecimal256     `json:"stack"`
+		Stack         []hexutil.U256              `json:"stack"`
 		ReturnData    hexutil.Bytes               `json:"returnData"`
 		Storage       map[common.Hash]common.Hash `json:"-"`
 		Depth         int                         `json:"depth"`
@@ -40,9 +40,9 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 	enc.Memory = s.Memory
 	enc.MemorySize = s.MemorySize
 	if s.Stack != nil {
-		enc.Stack = make([]*math.HexOrDecimal256, len(s.Stack))
+		enc.Stack = make([]hexutil.U256, len(s.Stack))
 		for k, v := range s.Stack {
-			enc.Stack[k] = (*math.HexOrDecimal256)(v)
+			enc.Stack[k] = hexutil.U256(v)
 		}
 	}
 	enc.ReturnData = s.ReturnData
@@ -64,7 +64,7 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 		GasCost       *math.HexOrDecimal64        `json:"gasCost"`
 		Memory        *hexutil.Bytes              `json:"memory"`
 		MemorySize    *int                        `json:"memSize"`
-		Stack         []*math.HexOrDecimal256     `json:"stack"`
+		Stack         []hexutil.U256              `json:"stack"`
 		ReturnData    *hexutil.Bytes              `json:"returnData"`
 		Storage       map[common.Hash]common.Hash `json:"-"`
 		Depth         *int                        `json:"depth"`
@@ -94,9 +94,9 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 		s.MemorySize = *dec.MemorySize
 	}
 	if dec.Stack != nil {
-		s.Stack = make([]*big.Int, len(dec.Stack))
+		s.Stack = make([]uint256.Int, len(dec.Stack))
 		for k, v := range dec.Stack {
-			s.Stack[k] = (*big.Int)(v)
+			s.Stack[k] = uint256.Int(v)
 		}
 	}
 	if dec.ReturnData != nil {

--- a/execution/tracing/tracers/logger/logger.go
+++ b/execution/tracing/tracers/logger/logger.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"math/big"
 	"os"
 	"slices"
 	"strings"
@@ -74,7 +73,7 @@ type StructLog struct {
 	GasCost       uint64                      `json:"gasCost"`
 	Memory        []byte                      `json:"memory,omitempty"`
 	MemorySize    int                         `json:"memSize"`
-	Stack         []*big.Int                  `json:"stack"`
+	Stack         []uint256.Int               `json:"stack"`
 	ReturnData    []byte                      `json:"returnData"`
 	Storage       map[common.Hash]common.Hash `json:"-"`
 	Depth         int                         `json:"depth"`
@@ -84,7 +83,7 @@ type StructLog struct {
 
 // overrides for gencodec
 type structLogMarshaling struct {
-	Stack       []*math.HexOrDecimal256
+	Stack       []hexutil.U256
 	Gas         math.HexOrDecimal64
 	GasCost     math.HexOrDecimal64
 	Memory      hexutil.Bytes
@@ -205,12 +204,10 @@ func (l *StructLogger) OnOpcode(pc uint64, opcode byte, gas, cost uint64, scope 
 		copy(mem, memory)
 	}
 	// Copy a snapshot of the current stack state to a new buffer
-	var stck []*big.Int
+	var stck []uint256.Int
 	if !l.cfg.DisableStack {
-		stck = make([]*big.Int, len(stack))
-		for i, item := range stack {
-			stck[i] = new(big.Int).Set(item.ToBig())
-		}
+		stck = make([]uint256.Int, len(stack))
+		copy(stck, stack)
 	}
 
 	stackLen := len(stack)
@@ -315,7 +312,8 @@ func FormatLogs(logs []StructLog) []StructLogRes {
 		if trace.Stack != nil {
 			stack := make([]string, len(trace.Stack))
 			for i, stackValue := range trace.Stack {
-				stack[i] = hex.EncodeToString(math.PaddedBigBytes(stackValue, 32))
+				b := stackValue.Bytes32()
+				stack[i] = hex.EncodeToString(b[:])
 			}
 			formatted[index].Stack = &stack
 		}
@@ -350,7 +348,7 @@ func WriteTrace(writer io.Writer, logs []StructLog) {
 		if len(log.Stack) > 0 {
 			fmt.Fprintln(writer, "Stack:")
 			for i, val := range slices.Backward(log.Stack) {
-				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, math.PaddedBigBytes(val, 32))
+				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, val.Bytes32())
 			}
 		}
 		if len(log.Memory) > 0 {

--- a/execution/tracing/tracers/logger/logger_json.go
+++ b/execution/tracing/tracers/logger/logger_json.go
@@ -22,7 +22,8 @@ package logger
 import (
 	"encoding/json"
 	"io"
-	"math/big"
+
+	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/math"
@@ -90,11 +91,8 @@ func (l *JSONLogger) OnOpcode(pc uint64, typ byte, gas, cost uint64, scope traci
 		log.Memory = memory
 	}
 	if !l.cfg.DisableStack {
-		//TODO(@holiman) improve this
-		logstack := make([]*big.Int, len(stack))
-		for i, item := range stack {
-			logstack[i] = item.ToBig()
-		}
+		logstack := make([]uint256.Int, len(stack))
+		copy(logstack, stack)
 		log.Stack = logstack
 	}
 	if l.cfg.EnableReturnData {


### PR DESCRIPTION
`evm statetest` spent nearly all its time on filesystem setup and on printing the trace, not on the EVM. Reported in #21080: goevmlab measured 20.3s for 100 runs of one fixture vs geth's 0.39s, with only 1.0s of user time.

Three costs, each removed in its own commit:

1. **A database per input file.** `runStateTest` built a temp datadir + MDBX env + aggregator for every file. Nothing is ever committed, so one env per process is enough (one per worker when `--workers > 1`, since two rw txs on one env deadlock). Isolation still comes from the per-subtest `tx.Rollback()` + `sd.Close()` without `Flush`, exactly as before.
2. **A second database per subtest.** `RunNoVerify` called `GenesisToBlock`, which opens another MDBX env plus aggregator and computes a genesis commitment over `pre`. Only the header is used and its state root is never read, so `GenesisWithoutStateToBlock` gives the same header for free. Its `dirs` argument became unused and is dropped from `Run`/`RunNoVerify`.
3. **The trace writer.** With the DB work gone, `JSONLogger.OnOpcode` was 69% of the profile. Two fixes: buffer stderr (it was one `write(2)` per opcode), and hold `StructLog.Stack` as `uint256.Int` instead of `*big.Int` (a `ToBig()` allocation per stack item per opcode). `hexutil.U256` marshals byte-identically to `math.HexOrDecimal256`, so the trace and `debug_traceTransaction` structLogs are unchanged.

`yes <fixture> | head -n 500 | evm statetest ...`, best of 5, n5 (Linux, 16 cores), ms per test:

| bench | main | this PR | Δ |
|---|---|---|---|
| `--json` trace on | 8.86 | 1.89 | −79% |
| no trace | 6.44 | 0.42 | −93% |

Per commit, same run: 8.82 → 2.61 (one DB per process) → 2.09 (buffered stderr) → 1.88 (uint256 stack) → 1.89 (per-subtest flush).

geth on the same box and fixture is 2.59 traced / 0.41 untraced, so this goes from 3.4x slower than geth to 1.4x faster with tracing on, and level without.

<details><summary>Correctness</summary>

- stdout and the 911-line stderr trace stay byte-identical to `main` on `cmd/evm/testdata/statetest.json` after every commit, and the root matches geth's.
- Directory mode over `execution/tests/test-corners/state` is identical to `main` at `--workers` 1, 2 and 4, and worker-count-invariant.
- New `TestStateTestBatchModeIsolatesFiles` interleaves four fixtures through one shared env and requires each to match its solo run. Checked that it goes red when the subtest tx is committed, so it does guard the reuse.
- `go test ./cmd/evm/... ./execution/tests/... ./execution/tracing/... ./rpc/ethapi/...` green; `go build ./...` clean.
- The buffered writer is only installed for `--workers 1`; with more workers the goroutines share the sink, so it stays unbuffered. It is flushed once per subtest, so a consumer streaming stderr still sees whole tests as they finish rather than at process exit — verified by piping stderr through `head` mid-run. That flush costs 0.01ms/test.
- Per-file test cases now run in sorted key order instead of Go map order, so repeated runs over the same file emit results in the same sequence.
</details>

<details><summary>Where the time went (measured)</summary>

Per file, before: `MkdirTemp` 0.06ms, `datadir.New` 0.8ms, `temporaltest.NewTestDB` 5.5ms, `db.Close` 5.3ms, `RemoveAll` 1.2ms — ~13ms, all filesystem. Per subtest: `GenesisToBlock` 5.3–27ms vs `GenesisWithoutStateToBlock` at 0.6us.

After those, a CPU profile put `JSONLogger.OnOpcode` at 69% of samples: `os.(*File).Write` 18%, and `json.Encoder.Encode` on a type that already has `MarshalJSON`, so the bytes are built by reflection and then re-scanned by `appendCompact` (~45% + 14%).

Still on the table, not done here: `StructLog.MarshalJSON` already emits compact JSON, so writing its bytes straight to the writer would skip both the reflect walk and `appendCompact`.
</details>
