### PR TITLE
execution/execmodule: drain read-ahead only before an actual unwind

### DIFF
--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -170,6 +170,7 @@ func (e *ExecModule) unwindIfNeeded(
 	canonicalHash common.Hash,
 	finishProgressBefore uint64,
 	isSynced bool,
+	suspendReadAhead func() error,
 ) (*ForkChoiceResult, error) {
 	var finalisedBlockNum uint64
 	lastKnownFinalisedHash := rawdb.ReadForkchoiceFinalized(tx)
@@ -279,6 +280,9 @@ func (e *ExecModule) unwindIfNeeded(
 				Status:          ExecutionStatusReorgTooDeep,
 			}, nil
 		}
+		if err := suspendReadAhead(); err != nil {
+			return nil, fmt.Errorf("suspend read-ahead: %w", err)
+		}
 		if err := e.pipelineExecutor.UnwindTo(unwindTarget, stagedsync.ForkChoice, tx); err != nil {
 			return nil, err
 		}
@@ -360,11 +364,20 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	})
 	defer cleanupBeforeSemaRelease()
 
-	resumeReadAhead, err := e.suspendReadAhead(ctx)
-	if err != nil {
-		return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, fmt.Errorf("suspend read-ahead: %w", err), false)
+	var resumeReadAhead func()
+	defer func() {
+		if resumeReadAhead != nil {
+			resumeReadAhead()
+		}
+	}()
+	suspendReadAhead := func() error {
+		resume, err := e.suspendReadAhead(ctx)
+		if err != nil {
+			return err
+		}
+		resumeReadAhead = resume
+		return nil
 	}
-	defer resumeReadAhead()
 
 	var validationError string
 
@@ -489,7 +502,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 	}
 
-	result, err := e.unwindIfNeeded(ctx, tx, currentContext, fcuHeader, blockHash, safeHash, finalizedHash, canonicalHash, finishProgressBefore, isSynced)
+	result, err := e.unwindIfNeeded(ctx, tx, currentContext, fcuHeader, blockHash, safeHash, finalizedHash, canonicalHash, finishProgressBefore, isSynced, suspendReadAhead)
 	if err != nil {
 		return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 	}


### PR DESCRIPTION
Stacked on #22444 (base branch: `test/statecache-delete-rpc-repro`); draft until it merges. Performance change, not a fix — it depends on #22444's fill admission for its safety argument.

## What

`updateForkChoice` drained any in-flight read-ahead warmup at the top of **every** FCU — duplicate and non-reorg FCUs included — blocking the tip hot path on the preceding newPayload's full warmup. This moves the drain into `unwindIfNeeded`'s unwind branch, so only an actual reorg waits.

## Why it is safe

- **Forward direction:** with #22444, a laggard warmup fill is admission-ordered against the flush cache-apply (`frontier >= appliedEnd` under the same lock), so nothing needs to wait for it.
- **Unwind direction:** still needs the drain — an unwind lowers the applied frontier, so a pre-unwind view passes admission and would pin a dead-fork value under the live epoch. The drain now sits immediately before `UnwindTo`/`RunUnwind`, matching `unwindToCommonCanonical` and `SetHead`, which already drain there.
- **Same window:** no new warmup can start while the FCU holds the semaphore, so draining at the unwind site bounds the same set of in-flight warmups as draining at FCU entry did.
- `forkValidator.ClearWithUnwind` (the deferred FCU cleanup) only clears fork-validator bookkeeping — no cache epoch bump — so no other epoch-bump site in the FCU flow needs the drain.

## Testing

`go test ./execution/execmodule/ ./execution/exec/` and `-race` over the Unwind/ForkChoice/SetHead tests; `make lint` clean.
