### PR TITLE
all: enable and resolve nilValReturn, evalOrder, returnAfterHttpError, weakCond, and builtinShadowDecl linter checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
         - ruleguard
       disabled-checks:
         - commentFormatting # disabled to avoid unnecessary friction on local lints and CI for minor whitespace changes without functional benefit
-        - nilValReturn
         - evalOrder
         - returnAfterHttpError
         - weakCond

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
         - ruleguard
       disabled-checks:
         - commentFormatting # disabled to avoid unnecessary friction on local lints and CI for minor whitespace changes without functional benefit
-        - weakCond
         - builtinShadowDecl
         - uncheckedInlineErr
         - preferStringWriter

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
         - ruleguard
       disabled-checks:
         - commentFormatting # disabled to avoid unnecessary friction on local lints and CI for minor whitespace changes without functional benefit
-        - builtinShadowDecl
         - uncheckedInlineErr
         - preferStringWriter
         - commentedOutCode

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
         - ruleguard
       disabled-checks:
         - commentFormatting # disabled to avoid unnecessary friction on local lints and CI for minor whitespace changes without functional benefit
-        - returnAfterHttpError
         - weakCond
         - builtinShadowDecl
         - uncheckedInlineErr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
         - ruleguard
       disabled-checks:
         - commentFormatting # disabled to avoid unnecessary friction on local lints and CI for minor whitespace changes without functional benefit
-        - evalOrder
         - returnAfterHttpError
         - weakCond
         - builtinShadowDecl

--- a/cl/persistence/state/state_accessors.go
+++ b/cl/persistence/state/state_accessors.go
@@ -83,7 +83,8 @@ func ReadSlotData(getFn GetValFn, slot uint64, cfg *clparams.BeaconChainConfig) 
 	}
 	buf := bytes.NewBuffer(v)
 
-	return sd, sd.ReadFrom(buf, cfg)
+	err = sd.ReadFrom(buf, cfg)
+	return sd, err
 }
 
 func ReadEpochData(getFn GetValFn, slot uint64, beaconConfig *clparams.BeaconChainConfig) (*EpochData, error) {
@@ -100,7 +101,8 @@ func ReadEpochData(getFn GetValFn, slot uint64, beaconConfig *clparams.BeaconCha
 	}
 	buf := bytes.NewBuffer(v)
 
-	return ed, ed.ReadFrom(buf)
+	err = ed.ReadFrom(buf)
+	return ed, err
 }
 
 // ReadCheckpoints reads the checkpoints from the database, Current, Previous and Finalized

--- a/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
+++ b/cl/phase1/forkchoice/fork_graph/fork_graph_disk.go
@@ -703,7 +703,8 @@ func (f *forkGraphDisk) GetPreviousParticipationIndicies(epoch uint64) (*solid.P
 		return nil, nil
 	}
 	out := solid.NewParticipationBitList(0, int(f.beaconCfg.ValidatorRegistryLimit))
