### PR TITLE
ci: bind cache/QA workflow inputs via env before shell

### DIFF
--- a/.github/actions/save-build-cache/action.yml
+++ b/.github/actions/save-build-cache/action.yml
@@ -15,7 +15,9 @@ runs:
     - name: Show build cache size
       if: ${{ always() }}
       shell: bash
-      run: time du -hs "${{ inputs.gocache }}" || true
+      env:
+        GOCACHE_PATH: ${{ inputs.gocache }}
+      run: time du -hs "$GOCACHE_PATH" || true
 
     - name: Display free disk space before saving build cache
       if: ${{ always() }}

--- a/.github/actions/save-mod-cache/action.yml
+++ b/.github/actions/save-mod-cache/action.yml
@@ -15,9 +15,11 @@ runs:
     - name: Show module cache size
       if: ${{ always() }}
       shell: bash
+      env:
+        MODCACHE_PATH: ${{ inputs.modcache-path }}
       run: |
-        time du -hs "${{ inputs.modcache-path }}" || true
-        time du -hs "${{ inputs.modcache-path }}/cache/download" || true
+        time du -hs "$MODCACHE_PATH" || true
+        time du -hs "$MODCACHE_PATH/cache/download" || true
 
     - uses: actions/cache/save@v5
       if: ${{ always() }}

--- a/.github/workflows/qa-rpc-integration-tests-latest.yml
+++ b/.github/workflows/qa-rpc-integration-tests-latest.yml
@@ -192,13 +192,14 @@ jobs:
         id: test_step
         env:
           RUNNER_WS: ${{ runner.workspace }}
+          FORCE_DUMP_RESPONSE: ${{ inputs.force_dump_response }}
         run: |
           commit=$(git -C "$RUNNER_WS/erigon" rev-parse --short HEAD)
           TEST_RESULT_DIR="$RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_integration_${commit}_http"
           echo "TEST_RESULT_DIR=$TEST_RESULT_DIR" >> $GITHUB_ENV
 
           DUMP_RESPONSE=""
-          if [[ "${{ inputs.force_dump_response }}" == "true" ]]; then
+          if [[ "$FORCE_DUMP_RESPONSE" == "true" ]]; then
             DUMP_RESPONSE="always-dump-response"
             echo "Force response dump is enabled"
           fi


### PR DESCRIPTION
## Summary
Bind composite-action and workflow `inputs.*` into step `env:` before shell use in:
- `.github/actions/save-build-cache`
- `.github/actions/save-mod-cache`
- `.github/workflows/qa-rpc-integration-tests-latest.yml` (`force_dump_response`)

Keeps `${{ }}` expansions out of `run:` scripts. `with:` / `if:` expressions are unchanged.

## Test plan
- [ ] Confirm YAML still validates
- [ ] Optional: re-run a workflow that saves Go caches / RPC integration path

Made with [Cursor](https://cursor.com)