### PR TITLE
execution/execmodule, node: remove the FCU background flush/commit path

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1162,11 +1162,6 @@ var (
 		Usage: "Enables background pruning post fcu",
 		Value: ethconfig.Defaults.FcuBackgroundPrune,
 	}
-	FcuBackgroundCommitFlag = cli.BoolFlag{
-		Name:  "fcu.background.commit",
-		Usage: "Enables background flush and commit",
-		Value: ethconfig.Defaults.FcuBackgroundCommit,
-	}
 	MCPDisableFlag = cli.BoolFlag{
 		Name:  "mcp.disable",
 		Usage: "Disables the embedded MCP server",
@@ -2026,7 +2021,6 @@ func SetEthConfig(nodeCtx context.Context, ctx *cli.Command, nodeConfig *nodecfg
 
 	cfg.FcuTimeout = ctx.Duration(FcuTimeoutFlag.Name)
 	cfg.FcuBackgroundPrune = ctx.Bool(FcuBackgroundPruneFlag.Name)
-	cfg.FcuBackgroundCommit = ctx.Bool(FcuBackgroundCommitFlag.Name)
 
 	// Executor performance toggles. When the user explicitly sets the CLI
 	// flag, it overrides the env-var default that dbg read at package init.

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -467,8 +467,6 @@ Flags for configuring Fork Choice Update behavior.
   * Default: `1s`
 * `--fcu.background.prune`: Enables background pruning after FCU.
   * Default: `true`
-* `--fcu.background.commit`: Enables background flush and commit after FCU.
-  * Default: `false`
 
 ### Execution
 

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2298,8 +2298,6 @@ Flags for configuring Fork Choice Update behavior.
   * Default: `1s`
 * `--fcu.background.prune`: Enables background pruning after FCU.
   * Default: `true`
-* `--fcu.background.commit`: Enables background flush and commit after FCU.
-  * Default: `false`
 
 ### Execution
 

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -104,11 +104,11 @@ func GetBlockHashFromMissingSegmentError(err error) (common.Hash, bool) {
 // machinery is unnecessary.
 type Cache struct {
 	execModule  *ExecModule
-	publishedSD func() *execctx.SharedDomains // returns the latest published SD from Events (for background commit)
+	publishedSD func() *execctx.SharedDomains // returns the latest published SD from Events
 }
 
 // SetPublishedSD wires the Cache to fall back to the published SD from Events
-// when the exec module's currentContext is nil (e.g. during background commit).
+// when the exec module's currentContext is nil (e.g. while an FCU commits).
 func (c *Cache) SetPublishedSD(provider func() *execctx.SharedDomains) {
 	c.publishedSD = provider
 }
@@ -123,7 +123,7 @@ func (c *Cache) View(_ context.Context, tx kv.TemporalTx) (kvcache.CacheView, er
 		context = c.execModule.currentContext
 		c.execModule.lock.RUnlock()
 	}
-	// Fall back to the published SD from Events during background commits
+	// Fall back to the published SD from Events while an FCU commits
 	// (currentContext is nil but the SD is still valid in memory).
 	if context == nil && c.publishedSD != nil {
 		context = c.publishedSD()
@@ -211,7 +211,6 @@ type ExecModule struct {
 	balRegenerator *bal.Regenerator
 
 	fcuBackgroundPrune      bool
-	fcuBackgroundCommit     bool
 	onlySnapDownloadOnStart bool
 	nextForkActivated       bool
 	// gas-weighted EWMA: accumulate gas and time separately so near-empty blocks don't skew the average
@@ -220,7 +219,7 @@ type ExecModule struct {
 
 	lock           sync.RWMutex
 	currentContext *execctx.SharedDomains
-	publishedSD    func() *execctx.SharedDomains // fallback for background commit
+	publishedSD    func() *execctx.SharedDomains // fallback while an FCU commits
 
 	// stateCache is a cache for state data (accounts, storage, code)
 	stateCache *cache.StateCache
@@ -249,7 +248,6 @@ func NewExecModule(
 	engine rules.Engine,
 	syncCfg ethconfig.Sync,
 	fcuBackgroundPrune bool,
-	fcuBackgroundCommit bool,
 	onlySnapDownloadOnStart bool,
 	readAheader *exec.BlockReadAheader,
 	stopNode func() error,
@@ -279,7 +277,6 @@ func NewExecModule(
 		syncCfg:                 syncCfg,
 		bacgroundCtx:            ctx,
 		fcuBackgroundPrune:      fcuBackgroundPrune,
-		fcuBackgroundCommit:     fcuBackgroundCommit,
 		onlySnapDownloadOnStart: onlySnapDownloadOnStart,
 		stateCache:              domainCache,
 		codeStore:               codeStore,
@@ -349,7 +346,7 @@ func (e *ExecModule) closeModuleContext() {
 func (e *ExecModule) ForkValidator() *ForkValidator { return e.forkValidator }
 
 // SetPublishedSD wires the ExecModule to fall back to the published SD from Events
-// when currentContext is nil (e.g. during background commit).
+// when currentContext is nil (e.g. while an FCU commits).
 func (e *ExecModule) SetPublishedSD(provider func() *execctx.SharedDomains) {
 	e.publishedSD = provider
 }

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -525,11 +525,9 @@ func TestReorgBackAndForwardIntoCanonicalChain(t *testing.T) {
 	}{
 		{name: "fg-prune"},
 		// bg-prune matches the hive erigon default (FcuBackgroundPrune=true): the
-		// background prune shares the pipeline sync with the next FCU's RunLoop.
-		// bg-commit hands the semaphore to its goroutine the same way; in both
-		// modes the handoff must not overlap the FCU goroutine's cleanup.
+		// background prune shares the pipeline sync with the next FCU's RunLoop,
+		// and its semaphore handoff must not overlap the FCU goroutine's cleanup.
 		{name: "bg-prune", opt: execmoduletester.WithFcuBackgroundPrune()},
-		{name: "bg-commit", opt: execmoduletester.WithFcuBackgroundCommit()},
 	}
 	for _, mode := range modes {
 		opts := []execmoduletester.Option{execmoduletester.WithGenesisSpec(&types.Genesis{Config: chain.AllProtocolChanges})}
@@ -1675,35 +1673,6 @@ func TestNotificationDispatchForegroundCommit(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestNotificationDispatchBackgroundCommit verifies that with background
-// commit enabled, notifications are still dispatched before FCU returns,
-// even though the DB commit happens asynchronously.
-//
-// Note: with background commit, subsequent blocks may fail validation
-// because the DB state hasn't caught up yet (the commit is async). This
-// test only processes the genesis → block 1 transition to verify that
-// notification dispatch works correctly in the background commit path.
-func TestNotificationDispatchBackgroundCommit(t *testing.T) {
-	// Background commit creates a race: FCU N returns before commit finishes,
-	// so FCU N+1 reads stale state from DB. This is the known limitation that
-	// the API-layer "latest head pointer" coordination is designed to solve.
-	// Once that's implemented, remove this skip and verify the full flow.
-	t.Skip("background commit requires API-layer coordination (latest head pointer) to work correctly")
-
-	m := execmoduletester.New(t, execmoduletester.WithFcuBackgroundCommit())
-
-	headerCh, unsub := m.Notifications.Events.AddHeaderSubscription()
-	defer unsub()
-
-	chainPack, err := m.GenerateChain(1, nil)
-	require.NoError(t, err)
-
-	err = m.InsertChain(chainPack)
-	require.NoError(t, err)
-
-	drainHeaders(t, headerCh, 2*time.Second)
-}
-
 // TestNotificationDispatchBackgroundPrune verifies that with the default
 // production configuration (foreground commit + background prune), notifications
 // are dispatched and data is committed before FCU returns. This was a real bug:
@@ -2346,12 +2315,11 @@ func TestInsertBlocksWithBatchedFCU(t *testing.T) {
 	}
 }
 
-// runBatchedFCUBadBlockRecovery is the shared body for the foreground- and
-// background-commit variants of the bad-block recovery test. Both FCU
-// cleanup branches — local SD close (foreground) and the additional
-// currentContext reset (background) — must leave the next InsertBlocks+FCU
-// cycle able to recover.
-func runBatchedFCUBadBlockRecovery(t *testing.T, bgCommit bool) {
+// TestInsertBlocksWithBatchedFCU_BadBlockRecovery covers the FCU cleanup path:
+// a bad-block FCU closes the local SharedDomains while the persistent
+// currentContext remains, and the next InsertBlocks+FCU cycle must
+// re-initialize the overlay on top of it and recover.
+func TestInsertBlocksWithBatchedFCU_BadBlockRecovery(t *testing.T) {
 	ctx := t.Context()
 	privKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -2362,19 +2330,12 @@ func runBatchedFCUBadBlockRecovery(t *testing.T, bgCommit bool) {
 			senderAddr: {Balance: new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)},
 		},
 	}
-	opts := []execmoduletester.Option{
+	m := execmoduletester.New(t,
 		execmoduletester.WithGenesisSpec(genesis),
 		execmoduletester.WithKey(privKey),
-	}
-	if bgCommit {
-		opts = append(opts, execmoduletester.WithFcuBackgroundCommit())
-	}
-	m := execmoduletester.New(t, opts...)
+	)
 
-	// Under background commit, a commit (including the genesis InsertBlocks inside
-	// New) lands asynchronously after the call returns. These polls let DB reads
-	// wait for the commit goroutine; both return immediately under foreground
-	// commit. Transient read errors are treated as "not ready yet" and retried.
+	// Transient read errors are treated as "not ready yet" and retried.
 	waitForGenesis := func() {
 		require.Eventually(t, func() bool {
 			var funded bool
@@ -2453,10 +2414,8 @@ func runBatchedFCUBadBlockRecovery(t *testing.T, bgCommit bool) {
 
 	// Phase 3: recovery — insert the real block 6 and FCU on it. This must
 	// succeed even though the bad-block FCU just closed the local
-	// SharedDomains. The persistent e.currentContext is either still
-	// pointing to the prior SD (foreground) or has been nil'd (background);
-	// both paths must let the next InsertBlocks re-initialize the overlay
-	// cleanly.
+	// SharedDomains: the persistent e.currentContext still points at the prior
+	// SD, and the next InsertBlocks must re-initialize the overlay cleanly.
 	recoverIns, err := m.InsertBlocks(ctx, []*types.Block{chainPack.Blocks[5]})
 	require.NoError(t, err, "InsertBlocks of the good block after a bad-block FCU must not error")
 	require.Equal(t, execmodule.ExecutionStatusSuccess, recoverIns)
@@ -2483,22 +2442,6 @@ func runBatchedFCUBadBlockRecovery(t *testing.T, bgCommit bool) {
 		require.NotNil(t, td)
 		return nil
 	}))
-}
-
-// TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Foreground covers the
-// foreground-commit cleanup path: a bad-block FCU closes the local
-// SharedDomains while the persistent currentContext remains, and the next
-// InsertBlocks must re-initialize the overlay on top of it.
-func TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Foreground(t *testing.T) {
-	runBatchedFCUBadBlockRecovery(t, false)
-}
-
-// TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Background covers the
-// background-commit cleanup path, where the bad-block FCU additionally resets
-// currentContext. Commits land asynchronously, so the shared body polls
-// committed state before asserting (see waitForGenesis/waitForBlock).
-func TestInsertBlocksWithBatchedFCU_BadBlockRecovery_Background(t *testing.T) {
-	runBatchedFCUBadBlockRecovery(t, true)
 }
 
 // transferGen returns a deterministic per-block tx generator: identical

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -356,12 +356,6 @@ func WithoutAmsterdamBuilderContracts() Option {
 	}
 }
 
-func WithFcuBackgroundCommit() Option {
-	return func(opts *options) {
-		opts.fcuBackgroundCommit = true
-	}
-}
-
 // WithAlwaysGenerateChangesets pins --experimental.always-generate-changesets
 // regardless of the tester default: true for tests that reorg deeper than
 // MaxReorgDepth, false for tests that rely on the windowed-changesets
@@ -404,7 +398,6 @@ type options struct {
 	pruneMode                     *prune.Mode
 	withTxPool                    bool
 	enableDomains                 []kv.Domain
-	fcuBackgroundCommit           bool
 	fcuBackgroundPrune            bool
 	alwaysGenerateChangesets      *bool
 	maxReorgDepth                 *uint64
@@ -521,7 +514,6 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 	cfg.Prune = pruneMode
 	cfg.ExperimentalBAL = opt.experimentalBAL
 	cfg.FcuBackgroundPrune = opt.fcuBackgroundPrune
-	cfg.FcuBackgroundCommit = opt.fcuBackgroundCommit
 
 	logLvl := log.LvlError
 	if lvl, ok := os.LookupEnv("EXEC_MODULE_TESTER_LOG_LEVEL"); ok {
@@ -803,7 +795,6 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 		engine,
 		cfg.Sync,
 		cfg.FcuBackgroundPrune,
-		cfg.FcuBackgroundCommit,
 		onlySnapDownloadOnStart,
 		readAheader,
 		func() error { return nil },

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -121,7 +121,7 @@ func (e *ExecModule) UpdateForkChoice(ctx context.Context, headHash, safeHash, f
 	// as the result lands on outcomeCh — for a merge-extending fork at tip the
 	// result is sent before flush/commit, so the consensus client is not blocked
 	// on the EL commit. The semaphore is released — by the forkchoice goroutine, or
-	// by the background commit/prune goroutine it hands off to — only after the FCU
+	// by the background prune goroutine it hands off to — only after the FCU
 	// cleanup has run, so any follow-up op (AssembleBlock, next FCU) that acquires
 	// the semaphore observes fully-settled state.
 	go func() {
@@ -352,8 +352,8 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	}()
 
 	defer UpdateForkChoiceDuration(time.Now())
-	// The next semaphore acquirer must observe settled state, so the bg-commit/
-	// bg-prune paths run this eagerly before handing the semaphore to their goroutine.
+	// The next semaphore acquirer must observe settled state, so the bg-prune
+	// path runs this eagerly before handing the semaphore to its goroutine.
 	cleanupBeforeSemaRelease := sync.OnceFunc(func() {
 		e.currentContext.ResetPendingUpdates()
 		e.forkValidator.ClearWithUnwind()
@@ -371,7 +371,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	// overlay (MemoryMutation) which implements kv.TemporalRwTx. No MDBX write
 	// lock is held during pipeline execution — a brief RwTx is opened only at
 	// commit time to flush everything atomically.
-	roTx, err := e.db.BeginTemporalRo(ctx) //nolint:gocritic // deferred via closure below (bg-commit path sets roTx=nil after ownership transfer)
+	roTx, err := e.db.BeginTemporalRo(ctx) //nolint:gocritic // deferred via closure below
 	if err != nil {
 		return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, false)
 	}
@@ -379,7 +379,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		if roTx != nil {
 			roTx.Rollback()
 		}
-	}() // closure: CommitCycle may reassign roTx; bg-commit path sets it to nil after ownership transfer
+	}() // closure: CommitCycle may reassign roTx, and leaves it nil if the reopen fails
 
 	// Check if InsertBlocks already created a block overlay with data
 	// (headers, bodies, TDs, canonical hashes).
@@ -650,9 +650,6 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		}
 		currentContext.Close()
 		currentContext = nil
-		if e.fcuBackgroundCommit {
-			e.closeModuleContext()
-		}
 	} else {
 		status = ExecutionStatusSuccess
 		// Update forks...
@@ -694,7 +691,7 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 		// After this, all consumers have the data — the semaphore can be
 		// released and flush/commit/prune can proceed without blocking the
 		// next FCU.
-		e.logger.Debug("[updateForkChoice] dispatching notifications", "head", blockHash, "bgCommit", e.fcuBackgroundCommit)
+		e.logger.Debug("[updateForkChoice] dispatching notifications", "head", blockHash)
 		if err := e.dispatchNotificationsFromOverlay(currentContext, finishProgressBefore); err != nil {
 			return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, fmt.Errorf("fcu: dispatch notifications: %w", err), stateFlushingInParallel)
 		}
@@ -712,56 +709,29 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 			}()
 		}
 
-		// Flush + commit: foreground by default, background only if
-		// fcuBackgroundCommit is explicitly enabled.
-		var commitTimings []any
-		if e.fcuBackgroundCommit {
-			// Transfer roTx + SD ownership to the goroutine so the outer
-			// defers become no-ops.
-			bgRoTx, bgSD := roTx, currentContext
-			roTx, currentContext = nil, nil
-			dispatcher := e.pipelineExecutor.Dispatcher()
+		// Flush + commit: pass the outer roTx so it gets released between
+		// Flush and Commit, so the commit sees openTxs=1 in MDBX.
+		commitTimings, err := e.runForkchoiceFlushCommit(currentContext, roTx, finishProgressBefore, isSynced)
+		if err != nil {
+			return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
+		}
+
+		// Prune: background by default (fcuBackgroundPrune=true). RunPrune
+		// shares the pipeline Sync with the next FCU's RunLoop, so the
+		// goroutine keeps the semaphore until done.
+		if e.fcuBackgroundPrune {
+			// Prune doesn't use the overlay/SD — tear down eagerly to free
+			// the RAM now and keep the outer defer out of the next FCU's way.
+			teardownOverlay()
 			handOffSemaphore(func() error {
-				defer bgSD.Close()
-				// bgRoTx is rolled back inside runForkchoiceFlushCommit between
-				// Flush and Commit so the commit sees openTxs=1 in MDBX; this
-				// defer is redundant (Rollback is idempotent).
-				defer bgRoTx.Rollback()
-				err := e.runPostForkchoice(bgSD, bgRoTx, finishProgressBefore, isSynced, initialCycle)
-				// Signal that the DB commit is done — RPC consumers can
-				// drop their SD reference and read from committed DB.
-				if dispatcher != nil {
-					dispatcher.PublishOverlay(nil)
-				}
-				return err
+				return e.runPostForkchoice(initialCycle)
 			})
 		} else {
-			// Foreground commit: pass the outer roTx so it gets released
-			// between Flush and Commit (same openTxs=2→1 optimization as
-			// the bg-commit path).
-			ct, err := e.runForkchoiceFlushCommit(currentContext, roTx, finishProgressBefore, isSynced)
+			pruneTimings, err := e.runForkchoicePrune(initialCycle)
 			if err != nil {
 				return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
 			}
-			commitTimings = ct
-
-			// Prune: background by default (fcuBackgroundPrune=true). RunPrune
-			// shares the pipeline Sync with the next FCU's RunLoop, so the
-			// goroutine keeps the semaphore until done.
-			if e.fcuBackgroundPrune {
-				// Prune doesn't use the overlay/SD — tear down eagerly to free
-				// the RAM now and keep the outer defer out of the next FCU's way.
-				teardownOverlay()
-				handOffSemaphore(func() error {
-					return e.runPostForkchoice(nil, nil, finishProgressBefore, isSynced, initialCycle)
-				})
-			} else {
-				pruneTimings, err := e.runForkchoicePrune(initialCycle)
-				if err != nil {
-					return sendForkchoiceErrorWithoutWaiting(e.logger, outcomeCh, err, stateFlushingInParallel)
-				}
-				commitTimings = append(commitTimings, pruneTimings...)
-			}
+			commitTimings = append(commitTimings, pruneTimings...)
 		}
 
 		e.logTimings("Timings: Forkchoice", commitTimings)
@@ -774,24 +744,12 @@ func (e *ExecModule) updateForkChoice(ctx context.Context, originalBlockHash, sa
 	}, stateFlushingInParallel)
 }
 
-// runPostForkchoice runs the enabled background FCU work: flush+commit+UpdateHead
-// when fcuBackgroundCommit (sd non-nil), prune when fcuBackgroundPrune.
-// Notifications have already been dispatched inline from the overlay.
-func (e *ExecModule) runPostForkchoice(sd *execctx.SharedDomains, bgRoTx kv.TemporalTx, finishProgressBefore uint64, isSynced bool, initialCycle bool) error {
-	var timings []any
-	if e.fcuBackgroundCommit && sd != nil {
-		commitTimings, err := e.runForkchoiceFlushCommit(sd, bgRoTx, finishProgressBefore, isSynced)
-		if err != nil {
-			return err
-		}
-		timings = append(timings, commitTimings...)
-	}
-	if e.fcuBackgroundPrune {
-		pruneTimings, err := e.runForkchoicePrune(initialCycle)
-		if err != nil {
-			return err
-		}
-		timings = append(timings, pruneTimings...)
+// runPostForkchoice runs the background FCU prune. Flush+commit and the
+// notification dispatch have already run inline.
+func (e *ExecModule) runPostForkchoice(initialCycle bool) error {
+	timings, err := e.runForkchoicePrune(initialCycle)
+	if err != nil {
+		return err
 	}
 	e.logTimings("Timings: Post-Forkchoice", timings)
 	return nil

--- a/execution/execmodule/getters.go
+++ b/execution/execmodule/getters.go
@@ -60,7 +60,7 @@ var errNotFound = errors.New("notfound")
 func (e *ExecModule) beginOverlayOrRo(ctx context.Context) (kv.TemporalTx, func(), error) {
 	e.lock.RLock()
 	sd := e.currentContext
-	// Fall back to published SD during background commit.
+	// Fall back to published SD while an FCU commits.
 	if sd == nil && e.publishedSD != nil {
 		sd = e.publishedSD()
 	}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2298,8 +2298,6 @@ Flags for configuring Fork Choice Update behavior.
   * Default: `1s`
 * `--fcu.background.prune`: Enables background pruning after FCU.
   * Default: `true`
-* `--fcu.background.commit`: Enables background flush and commit after FCU.
-  * Default: `false`
 
 ### Execution
 

--- a/node/cli/default_flags.go
+++ b/node/cli/default_flags.go
@@ -47,7 +47,6 @@ var DefaultFlags = []cli.Flag{
 	&utils.CommitmentHistoryDistanceFlag,
 	&utils.FcuTimeoutFlag,
 	&utils.FcuBackgroundPruneFlag,
-	&utils.FcuBackgroundCommitFlag,
 	&utils.ExecBatchedIOFlag,
 	&utils.ExecStateCacheFlag,
 	&utils.ExecWorkersFlag,

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -959,7 +959,6 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 		backend.engine,
 		config.Sync,
 		config.FcuBackgroundPrune,
-		config.FcuBackgroundCommit,
 		onlySnapDownloadOnStart,
 		backend.readAheader,
 		backend.stopNode,

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -111,11 +111,10 @@ var Defaults = Config{
 		ProduceE2:  true,
 		ProduceE3:  true,
 	},
-	FcuTimeout:          1 * time.Second,
-	FcuBackgroundPrune:  true,
-	FcuBackgroundCommit: false, // to enable, we need to 1) have rawdb API go via execctx and 2) revive Coherent cache for rpcdaemon
-	ExperimentalBAL:     false,
-	WarmupKzgCtxOnInit:  true,
+	FcuTimeout:         1 * time.Second,
+	FcuBackgroundPrune: true,
+	ExperimentalBAL:    false,
+	WarmupKzgCtxOnInit: true,
 }
 
 const DefaultChainDBPageSize = 16 * datasize.KB
@@ -276,9 +275,8 @@ type Config struct {
 	AllowAA bool
 
 	// fork choice update timeout
-	FcuTimeout          time.Duration
-	FcuBackgroundPrune  bool
-	FcuBackgroundCommit bool
+	FcuTimeout         time.Duration
+	FcuBackgroundPrune bool
 
 	MCPAddress string
 

--- a/node/ethconfig/gen_config.go
+++ b/node/ethconfig/gen_config.go
@@ -57,7 +57,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		AllowAA                             bool
 		FcuTimeout                          time.Duration
 		FcuBackgroundPrune                  bool
-		FcuBackgroundCommit                 bool
 		MCPAddress                          string
 		ErigondbDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
 		CommitmentPlainValues               *bool   `toml:",omitempty"`
@@ -98,7 +97,6 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.AllowAA = c.AllowAA
 	enc.FcuTimeout = c.FcuTimeout
 	enc.FcuBackgroundPrune = c.FcuBackgroundPrune
-	enc.FcuBackgroundCommit = c.FcuBackgroundCommit
 	enc.MCPAddress = c.MCPAddress
 	enc.ErigondbDomainStepsInFrozenFile = c.ErigondbDomainStepsInFrozenFile
 	enc.CommitmentPlainValues = c.CommitmentPlainValues
@@ -143,7 +141,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		AllowAA                             *bool
 		FcuTimeout                          *time.Duration
 		FcuBackgroundPrune                  *bool
-		FcuBackgroundCommit                 *bool
 		MCPAddress                          *string
 		ErigondbDomainStepsInFrozenFile     *uint64 `toml:",omitempty"`
 		CommitmentPlainValues               *bool   `toml:",omitempty"`
@@ -254,9 +251,6 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.FcuBackgroundPrune != nil {
 		c.FcuBackgroundPrune = *dec.FcuBackgroundPrune
-	}
-	if dec.FcuBackgroundCommit != nil {
-		c.FcuBackgroundCommit = *dec.FcuBackgroundCommit
 	}
 	if dec.MCPAddress != nil {
 		c.MCPAddress = *dec.MCPAddress


### PR DESCRIPTION
`--fcu.background.commit` has been default-off since it landed in #18756 (2026-01-23) and was never enabled on any branch — `release/3.4`, `release/3.5`, `release/3.6` and `main` all carry `FcuBackgroundCommit: false`.

It can't be turned on as-is: FCU N returns before its commit lands, so FCU N+1 reads stale state from the DB. That is why its own `TestNotificationDispatchBackgroundCommit` was skipped, and why the default carries the "needs rawdb API via execctx + Coherent cache revived for rpcdaemon" note. Removing it instead of carrying a dead branch through every FCU change.

## What goes

- `--fcu.background.commit` flag and `ethconfig.Config.FcuBackgroundCommit`
- the bg-commit branch in `updateForkChoice`: roTx/SD ownership transfer, the goroutine's `PublishOverlay(nil)` signal, and the extra `closeModuleContext` on the bad-block path
- `runPostForkchoice`'s commit half, so it takes only `initialCycle` (`sd`, `bgRoTx`, `finishProgressBefore`, `isSynced` were all bg-commit-only)
- `execmoduletester.WithFcuBackgroundCommit`

## What stays

Flush+commit is now unconditionally inline — identical to the behaviour every node already had. Background prune (`--fcu.background.prune`, default true) and `--sync.parallel-state-flushing` are untouched, as is the `publishedSD` fallback, which the foreground path also uses while a commit is in flight.

## Tests

`TestInsertBlocksWithBatchedFCU_BadBlockRecovery_{Foreground,Background}` collapse into one — both cleanup branches are the same path now. The `bg-commit` case drops out of `TestReorgBackAndForwardIntoCanonicalChain`, and the skipped `TestNotificationDispatchBackgroundCommit` goes with the feature it covered.

`go vet ./...` compiles clean; `./execution/execmodule/...`, `./node/ethconfig/...`, `./node/cli/...` pass.

The `docs/site/versioned_docs/version-v3.4` copy keeps the flag on purpose — 3.4 still has it.