-	return out, out.DecodeSSZ(b, 0)
+	err := out.DecodeSSZ(b, 0)
+	return out, err
 }
 
 func (f *forkGraphDisk) GetCurrentParticipationIndicies(epoch uint64) (*solid.ParticipationBitList, error) {
@@ -721,7 +722,8 @@ func (f *forkGraphDisk) GetCurrentParticipationIndicies(epoch uint64) (*solid.Pa
 		return nil, nil
 	}
 	out := solid.NewParticipationBitList(0, int(f.beaconCfg.ValidatorRegistryLimit))
-	return out, out.DecodeSSZ(b, 0)
+	err := out.DecodeSSZ(b, 0)
+	return out, err
 }
 
 func (f *forkGraphDisk) GetValidatorSet(blockRoot common.Hash) (*solid.ValidatorSet, error) {

--- a/cmd/bumper/internal/tui/tui.go
+++ b/cmd/bumper/internal/tui/tui.go
@@ -413,10 +413,12 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "e":
 			m.edit = cCurrent
-			return m, m.beginEdit()
+			cmd := m.beginEdit()
+			return m, cmd
 		case "m":
 			m.edit = cMin
-			return m, m.beginEdit()
+			cmd := m.beginEdit()
+			return m, cmd
 		case ".":
 			m.bump(minor)
 			return m, nil

--- a/cmd/rpctest/rpctest/bench1.go
+++ b/cmd/rpctest/rpctest/bench1.go
@@ -160,7 +160,7 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 			resultsCh <- res
 			if res.Err != nil {
 				fmt.Printf("Could not trace transaction (Erigon) %s: %v\n", txn.Hash, res.Err)
-				print(client, routes[Erigon], reqGen.debugTraceTransaction(txn.Hash, ""))
+				printRPCRequest(client, routes[Erigon], reqGen.debugTraceTransaction(txn.Hash, ""))
 			}
 
 			if trace.Error != nil {
@@ -172,7 +172,7 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 				res = reqGen.Geth("debug_traceTransaction", reqGen.debugTraceTransaction(txn.Hash, ""), &traceg)
 				resultsCh <- res
 				if res.Err != nil {
-					print(client, routes[Geth], reqGen.debugTraceTransaction(txn.Hash, ""))
+					printRPCRequest(client, routes[Geth], reqGen.debugTraceTransaction(txn.Hash, ""))
 					return fmt.Errorf("Could not trace transaction (geth) %s: %v", txn.Hash, res.Err)
 				}
 				if traceg.Error != nil {
@@ -189,7 +189,7 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 			res = reqGen.Erigon("eth_getTransactionReceipt", reqGen.getTransactionReceipt(txn.Hash), &receipt)
 			resultsCh <- res
 			if res.Err != nil {
-				print(client, routes[Erigon], reqGen.getTransactionReceipt(txn.Hash))
+				printRPCRequest(client, routes[Erigon], reqGen.getTransactionReceipt(txn.Hash))
 				return fmt.Errorf("Count not get receipt (Erigon): %s: %v", txn.Hash, res.Err)
 			}
 			if receipt.Error != nil {
@@ -200,7 +200,7 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 				res = reqGen.Geth("eth_getTransactionReceipt", reqGen.getTransactionReceipt(txn.Hash), &receiptg)
 				resultsCh <- res
 				if res.Err != nil {
-					print(client, routes[Geth], reqGen.getTransactionReceipt(txn.Hash))
+					printRPCRequest(client, routes[Geth], reqGen.getTransactionReceipt(txn.Hash))
 					return fmt.Errorf("Count not get receipt (geth): %s: %v", txn.Hash, res.Err)
 				}
 				if receiptg.Error != nil {
@@ -208,8 +208,8 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 				}
 				if !compareReceipts(&receipt, &receiptg) {
 					fmt.Printf("Different receipts block %d, txn %s\n", bn, txn.Hash)
-					print(client, routes[Geth], reqGen.getTransactionReceipt(txn.Hash))
-					print(client, routes[Erigon], reqGen.getTransactionReceipt(txn.Hash))
+					printRPCRequest(client, routes[Geth], reqGen.getTransactionReceipt(txn.Hash))
+					printRPCRequest(client, routes[Erigon], reqGen.getTransactionReceipt(txn.Hash))
 					return errors.New("Receipts are different")
 				}
 			}

--- a/cmd/rpctest/rpctest/bench3.go
+++ b/cmd/rpctest/rpctest/bench3.go
@@ -92,7 +92,7 @@ func Bench3(erigon_url, geth_url string) error {
 			`
 		var trace EthTxTrace
 		if err := post(client, erigon_url, fmt.Sprintf(template, txhash, req_id), &trace); err != nil {
-			print(client, erigon_url, fmt.Sprintf(template, txhash, req_id))
+			printRPCRequest(client, erigon_url, fmt.Sprintf(template, txhash, req_id))
 			return fmt.Errorf("Could not trace transaction %s: %v\n", txhash, err)
 		}
 		if trace.Error != nil {
@@ -100,13 +100,13 @@ func Bench3(erigon_url, geth_url string) error {
 		}
 		var traceg EthTxTrace
 		if err := post(client, geth_url, fmt.Sprintf(template, txhash, req_id), &traceg); err != nil {
-			print(client, geth_url, fmt.Sprintf(template, txhash, req_id))
+			printRPCRequest(client, geth_url, fmt.Sprintf(template, txhash, req_id))
 			return fmt.Errorf("Could not trace transaction g %s: %v\n", txhash, err)
 		}
 		if traceg.Error != nil {
 			return fmt.Errorf("Error tracing transaction g: %d %s\n", traceg.Error.Code, traceg.Error.Message)
 		}
-		//print(client, erigon_url, fmt.Sprintf(template, txhash, req_id))
+		//printRPCRequest(client, erigon_url, fmt.Sprintf(template, txhash, req_id))
 		if !compareTraces(&trace, &traceg) {
 			return fmt.Errorf("Different traces block %d, txn %s\n", 1720000, txhash)
 		}

--- a/cmd/rpctest/rpctest/bench4.go
+++ b/cmd/rpctest/rpctest/bench4.go
@@ -41,13 +41,13 @@ func Bench4(erigon_url string) error {
 		template = `{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["%s"],"id":%d}`
 		var trace EthTxTrace
 		if err := post(client, erigon_url, fmt.Sprintf(template, txhash, req_id), &trace); err != nil {
-			print(client, erigon_url, fmt.Sprintf(template, txhash, req_id))
+			printRPCRequest(client, erigon_url, fmt.Sprintf(template, txhash, req_id))
 			return fmt.Errorf("Could not trace transaction %s: %v\n", txhash, err)
 		}
 		if trace.Error != nil {
 			fmt.Printf("Error tracing transaction: %d %s\n", trace.Error.Code, trace.Error.Message)
 		}
-		print(client, erigon_url, fmt.Sprintf(template, txhash, req_id))
+		printRPCRequest(client, erigon_url, fmt.Sprintf(template, txhash, req_id))
 	}
 	to := common.HexToAddress("0x8b3b3b624c3c0397d3da8fd861512393d51dcbac")
 	sm := make(map[common.Hash]storageEntry)

--- a/cmd/rpctest/rpctest/bench6.go
+++ b/cmd/rpctest/rpctest/bench6.go
@@ -66,7 +66,7 @@ func Bench6(erigon_url string) error {
 `
 			var receipt EthReceipt
 			if err := post(client, erigon_url, fmt.Sprintf(template, txn.Hash, req_id), &receipt); err != nil {
-				print(client, erigon_url, fmt.Sprintf(template, txn.Hash, req_id))
+				printRPCRequest(client, erigon_url, fmt.Sprintf(template, txn.Hash, req_id))
 				return fmt.Errorf("Count not get receipt: %s: %v\n", txn.Hash, err)
 			}
 			if receipt.Error != nil {

--- a/cmd/rpctest/rpctest/utils.go
+++ b/cmd/rpctest/rpctest/utils.go
@@ -755,7 +755,7 @@ func post2(client *http.Client, url, request string) ([]byte, *fastjson.Value, e
 	return response, v, nil
 }
 
-func print(client *http.Client, url, request string) {
+func printRPCRequest(client *http.Client, url, request string) {
 	r, err := client.Post(url, "application/json", strings.NewReader(request))
 	if err != nil {
 		fmt.Printf("Could not print: %v\n", err)

--- a/db/seg/sais/sais_16.go
+++ b/db/seg/sais/sais_16.go
@@ -56,7 +56,7 @@ func sais_16_32(text []uint16, textMax int, sa, tmp []int32) {
 }
 
 func freq_16_32(text []uint16, freq, bucket []int32) []int32 {
-	if freq != nil && freq[0] >= 0 {
+	if len(freq) > 0 && freq[0] >= 0 {
 		return freq
 	}
 	if freq == nil {

--- a/db/seg/sais/sais_inner.go
+++ b/db/seg/sais/sais_inner.go
@@ -55,7 +55,7 @@ func sais_32(text []int32, textMax int, sa, tmp []int32) {
 }
 
 func freq_32(text []int32, freq, bucket []int32) []int32 {
-	if freq != nil && freq[0] >= 0 {
+	if len(freq) > 0 && freq[0] >= 0 {
 		return freq
 	}
 	if freq == nil {

--- a/execution/abi/bind/backends/simulated.go
+++ b/execution/abi/bind/backends/simulated.go
@@ -696,7 +696,8 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call bind.CallMsg) (
 			}
 			return true, nil, err // Bail out
 		}
-		return res.Failed(), res, nil
+		failed := res.Failed()
+		return failed, res, nil
 	}
 	// Execute the binary search and hone in on an executable gas limit
 	for lo+1 < hi {

--- a/execution/protocol/gaspool.go
+++ b/execution/protocol/gaspool.go
@@ -122,7 +122,7 @@ func (gp *GasPool) ConsumeState(amount uint64) error {
 // stateGas is never consumed, so seeding it has no observable effect there.
 func (gp *GasPool) AddGas(amount uint64) *GasPool {
 	if gp == nil {
-		return gp
+		return nil
 	}
 	gp.mu.Lock()
 	defer gp.mu.Unlock()
@@ -147,7 +147,7 @@ func (gp *GasPool) Gas() uint64 {
 // AddBlobGas extends the blob-gas budget.
 func (gp *GasPool) AddBlobGas(amount uint64) *GasPool {
 	if gp == nil {
-		return gp
+		return nil
 	}
 	gp.mu.Lock()
 	defer gp.mu.Unlock()

--- a/execution/tests/testutil/state_test_util.go
+++ b/execution/tests/testutil/state_test_util.go
@@ -554,7 +554,7 @@ func toMessage(tx stTransaction, ps stPostState, baseFee *uint256.Int) (protocol
 		return nil, fmt.Errorf("invalid txn data %q", dataHex)
 	}
 	var accessList types.AccessList
-	if tx.AccessLists != nil && tx.AccessLists[ps.Indexes.Data] != nil {
+	if len(tx.AccessLists) > ps.Indexes.Data && tx.AccessLists[ps.Indexes.Data] != nil {
 		accessList = *tx.AccessLists[ps.Indexes.Data]
 	}
 

--- a/node/app/workerpool/workerpool_test.go
+++ b/node/app/workerpool/workerpool_test.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/goleak"
 )
 
-const max = 20
+const maxWorkers = 20
 
 func TestExample(t *testing.T) {
 	defer goleak.VerifyNone(t)
@@ -66,18 +66,18 @@ func TestMaxWorkers(t *testing.T) {
 		t.Fatal("should have created one worker")
 	}
 
-	wp = New(max)
+	wp = New(maxWorkers)
 	defer wp.Stop()
 
-	if wp.Size() != max {
+	if wp.Size() != maxWorkers {
 		t.Fatal("wrong size returned")
 	}
 
-	started := make(chan struct{}, max)
+	started := make(chan struct{}, maxWorkers)
 	release := make(chan struct{})
 
 	// Start workers, and have them all wait on a channel before completing.
-	for range max {
+	for range maxWorkers {
 		wp.Submit(func() {
 			started <- struct{}{}
 			<-release
@@ -89,7 +89,7 @@ func TestMaxWorkers(t *testing.T) {
 		t.Fatal("Working Queue size returned should not be 0")
 	}
 	timeout := time.After(5 * time.Second)
-	for startCount := 0; startCount < max; {
+	for startCount := 0; startCount < maxWorkers; {
 		select {
 		case <-started:
 			startCount++
@@ -128,7 +128,7 @@ func TestReuseWorkers(t *testing.T) {
 func TestWorkerTimeout(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	wp := New(max)
+	wp := New(maxWorkers)
 	defer wp.Stop()
 
 	// Start workers, and have them all wait on ctx before completing.
@@ -146,19 +146,19 @@ func TestWorkerTimeout(t *testing.T) {
 	// Release workers.
 	cancel()
 
-	if countReady(wp) != max {
-		t.Fatal("Expected", max, "ready workers")
+	if countReady(wp) != maxWorkers {
+		t.Fatal("Expected", maxWorkers, "ready workers")
 	}
 
 	// Check that a worker timed out.
 	time.Sleep(idleTimeout*2 + idleTimeout/2)
-	if countReady(wp) != max-1 {
+	if countReady(wp) != maxWorkers-1 {
 		t.Fatal("First worker did not timeout")
 	}
 
 	// Check that another worker timed out.
 	time.Sleep(idleTimeout)
-	if countReady(wp) != max-2 {
+	if countReady(wp) != maxWorkers-2 {
 		t.Fatal("Second worker did not timeout")
 	}
 }
@@ -166,7 +166,7 @@ func TestWorkerTimeout(t *testing.T) {
 func TestStop(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	wp := New(max)
+	wp := New(maxWorkers)
 
 	// Start workers, and have them all wait on ctx before completing.
 	ctx, cancel := context.WithCancel(t.Context())
@@ -192,8 +192,8 @@ func TestStop(t *testing.T) {
 	wp = New(5)
 
 	release := make(chan struct{})
-	finished := make(chan struct{}, max)
-	for range max {
+	finished := make(chan struct{}, maxWorkers)
+	for range maxWorkers {
 		wp.Submit(func() {
 			<-release
 			finished <- struct{}{}
@@ -208,7 +208,7 @@ func TestStop(t *testing.T) {
 	wp.Stop()
 	var count int
 Count:
-	for count < max {
+	for count < maxWorkers {
 		select {
 		case <-finished:
 			count++
@@ -230,8 +230,8 @@ func TestStopWait(t *testing.T) {
 	// Start workers, and have them all wait on a channel before completing.
 	wp := New(5)
 	release := make(chan struct{})
-	finished := make(chan struct{}, max)
-	for range max {
+	finished := make(chan struct{}, maxWorkers)
+	for range maxWorkers {
 		wp.Submit(func() {
 			<-release
 			finished <- struct{}{}
@@ -244,7 +244,7 @@ func TestStopWait(t *testing.T) {
 		close(release)
 	}()
 	wp.StopWait()
-	for range max {
+	for range maxWorkers {
 		select {
 		case <-finished:
 		default:
@@ -337,16 +337,16 @@ func TestOverflow(t *testing.T) {
 func TestStopRace(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	wp := New(max)
+	wp := New(maxWorkers)
 	defer wp.Stop()
 
 	workRelChan := make(chan struct{})
 
 	var started sync.WaitGroup
-	started.Add(max)
+	started.Add(maxWorkers)
 
 	// Start workers, and have them all wait on a channel before completing.
-	for range max {
+	for range maxWorkers {
 		wp.Submit(func() {
 			started.Done()
 			<-workRelChan
@@ -641,12 +641,12 @@ func countReady(w *WorkerPool) int {
 		<-release
 	}
 	var readyCount int
-	for i := 0; i < max; i++ {
+	for i := 0; i < maxWorkers; i++ {
 		select {
 		case w.workerQueue <- wait:
 			readyCount++
 		case <-timeout:
-			i = max
+			i = maxWorkers
 		}
 	}
 

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -407,7 +407,8 @@ func doCall(ctx context.Context, caller *transactions.ReusableCaller, gasLimit u
 		}
 		return true, nil, err
 	}
-	return result.Failed(), result, nil
+	failed := result.Failed()
+	return failed, result, nil
 }
 
 type StorageKeysInfo struct {


### PR DESCRIPTION
Enables five `gocritic` linter rules (`nilValReturn`, `evalOrder`, `returnAfterHttpError`, `weakCond`, and `builtinShadowDecl`) in `.golangci.yml` and resolves all code violations across the repository.

1. **`nilValReturn`**
   - **Rule**: Flags returning a named variable containing `nil` instead of returning explicit `nil`. Returning a typed `nil` variable to an `error` or interface return type can create non-nil interface traps.
   - **Changes**: Refactored `AddGas` and `AddBlobGas` in `execution/protocol/gaspool.go` to directly `return nil`.

2. **`evalOrder`**
   - **Rule**: Flags expressions where argument evaluation ordering between side-effects and reads can lead to unspecified or unexpected behavior.
   - **Changes**: Disambiguated argument evaluation order across:
     - `cl/persistence/state/state_accessors.go`
     - `cl/phase1/forkchoice/fork_graph/fork_graph_disk.go`
     - `cmd/bumper/internal/tui/tui.go`
     - `execution/abi/bind/backends/simulated.go`
     - `rpc/jsonrpc/eth_call.go`

3. **`returnAfterHttpError`**
   - **Rule**: Ensures `http.Error` calls are immediately followed by a `return` statement to prevent writing multiple HTTP headers/bodies.
   - **Changes**: Enabled rule in `.golangci.yml` (zero violations present in codebase).

4. **`weakCond`**
   - **Rule**: Detects weak or redundant condition checks that can be written more cleanly or explicitly (such as bounds checking against slice lengths).
   - **Changes**: Refactored condition checks to use explicit length comparisons across:
     - `db/seg/sais/sais_16.go`
     - `db/seg/sais/sais_inner.go`
     - `execution/tests/testutil/state_test_util.go`

5. **`builtinShadowDecl`**
   - **Rule**: Prevents top-level or block declarations from shadowing Go pre-declared built-in identifiers (e.g. `max`, `print`, `len`, `new`).
   - **Changes**:
     - `node/app/workerpool/workerpool_test.go`: Renamed `const max = 20` to `const maxWorkers = 20` and updated test call sites.
     - `cmd/rpctest/rpctest/utils.go`: Renamed `func print(...)` to `func printRPCRequest(...)` and updated call sites across `bench1.go`, `bench3.go`, `bench4.go`, and `bench6.go`.
