### PR TITLE
db/kv/rawdbv3: fix nil-cursor branch shadowing the cursor in MaxTxNum

### DIFF
--- a/db/kv/rawdbv3/txnum.go
+++ b/db/kv/rawdbv3/txnum.go
@@ -66,7 +66,7 @@ type DefaultTxBlockIndex struct{}
 
 func (d *DefaultTxBlockIndex) MaxTxNum(_ context.Context, tx kv.Tx, c kv.Cursor, blockNum uint64) (maxTxNum uint64, ok bool, err error) {
 	if c == nil {
-		c, err := tx.Cursor(kv.MaxTxNum)
+		c, err = tx.Cursor(kv.MaxTxNum)
 		if err != nil {
 			return 0, false, err
 		}

--- a/db/kv/rawdbv3/txnum_test.go
+++ b/db/kv/rawdbv3/txnum_test.go
@@ -174,3 +174,24 @@ func BenchmarkMapTxNum2BlockNumIter(b *testing.B) {
 		}
 	})
 }
+
+func TestMaxTxNumNilCursor(t *testing.T) {
+	require := require.New(t)
+	dirs := datadir.New(t.TempDir())
+	db := mdbx.New(dbcfg.ChainDB, log.New()).InMem(t, dirs.Chaindata).MustOpen()
+	t.Cleanup(db.Close)
+
+	require.NoError(db.Update(t.Context(), func(tx kv.RwTx) error {
+		require.NoError(TxNums.Append(tx, 0, 3))
+		require.NoError(TxNums.Append(tx, 1, 99))
+		return nil
+	}))
+
+	require.NoError(db.View(t.Context(), func(tx kv.Tx) error {
+		maxTxNum, ok, err := DefaultTxBlockIndexInstance.MaxTxNum(t.Context(), tx, nil, 1)
+		require.NoError(err)
+		require.True(ok)
+		require.Equal(99, int(maxTxNum))
+		return nil
+	}))
+}


### PR DESCRIPTION
`DefaultTxBlockIndex.MaxTxNum` opens a cursor itself when the caller passes nil, but that branch uses `:=`, which declares a new `c` scoped to the `if` block. The outer `c` stays nil, so `c.SeekExact` on the next line dereferences nil.

Nothing in tree passes a nil cursor today, so this does not crash on main. It is reachable though: `MaxWithCursor` and `MinWithCursor` are exported and take a caller-supplied cursor, so the first caller to rely on the documented nil fallback gets a panic instead. `shadow` is disabled in `.golangci.yml`, which is why the linter never flagged it.

## Changes

- `db/kv/rawdbv3`: assign to the outer cursor instead of shadowing it
- regression test calling `MaxTxNum` with a nil cursor
