### PR TITLE
execution/state: validate an in-block-destruct storage dep by that destruct

### DIFF
--- a/execution/state/read_paths.go
+++ b/execution/state/read_paths.go
@@ -517,6 +517,11 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 						ReadHeader: ReadHeader{Source: MapRead, Version: sdVer},
 						Val:        true,
 					})
+					// The zero also depends on this floor still being the newest
+					// write: a storage write published above the destruct makes it
+					// the wrong answer. MapRead validates on version alone, so the
+					// recorded zero value is never compared.
+					s.versionedReads.SetHeader(addr, path, key, hdr)
 				}
 				r.outcome = outcomeReturnZero
 				r.source = MapRead

--- a/execution/state/read_paths.go
+++ b/execution/state/read_paths.go
@@ -513,10 +513,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 		if path == StoragePath {
 			if sdVer, ok := s.versionMap.FindDoneSelfDestructInRange(addr, hdr.Version.TxIndex, s.txIndex, true); ok {
 				if !commited {
-					s.versionedReads.SetSelfDestruct(addr, VersionedRead[bool]{
-						ReadHeader: ReadHeader{Source: MapRead, Version: sdVer},
-						Val:        true,
-					})
+					s.versionedReads.SetSelfDestructInRange(addr, sdVer)
 				}
 				r.outcome = outcomeReturnZero
 				r.source = MapRead

--- a/execution/state/read_paths.go
+++ b/execution/state/read_paths.go
@@ -495,12 +495,22 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 			s.versionedReads.SetHeader(addr, path, key, hdr)
 			panic(ErrDependency)
 		}
-		// CodePath trumped by SelfDestruct at >= DepIdx
-		if path == CodePath {
-			if destructed, sdres, ok := s.versionMap.ReadSelfDestruct(addr, s.txIndex); ok && sdres.Status() == MVReadResultDone && destructed && sdres.DepIdx() >= res.DepIdx() {
+		// Code and code size are trumped by a destruct at or above the cell. The
+		// revival that follows one clears the account's code without writing a
+		// CodePath cell, so a latest-only probe would hand back the pre-destruct
+		// code; scan the range instead, as the storage case below does.
+		if path == CodePath || path == CodeSizePath {
+			if sdVer, ok := s.versionMap.FindDoneSelfDestructInRange(addr, hdr.Version.TxIndex, s.txIndex, true); ok {
+				if !commited {
+					s.versionedReads.SetSelfDestructInRange(addr, VersionedRead[bool]{
+						ReadHeader: ReadHeader{Source: MapRead, Version: sdVer},
+						Val:        true,
+					})
+					s.versionedReads.SetHeader(addr, path, key, hdr)
+				}
 				r.outcome = outcomeReturnDefault
 				r.source = MapRead
-				r.version = Version{TxIndex: res.DepIdx(), Incarnation: res.Incarnation()}
+				r.version = sdVer
 				return
 			}
 		}

--- a/execution/state/read_paths.go
+++ b/execution/state/read_paths.go
@@ -513,7 +513,10 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 		if path == StoragePath {
 			if sdVer, ok := s.versionMap.FindDoneSelfDestructInRange(addr, hdr.Version.TxIndex, s.txIndex, true); ok {
 				if !commited {
-					s.versionedReads.SetSelfDestructInRange(addr, sdVer)
+					s.versionedReads.SetSelfDestructInRange(addr, VersionedRead[bool]{
+						ReadHeader: ReadHeader{Source: MapRead, Version: sdVer},
+						Val:        true,
+					})
 				}
 				r.outcome = outcomeReturnZero
 				r.source = MapRead

--- a/execution/state/revival_reader_test.go
+++ b/execution/state/revival_reader_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// destructThenRevive seeds a version map with a value at tx0, a destruct at tx1
+// and a revival at tx2 — the shape where the latest SelfDestruct entry is the
+// revival and so cannot answer "was this wiped".
+func destructThenRevive(vm *VersionMap, addr accounts.Address) {
+	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 1}, true, true)
+	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 2}, false, true)
+	writeFor(vm, addr, IncarnationPath, accounts.NilKey, Version{TxIndex: 2}, uint64(2), true)
+}
+
+func TestVersionedStateReader_StorageWipedByInRangeDestruct(t *testing.T) {
+	t.Parallel()
+	addr := getAddress(101)
+	key := accounts.InternKey(common.HexToHash("0x01"))
+
+	vm := NewVersionMap(nil)
+	writeFor(vm, addr, StoragePath, key, Version{TxIndex: 0}, *uint256.NewInt(5), true)
+	destructThenRevive(vm, addr)
+
+	vr := NewVersionedStateReader(3, ReadSet{}, vm, nil)
+	val, _, err := vr.ReadAccountStorage(addr, key)
+	require.NoError(t, err)
+	require.True(t, val.IsZero(), "the destruct wiped the slot; the revival did not restore it")
+}
+
+func TestVersionedStateReader_StorageSurvivesWhenRevivalRewrote(t *testing.T) {
+	t.Parallel()
+	addr := getAddress(102)
+	key := accounts.InternKey(common.HexToHash("0x01"))
+
+	vm := NewVersionMap(nil)
+	writeFor(vm, addr, StoragePath, key, Version{TxIndex: 0}, *uint256.NewInt(5), true)
+	destructThenRevive(vm, addr)
+	writeFor(vm, addr, StoragePath, key, Version{TxIndex: 2}, *uint256.NewInt(9), true)
+
+	vr := NewVersionedStateReader(3, ReadSet{}, vm, nil)
+	val, _, err := vr.ReadAccountStorage(addr, key)
+	require.NoError(t, err)
+	require.Equal(t, uint64(9), val.Uint64(), "a write above the destruct is the live value")
+}
+
+func TestVersionedStateReader_CodeWipedByInRangeDestruct(t *testing.T) {
+	t.Parallel()
+	addr := getAddress(103)
+
+	vm := NewVersionMap(nil)
+	vm.WriteCode(addr, Version{TxIndex: 0}, accounts.NewCode([]byte{0x60, 0x00}), true)
+	destructThenRevive(vm, addr)
+
+	vr := NewVersionedStateReader(3, ReadSet{}, vm, nil)
+	code, err := vr.ReadAccountCode(addr)
+	require.NoError(t, err)
+	require.Empty(t, code, "the revived account has no code until something writes it")
+
+	size, err := vr.ReadAccountCodeSize(addr)
+	require.NoError(t, err)
+	require.Zero(t, size, "code size must agree with code")
+}
+
+// The Done-branch guard for CodePath is latest-only, so a revival hides the
+// destruct and the pre-destruct code cell wins. CodeSizePath has no guard there
+// at all.
+func TestGetCodeAfterDestructThenRevivalIsEmpty(t *testing.T) {
+	t.Parallel()
+	addr := getAddress(104)
+
+	vm := NewVersionMap(nil)
+	vm.WriteCode(addr, Version{TxIndex: 0}, accounts.NewCode([]byte{0x60, 0x00}), true)
+	destructThenRevive(vm, addr)
+
+	reader := newAccountStateReader(addr)
+	ibs := NewWithVersionMap(NewVersionedStateReader(3, ReadSet{}, vm, reader), vm)
+	ibs.SetNoMaterialize(true)
+	ibs.SetTxContext(0, 3)
+	ibs.SetVersion(0)
+
+	code, err := ibs.GetCode(addr)
+	require.NoError(t, err)
+	require.Empty(t, code, "the destruct removed the code and the revival did not write any")
+
+	size, err := ibs.GetCodeSize(addr)
+	require.NoError(t, err)
+	require.Zero(t, size, "code size must agree with code")
+}

--- a/execution/state/revival_storage_read_test.go
+++ b/execution/state/revival_storage_read_test.go
@@ -137,3 +137,39 @@ func TestRangeDepEdgeOnlyFromTheDestructingTx(t *testing.T) {
 	require.True(t, HasReadDep(sdWrite(41, true), rs), "the destruct the dep names is a real edge")
 	require.False(t, HasReadDep(sdWrite(42, false), rs), "the revival above the destruct is not")
 }
+
+// The zero is justified by two facts: the destruct exists, and the storage floor
+// the range was scanned from is still the newest write. Recording only the first
+// lets a storage write published above the destruct go unnoticed, and the reader
+// keeps a zero that is no longer the right answer.
+func TestStorageReadInvalidatesWhenAPostDestructWritePublishes(t *testing.T) {
+	t.Parallel()
+	addr := getAddress(95)
+	key := accounts.InternKey(common.HexToHash("0x35"))
+
+	vm := NewVersionMap(nil)
+	writeFor(vm, addr, StoragePath, key, Version{TxIndex: 16}, *uint256.NewInt(7), true)
+	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 41}, true, true)
+	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 42}, false, true)
+	writeFor(vm, addr, IncarnationPath, accounts.NilKey, Version{TxIndex: 42}, uint64(3), true)
+
+	reader := newAccountStateReader(addr)
+	ibs := NewWithVersionMap(NewVersionedStateReader(44, ReadSet{}, vm, reader), vm)
+	ibs.SetNoMaterialize(true)
+	ibs.SetTxContext(0, 44)
+	ibs.SetVersion(0)
+
+	got, err := ibs.GetState(addr, key)
+	require.NoError(t, err)
+	require.True(t, got.IsZero(), "the destruct wiped the slot")
+
+	io := NewVersionedIO(45)
+	io.RecordReads(Version{TxIndex: 44}, ibs.VersionedReads())
+	require.Equal(t, VersionValid, vm.ValidateVersion(44, io, validateEqualVersion, false, ""),
+		"nothing has changed yet")
+
+	// A tx between the destruct and this reader publishes a new value for the slot.
+	writeFor(vm, addr, StoragePath, key, Version{TxIndex: 43}, *uint256.NewInt(9), true)
+	require.Equal(t, VersionInvalid, vm.ValidateVersion(44, io, validateEqualVersion, false, ""),
+		"the floor the zero was derived from moved, so the read must be re-run")
+}

