### PR TITLE
execution/state: walk the per-path maps directly in WriteSet.Normalize

### DIFF
--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -127,38 +127,112 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	// an address whose writes are all dropped still needs its account fields.
 	allAddresses := make(map[accounts.Address]bool)
 
-	for h := range writes.AllHeaders() {
-		if h.Path != AddressPath {
+	// Drop account-field writes for SD'd addresses so applyVersionedWrites
+	// takes the pure-delete branch instead of cleanup-before-recreate; drop
+	// raw StoragePath writes too (the self-destruct loop re-emits an
+	// explicit StoragePath=0 delete for every slot via sdStorageSlots).
+	for _, vw := range writes.balance {
+		allAddresses[vw.Address] = true
+		// EIP-8246 keeps the post-SD balance so the calculator can preserve a
+		// balance-only account (or delete it when zero); pre-8246 drops it so
+		// the account is purely deleted.
+		if sdSet[vw.Address] && !eip8246 {
+			continue
+		}
+		// Account fields: prefer the versionMap's accumulated value; fall back
+		// to the raw write when the map has none.
+		if !SetAccountFieldFromMap(filtered, vm, vw.Address, BalancePath, vw.Version, txIndex+1) {
+			filtered.SetBalance(vw.Address, vw)
+		}
+	}
+
+	for _, vw := range writes.nonce {
+		allAddresses[vw.Address] = true
+		if sdSet[vw.Address] {
+			continue
+		}
+		if !SetAccountFieldFromMap(filtered, vm, vw.Address, NoncePath, vw.Version, txIndex+1) {
+			filtered.SetNonce(vw.Address, vw)
+		}
+	}
+
+	for _, vw := range writes.incarnation {
+		allAddresses[vw.Address] = true
+		if sdSet[vw.Address] {
+			continue
+		}
+		if !SetAccountFieldFromMap(filtered, vm, vw.Address, IncarnationPath, vw.Version, txIndex+1) {
+			filtered.SetIncarnation(vw.Address, vw)
+		}
+	}
+
+	for _, vw := range writes.codeHash {
+		allAddresses[vw.Address] = true
+		if sdSet[vw.Address] {
+			continue
+		}
+		if !SetAccountFieldFromMap(filtered, vm, vw.Address, CodeHashPath, vw.Version, txIndex+1) {
+			filtered.SetCodeHash(vw.Address, vw)
+		}
+	}
+
+	// Only writes from the current (validated) incarnation are included from
+	// here down; stale entries from a prior incarnation are dropped.
+	for _, vw := range writes.code {
+		allAddresses[vw.Address] = true
+		if sdSet[vw.Address] || vw.Version.Incarnation != incarnation {
+			continue
+		}
+		filtered.SetCode(vw.Address, vw)
+	}
+
+	for _, vw := range writes.createContract {
+		allAddresses[vw.Address] = true
+		if vw.Version.Incarnation != incarnation {
+			continue
+		}
+		filtered.SetCreateContract(vw.Address, vw)
+	}
+
+	for _, vw := range writes.selfDestruct {
+		allAddresses[vw.Address] = true
+		// Only emit storage DELETE entries when the account was actually
+		// self-destructed (val=true).
+		if vw.Version.Incarnation != incarnation || !vw.Val {
+			continue
+		}
+		filtered.SetSelfDestruct(vw.Address, vw)
+		for _, slot := range sdStorageSlots(vw.Address) {
+			filtered.SetStorage(vw.Address, slot, &VersionedWrite[uint256.Int]{
+				WriteHeader: WriteHeader{
+					Address: vw.Address,
+					Path:    StoragePath,
+					Key:     slot,
+					Version: vw.Version,
+				},
+			})
+		}
+	}
+
+	// Code size is derived from the code bytes and isn't a domain field, so it's
+	// intentionally not carried into the calc/apply write set (as on serial).
+	// Cross-tx ReadCodeSize is served from the versionMap, which the worker
+	// populates directly — independent of this pass.
+	for addr := range writes.codeSize {
+		allAddresses[addr] = true
+	}
+
+	// writes.address is not walked: AddressPath is record-level — skip for
+	// field-level consumers.
+
+	for _, inner := range writes.storage {
+		for _, h := range inner {
 			allAddresses[h.Address] = true
-		}
-		// Drop account-field writes for SD'd addresses so applyVersionedWrites
-		// takes the pure-delete branch instead of cleanup-before-recreate; drop
-		// raw StoragePath writes too (the SelfDestructPath case re-emits an
-		// explicit StoragePath=0 delete for every slot via sdStorageSlots).
-		if sdSet[h.Address] {
-			switch h.Path {
-			case NoncePath, IncarnationPath, CodeHashPath, CodePath, StoragePath:
-				continue
-			case BalancePath:
-				// EIP-8246 keeps the post-SD balance so the calculator can
-				// preserve a balance-only account (or delete it when zero);
-				// pre-8246 drops it so the account is purely deleted.
-				if !eip8246 {
-					continue
-				}
-			}
-		}
-		switch h.Path {
-		case StoragePath:
 			// Only include writes from the current (validated) incarnation.
-			if h.Version.Incarnation != incarnation {
+			if sdSet[h.Address] || h.Version.Incarnation != incarnation {
 				continue
 			}
-			sw, ok := writes.GetStorage(h.Address, h.Key)
-			if !ok {
-				continue
-			}
-			writeVal := sw.Val
+			writeVal := h.Val
 			// If addr was self-destructed by an earlier TX in this block, its
 			// storage was wiped — the effective baseline for any slot not
 			// re-written since is 0, regardless of what the versionMap (prior
@@ -212,72 +286,7 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 					}
 				}
 			}
-			filtered.SetStorage(h.Address, h.Key, sw)
-		case BalancePath, NoncePath, IncarnationPath, CodeHashPath:
-			// Account fields: prefer the versionMap's accumulated value; fall
-			// back to the raw write when the map has none.
-			if !SetAccountFieldFromMap(filtered, vm, h.Address, h.Path, h.Version, txIndex+1) {
-				switch h.Path {
-				case BalancePath:
-					if vw, ok := writes.GetBalance(h.Address); ok {
-						filtered.SetBalance(h.Address, vw)
-					}
-				case NoncePath:
-					if vw, ok := writes.GetNonce(h.Address); ok {
-						filtered.SetNonce(h.Address, vw)
-					}
-				case IncarnationPath:
-					if vw, ok := writes.GetIncarnation(h.Address); ok {
-						filtered.SetIncarnation(h.Address, vw)
-					}
-				case CodeHashPath:
-					if vw, ok := writes.GetCodeHash(h.Address); ok {
-						filtered.SetCodeHash(h.Address, vw)
-					}
-				}
-			}
-		case CodePath:
-			if h.Version.Incarnation != incarnation {
-				continue
-			}
-			if vw, ok := writes.GetCode(h.Address); ok {
-				filtered.SetCode(h.Address, vw)
-			}
-		case CreateContractPath:
-			if h.Version.Incarnation != incarnation {
-				continue
-			}
-			if vw, ok := writes.GetCreateContract(h.Address); ok {
-				filtered.SetCreateContract(h.Address, vw)
-			}
-		case SelfDestructPath:
-			if h.Version.Incarnation != incarnation {
-				continue
-			}
-			// Only emit storage DELETE entries when the account was actually
-			// self-destructed (val=true).
-			sdw, ok := writes.GetSelfDestruct(h.Address)
-			if !ok || !sdw.Val {
-				continue
-			}
-			filtered.SetSelfDestruct(h.Address, sdw)
-			for _, slot := range sdStorageSlots(h.Address) {
-				filtered.SetStorage(h.Address, slot, &VersionedWrite[uint256.Int]{
-					WriteHeader: WriteHeader{
-						Address: h.Address,
-						Path:    StoragePath,
-						Key:     slot,
-						Version: h.Version,
-					},
-				})
-			}
-		case AddressPath:
-			// AddressPath is record-level — skip for field-level consumers.
-		case CodeSizePath:
-			// Code size is derived from the code bytes and isn't a domain field,
-			// so it's intentionally not carried into the calc/apply write set (as
-			// on serial). Cross-tx ReadCodeSize is served from the versionMap,
-			// which the worker populates directly — independent of this pass.
+			filtered.SetStorage(h.Address, h.Key, h)
 		}
 	}
 

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -122,7 +122,15 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		}
 	}
 
