### PR TITLE
publishable command: reject same snapshot range with different versions

### DIFF
--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2130,6 +2130,10 @@ func checkIfCaplinSnapshotsPublishable(dirs datadir.Dirs, emptyOk bool) error {
 }
 
 func checkIfBlockSnapshotsPublishable(snapDir string) error {
+	if err := checkNoDuplicateFileVersions(snapDir); err != nil {
+		return err
+	}
+
 	var sum uint64
 	var maxTo uint64
 	verMap := map[string]map[string]version.Versions{
@@ -2291,9 +2295,54 @@ var (
 	ErrSnapGap             = errors.New("gap in snapshot ranges")
 	ErrSnapMissingFile     = errors.New("missing snapshot file")
 	ErrSnapMaxStepMismatch = errors.New("max step mismatch across directories")
+
+	ErrSnapDuplicateVersions = errors.New("same snapshot range published under multiple versions")
 )
 
+// checkNoDuplicateFileVersions rejects publishing the same file twice under different
+// versions (e.g. v1.0-code.0-32.vi next to v1.1-code.0-32.vi): readers pick the highest
+// version, so the lower one is dead weight in the torrent and its hash mapping is ambiguous.
+// Subdirectories are skipped, so callers pass each snapshot directory they own.
+func checkNoDuplicateFileVersions(dirPaths ...string) error {
+	for _, dirPath := range dirPaths {
+		seen := map[string]string{}
+		if err := filepath.WalkDir(dirPath, func(path string, info fs.DirEntry, err error) error {
+			if err != nil {
+				if os.IsNotExist(err) { //it's ok if some file get removed during walk
+					return nil
+				}
+				return err
+			}
+			if info.IsDir() {
+				if path == dirPath {
+					return nil
+				}
+				return fs.SkipDir
+			}
+			if filepath.Ext(info.Name()) == ".tmp" {
+				return nil
+			}
+			masked, err := version.ReplaceVersionWithMask(info.Name())
+			if err != nil {
+				return nil // unversioned file, e.g. salt-blocks.txt
+			}
+			if prev, ok := seen[masked]; ok {
+				return fmt.Errorf("%w: %s and %s in %s", ErrSnapDuplicateVersions, prev, info.Name(), dirPath)
+			}
+			seen[masked] = info.Name()
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func checkStateSnapshotFiles(dirs datadir.Dirs, persistReceiptCache, commitmentHistory bool) error {
+	if err := checkNoDuplicateFileVersions(dirs.SnapDomain, dirs.SnapHistory, dirs.SnapIdx, dirs.SnapAccessors); err != nil {
+		return err
+	}
+
 	var maxStepDomain uint64 // across all files in SnapDomain
 	var accFiles []snaptype.FileInfo
 

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2305,34 +2305,14 @@ var (
 // Subdirectories are skipped, so callers pass each snapshot directory they own.
 func checkNoDuplicateFileVersions(dirPaths ...string) error {
 	for _, dirPath := range dirPaths {
-		seen := map[string]string{}
-		if err := filepath.WalkDir(dirPath, func(path string, info fs.DirEntry, err error) error {
-			if err != nil {
-				if os.IsNotExist(err) { //it's ok if some file get removed during walk
-					return nil
-				}
-				return err
-			}
-			if info.IsDir() {
-				if path == dirPath {
-					return nil
-				}
-				return fs.SkipDir
-			}
-			if filepath.Ext(info.Name()) == ".tmp" {
-				return nil
-			}
-			masked, err := version.ReplaceVersionWithMask(info.Name())
-			if err != nil {
-				return nil // unversioned file, e.g. salt-blocks.txt
-			}
-			if prev, ok := seen[masked]; ok {
-				return fmt.Errorf("%w: %s and %s in %s", ErrSnapDuplicateVersions, prev, info.Name(), dirPath)
-			}
-			seen[masked] = info.Name()
-			return nil
-		}); err != nil {
+		groups, err := version.GroupByMaskedName(filepath.Join(dirPath, "*"))
+		if err != nil {
 			return err
+		}
+		for _, g := range groups {
+			if len(g) > 1 {
+				return fmt.Errorf("%w: %s and %s in %s", ErrSnapDuplicateVersions, g[0].Name, g[1].Name, dirPath)
+			}
 		}
 	}
 	return nil

--- a/cmd/utils/app/snapshots_cmd.go
+++ b/cmd/utils/app/snapshots_cmd.go
@@ -2310,9 +2310,13 @@ func checkNoDuplicateFileVersions(dirPaths ...string) error {
 			return err
 		}
 		for _, g := range groups {
-			if len(g) > 1 {
-				return fmt.Errorf("%w: %s and %s in %s", ErrSnapDuplicateVersions, g[0].Name, g[1].Name, dirPath)
+			if len(g) < 2 {
+				continue
 			}
+			if !snaptype.IsSeedableExtension(g[0].Name) && !strings.HasSuffix(g[0].Name, ".torrent") {
+				continue // not an erigon snapshot file
+			}
+			return fmt.Errorf("%w: %s and %s in %s", ErrSnapDuplicateVersions, g[0].Name, g[1].Name, dirPath)
 		}
 	}
 	return nil

--- a/cmd/utils/app/snapshots_publishable_state_test.go
+++ b/cmd/utils/app/snapshots_publishable_state_test.go
@@ -809,3 +809,102 @@ func Test_CheckStateSnapshotFiles_IdxDomainMaxStepMismatch(t *testing.T) {
 	err := checkStateSnapshotFiles(dirs, false, false)
 	require.ErrorIs(t, err, ErrSnapMaxStepMismatch)
 }
+
+// --- Duplicate version checks: same type and range published under two versions ---
+
+func Test_CheckStateSnapshotFiles_DuplicateVersionsDomainKV(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapDomain, "v1.2-storage.0-128.kv")
+	err := checkStateSnapshotFiles(dirs, false, false)
+	require.ErrorIs(t, err, ErrSnapDuplicateVersions)
+}
+
+func Test_CheckStateSnapshotFiles_DuplicateVersionsDomainBT(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapDomain, "v1.2-accounts.0-128.bt")
+	err := checkStateSnapshotFiles(dirs, false, false)
+	require.ErrorIs(t, err, ErrSnapDuplicateVersions)
+}
+
+func Test_CheckStateSnapshotFiles_DuplicateVersionsHistoryV(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapHistory, "v2.0-accounts.0-128.v")
+	err := checkStateSnapshotFiles(dirs, false, false)
+	require.ErrorIs(t, err, ErrSnapDuplicateVersions)
+}
+
+func Test_CheckStateSnapshotFiles_DuplicateVersionsIdxEF(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapIdx, "v2.1-logaddrs.0-128.ef")
+	err := checkStateSnapshotFiles(dirs, false, false)
+	require.ErrorIs(t, err, ErrSnapDuplicateVersions)
+}
+
+func Test_CheckStateSnapshotFiles_DuplicateVersionsAccessorVI(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapAccessors, "v1.2-code.0-128.vi")
+	err := checkStateSnapshotFiles(dirs, false, false)
+	require.ErrorIs(t, err, ErrSnapDuplicateVersions)
+}
+
+func Test_CheckStateSnapshotFiles_DuplicateVersionsAccessorEFI(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapAccessors, "v1.2-tracesto.0-128.efi")
+	err := checkStateSnapshotFiles(dirs, false, false)
+	require.ErrorIs(t, err, ErrSnapDuplicateVersions)
+}
+
+func Test_CheckStateSnapshotFiles_DuplicateVersionsTorrent(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapAccessors, "v1.2-code.0-128.vi.torrent")
+	err := checkStateSnapshotFiles(dirs, false, false)
+	require.ErrorIs(t, err, ErrSnapDuplicateVersions)
+}
+
+// A .tmp leftover isn't a published file, so it must not trip the duplicate check.
+func Test_CheckStateSnapshotFiles_TmpFileIsNotDuplicate(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapDomain, "v1.2-storage.0-128.kv.tmp")
+	err := checkStateSnapshotFiles(dirs, false, false)
+	require.NoError(t, err)
+}
+
+// --- Block snapshot checks ---
+
+func Test_CheckIfBlockSnapshotsPublishable_SuccessCase(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	require.NoError(t, checkIfBlockSnapshotsPublishable(dirs.Snap))
+}
+
+func Test_CheckIfBlockSnapshotsPublishable_DuplicateVersionsSeg(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.Snap, "v1.2-000000-000100-headers.seg")
+	err := checkIfBlockSnapshotsPublishable(dirs.Snap)
+	require.ErrorIs(t, err, ErrSnapDuplicateVersions)
+}
+
+func Test_CheckIfBlockSnapshotsPublishable_DuplicateVersionsIdx(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.Snap, "v2.1-000000-000100-bodies.idx")
+	err := checkIfBlockSnapshotsPublishable(dirs.Snap)
+	require.ErrorIs(t, err, ErrSnapDuplicateVersions)
+}
+
+// The block check owns the snapshots root only; state subdirectories are the state check's business.
+func Test_CheckIfBlockSnapshotsPublishable_IgnoresStateSubdirs(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapDomain, "v1.2-storage.0-128.kv")
+	require.NoError(t, checkIfBlockSnapshotsPublishable(dirs.Snap))
+}

