### PR TITLE
[r3.6] exec: merge writeSets without cloning in the apply loop

### DIFF
--- a/execution/stagedsync/exec3_fee_merge_temp_test.go
+++ b/execution/stagedsync/exec3_fee_merge_temp_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package stagedsync
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+func feeMergeTestWrites(t *testing.T, addr accounts.Address, balance uint64) *state.WriteSet {
+	t.Helper()
+	ws := &state.WriteSet{}
+	ws.SetBalance(addr, &state.VersionedWrite[uint256.Int]{
+		WriteHeader: state.WriteHeader{Address: addr, Path: state.BalancePath},
+		Val:         *uint256.NewInt(balance),
+	})
+	return ws
+}
+
+// TestRecordFeeMergeReleasesSupersededTemp pins the three transitions the fee
+// merge goes through for one tx: the first merge has no temp to reclaim, a
+// revalidation round reclaims the temp it replaces, and a round whose input is
+// an execResult's TxOut (after a re-execution replaced the recorded slot)
+// reclaims nothing.
+func TestRecordFeeMergeReleasesSupersededTemp(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0x1111111111111111111111111111111111111111"))
+	be := &blockExecutor{feeMergeTemp: map[int]*state.WriteSet{}}
+
+	// First round: prev is the worker's TxOut, so nothing may be released.
+	txOut := feeMergeTestWrites(t, addr, 1)
+	temp1 := feeMergeTestWrites(t, addr, 2)
+	be.recordFeeMerge(0, txOut, temp1)
+	require.Same(t, temp1, be.feeMergeTemp[0])
+	require.Equal(t, 1, txOut.Count(), "TxOut must survive the fee merge")
+
+	// Revalidation round: prev is the temp the first round recorded, so it is
+	// superseded and reclaimed.
+	temp2 := feeMergeTestWrites(t, addr, 3)
+	be.recordFeeMerge(0, temp1, temp2)
+	require.Same(t, temp2, be.feeMergeTemp[0])
+	require.Equal(t, 0, temp1.Count(), "superseded fee-merge temp must be released")
+	require.Equal(t, 1, temp2.Count())
+
+	// After a re-execution the recorded slot is the new TxOut again, so the
+	// stale temp does not match prev and stays untouched.
+	txOut2 := feeMergeTestWrites(t, addr, 4)
+	temp3 := feeMergeTestWrites(t, addr, 5)
+	be.recordFeeMerge(0, txOut2, temp3)
+	require.Same(t, temp3, be.feeMergeTemp[0])
+	require.Equal(t, 1, txOut2.Count(), "TxOut must survive the fee merge")
+	require.Equal(t, 1, temp2.Count(), "a temp that is not prev must not be released")
+}
+
+// TestRecordFeeMergeReleaseKeepsSharedWrites pins what makes the release safe:
+// MergeInto shares VersionedWrite pointers rather than the maps holding them,
+// so pooling the superseded temp's maps leaves the surviving set readable.
+func TestRecordFeeMergeReleaseKeepsSharedWrites(t *testing.T) {
+	t.Parallel()
+
+	shared := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+	fresh := accounts.InternAddress(common.HexToAddress("0x3333333333333333333333333333333333333333"))
+	be := &blockExecutor{feeMergeTemp: map[int]*state.WriteSet{}}
+
+	temp1 := feeMergeTestWrites(t, shared, 7)
+	be.recordFeeMerge(0, feeMergeTestWrites(t, shared, 1), temp1)
+
+	tipWrites := feeMergeTestWrites(t, fresh, 9)
+	merged := temp1.MergeInto(tipWrites)
+	require.Same(t, tipWrites, merged)
+	be.recordFeeMerge(0, temp1, merged)
+
+	require.Equal(t, 0, temp1.Count())
+	vw, ok := merged.GetBalance(shared)
+	require.True(t, ok, "entry shared from the released temp must still be reachable")
+	require.Equal(t, uint64(7), vw.Val.Uint64())
+}

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -759,6 +759,10 @@ func (pe *parallelExecutor) execImpl(ctx context.Context, execStage *StageState,
 						}
 					}
 
+					// The BAL was the last reader of the recorded write sets;
+					// return their map containers to the pools.
+					applyResult.TxIO.ReleaseOutputMaps()
+
 					// Mark this block as fully applied. The exit-completeness
 					// check at channel-close compares this set against the
 					// expected [startBlockNum, maxBlockNum] range to detect
