### PR TITLE
qa-tests: add snapshot retirement test for the Gnosis chain

### DIFF
--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -22,7 +22,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chain: [ mainnet, gnosis ]  # Chain name as specified on the erigon command line
+        # chain: name as specified on the erigon command line.
+        # retirement_prune_distance: narrowed state-history window for the file
+        # retirement check, in blocks. It has to put the retirement cutoff between
+        # two snapshot-file boundaries, so it depends on how many blocks one step
+        # spans on that chain — see the file-retirement README in the QA repo.
+        include:
+          - chain: mainnet
+            retirement_prune_distance: 20000
+          - chain: gnosis
+            retirement_prune_distance: 50000
     env:
       ERIGON_DATA_DIR: ${{ github.workspace }}/erigon_data
       ERIGON_QA_PATH: /home/qarunner/erigon-qa
@@ -30,7 +39,7 @@ jobs:
       TRACKING_TIME_SECONDS: 7200 # 2 hours
       TOTAL_TIME_SECONDS: 43200 # 18 hours
       CHAIN: ${{ matrix.chain }}
-      RETIREMENT_PRUNE_DISTANCE: 20000 # narrowed state-history window, in blocks
+      RETIREMENT_PRUNE_DISTANCE: ${{ matrix.retirement_prune_distance }}
       RETIREMENT_TIMEOUT_SECONDS: 1800 # 30 minutes to observe the first retirement
 
     steps:
@@ -148,11 +157,9 @@ jobs:
       # narrower than the one it was synced with. That moves the retirement
       # cutoff past whole snapshot-file boundaries, so aged history files become
       # deletable within minutes instead of the days the default minimal window
-      # would need at tip. Gnosis is excluded until its step density is measured:
-      # 20000 blocks is a mainnet-calibrated value.
+      # would need at tip. The distance is per-chain: see the matrix above.
       - name: Test old state-history file retirement (minimal node)
         id: retirement_step
-        if: ${{ success() && env.CHAIN == 'mainnet' }}
         run: |
           set +e # Disable exit on error
 

--- a/.github/workflows/qa-sync-from-scratch-minimal-node.yml
+++ b/.github/workflows/qa-sync-from-scratch-minimal-node.yml
@@ -169,6 +169,18 @@ jobs:
           # Save the subsection reached status
           echo "test_executed=true" >> "$GITHUB_OUTPUT"
 
+          # Dump the measures into the log. They are also uploaded as an artifact,
+          # but whoever reads the workflow output should not need to know that.
+          # Before the verdict below, so a failing run prints them too.
+          RESULT_FILE="$GITHUB_WORKSPACE/result-retirement-$CHAIN.json"
+          echo "::group::File retirement measures (result-retirement-$CHAIN.json)"
+          if [ -f "$RESULT_FILE" ]; then
+            cat "$RESULT_FILE"
+          else
+            echo "no result file at $RESULT_FILE: the check script did not reach the point where it writes one"
+          fi
+          echo "::endgroup::"
+
           # Check the check script exit status
           if [ $test_exit_status -eq 0 ]; then
             echo "File retirement test completed successfully"


### PR DESCRIPTION
Enable snapshot retirement test on the Gnosis chain and also enhance logging.