### PR TITLE
execution/state: assert the warm-read fast path never serves a destructed account

### DIFF
--- a/execution/state/read_paths.go
+++ b/execution/state/read_paths.go
@@ -763,7 +763,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 // to resolve sibling-account reads without taking a typed callback.
 func readAccountInternal(s *IntraBlockState, addr accounts.Address) (*accounts.Account, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetAddress(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetAddress(addr); ok && s.warmHit(addr, tr.Source) {
 			if tr.Val != nil {
 				return tr.Val.Account(), tr.Source, tr.Version, nil
 			}
@@ -814,11 +814,33 @@ func (s *IntraBlockState) warmReadable(addr accounts.Address) bool {
 	return !dirty
 }
 
+// warmHit reports whether a recorded read may be served for addr.
+func (s *IntraBlockState) warmHit(addr accounts.Address, src ReadSource) bool {
+	if !warmSource(src) {
+		return false
+	}
+	if dbg.AssertEnabled {
+		assertNoDeletedResident(s.stateObjects, addr)
+	}
+	return true
+}
+
+// assertNoDeletedResident pins what the read-once fast path depends on: a
+// versioned IBS that also materializes stateObjects can hold an object deleted
+// by a prior tx's selfdestruct, and serving a recorded read for that address
+// would return its pre-destruct value. Tx-execution paths run versioned with
+// noMaterialize, which keeps stateObjects empty and the case unreachable.
+func assertNoDeletedResident(stateObjects map[accounts.Address]*stateObject, addr accounts.Address) {
+	if so, ok := stateObjects[addr]; ok && so.deleted {
+		panic(fmt.Sprintf("assert: warm read of %x with a deleted resident object; versioned tx execution must set noMaterialize", addr))
+	}
+}
+
 // readBalance returns the address's balance using the version-aware
 // read pipeline.  Inlines the storage-read fallback.
 func readBalance(s *IntraBlockState, addr accounts.Address) (uint256.Int, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetBalance(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetBalance(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}
@@ -865,7 +887,7 @@ func readBalance(s *IntraBlockState, addr accounts.Address) (uint256.Int, ReadSo
 // recordVR, records the read with currentBalance as the typed default.
 func refreshBalance(s *IntraBlockState, addr accounts.Address, currentBalance uint256.Int) (uint256.Int, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetBalance(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetBalance(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}
@@ -906,7 +928,7 @@ func refreshBalance(s *IntraBlockState, addr accounts.Address, currentBalance ui
 // readNonce returns the nonce using the version-aware read pipeline.
 func readNonce(s *IntraBlockState, addr accounts.Address) (uint64, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetNonce(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetNonce(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}
@@ -950,7 +972,7 @@ func readNonce(s *IntraBlockState, addr accounts.Address) (uint64, ReadSource, V
 
 func refreshNonce(s *IntraBlockState, addr accounts.Address, currentNonce uint64) (uint64, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetNonce(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetNonce(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}
@@ -985,7 +1007,7 @@ func refreshNonce(s *IntraBlockState, addr accounts.Address, currentNonce uint64
 // readIncarnation returns the incarnation counter.
 func readIncarnation(s *IntraBlockState, addr accounts.Address) (uint64, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetIncarnation(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetIncarnation(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}
@@ -1057,7 +1079,7 @@ func refreshIncarnation(s *IntraBlockState, addr accounts.Address, currentIncarn
 // the version-aware lookup honours the committed-only contract.
 func readCode(s *IntraBlockState, addr accounts.Address, commited bool) ([]byte, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetCode(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetCode(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}
@@ -1156,7 +1178,7 @@ func (c refreshedCode) codeHash(source ReadSource, accountHash accounts.CodeHash
 // readCodeSize returns the contract code size.
 func readCodeSize(s *IntraBlockState, addr accounts.Address) (int, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetCodeSize(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetCodeSize(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}
@@ -1211,7 +1233,7 @@ func readCodeSize(s *IntraBlockState, addr accounts.Address) (int, ReadSource, V
 // readCodeHash returns the contract code hash.
 func readCodeHash(s *IntraBlockState, addr accounts.Address) (accounts.CodeHash, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetCodeHash(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetCodeHash(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}
@@ -1258,7 +1280,7 @@ func readCodeHash(s *IntraBlockState, addr accounts.Address) (accounts.CodeHash,
 // refreshCodeHash is the in-memory-only variant for CodeHashPath.
 func refreshCodeHash(s *IntraBlockState, addr accounts.Address, currentHash accounts.CodeHash) (accounts.CodeHash, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetCodeHash(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetCodeHash(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}
@@ -1400,7 +1422,7 @@ func readCommittedState(s *IntraBlockState, addr accounts.Address, key accounts.
 // readSelfDestruct returns whether the account is selfdestructed.
 func readSelfDestruct(s *IntraBlockState, addr accounts.Address) (bool, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
-		if tr, ok := s.versionedReads.GetSelfDestruct(addr); ok && warmSource(tr.Source) {
+		if tr, ok := s.versionedReads.GetSelfDestruct(addr); ok && s.warmHit(addr, tr.Source) {
 			return tr.Val, tr.Source, tr.Version, nil
 		}
 	}

--- a/execution/state/warm_read_invariant_test.go
+++ b/execution/state/warm_read_invariant_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// The assert is checked directly rather than through warmReadable so the test
+// does not depend on the process-wide dbg.AssertEnabled flag.
+func TestAssertNoDeletedResident(t *testing.T) {
+	t.Parallel()
+	addr := accounts.InternAddress([20]byte{0x01})
+	other := accounts.InternAddress([20]byte{0x02})
+
+	objects := map[accounts.Address]*stateObject{}
+	assert.NotPanics(t, func() { assertNoDeletedResident(objects, addr) },
+		"no resident object: nothing to serve stale")
+
+	objects[addr] = &stateObject{}
+	assert.NotPanics(t, func() { assertNoDeletedResident(objects, addr) },
+		"live resident object is fine")
+
+	objects[addr] = &stateObject{deleted: true}
+	assert.Panics(t, func() { assertNoDeletedResident(objects, addr) },
+		"deleted resident object must trip the assert")
+
+	assert.NotPanics(t, func() { assertNoDeletedResident(objects, other) },
+		"a different address is unaffected")
+}


### PR DESCRIPTION
The read-once fast path added in #22409 returns a recorded read without re-consulting the version map:

```go
if s.warmReadable(addr) {
    if tr, ok := s.versionedReads.GetCodeHash(addr); ok && warmSource(tr.Source) {
        return tr.Val, ...
    }
}
```

`versionedReadCore` checks one thing ahead of its own read-once branch that this does not: a resident `stateObject` marked `deleted`, which `getStateObject` parks when a prior tx's selfdestruct becomes visible. Serving a recorded read for such an address returns its pre-destruct value.

That is safe today because tx-execution paths run versioned with `noMaterialize`, so `stateObjects` stays empty and no object is ever parked. Nothing states or checks that invariant.

## Change

The eleven gate sites now go through `warmHit`, which asserts it under `dbg.AssertEnabled`. No cost when assertions are off, which matters — these are hot read paths, and a real map lookup here measured +4-8% on warm account reads.

## Evidence

The **window** — deleted resident object, address not dirty — does occur, under `chain_makers`-driven execution (`TestCreate2Polymorth`, `TestCustomTraceReceiptDomain`, `TestInsertChain_TxGasExceedsBlockGasLimit_RejectsOnBothPaths`). An earlier, broader version of this assert that fired on the window alone tripped on all three.

The **hazard** — a recorded read actually served inside that window — does not. With the assert narrowed to the moment a value is about to be returned, `execution/state`, `stagedsync`, `tests` and `execmodule` are all green under `ERIGON_ASSERT=true`, plus `execution/state -race`.

So this guards a live edge, not an impossible one: the parallel executor and block builder are immune by construction (`noMaterialize`), and the serial executor has no version map at all, but versioned+materialized configurations do execute transactions.

## Note for #22993

#22993 adds the same fast path for storage, guarded by `warmStorageReadable`, which returns false when the resident object is deleted. The two compose: the storage gate bails out before the inner condition is evaluated, so `warmHit` is not reached and does not fire on the case that gate handles correctly. `TestVersionMapReadWriteDelete` covers it.