### PR TITLE
execution/state: yield write headers by pointer from AllHeaders

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2609,7 +2609,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			// Remove entries that were previously written but are no longer
 			// written — res.TxOut.Has answers membership directly, no cmp map.
 			for h := range prevWrites.AllHeaders() {
-				if !res.TxOut.Has(h) {
+				if !res.TxOut.Has(*h) {
 					hasWriteChange = true
 					be.versionMap.Delete(h.Address, h.Path, h.Key, txVersion.TxIndex, true)
 				}

--- a/execution/state/ibs_2cache_test.go
+++ b/execution/state/ibs_2cache_test.go
@@ -38,7 +38,7 @@ import (
 func writeIndex(writes *WriteSet) map[AccountKey]any {
 	idx := make(map[AccountKey]any)
 	for h := range writes.AllHeaders() {
-		idx[AccountKey{Path: h.Path, Key: h.Key}] = writeSetVal(writes, h)
+		idx[AccountKey{Path: h.Path, Key: h.Key}] = writeSetVal(writes, *h)
 	}
 	return idx
 }
@@ -48,7 +48,7 @@ func addrWriteIndex(writes *WriteSet, addr accounts.Address) map[AccountKey]any 
 	idx := make(map[AccountKey]any)
 	for h := range writes.AllHeaders() {
 		if h.Address == addr {
-			idx[AccountKey{Path: h.Path, Key: h.Key}] = writeSetVal(writes, h)
+			idx[AccountKey{Path: h.Path, Key: h.Key}] = writeSetVal(writes, *h)
 		}
 	}
 	return idx

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -3335,7 +3335,7 @@ func (sdb *IntraBlockState) ApplyVersionedWrites(writes *WriteSet) error {
 	// same-address write already loaded it, which changes the EIP-7928 BAL hash.
 	headers := make([]WriteHeader, 0, writes.Count())
 	for h := range writes.AllHeaders() {
-		headers = append(headers, h)
+		headers = append(headers, *h)
 	}
 	sortWriteHeaders(headers)
 	for _, hdr := range headers {

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1290,9 +1290,9 @@ func (s *WriteSet) Storages() iter.Seq2[accounts.Address, map[accounts.StorageKe
 	return maps.All(s.storage)
 }
 
-func eachWriteHeaderOf[T any](m map[accounts.Address]*VersionedWrite[T], yield func(WriteHeader) bool) bool {
+func eachWriteHeaderOf[T any](m map[accounts.Address]*VersionedWrite[T], yield func(*WriteHeader) bool) bool {
 	for _, vw := range m {
-		if !yield(vw.WriteHeader) {
+		if !yield(&vw.WriteHeader) {
 			return false
 		}
 	}
@@ -1301,8 +1301,11 @@ func eachWriteHeaderOf[T any](m map[accounts.Address]*VersionedWrite[T], yield f
 
 // AllHeaders visits the type-agnostic header of every write; the value is read
 // typed-by-path from the per-path maps, so nothing is erased to an interface.
-func (s *WriteSet) AllHeaders() iter.Seq[WriteHeader] {
-	return func(yield func(WriteHeader) bool) {
+//
+// The header is yielded by pointer, aliasing the write that holds it: read-only
+// for consumers, and never retained past the visit.
+func (s *WriteSet) AllHeaders() iter.Seq[*WriteHeader] {
+	return func(yield func(*WriteHeader) bool) {
 		if s == nil {
 			return
 		}
@@ -1319,7 +1322,7 @@ func (s *WriteSet) AllHeaders() iter.Seq[WriteHeader] {
 		}
 		for _, inner := range s.storage {
 			for _, vw := range inner {
-				if !yield(vw.WriteHeader) {
+				if !yield(&vw.WriteHeader) {
 					return
 				}
 			}
@@ -2173,7 +2176,7 @@ func (writes *WriteSet) HasNewWrite(cmpSet *WriteSet) bool {
 		return true
 	}
 	for h := range writes.AllHeaders() {
-		if !cmpSet.hasHeader(h) {
+		if !cmpSet.hasHeader(*h) {
 			return true
 		}
 	}

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -1385,7 +1385,7 @@ func TestWriteSet_AllHeaders_RoundTrip(t *testing.T) {
 	s, want := writeSetFixture()
 	var got []string
 	for h := range s.AllHeaders() {
-		got = append(got, headerValStr(s, h))
+		got = append(got, headerValStr(s, *h))
 	}
 	sort.Strings(got)
 	require.Equal(t, want, got)

--- a/execution/state/writeset_merge_test.go
+++ b/execution/state/writeset_merge_test.go
@@ -176,8 +176,8 @@ func assertSameWrites(t *testing.T, want, got *WriteSet) {
 	t.Helper()
 	require.Equal(t, want.Count(), got.Count())
 	for h := range want.AllHeaders() {
-		require.True(t, got.Has(h), "missing header %v", h)
-		assert.Equal(t, writeSetVal(want, h), writeSetVal(got, h), "value mismatch at %v", h)
+		require.True(t, got.Has(*h), "missing header %v", h)
+		assert.Equal(t, writeSetVal(want, *h), writeSetVal(got, *h), "value mismatch at %v", h)
 	}
 }
 
@@ -204,8 +204,8 @@ func TestWriteSetMergeInto_MatchedKeyKeepsNext(t *testing.T) {
 	nextVals := map[writeKey]any{}
 	for h := range next.AllHeaders() {
 		k := writeKey{addr: h.Address, key: h.Key, path: h.Path}
-		nextHeaders[k] = h
-		nextVals[k] = writeSetVal(next, h)
+		nextHeaders[k] = *h
+		nextVals[k] = writeSetVal(next, *h)
 	}
 	require.NotZero(t, matchedKeys(prevKeys, nextKeys), "fixture must have matched keys")
 


### PR DESCRIPTION
`WriteSet.AllHeaders` yields `WriteHeader` by value. The struct is 56 bytes — `Address` 8 + `Key` 8 + `Version` 32 (`BlockNum`, `TxNum`, `TxIndex`, `Incarnation`) + `Path` + two tracing reasons — so every write visited costs a 56-byte copy through the iterator's closure chain. Yielding `*WriteHeader` removes the copy; the header is embedded in the `VersionedWrite` that the map already holds, so the pointer is free to take.

Independent of #23034 and #23027, which remove `Normalize`'s use of this iterator; this speeds it up for everyone else.

## Numbers

Isolated walk — identical trivial work per write, only the traversal differs. AMD EPYC 4344P:

| walk | addrs=3/slots=1 | addrs=30/slots=10 |
|---|---|---|
| by value (today) | 443.2 ns | 4.690 µs |
| by pointer | 386.3 ns (**-12.8%**) | 3.716 µs (**-20.8%**) |

Through a real consumer, `BenchmarkWriteSetNormalize` on main vs this branch, 6 interleaved rounds of `-count=3`, same box:

```
                         │     main    │              this PR                │
                         │    sec/op   │   sec/op     vs base                │
addrs=3/slots=1-16         3.709µ ± 1%   3.632µ ± 1%   -2.08% (p=0.000 n=18)
addrs=4/slots=2-16         5.002µ ± 0%   4.827µ ± 1%   -3.49% (p=0.000 n=18)
addrs=16/slots=8-16        26.51µ ± 1%   24.76µ ± 1%   -6.63% (p=0.000 n=18)
addrs=30/slots=10-16       57.25µ ± 1%   53.54µ ± 1%   -6.47% (p=0.000 n=18)
geomean                    12.95µ        12.35µ        -4.69%
```

Allocations are unchanged. `Normalize` is only the most convenient consumer to measure through — #23034 stops it using `AllHeaders` at all, and the benefit then belongs entirely to the other callers: `IntraBlockState.balHeaders`, `WriteSet.Snapshot`, `WriteSet.HasNewWrite`, and two sites in `blockExecutor.nextResult`.

## Review

The type change is `iter.Seq[WriteHeader]` to `iter.Seq[*WriteHeader]`. Every caller of the form `for h := range ws.AllHeaders() { ... h.Field ... }` compiles unchanged, since field access through a pointer is identical. Only three sites needed an explicit `*h`, each because a value was genuinely required:

- `intra_block_state.go` — appending into a `[]WriteHeader` that is then sorted
- `versionedio.go` — `cmpSet.hasHeader(*h)`
- `exec3_parallel.go` — `res.TxOut.Has(*h)`

The rest of the diff is test call sites needing the same dereference.

**Aliasing.** The yielded pointer aliases the live write, so a consumer could now mutate the set through it. All six non-test call sites are read-only — they read `h.Address`/`h.Path`/`h.Key`/`h.Version`, call `h.String()`, or copy via `*h` — and none retains the pointer past the visit. The doc comment states the contract.
