### PR TITLE
execution/state: skip the domain read when the tx already found no account

### DIFF
--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -1589,7 +1589,8 @@ func (vr *versionedStateReader) TracePrefix() string {
 }
 
 func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*accounts.Account, error) {
-	if r, ok := vr.reads.GetAddress(address); ok && r.Val != nil && !r.Val.IsNil() {
+	r, recorded := vr.reads.GetAddress(address)
+	if recorded && r.Val != nil && !r.Val.IsNil() {
 		account := r.Val.Account()
 		updated := vr.applyVersionedUpdates(address, *account)
 		return &updated, nil
@@ -1614,7 +1615,9 @@ func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*acco
 		}
 	}
 
-	if vr.stateReader != nil {
+	// A recorded AddressPath read with no account is the tx's own conclusion that
+	// the address holds nothing; the domain cannot say otherwise.
+	if vr.stateReader != nil && !recorded {
 		account, err := vr.stateReader.ReadAccountData(address)
 
 		if err != nil {

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"testing"
@@ -1330,6 +1331,58 @@ func TestVersionedUpdates_EstimateCellConsumed(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok, "Estimate-cell storage must be found")
 	require.Equal(t, newStorage, storageGot, "Estimate-cell storage must be consumed, not stale")
+}
+
+// countingStateReader records how many account reads reached the domain.
+type countingStateReader struct {
+	minimalStateReader
+	acc            *accounts.Account
+	accountReads   int
+	failOnAccounts bool
+}
+
+func (r *countingStateReader) ReadAccountData(addr accounts.Address) (*accounts.Account, error) {
+	r.accountReads++
+	if r.failOnAccounts {
+		return nil, errors.New("domain must not be consulted")
+	}
+	return r.acc, nil
+}
+
+// A tx that read an address and found no account records the AddressPath entry
+// header-only; that entry is the answer, not a gap to fill from the domain.
+func TestVersionedStateReader_RecordedAbsentSkipsDomain(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xab5e17"))
+	reads := ReadSet{}
+	reads.SetAddress(addr, VersionedRead[AccountView]{
+		ReadHeader: ReadHeader{Source: StorageRead, Version: UnknownVersion},
+	})
+
+	reader := &countingStateReader{failOnAccounts: true}
+	vr := NewVersionedStateReader(3, reads, NewVersionMap(nil), reader)
+
+	got, err := vr.ReadAccountData(addr)
+	require.NoError(t, err)
+	require.Nil(t, got)
+	require.Zero(t, reader.accountReads, "recorded-absent read must not reach the domain")
+}
+
+func TestVersionedStateReader_UnrecordedAddressReadsDomain(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xc01d"))
+	domainAcc := accounts.NewAccount()
+	domainAcc.Nonce = 9
+	reader := &countingStateReader{acc: &domainAcc}
+	vr := NewVersionedStateReader(3, ReadSet{}, NewVersionMap(nil), reader)
+
+	got, err := vr.ReadAccountData(addr)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(9), got.Nonce)
+	require.Equal(t, 1, reader.accountReads)
 }
 
 // writeSetFixture builds a WriteSet covering every path, multiple addresses and


### PR DESCRIPTION
When the read set holds no account for an address, `versionedStateReader.ReadAccountData` went to the domain — including when the read set held an AddressPath entry that says there is no account. That entry is an answer, not a gap: `readAccountInternal` records it header-only before the load, and `accountRead` overwrites it with the account as soon as a load finds one, so a header-only entry means the load came back empty.

Implication "read set records the address -> the read returns nil", over `rpc/jsonrpc` + `execution/tests`: **10618/10618**, including the self-destruct / EIP-161 / CREATE2 family.

**Worth nothing on main today**, measured: apply-loop domain account reads through the versioned reader are 7506 with and without, whole `rpc/jsonrpc` suite. `Normalize` still gets the plain domain reader, so only the finalize IBS uses this path and it never asks for a recorded-absent address. Once `Normalize` takes the read-set reader (#23050), the same condition takes those reads 18961 -> 8926 (**-52.9%**).

Divergence not seen in 10618 samples: an account self-destructed by an earlier tx and revived by a balance-only credit writes no AddressPath cell, so the old path returned the pre-SD account where this one falls through to BAL synthesis.

Green: `execution/state`, `execution/stagedsync`, `execution/tests`, `rpc/jsonrpc`.
