### PR TITLE
exec: calcFees to make less version-map locks

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1945,7 +1945,9 @@ func (result *execResult) calcFees(
 		newCoinbaseBalance = coinbaseAcc.Balance
 	}
 	burntAddr := result.ExecutionResult.BurntContractAddress
-	hasBurnt := !burntAddr.IsNil()
+	// A burnt write can only differ from the pre-state when London adds a
+	// non-zero FeeBurnt, so skip the whole read otherwise.
+	hasBurnt := !burntAddr.IsNil() && chainRules.IsLondon && !result.ExecutionResult.FeeBurnt.IsZero()
 	var newBurntBalance uint256.Int
 	var burntAcc *accounts.Account
 	if hasBurnt {
@@ -2000,9 +2002,10 @@ func (result *execResult) calcFees(
 		newCoinbaseBalance.Add(&newCoinbaseBalance, &result.ExecutionResult.FeeTipped)
 	}
 	oldBurntBalance := newBurntBalance
-	if hasBurnt && chainRules.IsLondon {
+	if hasBurnt {
 		newBurntBalance.Add(&newBurntBalance, &result.ExecutionResult.FeeBurnt)
 	}
+	emitBurnt := hasBurnt && newBurntBalance != oldBurntBalance
 
 	// EIP-161 empty-removal: even when the tip is zero (newBal == oldBal)
 	// the coinbase must be "touched" so the commitment calculator sees the
@@ -2021,6 +2024,10 @@ func (result *execResult) calcFees(
 		coinbaseNonce == 0 && coinbaseEmptyCodeHash && !coinbaseHasCodeHashWrite
 	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
 		(coinbaseEmptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
+
+	if !emitCoinbase && !emitBurnt {
+		return nil, nil
+	}
 
 	addWrites := &state.WriteSet{}
 	if emitCoinbase {
@@ -2052,15 +2059,7 @@ func (result *execResult) calcFees(
 			// stale CallNewAccountGas (+25000) for a CALL-with-value to the
 			// coinbase mid-tx. Mainnet block 25151825 tx 31's SD+CREATE2-on-
 			// coinbase MEV pattern surfaced this divergence.
-			addrAcc := &accounts.Account{Balance: newCoinbaseBalance}
-			if coinbaseAcc != nil {
-				addrAcc.Nonce = coinbaseAcc.Nonce
-				addrAcc.Incarnation = coinbaseAcc.Incarnation
-				addrAcc.CodeHash = coinbaseAcc.CodeHash
-			} else {
-				addrAcc.Nonce = coinbaseNonce
-				addrAcc.CodeHash = accounts.EmptyCodeHash
-			}
+			addrAcc := feeAddressAccount(coinbaseAcc, newCoinbaseBalance, coinbaseNonce)
 			addWrites.SetAddress(result.Coinbase, &state.VersionedWrite[*accounts.Account]{
 				WriteHeader: state.WriteHeader{
 					Address: result.Coinbase,
@@ -2071,7 +2070,7 @@ func (result *execResult) calcFees(
 			})
 		}
 	}
-	if hasBurnt && newBurntBalance != oldBurntBalance {
+	if emitBurnt {
 		addWrites.SetBalance(burntAddr, &state.VersionedWrite[uint256.Int]{
 			WriteHeader: state.WriteHeader{
 				Address: burntAddr,
@@ -2082,14 +2081,7 @@ func (result *execResult) calcFees(
 			Val: newBurntBalance,
 		})
 		// Mirror the AddressPath emission above for the burnt address.
-		burntAddrAcc := &accounts.Account{Balance: newBurntBalance}
-		if burntAcc != nil {
-			burntAddrAcc.Nonce = burntAcc.Nonce
-			burntAddrAcc.Incarnation = burntAcc.Incarnation
-			burntAddrAcc.CodeHash = burntAcc.CodeHash
-		} else {
-			burntAddrAcc.CodeHash = accounts.EmptyCodeHash
-		}
+		burntAddrAcc := feeAddressAccount(burntAcc, newBurntBalance, 0)
 		addWrites.SetAddress(burntAddr, &state.VersionedWrite[*accounts.Account]{
 			WriteHeader: state.WriteHeader{
 				Address: burntAddr,
@@ -2101,6 +2093,15 @@ func (result *execResult) calcFees(
 	}
 
 	return addWrites, nil
+}
+
+// feeAddressAccount builds the AddressPath value for a fee credit from read, the
+// address's pre-credit account. nonce applies only when there is no pre-state.
+func feeAddressAccount(read *accounts.Account, balance uint256.Int, nonce uint64) *accounts.Account {
+	if read == nil {
+		return &accounts.Account{Balance: balance, Nonce: nonce, CodeHash: accounts.EmptyCodeHash}
+	}
+	return &accounts.Account{Balance: balance, Nonce: read.Nonce, Incarnation: read.Incarnation, CodeHash: read.CodeHash}
 }
 
 func (result *execResult) finalizeTx(

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1636,44 +1636,12 @@ func versionedUpdateAddress(vm *VersionMap, addr accounts.Address, txIndex int) 
 	return nil, false
 }
 
-func versionedUpdateBalance(vm *VersionMap, addr accounts.Address, txIndex int) (uint256.Int, bool) {
-	val, res, ok := vm.ReadBalance(addr, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val, true
-	}
-	return uint256.Int{}, false
-}
-
-func versionedUpdateNonce(vm *VersionMap, addr accounts.Address, txIndex int) (uint64, bool) {
-	val, res, ok := vm.ReadNonce(addr, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val, true
-	}
-	return 0, false
-}
-
-func versionedUpdateIncarnation(vm *VersionMap, addr accounts.Address, txIndex int) (uint64, bool) {
-	val, res, ok := vm.ReadIncarnation(addr, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val, true
-	}
-	return 0, false
-}
-
 func versionedUpdateCode(vm *VersionMap, addr accounts.Address, txIndex int) ([]byte, bool) {
 	val, res, ok := vm.ReadCode(addr, txIndex)
 	if ok && res.Status() != MVReadResultNone {
 		return val.Bytes, true
 	}
 	return nil, false
-}
-
-func versionedUpdateCodeHash(vm *VersionMap, addr accounts.Address, txIndex int) (accounts.CodeHash, bool) {
-	val, res, ok := vm.ReadCodeHash(addr, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val, true
-	}
-	return accounts.CodeHash{}, false
 }
 
 func versionedUpdateStorage(vm *VersionMap, addr accounts.Address, key accounts.StorageKey, txIndex int) (uint256.Int, bool) {
@@ -1684,24 +1652,12 @@ func versionedUpdateStorage(vm *VersionMap, addr accounts.Address, key accounts.
 	return uint256.Int{}, false
 }
 
-// applyVersionedUpdates applies updated from the version map to the account before returning it, this is necessary
-// for the account obkect becuase the state reader/.writer api's treat the subfileds as a group and this
-// may lead to updated from pervious transactions being missed where we only update a subset of the fiels as these won't
-// be recored as reads and hence the varification process will miss them.  We don't want to creat a fail but
-// we do  want to capture the updates
+// applyVersionedUpdates overlays the version map's per-field writes onto account.
+// The reader/writer API treats an account's sub-fields as one group, so a prior
+// tx that wrote only a subset would otherwise be lost here — and those fields are
+// not recorded as reads, so validation would not catch the miss either.
 func (vr versionedStateReader) applyVersionedUpdates(address accounts.Address, account accounts.Account) accounts.Account {
-	if update, ok := versionedUpdateBalance(vr.versionMap, address, vr.txIndex); ok {
-		account.Balance = update
-	}
-	if update, ok := versionedUpdateNonce(vr.versionMap, address, vr.txIndex); ok {
-		account.Nonce = update
-	}
-	if update, ok := versionedUpdateIncarnation(vr.versionMap, address, vr.txIndex); ok {
-		account.Incarnation = update
-	}
-	if update, ok := versionedUpdateCodeHash(vr.versionMap, address, vr.txIndex); ok {
-		account.CodeHash = update
-	}
+	vr.versionMap.applySubFieldWrites(address, vr.txIndex, &account)
 	return account
 }
 

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -352,17 +352,8 @@ func readFloor[T any](vm *VersionMap, addr accounts.Address, txIdx int, sel func
 	}
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	cells := sel(e)
-	if cells == nil {
-		return val, res, false
-	}
-	fk := UnknownDep
-	var fv *WriteCell[T]
-	cells.Descend(txIdx-1, func(k int, v *WriteCell[T]) bool {
-		fk, fv = k, v
-		return false
-	})
-	if fk == UnknownDep || fv == nil {
+	fk, fv := floorCell(sel(e), txIdx)
+	if fv == nil {
 		return val, res, false
 	}
 	res.depIdx = fk
@@ -374,6 +365,53 @@ func readFloor[T any](vm *VersionMap, addr accounts.Address, txIdx int, sel func
 		panic("unknown flag value")
 	}
 	return fv.Value, res, true
+}
+
+// floorCell returns the highest write strictly below txIdx, or (UnknownDep, nil)
+// when the path holds none. Caller must hold the address entry's read lock.
+func floorCell[T any](cells *btree.Map[int, *WriteCell[T]], txIdx int) (int, *WriteCell[T]) {
+	if cells == nil {
+		return UnknownDep, nil
+	}
+	fk := UnknownDep
+	var fv *WriteCell[T]
+	cells.Descend(txIdx-1, func(k int, v *WriteCell[T]) bool {
+		fk, fv = k, v
+		return false
+	})
+	if fk == UnknownDep {
+		return UnknownDep, nil
+	}
+	return fk, fv
+}
+
+// applySubFieldWrites layers the Balance/Nonce/Incarnation/CodeHash writes for
+// addr onto account, taking one entry lookup and one read lock where the
+// per-path ReadX primitives would take one of each. An Estimate cell counts the
+// same as a Done one — it holds the same latest in-block write, which finalize
+// reconstruction must consume rather than fall back to the pre-block DB value.
+func (vm *VersionMap) applySubFieldWrites(addr accounts.Address, txIdx int, account *accounts.Account) {
+	if vm == nil {
+		return
+	}
+	e := vm.load(addr)
+	if e == nil {
+		return
+	}
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if _, cell := floorCell(e.Balance, txIdx); cell != nil {
+		account.Balance = cell.Value
+	}
+	if _, cell := floorCell(e.Nonce, txIdx); cell != nil {
+		account.Nonce = cell.Value
+	}
+	if _, cell := floorCell(e.Incarnation, txIdx); cell != nil {
+		account.Incarnation = cell.Value
+	}
+	if _, cell := floorCell(e.CodeHash, txIdx); cell != nil {
+		account.CodeHash = cell.Value
+	}
 }
 
 func (vm *VersionMap) ReadAddress(addr accounts.Address, txIdx int) (*accounts.Account, ReadResult, bool) {


### PR DESCRIPTION
part of `processResults` func optimization

`calcFees` change: every sub-field read bottoms out in `readFloor`, which does a `VersionMap.load` (`sync.Map`) **plus** `AddressEntry.mu.RLock()`. The `versionedUpdate*` helpers read as plain value lookups, so this was easy to miss.

**Before** — per `ReadAccountData`:

```
ReadAccountData
├─ VersionMap.AccountLifecycle → ReadSelfDestruct → readFloor   load + RLock
├─ versionedUpdateAddress      → ReadAddress      → readFloor   load + RLock
└─ applyVersionedUpdates
   ├─ versionedUpdateBalance     → ReadBalance     → readFloor  load + RLock
   ├─ versionedUpdateNonce       → ReadNonce       → readFloor  load + RLock
   ├─ versionedUpdateIncarnation → ReadIncarnation → readFloor  load + RLock
   └─ versionedUpdateCodeHash    → ReadCodeHash    → readFloor  load + RLock
```

**After** — the four `versionedUpdate*` helpers are gone:

```
ReadAccountData
├─ VersionMap.AccountLifecycle → ReadSelfDestruct → readFloor   load + RLock
├─ versionedUpdateAddress      → ReadAddress      → readFloor   load + RLock
└─ applyVersionedUpdates
   └─ VersionMap.applySubFieldWrites                            load + RLock
      └─ floorCell × 4  (Balance / Nonce / Incarnation / CodeHash)
```

Two smaller cuts in `calcFees`: `hasBurnt` now folds in `IsLondon && !FeeBurnt.IsZero()`, skipping the second `ReadAccountData` entirely when no burnt write can result; and the `WriteSet` is allocated only once a write is known to be emitted.

Measured with a local `BenchmarkCalcFees` harness (not part of this PR) driving `calcFees` against a version map holding 128 prior txs of writes. n1 (Linux, AMD EPYC 4244P), the two sides built as separate test binaries and run interleaved under `taskset -c 0-7`, n=14:

| bench | main | this PR | Δ |
|---|---|---|---|
| CalcFees/preLondon sec/op | 323.1n | 265.9n | **-17.69%** |
| CalcFees/london sec/op | 574.0n | 454.1n | **-20.90%** |
| **geomean sec/op** | 430.7n | 347.5n | **-19.31%** |
| CalcFees/preLondon B/op | 432 | 432 | ~ |
| CalcFees/london B/op | 784 | 784 | ~ |
| CalcFees/preLondon allocs/op | 5 | 5 | ~ |
| CalcFees/london allocs/op | 9 | 9 | ~ |

Allocations unchanged — purely a lookup/lock-count win. No metric regressed. `go test -race ./execution/state/ ./execution/stagedsync/` clean.

<details><summary>Correctness notes</summary>

- `applySubFieldWrites` keeps the Done-OR-Estimate semantics of the `versionedUpdate*` helpers it replaces: `readFloor` returns `ok` for both flags, and an Estimate cell holds the same latest in-block write, which finalize reconstruction must consume rather than fall back to the pre-block DB value.
- The four sub-fields now come from one snapshot under a single `RLock`. Previously a `WriteBalance` could land between the `ReadBalance` and `ReadNonce` calls, so the account could mix pre- and post-write fields — the new read is strictly more consistent, never less.
- `floorCell` preserves the `fk == UnknownDep` guard, so a cell keyed at `UnknownDep` (-2) is still treated as absent.
- `hasBurnt` fold is behaviour-preserving: with `FeeBurnt == 0` or pre-London the old code read the burnt account, applied the `TxOut` override, then hit `newBurntBalance == oldBurntBalance` and emitted nothing. `emitBurnt` still carries the inequality check, so an overflow wrap cannot emit a spurious write.
- `calcFees` returning a nil `*WriteSet` is safe: `IsEmpty`, `Get*`, `ReleaseMaps` and `FlushVersionedWrites` are nil-receiver safe, and the apply loop gates on `!tipWrites.IsEmpty()` — the same gate an empty non-nil set hit before.
</details>

<details><summary>Rejected alternatives</summary>

**Reuse the `*accounts.Account` from `ReadAccountData` as the AddressPath write value** (-2 allocs/op, -23% B/op, a further -4.5% sec/op). Dropped: it needs every `versionedStateReader.ReadAccountData` return path to hand back a private copy. That holds only because each path deref-copies — in the versionMap branch `acc` is the *live* version-map pointer, and `CachedReader.ReadAccountData` in the same package returns its cached pointer directly. A future caching fast-path on `versionedStateReader.ReadAccountData` would silently turn the tip credit into version-map corruption.

**Bundle each credit's two `VersionedWrite`s and its account into one allocation.** 9 → 5 allocs/op, but B/op rose 784 → 976 and sec/op was flat.
</details>

<details><summary>Not addressed here</summary>

`existingWrites.MergeInto(tipWrites)` at the call site copies the tx's entire write set into the 2-4 entry tip set — O(tx writes) per validation round, likely larger than all of `calcFees`. The direction is deliberate: mutating `TxOut` in place would make the next round read a tipped coinbase balance as the worker's own write and double-tip. Needs a different design, not a flip.
</details>
