### PR TITLE
[r3.6] exec: drop eager formatting from hot paths

### DIFF
--- a/execution/protocol/txn_executor.go
+++ b/execution/protocol/txn_executor.go
@@ -84,6 +84,21 @@ func (e ErrExecAbortError) IsError() bool {
 	return e.OriginError != nil
 }
 
+// nonceError formats lazily: under parallel execution a nonce mismatch is a
+// routine re-execution signal whose text is discarded.
+type nonceError struct {
+	err        error // ErrNonceTooHigh or ErrNonceTooLow
+	from       accounts.Address
+	txNonce    uint64
+	stateNonce uint64
+}
+
+func (e *nonceError) Error() string {
+	return fmt.Sprintf("%s: address %v, tx: %d state: %d", e.err, e.from, e.txNonce, e.stateNonce)
+}
+
+func (e *nonceError) Unwrap() error { return e.err }
+
 type TxnExecutor struct {
 	gp                  *GasPool
 	msg                 Message
@@ -290,11 +305,9 @@ func (st *TxnExecutor) preCheck(gasBailout bool, intrinsicGasResult mdgas.Intrin
 			return fmt.Errorf("%w: %w", ErrTxnExecutionFailed, err)
 		}
 		if msgNonce := st.msg.Nonce(); stNonce < msgNonce {
-			return fmt.Errorf("%w: address %v, tx: %d state: %d", ErrNonceTooHigh,
-				from, msgNonce, stNonce)
+			return &nonceError{err: ErrNonceTooHigh, from: from, txNonce: msgNonce, stateNonce: stNonce}
 		} else if stNonce > msgNonce {
-			return fmt.Errorf("%w: address %v, tx: %d state: %d", ErrNonceTooLow,
-				from, msgNonce, stNonce)
+			return &nonceError{err: ErrNonceTooLow, from: from, txNonce: msgNonce, stateNonce: stNonce}
 		} else if stNonce+1 < stNonce {
 			return fmt.Errorf("%w: address %v, nonce: %d", ErrNonceMax,
 				from, stNonce)
@@ -391,7 +404,7 @@ func (st *TxnExecutor) ApplyFrame() (*evmtypes.ExecutionResult, error) {
 
 	// set code tx
 	auths := msg.Authorizations()
-	verifiedAuthorities, stateIgasRefill, err := st.verifyAuthorities(auths, contractCreation, rules.ChainID.String())
+	verifiedAuthorities, stateIgasRefill, err := st.verifyAuthorities(auths, contractCreation, rules.ChainID)
 	if err != nil {
 		return nil, err
 	}
@@ -555,7 +568,7 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 		return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.msg.Gas(), intrinsicGas)
 	}
 
-	verifiedAuthorities, stateIgasRefill, err := st.verifyAuthorities(auths, contractCreation, rules.ChainID.String())
+	verifiedAuthorities, stateIgasRefill, err := st.verifyAuthorities(auths, contractCreation, rules.ChainID)
 	if err != nil {
 		return nil, err
 	}
@@ -726,7 +739,7 @@ func (st *TxnExecutor) Execute(refunds bool, gasBailout bool) (result *evmtypes.
 	return result, nil
 }
 
-func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCreation bool, chainID string) ([]accounts.Address, uint64, error) {
+func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCreation bool, chainID *uint256.Int) ([]accounts.Address, uint64, error) {
 	var stateIgasRefill uint64
 	verifiedAuthorities := make([]accounts.Address, 0)
 	if auths != nil {
@@ -753,7 +766,7 @@ func (st *TxnExecutor) verifyAuthorities(auths []types.Authorization, contractCr
 			data.Reset()
 
 			// 1. chainId check
-			if !auth.ChainID.IsZero() && chainID != auth.ChainID.String() {
+			if !auth.ChainID.IsZero() && !auth.ChainID.Eq(chainID) {
 				log.Debug("invalid chainID, skipping", "chainId", auth.ChainID, "auth index", i)
 				refundSkippedAuth()
 				continue

--- a/execution/protocol/txn_executor_test.go
+++ b/execution/protocol/txn_executor_test.go
@@ -24,9 +24,11 @@ import (
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/mdgas"
 	"github.com/erigontech/erigon/execution/protocol/misc"
 	"github.com/erigontech/erigon/execution/protocol/params"
 	"github.com/erigontech/erigon/execution/state"
+	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
 	"github.com/erigontech/erigon/execution/vm"
@@ -345,4 +347,56 @@ func TestBuyGas_NilMaxFeePerBlobGasWithBlobs(t *testing.T) {
 	var err error
 	require.NotPanics(t, func() { err = st.buyGas(false) })
 	require.NoError(t, err)
+}
+
+// TestPreCheckNonceMismatchError pins the message text and the errors.Is
+// identity that block assembly and eth_simulate match on. The sender address
+// carries letters so the pinned text also covers EIP-55 casing.
+func TestPreCheckNonceMismatchError(t *testing.T) {
+	t.Parallel()
+
+	sender := accounts.InternAddress(common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"))
+	recipient := accounts.InternAddress(common.HexToAddress("0x2222222222222222222222222222222222222222"))
+
+	preCheckWithNonce := func(t *testing.T, stateNonce, msgNonce uint64) error {
+		t.Helper()
+		ibs := state.New(state.NewNoopReader())
+		require.NoError(t, ibs.SetNonce(sender, stateNonce, tracing.NonceChangeGenesis))
+
+		evm := newTestEVM(ibs, chain.TestChainOsakaConfig, 30_000_000)
+		msg := types.NewMessage(
+			sender, recipient, msgNonce, uint256.NewInt(0), 100_000,
+			uint256.NewInt(0), uint256.NewInt(0), uint256.NewInt(0),
+			nil, nil,
+			true,  // checkNonce
+			false, // checkTransaction
+			false, // checkGas
+			false, // isFree
+			nil,   // maxFeePerBlobGas
+		)
+		st := NewTxnExecutor(evm, msg, new(GasPool).AddGas(30_000_000))
+		return st.preCheck(false, mdgas.IntrinsicGasCalcResult{})
+	}
+
+	t.Run("nonce too high", func(t *testing.T) {
+		err := preCheckWithNonce(t, 3, 7)
+		require.ErrorIs(t, err, ErrNonceTooHigh)
+		require.NotErrorIs(t, err, ErrNonceTooLow)
+		require.Equal(t,
+			"nonce too high: address 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF, tx: 7 state: 3",
+			err.Error())
+	})
+
+	t.Run("nonce too low", func(t *testing.T) {
+		err := preCheckWithNonce(t, 7, 3)
+		require.ErrorIs(t, err, ErrNonceTooLow)
+		require.NotErrorIs(t, err, ErrNonceTooHigh)
+		require.Equal(t,
+			"nonce too low: address 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF, tx: 3 state: 7",
+			err.Error())
+	})
+
+	t.Run("matching nonce passes", func(t *testing.T) {
+		require.NoError(t, preCheckWithNonce(t, 5, 5))
+	})
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2594,10 +2594,8 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			}
 		}
 
-		tracePrefix := fmt.Sprintf("%d (%d.%d)", be.blockNum, txVersion.TxIndex, txVersion.Incarnation)
-
-		var trace bool
-		if trace = dbg.TraceTransactionIO && dbg.TraceTx(be.blockNum, txVersion.TxIndex); trace {
+		if dbg.TraceTransactionIO && dbg.TraceTx(be.blockNum, txVersion.TxIndex) {
+			tracePrefix := fmt.Sprintf("%d (%d.%d)", be.blockNum, txVersion.TxIndex, txVersion.Incarnation)
 			fmt.Println(tracePrefix, "RD", be.blockIO.ReadSet(txVersion.TxIndex).Len(), "WRT", be.blockIO.WriteSet(txVersion.TxIndex).Count())
 			be.blockIO.ReadSet(txVersion.TxIndex).TraceReads(tracePrefix)
 			for h := range be.blockIO.WriteSet(txVersion.TxIndex).AllHeaders() {


### PR DESCRIPTION
Cherry-pick of #22953 to release/3.6.

Relevant to the newPayload spikes on `dev-bm-bench-n2`: the `fmt.Sprintf` sits in `blockExecutor.nextResult`, which CPU profiles show is the serial bottleneck on high-conflict blocks (2.11s of exec-loop CPU in a 75s window vs 0.16s on release/3.5). The `fmt.Errorf` fires on every speculative nonce miss, and those blocks run ~1.07k invalidations each.

## r3.6-specific adaptations

- `verifyAuthorities` has a different signature on release/3.6 (returns `([]accounts.Address, uint64, error)`, no `gasRemaining` parameter); only the `chainID string` -> `chainID *uint256.Int` part was taken.
- The added characterization test drops `defer ibs.Close()` (`IntraBlockState.Close` is main-only, #22777) and imports `mdgas`/`tracing` explicitly. It passes on release/3.6 and pins the error text byte for byte.