### PR TITLE
db/state/execctx: record getter code reads in the getter's metrics

### DIFF
--- a/db/state/aggregator.go
+++ b/db/state/aggregator.go
@@ -2742,6 +2742,10 @@ func (at *AggregatorRoTx) GetLatestValSize(domain kv.Domain, k []byte, tx kv.Tx)
 	return at.d[domain].GetLatestValSize(k, tx)
 }
 
+func (at *AggregatorRoTx) MeteredGetLatestValSize(domain kv.Domain, k []byte, tx kv.Tx, metrics *kvmetrics.DomainMetrics, start time.Time) (size int, ok bool, err error) {
+	return at.d[domain].getLatestValSize(k, tx, metrics, start)
+}
+
 // MeteredGetLatestWithTxN returns the high-water txN alongside (value,
 // step) for tagging BranchCache entries so a lazy unwind can drop them by
 // (txN, epoch). Non-CommitmentDomain reads return txN=0.

--- a/db/state/domain.go
+++ b/db/state/domain.go
@@ -1560,6 +1560,10 @@ func (dt *DomainRoTx) getLatestFromFilesValSize(k []byte, maxTxNum uint64) (size
 }
 
 func (dt *DomainRoTx) GetLatestValSize(key []byte, roTx kv.Tx) (size int, found bool, err error) {
+	return dt.getLatestValSize(key, roTx, nil, time.Time{})
+}
+
+func (dt *DomainRoTx) getLatestValSize(key []byte, roTx kv.Tx, metrics *kvmetrics.DomainMetrics, start time.Time) (size int, found bool, err error) {
 	if dt.d.Disable {
 		return 0, false, nil
 	}
@@ -1568,9 +1572,16 @@ func (dt *DomainRoTx) GetLatestValSize(key []byte, roTx kv.Tx) (size int, found 
 		return 0, false, fmt.Errorf("getLatestFromDb: %w", err)
 	}
 	if found {
+		if metrics != nil && dbg.KVReadLevelledMetrics {
+			metrics.UpdateDbReads(dt.name, start)
+		}
 		return len(v), true, nil
 	}
-	return dt.getLatestFromFilesValSize(key, 0)
+	size, found, err = dt.getLatestFromFilesValSize(key, 0)
+	if metrics != nil && dbg.KVReadLevelledMetrics {
+		metrics.UpdateFileReadsUnique(dt.name, key, start)
+	}
+	return size, found, err
 }
 
 // Returns the first txNum from available history

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -630,7 +630,7 @@ func (gt *temporalGetter) GetLatestContext(ctx context.Context, name kv.Domain, 
 // so the existing kv.TemporalGetter interface is unchanged. txNum is the
 // caller's read txNum, used to stamp any cache entry it populates.
 func (gt *temporalGetter) GetCodeSize(addr []byte, txNum uint64) (int, bool, error) {
-	return gt.sd.getCodeSize(gt.tx, gt.view, addr, txNum)
+	return gt.sd.getCodeSize(gt.tx, gt.view, gt.m, addr, txNum)
 }
 
 // GetCode returns contract code via the content-addressed fast path (see
@@ -640,7 +640,7 @@ func (gt *temporalGetter) GetCodeSize(addr []byte, txNum uint64) (int, bool, err
 // (they resolve prevVal through GetLatest, which is addr-keyed). txNum is the
 // caller's read txNum, used to stamp any cache entry it populates.
 func (gt *temporalGetter) GetCode(addr []byte, txNum uint64) ([]byte, bool, error) {
-	return gt.sd.getCode(gt.tx, gt.view, addr, txNum)
+	return gt.sd.getCode(gt.tx, gt.view, gt.m, addr, txNum)
 }
 
 func (gt *temporalGetter) HasPrefix(name kv.Domain, prefix []byte) (firstKey []byte, firstVal []byte, ok bool, err error) {
@@ -1559,10 +1559,10 @@ func (sd *SharedDomains) getLatestMetered(domain kv.Domain, tx kv.TemporalTx, k 
 // Returns (size, true, nil) on success and (0, false, nil) only when
 // CodeDomain itself confirms no code.
 func (sd *SharedDomains) GetCodeSize(tx kv.TemporalTx, addr []byte, txNum uint64) (int, bool, error) {
-	return sd.getCodeSize(tx, sd.cacheReader(), addr, txNum)
+	return sd.getCodeSize(tx, sd.cacheReader(), nil, addr, txNum)
 }
 
-func (sd *SharedDomains) getCodeSize(tx kv.TemporalTx, view cache.ReadView, addr []byte, txNum uint64) (int, bool, error) {
+func (sd *SharedDomains) getCodeSize(tx kv.TemporalTx, view cache.ReadView, wm *kvmetrics.DomainMetrics, addr []byte, txNum uint64) (int, bool, error) {
 	if tx == nil {
 		return 0, false, errors.New("sd.GetCodeSize: unexpected nil tx")
 	}
@@ -1584,7 +1584,7 @@ func (sd *SharedDomains) getCodeSize(tx kv.TemporalTx, view cache.ReadView, addr
 		}
 	}
 
-	size, found, answered, err := sd.getLatestValSize(kv.CodeDomain, tx, addr, view)
+	size, found, answered, err := sd.getLatestValSize(kv.CodeDomain, tx, addr, wm, view)
 	if err != nil {
 		return 0, false, err
 	}
@@ -1598,7 +1598,7 @@ func (sd *SharedDomains) getCodeSize(tx kv.TemporalTx, view cache.ReadView, addr
 		return size, true, nil
 	}
 
-	v, _, err := sd.getLatestMetered(kv.CodeDomain, tx, addr, nil, view, withCodeHash(codeHash))
+	v, _, err := sd.getLatestMetered(kv.CodeDomain, tx, addr, wm, view, withCodeHash(codeHash))
 	if err != nil {
 		return 0, false, err
 	}
@@ -1608,20 +1608,45 @@ func (sd *SharedDomains) getCodeSize(tx kv.TemporalTx, view cache.ReadView, addr
 	return len(v), true, nil
 }
 
-func (sd *SharedDomains) getLatestValSize(domain kv.Domain, tx kv.TemporalTx, k []byte, view cache.ReadView) (size int, found bool, answered bool, err error) {
+func (sd *SharedDomains) getLatestValSize(domain kv.Domain, tx kv.TemporalTx, k []byte, wm *kvmetrics.DomainMetrics, view cache.ReadView) (size int, found bool, answered bool, err error) {
+	var start time.Time
+	if dbg.KVReadLevelledMetrics {
+		start = time.Now()
+		if wm == nil {
+			wm = sd.reqMetrics
+		}
+	}
 	v, _, maxStep, ok := sd.latestFromMem(domain, k)
 	if ok {
+		if dbg.KVReadLevelledMetrics {
+			wm.UpdateCacheReads(domain, start)
+		}
 		return len(v), true, true, nil
 	}
 	if sd.stateCache != nil {
-		if v, txNum, ok := view.GetWithTxNum(domain, k); ok && servableUnderBound(kv.Step(txNum/sd.StepSize()), maxStep) {
+		v, txNum, ok := view.GetWithTxNum(domain, k)
+		ok = ok && servableUnderBound(kv.Step(txNum/sd.StepSize()), maxStep)
+		if ok {
+			if dbg.KVReadLevelledMetrics {
+				wm.UpdateStateCacheHit(domain)
+			}
 			return len(v), true, true, nil
 		}
 	}
 	if maxStep != kv.NoStepBound {
 		return 0, false, false, nil
 	}
-	size, found, err = tx.GetLatestValSize(domain, k)
+	if dbg.KVReadLevelledMetrics && sd.stateCache != nil {
+		wm.UpdateStateCacheMiss(domain)
+	}
+	type meteredValSizeGetter interface {
+		MeteredGetLatestValSize(domain kv.Domain, k []byte, tx kv.Tx, metrics *kvmetrics.DomainMetrics, start time.Time) (int, bool, error)
+	}
+	if getter, ok := tx.AggTx().(meteredValSizeGetter); ok {
+		size, found, err = getter.MeteredGetLatestValSize(domain, k, tx, wm, start)
+	} else {
+		size, found, err = tx.GetLatestValSize(domain, k)
+	}
 	return size, found, true, err
 }
 
@@ -1640,10 +1665,10 @@ func (sd *SharedDomains) getLatestValSize(domain kv.Domain, tx kv.TemporalTx, k 
 // the write. Setters therefore resolve prevVal through GetLatest, which is
 // addr-keyed (domain-faithful); only getters use this codeHash shortcut.
 func (sd *SharedDomains) GetCode(tx kv.TemporalTx, addr []byte, txNum uint64) ([]byte, bool, error) {
-	return sd.getCode(tx, sd.cacheReader(), addr, txNum)
+	return sd.getCode(tx, sd.cacheReader(), nil, addr, txNum)
 }
 
-func (sd *SharedDomains) getCode(tx kv.TemporalTx, view cache.ReadView, addr []byte, txNum uint64) ([]byte, bool, error) {
+func (sd *SharedDomains) getCode(tx kv.TemporalTx, view cache.ReadView, wm *kvmetrics.DomainMetrics, addr []byte, txNum uint64) ([]byte, bool, error) {
 	if tx == nil {
 		return nil, false, errors.New("sd.GetCode: unexpected nil tx")
 	}
@@ -1669,7 +1694,7 @@ func (sd *SharedDomains) getCode(tx kv.TemporalTx, view cache.ReadView, addr []b
 	}
 
 	// Cold path: authoritative addr-keyed read (also populates the caches).
-	v, _, err := sd.getLatestMetered(kv.CodeDomain, tx, addr, nil, view, withCodeHash(codeHash))
+	v, _, err := sd.getLatestMetered(kv.CodeDomain, tx, addr, wm, view, withCodeHash(codeHash))
 	if err != nil {
 		return nil, false, err
 	}

--- a/db/state/execctx/statecache_readfill_test.go
+++ b/db/state/execctx/statecache_readfill_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/db/state/kvmetrics"
 	"github.com/erigontech/erigon/execution/cache"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
@@ -761,4 +762,53 @@ func TestGuardAggregatorForCache_ApplyOnlySkips(t *testing.T) {
 	f := &fakeForbidder{}
 	execctx.GuardAggregatorForCache(fakeHasAgg{f}, sc)
 	require.False(t, f.called)
+}
+
+// Getter code reads must record into the getter's own metrics instance, like
+// every other read through getLatestMetered.
+func TestGetterCodeReadsAreMetered(t *testing.T) {
+	old := dbg.KVReadLevelledMetrics
+	dbg.KVReadLevelledMetrics = true
+	t.Cleanup(func() { dbg.KVReadLevelledMetrics = old })
+
+	const stepSize = uint64(16)
+	ctx := t.Context()
+	db := newTestDb(t, stepSize)
+
+	addr := make([]byte, 20)
+	addr[0] = 0xcd
+	code := []byte{0xaa, 9, 9, 9}
+
+	rwTx, err := db.BeginTemporalRw(ctx)
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	sd, err := execctx.NewSharedDomains(ctx, rwTx, log.New())
+	require.NoError(t, err)
+	defer sd.Close()
+	sd.SetTxNum(10)
+	require.NoError(t, sd.DomainPut(kv.CodeDomain, rwTx, addr, code, 10, nil))
+	require.NoError(t, sd.Commit(ctx, rwTx))
+	sd.Close()
+
+	roTx, err := db.BeginTemporalRo(ctx)
+	require.NoError(t, err)
+	defer roTx.Rollback()
+	sd2, err := execctx.NewSharedDomains(ctx, roTx, log.New())
+	require.NoError(t, err)
+	defer sd2.Close()
+
+	wm := kvmetrics.NewDomainMetrics()
+	getter := sd2.AsGetterMetered(roTx, wm)
+	sizer, ok := getter.(interface {
+		GetCodeSize(addr []byte, txNum uint64) (int, bool, error)
+	})
+	require.True(t, ok)
+	size, found, err := sizer.GetCodeSize(addr, 20)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, len(code), size)
+
+	wm.RLock()
+	defer wm.RUnlock()
+	require.NotNil(t, wm.Domains[kv.CodeDomain], "the code read must be recorded in the getter's metrics")
 }


### PR DESCRIPTION
Stacked on #22444 (split out per review — unrelated to fill admission). `GetCode`/`GetCodeSize` reached `getLatestMetered` via the nil-metrics `GetLatest` wrapper, so code reads never appeared in the per-worker accounting that every other getter read feeds. Thread the getter's metrics through; plain `SharedDomains` wrappers keep passing nil. Focused red-green test included (`TestGetterCodeReadsAreMetered`); metering is inert unless `KV_READ_METRICS` is enabled, which the test toggles.