@@ -1140,6 +1144,8 @@ func (pe *parallelExecutor) execLoop(ctx context.Context) (err error) {
 				pe.abortCount.Add(int64(blockExecutor.cntAbort))
 				pe.invalidCount.Add(int64(blockExecutor.cntValidationFail))
 				pe.readCount.Add(blockExecutor.blockIO.ReadCount())
+				// Runs before sendResult, so the apply loop has not released the
+				// write-set maps yet.
 				pe.writeCount.Add(blockExecutor.blockIO.WriteCount())
 
 				if !blockExecutor.execStarted.IsZero() {
@@ -2258,6 +2264,11 @@ type blockExecutor struct {
 	tasks   []*execTask
 	results []*execResult
 
+	// feeMergeTemp[tx] is the write set the fee merge created and recorded for
+	// tx. A revalidation round merges again and supersedes it; every other
+	// recorded set is some execResult's TxOut, which stays live.
+	feeMergeTemp map[int]*state.WriteSet
+
 	// settledInput[tx]==true marks a task that was dispatched when every
 	// preceding task had already validated — so it executed against fully
 	// settled MVCC state, with no lower-indexed worker still in flight.
@@ -2404,6 +2415,7 @@ func newBlockExec(blockNum uint64, blockHash common.Hash, gasPool *protocol.GasP
 		begin:            time.Now(),
 		stats:            map[int]ExecutionStat{},
 		finalizedResults: map[int]*execResult{},
+		feeMergeTemp:     map[int]*state.WriteSet{},
 		settledInput:     map[int]bool{},
 		estimateDeps:     map[int][]int{},
 		preValidated:     map[int]bool{},
@@ -2431,6 +2443,18 @@ func (be *blockExecutor) invalidBlockResult(err error) *blockResult {
 		BlockHash: be.blockHash,
 		Err:       err,
 	}
+}
+
+// recordFeeMerge takes ownership of the set the fee merge just recorded for tx
+// and reclaims the one it superseded. Only a set an earlier fee merge created
+// may be released: prev is otherwise some execResult's TxOut, which stays live.
+// MergeInto shares VersionedWrite pointers rather than the maps holding them,
+// so pooling prev's maps leaves the writes merged now holds intact.
+func (be *blockExecutor) recordFeeMerge(tx int, prev, merged *state.WriteSet) {
+	if temp := be.feeMergeTemp[tx]; temp != nil && temp == prev && merged != temp {
+		temp.ReleaseMaps()
+	}
+	be.feeMergeTemp[tx] = merged
 }
 
 // tooManyRetries returns an invalid-block result when tx has exceeded its
@@ -2670,8 +2694,9 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			}
 			if !tipWrites.IsEmpty() {
 				existingWrites := be.blockIO.WriteSet(txVersion.TxIndex)
-				merged := MergeVersionedWrites(existingWrites, tipWrites)
+				merged := existingWrites.MergeInto(tipWrites)
 				be.blockIO.RecordWrites(txVersion, merged)
+				be.recordFeeMerge(tx, existingWrites, merged)
 			}
 		}
 
@@ -2789,7 +2814,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				if !addWrites.IsEmpty() {
 					// Merge finalization writes with existing execution writes.
 					existingWrites := be.blockIO.WriteSet(txVersion.TxIndex)
-					merged := MergeVersionedWrites(existingWrites, addWrites)
+					merged := existingWrites.MergeInto(addWrites)
 					be.blockIO.RecordWrites(txVersion, merged)
 
 					// Flush the merged writes (including fee calc changes)
@@ -3257,10 +3282,6 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 		be.execTasks.drainDeferred()
 		dispatch()
 	}
-}
-
-func MergeVersionedWrites(prev, next *state.WriteSet) *state.WriteSet {
-	return prev.Merge(next)
 }
 
 // normalizeWriteSet produces a clean write set from the versionMap's WriteSet

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -14,6 +14,7 @@ import (
 	"github.com/heimdalr/dag"
 	"github.com/holiman/uint256"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/protocol/params"
@@ -1118,53 +1119,62 @@ func (s *WriteSet) AllHeaders() iter.Seq[WriteHeader] {
 // ReleaseAndReset returns every *VersionedWrite[T] held by the set to its
 // typed sync.Pool, then returns the per-path maps to their map-pools.
 // Called at tx-finalize so both the VW values and the map buckets cycle
-// through pools rather than getting GC'd.
-//
-// Per-path sequence: walk the map releasing each value first; then the
-// map-pool's put() does clear() + Put, preserving the bucket array for
-// the next tx's checkout.  Pool-resident containers want clear() — the
-// usual "clear doesn't free memory" critique becomes a feature here.
+// through pools rather than getting GC'd. The values must go back before
+// ReleaseMaps clears the maps that hold them.
 func (s *WriteSet) ReleaseAndReset() {
 	for _, vw := range s.address {
 		releaseVWAddress(vw)
 	}
-	wsMapPoolAddress.put(s.address)
 	for _, vw := range s.balance {
 		releaseVWBalance(vw)
 	}
-	wsMapPoolBalance.put(s.balance)
 	for _, vw := range s.nonce {
 		releaseVWNonce(vw)
 	}
-	wsMapPoolNonce.put(s.nonce)
 	for _, vw := range s.incarnation {
 		releaseVWIncarnation(vw)
 	}
-	wsMapPoolIncarnation.put(s.incarnation)
 	for _, vw := range s.selfDestruct {
 		releaseVWSelfDestruct(vw)
 	}
-	wsMapPoolSelfDestruct.put(s.selfDestruct)
 	for _, vw := range s.createContract {
 		releaseVWCreateContract(vw)
 	}
-	wsMapPoolCreateContract.put(s.createContract)
 	for _, vw := range s.code {
 		releaseVWCode(vw)
 	}
-	wsMapPoolCode.put(s.code)
 	for _, vw := range s.codeHash {
 		releaseVWCodeHash(vw)
 	}
-	wsMapPoolCodeHash.put(s.codeHash)
 	for _, vw := range s.codeSize {
 		releaseVWCodeSize(vw)
 	}
-	wsMapPoolCodeSize.put(s.codeSize)
 	for _, inner := range s.storage {
 		for _, vw := range inner {
 			releaseVWStorage(vw)
 		}
+	}
+	s.ReleaseMaps()
+}
+
+// ReleaseMaps returns the map containers to their pools without releasing the
+// VersionedWrite values, which stay owned by GC — they may be shared with other
+// sets after MergeInto. Use ReleaseAndReset only for sets whose VWs came from
+// the vwPools and are exclusively owned.
+func (s *WriteSet) ReleaseMaps() {
+	if s == nil {
+		return
+	}
+	wsMapPoolAddress.put(s.address)
+	wsMapPoolBalance.put(s.balance)
+	wsMapPoolNonce.put(s.nonce)
+	wsMapPoolIncarnation.put(s.incarnation)
+	wsMapPoolSelfDestruct.put(s.selfDestruct)
+	wsMapPoolCreateContract.put(s.createContract)
+	wsMapPoolCode.put(s.code)
+	wsMapPoolCodeHash.put(s.codeHash)
+	wsMapPoolCodeSize.put(s.codeSize)
+	for _, inner := range s.storage {
 		wsPutStorageInner(inner)
 	}
 	wsPutStorageOuter(s.storage)
@@ -1862,6 +1872,68 @@ func (s *WriteSet) copyFrom(src *WriteSet) {
 	}
 }
 
+// copyMissingFrom adds the entries s does not already hold, sharing src's
+// *VersionedWrite pointers rather than cloning them — see MergeInto for what
+// the sharing costs the caller.
+func (s *WriteSet) copyMissingFrom(src *WriteSet) {
+	if src == nil {
+		return
+	}
+	for a, vw := range src.address {
+		if _, ok := s.address[a]; !ok {
+			s.SetAddress(a, vw)
+		}
+	}
+	for a, vw := range src.balance {
+		if _, ok := s.balance[a]; !ok {
+			s.SetBalance(a, vw)
+		}
+	}
+	for a, vw := range src.nonce {
+		if _, ok := s.nonce[a]; !ok {
+			s.SetNonce(a, vw)
+		}
+	}
+	for a, vw := range src.incarnation {
+		if _, ok := s.incarnation[a]; !ok {
+			s.SetIncarnation(a, vw)
+		}
+	}
+	for a, vw := range src.selfDestruct {
+		if _, ok := s.selfDestruct[a]; !ok {
+			s.SetSelfDestruct(a, vw)
+		}
+	}
+	for a, vw := range src.createContract {
+		if _, ok := s.createContract[a]; !ok {
+			s.SetCreateContract(a, vw)
+		}
+	}
+	for a, vw := range src.code {
+		if _, ok := s.code[a]; !ok {
+			s.SetCode(a, vw)
+		}
+	}
+	for a, vw := range src.codeHash {
+		if _, ok := s.codeHash[a]; !ok {
+			s.SetCodeHash(a, vw)
+		}
+	}
+	for a, vw := range src.codeSize {
+		if _, ok := s.codeSize[a]; !ok {
+			s.SetCodeSize(a, vw)
+		}
+	}
+	for a, inner := range src.storage {
+		own := s.storage[a]
+		for key, vw := range inner {
+			if _, ok := own[key]; !ok {
+				s.SetStorage(a, key, vw)
+			}
+		}
+	}
+}
+
 // Merge returns the union of prev and next, with next winning on (addr,path,key).
 func (prev *WriteSet) Merge(next *WriteSet) *WriteSet {
 	if prev.IsEmpty() {
@@ -1874,6 +1946,25 @@ func (prev *WriteSet) Merge(next *WriteSet) *WriteSet {
 	out.copyFrom(prev)
 	out.copyFrom(next)
 	return out
+}
+
+// MergeInto folds prev's entries into next in place and returns the surviving
+// set, next winning on (addr, path, key). That is next, except that an empty
+// side short-circuits to the other one — so the result can be prev, and a
+// caller that releases or mutates it must compare identity first. Unlike Merge
+// it shares *VersionedWrite pointers instead of cloning, so next must be
+// exclusively owned by the caller and neither side may mutate a shared
+// VersionedWrite in place afterwards; prev's maps are never touched, so
+// map-level deletes on prev stay safe.
+func (prev *WriteSet) MergeInto(next *WriteSet) *WriteSet {
+	if prev.IsEmpty() {
+		return next
+	}
+	if next.IsEmpty() {
+		return prev
+	}
+	next.copyMissingFrom(prev)
+	return next
 }
 
 // hasNewWrite: returns true if the current set has a new write compared to the input
@@ -1986,6 +2077,11 @@ type VersionedIO struct {
 	inputs   []versionedReadSet
 	outputs  []*WriteSet // write sets that should be checked during validation
 	accessed []AccessSet
+
+	// outputsReleased marks ReleaseOutputMaps having run. A read after that
+	// point sees emptied sets rather than failing, so under assertions the
+	// accessors panic instead. Only written when dbg.AssertEnabled.
+	outputsReleased bool
 }
 
 func NewVersionedIO(numTx int) *VersionedIO {
@@ -2029,6 +2125,7 @@ func (io *VersionedIO) ReadSetIncarnation(txnIdx int) int {
 }
 
 func (io *VersionedIO) WriteSet(txnIdx int) *WriteSet {
+	io.assertOutputsLive("WriteSet")
 	if len(io.outputs) <= txnIdx+1 {
 		return nil
 	}
@@ -2036,11 +2133,30 @@ func (io *VersionedIO) WriteSet(txnIdx int) *WriteSet {
 }
 
 func (io *VersionedIO) WriteCount() (count int64) {
+	io.assertOutputsLive("WriteCount")
 	for _, output := range io.outputs {
 		count += int64(output.Count())
 	}
 
 	return count
+}
+
+func (io *VersionedIO) assertOutputsLive(op string) {
+	if dbg.AssertEnabled && io != nil && io.outputsReleased {
+		panic("VersionedIO." + op + " after ReleaseOutputMaps: the write sets are emptied, so this read silently sees nothing")
+	}
+}
+
+// ReleaseOutputMaps returns every recorded write set's map containers to their
+// pools and empties the slots. Only for a VersionedIO whose last reader is
+// done; the shared VersionedWrite values are left to GC.
+func (io *VersionedIO) ReleaseOutputMaps() {
+	for _, output := range io.outputs {
+		output.ReleaseMaps()
+	}
+	if dbg.AssertEnabled {
+		io.outputsReleased = true
+	}
 }
 
 func (io *VersionedIO) ReadCount() (count int64) {

--- a/execution/state/writeset_merge_test.go
+++ b/execution/state/writeset_merge_test.go
@@ -1,0 +1,412 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"fmt"
+	"maps"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+func mergeAddr(b byte) accounts.Address {
+	return accounts.InternAddress([20]byte{b})
+}
+
+func mergeKey(b byte) accounts.StorageKey {
+	return accounts.InternKey([32]byte{b})
+}
+
+func balanceWrite(addr accounts.Address, val uint64, incarnation int) *VersionedWrite[uint256.Int] {
+	return &VersionedWrite[uint256.Int]{
+		WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Version: Version{TxIndex: 0, Incarnation: incarnation}},
+		Val:         *uint256.NewInt(val),
+	}
+}
+
+func nonceWrite(addr accounts.Address, val uint64, incarnation int) *VersionedWrite[uint64] {
+	return &VersionedWrite[uint64]{
+		WriteHeader: WriteHeader{Address: addr, Path: NoncePath, Version: Version{TxIndex: 0, Incarnation: incarnation}},
+		Val:         val,
+	}
+}
+
+func storageWrite(addr accounts.Address, key accounts.StorageKey, val uint64) *VersionedWrite[uint256.Int] {
+	return &VersionedWrite[uint256.Int]{
+		WriteHeader: WriteHeader{Address: addr, Path: StoragePath, Key: key, Version: Version{TxIndex: 0}},
+		Val:         *uint256.NewInt(val),
+	}
+}
+
+func addressWrite(addr accounts.Address, nonce uint64) *VersionedWrite[*accounts.Account] {
+	return &VersionedWrite[*accounts.Account]{
+		WriteHeader: WriteHeader{Address: addr, Path: AddressPath, Version: Version{TxIndex: 0}},
+		Val:         &accounts.Account{Nonce: nonce},
+	}
+}
+
+func incarnationWrite(addr accounts.Address, val uint64) *VersionedWrite[uint64] {
+	return &VersionedWrite[uint64]{
+		WriteHeader: WriteHeader{Address: addr, Path: IncarnationPath, Version: Version{TxIndex: 0}},
+		Val:         val,
+	}
+}
+
+func selfDestructWrite(addr accounts.Address, val bool) *VersionedWrite[bool] {
+	return &VersionedWrite[bool]{
+		WriteHeader: WriteHeader{Address: addr, Path: SelfDestructPath, Version: Version{TxIndex: 0}},
+		Val:         val,
+	}
+}
+
+func createContractWrite(addr accounts.Address, val bool) *VersionedWrite[bool] {
+	return &VersionedWrite[bool]{
+		WriteHeader: WriteHeader{Address: addr, Path: CreateContractPath, Version: Version{TxIndex: 0}},
+		Val:         val,
+	}
+}
+
+func codeWrite(addr accounts.Address, code []byte) *VersionedWrite[accounts.Code] {
+	return &VersionedWrite[accounts.Code]{
+		WriteHeader: WriteHeader{Address: addr, Path: CodePath, Version: Version{TxIndex: 0}},
+		Val:         accounts.NewCode(code),
+	}
+}
+
+func codeHashWrite(addr accounts.Address, b byte) *VersionedWrite[accounts.CodeHash] {
+	return &VersionedWrite[accounts.CodeHash]{
+		WriteHeader: WriteHeader{Address: addr, Path: CodeHashPath, Version: Version{TxIndex: 0}},
+		Val:         accounts.InternCodeHash(common.Hash{b}),
+	}
+}
+
+func codeSizeWrite(addr accounts.Address, val int) *VersionedWrite[int] {
+	return &VersionedWrite[int]{
+		WriteHeader: WriteHeader{Address: addr, Path: CodeSizePath, Version: Version{TxIndex: 0}},
+		Val:         val,
+	}
+}
+
+// Every path conflicts on address a — both sides write it with a different
+// value — so "next wins on a matched key" is exercised per-path instead of
+// passing vacuously. b is prev-only, c is next-only, and storage carries all
+// three shapes: k1 conflicts, k2 is prev-only, k3 is next-only.
+//
+// b's writes are the ones a merged set shares with prev, so they are what a
+// release test must assert. Its address and code writes make an accidental
+// release of a shared value fail deterministically: releaseVWAddress nils Val
+// and releaseVWCode clears the bytecode, while the other release funcs are
+// bare pool-Puts that leave the value readable until reuse.
+func mergeIntoFixture() (prev, next *WriteSet) {
+	a, b, c := mergeAddr(0xa1), mergeAddr(0xb2), mergeAddr(0xc3)
+	k1, k2, k3 := mergeKey(0x01), mergeKey(0x02), mergeKey(0x03)
+	prev = newWriteSet(
+		addressWrite(a, 5),
+		balanceWrite(a, 1, 0),
+		nonceWrite(a, 5, 0),
+		incarnationWrite(a, 0),
+		selfDestructWrite(a, false),
+		createContractWrite(a, false),
+		codeWrite(a, []byte{0x60, 0x00}),
+		codeHashWrite(a, 0x11),
+		codeSizeWrite(a, 2),
+		storageWrite(a, k1, 10),
+		storageWrite(a, k2, 20),
+		addressWrite(b, 6),
+		balanceWrite(b, 2, 0),
+		nonceWrite(b, 7, 0),
+		codeWrite(b, []byte{0x60, 0xaa}),
+		codeSizeWrite(b, 9),
+	)
+	next = newWriteSet(
+		addressWrite(a, 50),
+		balanceWrite(a, 100, 1),
+		nonceWrite(a, 50, 1),
+		incarnationWrite(a, 1),
+		selfDestructWrite(a, true),
+		createContractWrite(a, true),
+		codeWrite(a, []byte{0x60, 0x01, 0x02}),
+		codeHashWrite(a, 0x22),
+		codeSizeWrite(a, 3),
+		storageWrite(a, k1, 111),
+		storageWrite(a, k3, 33),
+		balanceWrite(c, 3, 1),
+		selfDestructWrite(c, true),
+	)
+	return prev, next
+}
+
+// writeKey is the identity a merge dedups on: (addr, path, key). Version is
+// excluded, so two writes to the same slot collide here.
+type writeKey struct {
+	addr accounts.Address
+	key  accounts.StorageKey
+	path AccountPath
+}
+
+func writeKeysOf(s *WriteSet) map[writeKey]bool {
+	keys := map[writeKey]bool{}
+	for h := range s.AllHeaders() {
+		keys[writeKey{addr: h.Address, key: h.Key, path: h.Path}] = true
+	}
+	return keys
+}
+
+func assertSameWrites(t *testing.T, want, got *WriteSet) {
+	t.Helper()
+	require.Equal(t, want.Count(), got.Count())
+	for h := range want.AllHeaders() {
+		require.True(t, got.Has(h), "missing header %v", h)
+		assert.Equal(t, writeSetVal(want, h), writeSetVal(got, h), "value mismatch at %v", h)
+	}
+}
+
+// MergeInto must produce the same union as the cloning Merge: next wins on
+// (addr, path, key), prev fills the gaps.
+func TestWriteSetMergeInto_MatchesMergeOracle(t *testing.T) {
+	prevOracle, nextOracle := mergeIntoFixture()
+	oracle := prevOracle.Merge(nextOracle)
+
+	prev, next := mergeIntoFixture()
+	merged := prev.MergeInto(next)
+
+	assert.Same(t, next, merged, "MergeInto must return next itself, not a copy")
+	assertSameWrites(t, oracle, merged)
+}
+
+// A key held by both sides keeps next's write and drops prev's — that is the
+// merge policy, not a lost write: the merged set still holds every (addr,
+// path, key) either side wrote.
+func TestWriteSetMergeInto_MatchedKeyKeepsNext(t *testing.T) {
+	prev, next := mergeIntoFixture()
+	prevKeys, nextKeys := writeKeysOf(prev), writeKeysOf(next)
+	nextHeaders := map[writeKey]WriteHeader{}
+	nextVals := map[writeKey]any{}
+	for h := range next.AllHeaders() {
+		k := writeKey{addr: h.Address, key: h.Key, path: h.Path}
+		nextHeaders[k] = h
+		nextVals[k] = writeSetVal(next, h)
+	}
+	require.NotZero(t, matchedKeys(prevKeys, nextKeys), "fixture must have matched keys")
+
+	merged := prev.MergeInto(next)
+
+	for k, h := range nextHeaders {
+		require.True(t, merged.Has(h), "next's write dropped at %v", h)
+		assert.Equal(t, nextVals[k], writeSetVal(merged, h), "next must win at %v", h)
+	}
+	union := prevKeys
+	maps.Copy(union, nextKeys)
+	assert.Equal(t, union, writeKeysOf(merged), "merged set must hold every key either side wrote")
+}
+
+func matchedKeys(a, b map[writeKey]bool) int {
+	n := 0
+	for k := range a {
+		if b[k] {
+			n++
+		}
+	}
+	return n
+}
+
+// prev is aliased by execResult.TxOut, which finalize later reads and mutates
+// (StripBalanceWrite deletes map entries). MergeInto must never touch prev's
+// maps, and deleting from prev afterwards must not affect the merged set.
+func TestWriteSetMergeInto_PrevStaysIndependent(t *testing.T) {
+	a := mergeAddr(0xa1)
+	b := mergeAddr(0xb2)
+
+	prev, next := mergeIntoFixture()
+	prevCount := prev.Count()
+	merged := prev.MergeInto(next)
+
+	assert.Equal(t, prevCount, prev.Count(), "MergeInto must not grow or shrink prev")
+	bw, ok := prev.balance[a]
+	require.True(t, ok)
+	assert.Equal(t, *uint256.NewInt(1), bw.Val, "prev's own value must survive")
+
+	// Simulate StripBalanceWrite on TxOut after the merge.
+	delete(prev.balance, b)
+	gotVW, ok := merged.balance[b]
+	require.True(t, ok, "merged set must keep entries deleted from prev")
+	assert.Equal(t, *uint256.NewInt(2), gotVW.Val)
+}
+
+func TestWriteSetMergeInto_EmptyEdges(t *testing.T) {
+	prev, next := mergeIntoFixture()
+
+	empty := &WriteSet{}
+	assert.Same(t, next, empty.MergeInto(next), "empty prev returns next")
+	assert.Same(t, prev, prev.MergeInto(&WriteSet{}), "empty next returns prev")
+	assert.Same(t, prev, prev.MergeInto(nil), "nil next returns prev")
+	assert.Same(t, next, (*WriteSet)(nil).MergeInto(next), "nil prev returns next")
+}
+
+// Fee-merge shape from the parallel apply loop: prev is a full tx write set,
+// next is the small calcFees output.
+func buildMergeBenchSets(addrs, slots int) (*WriteSet, *WriteSet) {
+	prev := &WriteSet{}
+	for i := range addrs {
+		addr := mergeAddr(byte(i + 1))
+		prev.SetBalance(addr, balanceWrite(addr, uint64(i+1), 0))
+		prev.SetNonce(addr, nonceWrite(addr, uint64(i), 0))
+		for s := range slots {
+			key := mergeKey(byte(s + 1))
+			prev.SetStorage(addr, key, storageWrite(addr, key, uint64(s)))
+		}
+	}
+	coinbase := mergeAddr(0xfe)
+	next := newWriteSet(balanceWrite(coinbase, 1000, 1))
+	return prev, next
+}
+
+// Both variants build their inputs inside the timed loop, since MergeInto
+// consumes next and cannot reuse one pair across iterations. That dilutes the
+// delta with the build cost, but it is the same cost on both sides - timing one
+// variant with a warm pair and the other with a fresh one measures the harness.
+func benchWriteSetMerge(b *testing.B, addrs, slots int, merge func(prev, next *WriteSet) *WriteSet) {
+	b.ReportAllocs()
+	for b.Loop() {
+		prev, next := buildMergeBenchSets(addrs, slots)
+		sinkWS = merge(prev, next)
+	}
+}
+
+func BenchmarkWriteSetMerge(b *testing.B) {
+	for _, size := range []struct{ addrs, slots int }{{4, 2}, {16, 8}} {
+		b.Run(fmt.Sprintf("addrs=%d/slots=%d", size.addrs, size.slots), func(b *testing.B) {
+			benchWriteSetMerge(b, size.addrs, size.slots, (*WriteSet).Merge)
+		})
+	}
+}
+
+func BenchmarkWriteSetMergeInto(b *testing.B) {
+	for _, size := range []struct{ addrs, slots int }{{4, 2}, {16, 8}} {
+		b.Run(fmt.Sprintf("addrs=%d/slots=%d", size.addrs, size.slots), func(b *testing.B) {
+			benchWriteSetMerge(b, size.addrs, size.slots, (*WriteSet).MergeInto)
+		})
+	}
+}
+
+// ReleaseMaps returns the map containers to their pools without touching the
+// VersionedWrite values, which may be shared with other sets after MergeInto.
+func TestWriteSetReleaseMaps(t *testing.T) {
+	a, b := mergeAddr(0xa1), mergeAddr(0xb2)
+	k2 := mergeKey(0x02)
+
+	prev, next := mergeIntoFixture()
+	merged := prev.MergeInto(next)
+
+	prev.ReleaseMaps()
+	assert.True(t, prev.IsEmpty(), "released set must be empty")
+
+	// The entries merged shares with prev are prev's non-conflicting ones —
+	// prev's writes on a lost the merge and never entered merged.
+	aw, ok := merged.address[b]
+	require.True(t, ok)
+	require.NotNil(t, aw.Val, "shared address write must not be released")
+	assert.Equal(t, uint64(6), aw.Val.Nonce)
+	cw, ok := merged.code[b]
+	require.True(t, ok)
+	assert.Equal(t, []byte{0x60, 0xaa}, cw.Val.Bytes, "shared code write must not be released")
+	bw, ok := merged.balance[b]
+	require.True(t, ok)
+	assert.Equal(t, *uint256.NewInt(2), bw.Val)
+	nw, ok := merged.nonce[b]
+	require.True(t, ok)
+	assert.Equal(t, uint64(7), nw.Val)
+	csw, ok := merged.codeSize[b]
+	require.True(t, ok)
+	assert.Equal(t, 9, csw.Val)
+	sw, ok := merged.storage[a][k2]
+	require.True(t, ok)
+	assert.Equal(t, *uint256.NewInt(20), sw.Val)
+
+	// A released set must be reusable.
+	prev.SetBalance(a, balanceWrite(a, 7, 2))
+	bw, ok = prev.balance[a]
+	require.True(t, ok)
+	assert.Equal(t, *uint256.NewInt(7), bw.Val)
+
+	// Double release and nil-map release must not panic.
+	prev.ReleaseMaps()
+	prev.ReleaseMaps()
+}
+
+func TestVersionedIOReleaseOutputMaps(t *testing.T) {
+	io := NewVersionedIO(2)
+	ws, _ := mergeIntoFixture()
+	io.RecordWrites(Version{TxIndex: 0}, ws)
+
+	require.NotZero(t, io.WriteCount())
+	io.ReleaseOutputMaps()
+
+	// Read the slots directly: the accessors panic under assertions once the
+	// outputs are released, which is the point of the guard.
+	for _, output := range io.outputs {
+		assert.True(t, output.IsEmpty(), "slots must be empty after release")
+	}
+
+	// Empty and already-released IO must not panic.
+	io.ReleaseOutputMaps()
+	NewVersionedIO(1).ReleaseOutputMaps()
+}
+
+// The apply-loop fee-merge pipeline around the merge itself: record the tx
+// write set into VersionedIO, merge the calcFees output, re-record, flush the
+// merged set into the VersionMap. Build cost of the inputs is identical in
+// both variants and included in the measured loop, since MergeInto consumes
+// next.
+func benchVersionedFeeMerge(b *testing.B, addrs, slots int, merge func(prev, next *WriteSet) *WriteSet) {
+	io := NewVersionedIO(1)
+	vm := NewVersionMap(nil)
+	version := Version{TxIndex: 0, Incarnation: 1}
+	b.ReportAllocs()
+	for b.Loop() {
+		txOut, tip := buildMergeBenchSets(addrs, slots)
+		io.RecordWrites(version, txOut)
+		merged := merge(txOut, tip)
+		io.RecordWrites(version, merged)
+		vm.FlushVersionedWrites(merged, true, "")
+		sinkWS = merged
+	}
+}
+
+func BenchmarkVersionedFeeMergeClone(b *testing.B) {
+	for _, size := range []struct{ addrs, slots int }{{4, 2}, {16, 8}} {
+		b.Run(fmt.Sprintf("addrs=%d/slots=%d", size.addrs, size.slots), func(b *testing.B) {
+			benchVersionedFeeMerge(b, size.addrs, size.slots, (*WriteSet).Merge)
+		})
+	}
+}
+
+func BenchmarkVersionedFeeMergeInto(b *testing.B) {
+	for _, size := range []struct{ addrs, slots int }{{4, 2}, {16, 8}} {
+		b.Run(fmt.Sprintf("addrs=%d/slots=%d", size.addrs, size.slots), func(b *testing.B) {
+			benchVersionedFeeMerge(b, size.addrs, size.slots, (*WriteSet).MergeInto)
+		})
+	}
+}
+
+var sinkWS *WriteSet


### PR DESCRIPTION
Cherry-pick of #22883 to release/3.6.

Motivation: on `dev-bm-bench-n2` (release/3.6) high-conflict blocks produce newPayload spikes up to 2161ms while `dev-bm-bench-n1` (release/3.5) stays at ~450ms on the same blocks. CPU profiles over the same 75s window show `blockExecutor.nextResult` at 2.11s on 3.6 vs 0.16s on 3.5, of which `MergeVersionedWrites` -> `WriteSet.Merge` -> `copyFrom` is 1.17s vs 0.04s. `Merge` allocates a fresh WriteSet and deep-copies both sides on every tx result, so the cost scales with re-executions. In a calm window (repeat% < 40) 3.6 is cheaper than 3.5, so the regression is conflict-only.

## r3.6-specific adaptations

release/3.6 has no `parallelExecutor.recordBlockExecMetrics` helper — the write-count comment sits at the inline metrics site in `execLoop` instead. Everything else applies unchanged; the net diff is identical to the merged commit 2ab92b3d26 (4 files, 668 insertions, 21 deletions).