### PR TITLE
build(deps): bump undici to 6.28.0 in test_report (Dependabot alerts #127-#129)

### DIFF
--- a/.github/workflows/scripts/test_report/package-lock.json
+++ b/.github/workflows/scripts/test_report/package-lock.json
@@ -409,9 +409,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/.github/workflows/scripts/test_report/package.json
+++ b/.github/workflows/scripts/test_report/package.json
@@ -16,6 +16,6 @@
     "typescript": "^5.4.0"
   },
   "overrides": {
-    "undici": "^6.27.0"
+    "undici": "^6.28.0"
   }
 }


### PR DESCRIPTION
## What

Bumps `undici` from **6.27.0 → 6.28.0** in `.github/workflows/scripts/test_report/`, resolving three Dependabot alerts (all `undici < 6.28.0`, npm):

| Alert | Severity | Advisory | CVE |
|-------|----------|----------|-----|
| [127](https://github.com/erigontech/erigon/security/dependabot/127) | Moderate | GHSA-8xcm-r25x-g524 | CVE-2026-16728 — response desync via retry interceptor |
| [128](https://github.com/erigontech/erigon/security/dependabot/128) | Moderate | GHSA-v3r7-h72x-cjcm | CVE-2026-16729 — cookie attribute injection |
| [129](https://github.com/erigontech/erigon/security/dependabot/129) | Moderate | GHSA-m8rv-5g2x-5cg5 | CVE-2026-15157 — CRLF injection via blob body `type` |

`undici` is a transitive dependency (via `@actions/github` / `@actions/http-client`, range `^6.23.0`). The manifest already pins it through `overrides`; this bumps that override to `^6.28.0` — still within the parent range — and regenerates the lockfile.

## Scope note

The `docs/site` undici bump (7.28.0 → 7.29.0, alerts [130](https://github.com/erigontech/erigon/security/dependabot/130) High, [131](https://github.com/erigontech/erigon/security/dependabot/131), [132](https://github.com/erigontech/erigon/security/dependabot/132), [133](https://github.com/erigontech/erigon/security/dependabot/133), [134](https://github.com/erigontech/erigon/security/dependabot/134)) is handled by #22996, already approved and in the merge queue. The two PRs touch disjoint files (`test_report` vs `docs/site`), so there is no merge conflict. Together they clear alerts 127–134.

The repo's third lockfile (`execution/tracing/tracers/internal/tracetest/testgenerator/`) has no `undici` dependency, so it needs no change.

## Verification

- `overrides.undici` set to `^6.28.0`; lockfile resolves `undici` to `6.28.0` with matching integrity hash.
- Minimal diff: only the override line + the single `undici` lock entry.