--- a/cmd/utils/app/snapshots_publishable_state_test.go
+++ b/cmd/utils/app/snapshots_publishable_state_test.go
@@ -877,6 +877,15 @@ func Test_CheckStateSnapshotFiles_TmpFileIsNotDuplicate(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_CheckStateSnapshotFiles_NonSnapshotVersionedFileIsNotDuplicate(t *testing.T) {
+	t.Parallel()
+	dirs := setupWorkingStateMockDatadir(t)
+	createMockFile(t, dirs.SnapDomain, "v1.0-storage.0-128.log")
+	createMockFile(t, dirs.SnapDomain, "v1.1-storage.0-128.log")
+	err := checkStateSnapshotFiles(dirs, false, false)
+	require.NoError(t, err)
+}
+
 // --- Block snapshot checks ---
 
 func Test_CheckIfBlockSnapshotsPublishable_SuccessCase(t *testing.T) {

--- a/db/version/file_version.go
+++ b/db/version/file_version.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -222,34 +221,62 @@ func (v Versions) MustSupport(ver Version, filename string) {
 	panic(msg)
 }
 
-// FindFilesWithVersionsByPattern return an filepath by pattern
+// FindFilesWithVersionsByPattern returns the highest-version file matching pattern.
 func FindFilesWithVersionsByPattern(pattern string) (string, Version, bool, error) {
-	matches, err := filepath.Glob(pattern)
+	groups, err := GroupByMaskedName(pattern)
 	if err != nil {
-		return "", Version{}, false, fmt.Errorf("invalid pattern: %w", err)
+		return "", Version{}, false, err
 	}
-
-	if len(matches) == 0 {
+	var best VersionedFile
+	found := false
+	for _, g := range groups {
+		for i := range g {
+			if !found || g[i].Version.Cmp(best.Version) > 0 {
+				best, found = g[i], true
+			}
+		}
+	}
+	if !found {
 		return "", Version{}, false, nil
 	}
-	if len(matches) > 1 {
-		slices.SortFunc(matches, func(a, b string) int {
-			_, fName1 := filepath.Split(a)
-			version1, _ := ParseVersion(fName1)
+	return best.Path, best.Version, true, nil
+}
 
-			_, fName2 := filepath.Split(b)
-			version2, _ := ParseVersion(fName2)
+// VersionedFile is a file paired with the version parsed from its name.
+type VersionedFile struct {
+	Path    string
+	Name    string
+	Version Version
+}
 
-			return version1.Cmp(version2)
-		})
-		_, fName := filepath.Split(matches[len(matches)-1])
-		ver, _ := ParseVersion(fName)
-
-		return matches[len(matches)-1], ver, true, nil
+// GroupByMaskedName is FindFilesWithVersionsByPattern without the collapse to the
+// highest version: it globs pattern and groups every match by its version-masked
+// name, so a key holding more than one entry is the same logical file present under
+// multiple versions. Pass "<dir>/*" to scan a whole directory. Unversioned matches
+// (e.g. salt-blocks.txt, subdirectories) and .tmp leftovers are skipped.
+func GroupByMaskedName(pattern string) (map[string][]VersionedFile, error) {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pattern: %w", err)
 	}
-	_, fName := filepath.Split(matches[0])
-	ver, _ := ParseVersion(fName)
-	return matches[0], ver, true, nil
+	groups := map[string][]VersionedFile{}
+	for _, path := range matches {
+		name := filepath.Base(path)
+		if filepath.Ext(name) == ".tmp" {
+			continue
+		}
+		masked, err := ReplaceVersionWithMask(name)
+		if err != nil {
+			continue // unversioned file or directory
+		}
+		ver, _ := ParseVersion(name)
+		groups[masked] = append(groups[masked], VersionedFile{
+			Path:    path,
+			Name:    name,
+			Version: ver,
+		})
+	}
+	return groups, nil
 }
 
 // MatchVersionedFile searches for files matching a pattern within a pre-scanned list.

--- a/db/version/file_version_test.go
+++ b/db/version/file_version_test.go
@@ -181,6 +181,49 @@ func TestFindFilesWithVersionsByPattern_InvalidPattern(t *testing.T) {
 	}
 }
 
+func TestGroupByMaskedName(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{
+		"v1.0-accounts.0-64.kv",
+		"v1.1-accounts.0-64.kv", // same logical file, different version
+		"v1.0-storage.0-64.kv",
+		"v1.0-accounts.0-64.kv.tmp", // .tmp leftover, must be skipped
+		"salt-blocks.txt",           // unversioned, must be skipped
+	} {
+		if err := touch(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("failed to create %q: %v", name, err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "history"), 0o755); err != nil {
+		t.Fatalf("failed to create subdir: %v", err)
+	}
+
+	groups, err := GroupByMaskedName(filepath.Join(dir, "*"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 masked groups, got %d: %v", len(groups), groups)
+	}
+	if got := groups["*-accounts.0-64.kv"]; len(got) != 2 {
+		t.Fatalf("expected 2 versions of accounts, got %d: %v", len(got), got)
+	}
+	if got := groups["*-storage.0-64.kv"]; len(got) != 1 {
+		t.Fatalf("expected 1 version of storage, got %d: %v", len(got), got)
+	}
+}
+
+func TestGroupByMaskedName_MissingDir(t *testing.T) {
+	groups, err := GroupByMaskedName(filepath.Join(t.TempDir(), "does-not-exist", "*"))
+	if err != nil {
+		t.Fatalf("expected no error for missing dir, got %v", err)
+	}
+	if len(groups) != 0 {
+		t.Fatalf("expected empty result, got %v", groups)
+	}
+}
+
 // touch creates an empty file (like the `touch` shell command).
 func touch(path string) error {
 	f, err := os.Create(path)


### PR DESCRIPTION
Makes `doPublishable` reject two files that differ only in version, e.g. `accessor/v1.0-code.0-32.vi` next to `accessor/v1.1-code.0-32.vi`. Readers pick the highest version, so the lower one is dead weight in the torrent and its hash mapping is ambiguous.

Towards erigontech/erigon-snapshot#1092.

### Before

Only `accounts` was covered, and only by accident: two versions of the same `accounts.kv` / `accounts.ef` landed twice in the range list and tripped the overlap check, reporting the misleading `overlap between (0-100000) and (0-100000) … (maybe run remove_overlaps)`. Every other type and extension passed silently, because `version.CheckIsThereFileWithSupportedVersion` → `FindFilesWithVersionsByPattern` deliberately returns the highest match when several versions exist.

Verified against a mock datadir: duplicate `domain/*.kv` (non-accounts), `domain/*.bt`, `history/*.v`, `idx/*.ef` (non-accounts), `accessor/*.vi` and `accessor/*.efi` all returned `nil`.

### Now

`checkNoDuplicateFileVersions` groups a directory's entries by filename with the version masked out, so one pass covers every extension in it — `.kv/.bt/.kvei/.kvi`, `.v`, `.ef`, `.vi/.efi`, `.seg/.idx`, and their `.torrent` companions — instead of threading a strict check through each of the ~12 `CheckIsThereFileWithSupportedVersion` call sites.

- `checkStateSnapshotFiles` scans `domain/`, `history/`, `idx/`, `accessor/`
- `checkIfBlockSnapshotsPublishable` scans the snapshots root (non-recursive, so it doesn't re-scan the state subdirs)
- unversioned files (`salt-blocks.txt`, `preverified.toml`) and `.tmp` leftovers are skipped
- both run before the range checks, so a duplicate reports as `ErrSnapDuplicateVersions` rather than as an overlap

### Tests

11 tests, written before the fix and confirmed failing for the right reason (7 returned `nil`, 2 returned the wrong overlap error):

- duplicate `domain/*.kv`, `domain/*.bt`, `history/*.v`, `idx/*.ef`, `accessor/*.vi`, `accessor/*.efi`, and a `.torrent`
- `Test_CheckStateSnapshotFiles_TmpFileIsNotDuplicate` — a `.tmp` leftover must not trip the check
- duplicate block `.seg` and `.idx`, plus `Test_CheckIfBlockSnapshotsPublishable_SuccessCase` (the block path had no success-case test)

Existing overlap tests are unaffected: they use one version across different ranges, so the masked keys differ.

### Note before merging

The datadirs catalogued in erigontech/erigon-snapshot#1092 (mainnet v31/v34, sepolia v34) carry exactly these duplicates today, so `snapshots publishable` and `seg integrity --check Publishable` will fail on them until they are cleaned up. The cleanup should land first, or the snapshotters go red.
