### PR TITLE
[r3.6] execution/state: yield write headers by pointer from AllHeaders

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2605,7 +2605,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			// Remove entries that were previously written but are no longer
 			// written — res.TxOut.Has answers membership directly, no cmp map.
 			for h := range prevWrites.AllHeaders() {
-				if !res.TxOut.Has(h) {
+				if !res.TxOut.Has(*h) {
 					hasWriteChange = true
 					be.versionMap.Delete(h.Address, h.Path, h.Key, txVersion.TxIndex, true)
 				}

--- a/execution/state/ibs_2cache_test.go
+++ b/execution/state/ibs_2cache_test.go
@@ -38,7 +38,7 @@ import (
 func writeIndex(writes *WriteSet) map[AccountKey]any {
 	idx := make(map[AccountKey]any)
 	for h := range writes.AllHeaders() {
-		idx[AccountKey{Path: h.Path, Key: h.Key}] = writeSetVal(writes, h)
+		idx[AccountKey{Path: h.Path, Key: h.Key}] = writeSetVal(writes, *h)
 	}
 	return idx
 }
@@ -48,7 +48,7 @@ func addrWriteIndex(writes *WriteSet, addr accounts.Address) map[AccountKey]any 
 	idx := make(map[AccountKey]any)
 	for h := range writes.AllHeaders() {
 		if h.Address == addr {
-			idx[AccountKey{Path: h.Path, Key: h.Key}] = writeSetVal(writes, h)
+			idx[AccountKey{Path: h.Path, Key: h.Key}] = writeSetVal(writes, *h)
 		}
 	}
 	return idx

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2998,7 +2998,7 @@ func (sdb *IntraBlockState) ApplyVersionedWrites(writes *WriteSet) error {
 	// same-address write already loaded it, which changes the EIP-7928 BAL hash.
 	headers := make([]WriteHeader, 0, writes.Count())
 	for h := range writes.AllHeaders() {
-		headers = append(headers, h)
+		headers = append(headers, *h)
 	}
 	sortWriteHeaders(headers)
 	for _, hdr := range headers {

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1079,9 +1079,9 @@ func (s *WriteSet) Storages() iter.Seq2[accounts.Address, map[accounts.StorageKe
 	return maps.All(s.storage)
 }
 
-func eachWriteHeaderOf[T any](m map[accounts.Address]*VersionedWrite[T], yield func(WriteHeader) bool) bool {
+func eachWriteHeaderOf[T any](m map[accounts.Address]*VersionedWrite[T], yield func(*WriteHeader) bool) bool {
 	for _, vw := range m {
-		if !yield(vw.WriteHeader) {
+		if !yield(&vw.WriteHeader) {
 			return false
 		}
 	}
@@ -1090,8 +1090,11 @@ func eachWriteHeaderOf[T any](m map[accounts.Address]*VersionedWrite[T], yield f
 
 // AllHeaders visits the type-agnostic header of every write; the value is read
 // typed-by-path from the per-path maps, so nothing is erased to an interface.
-func (s *WriteSet) AllHeaders() iter.Seq[WriteHeader] {
-	return func(yield func(WriteHeader) bool) {
+//
+// The header is yielded by pointer, aliasing the write that holds it: read-only
+// for consumers, and never retained past the visit.
+func (s *WriteSet) AllHeaders() iter.Seq[*WriteHeader] {
+	return func(yield func(*WriteHeader) bool) {
 		if s == nil {
 			return
 		}
@@ -1108,7 +1111,7 @@ func (s *WriteSet) AllHeaders() iter.Seq[WriteHeader] {
 		}
 		for _, inner := range s.storage {
 			for _, vw := range inner {
-				if !yield(vw.WriteHeader) {
+				if !yield(&vw.WriteHeader) {
 					return
 				}
 			}
@@ -1976,7 +1979,7 @@ func (writes *WriteSet) HasNewWrite(cmpSet *WriteSet) bool {
 		return true
 	}
 	for h := range writes.AllHeaders() {
-		if !cmpSet.hasHeader(h) {
+		if !cmpSet.hasHeader(*h) {
 			return true
 		}
 	}

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -1686,7 +1686,7 @@ func TestWriteSet_AllHeaders_RoundTrip(t *testing.T) {
 	s, want := writeSetFixture()
 	var got []string
 	for h := range s.AllHeaders() {
-		got = append(got, headerValStr(s, h))
+		got = append(got, headerValStr(s, *h))
 	}
 	sort.Strings(got)
 	require.Equal(t, want, got)

--- a/execution/state/writeset_merge_test.go
+++ b/execution/state/writeset_merge_test.go
@@ -176,8 +176,8 @@ func assertSameWrites(t *testing.T, want, got *WriteSet) {
 	t.Helper()
 	require.Equal(t, want.Count(), got.Count())
 	for h := range want.AllHeaders() {
-		require.True(t, got.Has(h), "missing header %v", h)
-		assert.Equal(t, writeSetVal(want, h), writeSetVal(got, h), "value mismatch at %v", h)
+		require.True(t, got.Has(*h), "missing header %v", h)
+		assert.Equal(t, writeSetVal(want, *h), writeSetVal(got, *h), "value mismatch at %v", h)
 	}
 }
 
@@ -204,8 +204,8 @@ func TestWriteSetMergeInto_MatchedKeyKeepsNext(t *testing.T) {
 	nextVals := map[writeKey]any{}
 	for h := range next.AllHeaders() {
 		k := writeKey{addr: h.Address, key: h.Key, path: h.Path}
-		nextHeaders[k] = h
-		nextVals[k] = writeSetVal(next, h)
+		nextHeaders[k] = *h
+		nextVals[k] = writeSetVal(next, *h)
 	}
 	require.NotZero(t, matchedKeys(prevKeys, nextKeys), "fixture must have matched keys")
 


### PR DESCRIPTION
Cherry-pick of #23037 to release/3.6.

## r3.6-specific adaptations

Hand-applied: release/3.6 has seven non-test callers against main's six, three of which need an explicit `*h` where a value is required.
