### PR TITLE
[r3.6] exec: cut calcFees version-map locks

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1926,7 +1926,9 @@ func (result *execResult) calcFees(
 		newCoinbaseBalance = coinbaseAcc.Balance
 	}
 	burntAddr := result.ExecutionResult.BurntContractAddress
-	hasBurnt := !burntAddr.IsNil()
+	// A burnt write can only differ from the pre-state when London adds a
+	// non-zero FeeBurnt, so skip the whole read otherwise.
+	hasBurnt := !burntAddr.IsNil() && chainRules.IsLondon && !result.ExecutionResult.FeeBurnt.IsZero()
 	var newBurntBalance uint256.Int
 	var burntAcc *accounts.Account
 	if hasBurnt {
@@ -1981,9 +1983,10 @@ func (result *execResult) calcFees(
 		newCoinbaseBalance.Add(&newCoinbaseBalance, &result.ExecutionResult.FeeTipped)
 	}
 	oldBurntBalance := newBurntBalance
-	if hasBurnt && chainRules.IsLondon {
+	if hasBurnt {
 		newBurntBalance.Add(&newBurntBalance, &result.ExecutionResult.FeeBurnt)
 	}
+	emitBurnt := hasBurnt && newBurntBalance != oldBurntBalance
 
 	// EIP-161 empty-removal: even when the tip is zero (newBal == oldBal)
 	// the coinbase must be "touched" so the commitment calculator sees the
@@ -2002,6 +2005,10 @@ func (result *execResult) calcFees(
 		coinbaseNonce == 0 && coinbaseEmptyCodeHash && !coinbaseHasCodeHashWrite
 	emitCoinbase := newCoinbaseBalance != oldCoinbaseBalance ||
 		(coinbaseEmptyRemoval && coinbaseEmptyPre && newCoinbaseBalance.IsZero())
+
+	if !emitCoinbase && !emitBurnt {
+		return nil, nil
+	}
 
 	addWrites := &state.WriteSet{}
 	if emitCoinbase {
@@ -2036,15 +2043,7 @@ func (result *execResult) calcFees(
 			// stale CallNewAccountGas (+25000) for a CALL-with-value to the
 			// coinbase mid-tx. Mainnet block 25151825 tx 31's SD+CREATE2-on-
 			// coinbase MEV pattern surfaced this divergence.
-			addrAcc := &accounts.Account{Balance: newCoinbaseBalance}
-			if coinbaseAcc != nil {
-				addrAcc.Nonce = coinbaseAcc.Nonce
-				addrAcc.Incarnation = coinbaseAcc.Incarnation
-				addrAcc.CodeHash = coinbaseAcc.CodeHash
-			} else {
-				addrAcc.Nonce = coinbaseNonce
-				addrAcc.CodeHash = accounts.EmptyCodeHash
-			}
+			addrAcc := feeAddressAccount(coinbaseAcc, newCoinbaseBalance, coinbaseNonce)
 			addWrites.SetAddress(result.Coinbase, &state.VersionedWrite[*accounts.Account]{
 				WriteHeader: state.WriteHeader{
 					Address: result.Coinbase,
@@ -2055,7 +2054,7 @@ func (result *execResult) calcFees(
 			})
 		}
 	}
-	if hasBurnt && newBurntBalance != oldBurntBalance {
+	if emitBurnt {
 		result.CollectorWrites = result.CollectorWrites.SetAccountBalanceOrDelete(
 			burntAddr, burntAcc, newBurntBalance,
 			tracing.BalanceDecreaseGasBuy, state.EIP161EmptyRemoval(chainRules.IsEIP161Enabled(), chainRules.IsAura, burntAddr))
@@ -2069,14 +2068,7 @@ func (result *execResult) calcFees(
 			Val: newBurntBalance,
 		})
 		// Mirror the AddressPath emission above for the burnt address.
-		burntAddrAcc := &accounts.Account{Balance: newBurntBalance}
-		if burntAcc != nil {
-			burntAddrAcc.Nonce = burntAcc.Nonce
-			burntAddrAcc.Incarnation = burntAcc.Incarnation
-			burntAddrAcc.CodeHash = burntAcc.CodeHash
-		} else {
-			burntAddrAcc.CodeHash = accounts.EmptyCodeHash
-		}
+		burntAddrAcc := feeAddressAccount(burntAcc, newBurntBalance, 0)
 		addWrites.SetAddress(burntAddr, &state.VersionedWrite[*accounts.Account]{
 			WriteHeader: state.WriteHeader{
 				Address: burntAddr,
@@ -2088,6 +2080,15 @@ func (result *execResult) calcFees(
 	}
 
 	return addWrites, nil
+}
+
+// feeAddressAccount builds the AddressPath value for a fee credit from read, the
+// address's pre-credit account. nonce applies only when there is no pre-state.
+func feeAddressAccount(read *accounts.Account, balance uint256.Int, nonce uint64) *accounts.Account {
+	if read == nil {
+		return &accounts.Account{Balance: balance, Nonce: nonce, CodeHash: accounts.EmptyCodeHash}
+	}
+	return &accounts.Account{Balance: balance, Nonce: read.Nonce, Incarnation: read.Incarnation, CodeHash: read.CodeHash}
 }
 
 func (result *execResult) finalizeTx(

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1439,44 +1439,12 @@ func versionedUpdateAddress(vm *VersionMap, addr accounts.Address, txIndex int) 
 	return nil, false
 }
 
-func versionedUpdateBalance(vm *VersionMap, addr accounts.Address, txIndex int) (uint256.Int, bool) {
-	val, res, ok := vm.ReadBalance(addr, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val, true
-	}
-	return uint256.Int{}, false
-}
-
-func versionedUpdateNonce(vm *VersionMap, addr accounts.Address, txIndex int) (uint64, bool) {
-	val, res, ok := vm.ReadNonce(addr, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val, true
-	}
-	return 0, false
-}
-
-func versionedUpdateIncarnation(vm *VersionMap, addr accounts.Address, txIndex int) (uint64, bool) {
-	val, res, ok := vm.ReadIncarnation(addr, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val, true
-	}
-	return 0, false
-}
-
 func versionedUpdateCode(vm *VersionMap, addr accounts.Address, txIndex int) ([]byte, bool) {
 	val, res, ok := vm.ReadCode(addr, txIndex)
 	if ok && res.Status() != MVReadResultNone {
 		return val.Bytes, true
 	}
 	return nil, false
-}
-
-func versionedUpdateCodeHash(vm *VersionMap, addr accounts.Address, txIndex int) (accounts.CodeHash, bool) {
-	val, res, ok := vm.ReadCodeHash(addr, txIndex)
-	if ok && res.Status() != MVReadResultNone {
-		return val, true
-	}
-	return accounts.CodeHash{}, false
 }
 
 func versionedUpdateStorage(vm *VersionMap, addr accounts.Address, key accounts.StorageKey, txIndex int) (uint256.Int, bool) {
@@ -1487,24 +1455,12 @@ func versionedUpdateStorage(vm *VersionMap, addr accounts.Address, key accounts.
 	return uint256.Int{}, false
 }
 
-// applyVersionedUpdates applies updated from the version map to the account before returning it, this is necessary
-// for the account obkect becuase the state reader/.writer api's treat the subfileds as a group and this
-// may lead to updated from pervious transactions being missed where we only update a subset of the fiels as these won't
-// be recored as reads and hence the varification process will miss them.  We don't want to creat a fail but
-// we do  want to capture the updates
+// applyVersionedUpdates overlays the version map's per-field writes onto account.
+// The reader/writer API treats an account's sub-fields as one group, so a prior
+// tx that wrote only a subset would otherwise be lost here — and those fields are
+// not recorded as reads, so validation would not catch the miss either.
 func (vr versionedStateReader) applyVersionedUpdates(address accounts.Address, account accounts.Account) accounts.Account {
-	if update, ok := versionedUpdateBalance(vr.versionMap, address, vr.txIndex); ok {
-		account.Balance = update
-	}
-	if update, ok := versionedUpdateNonce(vr.versionMap, address, vr.txIndex); ok {
-		account.Nonce = update
-	}
-	if update, ok := versionedUpdateIncarnation(vr.versionMap, address, vr.txIndex); ok {
-		account.Incarnation = update
-	}
-	if update, ok := versionedUpdateCodeHash(vr.versionMap, address, vr.txIndex); ok {
-		account.CodeHash = update
-	}
+	vr.versionMap.applySubFieldWrites(address, vr.txIndex, &account)
 	return account
 }
 

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -327,17 +327,8 @@ func readFloor[T any](vm *VersionMap, addr accounts.Address, txIdx int, sel func
 	if !present {
 		return val, res, false
 	}
-	cells := sel(e)
-	if cells == nil {
-		return val, res, false
-	}
-	fk := UnknownDep
-	var fv *WriteCell[T]
-	cells.Descend(txIdx-1, func(k int, v *WriteCell[T]) bool {
-		fk, fv = k, v
-		return false
-	})
-	if fk == UnknownDep || fv == nil {
+	fk, fv := floorCell(sel(e), txIdx)
+	if fv == nil {
 		return val, res, false
 	}
 	res.depIdx = fk
@@ -349,6 +340,53 @@ func readFloor[T any](vm *VersionMap, addr accounts.Address, txIdx int, sel func
 		panic("unknown flag value")
 	}
 	return fv.Value, res, true
+}
+
+// floorCell returns the highest write strictly below txIdx, or (UnknownDep, nil)
+// when the path holds none. Caller must hold vm.mu.RLock().
+func floorCell[T any](cells *btree.Map[int, *WriteCell[T]], txIdx int) (int, *WriteCell[T]) {
+	if cells == nil {
+		return UnknownDep, nil
+	}
+	fk := UnknownDep
+	var fv *WriteCell[T]
+	cells.Descend(txIdx-1, func(k int, v *WriteCell[T]) bool {
+		fk, fv = k, v
+		return false
+	})
+	if fk == UnknownDep {
+		return UnknownDep, nil
+	}
+	return fk, fv
+}
+
+// applySubFieldWrites layers the Balance/Nonce/Incarnation/CodeHash writes for
+// addr onto account, taking one map lookup and one read lock where the per-path
+// ReadX primitives would take one of each. An Estimate cell counts the same as a
+// Done one — it holds the same latest in-block write, which finalize
+// reconstruction must consume rather than fall back to the pre-block DB value.
+func (vm *VersionMap) applySubFieldWrites(addr accounts.Address, txIdx int, account *accounts.Account) {
+	if vm == nil {
+		return
+	}
+	vm.mu.RLock()
+	defer vm.mu.RUnlock()
+	e, present := vm.s[addr]
+	if !present {
+		return
+	}
+	if _, cell := floorCell(e.Balance, txIdx); cell != nil {
+		account.Balance = cell.Value
+	}
+	if _, cell := floorCell(e.Nonce, txIdx); cell != nil {
+		account.Nonce = cell.Value
+	}
+	if _, cell := floorCell(e.Incarnation, txIdx); cell != nil {
+		account.Incarnation = cell.Value
+	}
+	if _, cell := floorCell(e.CodeHash, txIdx); cell != nil {
+		account.CodeHash = cell.Value
+	}
 }
 
 func (vm *VersionMap) ReadAddress(addr accounts.Address, txIdx int) (*accounts.Account, ReadResult, bool) {


### PR DESCRIPTION
Backport of #23053 to `release/3.6`. Not a straight cherry-pick — see adaptations below.

`calcFees` runs once per tx per validation round in the single-threaded apply loop and reads two accounts (coinbase, burnt contract). Every sub-field read bottoms out in `readFloor`, which does a map lookup **plus** `vm.mu.RLock()`. The `versionedUpdate*` helpers read as plain value lookups, so this was easy to miss.

**Before** — per `ReadAccountData`:

```
ReadAccountData
├─ VersionMap.AccountLifecycle → ReadSelfDestruct → readFloor   lookup + RLock
├─ versionedUpdateAddress      → ReadAddress      → readFloor   lookup + RLock
└─ applyVersionedUpdates
   ├─ versionedUpdateBalance     → ReadBalance     → readFloor  lookup + RLock
   ├─ versionedUpdateNonce       → ReadNonce       → readFloor  lookup + RLock
   ├─ versionedUpdateIncarnation → ReadIncarnation → readFloor  lookup + RLock
   └─ versionedUpdateCodeHash    → ReadCodeHash    → readFloor  lookup + RLock
```

**After** — the four `versionedUpdate*` helpers are gone:

```
ReadAccountData
├─ VersionMap.AccountLifecycle → ReadSelfDestruct → readFloor   lookup + RLock
├─ versionedUpdateAddress      → ReadAddress      → readFloor   lookup + RLock
└─ applyVersionedUpdates
   └─ VersionMap.applySubFieldWrites                            lookup + RLock
      └─ floorCell × 4  (Balance / Nonce / Incarnation / CodeHash)
```

6 → 3 lookups and lock pairs per `ReadAccountData`; 12 → 6 per `calcFees`. `floorCell` is the btree descend factored out of `readFloor`, so both share it. Every `ReadAccountData` caller benefits, not just `calcFees`.

Plus: `hasBurnt` folds in `IsLondon && !FeeBurnt.IsZero()` so the second `ReadAccountData` is skipped when no burnt write can result, and the `WriteSet` is allocated only once a write is known to be emitted.

Measured with a local `BenchmarkCalcFees` harness (not part of this PR) against a version map holding 128 prior txs of writes. n1 (Linux, AMD EPYC 4244P), two test binaries run interleaved under `taskset -c 0-7`, n=12:

| bench | release/3.6 | this PR | Δ |
|---|---|---|---|
| CalcFees/preLondon sec/op | 319.7n | 266.0n | **-16.80%** |
| CalcFees/london sec/op | 565.0n | 462.8n | **-18.10%** |
| **geomean sec/op** | 425.0n | 350.9n | **-17.45%** |
| CalcFees/preLondon B/op | 448 | 448 | ~ |
| CalcFees/london B/op | 816 | 816 | ~ |
| CalcFees/preLondon allocs/op | 5 | 5 | ~ |
| CalcFees/london allocs/op | 9 | 9 | ~ |

Allocations unchanged — purely a lookup/lock-count win. No metric regressed.

## r3.6-specific adaptations

`release/3.6` predates the per-account lock split, so `VersionMap` still has a single global `mu sync.RWMutex` over a plain `map[accounts.Address]*AddressEntry`, where `main` has a `sync.Map` plus a per-`AddressEntry` mutex. Only `applySubFieldWrites` differs — six lines:

```go
// main                          // release/3.6 (this PR)
e := vm.load(addr)               vm.mu.RLock()
if e == nil { return }           defer vm.mu.RUnlock()
e.mu.RLock()                     e, present := vm.s[addr]
defer e.mu.RUnlock()             if !present { return }
```

Everything else — `floorCell`, the four helper deletions, all the `calcFees` changes — is identical to #23053. Diff size is the same on both branches (75+/80-, same 3 files).

The measured win is slightly smaller here than on main (-17.45% vs -19.31%) rather than larger as the global lock might suggest: the benchmark is single-threaded, so the global lock is uncontended and costs about what a per-account lock does. Any contention benefit would only show under real parallel execution and is not measured.
