### PR TITLE
metrics: parallel-exec conflict rate

### DIFF
--- a/cmd/prometheus/dashboards/erigon_internals.json
+++ b/cmd/prometheus/dashboards/erigon_internals.json
@@ -6567,11 +6567,11 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(exec_repeats{instance=~\"$instance\"}[$__rate_interval])/rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "rate(exec_repeats_total{instance=~\"$instance\"}[$__rate_interval]) / rate(exec_triggers{instance=~\"$instance\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "repeats: {{instance}}",
+              "legendFormat": "conflict rate",
               "range": true,
               "refId": "A"
             },
@@ -6582,12 +6582,12 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(exec_triggers{instance=~\"$instance\"}[$__rate_interval])/rate(exec_txs_done{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "rate(exec_discards_total{instance=~\"$instance\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "triggers: {{instance}}",
+              "legendFormat": "discards/s {{reason}}",
               "range": true,
               "refId": "B"
             }

--- a/cmd/prometheus/dashboards/erigon_internals.json
+++ b/cmd/prometheus/dashboards/erigon_internals.json
@@ -6567,11 +6567,11 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(exec_repeats_total{instance=~\"$instance\",mode=\"newpayload\"}[$__rate_interval]) / rate(exec_execs_total{instance=~\"$instance\",mode=\"newpayload\"}[$__rate_interval])",
+              "expr": "rate(exec_repeats_total{instance=~\"$instance\"}[$__rate_interval]) / rate(exec_execs_total{instance=~\"$instance\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "conflict rate (newPayload)",
+              "legendFormat": "conflict rate ({{mode}})",
               "range": true,
               "refId": "A"
             },
@@ -6582,12 +6582,12 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(exec_discards_total{instance=~\"$instance\",mode=\"newpayload\"}[$__rate_interval])",
+              "expr": "rate(exec_discards_total{instance=~\"$instance\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "discards/s {{reason}} (newPayload)",
+              "legendFormat": "discards/s {{reason}} ({{mode}})",
               "range": true,
               "refId": "B"
             }

--- a/cmd/prometheus/dashboards/erigon_internals.json
+++ b/cmd/prometheus/dashboards/erigon_internals.json
@@ -6567,11 +6567,11 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(exec_repeats_total{instance=~\"$instance\"}[$__rate_interval]) / rate(exec_triggers{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "rate(exec_repeats_total{instance=~\"$instance\",mode=\"newpayload\"}[$__rate_interval]) / rate(exec_execs_total{instance=~\"$instance\",mode=\"newpayload\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "conflict rate",
+              "legendFormat": "conflict rate (newPayload)",
               "range": true,
               "refId": "A"
             },
@@ -6582,12 +6582,12 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(exec_discards_total{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "rate(exec_discards_total{instance=~\"$instance\",mode=\"newpayload\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "discards/s {{reason}}",
+              "legendFormat": "discards/s {{reason}} (newPayload)",
               "range": true,
               "refId": "B"
             }

--- a/cmd/prometheus/dashboards/erigon_internals.json
+++ b/cmd/prometheus/dashboards/erigon_internals.json
@@ -6567,7 +6567,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(exec_repeats_total{instance=~\"$instance\"}[$__rate_interval]) / rate(exec_execs_total{instance=~\"$instance\"}[$__rate_interval])",
+              "expr": "rate(exec_repeats_total{instance=~\"$instance\"}[$__rate_interval]) / rate(exec_execs_total{instance=~\"$instance\"}[$__rate_interval]) * 100",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,

--- a/execution/stagedsync/exec3_metrics.go
+++ b/execution/stagedsync/exec3_metrics.go
@@ -666,11 +666,15 @@ func (p *Progress) LogExecution(rs *state.StateV3, ex executor) {
 		}
 
 		mxExecRepeats.SetInt(repeats)
-		// engine_newPayload drives fork validation; everything else is sync
-		// catch-up, where conflict behaviour is a different workload.
-		execMode := "sync"
-		if te.isForkValidation {
+		// Conflict behaviour differs by workload, so keep the modes apart:
+		// engine_newPayload validates one block at the tip, applying-blocks
+		// chews through a sync batch, and a from-scratch re-exec is neither.
+		execMode := "other"
+		switch {
+		case te.isForkValidation:
 			execMode = "newpayload"
+		case te.isApplyingBlocks:
+			execMode = "applyingblocks"
 		}
 		mxExecsTotal.WithLabelValues(execMode).AddUint64(execDiff)
 		mxRepeatsTotal.WithLabelValues(execMode).AddInt(repeats)

--- a/execution/stagedsync/exec3_metrics.go
+++ b/execution/stagedsync/exec3_metrics.go
@@ -45,6 +45,14 @@ var (
 	mxExecCodeReadRate    = metrics.NewGauge("exec_code_read_rate")
 	mxExecWriteRate       = metrics.NewGauge("exec_write_rate")
 
+	// Conflict signals for the parallel executor, as monotonic totals so the
+	// rate and the ratio are derived at query time rather than being fixed to
+	// this reporter's interval. The denominator for the ratio is the existing
+	// exec_triggers, which already carries the cumulative execution count.
+	mxRepeatsTotal  = metrics.GetOrCreateCounter("exec_repeats_total")
+	mxDiscardsTotal = metrics.GetOrCreateCounterVec("exec_discards_total", []string{"reason"},
+		"parallel-exec tasks thrown away, by reason")
+
 	mxExecDomainReads             = metrics.NewGauge(`exec_domain_read_rate{domain="all"}`)
 	mxExecDomainReadDuration      = metrics.NewGauge(`exec_domain_read_dur{domain="all"}`)
 	mxExecDomainCacheReads        = metrics.NewGauge(`exec_domain_cache_read_rate{domain="all"}`)
@@ -651,6 +659,9 @@ func (p *Progress) LogExecution(rs *state.StateV3, ex executor) {
 		}
 
 		mxExecRepeats.SetInt(repeats)
+		mxRepeatsTotal.AddInt(repeats)
+		mxDiscardsTotal.WithLabelValues("abort").AddUint64(abortCount - p.prevAbortCount)
+		mxDiscardsTotal.WithLabelValues("invalid").AddUint64(invalidCount - p.prevInvalidCount)
 		mxExecTriggers.SetInt(int(execCount))
 
 		p.prevExecCount = execCount

--- a/execution/stagedsync/exec3_metrics.go
+++ b/execution/stagedsync/exec3_metrics.go
@@ -45,14 +45,8 @@ var (
 	mxExecCodeReadRate    = metrics.NewGauge("exec_code_read_rate")
 	mxExecWriteRate       = metrics.NewGauge("exec_write_rate")
 
-	// Conflict signals for the parallel executor, as monotonic totals so the
-	// rate and the ratio are derived at query time rather than being fixed to
-	// this reporter's interval.
-	//
-	// exec_execs_total is the denominator rather than the existing
-	// exec_triggers: that one is a gauge holding the executor's own exec
-	// counter, which restarts with each executor, so it is not monotonic and
-	// rate() over it is meaningless.
+	// exec_execs_total, not the existing exec_triggers: that gauge holds the
+	// executor's own counter and restarts with it, so rate() sees a reset.
 	mxExecsTotal = metrics.GetOrCreateCounterVec("exec_execs_total", []string{"mode"},
 		"parallel-exec task executions, by sync mode")
 	mxRepeatsTotal = metrics.GetOrCreateCounterVec("exec_repeats_total", []string{"mode"},
@@ -666,9 +660,6 @@ func (p *Progress) LogExecution(rs *state.StateV3, ex executor) {
 		}
 
 		mxExecRepeats.SetInt(repeats)
-		// Conflict behaviour differs by workload, so keep the modes apart:
-		// engine_newPayload validates one block at the tip, applying-blocks
-		// chews through a sync batch, and a from-scratch re-exec is neither.
 		execMode := "other"
 		switch {
 		case te.isForkValidation:

--- a/execution/stagedsync/exec3_metrics.go
+++ b/execution/stagedsync/exec3_metrics.go
@@ -47,11 +47,18 @@ var (
 
 	// Conflict signals for the parallel executor, as monotonic totals so the
 	// rate and the ratio are derived at query time rather than being fixed to
-	// this reporter's interval. The denominator for the ratio is the existing
-	// exec_triggers, which already carries the cumulative execution count.
-	mxRepeatsTotal  = metrics.GetOrCreateCounter("exec_repeats_total")
-	mxDiscardsTotal = metrics.GetOrCreateCounterVec("exec_discards_total", []string{"reason"},
-		"parallel-exec tasks thrown away, by reason")
+	// this reporter's interval.
+	//
+	// exec_execs_total is the denominator rather than the existing
+	// exec_triggers: that one is a gauge holding the executor's own exec
+	// counter, which restarts with each executor, so it is not monotonic and
+	// rate() over it is meaningless.
+	mxExecsTotal = metrics.GetOrCreateCounterVec("exec_execs_total", []string{"mode"},
+		"parallel-exec task executions, by sync mode")
+	mxRepeatsTotal = metrics.GetOrCreateCounterVec("exec_repeats_total", []string{"mode"},
+		"parallel-exec re-executions, by sync mode")
+	mxDiscardsTotal = metrics.GetOrCreateCounterVec("exec_discards_total", []string{"mode", "reason"},
+		"parallel-exec tasks thrown away, by sync mode and reason")
 
 	mxExecDomainReads             = metrics.NewGauge(`exec_domain_read_rate{domain="all"}`)
 	mxExecDomainReadDuration      = metrics.NewGauge(`exec_domain_read_dur{domain="all"}`)
@@ -659,9 +666,16 @@ func (p *Progress) LogExecution(rs *state.StateV3, ex executor) {
 		}
 
 		mxExecRepeats.SetInt(repeats)
-		mxRepeatsTotal.AddInt(repeats)
-		mxDiscardsTotal.WithLabelValues("abort").AddUint64(abortCount - p.prevAbortCount)
-		mxDiscardsTotal.WithLabelValues("invalid").AddUint64(invalidCount - p.prevInvalidCount)
+		// engine_newPayload drives fork validation; everything else is sync
+		// catch-up, where conflict behaviour is a different workload.
+		execMode := "sync"
+		if te.isForkValidation {
+			execMode = "newpayload"
+		}
+		mxExecsTotal.WithLabelValues(execMode).AddUint64(execDiff)
+		mxRepeatsTotal.WithLabelValues(execMode).AddInt(repeats)
+		mxDiscardsTotal.WithLabelValues(execMode, "abort").AddUint64(abortCount - p.prevAbortCount)
+		mxDiscardsTotal.WithLabelValues(execMode, "invalid").AddUint64(invalidCount - p.prevInvalidCount)
 		mxExecTriggers.SetInt(int(execCount))
 
 		p.prevExecCount = execCount


### PR DESCRIPTION
Exports parallel-exec conflict signals, which today only exist in the `parallel executed` log line.

```promql
rate(exec_repeats_total{instance=~"$instance"}[$__rate_interval]) / rate(exec_execs_total{instance=~"$instance"}[$__rate_interval]) * 100
```

17.2% on n5, matching its logged `repeat%`. Also repoints the "Exec v3" panel, which divided by `exec_txs_done` — a metric exported nowhere.