+	// Addresses of every field-level write in the raw input, collected here so
+	// the fill loop below needs no second walk. Filtering must not narrow it:
+	// an address whose writes are all dropped still needs its account fields.
+	allAddresses := make(map[accounts.Address]bool)
+
 	for h := range writes.AllHeaders() {
+		if h.Path != AddressPath {
+			allAddresses[h.Address] = true
+		}
 		// Drop account-field writes for SD'd addresses so applyVersionedWrites
 		// takes the pure-delete branch instead of cleanup-before-recreate; drop
 		// raw StoragePath writes too (the SelfDestructPath case re-emits an
@@ -280,9 +288,6 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	// - Addresses with only storage writes (no balance/nonce changes)
 	// - Addresses whose storage writes were all filtered as no-ops
 	//   (the object was still dirty in the IBS)
-	allAddresses := make(map[accounts.Address]bool)
-	writes.forEachFieldAddr(func(addr accounts.Address) { allAddresses[addr] = true })
-
 	for addr := range allAddresses {
 		if sdSet[addr] {
 			// Don't fill account fields for SD'd addresses — same rationale as


### PR DESCRIPTION
Performance-only change to `WriteSet.Normalize`. No behaviour change intended; the review guide below is written around proving that.

Stacked below #23027, which builds on this.

## Why

`Normalize` runs once per tx result inside `blockExecutor.nextResult` — the single-threaded apply loop that is parallel execution's serialization point — so its cost is never spread across workers. CPU profile from `dev-bm-e3-ethmainnet-n5` (main, 10 min, 1282.60s total): `nextResult` 101.16s, of which `Normalize` is **32.20s (31.8%)**, the largest contributor even with #22923 and #22409 in.

`AllHeaders()` is `iter.Seq[WriteHeader]`: it yields the header but never the value, because the ten per-path maps hold different types and one iterator cannot yield a union without an interface. Three costs follow, per write:

1. **The value is erased, so every arm looks it back up** — `writes.GetBalance(h.Address)`, `writes.GetStorage(h.Address, h.Key)`: a second hash+probe of the entry the iterator just visited.
2. **56 bytes copied** — `WriteHeader` is Address 8 + Key 8 + Version 32 + Path + two tracing reasons.
3. **A `switch h.Path` per write**, re-deriving what the map identity already fixes.

Ranging the maps hands each branch its typed write directly and removes all three. `WriteSet.Apply` already does this, with the same reasoning recorded at `rw_v3.go:120`: *"Range the typed collections directly rather than AllHeaders()+GetX — the header walk plus a second per-value map probe is strictly more work."* This change makes `Normalize` consistent with `Apply`.

Isolated walk cost, identical trivial work per write, AMD EPYC 4344P:

| walk | addrs=3/slots=1 | addrs=30/slots=10 |
|---|---|---|
| `AllHeaders` (value) | 443.2 ns | 4.690 µs |
| `AllHeaders` + `Get*` (what this code did) | 381.1 ns | **8.569 µs** |
| per-path map loops | **316.4 ns** | **3.217 µs** |

At the wide shape the erased walk plus its forced re-lookup is 2.66x the cost of ranging the maps.

## Review guide

Old `switch` arm to new loop, one-to-one:

| old `case` | new loop | filter, unchanged |
|---|---|---|
| `BalancePath` | `range writes.balance` | `sdSet && !eip8246` → skip |
| `NoncePath` | `range writes.nonce` | `sdSet` → skip |
| `IncarnationPath` | `range writes.incarnation` | `sdSet` → skip |
| `CodeHashPath` | `range writes.codeHash` | `sdSet` → skip |
| `CodePath` | `range writes.code` | `sdSet` or wrong incarnation → skip |
| `CreateContractPath` | `range writes.createContract` | wrong incarnation → skip |
| `SelfDestructPath` | `range writes.selfDestruct` | wrong incarnation or `!Val` → skip |
| `StoragePath` | `range writes.storage` (nested) | `sdSet` or wrong incarnation → skip |
| `CodeSizePath` | `range writes.codeSize`, addresses only | never carried into output |
| `AddressPath` | not walked | never carried into output |

Three things worth checking explicitly:

- **The sdSet matrix is preserved.** The old pre-switch `if sdSet[h.Address]` block listed `Nonce/Incarnation/CodeHash/Code/Storage` → `continue`, and `Balance` → `continue` only when `!eip8246`. `CreateContract`, `SelfDestruct`, `CodeSize` and `Address` were absent from it, so they fell through and were processed for SD'd addresses too. The per-path filters reproduce that exactly, omissions included.
- **Reordering is safe.** Map iteration order across paths differs from `AllHeaders`' fixed order. Every arm writes to a distinct per-path map keyed by address, so no arm can overwrite another's output. The one cross-path emission — the self-destruct storage cascade emitting `StoragePath=0` — fires exactly for addresses in `sdSet`, whose raw storage writes are dropped, so the two can never touch the same `(addr, key)`.
- **Header fields, not map keys.** `eachWriteHeaderOf` yields `vw.WriteHeader`, so the old code addressed writes by `h.Address`/`h.Key`, not by map key. The new loops use `vw.Address`/`h.Key` for the same reason, so nothing changes if the two ever disagree.

The first commit is a prerequisite of the second: `allAddresses` (the fill loop's input) is now filled at the top of each per-path loop **before any filter**, since filtering must not narrow it — an address whose writes are all dropped still needs its account fields reconstructed. Walking `writes.codeSize` for addresses only, and not walking `writes.address`, together reproduce the old `Path != AddressPath` condition.

**Not changed:** the filter logic, the fill loop, EIP-7702 `CodePath` recovery, EIP-161 empty removal, and every error path.

## Risk

This is the most correctness-sensitive loop in the file — self-destruct semantics, incarnation filtering, storage no-op elision. Per the repo's TDD guidance no new tests were added for a pure refactor; existing coverage is the safety net. Green: `execution/state`, `execution/stagedsync`, `execution/tests`, including the tests the code comments name as pins for these branches (`TestSelfDestructReceive`, `TestEIP161AccountRemoval`, `TestCVE2020_26265`, `TestDeleteRecreateAccount`, `TestDeleteRecreateSlots`, `TestDeleteRecreateSlotsAcrossManyBlocks`).

## Numbers

`BenchmarkWriteSetNormalize`, main vs this branch, 6 interleaved rounds of `-count=3`, AMD EPYC 4344P:

```
                         │     main    │              this PR                 │
                         │    sec/op   │   sec/op     vs base                 │
addrs=3/slots=1-16         3.709µ ± 1%   3.312µ ± 1%  -10.68% (p=0.000 n=18)
addrs=4/slots=2-16         5.002µ ± 0%   4.479µ ± 1%  -10.45% (p=0.000 n=18)
addrs=16/slots=8-16        26.51µ ± 1%   22.50µ ± 1%  -15.13% (p=0.000 n=18)
addrs=30/slots=10-16       57.25µ ± 1%   48.84µ ± 1%  -14.69% (p=0.000 n=18)
geomean                    12.95µ        11.30µ       -12.77%
```

`B/op` and `allocs/op` unchanged — a copy-and-dispatch win, not an allocation one. The two narrower shapes come from #23027, which adds them; measured here on this branch for comparability.

For contrast, #23037 makes `AllHeaders` itself cheaper (yields the header by pointer) and reaches -4.69% geomean on the same benchmark — about a third of this, because the dominant cost is the erasure forcing a second map lookup, not the iterator.
