### PR TITLE
[r3.6] rawdb: receiptWriter - to hold long-living buffers, avoid per-tx allocs

### DIFF
--- a/db/kv/kv_interface.go
+++ b/db/kv/kv_interface.go
@@ -618,6 +618,9 @@ type CanReopenUnderlyingFilesTx interface {
 	ForceReopenUnderlyingFilesTx()
 }
 
+// TemporalPutDel does not borrow `k`/`v`/`prevVal` past the call: an
+// implementation that keeps them must copy. Callers are free to hand it reused
+// scratch, and some do.
 type TemporalPutDel interface {
 	// DomainPut
 	// Optimizations:

--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -31,7 +31,6 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
-	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -39,6 +38,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/db/kv/rawdbv3"
 	"github.com/erigontech/erigon/db/kv/stream"
+	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/rawdb/utils"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
@@ -1253,7 +1253,7 @@ type RCacheV2Query struct {
 
 // doesn't do DeriveFieldsV4ForCachedReceipt
 func ReceiptCacheV2Stream(tx kv.TemporalTx, fromTxNum, toTxNum uint64) (stream.Duo[uint64, *types.Receipt], error) {
-	it, err := tx.Debug().TraceKey(kv.RCacheDomain, receiptCacheKey, fromTxNum, toTxNum)
+	it, err := tx.Debug().TraceKey(kv.RCacheDomain, rawtemporaldb.ReceiptCacheKey, fromTxNum, toTxNum)
 	if err != nil {
 		return nil, err
 	}
@@ -1276,7 +1276,7 @@ func ReceiptCacheV2Stream(tx kv.TemporalTx, fromTxNum, toTxNum uint64) (stream.D
 }
 
 func ReadReceiptCacheV2(tx kv.TemporalTx, query RCacheV2Query) (*types.Receipt, bool, error) {
-	v, ok, err := tx.HistorySeek(kv.RCacheDomain, receiptCacheKey, query.TxNum+1 /*history storing value BEFORE-change*/)
+	v, ok, err := tx.HistorySeek(kv.RCacheDomain, rawtemporaldb.ReceiptCacheKey, query.TxNum+1 /*history storing value BEFORE-change*/)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1313,7 +1313,7 @@ func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdb
 
 	receiptIdx := 0
 	for txNum := minTxNum; txNum < maxTxNum+1; txNum++ {
-		v, ok, err := tx.HistorySeek(kv.RCacheDomain, receiptCacheKey, txNum+1)
+		v, ok, err := tx.HistorySeek(kv.RCacheDomain, rawtemporaldb.ReceiptCacheKey, txNum+1)
 		if err != nil {
 			return nil, err
 		}
@@ -1349,45 +1349,6 @@ func ReadReceiptsCacheV2(tx kv.TemporalTx, block *types.Block, txNumReader rawdb
 }
 
 func WriteReceiptCacheV2(tx kv.TemporalPutDel, receipt *types.Receipt, txNum uint64) error {
-	var toWrite []byte
-
-	if receipt != nil {
-		if len(receipt.Logs) > 0 && int(receipt.FirstLogIndexWithinBlock) != int(receipt.Logs[0].Index) {
-			panic(fmt.Sprintf("assert: FirstLogIndexWithinBlock is wrong: %d %d, blockNum=%d", receipt.FirstLogIndexWithinBlock, receipt.Logs[0].Index, receipt.BlockNumber.Uint64()))
-		}
-
-		var err error
-		storageReceipt := (*types.ReceiptForStorage)(receipt)
-		toWrite, err = rlp.EncodeToBytes(storageReceipt)
-		if err != nil {
-			return fmt.Errorf("WriteReceiptCache: %w", err)
-		}
-		if dbg.AssertEnabled {
-			storageReceipt2 := &types.ReceiptForStorage{}
-			if err := rlp.DecodeBytes(toWrite, storageReceipt2); err != nil {
-				panic(fmt.Sprintf("assert: receipt encode/decode round-trip: %v", err))
-			}
-			if storageReceipt.ContractAddress != storageReceipt2.ContractAddress {
-				panic(fmt.Sprintf("assert: %x, %x\n", storageReceipt.ContractAddress, storageReceipt2.ContractAddress))
-			}
-			if storageReceipt.FirstLogIndexWithinBlock != storageReceipt2.FirstLogIndexWithinBlock {
-				panic(fmt.Sprintf("assert: %x, %x\n", storageReceipt.FirstLogIndexWithinBlock, storageReceipt2.FirstLogIndexWithinBlock))
-			}
-			if storageReceipt.TransactionIndex != storageReceipt2.TransactionIndex {
-				panic(fmt.Sprintf("assert: TransactionIndex mismatch: %d, %d\n", storageReceipt.TransactionIndex, storageReceipt2.TransactionIndex))
-			}
-		}
-	} else {
-		toWrite = []byte{}
-	}
-
-	if err := tx.DomainPut(kv.RCacheDomain, receiptCacheKey, toWrite, txNum, nil); err != nil {
-		return fmt.Errorf("WriteReceiptCache: %w", err)
-	}
-
-	return nil
+	var w rawtemporaldb.ReceiptWriter
+	return w.Append(tx, receipt, txNum)
 }
-
-var (
-	receiptCacheKey = []byte{0x0}
-)

--- a/db/rawdb/rawtemporaldb/accessors_receipt.go
+++ b/db/rawdb/rawtemporaldb/accessors_receipt.go
@@ -1,10 +1,15 @@
 package rawtemporaldb
 
 import (
+	"bytes"
 	"encoding/binary"
+	"fmt"
 
+	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
 )
 
 var (
@@ -56,31 +61,76 @@ func ReceiptAsOf(tx kv.TemporalTx, txNum uint64) (cumGasUsed uint64, cumBlobGasu
 	return
 }
 
-func AppendReceipt(tx kv.TemporalPutDel, logIndexAfterTx uint32, cumGasUsedInBlock, cumBlobGasUsed uint64, txNum uint64) error {
-	{
-		var buf [binary.MaxVarintLen64]byte
-		i := binary.PutUvarint(buf[:], cumGasUsedInBlock)
-		if err := tx.DomainPut(kv.ReceiptDomain, CumulativeGasUsedInBlockKey, buf[:i], txNum, nil); err != nil {
-			return err
+// ReceiptCacheKey is the single RCacheDomain key; the value is the encoded receipt.
+var ReceiptCacheKey = []byte{0x0}
+
+// ReceiptWriter is a reusable, single-goroutine encoder for the receipt domains.
+// It hands its own scratch to DomainPut, which does not borrow it - see
+// kv.TemporalPutDel.
+type ReceiptWriter struct {
+	buf          [binary.MaxVarintLen64]byte
+	rlpEncodeBuf bytes.Buffer
+}
+
+// Append stores the receipt in RCacheDomain.
+func (w *ReceiptWriter) Append(tx kv.TemporalPutDel, receipt *types.Receipt, txNum uint64) error {
+	var toWrite []byte
+
+	if receipt != nil {
+		if len(receipt.Logs) > 0 && int(receipt.FirstLogIndexWithinBlock) != int(receipt.Logs[0].Index) {
+			panic(fmt.Sprintf("assert: FirstLogIndexWithinBlock is wrong: %d %d, blockNum=%d", receipt.FirstLogIndexWithinBlock, receipt.Logs[0].Index, receipt.BlockNumber.Uint64()))
 		}
+
+		storageReceipt := (*types.ReceiptForStorage)(receipt)
+		w.rlpEncodeBuf.Reset()
+		if err := rlp.Encode(&w.rlpEncodeBuf, storageReceipt); err != nil {
+			return fmt.Errorf("ReceiptWriter.Append: encode: %w", err)
+		}
+		toWrite = w.rlpEncodeBuf.Bytes()
+		if dbg.AssertEnabled {
+			storageReceipt2 := &types.ReceiptForStorage{}
+			if err := rlp.DecodeBytes(toWrite, storageReceipt2); err != nil {
+				panic(fmt.Sprintf("assert: receipt encode/decode round-trip: %v", err))
+			}
+			if storageReceipt.ContractAddress != storageReceipt2.ContractAddress {
+				panic(fmt.Sprintf("assert: %x, %x\n", storageReceipt.ContractAddress, storageReceipt2.ContractAddress))
+			}
+			if storageReceipt.FirstLogIndexWithinBlock != storageReceipt2.FirstLogIndexWithinBlock {
+				panic(fmt.Sprintf("assert: %x, %x\n", storageReceipt.FirstLogIndexWithinBlock, storageReceipt2.FirstLogIndexWithinBlock))
+			}
+			if storageReceipt.TransactionIndex != storageReceipt2.TransactionIndex {
+				panic(fmt.Sprintf("assert: TransactionIndex mismatch: %d, %d\n", storageReceipt.TransactionIndex, storageReceipt2.TransactionIndex))
+			}
+		}
+	} else {
+		toWrite = []byte{}
 	}
 
-	{
-		var buf [binary.MaxVarintLen64]byte
-		i := binary.PutUvarint(buf[:], cumBlobGasUsed)
-		if err := tx.DomainPut(kv.ReceiptDomain, CumulativeBlobGasUsedInBlockKey, buf[:i], txNum, nil); err != nil {
-			return err
-		}
-	}
-
-	{
-		var buf [binary.MaxVarintLen64]byte
-		i := binary.PutUvarint(buf[:], uint64(logIndexAfterTx))
-		if err := tx.DomainPut(kv.ReceiptDomain, LogIndexAfterTxKey, buf[:i], txNum, nil); err != nil {
-			return err
-		}
+	if err := tx.DomainPut(kv.RCacheDomain, ReceiptCacheKey, toWrite, txNum, nil); err != nil {
+		return fmt.Errorf("ReceiptWriter.Append: %w", err)
 	}
 	return nil
+}
+
+func (w *ReceiptWriter) AppendMetadata(tx kv.TemporalPutDel, logIndexAfterTx uint32, cumGasUsedInBlock, cumBlobGasUsed uint64, txNum uint64) error {
+	i := binary.PutUvarint(w.buf[:], cumGasUsedInBlock)
+	if err := tx.DomainPut(kv.ReceiptDomain, CumulativeGasUsedInBlockKey, w.buf[:i], txNum, nil); err != nil {
+		return err
+	}
+	i = binary.PutUvarint(w.buf[:], cumBlobGasUsed)
+	if err := tx.DomainPut(kv.ReceiptDomain, CumulativeBlobGasUsedInBlockKey, w.buf[:i], txNum, nil); err != nil {
+		return err
+	}
+	i = binary.PutUvarint(w.buf[:], uint64(logIndexAfterTx))
+	if err := tx.DomainPut(kv.ReceiptDomain, LogIndexAfterTxKey, w.buf[:i], txNum, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func AppendReceiptMetadata(tx kv.TemporalPutDel, logIndexAfterTx uint32, cumGasUsedInBlock, cumBlobGasUsed uint64, txNum uint64) error {
+	var w ReceiptWriter
+	return w.AppendMetadata(tx, logIndexAfterTx, cumGasUsedInBlock, cumBlobGasUsed, txNum)
 }
 
 func uvarint(in []byte) (res uint64) {

--- a/db/rawdb/rawtemporaldb/accessors_receipt_test.go
+++ b/db/rawdb/rawtemporaldb/accessors_receipt_test.go
@@ -2,19 +2,25 @@ package rawtemporaldb_test
 
 import (
 	"encoding/binary"
+	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/state/execctx"
+	"github.com/erigontech/erigon/db/state/statecfg"
+	"github.com/erigontech/erigon/execution/rlp"
+	"github.com/erigontech/erigon/execution/types"
 )
 
-func TestAppendReceipt(t *testing.T) {
+func TestAppendReceiptMetadata(t *testing.T) {
 	dirs, require := datadir.New(t.TempDir()), require.New(t)
 	db := temporaltest.NewTestDB(t, dirs)
 	tx, err := db.BeginTemporalRw(t.Context())
@@ -26,16 +32,16 @@ func TestAppendReceipt(t *testing.T) {
 	require.NoError(err)
 	defer doms.Close()
 
-	err = rawtemporaldb.AppendReceipt(doms.AsPutDel(ttx), 1, 10, 0, 0) // 1 log
+	err = rawtemporaldb.AppendReceiptMetadata(doms.AsPutDel(ttx), 1, 10, 0, 0) // 1 log
 	require.NoError(err)
 
-	err = rawtemporaldb.AppendReceipt(doms.AsPutDel(ttx), 1, 11, 0, 1) // 0 log
+	err = rawtemporaldb.AppendReceiptMetadata(doms.AsPutDel(ttx), 1, 11, 0, 1) // 0 log
 	require.NoError(err)
 
-	err = rawtemporaldb.AppendReceipt(doms.AsPutDel(ttx), 4, 12, 0, 3) // 3 logs
+	err = rawtemporaldb.AppendReceiptMetadata(doms.AsPutDel(ttx), 4, 12, 0, 3) // 3 logs
 	require.NoError(err)
 
-	err = rawtemporaldb.AppendReceipt(doms.AsPutDel(ttx), 4, 14, 0, 4) // 0 log
+	err = rawtemporaldb.AppendReceiptMetadata(doms.AsPutDel(ttx), 4, 14, 0, 4) // 0 log
 	require.NoError(err)
 
 	err = doms.Flush(t.Context(), tx)
@@ -104,6 +110,67 @@ func TestAppendReceipt(t *testing.T) {
 	// reader
 
 }
+
+// One ReceiptWriter reused across transactions hands the same scratch to
+// SharedDomains every time; each value must still land distinct.
+func TestReceiptWriterReuseAgainstDomains(t *testing.T) {
+	dirs, require := datadir.New(t.TempDir()), require.New(t)
+
+	// RCacheDomain ignores writes unless the node opts in.
+	savedRCache := statecfg.Schema.RCacheDomain
+	statecfg.EnableHistoricalRCache()
+	t.Cleanup(func() { statecfg.Schema.RCacheDomain = savedRCache })
+
+	db := temporaltest.NewTestDB(t, dirs)
+	tx, err := db.BeginTemporalRw(t.Context())
+	require.NoError(err)
+	defer tx.Rollback()
+
+	doms, err := execctx.NewSharedDomains(t.Context(), tx, log.New())
+	require.NoError(err)
+	defer doms.Close()
+
+	var w rawtemporaldb.ReceiptWriter
+	putter := doms.AsPutDel(tx)
+
+	const txs uint64 = 4
+	for i := range txs {
+		receipt := &types.Receipt{
+			Type:                     types.DynamicFeeTxType,
+			Status:                   types.ReceiptStatusSuccessful,
+			CumulativeGasUsed:        10 + i,
+			GasUsed:                  21000 + i,
+			ContractAddress:          common.BigToAddress(new(big.Int).SetUint64(i + 1)),
+			TransactionIndex:         uint(i),
+			BlockNumber:              uint256.NewInt(1),
+			FirstLogIndexWithinBlock: uint32(i),
+		}
+		require.NoError(w.Append(putter, receipt, i))
+		require.NoError(w.AppendMetadata(putter, uint32(i), 10+i, 100+i, i))
+	}
+	require.NoError(doms.Flush(t.Context(), tx))
+
+	for i := range txs {
+		cumGasUsed, cumBlobGasUsed, logIdxAfterTx, err := rawtemporaldb.ReceiptAsOf(tx, i+1)
+		require.NoError(err)
+		require.Equal(10+i, cumGasUsed)
+		require.Equal(100+i, cumBlobGasUsed)
+		require.Equal(uint32(i), logIdxAfterTx)
+
+		// i < txs-1 resolves out of history (the ETL copy), the last out of
+		// latest state (the bytes.Clone copy).
+		v, ok, err := tx.GetAsOf(kv.RCacheDomain, rawtemporaldb.ReceiptCacheKey, i+1)
+		require.NoError(err)
+		require.True(ok)
+		var got types.ReceiptForStorage
+		require.NoError(rlp.DecodeBytes(v, &got))
+		require.Equal(10+i, got.CumulativeGasUsed)
+		require.Equal(21000+i, got.GasUsed)
+		require.Equal(common.BigToAddress(new(big.Int).SetUint64(i+1)), got.ContractAddress)
+		require.Equal(uint(i), got.TransactionIndex)
+	}
+}
+
 func uvarint(in []byte) (res uint64) {
 	res, _ = binary.Uvarint(in)
 	return res

--- a/db/rawdb/rawtemporaldb/export_test.go
+++ b/db/rawdb/rawtemporaldb/export_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package rawtemporaldb
+
+import "encoding/binary"
+
+// ReceiptValueForTest is the value encoding, for assertions in tests.
+func ReceiptValueForTest(v uint64) []byte {
+	var buf [binary.MaxVarintLen64]byte
+	i := binary.PutUvarint(buf[:], v)
+	return buf[:i]
+}

--- a/db/rawdb/rawtemporaldb/receipt_writer_alloc_test.go
+++ b/db/rawdb/rawtemporaldb/receipt_writer_alloc_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package rawtemporaldb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/race"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+// countingPutDel records the values it is handed, copying them the way the
+// domain writer does. copy=false keeps it allocation-free for the alloc test.
+type countingPutDel struct {
+	puts [][]byte
+	copy bool
+}
+
+func (p *countingPutDel) DomainPut(domain kv.Domain, k, v []byte, txNum uint64, prevVal []byte) error {
+	if p.copy {
+		p.puts = append(p.puts, append([]byte(nil), v...))
+	}
+	return nil
+}
+
+func (p *countingPutDel) DomainDel(domain kv.Domain, k []byte, txNum uint64, prevVal []byte) error {
+	return nil
+}
+
+func (p *countingPutDel) DomainDelPrefix(domain kv.Domain, prefix []byte, txNum uint64) error {
+	return nil
+}
+
+// A reused ReceiptWriter must keep its varint scratch off the heap: this runs
+// once per transaction applied.
+func TestReceiptWriterAppendMetadataIsAllocationFree(t *testing.T) {
+	var w rawtemporaldb.ReceiptWriter
+	putter := &countingPutDel{}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if err := w.AppendMetadata(putter, 7, 21000, 131072, 42); err != nil {
+			t.Fatal(err)
+		}
+	})
+	require.Zero(t, allocs, "ReceiptWriter.AppendMetadata must not allocate")
+}
+
+// Reusing one scratch across the three puts is only safe because each value is
+// copied on the way in; pin that the three values reach the putter distinct.
+func TestReceiptWriterAppendMetadataValuesAreDistinct(t *testing.T) {
+	t.Parallel()
+	var w rawtemporaldb.ReceiptWriter
+	putter := &countingPutDel{copy: true}
+
+	require.NoError(t, w.AppendMetadata(putter, 7, 21000, 131072, 42))
+	require.Len(t, putter.puts, 3)
+	require.Equal(t, rawtemporaldb.ReceiptValueForTest(21000), putter.puts[0])
+	require.Equal(t, rawtemporaldb.ReceiptValueForTest(131072), putter.puts[1])
+	require.Equal(t, rawtemporaldb.ReceiptValueForTest(7), putter.puts[2])
+}
+
+func receiptFixture() *types.Receipt {
+	logs := make(types.Logs, 3)
+	for i := range logs {
+		logs[i] = &types.Log{
+			Address: common.HexToAddress(fmt.Sprintf("0x%02x", 0xa0+i)),
+			Topics:  []common.Hash{common.HexToHash("0x11"), common.HexToHash("0x22")},
+			Data:    []byte{0x01, 0x02, 0x03, byte(i)},
+			Index:   hexutil.Uint(7 + i),
+		}
+	}
+	return &types.Receipt{
+		Type:                     types.DynamicFeeTxType,
+		Status:                   types.ReceiptStatusSuccessful,
+		CumulativeGasUsed:        123456,
+		Logs:                     logs,
+		GasUsed:                  21000,
+		ContractAddress:          common.HexToAddress("0xdead"),
+		TransactionIndex:         4,
+		BlockNumber:              uint256.NewInt(1),
+		FirstLogIndexWithinBlock: 7,
+	}
+}
+
+// The RCache write runs once per transaction applied too; guard it against the
+// scratch going back on the stack of Append.
+func TestReceiptWriterAppendIsAllocationFree(t *testing.T) {
+	var w rawtemporaldb.ReceiptWriter
+	receipt := receiptFixture()
+	putter := &countingPutDel{}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if err := w.Append(putter, receipt, 42); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !race.Enabled { // the race detector allocates inside sync.Pool
+		require.Zero(t, allocs, "ReceiptWriter.Append must not allocate")
+	}
+}
+
+// BenchmarkPerTxReceiptWrite is what one applied transaction pays on the receipt
+// path: the storage encoding into RCacheDomain plus the three ReceiptDomain
+// counters.
+func BenchmarkPerTxReceiptWrite(b *testing.B) {
+	var w rawtemporaldb.ReceiptWriter
+	receipt := receiptFixture()
+	putter := &countingPutDel{}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := w.Append(putter, receipt, 42); err != nil {
+			b.Fatal(err)
+		}
+		if err := w.AppendMetadata(putter, 7, receipt.CumulativeGasUsed, 131072, 42); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -2022,7 +2022,7 @@ func TestReceiptAsOf_InFlightBlockLogIndex(t *testing.T) {
 	committed, err := execctx.NewSharedDomains(ctx, tx, logger)
 	require.NoError(t, err)
 	defer committed.Close()
-	require.NoError(t, rawtemporaldb.AppendReceipt(committed.AsPutDel(tx), committedLogIdx, 0, 0, committedTxNum))
+	require.NoError(t, rawtemporaldb.AppendReceiptMetadata(committed.AsPutDel(tx), committedLogIdx, 0, 0, committedTxNum))
 	require.NoError(t, committed.Flush(ctx, tx))
 	committed.Close()
 
@@ -2034,7 +2034,7 @@ func TestReceiptAsOf_InFlightBlockLogIndex(t *testing.T) {
 	require.NoError(t, err)
 	defer sd.Close()
 	require.NoError(t, sd.InitBlockOverlay(tx, t.TempDir()))
-	require.NoError(t, rawtemporaldb.AppendReceipt(sd.AsPutDel(tx), inFlightLogIdx, 0, 0, inFlightTxNum))
+	require.NoError(t, rawtemporaldb.AppendReceiptMetadata(sd.AsPutDel(tx), inFlightLogIdx, 0, 0, inFlightTxNum))
 
 	_, _, got, err := rawtemporaldb.ReceiptAsOf(sd.BlockOverlay().NewReadView(tx), inFlightTxNum+1)
 	require.NoError(t, err)

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1409,7 +1409,7 @@ func TestParallelResumeBoundaryOffsets(t *testing.T) {
 
 	// Write mock receipt for transaction 0 in the database at txNum = 1
 	seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
-		return rawtemporaldb.AppendReceipt(putter, 5, 21000, 12000, 1)
+		return rawtemporaldb.AppendReceiptMetadata(putter, 5, 21000, 12000, 1)
 	})
 
 	chainSpec, _ := chainspec.ChainSpecByName(networkname.Mainnet)
@@ -1500,7 +1500,7 @@ func TestParallelResumeReconstructsPriorReceipts(t *testing.T) {
 		if err := putter.DomainPut(kv.AccountsDomain, senderIsCoinbaseKey.rawAddress[:], accounts.SerialiseV3(&acc), 0, nil); err != nil {
 			return err
 		}
-		return rawtemporaldb.AppendReceipt(putter, 0, 21000, 0, 1)
+		return rawtemporaldb.AppendReceiptMetadata(putter, 0, 21000, 0, 1)
 	})
 
 	txTask := &exec.TxTask{
@@ -1573,7 +1573,7 @@ func TestParallelResumeReconstructionFailureIsNonFatal(t *testing.T) {
 	// Store tx0's receipt values but leave the sender unfunded: the RCacheV2
 	// probe misses and the prefix replay fails on insufficient funds.
 	seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
-		return rawtemporaldb.AppendReceipt(putter, 0, 21000, 0, 1)
+		return rawtemporaldb.AppendReceiptMetadata(putter, 0, 21000, 0, 1)
 	})
 
 	txTask := &exec.TxTask{

--- a/execution/stagedsync/stage_custom_trace.go
+++ b/execution/stagedsync/stage_custom_trace.go
@@ -34,7 +34,6 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/backup"
 	"github.com/erigontech/erigon/db/kv/kvcfg"
-	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/snapshotsync/blocksnapshots"
 	dbstate "github.com/erigontech/erigon/db/state"
@@ -332,6 +331,8 @@ func customTraceBatch(ctx context.Context, produce Produce, cfg *exec.ExecArgs, 
 	defer logEvery.Stop()
 
 	var cumulativeBlobGasUsedInBlock uint64
+	// The reduce side runs on a single goroutine, so one writer serves the whole batch.
+	var receipts rawtemporaldb.ReceiptWriter
 
 	txNumsReader := cfg.BlockReader.TxnumReader()
 	fromTxNum, _ := txNumsReader.Min(ctx, tx, fromBlock)
@@ -378,7 +379,7 @@ func customTraceBatch(ctx context.Context, produce Produce, cfg *exec.ExecArgs, 
 					}
 				}
 
-				if err := rawtemporaldb.AppendReceipt(putter, logIndexAfterTx, cumGasUsed, cumulativeBlobGasUsedInBlock, txTask.TxNum); err != nil {
+				if err := receipts.AppendMetadata(putter, logIndexAfterTx, cumGasUsed, cumulativeBlobGasUsedInBlock, txTask.TxNum); err != nil {
 					return err
 				}
 
@@ -400,7 +401,7 @@ func customTraceBatch(ctx context.Context, produce Produce, cfg *exec.ExecArgs, 
 						}
 					}
 				}
-				if err := rawdb.WriteReceiptCacheV2(putter, receipt, txTask.TxNum); err != nil {
+				if err := receipts.Append(putter, receipt, txTask.TxNum); err != nil {
 					return err
 				}
 			}

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -32,7 +32,6 @@ import (
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
-	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/db/rawdb/rawtemporaldb"
 	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain"
@@ -47,6 +46,11 @@ type StateV3 struct {
 	persistReceiptsCacheV2 bool
 	txNum                  uint64
 	trace                  atomic.Bool
+
+	// Scratch for the per-transaction index writes; the apply goroutine alone
+	// touches them.
+	receiptsWriter rawtemporaldb.ReceiptWriter
+	traceAddr      common.Address
 }
 
 func NewStateV3(domains *execctx.SharedDomains, persistReceiptsCacheV2 bool, logger log.Logger) *StateV3 {
@@ -447,15 +451,15 @@ func (rs *StateV3) CommitStepBoundary(ctx context.Context, roTx kv.TemporalTx, b
 func (rs *StateV3) applyLogsAndTraces4(tx kv.TemporalTx, txNum uint64, receipt *types.Receipt, cummulativeBlobGas uint64, logs []*types.Log, traceFroms map[accounts.Address]struct{}, traceTos map[accounts.Address]struct{}, historyExecution bool, skipReceiptCache bool) error {
 	domains := rs.domains
 	for addr := range traceFroms {
-		addrValue := addr.Value()
-		if err := domains.IndexAdd(kv.TracesFromIdx, addrValue[:], txNum); err != nil {
+		rs.traceAddr = addr.Value()
+		if err := domains.IndexAdd(kv.TracesFromIdx, rs.traceAddr[:], txNum); err != nil {
 			return err
 		}
 	}
 
 	for addr := range traceTos {
-		addrValue := addr.Value()
-		if err := domains.IndexAdd(kv.TracesToIdx, addrValue[:], txNum); err != nil {
+		rs.traceAddr = addr.Value()
+		if err := domains.IndexAdd(kv.TracesToIdx, rs.traceAddr[:], txNum); err != nil {
 			return err
 		}
 	}
@@ -471,20 +475,26 @@ func (rs *StateV3) applyLogsAndTraces4(tx kv.TemporalTx, txNum uint64, receipt *
 		}
 	}
 
+	var putter kv.TemporalPutDel
+
 	if receipt != nil {
 		if !historyExecution {
 			blockLogIndex := receipt.FirstLogIndexWithinBlock
 			if !rawtemporaldb.ReceiptStoresFirstLogIdx(tx) {
 				blockLogIndex += uint32(len(receipt.Logs))
 			}
-			if err := rawtemporaldb.AppendReceipt(rs.domains.AsPutDel(tx), blockLogIndex, receipt.CumulativeGasUsed, cummulativeBlobGas, txNum); err != nil {
+			putter = domains.AsPutDel(tx)
+			if err := rs.receiptsWriter.AppendMetadata(putter, blockLogIndex, receipt.CumulativeGasUsed, cummulativeBlobGas, txNum); err != nil {
 				return err
 			}
 		}
 	}
 
 	if rs.persistReceiptsCacheV2 && !skipReceiptCache {
-		if err := rawdb.WriteReceiptCacheV2(rs.domains.AsPutDel(tx), receipt, txNum); err != nil {
+		if putter == nil {
+			putter = domains.AsPutDel(tx)
+		}
+		if err := rs.receiptsWriter.Append(putter, receipt, txNum); err != nil {
 			return err
 		}
 	}

--- a/execution/types/receipt.go
+++ b/execution/types/receipt.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"sync"
 
 	"github.com/holiman/uint256"
 
@@ -116,7 +117,7 @@ type storedReceiptRLP struct {
 	CumulativeGasUsed uint64
 	FirstLogIndex     uint32 // Logs have their own incremental Index within block. To allow calc it without re-executing whole block - can store it in Receipt
 
-	Logs []*LogForStorage
+	Logs []rlpStorageLog
 
 	TransactionIndex uint
 	ContractAddress  common.Address
@@ -377,21 +378,51 @@ func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
 		r.FirstLogIndexWithinBlock = uint32(r.Logs[0].Index)
 	}
 
-	logsForStorage := make([]*LogForStorage, len(r.Logs))
-	for i, l := range r.Logs {
-		logsForStorage[i] = (*LogForStorage)(l)
+	s := storedReceiptScratchPool.Get().(*storedReceiptScratch)
+	defer s.release()
+
+	s.logs = slices.Grow(s.logs[:0], len(r.Logs))
+	for _, l := range r.Logs {
+		s.logs = append(s.logs, rlpStorageLog{Address: l.Address, Topics: l.Topics, Data: l.Data})
 	}
-	return rlp.Encode(w, &storedReceiptRLP{
+	s.rec = storedReceiptRLP{
 		Type:              r.Type,
 		PostStateOrStatus: (*Receipt)(r).statusEncoding(),
 		CumulativeGasUsed: r.CumulativeGasUsed,
 		FirstLogIndex:     r.FirstLogIndexWithinBlock,
 
-		Logs:             logsForStorage,
+		Logs:             s.logs,
 		GasUsed:          r.GasUsed,
 		ContractAddress:  r.ContractAddress,
 		TransactionIndex: r.TransactionIndex,
-	})
+	}
+	return rlp.Encode(w, &s.rec)
+}
+
+// storedReceiptScratch keeps the reflection encoder's input off the heap: the
+// encoder needs an addressable struct and a log slice, and a receipt is encoded
+// once per transaction executed.
+type storedReceiptScratch struct {
+	rec  storedReceiptRLP
+	logs []rlpStorageLog
+}
+
+var storedReceiptScratchPool = sync.Pool{New: func() any { return new(storedReceiptScratch) }}
+
+// maxPooledLogs bounds what one pooled scratch keeps alive; a receipt with an
+// outlier log count is not worth pinning its backing array in the pool.
+const maxPooledLogs = 1024
+
+// release drops the borrowed topic and data slices so a pooled scratch never
+// keeps a receipt's logs alive.
+func (s *storedReceiptScratch) release() {
+	if cap(s.logs) > maxPooledLogs {
+		s.logs = nil
+	} else {
+		clear(s.logs)
+	}
+	s.rec = storedReceiptRLP{}
+	storedReceiptScratchPool.Put(s)
 }
 
 func decodeLogsForStorage(s *rlp.Stream) (Logs, error) {

--- a/execution/types/receipt_storage_enc_test.go
+++ b/execution/types/receipt_storage_enc_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/execution/rlp"
+)
+
+// storageReceiptGolden is the RCacheDomain encoding of storageReceiptFixture,
+// captured before the encoder was made allocation-free.
+const storageReceiptGolden = "f9014302018301e24007f90120f85e9400000000000000000000000000000000000000a0f842a00000000000000000000000000000000000000000000000000000000000000011a000000000000000000000000000000000000000000000000000000000000000228401020300f85e9400000000000000000000000000000000000000a1f842a00000000000000000000000000000000000000000000000000000000000000011a000000000000000000000000000000000000000000000000000000000000000228401020301f85e9400000000000000000000000000000000000000a2f842a00000000000000000000000000000000000000000000000000000000000000011a0000000000000000000000000000000000000000000000000000000000000002284010203020494000000000000000000000000000000000000dead825208"
+
+func storageReceiptFixture() *ReceiptForStorage {
+	logs := make(Logs, 3)
+	for i := range logs {
+		logs[i] = &Log{
+			Address: common.HexToAddress(fmt.Sprintf("0x%02x", 0xa0+i)),
+			Topics:  []common.Hash{common.HexToHash("0x11"), common.HexToHash("0x22")},
+			Data:    []byte{0x01, 0x02, 0x03, byte(i)},
+			Index:   hexutil.Uint(7 + i),
+		}
+	}
+	r := &Receipt{
+		Type:                     DynamicFeeTxType,
+		Status:                   ReceiptStatusSuccessful,
+		CumulativeGasUsed:        123456,
+		Logs:                     logs,
+		GasUsed:                  21000,
+		ContractAddress:          common.HexToAddress("0xdead"),
+		TransactionIndex:         4,
+		FirstLogIndexWithinBlock: 7,
+	}
+	return (*ReceiptForStorage)(r)
+}
+
+// The RCacheDomain holds these bytes across restarts, so the storage encoding
+// is a format: pin it against a golden so an encoder rewrite cannot move it.
+func TestReceiptForStorage_EncodingIsStable(t *testing.T) {
+	t.Parallel()
+	got, err := rlp.EncodeToBytes(storageReceiptFixture())
+	require.NoError(t, err)
+	require.Equal(t, storageReceiptGolden, hex.EncodeToString(got))
+}
+
+func TestReceiptForStorage_RoundTrip(t *testing.T) {
+	t.Parallel()
+	enc, err := rlp.EncodeToBytes(storageReceiptFixture())
+	require.NoError(t, err)
+
+	var got ReceiptForStorage
+	require.NoError(t, rlp.DecodeBytes(enc, &got))
+
+	want := storageReceiptFixture()
+	require.Equal(t, want.CumulativeGasUsed, got.CumulativeGasUsed)
+	require.Equal(t, want.ContractAddress, got.ContractAddress)
+	require.Equal(t, want.TransactionIndex, got.TransactionIndex)
+	require.Equal(t, want.FirstLogIndexWithinBlock, got.FirstLogIndexWithinBlock)
+	require.Len(t, got.Logs, len(want.Logs))
+	for i, l := range got.Logs {
+		require.Equal(t, want.Logs[i].Address, l.Address)
+		require.Equal(t, want.Logs[i].Topics, l.Topics)
+		require.Equal(t, []byte(want.Logs[i].Data), []byte(l.Data))
+	}
+}
+
+func BenchmarkReceiptForStorageEncode(b *testing.B) {
+	r := storageReceiptFixture()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := rlp.EncodeToBytes(r); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/rpc/jsonrpc/receipts/receipts_generator_overlay_test.go
+++ b/rpc/jsonrpc/receipts/receipts_generator_overlay_test.go
@@ -67,7 +67,7 @@ func TestGetReceiptLogIndexThroughOverlay(t *testing.T) {
 	require.NoError(t, err)
 	defer sd.Close()
 	require.NoError(t, sd.InitBlockOverlay(tx, t.TempDir()))
-	require.NoError(t, rawtemporaldb.AppendReceipt(sd.AsPutDel(tx), overlayLogIdx, 0, 0, txNum))
+	require.NoError(t, rawtemporaldb.AppendReceiptMetadata(sd.AsPutDel(tx), overlayLogIdx, 0, 0, txNum))
 
 	events := shards.NewEvents()
 	events.PublishOverlay(sd)


### PR DESCRIPTION
Cherry-pick of #22899 to release/3.6. Applies cleanly, no adaptations.