### PR TITLE
execution/state: stop re-encoding committed accounts on the apply-loop read

### DIFF
--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -1156,6 +1156,32 @@ func (c *BlockStateCache) DeleteAccount(addr accounts.Address, txNum uint64) {
 	c.mu.Unlock()
 }
 
+// GetCurrentAccountDecoded returns the latest account (including intra-block
+// writes), avoiding GetCurrentAccount's re-encode of the committed entry.
+func (c *BlockStateCache) GetCurrentAccountDecoded(addr accounts.Address) (*accounts.Account, bool, error) {
+	c.mu.RLock()
+	enc, written := c.currentAccounts[addr]
+	c.mu.RUnlock()
+	if written {
+		if enc == nil {
+			return nil, true, nil
+		}
+		acc := new(accounts.Account)
+		if err := accounts.DeserialiseV3(acc, enc); err != nil {
+			return nil, true, err
+		}
+		return acc, true, nil
+	}
+	if acc, ok := c.GetCommittedAccount(addr); ok {
+		if acc == nil {
+			return nil, true, nil
+		}
+		result := *acc
+		return &result, true, nil
+	}
+	return nil, false, nil
+}
+
 // GetCurrentAccount returns the latest account blob (including intra-block writes).
 // Falls back to committed state if no write exists. Returns (nil, false) if not cached.
 func (c *BlockStateCache) GetCurrentAccount(addr accounts.Address) ([]byte, bool) {
@@ -1309,16 +1335,13 @@ func (r *CachedReaderV3) SetBlockStateCache(cache *BlockStateCache) {
 func (r *CachedReaderV3) ReadAccountData(address accounts.Address) (*accounts.Account, error) {
 	if r.blockCache != nil {
 		if r.readCurrent {
-			// Read from write buffer — sees accumulated per-TX writes.
-			if enc, ok := r.blockCache.GetCurrentAccount(address); ok {
-				if enc == nil {
-					return nil, nil
-				}
-				var acc accounts.Account
-				if err := accounts.DeserialiseV3(&acc, enc); err != nil {
-					return nil, err
-				}
-				return &acc, nil
+			// Sees accumulated per-TX writes.
+			acc, ok, err := r.blockCache.GetCurrentAccountDecoded(address)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				return acc, nil
 			}
 		} else {
 			// Read from committed cache — stable pre-block view.

--- a/execution/state/rw_v3_allocs_test.go
+++ b/execution/state/rw_v3_allocs_test.go
@@ -19,9 +19,11 @@ package state
 import (
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
@@ -90,4 +92,100 @@ func TestStateReader_ReadMethods_Allocs(t *testing.T) {
 			require.Equal(t, tc.want, allocs, "%s: alloc count changed", tc.name)
 		})
 	}
+}
+
+func cacheReadTestAccount() *accounts.Account {
+	acc := accounts.NewAccount()
+	acc.Nonce = 42
+	acc.Balance = *uint256.NewInt(1e18)
+	acc.Incarnation = 1
+	acc.CodeHash = accounts.InternCodeHash(crypto.Keccak256Hash([]byte{0x60, 0x00}))
+	return &acc
+}
+
+func TestCachedReaderV3_CurrentReadsCommittedWhenUnwritten(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xc0ffee"))
+	want := cacheReadTestAccount()
+
+	cache := NewBlockStateCache()
+	cache.PutCommittedAccount(addr, want)
+	got, err := NewCurrentCachedReaderV3(nil, cache).ReadAccountData(addr)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, want.Nonce, got.Nonce)
+	require.Equal(t, want.Balance, got.Balance)
+	require.Equal(t, want.Incarnation, got.Incarnation)
+	require.Equal(t, want.CodeHash, got.CodeHash)
+	require.NotSame(t, want, got, "the caller must not be able to mutate the cached account")
+}
+
+// A write this block shadows the committed view, and a nil write means the
+// account was destroyed — neither may fall through to the committed entry.
+func TestCachedReaderV3_CurrentPrefersBlockWrite(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xc0ffee"))
+	cache := NewBlockStateCache()
+	cache.PutCommittedAccount(addr, cacheReadTestAccount())
+
+	written := cacheReadTestAccount()
+	written.Nonce = 43
+	cache.WriteAccount(addr, accounts.SerialiseV3(written), 1)
+	got, err := NewCurrentCachedReaderV3(nil, cache).ReadAccountData(addr)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(43), got.Nonce)
+
+	cache.WriteAccount(addr, nil, 2)
+	got, err = NewCurrentCachedReaderV3(nil, cache).ReadAccountData(addr)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestCachedReaderV3_CurrentReturnsNilForCommittedAbsence(t *testing.T) {
+	t.Parallel()
+
+	addr := accounts.InternAddress(common.HexToAddress("0xdead"))
+	cache := NewBlockStateCache()
+	cache.PutCommittedAccount(addr, nil)
+	got, err := NewCurrentCachedReaderV3(nil, cache).ReadAccountData(addr)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+// BenchmarkCachedReaderAccountRead prices one apply-loop account read that hits
+// the block state cache, on each of its two paths.
+func BenchmarkCachedReaderAccountRead(b *testing.B) {
+	addr := accounts.InternAddress(common.HexToAddress("0xc0ffee"))
+	acc := cacheReadTestAccount()
+
+	b.Run("committed", func(b *testing.B) {
+		cache := NewBlockStateCache()
+		cache.PutCommittedAccount(addr, acc)
+		r := NewCurrentCachedReaderV3(nil, cache)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			got, err := r.ReadAccountData(addr)
+			if err != nil || got == nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("written", func(b *testing.B) {
+		cache := NewBlockStateCache()
+		cache.WriteAccount(addr, accounts.SerialiseV3(acc), 1)
+		r := NewCurrentCachedReaderV3(nil, cache)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			got, err := r.ReadAccountData(addr)
+			if err != nil || got == nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
`CachedReaderV3` with `readCurrent=true` asked `GetCurrentAccount` for an account blob and decoded it. That helper checks the write buffer first, then falls back to `committedAccounts` — which holds accounts **already decoded** — and re-encodes one, purely so the caller can decode it back. `SerialiseV3` allocates, `DeserialiseV3` runs, and both throw away work the cache had done.

`GetCurrentAccountDecoded` serves callers that want an account rather than a blob. `GetCurrentAccount` is unchanged — its three other callers want the blob.

`benchstat` vs current head, n=6:

| | before | after | |
|---|---|---|---|
| committed, sec/op | 63.50n | 24.38n | **-61.6%** |
| committed, B/op | 144 | 96 | -33.3% |
| committed, allocs/op | 2 | 1 | -50% |
| write buffer, sec/op | 39.32n | 39.46n | ~ (p=0.699) |

The committed path is taken 7933 times over the `rpc/jsonrpc` suite, against 1765 for the write-buffer path, so it is the common one: the apply loop mostly reads addresses no transaction has written yet this block.

Equivalent, not just faster: the two paths differed in that `SerialiseV3` carries only Nonce/Balance/CodeHash/Incarnation, so the round trip zeroed `Root` and `PrevIncarnation`. The single filler of `committedAccounts` stores a `DeserialiseV3` result, where both are already zero. The three new tests pass on the current head as well as on this branch, so they pin the equivalence rather than the change.

Green: `execution/state`, `execution/stagedsync`, `execution/tests`, `rpc/jsonrpc`.