--- a/execution/state/revival_storage_read_test.go
+++ b/execution/state/revival_storage_read_test.go
@@ -60,6 +60,32 @@ func TestStorageReadAcrossDestructThenRevivalValidates(t *testing.T) {
 		"the reader justified the zero by an in-range destruct; the validator must accept the same justification")
 }
 
+// The dep lives in its own map, so every read-set operation has to carry it like
+// the per-path maps do — a merge that drops it silently retires the check.
+func TestStorageReadRangeDepSurvivesMerge(t *testing.T) {
+	t.Parallel()
+	addr := getAddress(93)
+
+	var src ReadSet
+	src.SetSelfDestructInRange(addr, Version{TxIndex: 40, Incarnation: 1})
+	require.Equal(t, 1, src.Len(), "the dep is an entry and must be counted")
+
+	var dst ReadSet
+	dst.MergeFrom(src)
+	require.True(t, dst.hasAddr(addr))
+
+	vm := NewVersionMap(nil)
+	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 41}, true, true)
+
+	io := NewVersionedIO(44)
+	io.RecordReads(Version{TxIndex: 43}, dst)
+	require.Equal(t, VersionInvalid, vm.ValidateVersion(43, io, validateEqualVersion, false, ""),
+		"the merged dep names a destruct at tx 40 that is not in the map")
+
+	dst.Delete(addr)
+	require.False(t, dst.hasAddr(addr))
+}
+
 // The guard the fix must not trade away: when the destruct the read depended on
 // is gone from the map, the read is genuinely stale and must still invalidate.
 func TestStorageReadInvalidatesWhenDependedDestructVanishes(t *testing.T) {

--- a/execution/state/revival_storage_read_test.go
+++ b/execution/state/revival_storage_read_test.go
@@ -67,7 +67,10 @@ func TestStorageReadRangeDepSurvivesMerge(t *testing.T) {
 	addr := getAddress(93)
 
 	var src ReadSet
-	src.SetSelfDestructInRange(addr, Version{TxIndex: 40, Incarnation: 1})
+	src.SetSelfDestructInRange(addr, VersionedRead[bool]{
+		ReadHeader: ReadHeader{Source: MapRead, Version: Version{TxIndex: 40, Incarnation: 1}},
+		Val:        true,
+	})
 	require.Equal(t, 1, src.Len(), "the dep is an entry and must be counted")
 
 	var dst ReadSet
@@ -100,8 +103,37 @@ func TestStorageReadInvalidatesWhenDependedDestructVanishes(t *testing.T) {
 	io := NewVersionedIO(44)
 	rs := ReadSet{}
 	// A read that depended on a destruct at tx 40 — no such entry exists.
-	rs.SetSelfDestructInRange(addr, Version{TxIndex: 40, Incarnation: 1})
+	rs.SetSelfDestructInRange(addr, VersionedRead[bool]{
+		ReadHeader: ReadHeader{Source: MapRead, Version: Version{TxIndex: 40, Incarnation: 1}},
+		Val:        true,
+	})
 	io.RecordReads(Version{TxIndex: 43}, rs)
 	require.Equal(t, VersionInvalid, vm.ValidateVersion(43, io, validateEqualVersion, false, ""),
 		"a read pinned to a destruct that is not in the map must invalidate")
+}
+
+// The DAG edge for a range dep belongs to the tx that did the destruct, not to
+// the revival sitting above it — both write SelfDestructPath, and an edge from
+// the revival is a dependency that isn't there.
+func TestRangeDepEdgeOnlyFromTheDestructingTx(t *testing.T) {
+	t.Parallel()
+	addr := getAddress(94)
+
+	var rs ReadSet
+	rs.SetSelfDestructInRange(addr, VersionedRead[bool]{
+		ReadHeader: ReadHeader{Source: MapRead, Version: Version{TxIndex: 41, Incarnation: 1}},
+		Val:        true,
+	})
+
+	sdWrite := func(txIdx int, val bool) *WriteSet {
+		ws := &WriteSet{}
+		ws.SetSelfDestruct(addr, &VersionedWrite[bool]{
+			WriteHeader: WriteHeader{Address: addr, Path: SelfDestructPath, Version: Version{TxIndex: txIdx}},
+			Val:         val,
+		})
+		return ws
+	}
+
+	require.True(t, HasReadDep(sdWrite(41, true), rs), "the destruct the dep names is a real edge")
+	require.False(t, HasReadDep(sdWrite(42, false), rs), "the revival above the destruct is not")
 }

--- a/execution/state/revival_storage_read_test.go
+++ b/execution/state/revival_storage_read_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// A storage slot written before an in-block SELFDESTRUCT, read after a later tx
+// revived the account: the reader must return zero (the destruct wiped it) and
+// the read it records must validate. The reader justifies the zero by scanning
+// the range for the destruct, so it records that destruct's version rather than
+// the latest SelfDestruct entry — and the validator has to judge it the same way,
+// or the read can never be made valid and the tx exhausts its incarnations.
+func TestStorageReadAcrossDestructThenRevivalValidates(t *testing.T) {
+	t.Parallel()
+	addr := getAddress(91)
+	key := accounts.InternKey(common.HexToHash("0x33"))
+
+	vm := NewVersionMap(nil)
+	// Slot written, then destructed, then the account revived above the destruct.
+	writeFor(vm, addr, StoragePath, key, Version{TxIndex: 16}, *uint256.NewInt(0xAA), true)
+	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 41}, true, true)
+	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 42}, false, true)
+	writeFor(vm, addr, IncarnationPath, accounts.NilKey, Version{TxIndex: 42}, uint64(3), true)
+
+	reader := newAccountStateReader(addr)
+	ibs := NewWithVersionMap(NewVersionedStateReader(43, ReadSet{}, vm, reader), vm)
+	ibs.SetNoMaterialize(true)
+	ibs.SetTxContext(0, 43)
+	ibs.SetVersion(0)
+
+	got, err := ibs.GetState(addr, key)
+	require.NoError(t, err)
+	require.True(t, got.IsZero(), "the destruct wiped the slot, so the read is zero")
+
+	io := NewVersionedIO(44)
+	io.RecordReads(Version{TxIndex: 43}, ibs.VersionedReads())
+	require.Equal(t, VersionValid, vm.ValidateVersion(43, io, validateEqualVersion, false, ""),
+		"the reader justified the zero by an in-range destruct; the validator must accept the same justification")
+}
+
+// The guard the fix must not trade away: when the destruct the read depended on
+// is gone from the map, the read is genuinely stale and must still invalidate.
+func TestStorageReadInvalidatesWhenDependedDestructVanishes(t *testing.T) {
+	t.Parallel()
+	addr := getAddress(92)
+	key := accounts.InternKey(common.HexToHash("0x34"))
+
+	vm := NewVersionMap(nil)
+	writeFor(vm, addr, StoragePath, key, Version{TxIndex: 16}, *uint256.NewInt(0xAA), true)
+	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 41}, true, true)
+
+	io := NewVersionedIO(44)
+	rs := ReadSet{}
+	// A read that depended on a destruct at tx 40 — no such entry exists.
+	rs.SetSelfDestructInRange(addr, Version{TxIndex: 40, Incarnation: 1})
+	io.RecordReads(Version{TxIndex: 43}, rs)
+	require.Equal(t, VersionInvalid, vm.ValidateVersion(43, io, validateEqualVersion, false, ""),
+		"a read pinned to a destruct that is not in the map must invalidate")
+}

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -106,16 +106,21 @@ func NewAccountView(acc *accounts.Account) AccountView { return concreteAccountV
 // non-storage probes to a single map lookup.  All maps are lazily allocated
 // on first write.
 type ReadSet struct {
-	address        map[accounts.Address]VersionedRead[AccountView]
-	balance        map[accounts.Address]VersionedRead[uint256.Int]
-	nonce          map[accounts.Address]VersionedRead[uint64]
-	incarnation    map[accounts.Address]VersionedRead[uint64]
-	selfDestruct   map[accounts.Address]VersionedRead[bool]
-	createContract map[accounts.Address]VersionedRead[bool]
-	code           map[accounts.Address]VersionedRead[[]byte]
-	codeHash       map[accounts.Address]VersionedRead[accounts.CodeHash]
-	codeSize       map[accounts.Address]VersionedRead[int]
-	storage        map[accounts.Address]map[accounts.StorageKey]VersionedRead[uint256.Int]
+	address      map[accounts.Address]VersionedRead[AccountView]
+	balance      map[accounts.Address]VersionedRead[uint256.Int]
+	nonce        map[accounts.Address]VersionedRead[uint64]
+	incarnation  map[accounts.Address]VersionedRead[uint64]
+	selfDestruct map[accounts.Address]VersionedRead[bool]
+	// A storage read whose cell predates an in-block SELFDESTRUCT is justified by
+	// that destruct rather than by the latest SelfDestruct entry, which a later
+	// revival moves. Kept apart so the validator checks the destruct it actually
+	// depended on still exists, instead of comparing against the latest.
+	selfDestructInRange map[accounts.Address]Version
+	createContract      map[accounts.Address]VersionedRead[bool]
+	code                map[accounts.Address]VersionedRead[[]byte]
+	codeHash            map[accounts.Address]VersionedRead[accounts.CodeHash]
+	codeSize            map[accounts.Address]VersionedRead[int]
+	storage             map[accounts.Address]map[accounts.StorageKey]VersionedRead[uint256.Int]
 
 	// access carries EIP-7928 "address was accessed" marks (with the
 	// non-revertable "real EVM access" bit) on the read side, so the access set
@@ -142,6 +147,13 @@ func (s *ReadSet) SetNonce(addr accounts.Address, tr VersionedRead[uint64]) {
 func (s *ReadSet) SetIncarnation(addr accounts.Address, tr VersionedRead[uint64]) {
 	readSetPut(&s.incarnation, addr, tr)
 }
+func (s *ReadSet) SetSelfDestructInRange(addr accounts.Address, ver Version) {
+	if s.selfDestructInRange == nil {
+		s.selfDestructInRange = map[accounts.Address]Version{}
+	}
+	s.selfDestructInRange[addr] = ver
+}
+
 func (s *ReadSet) SetSelfDestruct(addr accounts.Address, tr VersionedRead[bool]) {
 	readSetPut(&s.selfDestruct, addr, tr)
 }

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -350,6 +350,9 @@ func (s *ReadSet) hasAddr(addr accounts.Address) bool {
 	if _, ok := s.selfDestruct[addr]; ok {
 		return true
 	}
+	if _, ok := s.selfDestructInRange[addr]; ok {
+		return true
+	}
 	if _, ok := s.createContract[addr]; ok {
 		return true
 	}
@@ -373,6 +376,7 @@ func (s *ReadSet) Delete(addr accounts.Address) {
 	delete(s.nonce, addr)
 	delete(s.incarnation, addr)
 	delete(s.selfDestruct, addr)
+	delete(s.selfDestructInRange, addr)
 	delete(s.createContract, addr)
 	delete(s.code, addr)
 	delete(s.codeHash, addr)
@@ -384,7 +388,7 @@ func (s *ReadSet) Delete(addr accounts.Address) {
 // can be called on a function-returned read set directly.
 func (s ReadSet) Len() int {
 	n := len(s.address) + len(s.balance) + len(s.nonce) + len(s.incarnation) +
-		len(s.selfDestruct) + len(s.createContract) +
+		len(s.selfDestruct) + len(s.selfDestructInRange) + len(s.createContract) +
 		len(s.code) + len(s.codeHash) + len(s.codeSize)
 	for _, inner := range s.storage {
 		n += len(inner)
@@ -408,6 +412,9 @@ func (s *ReadSet) mergeFrom(src ReadSet) {
 	}
 	for a, tr := range src.selfDestruct {
 		readSetPut(&s.selfDestruct, a, tr)
+	}
+	for a, ver := range src.selfDestructInRange {
+		s.SetSelfDestructInRange(a, ver)
 	}
 	for a, tr := range src.createContract {
 		readSetPut(&s.createContract, a, tr)
@@ -2942,6 +2949,11 @@ func HasReadDep(txFrom *WriteSet, txTo ReadSet) bool {
 	for h := range txFrom.AllHeaders() {
 		if _, ok := txTo.getHeader(h.Address, h.Path, h.Key); ok {
 			return true
+		}
+		if h.Path == SelfDestructPath {
+			if _, ok := txTo.selfDestructInRange[h.Address]; ok {
+				return true
+			}
 		}
 	}
 	return false

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -471,6 +471,9 @@ func (s ReadSet) TraceReads(prefix string) {
 	for addr, tr := range s.selfDestruct {
 		fmt.Println(prefix, "RD", traceReadStr(addr, SelfDestructPath, accounts.NilKey, tr.ReadHeader, valueString(SelfDestructPath, tr.Val)))
 	}
+	for addr, tr := range s.selfDestructInRange {
+		fmt.Println(prefix, "RD in-range", traceReadStr(addr, SelfDestructPath, accounts.NilKey, tr.ReadHeader, valueString(SelfDestructPath, tr.Val)))
+	}
 	for addr, tr := range s.createContract {
 		fmt.Println(prefix, "RD", traceReadStr(addr, CreateContractPath, accounts.NilKey, tr.ReadHeader, valueString(CreateContractPath, tr.Val)))
 	}
@@ -518,6 +521,7 @@ func (s ReadSet) eachHeader(yield func(ReadHeader) bool) {
 		!eachHeaderOf(s.nonce, yield) ||
 		!eachHeaderOf(s.incarnation, yield) ||
 		!eachHeaderOf(s.selfDestruct, yield) ||
+		!eachHeaderOf(s.selfDestructInRange, yield) ||
 		!eachHeaderOf(s.createContract, yield) ||
 		!eachHeaderOf(s.code, yield) ||
 		!eachHeaderOf(s.codeHash, yield) ||

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -115,7 +115,7 @@ type ReadSet struct {
 	// that destruct rather than by the latest SelfDestruct entry, which a later
 	// revival moves. Kept apart so the validator checks the destruct it actually
 	// depended on still exists, instead of comparing against the latest.
-	selfDestructInRange map[accounts.Address]Version
+	selfDestructInRange map[accounts.Address]VersionedRead[bool]
 	createContract      map[accounts.Address]VersionedRead[bool]
 	code                map[accounts.Address]VersionedRead[[]byte]
 	codeHash            map[accounts.Address]VersionedRead[accounts.CodeHash]
@@ -147,11 +147,8 @@ func (s *ReadSet) SetNonce(addr accounts.Address, tr VersionedRead[uint64]) {
 func (s *ReadSet) SetIncarnation(addr accounts.Address, tr VersionedRead[uint64]) {
 	readSetPut(&s.incarnation, addr, tr)
 }
-func (s *ReadSet) SetSelfDestructInRange(addr accounts.Address, ver Version) {
-	if s.selfDestructInRange == nil {
-		s.selfDestructInRange = map[accounts.Address]Version{}
-	}
-	s.selfDestructInRange[addr] = ver
+func (s *ReadSet) SetSelfDestructInRange(addr accounts.Address, tr VersionedRead[bool]) {
+	readSetPut(&s.selfDestructInRange, addr, tr)
 }
 
 func (s *ReadSet) SetSelfDestruct(addr accounts.Address, tr VersionedRead[bool]) {
@@ -319,6 +316,7 @@ func (s *ReadSet) ScanAddr(addr accounts.Address, fn func(path AccountPath, key 
 		scanAddrPath(s.nonce, addr, NoncePath, fn) +
 		scanAddrPath(s.incarnation, addr, IncarnationPath, fn) +
 		scanAddrPath(s.selfDestruct, addr, SelfDestructPath, fn) +
+		scanAddrPath(s.selfDestructInRange, addr, SelfDestructPath, fn) +
 		scanAddrPath(s.createContract, addr, CreateContractPath, fn) +
 		scanAddrPath(s.code, addr, CodePath, fn) +
 		scanAddrPath(s.codeHash, addr, CodeHashPath, fn) +
@@ -413,8 +411,8 @@ func (s *ReadSet) mergeFrom(src ReadSet) {
 	for a, tr := range src.selfDestruct {
 		readSetPut(&s.selfDestruct, a, tr)
 	}
-	for a, ver := range src.selfDestructInRange {
-		s.SetSelfDestructInRange(a, ver)
+	for a, tr := range src.selfDestructInRange {
+		readSetPut(&s.selfDestructInRange, a, tr)
 	}
 	for a, tr := range src.createContract {
 		readSetPut(&s.createContract, a, tr)
@@ -2479,6 +2477,12 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 			}
 			ensureAccountState(ac, addr)
 		}
+		for addr, tr := range rs.selfDestructInRange {
+			if addr.IsNil() || tr.internal {
+				continue
+			}
+			ensureAccountState(ac, addr)
+		}
 		for addr, tr := range rs.createContract {
 			if addr.IsNil() || tr.internal {
 				continue
@@ -2950,8 +2954,10 @@ func HasReadDep(txFrom *WriteSet, txTo ReadSet) bool {
 		if _, ok := txTo.getHeader(h.Address, h.Path, h.Key); ok {
 			return true
 		}
+		// A range dep names one specific destruct, so only its writer is a real
+		// edge — the revival that sits above it writes SelfDestructPath too.
 		if h.Path == SelfDestructPath {
-			if _, ok := txTo.selfDestructInRange[h.Address]; ok {
+			if tr, ok := txTo.selfDestructInRange[h.Address]; ok && tr.Version.TxIndex == h.Version.TxIndex {
 				return true
 			}
 		}

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1681,28 +1681,12 @@ func versionedUpdateIncarnation(vm *VersionMap, addr accounts.Address, txIndex i
 	return 0, false
 }
 
-func versionedUpdateCode(vm *VersionMap, addr accounts.Address, txIndex int) ([]byte, bool) {
-	val, res, ok := vm.ReadCode(addr, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val.Bytes, true
-	}
-	return nil, false
-}
-
 func versionedUpdateCodeHash(vm *VersionMap, addr accounts.Address, txIndex int) (accounts.CodeHash, bool) {
 	val, res, ok := vm.ReadCodeHash(addr, txIndex)
 	if ok && res.Status() != MVReadResultNone {
 		return val, true
 	}
 	return accounts.CodeHash{}, false
-}
-
-func versionedUpdateStorage(vm *VersionMap, addr accounts.Address, key accounts.StorageKey, txIndex int) (uint256.Int, bool) {
-	val, res, ok := vm.ReadStorage(addr, key, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val, true
-	}
-	return uint256.Int{}, false
 }
 
 // applyVersionedUpdates applies updated from the version map to the account before returning it, this is necessary
@@ -1759,8 +1743,15 @@ func (vr versionedStateReader) ReadAccountStorage(address accounts.Address, key 
 				return uint256.Int{}, false, nil
 			}
 		}
-		if val, ok := versionedUpdateStorage(vr.versionMap, address, key, vr.txIndex); ok {
+		val, res, ok := vr.versionMap.ReadStorage(address, key, vr.txIndex)
+		if ok && res.Status() != MVReadResultNone {
+			if vr.versionMap.wipedByInRangeDestruct(address, res.Version().TxIndex, vr.txIndex) {
+				return uint256.Int{}, false, nil
+			}
 			return val, true, nil
+		}
+		if vr.versionMap.wipedByInRangeDestruct(address, -1, vr.txIndex) {
+			return uint256.Int{}, false, nil
 		}
 	}
 
@@ -1796,8 +1787,15 @@ func (vr versionedStateReader) ReadAccountCode(address accounts.Address) ([]byte
 				return nil, nil
 			}
 		}
-		if code, ok := versionedUpdateCode(vr.versionMap, address, vr.txIndex); ok {
-			return code, nil
+		code, res, ok := vr.versionMap.ReadCode(address, vr.txIndex)
+		if ok && res.Status() != MVReadResultNone {
+			if vr.versionMap.wipedByInRangeDestruct(address, res.Version().TxIndex, vr.txIndex) {
+				return nil, nil
+			}
+			return code.Bytes, nil
+		}
+		if vr.versionMap.wipedByInRangeDestruct(address, -1, vr.txIndex) {
+			return nil, nil
 		}
 	}
 
@@ -1819,8 +1817,15 @@ func (vr versionedStateReader) ReadAccountCodeSize(address accounts.Address) (in
 				return 0, nil
 			}
 		}
-		if code, ok := versionedUpdateCode(vr.versionMap, address, vr.txIndex); ok {
-			return len(code), nil
+		code, res, ok := vr.versionMap.ReadCode(address, vr.txIndex)
+		if ok && res.Status() != MVReadResultNone {
+			if vr.versionMap.wipedByInRangeDestruct(address, res.Version().TxIndex, vr.txIndex) {
+				return 0, nil
+			}
+			return len(code.Bytes), nil
+		}
+		if vr.versionMap.wipedByInRangeDestruct(address, -1, vr.txIndex) {
+			return 0, nil
 		}
 	}
 

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -1165,8 +1165,8 @@ func (vm *VersionMap) ValidateVersion(txIdx int, lastIO *VersionedIO, checkVersi
 	}
 	// Range deps assert that a specific destruct happened, not what the latest
 	// SelfDestruct entry says — a revival above it does not make them stale.
-	for a, ver := range rs.selfDestructInRange {
-		if !vm.HasDoneSelfDestructAt(a, ver, true) {
+	for a, tr := range rs.selfDestructInRange {
+		if !vm.HasDoneSelfDestructAt(a, tr.Version, tr.Val) {
 			valid = VersionInvalid
 			return
 		}

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -581,6 +581,28 @@ func (vm *VersionMap) AnyDoneSelfDestructEquals(addr accounts.Address, txIdxLimi
 	return found
 }
 
+// HasDoneSelfDestructAt reports whether a Done SelfDestruct cell holding target
+// sits at exactly ver.
+func (vm *VersionMap) HasDoneSelfDestructAt(addr accounts.Address, ver Version, target bool) bool {
+	if vm == nil {
+		return false
+	}
+	e := vm.load(addr)
+	if e == nil {
+		return false
+	}
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.SelfDestruct == nil {
+		return false
+	}
+	cell, ok := e.SelfDestruct.Get(ver.TxIndex)
+	if !ok || cell == nil {
+		return false
+	}
+	return cell.flag == FlagDone && cell.Value == target && cell.incarnation == ver.Incarnation
+}
+
 // FindDoneSelfDestructInRange returns the version of the highest Done
 // SelfDestruct write with lo <= TxIdx < hi whose value == target, if any.
 // Read-side mirror of AnyDoneSelfDestructEquals: it finds an in-block
@@ -1138,6 +1160,14 @@ func (vm *VersionMap) ValidateVersion(txIdx int, lastIO *VersionedIO, checkVersi
 	}
 	for a, tr := range rs.selfDestruct {
 		if !ok(noValueRead(a, SelfDestructPath, accounts.NilKey, tr.ReadHeader)) {
+			return
+		}
+	}
+	// Range deps assert that a specific destruct happened, not what the latest
+	// SelfDestruct entry says — a revival above it does not make them stale.
+	for a, ver := range rs.selfDestructInRange {
+		if !vm.HasDoneSelfDestructAt(a, ver, true) {
+			valid = VersionInvalid
 			return
 		}
 	}

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -581,6 +581,22 @@ func (vm *VersionMap) AnyDoneSelfDestructEquals(addr accounts.Address, txIdxLimi
 	return found
 }
 
+// wipedByInRangeDestruct reports whether an in-block SELFDESTRUCT cleared the
+// value a reader would otherwise return. floor is the tx index of the version
+// map cell holding that value, or -1 when it comes from before the block. The
+// latest SelfDestruct entry cannot answer this on its own: once the account is
+// revived, that entry is the revival.
+func (vm *VersionMap) wipedByInRangeDestruct(addr accounts.Address, floor, txIndex int) bool {
+	if vm == nil {
+		return false
+	}
+	if floor < 0 {
+		return vm.AnyDoneSelfDestructEquals(addr, txIndex-1, true)
+	}
+	_, found := vm.FindDoneSelfDestructInRange(addr, floor, txIndex, true)
+	return found
+}
+
 // HasDoneSelfDestructAt reports whether a Done SelfDestruct cell holding target
 // sits at exactly ver.
 func (vm *VersionMap) HasDoneSelfDestructAt(addr accounts.Address, ver Version, target bool) bool {

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -169,11 +169,13 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			originVal, origin, originOK := vm.ReadStorage(h.Address, h.Key, txIndex)
 			originValid := originOK && origin.Status() == MVReadResultDone
 			if originValid {
-				// A destruct above the baseline write wiped the slot, so the baseline
-				// is 0 rather than what that write left, and re-writing the old value
-				// is a real change. Only a range scan sees this: once the account is
-				// revived, the latest SelfDestruct entry is the revival.
-				if _, wiped := vm.FindDoneSelfDestructInRange(h.Address, origin.Version().TxIndex+1, txIndex, true); wiped {
+				// A destruct at or above the baseline write wiped the slot, so the
+				// baseline is 0 rather than what that write left, and re-writing the
+				// old value is a real change. Only a range scan sees this: once the
+				// account is revived, the latest SelfDestruct entry is the revival.
+				// The origin's own TxIndex counts — a tx that writes a slot and then
+				// destructs leaves both cells at that index, and the destruct wins.
+				if _, wiped := vm.FindDoneSelfDestructInRange(h.Address, origin.Version().TxIndex, txIndex, true); wiped {
 					originValid = false
 				}
 			}

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -159,16 +159,24 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			// flushed back to the versionMap, so without this a resurrect TX
 			// that re-writes a slot to its pre-SD value is wrongly dropped as a
 			// no-op (TestDeleteRecreateSlotsAcrossManyBlocks).
-			sdTxIdx, sdOk := -1, false
+			sdOk := false
 			if v, sd, _ := vm.ReadSelfDestruct(h.Address, txIndex); sd.Status() == MVReadResultDone && v {
-				sdTxIdx, sdOk = sd.Version().TxIndex, true
+				sdOk = true
 			}
 			// No-op filter: compare against origin (what this TX would have read).
 			// First check versionMap floor (prior TX's write in this block).
 			// Then fall back to stateReader (pre-block value from domain).
 			originVal, origin, originOK := vm.ReadStorage(h.Address, h.Key, txIndex)
-			originValid := originOK && origin.Status() == MVReadResultDone &&
-				!(sdOk && sdTxIdx > origin.Version().TxIndex)
+			originValid := originOK && origin.Status() == MVReadResultDone
+			if originValid {
+				// A destruct above the baseline write wiped the slot, so the baseline
+				// is 0 rather than what that write left, and re-writing the old value
+				// is a real change. Only a range scan sees this: once the account is
+				// revived, the latest SelfDestruct entry is the revival.
+				if _, wiped := vm.FindDoneSelfDestructInRange(h.Address, origin.Version().TxIndex+1, txIndex, true); wiped {
+					originValid = false
+				}
+			}
 			switch {
 			case originValid:
 				if writeVal.Eq(&originVal) {

--- a/execution/state/writeset_normalize_test.go
+++ b/execution/state/writeset_normalize_test.go
@@ -309,3 +309,29 @@ func TestNormalize_DropsNoOpWhenDestructPrecedesBaselineWrite(t *testing.T) {
 	_, ok := out.GetStorage(addr, key)
 	require.False(t, ok, "no destruct after the baseline write, so writing the same value is a no-op")
 }
+
+// A tx that writes a slot and then self-destructs leaves both cells at its own
+// TxIndex, and the destruct wins: the slot is gone. A later revival re-writing
+// that value is a real change, so the baseline scan has to include the origin
+// write's own TxIndex, not start above it.
+func TestNormalize_KeepsRewriteWhenDestructSharesTheOriginTxIndex(t *testing.T) {
+	t.Parallel()
+	addr := accounts.InternAddress(common.HexToAddress("0x7d"))
+	key := accounts.InternKey(common.HexToHash("0x32"))
+	val := *uint256.NewInt(5)
+
+	vm := NewVersionMap(nil)
+	vm.WriteStorage(addr, key, Version{TxIndex: 10}, val, true)
+	vm.WriteSelfDestruct(addr, Version{TxIndex: 10}, true, true)
+
+	ws := &WriteSet{}
+	ws.SetStorage(addr, key, &VersionedWrite[uint256.Int]{
+		WriteHeader: WriteHeader{Address: addr, Path: StoragePath, Key: key, Version: Version{TxIndex: 20}},
+		Val:         val,
+	})
+
+	out, err := ws.Normalize(vm, 20, 0, &minimalStateReader{}, nil, false, false, false)
+	require.NoError(t, err)
+	_, ok := out.GetStorage(addr, key)
+	require.True(t, ok, "the destruct at the same TxIndex wiped the slot, so the re-write is a real change")
+}

--- a/execution/state/writeset_normalize_test.go
+++ b/execution/state/writeset_normalize_test.go
@@ -255,3 +255,57 @@ func TestAssertSelfDestructNormalized(t *testing.T) {
 		ws.assertSelfDestructNormalized()
 	}, "balance and storage deletes are legal on a self-destructed address")
 }
+
+// A slot written before an in-block SELFDESTRUCT and re-written to the same value
+// by a tx after the revival: the destruct wiped the slot, so the re-write is a
+// real change, not a no-op. The pre-destruct write is not a valid baseline for
+// it, and the latest SelfDestruct entry is the revival, which says nothing about
+// the destruct that did the wiping.
+func TestNormalize_KeepsRewriteOfPreDestructValueAfterRevival(t *testing.T) {
+	t.Parallel()
+	addr := accounts.InternAddress(common.HexToAddress("0x7f"))
+	key := accounts.InternKey(common.HexToHash("0x32"))
+	val := *uint256.NewInt(0x593d)
+
+	vm := NewVersionMap(nil)
+	vm.WriteStorage(addr, key, Version{TxIndex: 16}, val, true)
+	vm.WriteSelfDestruct(addr, Version{TxIndex: 41}, true, true)
+	vm.WriteSelfDestruct(addr, Version{TxIndex: 42}, false, true)
+
+	ws := &WriteSet{}
+	ws.SetStorage(addr, key, &VersionedWrite[uint256.Int]{
+		WriteHeader: WriteHeader{Address: addr, Path: StoragePath, Key: key, Version: Version{TxIndex: 43}},
+		Val:         val,
+	})
+
+	out, err := ws.Normalize(vm, 43, 0, &minimalStateReader{}, nil, false, false, false)
+	require.NoError(t, err)
+	got, ok := out.GetStorage(addr, key)
+	require.True(t, ok, "the destruct wiped the slot, so re-writing the pre-destruct value is a real change")
+	require.True(t, got.Val.Eq(&val))
+}
+
+// The no-op filter must still drop a genuine no-op: same value, same slot, with
+// the destruct sitting below the baseline write rather than above it.
+func TestNormalize_DropsNoOpWhenDestructPrecedesBaselineWrite(t *testing.T) {
+	t.Parallel()
+	addr := accounts.InternAddress(common.HexToAddress("0x7e"))
+	key := accounts.InternKey(common.HexToHash("0x32"))
+	val := *uint256.NewInt(0x593d)
+
+	vm := NewVersionMap(nil)
+	vm.WriteSelfDestruct(addr, Version{TxIndex: 10}, true, true)
+	vm.WriteSelfDestruct(addr, Version{TxIndex: 11}, false, true)
+	vm.WriteStorage(addr, key, Version{TxIndex: 16}, val, true)
+
+	ws := &WriteSet{}
+	ws.SetStorage(addr, key, &VersionedWrite[uint256.Int]{
+		WriteHeader: WriteHeader{Address: addr, Path: StoragePath, Key: key, Version: Version{TxIndex: 43}},
+		Val:         val,
+	})
+
+	out, err := ws.Normalize(vm, 43, 0, &minimalStateReader{}, nil, false, false, false)
+	require.NoError(t, err)
+	_, ok := out.GetStorage(addr, key)
+	require.False(t, ok, "no destruct after the baseline write, so writing the same value is a no-op")
+}


### PR DESCRIPTION
Parallel execution cannot get past mainnet block 11,133,845. It halts with `too many validator-invalid retries: 170, expected: 169`, and once that is fixed the same block silently loses a storage slot, which surfaces four blocks later as `gas used by execution: 12442473, in header: 12459573` at 11,133,849.

Both are the same mistake in two places. An account is SELFDESTRUCTed by one tx and revived by a later one in the same block. Code that needs to know "was this slot wiped by a destruct" asks for the *latest* `SelfDestruct` entry — which, after the revival, is the revival. The destruct becomes invisible.

## Changes

**Read validation** (`read_paths.go`, `versionmap.go`, `versionedio.go`). A storage cell written before the destruct reads as zero, and the reader justifies that by scanning the range for the destruct, recording that destruct's version — `(41.1)`. `ValidateVersion` checked the entry latest-only, got the revival `(42.1)`, and could never pass, so tx 43 burned its whole incarnation budget. Range-derived dependencies now live in their own map and are validated by the existence of the destruct they named; latest-based reads keep the latest-only rule, since a revival above them does make those stale. The new map is carried through `mergeFrom`, `Len`, `Delete`, `hasAddr` and `HasReadDep` so a finalize-time merge cannot drop a dependency and `BuildDAG` keeps the edge from the destructing tx to the reader.

**Write normalization** (`writeset_normalize.go`). `Normalize` drops a storage write whose value equals the versionMap floor for that slot, as a no-op. With a destruct between that floor write and this tx, the slot was wiped, the baseline is 0, and re-writing the old value is a real change. The guard used the latest `SelfDestruct` entry, so at 11,133,845 tx 43's re-write of slot `0x32` back to its pre-destruct value was dropped — the account kept `0` where consensus has `0x593d`. A sibling slot survived only because it had no pre-destruct write and so took a different branch. The baseline is now invalidated by a range scan, matching the read path.

## Verification

Archive node replaying mainnet from 11,133,057:

| | before | after |
|---|---|---|
| 11,133,845 | halts, `170, expected: 169` | executes |
| 11,133,849 | `gas used by execution` mismatch, Δ 17,100 | executes |
| reached | 11,133,844 | **11,135,318** |
| wrong trie roots | — | 0 |

Per-tx gas across block 11,133,849 was diffed against canonical receipts: before the second fix exactly two txs differed (+2,100 and −19,200, netting the reported 17,100), traced to `SSTORE` charging `SLOAD_GAS` instead of `SSTORE_SET_GAS` because the slot's committed value was wrong. Both now match.

`execution/state` and `execution/stagedsync` green, `make lint` clean. Fixes #23020.
