### PR TITLE
[r3.6] common: make common.Copy a func and inline it away

### DIFF
--- a/cl/antiquary/antiquary_test.go
+++ b/cl/antiquary/antiquary_test.go
@@ -60,7 +60,7 @@ func collectAll(t *testing.T, c *etl.Collector) map[string][]byte {
 	t.Helper()
 	result := make(map[string][]byte)
 	c.Load(nil, "", func(k, v []byte, _ etl.CurrentTableReader, next etl.LoadNextFunc) error { //nolint:gocritic
-		result[string(k)] = common.Copy(v)
+		result[string(k)] = bytes.Clone(v)
 		return next(nil, nil, nil)
 	}, etl.TransformArgs{})
 	return result

--- a/cl/antiquary/state_antiquary.go
+++ b/cl/antiquary/state_antiquary.go
@@ -382,7 +382,7 @@ func (s *Antiquary) IncrementBeaconState(ctx context.Context, to uint64) error {
 			if writeErr = validator.WriteTo(buf); writeErr != nil {
 				return false
 			}
-			if writeErr = rwTx.Put(kv.StaticValidators, base_encoding.Encode64ToBytes4(validatorIndex), common.Copy(buf.Bytes())); writeErr != nil {
+			if writeErr = rwTx.Put(kv.StaticValidators, base_encoding.Encode64ToBytes4(validatorIndex), bytes.Clone(buf.Bytes())); writeErr != nil {
 				return false
 			}
 			return true

--- a/cl/antiquary/state_prune_reader_test.go
+++ b/cl/antiquary/state_prune_reader_test.go
@@ -233,7 +233,7 @@ func TestPruneStateBalancesForwardAndReverseDumpPaths(t *testing.T) {
 	epochDiff := func(oldSlot, newSlot uint64) []byte {
 		var b bytes.Buffer
 		require.NoError(t, base_encoding.ComputeCompressedSerializedUint64ListDiff(&b, balancesAt(oldSlot), balancesAt(newSlot)))
-		return common.Copy(b.Bytes())
+		return bytes.Clone(b.Bytes())
 	}
 	compressor, err := zstd.NewWriter(nil)
 	require.NoError(t, err)
@@ -243,7 +243,7 @@ func TestPruneStateBalancesForwardAndReverseDumpPaths(t *testing.T) {
 		var b bytes.Buffer
 		sdata := &state_accessors.SlotData{Version: clparams.BellatrixVersion, ValidatorLength: valCount, Eth1Data: &cltypes.Eth1Data{}, Fork: &cltypes.Fork{}}
 		require.NoError(t, sdata.WriteTo(&b))
-		return common.Copy(b.Bytes())
+		return bytes.Clone(b.Bytes())
 	}
 
 	require.NoError(t, db.Update(ctx, func(tx kv.RwTx) error {

--- a/cl/cltypes/eth1_block.go
+++ b/cl/cltypes/eth1_block.go
@@ -17,6 +17,7 @@
 package cltypes
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -460,7 +461,7 @@ func (b *Eth1Block) getSchema() []any {
 // RlpHeader returns the equivalent types.Header struct with RLP-based fields.
 func (b *Eth1Block) RlpHeader(parentRoot *common.Hash, executionReqHash common.Hash) (*types.Header, error) {
 	// Reverse the order of the bytes in the BaseFeePerGas array and convert it to a big integer.
-	reversedBaseFeePerGas := common.Copy(b.BaseFeePerGas[:])
+	reversedBaseFeePerGas := bytes.Clone(b.BaseFeePerGas[:])
 	for i, j := 0, len(reversedBaseFeePerGas)-1; i < j; i, j = i+1, j-1 {
 		reversedBaseFeePerGas[i], reversedBaseFeePerGas[j] = reversedBaseFeePerGas[j], reversedBaseFeePerGas[i]
 	}

--- a/cl/cltypes/solid/byte_list.go
+++ b/cl/cltypes/solid/byte_list.go
@@ -17,12 +17,12 @@
 package solid
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
 
 	"github.com/erigontech/erigon/cl/merkle_tree"
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/clonable"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/length"
@@ -91,7 +91,7 @@ func (b *ByteListSSZ) DecodeSSZ(buf []byte, _ int) error {
 	if uint64(len(buf)) > b.limit {
 		return fmt.Errorf("ByteListSSZ: SSZ data length %d exceeds limit %d", len(buf), b.limit)
 	}
-	b.data = common.Copy(buf)
+	b.data = bytes.Clone(buf)
 	return nil
 }
 
@@ -128,7 +128,7 @@ func (b *ByteListSSZ) HashSSZ() ([32]byte, error) {
 
 // Bytes returns a copy of the underlying data.
 func (b *ByteListSSZ) Bytes() []byte {
-	return common.Copy(b.data)
+	return bytes.Clone(b.data)
 }
 
 // SetBytes replaces the underlying data with a copy of the provided slice.
@@ -137,7 +137,7 @@ func (b *ByteListSSZ) SetBytes(buf []byte) error {
 	if uint64(len(buf)) > b.limit {
 		return fmt.Errorf("ByteListSSZ: data length %d exceeds limit %d", len(buf), b.limit)
 	}
-	b.data = common.Copy(buf)
+	b.data = bytes.Clone(buf)
 	return nil
 }
 

--- a/cl/cltypes/solid/extra_data.go
+++ b/cl/cltypes/solid/extra_data.go
@@ -17,6 +17,7 @@
 package solid
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 
@@ -101,7 +102,7 @@ func (e *ExtraData) DecodeSSZ(buf []byte, _ int) error {
 
 // Bytes returns a copy of the ExtraData bytes.
 func (e *ExtraData) Bytes() []byte {
-	return common.Copy(e.data[:e.l])
+	return bytes.Clone(e.data[:e.l])
 }
 
 // SetBytes sets the ExtraData bytes from the provided byte slice.

--- a/cl/cltypes/solid/hash_list.go
+++ b/cl/cltypes/solid/hash_list.go
@@ -17,6 +17,7 @@
 package solid
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/erigontech/erigon/cl/merkle_tree"
@@ -127,7 +128,7 @@ func (h *hashList) DecodeSSZ(buf []byte, _ int) error {
 		return ssz.ErrBadDynamicLength
 	}
 	h.MerkleTree = nil
-	h.u = common.Copy(buf)
+	h.u = bytes.Clone(buf)
 	h.l = len(h.u) / length.Hash
 	return nil
 }

--- a/cl/cltypes/solid/list_ssz.go
+++ b/cl/cltypes/solid/list_ssz.go
@@ -17,6 +17,7 @@
 package solid
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/erigontech/erigon/cl/merkle_tree"
@@ -212,7 +213,7 @@ func (l *ListSSZ[T]) ShallowCopy() *ListSSZ[T] {
 		limit:           l.limit,
 		static:          l.static,
 		bytesPerElement: l.bytesPerElement,
-		root:            common.Hash(common.Copy(l.root[:])),
+		root:            common.Hash(bytes.Clone(l.root[:])),
 	}
 	copy(cpy.list, l.list)
 	return cpy

--- a/cl/p2p/p2p.go
+++ b/cl/p2p/p2p.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"net"
@@ -9,10 +10,16 @@ import (
 	"time"
 
 	"github.com/OffchainLabs/go-bitfield"
+	"github.com/libp2p/go-libp2p"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/metrics"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/utils/eth_clock"
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/log/v3"
 	elp2p "github.com/erigontech/erigon/p2p"
@@ -20,12 +27,6 @@ import (
 	"github.com/erigontech/erigon/p2p/enode"
 	"github.com/erigontech/erigon/p2p/enr"
 	p2pnat "github.com/erigontech/erigon/p2p/nat"
-	"github.com/libp2p/go-libp2p"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/host"
-	"github.com/libp2p/go-libp2p/core/metrics"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/multiformats/go-multiaddr"
 )
 
 type P2PConfig struct {
@@ -265,7 +266,7 @@ func (s *p2pManager) UpdateENRAttSubnets(subnetIndex int, on bool) {
 		log.Error("[Sentinel] Could not load AttSubnetKey", "err", err)
 		return
 	}
-	subnetField = common.Copy(subnetField)
+	subnetField = bytes.Clone(subnetField)
 	if subnetIndex < 0 {
 		log.Error("[Sentinel] Subnet index out of range", "subnetIndex", subnetIndex, "len", len(subnetField))
 		return
@@ -290,7 +291,7 @@ func (s *p2pManager) UpdateENRSyncNets(subnetIndex int, on bool) {
 		log.Error("[Sentinel] Could not load SyncCommsSubnetKey", "err", err)
 		return
 	}
-	subnetField = common.Copy(subnetField)
+	subnetField = bytes.Clone(subnetField)
 	if len(subnetField) <= subnetIndex/8 {
 		log.Error("[Sentinel] Sync subnet index out of range", "subnetIndex", subnetIndex, "len", len(subnetField))
 		return

--- a/cl/persistence/beacon_indicies/indicies.go
+++ b/cl/persistence/beacon_indicies/indicies.go
@@ -356,7 +356,7 @@ func WriteBeaconBlock(ctx context.Context, tx kv.RwTx, block *cltypes.SignedBeac
 	if err := encoder.Close(); err != nil {
 		return err
 	}
-	if err := tx.Put(kv.BeaconBlocks, dbutils.BlockBodyKey(block.Block.Slot, blockRoot), common.Copy(buf.Bytes())); err != nil {
+	if err := tx.Put(kv.BeaconBlocks, dbutils.BlockBodyKey(block.Block.Slot, blockRoot), bytes.Clone(buf.Bytes())); err != nil {
 		return err
 	}
 	return nil
@@ -509,6 +509,6 @@ func AddBlockRootToParentRootsIndex(tx kv.RwTx, parentRoot, blockRoot common.Has
 		}
 	}
 
-	roots = append(common.Copy(roots), blockRoot[:]...)
+	roots = append(bytes.Clone(roots), blockRoot[:]...)
 	return tx.Put(kv.ParentRootToBlockRoots, parentRoot[:], roots)
 }

--- a/cl/persistence/state/validator_events.go
+++ b/cl/persistence/state/validator_events.go
@@ -17,6 +17,7 @@
 package state_accessors
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"sync"
@@ -51,7 +52,7 @@ func NewStateEvents() *StateEvents {
 }
 
 func NewStateEventsFromBytes(buf []byte) *StateEvents {
-	return &StateEvents{buf: common.Copy(buf)}
+	return &StateEvents{buf: bytes.Clone(buf)}
 }
 
 func (se *StateEvents) AddValidator(validatorIndex uint64, validator solid.Validator) {
@@ -116,7 +117,7 @@ func (se *StateEvents) ChangeSlashed(validatorIndex uint64, slashed bool) {
 func (se *StateEvents) CopyBytes() []byte {
 	se.mu.Lock()
 	defer se.mu.Unlock()
-	return common.Copy(se.buf)
+	return bytes.Clone(se.buf)
 }
 
 func (se *StateEvents) Reset() {

--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -17,6 +17,7 @@
 package execution_client
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -123,7 +124,7 @@ func (cc *ExecutionClientEngine) Close() {
 
 // buildExecutionPayload converts a CL Eth1Block into an Engine API ExecutionPayload.
 func buildExecutionPayload(payload *cltypes.Eth1Block) *engine_types.ExecutionPayload {
-	reversedBaseFeePerGas := common.Copy(payload.BaseFeePerGas[:])
+	reversedBaseFeePerGas := bytes.Clone(payload.BaseFeePerGas[:])
 	for i, j := 0, len(reversedBaseFeePerGas)-1; i < j; i, j = i+1, j-1 {
 		reversedBaseFeePerGas[i], reversedBaseFeePerGas[j] = reversedBaseFeePerGas[j], reversedBaseFeePerGas[i]
 	}

--- a/cl/phase1/forkchoice/fork_graph/participation_indicies_store.go
+++ b/cl/phase1/forkchoice/fork_graph/participation_indicies_store.go
@@ -1,9 +1,8 @@
 package fork_graph
 
 import (
+	"bytes"
 	"sync"
-
-	"github.com/erigontech/erigon/common"
 )
 
 type participationIndiciesStore struct {
@@ -21,7 +20,7 @@ func (p *participationIndiciesStore) get(epoch uint64) ([]byte, bool) {
 func (p *participationIndiciesStore) add(epoch uint64, participations []byte) {
 	prevBitlistInterface, ok := p.s.Load(epoch)
 	if !ok {
-		p.s.Store(epoch, common.Copy(participations))
+		p.s.Store(epoch, bytes.Clone(participations))
 		return
 	}
 	// Reuse the existing slice if possible

--- a/cl/phase1/network/services/aggregate_and_proof_service.go
+++ b/cl/phase1/network/services/aggregate_and_proof_service.go
@@ -17,6 +17,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -40,7 +41,7 @@ import (
 	"github.com/erigontech/erigon/cl/pool"
 	"github.com/erigontech/erigon/cl/utils/bls"
 	"github.com/erigontech/erigon/cl/validator/validator_params"
-	"github.com/erigontech/erigon/common"
+
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/node/gointerfaces/sentinelproto"
@@ -462,7 +463,7 @@ func AggregateMessageSignature(
 			return err
 		}
 		pk := val.PublicKeyBytes()
-		pks = append(pks, common.Copy(pk))
+		pks = append(pks, bytes.Clone(pk))
 		return nil
 	}); err != nil {
 		return nil, nil, nil, err

--- a/cl/phase1/network/services/sync_contribution_service.go
+++ b/cl/phase1/network/services/sync_contribution_service.go
@@ -385,7 +385,7 @@ func verifySyncContributionProofAggregatedSignature(s *state.CachingBeaconState,
 	subCommitteePubsKeys := make([][]byte, 0, len(subCommitteeKeys))
 	for i, key := range subCommitteeKeys {
 		if utils.IsBitOn(contribution.AggregationBits, i) {
-			subCommitteePubsKeys = append(subCommitteePubsKeys, common.Copy(key[:]))
+			subCommitteePubsKeys = append(subCommitteePubsKeys, bytes.Clone(key[:]))
 		}
 	}
 

--- a/cl/sentinel/handlers/blobs_test.go
+++ b/cl/sentinel/handlers/blobs_test.go
@@ -127,7 +127,7 @@ func TestBlobsByRangeHandler(t *testing.T) {
 		return
 	}
 
-	reqData := common.Copy(reqBuf.Bytes())
+	reqData := bytes.Clone(reqBuf.Bytes())
 	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.BlobSidecarByRangeProtocolV1))
 	require.NoError(t, err)
 
@@ -251,7 +251,7 @@ func TestBlobsByIdentifiersHandler(t *testing.T) {
 		return
 	}
 
-	reqData := common.Copy(reqBuf.Bytes())
+	reqData := bytes.Clone(reqBuf.Bytes())
 	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.BlobSidecarByRootProtocolV1))
 	require.NoError(t, err)
 

--- a/cl/sentinel/handlers/blocks_by_head_test.go
+++ b/cl/sentinel/handlers/blocks_by_head_test.go
@@ -193,7 +193,7 @@ func writeBlocksByHeadRequest(t *testing.T, stream network.Stream, root common.H
 	}
 	var reqBuf bytes.Buffer
 	require.NoError(t, ssz_snappy.EncodeAndWrite(&reqBuf, req))
-	_, err := stream.Write(common.Copy(reqBuf.Bytes()))
+	_, err := stream.Write(bytes.Clone(reqBuf.Bytes()))
 	require.NoError(t, err)
 }
 

--- a/cl/sentinel/handlers/blocks_by_range_test.go
+++ b/cl/sentinel/handlers/blocks_by_range_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/erigontech/erigon/cl/sentinel/communication/ssz_snappy"
 	"github.com/erigontech/erigon/cl/sentinel/peers"
 	"github.com/erigontech/erigon/cl/utils"
-	"github.com/erigontech/erigon/common"
 )
 
 func TestBlocksByRootHandler(t *testing.T) {
@@ -98,7 +97,7 @@ func TestBlocksByRootHandler(t *testing.T) {
 		return
 	}
 
-	reqData := common.Copy(reqBuf.Bytes())
+	reqData := bytes.Clone(reqBuf.Bytes())
 	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.BeaconBlocksByRangeProtocolV2))
 	require.NoError(t, err)
 

--- a/cl/sentinel/handlers/blocks_by_root_test.go
+++ b/cl/sentinel/handlers/blocks_by_root_test.go
@@ -101,7 +101,7 @@ func TestBlocksByRangeHandler(t *testing.T) {
 		return
 	}
 
-	reqData := common.Copy(reqBuf.Bytes())
+	reqData := bytes.Clone(reqBuf.Bytes())
 	stream, err := host1.NewStream(ctx, host.ID(), protocol.ID(communication.BeaconBlocksByRootProtocolV2))
 	require.NoError(t, err)
 

--- a/cl/sentinel/handlers/light_client_test.go
+++ b/cl/sentinel/handlers/light_client_test.go
@@ -252,7 +252,7 @@ func TestLightClientBootstrap(t *testing.T) {
 	}
 	require.NoError(t, err)
 
-	reqData := common.Copy(reqBuf.Bytes())
+	reqData := bytes.Clone(reqBuf.Bytes())
 	_, err = stream.Write(reqData)
 	require.NoError(t, err)
 
@@ -327,7 +327,7 @@ func TestLightClientUpdates(t *testing.T) {
 	}
 	require.NoError(t, err)
 
-	reqData := common.Copy(reqBuf.Bytes())
+	reqData := bytes.Clone(reqBuf.Bytes())
 	_, err = stream.Write(reqData)
 	require.NoError(t, err)
 

--- a/cl/validator/sync_contribution_pool/sync_contribution_pool.go
+++ b/cl/validator/sync_contribution_pool/sync_contribution_pool.go
@@ -174,7 +174,7 @@ func (s *syncContributionPoolImpl) AddSyncCommitteeMessage(headState *state.Cach
 			}
 			utils.FlipBitOn(contribution.AggregationBits, int(i-startSubCommittee))
 			// Note: it's possible that one validator appears multiple times in the subcommittee.
-			signatures = append(signatures, common.Copy(message.Signature[:]))
+			signatures = append(signatures, bytes.Clone(message.Signature[:]))
 		}
 	}
 	if len(signatures) == 0 {
@@ -182,7 +182,7 @@ func (s *syncContributionPoolImpl) AddSyncCommitteeMessage(headState *state.Cach
 		return errors.New("validator not found in sync committee")
 	}
 	// Compute the aggregated signature.
-	signatures = append(signatures, common.Copy(contribution.Signature[:]))
+	signatures = append(signatures, bytes.Clone(contribution.Signature[:]))
 	aggregatedSignature, err := bls.AggregateSignatures(signatures)
 	if err != nil {
 		return err

--- a/cmd/integration/commands/refetence_db.go
+++ b/cmd/integration/commands/refetence_db.go
@@ -380,7 +380,7 @@ MainLoop:
 			if !fileScanner.Scan() {
 				break MainLoop
 			}
-			k := common.Copy(fileScanner.Bytes())
+			k := bytes.Clone(fileScanner.Bytes())
 			if bytes.Equal(k, endData) {
 				break
 			}
@@ -388,7 +388,7 @@ MainLoop:
 			if !fileScanner.Scan() {
 				break MainLoop
 			}
-			v := common.Copy(fileScanner.Bytes())
+			v := bytes.Clone(fileScanner.Bytes())
 			v = common.FromHex(string(v[1:]))
 
 			if casted, ok := c.(kv.RwCursorDupSort); ok {

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -38,7 +38,8 @@ func ByteCount(b uint64) string {
 
 }
 
-var Copy = bytes.Clone
+//go:fix inline
+func Copy(b []byte) []byte { return bytes.Clone(b) }
 
 func EnsureEnoughSize(in []byte, size int) []byte {
 	if cap(in) < size {

--- a/common/bytes_test.go
+++ b/common/bytes_test.go
@@ -27,7 +27,7 @@ import (
 func TestCopyBytes(t *testing.T) {
 	input := []byte{1, 2, 3, 4}
 
-	v := Copy(input)
+	v := bytes.Clone(input)
 	if !bytes.Equal(v, []byte{1, 2, 3, 4}) {
 		t.Fatal("not equal after copy")
 	}

--- a/common/crypto/signature_test.go
+++ b/common/crypto/signature_test.go
@@ -25,7 +25,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/math"
 )
@@ -65,13 +64,13 @@ func TestVerifySignature(t *testing.T) {
 	if VerifySignature(testpubkey, testmsg, nil) {
 		t.Errorf("nil signature valid")
 	}
-	if VerifySignature(testpubkey, testmsg, append(common.Copy(sig), 1, 2, 3)) {
+	if VerifySignature(testpubkey, testmsg, append(bytes.Clone(sig), 1, 2, 3)) {
 		t.Errorf("signature valid with extra bytes at the end")
 	}
 	if VerifySignature(testpubkey, testmsg, sig[:len(sig)-2]) {
 		t.Errorf("signature valid even though it's incomplete")
 	}
-	wrongkey := common.Copy(testpubkey)
+	wrongkey := bytes.Clone(testpubkey)
 	wrongkey[10]++
 	if VerifySignature(wrongkey, testmsg, sig) {
 		t.Errorf("signature valid with wrong public key")
@@ -102,7 +101,7 @@ func TestDecompressPubkey(t *testing.T) {
 	if _, err := DecompressPubkey(testpubkeyc[:5]); err == nil {
 		t.Errorf("no error for incomplete pubkey")
 	}
-	if _, err := DecompressPubkey(append(common.Copy(testpubkeyc), 1, 2, 3)); err == nil {
+	if _, err := DecompressPubkey(append(bytes.Clone(testpubkeyc), 1, 2, 3)); err == nil {
 		t.Errorf("no error for pubkey with extra bytes at the end")
 	}
 }

--- a/db/datastruct/btindex/btree_index_test.go
+++ b/db/datastruct/btindex/btree_index_test.go
@@ -129,7 +129,7 @@ func Test_BtreeIndex_Seek(t *testing.T) {
 		// require.EqualValues(t, uint64(i), cur.Value())
 	}
 	for i := 1; i < len(keys); i++ {
-		alt := common.Copy(keys[i])
+		alt := bytes.Clone(keys[i])
 		for j := len(alt) - 1; j >= 0; j-- {
 			if alt[j] > 0 {
 				alt[j] -= 1
@@ -222,7 +222,7 @@ func writeV0Index(tb testing.TB, dataPath, indexPath string, compressed seg.File
 			key, _ = r.Next(key[:0])
 			ef.AddOffset(pos)
 			if di%m == 0 {
-				nodes = append(nodes, v0node{key: common.Copy(key), di: di})
+				nodes = append(nodes, v0node{key: bytes.Clone(key), di: di})
 			}
 			di++
 			pos, _ = r.Skip()
@@ -598,7 +598,7 @@ func TestBpsTree_Seek(t *testing.T) {
 	//tr := newTrie()
 	ef := eliasfano32.NewEliasFano(uint64(keyCount), ps[len(ps)-1])
 	for i := 0; i < len(ps); i++ {
-		//tr.insert(Node{i: uint64(i), key: common.Copy(keys[i]), off: ps[i]})
+		//tr.insert(Node{i: uint64(i), key: bytes.Clone(keys[i]), off: ps[i]})
 		ef.AddOffset(ps[i])
 	}
 	ef.Build()
@@ -636,8 +636,8 @@ func (b *mockIndexReader) newCursor(k, v []byte, di uint64, g *seg.Reader) *Curs
 	return &Cursor{
 		ef:     b.ef,
 		getter: g,
-		key:    common.Copy(k),
-		value:  common.Copy(v),
+		key:    bytes.Clone(k),
+		value:  bytes.Clone(v),
 		d:      di,
 	}
 }

--- a/db/datastruct/btindex/nodeofft_ef_test.go
+++ b/db/datastruct/btindex/nodeofft_ef_test.go
@@ -8,12 +8,12 @@
 package btindex
 
 import (
+	"bytes"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/seg"
 )
@@ -40,7 +40,7 @@ func Test_BtreeIndex_NodeOfftEF_V0_V2(t *testing.T) {
 	for gt.HasNext() {
 		k, _ := gt.Next(nil)
 		v, _ := gt.Next(nil)
-		truth[string(k)] = common.Copy(v)
+		truth[string(k)] = bytes.Clone(v)
 	}
 	d.Close()
 

--- a/db/datastruct/btindex/testhelpers_test.go
+++ b/db/datastruct/btindex/testhelpers_test.go
@@ -1,6 +1,7 @@
 package btindex
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	randOld "math/rand"
@@ -12,7 +13,6 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/background"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/etl"
@@ -39,7 +39,7 @@ func pivotKeysFromKV(dataPath string) ([][]byte, error) {
 			break
 		}
 		key, _ := getter.Next(key[:0])
-		listing = append(listing, common.Copy(key))
+		listing = append(listing, bytes.Clone(key))
 		getter.Skip()
 	}
 	decomp.Close()

--- a/db/downloader/util.go
+++ b/db/downloader/util.go
@@ -38,7 +38,6 @@ import (
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/metainfo"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	dir2 "github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -334,7 +333,7 @@ func readPeerID(db kv.RoDB) (peerID []byte, err error) {
 		if err != nil {
 			return fmt.Errorf("get peer id: %w", err)
 		}
-		peerID = common.Copy(peerIDFromDB)
+		peerID = bytes.Clone(peerIDFromDB)
 		return nil
 	}); err != nil {
 		return nil, err

--- a/db/etl/buffers.go
+++ b/db/etl/buffers.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/c2h5oh/datasize"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 )
 
@@ -357,7 +356,7 @@ func (b *oldestEntrySortableBuffer) Put(k, v []byte) {
 	}
 
 	b.size += len(k)*2 + len(v)
-	b.entries[string(k)] = common.Copy(v)
+	b.entries[string(k)] = bytes.Clone(v)
 }
 
 func (b *oldestEntrySortableBuffer) Size() int      { return b.size }

--- a/db/etl/collector.go
+++ b/db/etl/collector.go
@@ -337,7 +337,7 @@ func mergeSortFiles(logPrefix string, providers []dataProvider, loadFunc simpleL
 					}
 				}
 				prevK = element.Key
-				prevV = common.Copy(element.Value) // copy needed: prevV is mutated by append below; element.Value may point into read-only mmap
+				prevV = bytes.Clone(element.Value) // copy needed: prevV is mutated by append below; element.Value may point into read-only mmap
 			} else {
 				prevV = append(prevV, element.Value...)
 			}

--- a/db/etl/etl.go
+++ b/db/etl/etl.go
@@ -43,7 +43,7 @@ func NextKey(key []byte) ([]byte, error) {
 	if len(key) == 0 {
 		return key, errors.New("could not apply NextKey for the empty key")
 	}
-	nextKey := common.Copy(key)
+	nextKey := bytes.Clone(key)
 	for i := len(key) - 1; i >= 0; i-- {
 		b := nextKey[i]
 		if b < 0xFF {

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -531,7 +531,7 @@ func TestAppendAndSortPrefixes(t *testing.T) {
 	require := require.New(t)
 
 	key := common.FromHex("ed7229d50cde8de174cc64a882a0833ca5f11669")
-	key1 := append(common.Copy(key), make([]byte, 16)...)
+	key1 := append(bytes.Clone(key), make([]byte, 16)...)
 
 	keys := make([]string, 0)
 	for i := 10; i >= 0; i-- {
@@ -650,7 +650,7 @@ func TestAppendAcrossMemProviders(t *testing.T) {
 	type kv struct{ k, v []byte }
 	var results []kv
 	loadFunc := func(k, v []byte) error {
-		results = append(results, kv{common.Copy(k), common.Copy(v)})
+		results = append(results, kv{bytes.Clone(k), bytes.Clone(v)})
 		return nil
 	}
 
@@ -825,8 +825,8 @@ func TestMixedProvidersMergeSortFiles(t *testing.T) {
 	loadFunc := func(k, v []byte) error {
 		// Must copy because providers return zero-copy references
 		results = append(results, sortableBufferEntry{
-			key:   common.Copy(k),
-			value: common.Copy(v),
+			key:   bytes.Clone(k),
+			value: bytes.Clone(v),
 		})
 		return nil
 	}

--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -1728,7 +1728,7 @@ func reverseCheckDomainKeys(ctx context.Context, decomp *seg.Decompressor, domai
 		defer close(refCh)
 		errCh <- sortedKeys.Load(nil, "", func(k, v []byte, _ etl.CurrentTableReader, _ etl.LoadNextFunc) error { //nolint:gocritic
 			select {
-			case refCh <- common.Copy(k):
+			case refCh <- bytes.Clone(k):
 				return nil
 			case <-loadCtx.Done():
 				return loadCtx.Err()
@@ -1774,8 +1774,8 @@ func reverseCheckDomainKeys(ctx context.Context, decomp *seg.Decompressor, domai
 		if !hasRef || !bytes.Equal(refKey, key) {
 			// Collect for no-op verification against previous files.
 			missingEntries = append(missingEntries, missingEntry{
-				key: common.Copy(key),
-				val: common.Copy(val),
+				key: bytes.Clone(key),
+				val: bytes.Clone(val),
 			})
 		}
 	}
@@ -2153,8 +2153,8 @@ func checkHashVerification(ctx context.Context, file state.VisibleFile, stepSize
 
 			// Copy data since buffers are reused.
 			item := hashWorkItem{
-				branchKey:   common.Copy(branchKey),
-				branchValue: common.Copy(branchValue),
+				branchKey:   bytes.Clone(branchKey),
+				branchValue: bytes.Clone(branchValue),
 			}
 
 			select {
@@ -2224,7 +2224,7 @@ func verifyHashItem(
 					return key, nil
 				}
 				val, _ := stoReader.Next(valBuf[:0])
-				storageValues[string(plainKey)] = common.Copy(val)
+				storageValues[string(plainKey)] = bytes.Clone(val)
 			} else if preloadedStoValues != nil {
 				strKey := string(plainKey)
 				if val, ok := preloadedStoValues[strKey]; ok {
@@ -2250,7 +2250,7 @@ func verifyHashItem(
 				return key, nil
 			}
 			val, _ := accReader.Next(valBuf[:0])
-			accountValues[string(plainKey)] = common.Copy(val)
+			accountValues[string(plainKey)] = bytes.Clone(val)
 		} else if preloadedAccValues != nil {
 			strKey := string(plainKey)
 			if val, ok := preloadedAccValues[strKey]; ok {
@@ -2303,7 +2303,7 @@ func preloadDomainValues(commitmentFile string, oldDomain, newDomain kv.Domain, 
 		}
 		val, _ := reader.Next(valBuf[:0])
 		if len(key) == expectedKeyLen {
-			values[string(key)] = common.Copy(val)
+			values[string(key)] = bytes.Clone(val)
 		}
 	}
 	return values, nil

--- a/db/integrity/commitment_state_verify_test.go
+++ b/db/integrity/commitment_state_verify_test.go
@@ -17,13 +17,13 @@
 package integrity_test
 
 import (
+	"bytes"
 	"math/rand"
 	"testing"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -81,7 +81,7 @@ func TestCheckStateVerify(t *testing.T) {
 		err = domains.DomainPut(kv.AccountsDomain, tx, addr, buf, txNum, nil)
 		require.NoError(t, err)
 
-		storageKey := append(common.Copy(addr), loc...)
+		storageKey := append(bytes.Clone(addr), loc...)
 		err = domains.DomainPut(kv.StorageDomain, tx, storageKey, []byte{addr[0], loc[0]}, txNum, nil)
 		require.NoError(t, err)
 
@@ -160,17 +160,17 @@ func TestCheckStateVerify_NoopWrite(t *testing.T) {
 		err = domains.DomainPut(kv.AccountsDomain, tx, addr, buf, txNum, nil)
 		require.NoError(t, err)
 
-		storageKey := append(common.Copy(addr), loc...)
+		storageKey := append(bytes.Clone(addr), loc...)
 		storageVal := []byte{addr[0], loc[0]}
 		err = domains.DomainPut(kv.StorageDomain, tx, storageKey, storageVal, txNum, nil)
 		require.NoError(t, err)
 
 		// Save one entry from step 1 (txNum 100-199) for re-writing in step range 2.
 		if txNum == 150 {
-			noopAddr = common.Copy(addr)
-			noopStorageKey = common.Copy(storageKey)
-			noopAccBuf = common.Copy(buf)
-			noopStorageVal = common.Copy(storageVal)
+			noopAddr = bytes.Clone(addr)
+			noopStorageKey = bytes.Clone(storageKey)
+			noopAccBuf = bytes.Clone(buf)
+			noopStorageVal = bytes.Clone(storageVal)
 		}
 
 		blockNum := txNum
@@ -195,7 +195,7 @@ func TestCheckStateVerify_NoopWrite(t *testing.T) {
 		err = domains.DomainPut(kv.AccountsDomain, tx, addr, buf, txNum, nil)
 		require.NoError(t, err)
 
-		storageKey := append(common.Copy(addr), loc...)
+		storageKey := append(bytes.Clone(addr), loc...)
 		err = domains.DomainPut(kv.StorageDomain, tx, storageKey, []byte{addr[0], loc[0]}, txNum, nil)
 		require.NoError(t, err)
 
@@ -279,7 +279,7 @@ func TestVerifyBranchHashesFromDB(t *testing.T) {
 		err = domains.DomainPut(kv.AccountsDomain, tx, addr, accBuf, txNum, nil)
 		require.NoError(t, err)
 
-		storageKey := append(common.Copy(addr), loc...)
+		storageKey := append(bytes.Clone(addr), loc...)
 		storageVal := []byte{addr[0], loc[0]}
 		err = domains.DomainPut(kv.StorageDomain, tx, storageKey, storageVal, txNum, nil)
 		require.NoError(t, err)

--- a/db/integrity/commitment_version_integration_test.go
+++ b/db/integrity/commitment_version_integration_test.go
@@ -17,6 +17,7 @@
 package integrity_test
 
 import (
+	"bytes"
 	"context"
 	"math/rand"
 	"strings"
@@ -25,7 +26,6 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -108,7 +108,7 @@ func writeAndBuild(t *testing.T, ctx context.Context, db kv.TemporalRwDB, agg *s
 		acc := accounts.Account{Nonce: txNum, Balance: *uint256.NewInt(txNum * 1000), CodeHash: accounts.EmptyCodeHash}
 		require.NoError(t, domains.DomainPut(kv.AccountsDomain, tx, addr, accounts.SerialiseV3(&acc), txNum, nil))
 
-		storageKey := append(common.Copy(addr), loc...)
+		storageKey := append(bytes.Clone(addr), loc...)
 		require.NoError(t, domains.DomainPut(kv.StorageDomain, tx, storageKey, []byte{addr[0], loc[0]}, txNum, nil))
 
 		_, err = domains.ComputeCommitment(ctx, tx, true, txNum, txNum, "test", nil)

--- a/db/kv/helpers.go
+++ b/db/kv/helpers.go
@@ -17,6 +17,7 @@
 package kv
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"encoding/binary"
@@ -129,7 +130,7 @@ func BigChunks(db RoDB, table string, from []byte, walker func(tx Tx, k, v []byt
 				stop = true
 			}
 
-			from = common.Copy(k) // next transaction will start from this key
+			from = bytes.Clone(k) // next transaction will start from this key
 
 			return nil
 		}); err != nil {
@@ -324,7 +325,7 @@ func (d *DomainDiff) DomainUpdate(k []byte, step Step, prevValue []byte) {
 		if prevValue == nil {
 			d.prevValues[valsKeySCopy] = []byte{} // no previous value (new key)
 		} else {
-			d.prevValues[valsKeySCopy] = common.Copy(prevValue)
+			d.prevValues[valsKeySCopy] = bytes.Clone(prevValue)
 		}
 		d.prevValsSlice = nil
 	}

--- a/db/kv/kvcache/cache.go
+++ b/db/kv/kvcache/cache.go
@@ -411,7 +411,7 @@ func (c *Coherent) Get(k []byte, tx kv.TemporalTx, id uint64) (v []byte, err err
 
 	defer c.lock.Unlock()
 
-	v = c.add(common.Copy(k), common.Copy(v), r, id).V
+	v = c.add(bytes.Clone(k), bytes.Clone(v), r, id).V
 	return v, nil
 }
 
@@ -436,7 +436,7 @@ func (c *Coherent) GetCode(k []byte, tx kv.TemporalTx, id uint64) (v []byte, err
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	v = c.addCode(common.Copy(k), common.Copy(v), r, id).V
+	v = c.addCode(bytes.Clone(k), bytes.Clone(v), r, id).V
 	return v, nil
 }
 func (c *Coherent) removeOldest(r *CoherentRoot) {

--- a/db/kv/kvcache/cache_test.go
+++ b/db/kv/kvcache/cache_test.go
@@ -212,7 +212,7 @@ func TestAPI(t *testing.T) {
 					}
 
 					select {
-					case res[idx] <- common.Copy(v):
+					case res[idx] <- bytes.Clone(v):
 					case <-ctx.Done():
 						panic("Context done while sending result")
 					}

--- a/db/kv/kvcache/latest_batch.go
+++ b/db/kv/kvcache/latest_batch.go
@@ -17,6 +17,7 @@
 package kvcache
 
 import (
+	"bytes"
 	"context"
 	"sync"
 
@@ -65,7 +66,7 @@ func (c *LatestBatchCache) OnNewBlock(sc *remoteproto.StateChangeBatch) {
 				if c.accounts == nil {
 					c.accounts = make(map[common.Address][]byte)
 				}
-				c.accounts[addr] = common.Copy(change.Changes[i].Data)
+				c.accounts[addr] = bytes.Clone(change.Changes[i].Data)
 			case remoteproto.Action_REMOVE:
 				addr := gointerfaces.ConvertH160toAddress(change.Changes[i].Address)
 				delete(c.accounts, addr)
@@ -84,7 +85,7 @@ func (c *LatestBatchCache) Get(k []byte, tx kv.TemporalTx, id uint64) ([]byte, e
 		c.mu.RLock()
 		if v, ok := c.accounts[common.BytesToAddress(k)]; ok {
 			c.mu.RUnlock()
-			return common.Copy(v), nil
+			return bytes.Clone(v), nil
 		}
 		c.mu.RUnlock()
 		v, _, err := tx.GetLatest(kv.AccountsDomain, k)

--- a/db/kv/membatchwithdb/memory_mutation.go
+++ b/db/kv/membatchwithdb/memory_mutation.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/c2h5oh/datasize"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbcfg"
@@ -835,8 +834,8 @@ func (m *MemoryMutation) Diff() (*MemoryDiff, error) {
 					return nil, err
 				}
 				memDiff.diff[t] = append(memDiff.diff[t], entry{
-					k: common.Copy(k),
-					v: common.Copy(v),
+					k: bytes.Clone(k),
+					v: bytes.Clone(v),
 				})
 			}
 		} else {
@@ -854,8 +853,8 @@ func (m *MemoryMutation) Diff() (*MemoryDiff, error) {
 					return nil, err
 				}
 				memDiff.diff[t] = append(memDiff.diff[t], entry{
-					k: common.Copy(k),
-					v: common.Copy(v),
+					k: bytes.Clone(k),
+					v: bytes.Clone(v),
 				})
 			}
 		}

--- a/db/kv/membatchwithdb/memory_mutation_cursor.go
+++ b/db/kv/membatchwithdb/memory_mutation_cursor.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 )
 
@@ -137,7 +136,7 @@ func (m *memoryMutationCursor) Current() ([]byte, []byte, error) {
 	if m.isTableCleared() {
 		return m.memCursor.Current()
 	}
-	return common.Copy(m.currentPair.key), common.Copy(m.currentPair.value), nil
+	return bytes.Clone(m.currentPair.key), bytes.Clone(m.currentPair.value), nil
 }
 
 func (m *memoryMutationCursor) skipIntersection(memKey, memValue, dbKey, dbValue []byte, t NextType) (newDbKey []byte, newDbValue []byte, err error) {
@@ -281,16 +280,16 @@ func (m *memoryMutationCursor) SeekExact(seek []byte) ([]byte, []byte, error) {
 }
 
 func (m *memoryMutationCursor) Put(k, v []byte) error {
-	return m.mutation.Put(m.table, common.Copy(k), common.Copy(v))
+	return m.mutation.Put(m.table, bytes.Clone(k), bytes.Clone(v))
 }
 
 func (m *memoryMutationCursor) Append(k []byte, v []byte) error {
-	return m.mutation.Append(m.table, common.Copy(k), common.Copy(v))
+	return m.mutation.Append(m.table, bytes.Clone(k), bytes.Clone(v))
 
 }
 
 func (m *memoryMutationCursor) AppendDup(k []byte, v []byte) error {
-	return m.memCursor.AppendDup(common.Copy(k), common.Copy(v))
+	return m.memCursor.AppendDup(bytes.Clone(k), bytes.Clone(v))
 }
 
 func (m *memoryMutationCursor) PutNoDupData(key, value []byte) error {

--- a/db/kv/membatchwithdb/memory_store.go
+++ b/db/kv/membatchwithdb/memory_store.go
@@ -28,7 +28,6 @@ import (
 
 	btree2 "github.com/tidwall/btree"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
@@ -133,7 +132,7 @@ func (s *memStore) GetOne(table string, key []byte) ([]byte, error) {
 	if !found {
 		return nil, nil
 	}
-	return common.Copy(item.v), nil
+	return bytes.Clone(item.v), nil
 }
 
 func (s *memStore) Rollback() {}
@@ -205,7 +204,7 @@ func (s *memStore) Put(table string, k, v []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	t := s.getOrCreateTable(table)
-	t.tree.Set(memEntry{k: common.Copy(k), v: common.Copy(v)})
+	t.tree.Set(memEntry{k: bytes.Clone(k), v: bytes.Clone(v)})
 	// Keep sequences map in sync when writing to the Sequence table.
 	if table == kv.Sequence && len(v) >= 8 {
 		s.sequences[string(k)] = binary.BigEndian.Uint64(v)
@@ -255,7 +254,7 @@ func (s *memStore) IncrementSequence(bucket string, amount uint64) (uint64, erro
 	v := make([]byte, 8)
 	binary.BigEndian.PutUint64(v, current+amount)
 	t := s.getOrCreateTable(kv.Sequence)
-	t.tree.Set(memEntry{k: common.Copy([]byte(bucket)), v: v})
+	t.tree.Set(memEntry{k: bytes.Clone([]byte(bucket)), v: v})
 	return current, nil
 }
 
@@ -266,7 +265,7 @@ func (s *memStore) ResetSequence(bucket string, newValue uint64) error {
 	v := make([]byte, 8)
 	binary.BigEndian.PutUint64(v, newValue)
 	t := s.getOrCreateTable(kv.Sequence)
-	t.tree.Set(memEntry{k: common.Copy([]byte(bucket)), v: v})
+	t.tree.Set(memEntry{k: bytes.Clone([]byte(bucket)), v: v})
 	return nil
 }
 
@@ -481,7 +480,7 @@ func (c *memStoreCursor) First() ([]byte, []byte, error) {
 	}
 	c.current = iter.Item()
 	iter.Release()
-	return common.Copy(c.current.k), common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.k), bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) Last() ([]byte, []byte, error) {
@@ -496,7 +495,7 @@ func (c *memStoreCursor) Last() ([]byte, []byte, error) {
 	}
 	c.current = iter.Item()
 	iter.Release()
-	return common.Copy(c.current.k), common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.k), bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) Seek(seek []byte) ([]byte, []byte, error) {
@@ -511,7 +510,7 @@ func (c *memStoreCursor) Seek(seek []byte) ([]byte, []byte, error) {
 	}
 	c.current = iter.Item()
 	iter.Release()
-	return common.Copy(c.current.k), common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.k), bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) SeekExact(key []byte) ([]byte, []byte, error) {
@@ -547,7 +546,7 @@ func (c *memStoreCursor) Next() ([]byte, []byte, error) {
 	}
 	c.current = iter.Item()
 	iter.Release()
-	return common.Copy(c.current.k), common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.k), bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) Prev() ([]byte, []byte, error) {
@@ -571,14 +570,14 @@ func (c *memStoreCursor) Prev() ([]byte, []byte, error) {
 	}
 	c.current = iter.Item()
 	iter.Release()
-	return common.Copy(c.current.k), common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.k), bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) Current() ([]byte, []byte, error) {
 	if !c.valid {
 		return nil, nil, nil
 	}
-	return common.Copy(c.current.k), common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.k), bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) NextDup() ([]byte, []byte, error) {
@@ -606,7 +605,7 @@ func (c *memStoreCursor) NextDup() ([]byte, []byte, error) {
 	if !bytes.Equal(c.current.k, currentKey) {
 		return nil, nil, nil
 	}
-	return common.Copy(c.current.k), common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.k), bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) NextNoDup() ([]byte, []byte, error) {
@@ -633,7 +632,7 @@ func (c *memStoreCursor) NextNoDup() ([]byte, []byte, error) {
 		c.current = iter.Item()
 		if !bytes.Equal(c.current.k, currentKey) {
 			iter.Release()
-			return common.Copy(c.current.k), common.Copy(c.current.v), nil
+			return bytes.Clone(c.current.k), bytes.Clone(c.current.v), nil
 		}
 	}
 }
@@ -653,7 +652,7 @@ func (c *memStoreCursor) SeekBothRange(key, value []byte) ([]byte, error) {
 	if !bytes.Equal(c.current.k, key) {
 		return nil, nil
 	}
-	return common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) SeekBothExact(key, value []byte) ([]byte, []byte, error) {
@@ -671,7 +670,7 @@ func (c *memStoreCursor) SeekBothExact(key, value []byte) ([]byte, []byte, error
 	if !bytes.Equal(c.current.k, key) || !bytes.Equal(c.current.v, value) {
 		return nil, nil, nil
 	}
-	return common.Copy(c.current.k), common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.k), bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) FirstDup() ([]byte, error) {
@@ -680,7 +679,7 @@ func (c *memStoreCursor) FirstDup() ([]byte, error) {
 	}
 	c.store.mu.RLock()
 	defer c.store.mu.RUnlock()
-	currentKey := common.Copy(c.current.k)
+	currentKey := bytes.Clone(c.current.k)
 	iter := c.table.tree.Iter()
 	c.valid = iter.Seek(memEntry{k: currentKey})
 	if !c.valid || !bytes.Equal(iter.Item().k, currentKey) {
@@ -689,7 +688,7 @@ func (c *memStoreCursor) FirstDup() ([]byte, error) {
 	}
 	c.current = iter.Item()
 	iter.Release()
-	return common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) LastDup() ([]byte, error) {
@@ -698,7 +697,7 @@ func (c *memStoreCursor) LastDup() ([]byte, error) {
 	}
 	c.store.mu.RLock()
 	defer c.store.mu.RUnlock()
-	currentKey := common.Copy(c.current.k)
+	currentKey := bytes.Clone(c.current.k)
 	iter := c.table.tree.Iter()
 	nextKey, ok := kv.NextSubtree(currentKey)
 	if ok {
@@ -717,7 +716,7 @@ func (c *memStoreCursor) LastDup() ([]byte, error) {
 	}
 	c.current = iter.Item()
 	iter.Release()
-	return common.Copy(c.current.v), nil
+	return bytes.Clone(c.current.v), nil
 }
 
 func (c *memStoreCursor) PrevDup() ([]byte, []byte, error)   { panic("PrevDup not implemented") }
@@ -797,7 +796,7 @@ func (s *memStore) collectRange(t *memTable, fromPrefix, toPrefix []byte, asc bo
 			if toPrefix != nil && bytes.Compare(item.k, toPrefix) >= 0 {
 				break
 			}
-			entries = append(entries, memEntry{k: common.Copy(item.k), v: common.Copy(item.v)})
+			entries = append(entries, memEntry{k: bytes.Clone(item.k), v: bytes.Clone(item.v)})
 			valid = iter.Next()
 		}
 	} else {
@@ -821,7 +820,7 @@ func (s *memStore) collectRange(t *memTable, fromPrefix, toPrefix []byte, asc bo
 			if fromPrefix != nil && bytes.Compare(item.k, fromPrefix) < 0 {
 				break
 			}
-			entries = append(entries, memEntry{k: common.Copy(item.k), v: common.Copy(item.v)})
+			entries = append(entries, memEntry{k: bytes.Clone(item.k), v: bytes.Clone(item.v)})
 			valid = iter.Prev()
 		}
 	}
@@ -845,7 +844,7 @@ func (s *memStore) collectRangeDupSort(t *memTable, key []byte, fromPrefix, toPr
 			if toPrefix != nil && bytes.Compare(item.v, toPrefix) >= 0 {
 				break
 			}
-			entries = append(entries, memEntry{k: common.Copy(item.k), v: common.Copy(item.v)})
+			entries = append(entries, memEntry{k: bytes.Clone(item.k), v: bytes.Clone(item.v)})
 			valid = iter.Next()
 		}
 	} else {
@@ -883,7 +882,7 @@ func (s *memStore) collectRangeDupSort(t *memTable, key []byte, fromPrefix, toPr
 			if fromPrefix != nil && bytes.Compare(item.v, fromPrefix) < 0 {
 				break
 			}
-			entries = append(entries, memEntry{k: common.Copy(item.k), v: common.Copy(item.v)})
+			entries = append(entries, memEntry{k: bytes.Clone(item.k), v: bytes.Clone(item.v)})
 			valid = iter.Prev()
 		}
 	}

--- a/db/kv/prune/prune.go
+++ b/db/kv/prune/prune.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/etl"
 	"github.com/erigontech/erigon/db/kv"
@@ -231,7 +230,7 @@ func TableScanningPrune(
 	}
 
 	if prevStat.KeyProgress != Done {
-		txnb := common.Copy(keyCursorPosition.StartKey)
+		txnb := bytes.Clone(keyCursorPosition.StartKey)
 		// This deletion iterator goes last to preserve invariant: if some `txNum=N` pruned - it's pruned Fully
 		for ; txnb != nil; txnb, _, err = keysCursor.NextNoDup() {
 			if err != nil {
@@ -239,7 +238,7 @@ func TableScanningPrune(
 			}
 			select {
 			case <-ctx.Done():
-				stat.LastPrunedKey = common.Copy(txnb)
+				stat.LastPrunedKey = bytes.Clone(txnb)
 				stat.KeyProgress = InProgress
 				return stat, nil
 			default:
@@ -332,7 +331,7 @@ func tableScanningPrune(
 		}
 
 		if ctx.Err() != nil {
-			return common.Copy(val), nil
+			return bytes.Clone(val), nil
 		}
 
 		// Different storage modes have different dup-iteration orders:
@@ -426,9 +425,9 @@ func tableScanningPrune(
 				time.Sleep(*throttling)
 			}
 			if ctx.Err() != nil {
-				stat.LastPrunedValue = common.Copy(val)
+				stat.LastPrunedValue = bytes.Clone(val)
 				stat.ValueProgress = InProgress
-				return common.Copy(val), nil
+				return bytes.Clone(val), nil
 			}
 		}
 	nextKey:

--- a/db/kv/remotedbserver/remotedbserver.go
+++ b/db/kv/remotedbserver/remotedbserver.go
@@ -17,6 +17,7 @@
 package remotedbserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -260,8 +261,8 @@ func (s *KvServer) Tx(stream remoteproto.KV_TxServer) error {
 				if err != nil {
 					return fmt.Errorf("kvserver: %w", err)
 				}
-				c.k = common.Copy(k)
-				c.v = common.Copy(v)
+				c.k = bytes.Clone(k)
+				c.v = bytes.Clone(v)
 			}
 
 			if err := s.renew(stream.Context(), id); err != nil {
@@ -661,8 +662,8 @@ func (s *KvServer) HistoryRange(_ context.Context, req *remoteproto.HistoryRange
 			if err != nil {
 				return err
 			}
-			key := common.Copy(k)
-			value := common.Copy(v)
+			key := bytes.Clone(k)
+			value := bytes.Clone(v)
 			reply.Keys = append(reply.Keys, key)
 			reply.Values = append(reply.Values, value)
 		}
@@ -702,8 +703,8 @@ func (s *KvServer) RangeAsOf(_ context.Context, req *remoteproto.RangeAsOfReq) (
 			if err != nil {
 				return err
 			}
-			key := common.Copy(k)
-			value := common.Copy(v)
+			key := bytes.Clone(k)
+			value := bytes.Clone(v)
 			reply.Keys = append(reply.Keys, key)
 			reply.Values = append(reply.Values, value)
 			limit--

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/c2h5oh/datasize"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -114,9 +113,9 @@ func AppliedMigrations(tx kv.Tx, withPayload bool) (map[string][]byte, error) {
 			return nil
 		}
 		if withPayload {
-			applied[string(common.Copy(k))] = common.Copy(v)
+			applied[string(bytes.Clone(k))] = bytes.Clone(v)
 		} else {
-			applied[string(common.Copy(k))] = []byte{}
+			applied[string(bytes.Clone(k))] = []byte{}
 		}
 		return nil
 	})

--- a/db/rawdb/accessors_chain.go
+++ b/db/rawdb/accessors_chain.go
@@ -896,7 +896,7 @@ func PruneBlocks(tx kv.RwTx, blockTo uint64, blocksDeleteLimit int) (deleted int
 		}
 		// Copying k because otherwise the same memory will be reused
 		// for the next key and Delete below will end up deleting 1 more record than required
-		kCopy := common.Copy(k)
+		kCopy := bytes.Clone(k)
 		if err = tx.Delete(kv.Senders, kCopy); err != nil {
 			return deleted, err
 		}
@@ -947,7 +947,7 @@ func TruncateBlocks(ctx context.Context, tx kv.RwTx, blockFrom uint64) error {
 		}
 		// Copying k because otherwise the same memory will be reused
 		// for the next key and Delete below will end up deleting 1 more record than required
-		kCopy := common.Copy(k)
+		kCopy := bytes.Clone(k)
 		if err := tx.Delete(kv.Senders, kCopy); err != nil {
 			return err
 		}

--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -33,7 +33,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dir"
 	dir2 "github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -472,14 +471,14 @@ func (db *DictionaryBuilder) Pop() any {
 
 func (db *DictionaryBuilder) processWord(chars []byte, score uint64) {
 	if db.Len()+1 <= db.softLimit {
-		heap.Push(db, &Pattern{word: common.Copy(chars), score: score})
+		heap.Push(db, &Pattern{word: bytes.Clone(chars), score: score})
 		return
 	}
 
 	// RemoveFile the element with smallest score
 	elem := heap.Pop(db).(*Pattern)
 	if elem == nil {
-		heap.Push(db, &Pattern{word: common.Copy(chars), score: score})
+		heap.Push(db, &Pattern{word: bytes.Clone(chars), score: score})
 		return
 	}
 	elem.word = append(elem.word[:0], chars...)

--- a/db/seg/seg_paged_rw.go
+++ b/db/seg/seg_paged_rw.go
@@ -179,9 +179,9 @@ func (g *PagedReader) Reset(offset uint64) {
 //		for {
 //			var keys [][]byte
 //			fst, _ := g.page.First()
-//			fst = common.Copy(fst)
+//			fst = bytes.Clone(fst)
 //			lst, _ := g.page.Last()
-//			lst = common.Copy(lst)
+//			lst = bytes.Clone(lst)
 //			fmt.Printf("page: %d, offset=%d, keys: %d %x-%x\n", i, g.currentPageOffset, len(keys), fst, lst)
 //			i++
 //			if !g.HasNextPage() {

--- a/db/seg/seg_paged_rw_test.go
+++ b/db/seg/seg_paged_rw_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
@@ -105,7 +104,7 @@ type multyBytesWriter struct {
 }
 
 func (w *multyBytesWriter) Write(p []byte) (n int, err error) {
-	w.buffer = append(w.buffer, common.Copy(p))
+	w.buffer = append(w.buffer, bytes.Clone(p))
 	return len(p), nil
 }
 func (w *multyBytesWriter) Bytes() [][]byte                { return w.buffer }

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -17,6 +17,7 @@
 package snapshotsync
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"encoding/binary"
@@ -87,7 +88,7 @@ func getKvGetterForStateTable(db kv.RoDB, tableName string) KeyValueGetter {
 		if err := db.View(context.TODO(), func(tx kv.Tx) error {
 			key = base_encoding.Encode64ToBytes4(numId)
 			value, err = tx.GetOne(tableName, key)
-			value = common.Copy(value)
+			value = bytes.Clone(value)
 			return err
 		}); err != nil {
 			return nil, nil, err

--- a/db/state/aggregator_bench_test.go
+++ b/db/state/aggregator_bench_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/background"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/length"
@@ -386,7 +385,7 @@ func Benchmark_BTree_SeekThenNext(b *testing.B) {
 				panic("mistmatch")
 			}
 
-			prevKey := common.Copy(keys[p])
+			prevKey := bytes.Clone(keys[p])
 			ntimer := time.Duration(0)
 			nextKeys := 5000
 			for range nextKeys {
@@ -612,7 +611,7 @@ func pivotKeysFromKV(dataPath string) ([][]byte, error) {
 			break
 		}
 		key, _ := getter.Next(key[:0])
-		listing = append(listing, common.Copy(key))
+		listing = append(listing, bytes.Clone(key))
 		getter.Skip()
 	}
 	decomp.Close()

--- a/db/state/aggregator_test.go
+++ b/db/state/aggregator_test.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -30,7 +31,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/background"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -93,7 +93,7 @@ func pivotKeysFromKV(dataPath string) ([][]byte, error) {
 			break
 		}
 		key, _ := getter.Next(key[:0])
-		listing = append(listing, common.Copy(key))
+		listing = append(listing, bytes.Clone(key))
 		getter.Skip()
 	}
 	decomp.Close()
@@ -241,12 +241,12 @@ func generateInputData(tb testing.TB, keySize, valueSize, keyCount int) ([][]byt
 		n, err := rnd.Read(bk)
 		require.Equal(tb, keySize, n)
 		require.NoError(tb, err)
-		keys[i] = common.Copy(bk[:n])
+		keys[i] = bytes.Clone(bk[:n])
 
 		n, err = rnd.Read(bv[:rnd.IntN(valueSize)+1])
 		require.NoError(tb, err)
 
-		values[i] = common.Copy(bv[:n])
+		values[i] = bytes.Clone(bv[:n])
 	}
 	return keys, values
 }

--- a/db/state/domain_stream.go
+++ b/db/state/domain_stream.go
@@ -212,7 +212,7 @@ func (hi *DomainLatestIterFile) init(domainRoTx *DomainRoTx) error {
 			}
 
 			if key != nil && (hi.to == nil || bytes.Compare(key, hi.to) < 0) {
-				heap.Push(hi.h, &CursorItem{t: FILE_CURSOR, key: common.Copy(key), val: common.Copy(value), kvReader: reader, endTxNum: txNum, reverse: true})
+				heap.Push(hi.h, &CursorItem{t: FILE_CURSOR, key: bytes.Clone(key), val: bytes.Clone(value), kvReader: reader, endTxNum: txNum, reverse: true})
 			}
 		}
 	}
@@ -241,7 +241,7 @@ func (hi *DomainLatestIterFile) initCursorOnDB(domainRoTx *DomainRoTx) error {
 			step := ^binary.BigEndian.Uint64(stepBytes)
 			endTxNum := step * domainRoTx.d.stepSize
 			if endTxNum >= hi.filesEndTxNum {
-				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(k), val: common.Copy(value), cNonDup: valsCursor, endTxNum: endTxNum, reverse: true})
+				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: bytes.Clone(k), val: bytes.Clone(value), cNonDup: valsCursor, endTxNum: endTxNum, reverse: true})
 				pushed = true
 				break
 			}
@@ -271,7 +271,7 @@ func (hi *DomainLatestIterFile) initCursorOnDB(domainRoTx *DomainRoTx) error {
 			step := ^binary.BigEndian.Uint64(stepBytes)
 			endTxNum := step * domainRoTx.d.stepSize
 			if endTxNum >= hi.filesEndTxNum {
-				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: common.Copy(key), val: common.Copy(val), cDup: valsCursor, endTxNum: endTxNum, reverse: true})
+				heap.Push(hi.h, &CursorItem{t: DB_CURSOR, key: bytes.Clone(key), val: bytes.Clone(val), cDup: valsCursor, endTxNum: endTxNum, reverse: true})
 				pushed = true
 				break
 			}
@@ -317,9 +317,9 @@ func (hi *DomainLatestIterFile) advanceLargeValsDBCursor(ci1 *CursorItem) error 
 		step := ^binary.BigEndian.Uint64(stepBytes)
 		endTxNum := step * hi.aggStep
 		if endTxNum >= hi.filesEndTxNum {
-			ci1.key = common.Copy(k[:len(k)-8])
+			ci1.key = bytes.Clone(k[:len(k)-8])
 			ci1.endTxNum = endTxNum
-			ci1.val = common.Copy(v)
+			ci1.val = bytes.Clone(v)
 			heap.Push(hi.h, ci1)
 			pushed = true
 			break
@@ -348,9 +348,9 @@ func (hi *DomainLatestIterFile) advanceDupSortDBCursor(ci1 *CursorItem) error {
 		step := ^binary.BigEndian.Uint64(stepBytes)
 		endTxNum := step * hi.aggStep
 		if endTxNum >= hi.filesEndTxNum {
-			ci1.key = common.Copy(k)
+			ci1.key = bytes.Clone(k)
 			ci1.endTxNum = endTxNum
-			ci1.val = common.Copy(v)
+			ci1.val = bytes.Clone(v)
 			heap.Push(hi.h, ci1)
 			pushed = true
 			break
@@ -386,8 +386,8 @@ func (hi *DomainLatestIterFile) advanceInFiles() error {
 					if ci1.kvReader.HasNext() {
 						k, _ := ci1.kvReader.Next(nil)
 						v, _ := ci1.kvReader.Next(nil)
-						ci1.key = common.Copy(k)
-						ci1.val = common.Copy(v)
+						ci1.key = bytes.Clone(k)
+						ci1.val = bytes.Clone(v)
 						if ci1.key != nil && (hi.to == nil || bytes.Compare(ci1.key, hi.to) < 0) {
 							heap.Push(hi.h, ci1)
 						}
@@ -443,7 +443,7 @@ func (hi *DomainLatestIterFile) Next() ([]byte, []byte, error) {
 	}
 	order.Asc.Assert(hi.kBackup, hi.nextKey)
 	// TODO: remove `common.Copy`. it protecting from some existing bug. https://github.com/erigontech/erigon/issues/12672
-	return common.Copy(hi.kBackup), common.Copy(hi.vBackup), nil
+	return bytes.Clone(hi.kBackup), bytes.Clone(hi.vBackup), nil
 }
 
 // debugIteratePrefix iterates over key-value pairs of the storage domain that start with given prefix
@@ -480,7 +480,7 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 		v = ramIter.Value()[len(ramIter.Value())-1].data
 
 		if len(k) > 0 && bytes.HasPrefix(k, prefix) {
-			heap.Push(cpPtr, &CursorItem{t: RAM_CURSOR, key: common.Copy(k), val: common.Copy(v), iter: ramIter, endTxNum: math.MaxUint64, reverse: true})
+			heap.Push(cpPtr, &CursorItem{t: RAM_CURSOR, key: bytes.Clone(k), val: bytes.Clone(v), iter: ramIter, endTxNum: math.MaxUint64, reverse: true})
 		}
 	}
 
@@ -497,7 +497,7 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 		step := kv.Step(^binary.BigEndian.Uint64(v[:8]))
 		if step.ToTxNum(dt.stepSize) >= filesEndTxNum {
 			val := v[8:]
-			heap.Push(cpPtr, &CursorItem{t: DB_CURSOR, key: common.Copy(k), val: common.Copy(val), cDup: valsCursor, endTxNum: step.ToTxNum(dt.stepSize), reverse: true})
+			heap.Push(cpPtr, &CursorItem{t: DB_CURSOR, key: bytes.Clone(k), val: bytes.Clone(val), cDup: valsCursor, endTxNum: step.ToTxNum(dt.stepSize), reverse: true})
 			break
 		}
 		if k, v, err = valsCursor.NextNoDup(); err != nil {
@@ -523,8 +523,8 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 	}
 
 	for cp.Len() > 0 {
-		lastKey := common.Copy(cp[0].key)
-		lastVal := common.Copy(cp[0].val)
+		lastKey := bytes.Clone(cp[0].key)
+		lastVal := bytes.Clone(cp[0].val)
 		// Advance all the items that have this key (including the top)
 		for cp.Len() > 0 && bytes.Equal(cp[0].key, lastKey) {
 			ci1 := heap.Pop(cpPtr).(*CursorItem)
@@ -533,8 +533,8 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 				if ci1.iter.Next() {
 					k = common.ToBytesZeroCopy(ci1.iter.Key())
 					if k != nil && bytes.HasPrefix(k, prefix) {
-						ci1.key = common.Copy(k)
-						ci1.val = common.Copy(ci1.iter.Value()[len(ci1.iter.Value())-1].data)
+						ci1.key = bytes.Clone(k)
+						ci1.val = bytes.Clone(ci1.iter.Value()[len(ci1.iter.Value())-1].data)
 						heap.Push(cpPtr, ci1)
 					}
 				}
@@ -579,9 +579,9 @@ func (dt *DomainRoTx) debugIteratePrefixLatest(prefix []byte, ramIter btree2.Map
 					}
 					step := kv.Step(^binary.BigEndian.Uint64(v[:8]))
 					if step.ToTxNum(dt.stepSize) >= filesEndTxNum {
-						ci1.key = common.Copy(k)
+						ci1.key = bytes.Clone(k)
 						ci1.endTxNum = step.ToTxNum(dt.stepSize)
-						ci1.val = common.Copy(v[8:])
+						ci1.val = bytes.Clone(v[8:])
 						heap.Push(cpPtr, ci1)
 						pushed = true
 						break

--- a/db/state/domain_stream_test.go
+++ b/db/state/domain_stream_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	btree2 "github.com/tidwall/btree"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/state/statecfg"
@@ -221,7 +220,7 @@ func TestDomain_IteratePrefix_PrefersFilesOverDB(t *testing.T) {
 	var ramIter btree2.MapIter[string, []dataWithTxNum]
 	err = dt.debugIteratePrefixLatest(prefix, ramIter, func(k, v []byte) (bool, error) {
 		if bytes.Equal(k, key[:]) {
-			gotVal = common.Copy(v)
+			gotVal = bytes.Clone(v)
 		}
 		return true, nil
 	}, roTx)
@@ -322,7 +321,7 @@ func TestDomainLatestIterFile_PrefersFilesOverDB(t *testing.T) {
 		k, v, err := iter.Next()
 		require.NoError(err)
 		if bytes.Equal(k, key[:]) {
-			gotVal = common.Copy(v)
+			gotVal = bytes.Clone(v)
 		}
 	}
 
@@ -422,7 +421,7 @@ func TestDomainLatestIterFile_PrefersFilesOverDB_LargeValues(t *testing.T) {
 		k, v, err := iter2.Next()
 		require.NoError(err)
 		if bytes.Equal(k, key[:]) {
-			gotVal = common.Copy(v)
+			gotVal = bytes.Clone(v)
 		}
 	}
 

--- a/db/state/domain_test.go
+++ b/db/state/domain_test.go
@@ -625,7 +625,7 @@ func checkDomainFileSortedKeyOrder(t *testing.T, dt *DomainRoTx) {
 					"file %d [%d-%d) pair %d: key %x not > prevKey %x",
 					i, f.startTxNum, f.endTxNum, pairIdx, key, prevKey)
 			}
-			prevKey = common.Copy(key)
+			prevKey = bytes.Clone(key)
 			if r.HasNext() {
 				r.Skip() // skip value
 			}
@@ -1117,7 +1117,7 @@ func TestNewSegStreamReader(t *testing.T) {
 		if prevK != nil {
 			require.Negative(t, bytes.Compare(prevK, k))
 		}
-		prevK = common.Copy(k)
+		prevK = bytes.Clone(k)
 
 		require.NoError(t, err)
 		require.NotEmpty(t, v)
@@ -2028,7 +2028,7 @@ func TestDomain_CanScanPruneAfterAggregation(t *testing.T) {
 		p := []byte{}
 		for i := range updates {
 			writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, p)
-			p = common.Copy(updates[i].value)
+			p = bytes.Clone(updates[i].value)
 		}
 	}
 
@@ -2129,7 +2129,7 @@ func TestDomain_PruneAfterAggregation(t *testing.T) {
 		p := []byte{}
 		for i := range updates {
 			writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, p)
-			p = common.Copy(updates[i].value)
+			p = bytes.Clone(updates[i].value)
 		}
 	}
 
@@ -2915,7 +2915,7 @@ func TestDomainContext_findShortenedKey(t *testing.T) {
 		p := []byte{}
 		for i := range updates {
 			writer.PutWithPrev([]byte(key), updates[i].value, updates[i].txNum, p)
-			p = common.Copy(updates[i].value)
+			p = bytes.Clone(updates[i].value)
 		}
 	}
 
@@ -3128,8 +3128,8 @@ func TestCommitmentDomain_DebugRangeLatest(t *testing.T) {
 				binary.BigEndian.PutUint64(k[:], keyNum)
 				binary.BigEndian.PutUint64(v[:], valNum)
 				err = writer.PutWithPrev(k[:], v[:], txNum, prev[keyNum])
-				prev[keyNum] = common.Copy(v[:])
-				keysLatest[string(k[:])] = common.Copy(v[:])
+				prev[keyNum] = bytes.Clone(v[:])
+				keysLatest[string(k[:])] = bytes.Clone(v[:])
 				require.NoError(t, err)
 			}
 		}
@@ -3238,7 +3238,7 @@ func TestDomain_DebugRangeLatestFromFiles(t *testing.T) {
 				binary.BigEndian.PutUint64(k[:], keyNum)
 				binary.BigEndian.PutUint64(v[:], txNum)
 				err = writer.PutWithPrev(k[:], v[:], txNum, prev[keyNum])
-				prev[keyNum] = common.Copy(v[:])
+				prev[keyNum] = bytes.Clone(v[:])
 				fileKeyNums[keyNum] = true
 				require.NoError(t, err)
 			}

--- a/db/state/execctx/domain_shared.go
+++ b/db/state/execctx/domain_shared.go
@@ -1017,7 +1017,7 @@ func (sd *SharedDomains) Commit(ctx context.Context, tx kv.RwTx, validate ...fun
 						if len(v) < 8 {
 							continue
 						}
-						m[string(common.Copy(k))] = common.Copy(v[8:])
+						m[string(bytes.Clone(k))] = bytes.Clone(v[8:])
 						if scanned += len(k) + len(v); scanned >= budget {
 							return
 						}

--- a/db/state/execctx/domain_shared_test.go
+++ b/db/state/execctx/domain_shared_test.go
@@ -71,7 +71,7 @@ func newTestDb(tb testing.TB, stepSize uint64) kv.TemporalRwDB {
 }
 
 func composite(k, k2 []byte) []byte {
-	return append(common.Copy(k), k2...)
+	return append(bytes.Clone(k), k2...)
 }
 
 func TestSharedDomain_Unwind(t *testing.T) {
@@ -1509,7 +1509,7 @@ func TestDomainPut_HistoryCorrectness(t *testing.T) {
 	domainCases := []domainCase{
 		{
 			domain:  kv.AccountsDomain,
-			makeKey: func() []byte { return common.Copy(addr) },
+			makeKey: func() []byte { return bytes.Clone(addr) },
 			makeVal: func(i int) []byte {
 				acc := accounts3.Account{
 					Nonce:    uint64(i),
@@ -1522,13 +1522,13 @@ func TestDomainPut_HistoryCorrectness(t *testing.T) {
 		},
 		{
 			domain:          kv.StorageDomain,
-			makeKey:         func() []byte { return common.Copy(storageKey) },
+			makeKey:         func() []byte { return bytes.Clone(storageKey) },
 			makeVal:         func(i int) []byte { return binary.BigEndian.AppendUint64(nil, uint64(i)) },
 			historyKeyTable: kv.TblStorageHistoryKeys,
 		},
 		{
 			domain:          kv.CodeDomain,
-			makeKey:         func() []byte { return common.Copy(addr) },
+			makeKey:         func() []byte { return bytes.Clone(addr) },
 			makeVal:         func(i int) []byte { return binary.BigEndian.AppendUint64(nil, uint64(i)) },
 			historyKeyTable: kv.TblCodeHistoryKeys,
 		},

--- a/db/state/execctx/pin_branch_resolver.go
+++ b/db/state/execctx/pin_branch_resolver.go
@@ -17,7 +17,7 @@
 package execctx
 
 import (
-	"github.com/erigontech/erigon/common"
+	"bytes"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/commitment"
 )
@@ -39,7 +39,7 @@ func pinBranchResolver(ttx kv.TemporalGetter) commitment.BatchBranchResolver {
 				return nil, err
 			}
 			if len(v) > 0 {
-				vals[i] = common.Copy(v)
+				vals[i] = bytes.Clone(v)
 			}
 		}
 		return vals, nil

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -29,7 +29,6 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/background"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -1535,7 +1534,7 @@ func (ht *HistoryRoTx) idxRangeOnDB(key []byte, startTxNum, endTxNum int, asc or
 			fromTxNum = uint64(startTxNum)
 		}
 		binary.BigEndian.PutUint64(from[len(key):], fromTxNum)
-		to := common.Copy(from)
+		to := bytes.Clone(from)
 		toTxNum := uint64(math.MaxUint64)
 		if endTxNum >= 0 {
 			toTxNum = uint64(endTxNum)

--- a/db/state/history_key_txnum_range.go
+++ b/db/state/history_key_txnum_range.go
@@ -21,7 +21,6 @@ import (
 	"container/heap"
 	"encoding/binary"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/order"
 	"github.com/erigontech/erigon/db/kv/stream"
@@ -205,7 +204,7 @@ func (hi *HistoryKeyTxNumIterDB) Close() {
 
 // setNext copies k (cursor ops invalidate previous return values).
 func (hi *HistoryKeyTxNumIterDB) setNext(k []byte, txNum uint64) {
-	hi.nextKey = common.Copy(k)
+	hi.nextKey = bytes.Clone(k)
 	hi.nextTxNum = txNum
 }
 
@@ -289,7 +288,7 @@ func (hi *HistoryKeyTxNumIterDB) advanceLargeVals() error {
 			hi.nextKey = nil
 			return nil
 		}
-		seek := append(common.Copy(k[:len(k)-8]), hi.startTxKey[:]...)
+		seek := append(bytes.Clone(k[:len(k)-8]), hi.startTxKey[:]...)
 		k, _, err = hi.valsC.Seek(seek)
 		if err != nil {
 			return err
@@ -306,7 +305,7 @@ func (hi *HistoryKeyTxNumIterDB) advanceLargeVals() error {
 		return nil
 	}
 	if hi.nextKey != nil && !bytes.Equal(k[:len(k)-8], hi.nextKey) {
-		seek := append(common.Copy(k[:len(k)-8]), hi.startTxKey[:]...)
+		seek := append(bytes.Clone(k[:len(k)-8]), hi.startTxKey[:]...)
 		k, _, err = hi.valsC.Seek(seek)
 		if err != nil {
 			return err
@@ -333,7 +332,7 @@ func (hi *HistoryKeyTxNumIterDB) scanLargeVals(k []byte) error {
 			continue
 		}
 		if txNum < binary.BigEndian.Uint64(hi.startTxKey[:]) {
-			seek := append(common.Copy(k[:len(k)-8]), hi.startTxKey[:]...)
+			seek := append(bytes.Clone(k[:len(k)-8]), hi.startTxKey[:]...)
 			var err error
 			k, _, err = hi.valsC.Seek(seek)
 			if err != nil {

--- a/db/state/history_stream.go
+++ b/db/state/history_stream.go
@@ -23,7 +23,6 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -215,7 +214,7 @@ func (hi *HistoryRangeAsOfFiles) Next() ([]byte, []byte, error) {
 	}
 	hi.orderAscend.Assert(hi.kBackup, hi.nextKey)
 	// TODO: remove `common.Copy`. it protecting from some existing bug. https://github.com/erigontech/erigon/issues/12672
-	return common.Copy(hi.kBackup), common.Copy(hi.vBackup), nil
+	return bytes.Clone(hi.kBackup), bytes.Clone(hi.vBackup), nil
 }
 
 // HistoryRangeAsOfDB - returns state range at given time in history
@@ -284,7 +283,7 @@ func (hi *HistoryRangeAsOfDB) advanceLargeVals() error {
 			hi.nextKey = nil
 			return nil
 		}
-		seek = append(common.Copy(firstKey[:len(firstKey)-8]), hi.startTxKey[:]...)
+		seek = append(bytes.Clone(firstKey[:len(firstKey)-8]), hi.startTxKey[:]...)
 	} else {
 		next, ok := kv.NextSubtree(hi.nextKey)
 		if !ok {
@@ -399,7 +398,7 @@ func (hi *HistoryRangeAsOfDB) Next() ([]byte, []byte, error) {
 	}
 	hi.orderAscend.Assert(hi.kBackup, hi.nextKey)
 	// TODO: remove `common.Copy`. it protecting from some existing bug. https://github.com/erigontech/erigon/issues/12672
-	return common.Copy(hi.kBackup), common.Copy(hi.vBackup), nil
+	return bytes.Clone(hi.kBackup), bytes.Clone(hi.vBackup), nil
 }
 
 // HistoryChangesIterFiles - producing state-patch for Unwind - return state-patch for Unwind: "what keys changed between `[from, to)` and what was their value BEFORE txNum"
@@ -571,7 +570,7 @@ func (hi *HistoryChangesIterDB) advanceLargeVals() error {
 			hi.nextKey = nil
 			return nil
 		}
-		seek = append(common.Copy(firstKey[:len(firstKey)-8]), hi.startTxKey[:]...)
+		seek = append(bytes.Clone(firstKey[:len(firstKey)-8]), hi.startTxKey[:]...)
 	} else {
 		next, ok := kv.NextSubtree(hi.nextKey)
 		if !ok {
@@ -958,7 +957,7 @@ func (ht *HistoryTraceKeyDB) advanceSmallVals() error {
 		ht.k = nil
 	}
 	ht.v = ht.v[8:]
-	ht.v = common.Copy(ht.v)
+	ht.v = bytes.Clone(ht.v)
 	return nil
 }
 

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -568,7 +568,7 @@ func TestHistoryCanPrune(t *testing.T) {
 			err = writer.AddPrevValue(append(addr, val...), i, prev)
 			require.NoError(err)
 
-			prev = common.Copy(val)
+			prev = bytes.Clone(val)
 		}
 
 		require.NoError(writer.Flush(ctx, tx))
@@ -1111,7 +1111,7 @@ func checkHistoryNoDuplicates(t *testing.T, hc *HistoryRoTx) {
 				"duplicate history entry for key %x: same value %x at txNum=%d and txNum=%d",
 				key, val, prev.txNum, txNum)
 		}
-		prevByKey[ks] = prevEntry{val: common.Copy(val), txNum: txNum}
+		prevByKey[ks] = prevEntry{val: bytes.Clone(val), txNum: txNum}
 	}
 }
 

--- a/db/state/squeeze_test.go
+++ b/db/state/squeeze_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
@@ -81,12 +80,12 @@ func generateInputData(tb testing.TB, keySize, valueSize, keyCount int) ([][]byt
 		n, err := rnd.Read(bk)
 		require.Equal(tb, keySize, n)
 		require.NoError(tb, err)
-		keys[i] = common.Copy(bk[:n])
+		keys[i] = bytes.Clone(bk[:n])
 
 		n, err = rnd.Read(bv[:rnd.IntN(valueSize)+1])
 		require.NoError(tb, err)
 
-		values[i] = common.Copy(bv[:n])
+		values[i] = bytes.Clone(bv[:n])
 	}
 	return keys, values
 }
@@ -416,7 +415,7 @@ func TestAggregator_RebuildCommitmentBasedOnFiles(t *testing.T) {
 }
 
 func composite(k, k2 []byte) []byte {
-	return append(common.Copy(k), k2...)
+	return append(bytes.Clone(k), k2...)
 }
 
 // makeAccountAddr generates a deterministic 20-byte account address with uniform
@@ -559,7 +558,7 @@ func aggregatorV3_RestartOnDatadir(t *testing.T, rc runCfg) {
 		err = domains.DomainPut(kv.StorageDomain, tx, composite(addr, loc), []byte{addr[0], loc[0]}, txNum, nil)
 		require.NoError(t, err)
 
-		err = domains.DomainPut(kv.CommitmentDomain, tx, someKey, common.Copy(aux[:]), txNum, nil)
+		err = domains.DomainPut(kv.CommitmentDomain, tx, someKey, bytes.Clone(aux[:]), txNum, nil)
 		require.NoError(t, err)
 		maxWrite = txNum
 	}

--- a/db/state/temporal_mem_batch.go
+++ b/db/state/temporal_mem_batch.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"bytes"
 	"cmp"
 	"context"
 	"encoding/binary"
@@ -178,7 +179,7 @@ func (sd *TemporalMemBatch) putLatest(domain kv.Domain, key string, val []byte, 
 
 	// Own the bytes now: val may alias a .kv mmap (the foreground exec tx's file generation)
 	// that a background merge can munmap while a concurrent commitment worker reads sd.mem.
-	valWithStep := dataWithTxNum{data: common.Copy(val), txNum: txNum}
+	valWithStep := dataWithTxNum{data: bytes.Clone(val), txNum: txNum}
 	putKeySize := 0
 	putValueSize := 0
 	if domain == kv.StorageDomain {
@@ -429,8 +430,8 @@ func (sd *TemporalMemBatch) HasPrefix(domain kv.Domain, prefix []byte, roTx kv.T
 			v = lv
 		}
 		if len(v) > 0 {
-			firstKey = common.Copy(k)
-			firstVal = common.Copy(v)
+			firstKey = bytes.Clone(k)
+			firstVal = bytes.Clone(v)
 			hasPrefix = true
 			return false, nil // do not continue, end on first occurrence
 		}

--- a/db/test/aggregator_ext_test.go
+++ b/db/test/aggregator_ext_test.go
@@ -17,6 +17,7 @@
 package test
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"math"
@@ -31,7 +32,6 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -797,7 +797,7 @@ func extractKVErrIterator(t *testing.T, it stream.KV) map[string][]byte {
 	for it.HasNext() {
 		k, v, err := it.Next()
 		require.NoError(t, err)
-		accounts[hex.EncodeToString(k)] = common.Copy(v)
+		accounts[hex.EncodeToString(k)] = bytes.Clone(v)
 	}
 
 	return accounts

--- a/db/test/domain_shared_bench_test.go
+++ b/db/test/domain_shared_bench_test.go
@@ -17,6 +17,7 @@
 package test
 
 import (
+	"bytes"
 	"cmp"
 	"encoding/binary"
 	randOld "math/rand"
@@ -28,7 +29,6 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -61,7 +61,7 @@ func testDbAndAggregatorBench(b *testing.B, aggStep uint64) (kv.TemporalRwDB, *s
 }
 
 func composite(k, k2 []byte) []byte {
-	return append(common.Copy(k), k2...)
+	return append(bytes.Clone(k), k2...)
 }
 
 func Benchmark_SharedDomains_GetLatest(t *testing.B) {
@@ -199,7 +199,7 @@ func BenchmarkSharedDomains_ComputeCommitment(b *testing.B) {
 			if v == nil {
 				continue
 			}
-			touches = append(touches, keyTouch{dom, []byte(key), common.Copy(v)})
+			touches = append(touches, keyTouch{dom, []byte(key), bytes.Clone(v)})
 		}
 	}
 
@@ -477,7 +477,7 @@ func generateSharedDomainsUpdatesForBench(b *testing.B, domains *execctx.SharedD
 
 			prevKeys[string(sk)] = struct{}{}
 
-			err = domains.DomainPut(kv.StorageDomain, tx, sk, append(common.Copy(prev), []byte("v")...), txNum, prev)
+			err = domains.DomainPut(kv.StorageDomain, tx, sk, append(bytes.Clone(prev), []byte("v")...), txNum, prev)
 			require.NoError(b, err)
 		}
 	}

--- a/db/test/domains_restart_test.go
+++ b/db/test/domains_restart_test.go
@@ -17,6 +17,7 @@
 package test
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io/fs"
@@ -476,7 +477,7 @@ func TestCommit(t *testing.T) {
 		require.NoError(t, err)
 		loc[0] = byte(i)
 
-		err = domains.DomainPut(kv.StorageDomain, tx, append(common.Copy(addr), loc...), []byte("0401"), txNum, nil)
+		err = domains.DomainPut(kv.StorageDomain, tx, append(bytes.Clone(addr), loc...), []byte("0401"), txNum, nil)
 		require.NoError(t, err)
 	}
 
@@ -507,7 +508,7 @@ func TestCommitmentContextTraceWriter(t *testing.T) {
 	addr := common.Hex2Bytes("8e5476fc5990638a4fb0b5fd3f61bb4b5c5f395e")
 	for i := 1; i < 12; i++ { // diverging first nibbles force a branch node
 		addr[0] = byte(i * 16)
-		require.NoError(t, domains.DomainPut(kv.AccountsDomain, tx, common.Copy(addr), val, 0, nil))
+		require.NoError(t, domains.DomainPut(kv.AccountsDomain, tx, bytes.Clone(addr), val, 0, nil))
 	}
 
 	var trace strings.Builder

--- a/execution/builder/create_block.go
+++ b/execution/builder/create_block.go
@@ -17,6 +17,7 @@
 package builder
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -213,7 +214,7 @@ func createBlock(ctx context.Context, sd *execctx.SharedDomains, tx kv.TemporalT
 	if daoBlock := cfg.chainConfig.DAOForkBlock; daoBlock != nil {
 		// Check whether the block is among the fork extra-override range
 		if header.Number.Uint64() >= *daoBlock && header.Number.Uint64() < *daoBlock+misc.DAOForkExtraRange {
-			header.Extra = common.Copy(misc.DAOForkBlockExtra)
+			header.Extra = bytes.Clone(misc.DAOForkBlockExtra)
 		}
 	}
 

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -26,7 +26,6 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/elastic/go-freelru"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/cachebudget"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/maphash"
@@ -442,7 +441,7 @@ func (c *GenericCache[T]) putStriped(key []byte, value T, txNum uint64, overwrit
 	if hasExisting {
 		lru.Remove(h)
 	}
-	keyCopy := common.Copy(key)
+	keyCopy := bytes.Clone(key)
 	if lru.Add(h, entry[T]{key: keyCopy, val: value, size: newSize, txNum: txNum, epoch: ep}) {
 		c.evictions.Add(1)
 	}

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/c2h5oh/datasize"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
@@ -164,9 +163,9 @@ func (c *StateCache) putCodeWithHash(addr, code, codeHash []byte, txNum uint64, 
 		return
 	}
 	if overwrite {
-		cc.PutWithCodeHash(addr, common.Copy(code), codeHash, txNum)
+		cc.PutWithCodeHash(addr, bytes.Clone(code), codeHash, txNum)
 	} else {
-		cc.PutWithCodeHashIfAbsent(addr, common.Copy(code), codeHash, txNum)
+		cc.PutWithCodeHashIfAbsent(addr, bytes.Clone(code), codeHash, txNum)
 	}
 }
 
@@ -242,9 +241,9 @@ func (c *StateCache) put(domain kv.Domain, key []byte, value []byte, txNum uint6
 		return
 	}
 	if overwrite {
-		cache.Put(key, common.Copy(value), txNum)
+		cache.Put(key, bytes.Clone(value), txNum)
 	} else {
-		cache.PutIfAbsent(key, common.Copy(value), txNum)
+		cache.PutIfAbsent(key, bytes.Clone(value), txNum)
 	}
 }
 

--- a/execution/commitment/calculator_touches_test.go
+++ b/execution/commitment/calculator_touches_test.go
@@ -1,6 +1,7 @@
 package commitment
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -125,7 +126,7 @@ func TestTouchKey_AccountAndCodeShareKey(t *testing.T) {
 
 	addr := common.FromHex("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
 	slot := common.FromHex("0000000000000000000000000000000000000000000000000000000000000004")
-	stgKey := append(common.Copy(addr), slot...)
+	stgKey := append(bytes.Clone(addr), slot...)
 
 	updates := NewUpdates(ModeUpdate, t.TempDir(), keyHasherNoop)
 	acc := accounts.Account{Nonce: 1, Balance: *uint256.NewInt(100)}

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -273,9 +273,9 @@ func getDeferredUpdate(prefix []byte, raw, prev []byte) *DeferredBranchUpdate {
 	getDeferredUpdateCount.Add(1)
 	upd := deferredUpdatePool.Get().(*DeferredBranchUpdate)
 
-	upd.prefix = common.Copy(prefix)
-	upd.raw = common.Copy(raw)
-	upd.prev = common.Copy(prev)
+	upd.prefix = bytes.Clone(prefix)
+	upd.raw = bytes.Clone(raw)
+	upd.prev = bytes.Clone(prev)
 	upd.encoded = nil
 
 	return upd
@@ -389,7 +389,7 @@ func mergeDeferredUpdate(upd *DeferredBranchUpdate, merger *BranchMerger) error 
 		if err != nil {
 			return err
 		}
-		upd.encoded = common.Copy(merged)
+		upd.encoded = bytes.Clone(merged)
 		return nil
 	}
 	upd.encoded = upd.raw
@@ -533,8 +533,8 @@ func (be *BranchEncoder) CollectUpdate(
 		}
 	}
 
-	prefixCopy := common.Copy(prefix)
-	updateCopy := common.Copy(update)
+	prefixCopy := bytes.Clone(prefix)
+	updateCopy := bytes.Clone(update)
 	if err = ctx.PutBranch(prefixCopy, updateCopy, prev); err != nil {
 		return err
 	}
@@ -1778,7 +1778,7 @@ func (t *Updates) TouchHashedKey(hashedKey []byte) {
 			t.keys[dedupKey] = struct{}{}
 		}
 	case ModeUpdate:
-		pivot := &KeyUpdate{hashedKey: common.Copy(hashedKey), update: new(Update)}
+		pivot := &KeyUpdate{hashedKey: bytes.Clone(hashedKey), update: new(Update)}
 		t.tree.ReplaceOrInsert(pivot)
 	default:
 	}

--- a/execution/commitment/commitment_bench_test.go
+++ b/execution/commitment/commitment_bench_test.go
@@ -17,13 +17,13 @@
 package commitment
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"testing"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,7 +110,7 @@ func BenchmarkBranchMerger_Merge(b *testing.B) {
 		enc1, err := be.EncodeBranch(bm, tm, am, &cellData)
 		require.NoError(b, err)
 
-		copies[i] = common.Copy(enc1)
+		copies[i] = bytes.Clone(enc1)
 	}
 
 	bmg := NewHexBranchMerger(4096)
@@ -145,7 +145,7 @@ func benchReplacePlainKeys(b *testing.B, data BranchData, buf []byte, fn func(ke
 func encodeSyntheticBranch(b *testing.B, nCells int) (BranchData, uint16) {
 	b.Helper()
 	_, bm, enc := encodeCellRow(b, nCells)
-	return BranchData(common.Copy(enc)), bm
+	return BranchData(bytes.Clone(enc)), bm
 }
 
 // preshortenBranchData shortens keys in enc and returns the shortened data plus
@@ -160,13 +160,13 @@ func preshortenBranchData(b *testing.B, enc BranchData) (BranchData, map[string]
 		} else {
 			short = key[:4]
 		}
-		keyMap[string(short)] = common.Copy(key)
+		keyMap[string(short)] = bytes.Clone(key)
 		return short, nil
 	})
 	if err != nil {
 		b.Fatal(err)
 	}
-	return BranchData(common.Copy(shortened)), keyMap
+	return BranchData(bytes.Clone(shortened)), keyMap
 }
 
 func BenchmarkBranchData_ReplacePlainKeys(b *testing.B) {

--- a/execution/commitment/commitment_test.go
+++ b/execution/commitment/commitment_test.go
@@ -528,7 +528,7 @@ func TestBranchData_ReplacePlainKeys(t *testing.T) {
 
 	_, _, enc := encodeCellRow(t, 16)
 
-	original := common.Copy(enc)
+	original := bytes.Clone(enc)
 
 	target := make([]byte, 0, len(enc))
 	oldKeys := make([][]byte, 0)
@@ -552,7 +552,7 @@ func TestBranchData_ReplacePlainKeys(t *testing.T) {
 	require.EqualValues(t, original, replacedBack)
 
 	t.Run("merge replaced and original back", func(t *testing.T) {
-		orig := common.Copy(original)
+		orig := bytes.Clone(original)
 
 		merged, err := replaced.MergeHexBranches(original, nil)
 		require.NoError(t, err)
@@ -569,7 +569,7 @@ func TestBranchData_ReplacePlainKeys_WithEmpty(t *testing.T) {
 
 	_, _, enc := encodeCellRow(t, 16)
 
-	original := common.Copy(enc)
+	original := bytes.Clone(enc)
 
 	target := make([]byte, 0, len(enc))
 	oldKeys := make([][]byte, 0)
@@ -593,7 +593,7 @@ func TestBranchData_ReplacePlainKeys_WithEmpty(t *testing.T) {
 	require.EqualValues(t, original, replacedBack)
 
 	t.Run("merge replaced and original back", func(t *testing.T) {
-		orig := common.Copy(original)
+		orig := bytes.Clone(original)
 
 		merged, err := replaced.MergeHexBranches(original, nil)
 		require.NoError(t, err)
@@ -612,7 +612,7 @@ func TestBranchData_ReplacePlainKeys_PartialChange(t *testing.T) {
 
 	_, _, enc := encodeCellRow(t, 16)
 
-	original := common.Copy(enc)
+	original := bytes.Clone(enc)
 
 	// Collect original keys and shorten only account keys.
 	type keyRecord struct {
@@ -620,10 +620,10 @@ func TestBranchData_ReplacePlainKeys_PartialChange(t *testing.T) {
 		isStorage bool
 	}
 	var origKeys []keyRecord
-	replaced, err := BranchData(common.Copy(enc)).ReplacePlainKeys(
+	replaced, err := BranchData(bytes.Clone(enc)).ReplacePlainKeys(
 		make([]byte, 0, len(enc)),
 		func(key []byte, isStorage bool) ([]byte, error) {
-			origKeys = append(origKeys, keyRecord{common.Copy(key), isStorage})
+			origKeys = append(origKeys, keyRecord{bytes.Clone(key), isStorage})
 			if isStorage {
 				return nil, nil // keep original
 			}
@@ -769,7 +769,7 @@ func (r *recordingCtx) Branch(_ []byte) ([]byte, kv.Step, error) {
 }
 func (r *recordingCtx) PutBranch(prefix, data, prev []byte) error {
 	r.puts = append(r.puts, struct{ prefix, data, prev []byte }{
-		common.Copy(prefix), common.Copy(data), common.Copy(prev),
+		bytes.Clone(prefix), bytes.Clone(data), bytes.Clone(prev),
 	})
 	return nil
 }

--- a/execution/commitment/commitmentdb/commitment_context.go
+++ b/execution/commitment/commitmentdb/commitment_context.go
@@ -989,7 +989,7 @@ func (sdc *TrieContext) Branch(pref []byte) ([]byte, kv.Step, error) {
 	if sdc.traceW != nil {
 		fmt.Fprintf(sdc.traceW, "[SDC] Branch read %x => %x\n", pref, enc)
 	}
-	return common.Copy(enc), step, nil
+	return bytes.Clone(enc), step, nil
 }
 
 func (sdc *TrieContext) PutBranch(prefix []byte, data []byte, prevData []byte) error {

--- a/execution/commitment/deepfold_regression_test.go
+++ b/execution/commitment/deepfold_regression_test.go
@@ -17,6 +17,7 @@
 package commitment
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"testing"
@@ -289,7 +290,7 @@ func TestSingletonAccountOnlyRetouchKeepsStorage(t *testing.T) {
 	ut2 := WrapKeyUpdates(t, ModeDirect, KeyToHexNibbleHash, k2, u2)
 	got, err := tr.Process(ctx, ut2, "", nil, WarmupConfig{})
 	require.NoError(t, err)
-	got = common.Copy(got)
+	got = bytes.Clone(got)
 	ut2.Close()
 
 	msr := NewMockState(t)

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -1404,7 +1404,7 @@ func (hph *HexPatriciaHashed) witnessMaterializeBranch(branchPrefix []byte, chil
 		if len(cellHash) == length.Hash+1 { // strip the 0xa0 prefix
 			cellHash = cellHash[1:]
 		}
-		fullNode.Children[nibble] = trie.NewHashNode(common.Copy(cellHash))
+		fullNode.Children[nibble] = trie.NewHashNode(bytes.Clone(cellHash))
 		bitset ^= bit
 	}
 	return fullNode, nil
@@ -2163,7 +2163,7 @@ func (hph *HexPatriciaHashed) detectCollapseBeforeDelete(hashedKey []byte) {
 		fmt.Fprintf(hph.traceW, "[collapse] found at parentRow=%d depth=%d: deleteNibble=%x, siblingNibble=%x, siblingPath=%s (len=%d), hashLen=%d, extLen=%d\n",
 			parentRow, depth, deleteNibble, siblingNibble, compactSibling, len(siblingPath), siblingCell.hashLen, siblingCell.hashedExtLen)
 	}
-	hph.collapseTracer(siblingPath, common.Copy(hph.currentKey[:depth]))
+	hph.collapseTracer(siblingPath, bytes.Clone(hph.currentKey[:depth]))
 }
 
 // detectCascadingCollapseAtRow detects a FullNode→ShortNode collapse caused by
@@ -2187,7 +2187,7 @@ func (hph *HexPatriciaHashed) detectCascadingCollapseAtRow(row int) {
 		fmt.Fprintf(hph.traceW, "[cascade-collapse] found at row=%d depth=%d: survivingNibble=%x, siblingPath=%s (len=%d), hashLen=%d, hashedExtLen=%d\n",
 			row, depth, survivingNibble, compactSibling, len(siblingPath), survivingCell.hashLen, survivingCell.hashedExtLen)
 	}
-	hph.collapseTracer(siblingPath, common.Copy(hph.currentKey[:depth]))
+	hph.collapseTracer(siblingPath, bytes.Clone(hph.currentKey[:depth]))
 }
 
 // fetches cell by key and set touch/after maps. Requires that prefix to be already unfolded
@@ -2423,7 +2423,7 @@ func (hph *HexPatriciaHashed) Witnesses(ctx context.Context, updates *Updates, p
 
 	provedKeys = make([][]byte, 0, updates.Size())
 	err = updates.HashSort(ctx, nil, func(hashedKey, plainKey []byte, stateUpdate *Update) error {
-		provedKeys = append(provedKeys, common.Copy(hashedKey))
+		provedKeys = append(provedKeys, bytes.Clone(hashedKey))
 		if len(plainKey) > 0 {
 			if int16(len(plainKey)) == hph.accountKeyLen {
 				if _, err := hph.accountFromCacheOrDB(plainKey); err != nil {

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -808,7 +808,7 @@ func Test_HexPatriciaHashed_ProcessUpdates_UniqueRepresentation_AfterStateRestor
 			require.NoError(t, err)
 
 			t.Logf("trieSequential root @%d hash %x\n", i, sequentialRoot)
-			rSeq = common.Copy(sequentialRoot)
+			rSeq = bytes.Clone(sequentialRoot)
 
 			updsOne.Close()
 
@@ -835,7 +835,7 @@ func Test_HexPatriciaHashed_ProcessUpdates_UniqueRepresentation_AfterStateRestor
 		require.NoError(t, err)
 		t.Logf("trieBatch of %d root hash %x\n", len(updates), rh)
 
-		rBatch = common.Copy(rh)
+		rBatch = bytes.Clone(rh)
 		updsTwo.Close()
 	}
 	require.Equal(t, rBatch, rSeq, "sequential and trieBatch root should match")
@@ -908,7 +908,7 @@ func Test_HexPatriciaHashed_ProcessUpdates_UniqueRepresentationInTheMiddle(t *te
 			require.NoError(t, err)
 
 			t.Logf("sequential root @%d hash %x\n", i, sequentialRoot)
-			rSeq = common.Copy(sequentialRoot)
+			rSeq = bytes.Clone(sequentialRoot)
 
 			updsOne.Close()
 
@@ -921,7 +921,7 @@ func Test_HexPatriciaHashed_ProcessUpdates_UniqueRepresentationInTheMiddle(t *te
 
 				err = sequential.SetState(prevState)
 				require.NoError(t, err)
-				somewhereRoot = common.Copy(sequentialRoot)
+				somewhereRoot = bytes.Clone(sequentialRoot)
 			}
 		}
 	}
@@ -943,7 +943,7 @@ func Test_HexPatriciaHashed_ProcessUpdates_UniqueRepresentationInTheMiddle(t *te
 		require.NoError(t, err)
 		t.Logf("(second half) batch of %d root hash %x\n", len(updates)-somewhere, rh)
 
-		rBatch = common.Copy(rh)
+		rBatch = bytes.Clone(rh)
 		updsTwo.Close()
 	}
 	require.Equal(t, rBatch, rSeq, "sequential and batch root should match")
@@ -1139,7 +1139,7 @@ func TestCell_fillFromFields(t *testing.T) {
 	enc, err := be.EncodeBranch(bm, bm, bm, &cellData)
 	require.NoError(t, err)
 
-	//original := common.Copy(enc)
+	//original := bytes.Clone(enc)
 	fmt.Printf("%s\n", enc.String())
 
 	tm, am, decRow, err := enc.decodeCells()
@@ -1336,7 +1336,7 @@ func Test_HexPatriciaHashed_ProcessWithDozensOfStorageKeys(t *testing.T) {
 	//	trieOne.keccak.Read(hashed)
 	//	prefixesCnt[string(hashed[:5])]++
 	//	if c := prefixesCnt[string(hashed[:5])]; c < 5 {
-	//		prefixes[string(hashed[:5])] = append(prefixes[string(hashed[:5])], common.Copy(noise))
+	//		prefixes[string(hashed[:5])] = append(prefixes[string(hashed[:5])], bytes.Clone(noise))
 	//	}
 	//}
 	//
@@ -1369,7 +1369,7 @@ func Test_HexPatriciaHashed_ProcessWithDozensOfStorageKeys(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Logf("sequential root @%d hash %x\n", i, sequentialRoot)
-			rSeq = common.Copy(sequentialRoot)
+			rSeq = bytes.Clone(sequentialRoot)
 
 			updsOne.Close()
 		}
@@ -1387,7 +1387,7 @@ func Test_HexPatriciaHashed_ProcessWithDozensOfStorageKeys(t *testing.T) {
 
 		updsTwo.Close()
 
-		rBatch = common.Copy(rh)
+		rBatch = bytes.Clone(rh)
 	}
 	require.Equal(t, rBatch, rSeq, "sequential and batch root should match")
 }

--- a/execution/commitment/parallel_testkit_test.go
+++ b/execution/commitment/parallel_testkit_test.go
@@ -155,7 +155,7 @@ func processRoot(t *testing.T, trie Trie, ut *Updates) []byte {
 	t.Helper()
 	root, err := trie.Process(context.Background(), ut, "", nil, WarmupConfig{})
 	require.NoError(t, err)
-	return common.Copy(root)
+	return bytes.Clone(root)
 }
 
 func processModeBatch(t *testing.T, ms *MockState, mode runMode, workers int, keys [][]byte, upds []Update) []byte {
@@ -213,7 +213,7 @@ func processModeBatchState(t *testing.T, ms *MockState, mode runMode, workers in
 		r, err := sc.Process(ctx)
 		require.NoError(t, err)
 		sc.PromoteRootInto(tmpl)
-		return common.Copy(r), encoded(tmpl)
+		return bytes.Clone(r), encoded(tmpl)
 	case modeStreamingPublic:
 		cfg := DefaultTrieConfig()
 		cfg.Variant = VariantStreamingHexPatricia

--- a/execution/commitment/patricia_state_mock_test.go
+++ b/execution/commitment/patricia_state_mock_test.go
@@ -17,6 +17,7 @@
 package commitment
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -380,7 +381,7 @@ func (ub *UpdateBuilder) Build() (plainKeys [][]byte, updates []Update) {
 				hashedKey[64+i*2] = (c >> 4) & 0xf
 				hashedKey[64+i*2+1] = c & 0xf
 			}
-			hs := string(common.Copy(hashedKey))
+			hs := string(bytes.Clone(hashedKey))
 			hashed = append(hashed, hs)
 			preimages[hs] = []byte(sk1)
 			preimages2[hs] = []byte(sk2)

--- a/execution/commitment/preload_parallel.go
+++ b/execution/commitment/preload_parallel.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
@@ -54,7 +53,7 @@ type pathKey struct {
 
 func toPathKey(path []byte) pathKey {
 	// HexToCompact result may alias a reused buffer, so copy it.
-	return pathKey{path: path, key: common.Copy(nibbles.HexToCompact(path))}
+	return pathKey{path: path, key: bytes.Clone(nibbles.HexToCompact(path))}
 }
 
 // ContractTrunkPreloadParallel is the wave-BFS analogue of ContractTrunkPreload.
@@ -97,7 +96,7 @@ func NewContractTrunkPreloadParallel(contractHash []byte) (*ContractTrunkPreload
 	if len(contractHash) != 32 {
 		return nil, fmt.Errorf("NewContractTrunkPreloadParallel: contractHash must be 32 bytes, got %d", len(contractHash))
 	}
-	contractHashCopy := common.Copy(contractHash)
+	contractHashCopy := bytes.Clone(contractHash)
 	return &ContractTrunkPreloadParallel{
 		contractHash:    contractHashCopy,
 		frontier:        []pathKey{toPathKey(ContractNibbles(contractHashCopy))},
@@ -185,7 +184,7 @@ func (p *ContractTrunkPreloadParallel) Run(
 		// floor drops a preloaded pin before the cStep<=maxStep gate is consulted,
 		// so leaving step unset only keeps that gate trivially true for live pins.
 		cache.PinEntry(pk.key, v, 0, p.pinTxNum)
-		p.pinnedPrefixes = append(p.pinnedPrefixes, common.Copy(pk.key))
+		p.pinnedPrefixes = append(p.pinnedPrefixes, bytes.Clone(pk.key))
 		p.usedBytes += cost
 		p.pinned++
 		chunkPinned++

--- a/execution/commitment/recording_context.go
+++ b/execution/commitment/recording_context.go
@@ -17,7 +17,7 @@
 package commitment
 
 import (
-	"github.com/erigontech/erigon/common"
+	"bytes"
 	"github.com/erigontech/erigon/db/kv"
 )
 
@@ -57,7 +57,7 @@ func (rc *RecordingContext) Branch(prefix []byte) ([]byte, kv.Step, error) {
 		return data, step, err
 	}
 	if data != nil {
-		rc.branches[string(common.Copy(prefix))] = common.Copy(data)
+		rc.branches[string(bytes.Clone(prefix))] = bytes.Clone(data)
 	}
 	return data, step, nil
 }
@@ -70,7 +70,7 @@ func (rc *RecordingContext) Account(plainKey []byte) (*Update, error) {
 	if u != nil {
 		var numBuf [10]byte
 		encoded := u.Encode(nil, numBuf[:])
-		rc.accounts[string(common.Copy(plainKey))] = encoded
+		rc.accounts[string(bytes.Clone(plainKey))] = encoded
 	}
 	return u, nil
 }
@@ -83,15 +83,15 @@ func (rc *RecordingContext) Storage(plainKey []byte) (*Update, error) {
 	if u != nil {
 		var numBuf [10]byte
 		encoded := u.Encode(nil, numBuf[:])
-		rc.storages[string(common.Copy(plainKey))] = encoded
+		rc.storages[string(bytes.Clone(plainKey))] = encoded
 	}
 	return u, nil
 }
 
 func (rc *RecordingContext) PutBranch(prefix []byte, data []byte, prevData []byte) error {
-	rc.putBranches[string(common.Copy(prefix))] = BranchWrite{
-		PrevData: common.Copy(prevData),
-		NewData:  common.Copy(data),
+	rc.putBranches[string(bytes.Clone(prefix))] = BranchWrite{
+		PrevData: bytes.Clone(prevData),
+		NewData:  bytes.Clone(data),
 	}
 	return rc.inner.PutBranch(prefix, data, prevData)
 }

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -17,6 +17,7 @@
 package commitment
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -29,7 +30,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 )
 
@@ -656,7 +656,7 @@ func (o *overlayContext) PutBranch(prefix, data, _ []byte) error {
 	if o.writes == nil {
 		o.writes = make(map[string][]byte)
 	}
-	o.writes[string(prefix)] = common.Copy(data)
+	o.writes[string(prefix)] = bytes.Clone(data)
 	o.flushed = true
 	return nil
 }
@@ -889,13 +889,13 @@ func applyDeferredGuarded(ctx PatriciaContext, deferred []*DeferredBranchUpdate,
 		}
 		key := string(upd.prefix)
 		if prev, ok := applied[key]; ok {
-			upd.prev = common.Copy(prev)
+			upd.prev = bytes.Clone(prev)
 		} else {
 			prev, _, err := ctx.Branch(upd.prefix)
 			if err != nil {
 				return err
 			}
-			upd.prev = common.Copy(prev)
+			upd.prev = bytes.Clone(prev)
 		}
 		if err := mergeDeferredUpdate(upd, merger); err != nil {
 			return err
@@ -907,7 +907,7 @@ func applyDeferredGuarded(ctx PatriciaContext, deferred []*DeferredBranchUpdate,
 		if err := ctx.PutBranch(upd.prefix, upd.encoded, upd.prev); err != nil {
 			return err
 		}
-		applied[key] = common.Copy(upd.encoded)
+		applied[key] = bytes.Clone(upd.encoded)
 	}
 	return nil
 }

--- a/execution/commitment/streaming_commitment_test.go
+++ b/execution/commitment/streaming_commitment_test.go
@@ -369,7 +369,7 @@ func newDrainContext(ms *MockState) *drainContext {
 }
 
 func (d *drainContext) PutBranch(prefix, data, _ []byte) error {
-	d.pending[string(prefix)] = common.Copy(data)
+	d.pending[string(prefix)] = bytes.Clone(data)
 	return nil
 }
 

--- a/execution/commitment/testutil_test.go
+++ b/execution/commitment/testutil_test.go
@@ -20,6 +20,7 @@
 package commitment
 
 import (
+	"bytes"
 	"context"
 	"math/bits"
 	"math/rand"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/length"
 )
 
@@ -59,7 +59,7 @@ func processSeq(tb testing.TB, ms *MockState, trie *HexPatriciaHashed, plainKeys
 		r, err := trie.Process(ctx, upds, "", nil, WarmupConfig{})
 		upds.Close()
 		require.NoError(tb, err)
-		root = common.Copy(r)
+		root = bytes.Clone(r)
 	}
 	return root
 }
@@ -72,7 +72,7 @@ func processBatch(tb testing.TB, ms *MockState, trie *HexPatriciaHashed, plainKe
 	defer upds.Close()
 	root, err := trie.Process(context.Background(), upds, "", nil, WarmupConfig{})
 	require.NoError(tb, err)
-	return common.Copy(root)
+	return bytes.Clone(root)
 }
 
 // processFreshTrie builds a fresh trie/state, applies the updates in a single ModeDirect batch and

--- a/execution/commitment/trie/hashbuilder.go
+++ b/execution/commitment/trie/hashbuilder.go
@@ -17,6 +17,7 @@
 package trie
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -83,7 +84,7 @@ func (hb *HashBuilder) leaf(length int, keyHex []byte, val rlp.RlpSerializable) 
 		return fmt.Errorf("length %d", length)
 	}
 	key := keyHex[len(keyHex)-length:]
-	s := &ShortNode{Key: common.Copy(key), Val: ValueNode(common.Copy(val.RawBytes()))}
+	s := &ShortNode{Key: bytes.Clone(key), Val: ValueNode(bytes.Clone(val.RawBytes()))}
 	hb.nodeStack = append(hb.nodeStack, s)
 	if err := hb.leafHashWithKeyVal(key, val); err != nil {
 		return err
@@ -225,7 +226,7 @@ func (hb *HashBuilder) accountLeaf(length int, keyHex []byte, balance *uint256.I
 			// Root is on top of the stack
 			root = hb.nodeStack[len(hb.nodeStack)-popped-1]
 			if root == nil {
-				root = &HashNode{hash: common.Copy(hb.acc.Root[:])}
+				root = &HashNode{hash: bytes.Clone(hb.acc.Root[:])}
 			}
 		}
 		popped++
@@ -260,7 +261,7 @@ func (hb *HashBuilder) accountLeaf(length int, keyHex []byte, balance *uint256.I
 	}
 
 	a := &AccountNode{accCopy, root, true, accountCode, accountCodeSize}
-	s := &ShortNode{Key: common.Copy(key), Val: a}
+	s := &ShortNode{Key: bytes.Clone(key), Val: a}
 	// this invocation will take care of the popping given number of items from both hash stack and node stack,
 	// pushing resulting hash to the hash stack, and nil to the node stack
 	if err = hb.accountLeafHashWithKey(key, popped); err != nil {
@@ -365,10 +366,10 @@ func (hb *HashBuilder) extension(key []byte) error {
 	var s *ShortNode
 	switch n := nd.(type) {
 	case nil:
-		branchHash := common.Copy(hb.hashStack[len(hb.hashStack)-length2.Hash:])
-		s = &ShortNode{Key: common.Copy(key), Val: &HashNode{hash: branchHash}}
+		branchHash := bytes.Clone(hb.hashStack[len(hb.hashStack)-length2.Hash:])
+		s = &ShortNode{Key: bytes.Clone(key), Val: &HashNode{hash: branchHash}}
 	case *FullNode:
-		s = &ShortNode{Key: common.Copy(key), Val: n}
+		s = &ShortNode{Key: bytes.Clone(key), Val: n}
 	default:
 		return fmt.Errorf("wrong Val type for an extension: %T", nd)
 	}
@@ -442,7 +443,7 @@ func (hb *HashBuilder) extensionHash(key []byte) error {
 	}
 	var capture []byte //nolint: used for tracing
 	if hb.trace {
-		capture = common.Copy(branchHash[:length2.Hash+1])
+		capture = bytes.Clone(branchHash[:length2.Hash+1])
 	}
 	if _, err := writer.Write(branchHash[:length2.Hash+1]); err != nil {
 		return err
@@ -478,7 +479,7 @@ func (hb *HashBuilder) branch(set uint16) error {
 	for digit := range uint(16) {
 		if ((1 << digit) & set) != 0 {
 			if nodes[i] == nil {
-				f.Children[digit] = &HashNode{hash: common.Copy(hashes[hashStackStride*i+1 : hashStackStride*(i+1)])}
+				f.Children[digit] = &HashNode{hash: bytes.Clone(hashes[hashStackStride*i+1 : hashStackStride*(i+1)])}
 			} else {
 				f.Children[digit] = nodes[i]
 			}
@@ -605,7 +606,7 @@ func (hb *HashBuilder) code(code []byte) error {
 	if hb.trace {
 		fmt.Printf("CODE\n")
 	}
-	codeCopy := common.Copy(code)
+	codeCopy := bytes.Clone(code)
 	n := CodeNode(codeCopy)
 	hb.nodeStack = append(hb.nodeStack, n)
 	hb.sha.Reset()

--- a/execution/commitment/trie/proof.go
+++ b/execution/commitment/trie/proof.go
@@ -50,7 +50,7 @@ func (t *Trie) Prove(key []byte, fromLevel int, storage bool) ([][]byte, error) 
 		case *ShortNode:
 			if fromLevel == 0 {
 				if rlp, err := hasher.hashChildren(n, 0); err == nil {
-					proof = append(proof, common.Copy(rlp))
+					proof = append(proof, bytes.Clone(rlp))
 				} else {
 					return nil, err
 				}
@@ -72,7 +72,7 @@ func (t *Trie) Prove(key []byte, fromLevel int, storage bool) ([][]byte, error) 
 		case *DuoNode:
 			if fromLevel == 0 {
 				if rlp, err := hasher.hashChildren(n, 0); err == nil {
-					proof = append(proof, common.Copy(rlp))
+					proof = append(proof, bytes.Clone(rlp))
 				} else {
 					return nil, err
 				}
@@ -94,7 +94,7 @@ func (t *Trie) Prove(key []byte, fromLevel int, storage bool) ([][]byte, error) 
 		case *FullNode:
 			if fromLevel == 0 {
 				if rlp, err := hasher.hashChildren(n, 0); err == nil {
-					proof = append(proof, common.Copy(rlp))
+					proof = append(proof, bytes.Clone(rlp))
 				} else {
 					return nil, err
 				}
@@ -143,7 +143,7 @@ func (t *Trie) WitnessNodesForKeys(hexKeys [][]byte) ([][]byte, error) {
 		if _, ok := seen[string(rlp)]; ok {
 			return nil
 		}
-		c := common.Copy(rlp)
+		c := bytes.Clone(rlp)
 		// c is appended to out and never mutated, so alias it as the set key
 		// instead of allocating a second copy of the same bytes.
 		seen[common.ToStringZeroCopy(c)] = struct{}{}
@@ -245,7 +245,7 @@ func WitnessNodesForKeysFromNodes(nodes, hexKeys [][]byte) ([][]byte, error) {
 		if _, ok := seen[string(rlp)]; ok {
 			return nil
 		}
-		c := common.Copy(rlp)
+		c := bytes.Clone(rlp)
 		seen[common.ToStringZeroCopy(c)] = struct{}{}
 		out = append(out, c)
 		return nil

--- a/execution/commitment/trie/retain_list_builder.go
+++ b/execution/commitment/trie/retain_list_builder.go
@@ -1,7 +1,8 @@
 package trie
 
 import (
-	"github.com/erigontech/erigon/common"
+	"bytes"
+
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
@@ -25,12 +26,12 @@ func NewRetainListBuilder() *RetainListBuilder {
 
 // AddTouch adds a key (in KEY encoding) into the read/change set of account keys
 func (rlb *RetainListBuilder) AddTouch(touch []byte) {
-	rlb.touches = append(rlb.touches, common.Copy(touch))
+	rlb.touches = append(rlb.touches, bytes.Clone(touch))
 }
 
 // AddStorageTouch adds a key (in KEY encoding) into the read/change set of storage keys
 func (rlb *RetainListBuilder) AddStorageTouch(touch []byte) {
-	rlb.storageTouches = append(rlb.storageTouches, common.Copy(touch))
+	rlb.storageTouches = append(rlb.storageTouches, bytes.Clone(touch))
 }
 
 // ExtractTouches returns accumulated read/change sets and clears them for the next block's execution

--- a/execution/commitment/trie/structural_test.go
+++ b/execution/commitment/trie/structural_test.go
@@ -20,6 +20,7 @@
 package trie
 
 import (
+	"bytes"
 	"encoding/binary"
 	"slices"
 	"testing"
@@ -221,7 +222,7 @@ func TestEmbeddedStorage(t *testing.T) {
 	// (only different in the last nibble before the cutoff)
 	cutoff := 2 * length.Hash
 	last := hexKeys[len(hexKeys)-1]
-	finalSucc := append(common.Copy(last[:cutoff-1]), last[cutoff-1]+1)
+	finalSucc := append(bytes.Clone(last[:cutoff-1]), last[cutoff-1]+1)
 
 	genStructStepsOver(t, hb, retainAll, nil, hexKeys, func(i int) GenStructStepData {
 		return &GenStructStepLeafData{rlp.RlpSerializableBytes(valueShort)}
@@ -274,7 +275,7 @@ func TestEmbeddedStorage11(t *testing.T) {
 	}
 	cutoff := 2 * (length.Hash + common.IncarnationLength)
 	last := hexKeys[len(hexKeys)-1]
-	finalSucc := append(common.Copy(last[:cutoff-1]), last[cutoff-1]+1)
+	finalSucc := append(bytes.Clone(last[:cutoff-1]), last[cutoff-1]+1)
 
 	genStructStepsOver(t, hb, retainNone, nil, hexKeys, func(i int) GenStructStepData {
 		return &GenStructStepLeafData{rlp.RlpSerializableBytes(keys[i].v)}

--- a/execution/commitment/trie/trie.go
+++ b/execution/commitment/trie/trie.go
@@ -543,9 +543,9 @@ func findSubTriesToLoad(nd Node, nibblePath []byte, hook []byte, rl RetainDecide
 		}
 		return newPrefixes, newFixedBits, newHooks
 	case *HashNode:
-		newPrefixes = append(prefixes, common.Copy(dbPrefix))
+		newPrefixes = append(prefixes, bytes.Clone(dbPrefix))
 		newFixedBits = append(fixedbits, bits)
-		newHooks = append(hooks, common.Copy(hook))
+		newHooks = append(hooks, bytes.Clone(hook))
 		return newPrefixes, newFixedBits, newHooks
 	}
 	return prefixes, fixedbits, hooks
@@ -597,7 +597,7 @@ func (t *Trie) insertRecursive(origNode Node, key []byte, pos int, value Node) (
 	var nn Node
 	switch n := origNode.(type) {
 	case nil:
-		return true, NewShortNode(common.Copy(key[pos:]), value)
+		return true, NewShortNode(bytes.Clone(key[pos:]), value)
 	case *AccountNode:
 		updated, nn = t.insertRecursive(n.Storage, key, pos, value)
 		if updated {
@@ -622,13 +622,13 @@ func (t *Trie) insertRecursive(origNode Node, key []byte, pos int, value Node) (
 			if len(n.Key) == matchlen+1 {
 				c1 = n.Val
 			} else {
-				c1 = NewShortNode(common.Copy(n.Key[matchlen+1:]), n.Val)
+				c1 = NewShortNode(bytes.Clone(n.Key[matchlen+1:]), n.Val)
 			}
 			var c2 Node
 			if len(key) == pos+matchlen+1 {
 				c2 = value
 			} else {
-				c2 = NewShortNode(common.Copy(key[pos+matchlen+1:]), value)
+				c2 = NewShortNode(bytes.Clone(key[pos+matchlen+1:]), value)
 			}
 			branch := &DuoNode{}
 			if n.Key[matchlen] < key[pos+matchlen] {
@@ -645,7 +645,7 @@ func (t *Trie) insertRecursive(origNode Node, key []byte, pos int, value Node) (
 				newNode = branch // current node leaves the generation, but new node branch joins it
 			} else {
 				// Otherwise, replace it with a short node leading up to the branch.
-				n.Key = common.Copy(key[pos : pos+matchlen])
+				n.Key = bytes.Clone(key[pos : pos+matchlen])
 				n.Val = branch
 				n.ref.len = 0
 				newNode = n
@@ -676,7 +676,7 @@ func (t *Trie) insertRecursive(origNode Node, key []byte, pos int, value Node) (
 			if len(key) == pos+1 {
 				child = value
 			} else {
-				child = NewShortNode(common.Copy(key[pos+1:]), value)
+				child = NewShortNode(bytes.Clone(key[pos+1:]), value)
 			}
 			newnode := &FullNode{}
 			newnode.Children[i1] = n.child1
@@ -694,7 +694,7 @@ func (t *Trie) insertRecursive(origNode Node, key []byte, pos int, value Node) (
 			if len(key) == pos+1 {
 				n.Children[key[pos]] = value
 			} else {
-				n.Children[key[pos]] = NewShortNode(common.Copy(key[pos+1:]), value)
+				n.Children[key[pos]] = NewShortNode(bytes.Clone(key[pos+1:]), value)
 			}
 			updated = true
 			n.ref.len = 0
@@ -1291,7 +1291,7 @@ func (t *Trie) RLPEncode() ([][]byte, error) {
 			hash := crypto.Keccak256Hash(nodeRLP)
 			if _, ok := seen[hash]; !ok {
 				seen[hash] = struct{}{}
-				nodes = append(nodes, common.Copy(nodeRLP))
+				nodes = append(nodes, bytes.Clone(nodeRLP))
 			}
 			return collect(n.Val)
 
@@ -1303,7 +1303,7 @@ func (t *Trie) RLPEncode() ([][]byte, error) {
 			hash := crypto.Keccak256Hash(nodeRLP)
 			if _, ok := seen[hash]; !ok {
 				seen[hash] = struct{}{}
-				nodes = append(nodes, common.Copy(nodeRLP))
+				nodes = append(nodes, bytes.Clone(nodeRLP))
 			}
 			if err := collect(n.child1); err != nil {
 				return err
@@ -1318,7 +1318,7 @@ func (t *Trie) RLPEncode() ([][]byte, error) {
 			hash := crypto.Keccak256Hash(nodeRLP)
 			if _, ok := seen[hash]; !ok {
 				seen[hash] = struct{}{}
-				nodes = append(nodes, common.Copy(nodeRLP))
+				nodes = append(nodes, bytes.Clone(nodeRLP))
 			}
 			for i := range 17 {
 				if n.Children[i] != nil {

--- a/execution/commitment/witness_node_set.go
+++ b/execution/commitment/witness_node_set.go
@@ -17,9 +17,8 @@
 package commitment
 
 import (
+	"bytes"
 	"fmt"
-
-	"github.com/erigontech/erigon/common"
 )
 
 // witnessNodeSet collects consensus trie nodes emitted during a witness fold,
@@ -35,7 +34,7 @@ func (s *witnessNodeSet) onNode(rlp, hash []byte) {
 	if _, ok := s.byHash[k]; ok {
 		return
 	}
-	s.byHash[k] = common.Copy(rlp)
+	s.byHash[k] = bytes.Clone(rlp)
 }
 
 // nodes returns the captured nodes root first, per the RLPDecode contract that

--- a/execution/commitment/witness_strict_test.go
+++ b/execution/commitment/witness_strict_test.go
@@ -17,12 +17,12 @@
 package commitment
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/execution/commitment/trie"
 )
@@ -38,7 +38,7 @@ func assertPresentStrict(t *testing.T, wt *trie.Trie, plainKey []byte) {
 }
 
 func storageKey(account, slot []byte) []byte {
-	return append(common.Copy(account), slot...)
+	return append(bytes.Clone(account), slot...)
 }
 
 func benchWitnessTrie(b *testing.B) (*HexPatriciaHashed, [][]byte) {

--- a/execution/engineapi/engine_types/ssz.go
+++ b/execution/engineapi/engine_types/ssz.go
@@ -4,6 +4,7 @@
 package engine_types
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -134,7 +135,7 @@ func (p *ExecutionPayload) ToSSZBlock(version clparams.StateVersion) (*cltypes.E
 }
 
 func ExecutionPayloadFromSSZBlock(block *cltypes.Eth1Block, version clparams.StateVersion) *ExecutionPayload {
-	baseFeeBytes := common.Copy(block.BaseFeePerGas[:])
+	baseFeeBytes := bytes.Clone(block.BaseFeePerGas[:])
 	for i, j := 0, len(baseFeeBytes)-1; i < j; i, j = i+1, j-1 {
 		baseFeeBytes[i], baseFeeBytes[j] = baseFeeBytes[j], baseFeeBytes[i]
 	}
@@ -489,7 +490,7 @@ func kzgCommitmentBytes(list *solid.ListSSZ[*cltypes.KZGCommitment]) []hexutil.B
 	out := make([]hexutil.Bytes, 0, list.Len())
 	list.Range(func(_ int, v *cltypes.KZGCommitment, _ int) bool {
 		value := *v
-		out = append(out, common.Copy(value[:]))
+		out = append(out, bytes.Clone(value[:]))
 		return true
 	})
 	return out
@@ -499,7 +500,7 @@ func kzgProofBytes(list *solid.ListSSZ[*cltypes.KZGProof]) []hexutil.Bytes {
 	out := make([]hexutil.Bytes, 0, list.Len())
 	list.Range(func(_ int, v *cltypes.KZGProof, _ int) bool {
 		value := *v
-		out = append(out, common.Copy(value[:]))
+		out = append(out, bytes.Clone(value[:]))
 		return true
 	})
 	return out
@@ -509,7 +510,7 @@ func blobBytes(list *solid.ListSSZ[*cltypes.Blob]) []hexutil.Bytes {
 	out := make([]hexutil.Bytes, 0, list.Len())
 	list.Range(func(_ int, v *cltypes.Blob, _ int) bool {
 		value := *v
-		out = append(out, common.Copy(value[:]))
+		out = append(out, bytes.Clone(value[:]))
 		return true
 	})
 	return out
@@ -526,8 +527,8 @@ func (b *BlobAndProofV1) DecodeSSZ(buf []byte, version int) error {
 	if err := ssz2.UnmarshalSSZ(buf, version, blob, proof); err != nil {
 		return err
 	}
-	b.Blob = common.Copy(blob[:])
-	b.Proof = common.Copy(proof[:])
+	b.Blob = bytes.Clone(blob[:])
+	b.Proof = bytes.Clone(proof[:])
 	return nil
 }
 func (b *BlobAndProofV1) HashSSZ() ([32]byte, error) { return [32]byte{}, nil }
@@ -547,7 +548,7 @@ func (b *BlobAndProofV2) DecodeSSZ(buf []byte, version int) error {
 	if err := ssz2.UnmarshalSSZ(buf, version, blob, proofs); err != nil {
 		return err
 	}
-	b.Blob = common.Copy(blob[:])
+	b.Blob = bytes.Clone(blob[:])
 	b.CellProofs = kzgProofBytes(proofs)
 	return nil
 }

--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"sync/atomic"
@@ -170,7 +171,7 @@ func (bra *BlockReadAheader) AddSenders(senders []byte, blockHash common.Hash) {
 	if _, ok := bra.bodies.Get(blockHash); !ok {
 		return
 	}
-	bra.senders.Add(blockHash, common.Copy(senders))
+	bra.senders.Add(blockHash, bytes.Clone(senders))
 }
 
 // warmBody warms state for all transactions in a body using multiple workers.

--- a/execution/notifications/accumulator.go
+++ b/execution/notifications/accumulator.go
@@ -17,6 +17,7 @@
 package notifications
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/erigontech/erigon/common"
@@ -89,7 +90,7 @@ func (a *Accumulator) StartChange(h *types.Header, txs [][]byte, unwind bool) {
 	if txs != nil {
 		a.latestChange.Txs = make([][]byte, len(txs))
 		for i := range txs {
-			a.latestChange.Txs[i] = common.Copy(txs[i])
+			a.latestChange.Txs[i] = bytes.Clone(txs[i])
 		}
 	}
 }

--- a/execution/protocol/block_exec.go
+++ b/execution/protocol/block_exec.go
@@ -195,7 +195,7 @@ func ExecuteBlockEphemerally(
 		TxRoot:      types.DeriveSha(includedTxs),
 		ReceiptRoot: receiptSha,
 		Bloom:       bloom,
-		LogsHash:    rlpHash(blockLogs),
+		LogsHash:    types.RlpHash(blockLogs),
 		Receipts:    receipts,
 		Difficulty:  (*math.HexOrDecimal256)(header.Difficulty.ToBig()),
 		GasUsed:     math.HexOrDecimal64(blockGasUsed),
@@ -226,8 +226,6 @@ func ExecuteBlockEphemerally(
 
 	return execRs, nil
 }
-
-var rlpHash = types.RlpHash
 
 func SysCallContract(contract accounts.Address, data []byte, chainConfig *chain.Config, ibs *state.IntraBlockState, header *types.Header, engine rules.EngineReader, constCall bool, vmCfg vm.Config) (result []byte, err error) {
 	isBor := chainConfig.Bor != nil

--- a/execution/stagedsync/stage_execute.go
+++ b/execution/stagedsync/stage_execute.go
@@ -17,6 +17,7 @@
 package stagedsync
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -269,7 +270,7 @@ func stateChangesStreamAtUnwind(ctx context.Context,
 		copy(address[:], k[:length.Addr])
 		copy(location[:], k[length.Addr:])
 		if accumulator != nil {
-			accumulator.ChangeStorage(address, currentInc, location, common.Copy(v))
+			accumulator.ChangeStorage(address, currentInc, location, bytes.Clone(v))
 		}
 		if dbg.TraceUnwinds && dbg.TraceDomain(uint16(kv.StorageDomain)) {
 			if v == nil {

--- a/execution/stagedsync/stage_finish.go
+++ b/execution/stagedsync/stage_finish.go
@@ -17,6 +17,7 @@
 package stagedsync
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"time"
@@ -103,7 +104,7 @@ func NotifyNewHeaders(ctx context.Context, notifyFrom, notifyTo uint64, notifier
 		}
 		headerRLP := rawdb.ReadHeaderRLP(tx, common.BytesToHash(hash), blockNum)
 		if headerRLP != nil {
-			headersRlp = append(headersRlp, common.Copy(headerRLP))
+			headersRlp = append(headersRlp, bytes.Clone(headerRLP))
 		}
 		return common.Stopped(ctx.Done())
 	}); err != nil {

--- a/execution/state/dump.go
+++ b/execution/state/dump.go
@@ -20,6 +20,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -229,7 +230,7 @@ func (d *Dumper) DumpToCollector(ctx context.Context, c DumpCollector, excludeCo
 				loc := k[20:]
 				account.Storage[common.BytesToHash(loc).String()] = common.Bytes2Hex(vs)
 				h := crypto.Keccak256Hash(loc)
-				t.Update(h[:], common.Copy(vs))
+				t.Update(h[:], bytes.Clone(vs))
 			}
 			r.Close()
 

--- a/execution/tests/blockgen/chain_makers.go
+++ b/execution/tests/blockgen/chain_makers.go
@@ -20,6 +20,7 @@
 package blockgen
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"errors"
@@ -559,7 +560,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine rules.Engin
 		// Mutate the state and block according to any hard-fork specs
 		if daoBlock := config.DAOForkBlock; daoBlock != nil {
 			if b.header.Number.Uint64() >= *daoBlock && b.header.Number.Uint64() < *daoBlock+misc.DAOForkExtraRange {
-				b.header.Extra = common.Copy(misc.DAOForkBlockExtra)
+				b.header.Extra = bytes.Clone(misc.DAOForkBlockExtra)
 			}
 		}
 		// Set ParentBeaconBlockRoot for Cancun+ blocks before InitializeBlockExecution

--- a/execution/tests/testutil/state_test_util.go
+++ b/execution/tests/testutil/state_test_util.go
@@ -269,7 +269,7 @@ func (t *StateTest) Run(tb testing.TB, sd *execctx.SharedDomains, tx kv.Temporal
 	if root != common.Hash(post.Root) {
 		return st, root, fmt.Errorf("post state root mismatch: got %x, want %x", root, post.Root)
 	}
-	if logs := rlpHash(st.Logs()); logs != common.Hash(post.Logs) {
+	if logs := types.RlpHash(st.Logs()); logs != common.Hash(post.Logs) {
 		return st, root, fmt.Errorf("post state logs hash mismatch: got %x, want %x", logs, post.Logs)
 	}
 	return st, root, nil
@@ -495,8 +495,6 @@ func (t *StateTest) genesis(config *chain.Config) *types.Genesis {
 		SlotNumber: t.Json.Env.SlotNumber,
 	}
 }
-
-var rlpHash = types.RlpHash
 
 func vmTestBlockHash(n uint64) (common.Hash, error) {
 	return crypto.Keccak256Hash([]byte(new(big.Int).SetUint64(n).String())), nil

--- a/execution/tracing/tracers/js/goja.go
+++ b/execution/tracing/tracers/js/goja.go
@@ -20,6 +20,7 @@
 package js
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -364,7 +365,7 @@ func (t *jsTracer) OnEnter(depth int, typ byte, from accounts.Address, to accoun
 	t.frame.typ = vm.OpCode(typ).String()
 	t.frame.from = from
 	t.frame.to = to
-	t.frame.input = common.Copy(input)
+	t.frame.input = bytes.Clone(input)
 	t.frame.gas = uint(gas)
 	t.frame.value = nil
 	t.frame.value = value.ToBig()
@@ -391,7 +392,7 @@ func (t *jsTracer) OnExit(depth int, output []byte, gasUsed uint64, err error, r
 	}
 
 	t.frameResult.gasUsed = uint(gasUsed)
-	t.frameResult.output = common.Copy(output)
+	t.frameResult.output = bytes.Clone(output)
 	t.frameResult.err = err
 
 	if _, err := t.exit(t.obj, t.frameResultValue); err != nil {
@@ -501,7 +502,7 @@ func (t *jsTracer) setBuiltinFunctions() {
 			vm.Interrupt(err)
 			return nil
 		}
-		code = common.Copy(code)
+		code = bytes.Clone(code)
 		codeHash := accounts.InternCodeHash(crypto.Keccak256Hash(code))
 		contractAddr := types.CreateAddress2(addr, common.HexToHash(salt), codeHash)
 		b := contractAddr[:]
@@ -856,7 +857,7 @@ func (co *contractObj) GetValue() goja.Value {
 }
 
 func (co *contractObj) GetInput() goja.Value {
-	input := common.Copy(co.scope.CallInput())
+	input := bytes.Clone(co.scope.CallInput())
 	res, err := co.toBuf(co.vm, input)
 	if err != nil {
 		co.vm.Interrupt(err)

--- a/execution/tracing/tracers/native/call.go
+++ b/execution/tracing/tracers/native/call.go
@@ -20,6 +20,7 @@
 package native
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"math/big"
@@ -77,7 +78,7 @@ func (f *callFrame) failed() bool {
 }
 
 func (f *callFrame) processOutput(output []byte, err error) {
-	output = common.Copy(output)
+	output = bytes.Clone(output)
 	if err == nil {
 		f.Output = output
 		return
@@ -170,7 +171,7 @@ func (t *callTracer) CaptureStart(env *vm.EVM, from accounts.Address, to account
 		Type:  vm.CALL,
 		From:  from.Value(),
 		To:    toValue,
-		Input: common.Copy(input),
+		Input: bytes.Clone(input),
 		Gas:   t.gasLimit, // gas has intrinsicGas already subtracted
 	}
 	if value != nil {
@@ -216,7 +217,7 @@ func (t *callTracer) OnEnter(depth int, typ byte, from accounts.Address, to acco
 		Type:  vm.OpCode(typ),
 		From:  from.Value(),
 		To:    toValue,
-		Input: common.Copy(input),
+		Input: bytes.Clone(input),
 		Gas:   gas,
 	}
 

--- a/execution/types/access_list_tx.go
+++ b/execution/types/access_list_tx.go
@@ -20,6 +20,7 @@
 package types
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -65,7 +66,7 @@ func (tx *AccessListTx) copy() *AccessListTx {
 				TransactionMisc: TransactionMisc{},
 				Nonce:           tx.Nonce,
 				To:              tx.To, // TODO: copy pointed-to address
-				Data:            common.Copy(tx.Data),
+				Data:            bytes.Clone(tx.Data),
 				GasLimit:        tx.GasLimit,
 				Value:           tx.Value,
 				V:               tx.V,

--- a/execution/types/block.go
+++ b/execution/types/block.go
@@ -21,6 +21,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -1361,7 +1362,7 @@ func (b *Block) ParentHash() common.Hash  { return b.header.ParentHash }
 func (b *Block) TxHash() common.Hash      { return b.header.TxHash }
 func (b *Block) ReceiptHash() common.Hash { return b.header.ReceiptHash }
 func (b *Block) UncleHash() common.Hash   { return b.header.UncleHash }
-func (b *Block) Extra() []byte            { return common.Copy(b.header.Extra) }
+func (b *Block) Extra() []byte            { return bytes.Clone(b.header.Extra) }
 func (b *Block) BaseFee() *uint256.Int {
 	if b.header.BaseFee == nil {
 		return nil

--- a/execution/types/block_test.go
+++ b/execution/types/block_test.go
@@ -513,12 +513,12 @@ func TestCanEncodeAndDecodeRawBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rlpBytes := common.Copy(writer.Bytes())
+	rlpBytes := bytes.Clone(writer.Bytes())
 	writer.Reset()
 	writer.WriteString(hexutil.Encode(rlpBytes))
 
 	var rawBody RawBody
-	fromHex := common.Copy(common.FromHex(writer.String()))
+	fromHex := bytes.Clone(common.FromHex(writer.String()))
 	bodyReader := bytes.NewReader(fromHex)
 	stream := rlp.NewStream(bodyReader, 0)
 
@@ -845,7 +845,7 @@ func TestBlockRawBodyFromBinaryTxsMatchesEncoded(t *testing.T) {
 			if tr.RandTransaction(txType).MarshalBinary(&buf) != nil {
 				continue
 			}
-			binaryTxn := common.Copy(buf.Bytes())
+			binaryTxn := bytes.Clone(buf.Bytes())
 			if decoded, err := DecodeTransaction(binaryTxn); err == nil {
 				binaryTxs[i], txns[i] = binaryTxn, decoded
 			}

--- a/execution/types/dynamic_fee_tx.go
+++ b/execution/types/dynamic_fee_tx.go
@@ -20,6 +20,7 @@
 package types
 
 import (
+	"bytes"
 	"errors"
 	"io"
 
@@ -56,7 +57,7 @@ func (tx *DynamicFeeTransaction) copy() *DynamicFeeTransaction {
 			TransactionMisc: TransactionMisc{},
 			Nonce:           tx.Nonce,
 			To:              tx.To, // TODO: copy pointed-to address
-			Data:            common.Copy(tx.Data),
+			Data:            bytes.Clone(tx.Data),
 			GasLimit:        tx.GasLimit,
 			Value:           tx.Value,
 			V:               tx.V,

--- a/execution/types/hashing_test.go
+++ b/execution/types/hashing_test.go
@@ -103,7 +103,7 @@ func legacyDeriveSha(list DerivableList) common.Hash {
 		valbuf.Reset()
 		_ = rlp.Encode(keybuf, uint(i))
 		list.EncodeIndex(i, valbuf)
-		trie.Update(keybuf.Bytes(), common.Copy(valbuf.Bytes()))
+		trie.Update(keybuf.Bytes(), bytes.Clone(valbuf.Bytes()))
 	}
 	return trie.Hash()
 }

--- a/execution/types/legacy_tx.go
+++ b/execution/types/legacy_tx.go
@@ -20,6 +20,7 @@
 package types
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -183,7 +184,7 @@ func (tx *LegacyTx) copy() *LegacyTx {
 			TransactionMisc: TransactionMisc{},
 			Nonce:           tx.Nonce,
 			To:              tx.To, // TODO: copy pointed-to address
-			Data:            common.Copy(tx.Data),
+			Data:            bytes.Clone(tx.Data),
 			GasLimit:        tx.GasLimit,
 			Value:           tx.Value,
 			V:               tx.V,

--- a/execution/types/transaction.go
+++ b/execution/types/transaction.go
@@ -315,7 +315,7 @@ func MarshalTransactionsBinary(txs Transactions) ([][]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		result[i] = common.Copy(buf.Bytes())
+		result[i] = bytes.Clone(buf.Bytes())
 	}
 	return result, nil
 }

--- a/execution/vm/contracts.go
+++ b/execution/vm/contracts.go
@@ -20,6 +20,7 @@
 package vm
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
@@ -409,7 +410,7 @@ func (c *dataCopy) RequiredGas(input []byte) uint64 {
 	return ToWordSize(uint64(len(input)))*params.IdentityPerWordGas + params.IdentityBaseGas
 }
 func (c *dataCopy) Run(in []byte) ([]byte, error) {
-	return common.Copy(in), nil
+	return bytes.Clone(in), nil
 }
 
 func (c *dataCopy) Name() string {

--- a/execution/vm/evmtypes/evmtypes.go
+++ b/execution/vm/evmtypes/evmtypes.go
@@ -17,6 +17,8 @@
 package evmtypes
 
 import (
+	"bytes"
+
 	"github.com/holiman/uint256"
 
 	"github.com/erigontech/erigon/common"
@@ -98,7 +100,7 @@ func (result *ExecutionResult) Return() []byte {
 	if result.Err != nil {
 		return nil
 	}
-	return common.Copy(result.ReturnData)
+	return bytes.Clone(result.ReturnData)
 }
 
 // Revert returns the concrete revert reason if the execution is aborted by `REVERT`
@@ -107,7 +109,7 @@ func (result *ExecutionResult) Revert() []byte {
 	if !result.Reverted {
 		return nil
 	}
-	return common.Copy(result.ReturnData)
+	return bytes.Clone(result.ReturnData)
 }
 
 type (

--- a/execution/vm/instructions.go
+++ b/execution/vm/instructions.go
@@ -20,6 +20,7 @@
 package vm
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 
@@ -1115,7 +1116,7 @@ func opCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error) {
 	}
 	stack.push(temp)
 	if err == nil || err == ErrExecutionReverted {
-		ret = common.Copy(ret)
+		ret = bytes.Clone(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
@@ -1170,7 +1171,7 @@ func opCallCode(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, error)
 	}
 	stack.push(temp)
 	if err == nil || err == ErrExecutionReverted {
-		ret = common.Copy(ret)
+		ret = bytes.Clone(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 
@@ -1215,7 +1216,7 @@ func opDelegateCall(pc uint64, evm *EVM, scope *CallContext) (uint64, []byte, er
 	}
 	stack.push(temp)
 	if err == nil || err == ErrExecutionReverted {
-		ret = common.Copy(ret)
+		ret = bytes.Clone(ret)
 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
 	}
 

--- a/node/shards/trie_cache.go
+++ b/node/shards/trie_cache.go
@@ -211,7 +211,7 @@ func (sc *StateCache) SetAccountHashesRead(prefix []byte, hasState, hasTree, has
 	cpy := make([]common.Hash, len(hashes))
 	copy(cpy, hashes)
 	ai := AccountHashItem{
-		addrHashPrefix: common.Copy(prefix),
+		addrHashPrefix: bytes.Clone(prefix),
 		hasState:       hasState,
 		hasTree:        hasTree,
 		hasHash:        hasHash,
@@ -227,7 +227,7 @@ func (sc *StateCache) SetAccountHashWrite(prefix []byte, hasState, hasTree, hasH
 	assertSubset(hasTree, hasState)
 	assertSubset(hasHash, hasState)
 	ai := AccountHashItem{
-		addrHashPrefix: common.Copy(prefix),
+		addrHashPrefix: bytes.Clone(prefix),
 		hasState:       hasState,
 		hasTree:        hasTree,
 		hasHash:        hasHash,
@@ -253,7 +253,7 @@ func (sc *StateCache) SetStorageHashRead(addrHash common.Hash, incarnation uint6
 	ai := StorageHashItem{
 		addrHash:      addrHash,
 		incarnation:   incarnation,
-		locHashPrefix: common.Copy(locHashPrefix),
+		locHashPrefix: bytes.Clone(locHashPrefix),
 		hasState:      hasState,
 		hasTree:       hasTree,
 		hasHash:       hasHash,
@@ -268,7 +268,7 @@ func (sc *StateCache) SetStorageHashWrite(addrHash common.Hash, incarnation uint
 	ai := StorageHashItem{
 		addrHash:      addrHash,
 		incarnation:   incarnation,
-		locHashPrefix: common.Copy(locHashPrefix),
+		locHashPrefix: bytes.Clone(locHashPrefix),
 		hasState:      hasState,
 		hasTree:       hasTree,
 		hasHash:       hasHash,
@@ -285,7 +285,7 @@ func (sc *StateCache) SetStorageHashDelete(addrHash common.Hash, incarnation uin
 	ai := StorageHashItem{
 		addrHash:      addrHash,
 		incarnation:   incarnation,
-		locHashPrefix: common.Copy(locHashPrefix),
+		locHashPrefix: bytes.Clone(locHashPrefix),
 		hasState:      hasState,
 		hasTree:       hasTree,
 		hasHash:       hasHash,

--- a/p2p/transport.go
+++ b/p2p/transport.go
@@ -30,7 +30,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/bitutil"
 	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/p2p/rlpx"
@@ -73,7 +72,7 @@ func (t *rlpxTransport) ReadMsg() (Msg, error) {
 		// Protocol messages are dispatched to subprotocol handlers asynchronously,
 		// but package rlpx may reuse the returned 'data' buffer on the next call
 		// to Read. Copy the message data to avoid this being an issue.
-		data = common.Copy(data)
+		data = bytes.Clone(data)
 		msg = Msg{
 			ReceivedAt: time.Now(),
 			Code:       code,

--- a/polygon/bridge/snapshot_store.go
+++ b/polygon/bridge/snapshot_store.go
@@ -415,7 +415,7 @@ func (s *SnapshotStore) EventsByIdFromSnapshot(from uint64, to time.Time, limit 
 		for gg.HasNext() {
 			buf, _ = gg.Next(buf[:0])
 
-			raw := rlp.RawValue(common.Copy(buf[length.Hash+length.BlockNum+8:]))
+			raw := rlp.RawValue(bytes.Clone(buf[length.Hash+length.BlockNum+8:]))
 			var event EventRecordWithTime
 			if err := event.UnmarshallBytes(raw); err != nil {
 				return nil, false, err

--- a/rpc/jsonrpc/debug_execution_witness.go
+++ b/rpc/jsonrpc/debug_execution_witness.go
@@ -349,8 +349,8 @@ func (s *RecordingState) UpdateAccountData(address accounts.Address, original, a
 func (s *RecordingState) UpdateAccountCode(address accounts.Address, incarnation uint64, codeHash accounts.CodeHash, code []byte) error {
 	addr := address.Value()
 	s.ModifiedAccounts[addr] = struct{}{}
-	s.codeOverlay[addr] = common.Copy(code)
-	s.ModifiedCode[addr] = common.Copy(code)
+	s.codeOverlay[addr] = bytes.Clone(code)
+	s.ModifiedCode[addr] = bytes.Clone(code)
 	if len(code) > 0 {
 		s.createdCodeHashes[codeHash.Value()] = struct{}{}
 	}
@@ -494,7 +494,7 @@ func (s *RecordingState) OnCodeAccess(address accounts.Address, code []byte) {
 func (s *RecordingState) GetAccessedCode() map[common.Address][]byte {
 	result := make(map[common.Address][]byte, len(s.AccessedCode))
 	for addr, code := range s.AccessedCode {
-		result[addr] = common.Copy(code)
+		result[addr] = bytes.Clone(code)
 	}
 	return result
 }
@@ -506,7 +506,7 @@ func (s *RecordingState) GetAccessedCode() map[common.Address][]byte {
 func (s *RecordingState) GetPreStateCode() map[common.Address][]byte {
 	result := make(map[common.Address][]byte, len(s.PreStateCode))
 	for addr, code := range s.PreStateCode {
-		result[addr] = common.Copy(code)
+		result[addr] = bytes.Clone(code)
 	}
 	return result
 }
@@ -515,7 +515,7 @@ func (s *RecordingState) GetPreStateCode() map[common.Address][]byte {
 func (s *RecordingState) GetModifiedCode() map[common.Address][]byte {
 	result := make(map[common.Address][]byte, len(s.ModifiedCode))
 	for addr, code := range s.ModifiedCode {
-		result[addr] = common.Copy(code)
+		result[addr] = bytes.Clone(code)
 	}
 	return result
 }
@@ -1104,8 +1104,8 @@ func detectCollapseSiblings(
 	var candidates []collapseCandidate
 	sdCtx.SetCollapseTracer(func(hashedKeyPath, branchPrefix []byte) {
 		candidates = append(candidates, collapseCandidate{
-			siblingPath:  common.Copy(hashedKeyPath),
-			branchPrefix: common.Copy(branchPrefix),
+			siblingPath:  bytes.Clone(hashedKeyPath),
+			branchPrefix: bytes.Clone(branchPrefix),
 		})
 	})
 	defer sdCtx.SetCollapseTracer(nil)
@@ -1182,7 +1182,7 @@ func buildWitnessTrie(
 	}
 
 	for _, node := range witnessNodes {
-		encodedNodes = append(encodedNodes, common.Copy(node))
+		encodedNodes = append(encodedNodes, bytes.Clone(node))
 	}
 	return encodedNodes, nil
 }

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -853,7 +853,7 @@ func (api *BaseAPI) getWitness(ctx context.Context, db kv.TemporalRoDB, blockNrO
 		logger.Warn("state root mismatch after stateless execution", "actual", newStateRoot, "expected", block.Root())
 	}
 
-	return common.Copy(witnessBuffer.Bytes()), nil
+	return bytes.Clone(witnessBuffer.Bytes()), nil
 }
 
 // emptyWitnessBytes serializes an empty op-stream witness, used for genesis and

--- a/rpc/jsonrpc/otterscan_trace_transaction.go
+++ b/rpc/jsonrpc/otterscan_trace_transaction.go
@@ -17,6 +17,7 @@
 package jsonrpc
 
 import (
+	"bytes"
 	"context"
 	"math/big"
 
@@ -87,7 +88,7 @@ func (t *TransactionTracer) OnEnter(depth int, typRaw byte, from accounts.Addres
 	t.depth = depth
 	typ := vm.OpCode(typRaw)
 
-	inputCopy := common.Copy(input)
+	inputCopy := bytes.Clone(input)
 	_value := new(big.Int)
 	_value.Set(value.ToBig())
 
@@ -132,5 +133,5 @@ func (t *TransactionTracer) OnExit(depth int, output []byte, gasUsed uint64, err
 	pop := t.stack[lastIdx]
 	t.stack = t.stack[:lastIdx]
 
-	pop.Output = common.Copy(output)
+	pop.Output = bytes.Clone(output)
 }

--- a/rpc/jsonrpc/parity_api.go
+++ b/rpc/jsonrpc/parity_api.go
@@ -17,6 +17,7 @@
 package jsonrpc
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -94,7 +95,7 @@ func (api *ParityAPIImpl) ListStorageKeys(ctx context.Context, account common.Ad
 		if err != nil {
 			return nil, err
 		}
-		keys = append(keys, common.Copy(k[20:]))
+		keys = append(keys, bytes.Clone(k[20:]))
 	}
 	return keys, nil
 }

--- a/rpc/jsonrpc/storage_range.go
+++ b/rpc/jsonrpc/storage_range.go
@@ -85,7 +85,7 @@ func storageRangeAt(ttx kv.TemporalTx, contractAddress common.Address, start []b
 func storageRangeAtErigon(ttx kv.TemporalTx, contractAddress common.Address, start []byte, txNum uint64, maxResult int) (StorageRangeResult, error) {
 	result := StorageRangeResult{Storage: storageMap{}}
 
-	fromKey := append(common.Copy(contractAddress[:]), start...)
+	fromKey := append(bytes.Clone(contractAddress[:]), start...)
 	toKey, _ := kv.NextSubtree(contractAddress[:])
 
 	r, err := ttx.RangeAsOf(kv.StorageDomain, fromKey, toKey, txNum, order.Asc, kv.Unlim) //no limit because need skip empty records
@@ -135,7 +135,7 @@ func storageRangeAtGethCompat(ttx kv.TemporalTx, contractAddress common.Address,
 
 	// Always scan all storage for this contract — we need to sort by hashed key
 	// to match Geth's trie-based iteration order.
-	fromKey := common.Copy(contractAddress[:])
+	fromKey := bytes.Clone(contractAddress[:])
 	toKey, _ := kv.NextSubtree(fromKey)
 
 	r, err := ttx.RangeAsOf(kv.StorageDomain, fromKey, toKey, txNum, order.Asc, kv.Unlim)

--- a/rpc/jsonrpc/trace_adhoc.go
+++ b/rpc/jsonrpc/trace_adhoc.go
@@ -394,7 +394,7 @@ func (ot *OeTracer) captureStartOrEnter(deep bool, typ vm.OpCode, from accounts.
 			vmTrace = ot.r.VmTrace
 		}
 		if create {
-			vmTrace.Code = common.Copy(input)
+			vmTrace.Code = bytes.Clone(input)
 			if ot.lastVmOp != nil {
 				ot.lastVmOp.Cost += int(gas)
 			}
@@ -447,7 +447,7 @@ func (ot *OeTracer) captureStartOrEnter(deep bool, typ vm.OpCode, from accounts.
 		action.From = from.Value()
 		action.CreationMethod = strings.ToLower(typ.String())
 		action.Gas.ToInt().SetUint64(gas)
-		action.Init = common.Copy(input)
+		action.Init = bytes.Clone(input)
 		action.Value.ToInt().Set(value.ToBig())
 		trace.Action = &action
 	} else if typ == vm.SELFDESTRUCT {
@@ -473,7 +473,7 @@ func (ot *OeTracer) captureStartOrEnter(deep bool, typ vm.OpCode, from accounts.
 		action.From = from.Value()
 		action.To = to.Value()
 		action.Gas.ToInt().SetUint64(gas)
-		action.Input = common.Copy(input)
+		action.Input = bytes.Clone(input)
 		action.Value.ToInt().Set(value.ToBig())
 		trace.Action = &action
 	}
@@ -509,7 +509,7 @@ func (ot *OeTracer) captureEndOrExit(deep bool, output []byte, gasUsed uint64, e
 		}
 	}
 	if !deep {
-		ot.r.Output = common.Copy(output)
+		ot.r.Output = bytes.Clone(output)
 	}
 	ignoreError := false
 	topTrace := ot.traceStack[len(ot.traceStack)-1]
@@ -523,11 +523,11 @@ func (ot *OeTracer) captureEndOrExit(deep bool, output []byte, gasUsed uint64, e
 			case CALL:
 				topTrace.Result.(*TraceResult).GasUsed = new(hexutil.Big)
 				topTrace.Result.(*TraceResult).GasUsed.ToInt().SetUint64(gasUsed)
-				topTrace.Result.(*TraceResult).Output = common.Copy(output)
+				topTrace.Result.(*TraceResult).Output = bytes.Clone(output)
 			case CREATE:
 				topTrace.Result.(*CreateTraceResult).GasUsed = new(hexutil.Big)
 				topTrace.Result.(*CreateTraceResult).GasUsed.ToInt().SetUint64(gasUsed)
-				topTrace.Result.(*CreateTraceResult).Code = common.Copy(output)
+				topTrace.Result.(*CreateTraceResult).Code = bytes.Clone(output)
 			}
 		} else {
 			topTrace.Result = nil
@@ -537,9 +537,9 @@ func (ot *OeTracer) captureEndOrExit(deep bool, output []byte, gasUsed uint64, e
 		if len(output) > 0 {
 			switch topTrace.Type {
 			case CALL:
-				topTrace.Result.(*TraceResult).Output = common.Copy(output)
+				topTrace.Result.(*TraceResult).Output = bytes.Clone(output)
 			case CREATE:
-				topTrace.Result.(*CreateTraceResult).Code = common.Copy(output)
+				topTrace.Result.(*CreateTraceResult).Code = bytes.Clone(output)
 			}
 		}
 		switch topTrace.Type {
@@ -1230,7 +1230,7 @@ func (api *TraceAPIImpl) Call(ctx context.Context, args TraceCallParam, traceTyp
 	if ot.Tracer() != nil && ot.Tracer().Hooks.OnTxEnd != nil {
 		ot.Tracer().OnTxEnd(&types.Receipt{GasUsed: execResult.ReceiptGasUsed}, nil)
 	}
-	traceResult.Output = common.Copy(execResult.ReturnData)
+	traceResult.Output = bytes.Clone(execResult.ReturnData)
 	if traceTypeStateDiff {
 		sdMap := make(map[accounts.Address]*StateDiffAccount)
 		traceResult.StateDiff = sdMap
@@ -1550,7 +1550,7 @@ func (api *TraceAPIImpl) doCallBlock(ctx context.Context, dbtx kv.Tx, stateReade
 		}
 
 		chainRules := blockCtx.Rules(chainConfig)
-		traceResult.Output = common.Copy(execResult.ReturnData)
+		traceResult.Output = bytes.Clone(execResult.ReturnData)
 		if traceTypeStateDiff {
 			initialIbs := state.New(cloneReader)
 			if !txFinalized {
@@ -1754,7 +1754,7 @@ func (api *TraceAPIImpl) doCall(ctx context.Context, dbtx kv.Tx, stateReader sta
 	}
 
 	chainRules := blockCtx.Rules(chainConfig)
-	traceResult.Output = common.Copy(execResult.ReturnData)
+	traceResult.Output = bytes.Clone(execResult.ReturnData)
 	if traceTypeStateDiff {
 		initialIbs := state.New(cloneReader)
 		if !txFinalized {
@@ -1912,7 +1912,7 @@ func (api *TraceAPIImpl) RawTransaction(ctx context.Context, encodedTx hexutil.B
 		ot.Tracer().OnTxEnd(&types.Receipt{GasUsed: execResult.ReceiptGasUsed}, nil)
 	}
 
-	traceResult.Output = common.Copy(execResult.ReturnData)
+	traceResult.Output = bytes.Clone(execResult.ReturnData)
 
 	if traceTypeStateDiff {
 		sdMap := make(map[accounts.Address]*StateDiffAccount)

--- a/rpc/jsonrpc/trace_filtering.go
+++ b/rpc/jsonrpc/trace_filtering.go
@@ -17,6 +17,7 @@
 package jsonrpc
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -681,7 +682,7 @@ func (api *TraceAPIImpl) filterV3(ctx context.Context, dbtx kv.TemporalTx, fromB
 		if ot.Tracer() != nil && ot.Tracer().Hooks.OnTxEnd != nil {
 			ot.Tracer().OnTxEnd(&types.Receipt{GasUsed: execResult.ReceiptGasUsed}, nil)
 		}
-		traceResult.Output = common.Copy(execResult.ReturnData)
+		traceResult.Output = bytes.Clone(execResult.ReturnData)
 		if err = ibs.FinalizeTx(evm.ChainRules(), noop); err != nil {
 			if first {
 				first = false
@@ -1086,7 +1087,7 @@ func (api *TraceAPIImpl) doCallBlockParallel(
 					return
 				}
 
-				traceResult.Output = common.Copy(execResult.ReturnData)
+				traceResult.Output = bytes.Clone(execResult.ReturnData)
 				results[job.txIndex] = traceResult
 			}
 		})

--- a/txnprovider/txpool/announcements.go
+++ b/txnprovider/txpool/announcements.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"sort"
 
-	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/length"
 )
 
@@ -120,9 +119,9 @@ func (a Announcements) Copy() Announcements {
 		return a
 	}
 	c := Announcements{
-		ts:     common.Copy(a.ts),
+		ts:     bytes.Clone(a.ts),
 		sizes:  make([]uint32, len(a.sizes)),
-		hashes: common.Copy(a.hashes),
+		hashes: bytes.Clone(a.hashes),
 	}
 	copy(c.sizes, a.sizes)
 	return c

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -603,7 +603,7 @@ func (p *TxPool) GetRlp(tx kv.Tx, hash []byte) ([]byte, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	rlpTx, _, _, err := p.getRlpLocked(tx, hash)
-	return common.Copy(rlpTx), err
+	return bytes.Clone(rlpTx), err
 }
 
 func (p *TxPool) AppendAllAnnouncements(types []byte, sizes []uint32, hashes []byte) ([]byte, []uint32, []byte) {
@@ -686,7 +686,7 @@ func (p *TxPool) getCachedBlobTxnLocked(tx kv.Tx, hash []byte) (*metaTxn, error)
 	if len(v) == 0 {
 		return nil, nil
 	}
-	txnRlp := common.Copy(v[20:])
+	txnRlp := bytes.Clone(v[20:])
 	parseCtx := NewTxnParseContext(p.chainID)
 	parseCtx.WithSender(false)
 	txnSlot := &TxnSlot{}

--- a/txnprovider/txpool/txpool_grpc_server.go
+++ b/txnprovider/txpool/txpool_grpc_server.go
@@ -17,6 +17,7 @@
 package txpool
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"math"
@@ -134,7 +135,7 @@ func (s *GrpcServer) All(ctx context.Context, _ *txpoolproto.AllRequest) (*txpoo
 		reply.Txs = append(reply.Txs, &txpoolproto.AllReply_Tx{
 			Sender:  gointerfaces.ConvertAddressToH160(sender),
 			TxnType: convertSubPoolType(t),
-			RlpTx:   common.Copy(rlp),
+			RlpTx:   bytes.Clone(rlp),
 		})
 	}, tx)
 	return reply, nil


### PR DESCRIPTION
Cherry-pick of #22741 to release/3.6.

Straight pick rather than a re-implementation: only one hunk conflicted (`execution/commitment/trie/trie.go`, where main had picked up a `sloppyReassign` rewrite that release/3.6 does not have) — release/3.6's `append` form is kept, with `common.Copy` swapped for `bytes.Clone`. Net diff matches the source commit exactly: 127 files, 428 insertions, 413 deletions.

`common.Copy` stays as a real function carrying `//go:fix inline`, so nothing outside the repo breaks and no deprecated shim is needed.