### PR TITLE
go.mod: revert go-eth-kzg verifier optimization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -464,5 +464,3 @@ tool (
 	google.golang.org/protobuf/cmd/protoc-gen-go
 	mvdan.cc/gofumpt
 )
-
-replace github.com/crate-crypto/go-eth-kzg => github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/crate-crypto/go-eth-kzg v1.5.0 h1:FYRiJMJG2iv+2Dy3fi14SVGjcPteZ5HAAUe4YWlJygc=
+github.com/crate-crypto/go-eth-kzg v1.5.0/go.mod h1:J9/u5sWfznSObptgfa92Jq8rTswn6ahQWEuiLHOjCUI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/curioswitch/go-reassign v0.3.0 h1:dh3kpQHuADL3cobV/sSGETA8DOv457dwl+fbBAhrQPs=
 github.com/curioswitch/go-reassign v0.3.0/go.mod h1:nApPCCTtqLJN/s8HfItCcKV0jIPwluBOvZP+dsJGA88=
@@ -328,8 +330,6 @@ github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2 h1:B
 github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268 h1:NHl4+DjblLuHBJradIg9KriKmtByjRvLqLhkVODibac=
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
-github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07 h1:0VpFIthaJzGs3iwyrKCj67wptrNq7KKiLhilDCRPqwk=
-github.com/erigontech/go-eth-kzg v0.0.0-20260401161010-070339460d07/go.mod h1:J9/u5sWfznSObptgfa92Jq8rTswn6ahQWEuiLHOjCUI=
 github.com/erigontech/mdbx-go v0.40.3 h1:tNFzVF4gs0DxCWGBb91jRKQNA+IeMonOK3LHvuxh5qo=
 github.com/erigontech/mdbx-go v0.40.3/go.mod h1:QmkpLmcJX5+Fyu9u8eGsyPwoBDrIZJBBLgJHBMFStWE=
 github.com/erigontech/secp256k1 v1.3.0 h1:lf/lNUBtgZ21yJjn1sYNkYnEy4bkZIcxvcEdlrHs14I=


### PR DESCRIPTION
## Summary

- Remove the module-wide replacement of `crate-crypto/go-eth-kzg` with the Erigon fork.
- Restore the released upstream `go-eth-kzg v1.5.0` checksums.

## Rationale

#20273 pinned Erigon to the implementation from [crate-crypto/go-eth-kzg#131](https://github.com/crate-crypto/go-eth-kzg/pull/131). That upstream change remains a draft and has not been merged. Revert to the released upstream implementation while potential correctness concerns are investigated.

The optimization can be reconsidered after the concerns are resolved and the change is accepted upstream.

## Testing

- `go test -count=1 -run TestPrecompiledPointEvaluation ./execution/vm/`
- `go test -count=1 ./common/crypto/kzg`
- `make lint`
- `make erigon integration`