### PR TITLE
execution/commitment/trie: dedup identical merge branches in HashWithModifications

### DIFF
--- a/execution/commitment/trie/stream.go
+++ b/execution/commitment/trie/stream.go
@@ -804,29 +804,15 @@ func HashWithModifications(
 			storageKeyHex = storageKeyHex[:len(storageKeyHex)-1]
 			si++
 		}
-		switch {
-		case accountKeyHex == nil:
-			copy(stream.keyBytes[offset:], storageKeyHex)
-			stream.keySizes[ki] = uint8(len(storageKeyHex))
-			stream.itemTypes[ki] = StorageStreamItem
-			ki++
-			offset += len(storageKeyHex)
-			storageKeyHex = nil // consumed
-		case storageKeyHex == nil:
+		emitAccount := accountKeyHex != nil && (storageKeyHex == nil || bytes.Compare(accountKeyHex, storageKeyHex) < 0)
+		if emitAccount {
 			copy(stream.keyBytes[offset:], accountKeyHex)
 			stream.keySizes[ki] = uint8(len(accountKeyHex))
 			stream.itemTypes[ki] = AccountStreamItem
 			ki++
 			offset += len(accountKeyHex)
 			accountKeyHex = nil // consumed
-		case bytes.Compare(accountKeyHex, storageKeyHex) < 0:
-			copy(stream.keyBytes[offset:], accountKeyHex)
-			stream.keySizes[ki] = uint8(len(accountKeyHex))
-			stream.itemTypes[ki] = AccountStreamItem
-			ki++
-			offset += len(accountKeyHex)
-			accountKeyHex = nil // consumed
-		default:
+		} else {
 			copy(stream.keyBytes[offset:], storageKeyHex)
 			stream.keySizes[ki] = uint8(len(storageKeyHex))
 			stream.itemTypes[ki] = StorageStreamItem


### PR DESCRIPTION
## What

Resolves two SonarQube `go:S1871` findings ("Two branches in a conditional structure should not have exactly the same implementation") in `execution/commitment/trie/stream.go`.

The account/storage merge loop in `HashWithModifications` was a four-case `switch` with only **two** distinct bodies:

- the **account-emit** body appeared in both `case storageKeyHex == nil` and `case bytes.Compare(accountKeyHex, storageKeyHex) < 0` (the "same as line 816" finding);
- the **storage-emit** body appeared in both `case accountKeyHex == nil` and `default` (the "same as line 809" finding).

Collapsed to a single decision so each body exists once:

```go
emitAccount := accountKeyHex != nil && (storageKeyHex == nil || bytes.Compare(accountKeyHex, storageKeyHex) < 0)
if emitAccount { /* emit account */ } else { /* emit storage */ }
```

## Why it's behavior-preserving

- The loop invariant guarantees at least one of the two keys is non-nil each iteration.
- The existing comment states merged keys are never equal, so `account >= storage` deterministically means "emit storage" — exactly what the old `default` case did.

Pure refactor, no behavior change — existing tests are the safety net (no new tests per the repo's TDD guidance for pure refactors).

## Verification

- `go build ./execution/commitment/trie/` ✅
- Full package tests incl. `TestHashWithModifications{Empty,NoChanges,Changes}` ✅
- `gofmt` clean, `go vet` clean, `golangci-lint` on the package → 0 issues