### PR TITLE
db/snapshotsync, db/integrity, db/snapcfg: caplin snapshot review follow-up

### DIFF
--- a/db/integrity/torrent_verify.go
+++ b/db/integrity/torrent_verify.go
@@ -89,8 +89,7 @@ func VerifyTorrentFiles(ctx context.Context, dir string, failFast bool, logger l
 	var completedBytes atomic.Uint64
 	var completedFiles atomic.Uint64
 
-	parent := ctx
-	g, ctx := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(runtime.GOMAXPROCS(-1) * 4)
 
 	// Progress logging
@@ -99,7 +98,7 @@ func VerifyTorrentFiles(ctx context.Context, dir string, failFast bool, logger l
 	go func() {
 		for {
 			select {
-			case <-ctx.Done():
+			case <-gctx.Done():
 				return
 			case <-logEvery.C:
 				logger.Info("[verify] progress",
@@ -117,14 +116,14 @@ func VerifyTorrentFiles(ctx context.Context, dir string, failFast bool, logger l
 	for _, torrentFile := range toVerify {
 		g.Go(func() error {
 			defer completedFiles.Add(1)
-			err := verifyFileFromTorrent(ctx, torrentFile, &completedBytes)
+			err := verifyFileFromTorrent(gctx, torrentFile, &completedBytes)
 			if err != nil {
 				if failFast {
 					return err
 				}
 				// A cancelled run is a shutdown, not corruption: counting it would
 				// report every in-flight file as a verification failure.
-				if ctx.Err() != nil {
+				if gctx.Err() != nil {
 					return nil
 				}
 				logger.Warn("[verify] file failed", "file", torrentFile, "err", err)
@@ -147,9 +146,9 @@ func VerifyTorrentFiles(ctx context.Context, dir string, failFast bool, logger l
 		verifyErr = fmt.Errorf("%d file(s) failed verification, first: %w", failed, firstFailure)
 	}
 	// Without failFast the workers only warn, so an interrupted run would
-	// otherwise be indistinguishable from a complete one. The errgroup's own
-	// ctx is always cancelled by now, hence the parent.
-	if err := parent.Err(); err != nil {
+	// otherwise be indistinguishable from a complete one. gctx is always
+	// cancelled by now, hence ctx.
+	if err := ctx.Err(); err != nil {
 		return errors.Join(scanErr, verifyErr, err)
 	}
 	if err := errors.Join(scanErr, verifyErr); err != nil {
@@ -165,7 +164,8 @@ func VerifyTorrentFiles(ctx context.Context, dir string, failFast bool, logger l
 // another disk is a supported layout — and the resolved path doubles as the
 // cycle guard. Paths that could not be read are reported through the error
 // together with the files that were reached: they may hide any number of
-// torrents, so the caller verifies what it got and still fails the run.
+// torrents, so the caller verifies what it got and still fails the run. A data
+// file hides nothing, so an unreadable one is left to the caller to report.
 func collectTorrentFiles(ctx context.Context, dir string, logger log.Logger) (files []string, err error) {
 	visited := map[string]struct{}{}
 	var skipped int
@@ -177,8 +177,41 @@ func collectTorrentFiles(ctx context.Context, dir string, logger log.Logger) (fi
 			firstSkipped = fmt.Errorf("%s: %w", path, err)
 		}
 	}
+	isDataFile := func(path string) bool {
+		_, err := os.Lstat(path + ".torrent")
+		return err == nil
+	}
 
 	var walk func(string) error
+
+	visitEntry := func(parentDir string, e fs.DirEntry) error {
+		child := filepath.Join(parentDir, e.Name())
+		isDir := e.IsDir()
+		if e.Type()&fs.ModeSymlink != 0 {
+			info, err := os.Stat(child)
+			if err != nil {
+				if !isDataFile(child) {
+					skip(child, err)
+				}
+				return nil
+			}
+			isDir = info.IsDir()
+		}
+		if isDir {
+			if err := walk(child); err != nil {
+				if ctx.Err() != nil {
+					return err
+				}
+				skip(child, err)
+			}
+			return nil
+		}
+		if strings.HasSuffix(e.Name(), ".torrent") {
+			files = append(files, child)
+		}
+		return nil
+	}
+
 	walk = func(path string) error {
 		resolved, err := filepath.EvalSymlinks(path)
 		if err != nil {
@@ -194,33 +227,13 @@ func collectTorrentFiles(ctx context.Context, dir string, logger log.Logger) (fi
 			return err
 		}
 		for _, e := range entries {
-			child := filepath.Join(resolved, e.Name())
-			isDir := e.IsDir()
-			if e.Type()&fs.ModeSymlink != 0 {
-				info, err := os.Stat(child)
-				if err != nil {
-					skip(child, err)
-					continue
-				}
-				isDir = info.IsDir()
+			if err := visitEntry(resolved, e); err != nil {
+				return err
 			}
-			if isDir {
-				// Cancellation stops the descent, which is where the cost is; entries
-				// already reached stay in the report so the caller still learns what
-				// was wrong with them.
-				if err := ctx.Err(); err != nil {
-					return err
-				}
-				if err := walk(child); err != nil {
-					if ctx.Err() != nil {
-						return err
-					}
-					skip(child, err)
-				}
-				continue
-			}
-			if strings.HasSuffix(e.Name(), ".torrent") {
-				files = append(files, child)
+			// Checked after the entry is accounted for, so a cancelled scan still
+			// reports what was wrong with the entries it reached.
+			if err := ctx.Err(); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/db/integrity/torrent_verify_test.go
+++ b/db/integrity/torrent_verify_test.go
@@ -19,6 +19,7 @@ package integrity
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -170,9 +171,9 @@ func TestVerifyTorrentFilesUnresolvableSubdirFailFast(t *testing.T) {
 	require.ErrorContains(t, err, "hash mismatch")
 }
 
-// A data file that exists but cannot be stat'ed must be accounted for like an
-// unreadable path — skipped and reported — instead of aborting the run before a
-// single piece hash is checked.
+// A data file that exists but cannot be stat'ed must be skipped and reported
+// instead of aborting the run before a single piece hash is checked. It hides no
+// torrents, so it counts once, as a data file — never also as an unreadable path.
 func TestVerifyTorrentFilesUnreadableDataFile(t *testing.T) {
 	dir := t.TempDir()
 	writeTorrentPair(t, dir, "corrupt.seg", true)
@@ -186,7 +187,8 @@ func TestVerifyTorrentFilesUnreadableDataFile(t *testing.T) {
 
 	err := VerifyTorrentFiles(context.Background(), dir, false, log.New())
 	require.Error(t, err)
-	require.ErrorContains(t, err, "unreadable data file(s)")
+	require.ErrorContains(t, err, "1 unreadable data file(s)")
+	require.NotContains(t, err.Error(), "unreadable path(s)")
 	// The reachable file was still verified rather than skipped by the abort.
 	require.ErrorContains(t, err, "1 file(s) failed verification")
 }
@@ -204,6 +206,24 @@ func TestVerifyTorrentFilesCancelledKeepsScanError(t *testing.T) {
 	err := VerifyTorrentFiles(ctx, dir, false, log.New())
 	require.ErrorIs(t, err, context.Canceled)
 	require.ErrorContains(t, err, "1 unreadable path(s)")
+}
+
+// Cancellation must be observed while iterating a directory's own entries, not
+// only when descending into a subdirectory: the flat dirs are the largest ones.
+func TestCollectTorrentFilesCancelledFlatDir(t *testing.T) {
+	dir := t.TempDir()
+	const total = 64
+	for i := range total {
+		name := filepath.Join(dir, fmt.Sprintf("f%02d.seg.torrent", i))
+		require.NoError(t, os.WriteFile(name, nil, 0o644))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	files, err := collectTorrentFiles(ctx, dir, log.New())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, len(files), total)
 }
 
 // A symlink pointing back at an ancestor must not send the scan into unbounded

--- a/db/snapcfg/util.go
+++ b/db/snapcfg/util.go
@@ -130,6 +130,27 @@ func keepNewest(best *btree.Map[string, PreverifiedItem], kept *btree.Map[string
 	kept.Set(key, v)
 }
 
+const maxLoggedDroppedNames = 16
+
+// droppedNames returns the names in all that kept no longer contains, capped at
+// limit, along with the total dropped count.
+func droppedNames(all, kept []PreverifiedItem, limit int) (names []string, dropped int) {
+	keptNames := make(map[string]struct{}, len(kept))
+	for _, item := range kept {
+		keptNames[item.Name] = struct{}{}
+	}
+	for _, item := range all {
+		if _, ok := keptNames[item.Name]; ok {
+			continue
+		}
+		dropped++
+		if len(names) < limit {
+			names = append(names, item.Name)
+		}
+	}
+	return names, dropped
+}
+
 func (p Preverified) Typed(types []snaptype.Type) Preverified {
 	var bestVersions btree.Map[string, PreverifiedItem]
 	var keptVersions btree.Map[string, snaptype.Version]
@@ -246,14 +267,9 @@ func (p Preverified) Typed(types []snaptype.Type) Preverified {
 		return strings.Compare(i.Name, j.Name)
 	})
 	if len(p.Items) != len(versioned) {
-		log.Root().Warn("Preverified list reduced after applying type filter", "from", len(p.Items), "to", len(versioned))
-		// for _, v := range p.Items {
-		// 	if !slices.ContainsFunc(versioned, func(item PreverifiedItem) bool {
-		// 		return item.Name == v.Name
-		// 	}) {
-		// 		log.Root().Warn("Preverified item removed by type filter", "name", v.Name)
-		// 	}
-		// }
+		names, dropped := droppedNames(p.Items, versioned, maxLoggedDroppedNames)
+		log.Root().Warn("Preverified list reduced after applying type filter",
+			"from", len(p.Items), "to", len(versioned), "dropped", dropped, "names", strings.Join(names, ","))
 	} else {
 		log.Root().Debug("Preverified list has same len after applying type filter", "len", len(p.Items))
 	}

--- a/db/snapcfg/util_test.go
+++ b/db/snapcfg/util_test.go
@@ -60,6 +60,35 @@ func TestTypedCaplinDropsUnparseableVersion(t *testing.T) {
 	require.Equal(t, []string{"caplin/v1.1-000000-000100-BlockRoot.seg"}, names)
 }
 
+func TestDroppedNamesReportsUnparseableCaplinEntry(t *testing.T) {
+	items := PreverifiedItems{
+		{Name: "caplin/salt-blocks.txt", Hash: "no-version"},
+		{Name: "caplin/v1.1-000000-000100-BlockRoot.seg", Hash: "in-window"},
+	}
+	typed := Preverified{Items: items}.Typed(snaptype.CaplinSnapshotTypes)
+
+	names, total := droppedNames(items, typed.Items, maxLoggedDroppedNames)
+	require.Equal(t, 1, total)
+	require.Equal(t, []string{"caplin/salt-blocks.txt"}, names)
+}
+
+func TestDroppedNamesCapsEnumeration(t *testing.T) {
+	items := PreverifiedItems{
+		{Name: "caplin/bad1-000000-000100-BlockRoot.seg"},
+		{Name: "caplin/bad2-000000-000100-BlockRoot.seg"},
+		{Name: "caplin/bad3-000000-000100-BlockRoot.seg"},
+		{Name: "caplin/v1.1-000000-000100-BlockRoot.seg"},
+	}
+	typed := Preverified{Items: items}.Typed(snaptype.CaplinSnapshotTypes)
+
+	names, total := droppedNames(items, typed.Items, 2)
+	require.Equal(t, 3, total)
+	require.Equal(t, []string{
+		"caplin/bad1-000000-000100-BlockRoot.seg",
+		"caplin/bad2-000000-000100-BlockRoot.seg",
+	}, names)
+}
+
 // keepNewest is shared by the caplin and the generic branch, and it compares the
 // versions it was given rather than re-deriving them from the stored item's name.
 func TestKeepNewestPrefersHigherVersion(t *testing.T) {

--- a/db/snapshotsync/freezeblocks/caplin_snapshots.go
+++ b/db/snapshotsync/freezeblocks/caplin_snapshots.go
@@ -550,12 +550,5 @@ func (s *CaplinSnapshots) FrozenBlobs() uint64 {
 	if s.beaconCfg.DenebForkEpoch == math.MaxUint64 {
 		return 0
 	}
-	view := s.View()
-	defer view.Close()
-
-	segments := view.BlobSidecars()
-	if len(segments) == 0 {
-		return 0
-	}
-	return segments[len(segments)-1].To()
+	return s.VisibleSegmentsMaxTo(snaptype.BlobSidecars.Enum())
 }

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -511,6 +511,7 @@ type BaseRoSnapshots struct {
 
 	dir               string
 	segmentsMinByType map[snaptype.Enum]*atomic.Uint64 // min block number per segment type
+	dirtyMaxByType    map[snaptype.Enum]*atomic.Uint64 // max height per segment type, indexed or not
 	idxMax            atomic.Uint64                    // all types of .idx files are available - up to this number
 	cfg               ethconfig.BlocksFreezing
 	snCfg             *snapcfg.Cfg
@@ -592,6 +593,7 @@ func newRoSnapshots(cfg ethconfig.BlocksFreezing, snapDir string, types []snapty
 		alignMin:          alignMin,
 		operators:         map[snaptype.Enum]*retireOperators{},
 		segmentsMinByType: make(map[snaptype.Enum]*atomic.Uint64),
+		dirtyMaxByType:    make(map[snaptype.Enum]*atomic.Uint64),
 	}
 	for _, snapType := range types {
 		s.dirty[snapType.Enum()] = btree.NewBTreeGOptions[*DirtySegment](DirtySegmentLess, btree.Options{Degree: 128, NoLocks: false})
@@ -604,6 +606,7 @@ func newRoSnapshots(cfg ethconfig.BlocksFreezing, snapDir string, types []snapty
 		u := &atomic.Uint64{}
 		u.Store(math.MaxUint64)
 		s.segmentsMinByType[t] = u
+		s.dirtyMaxByType[t] = &atomic.Uint64{}
 	}
 
 	s.dirtyLock.Lock()
@@ -654,15 +657,38 @@ func (s *BaseRoSnapshots) VisibleBlocksAvailable(t snaptype.Enum) uint64 {
 // DirtySegmentsMax is the tip of the data on disk, index or no index: unlike
 // DirtyBlocksAvailable it does not stop at the first unindexed segment, so a producer
 // can see a range it has dumped but not yet indexed.
+// DirtySegmentsMax is read per downloaded block, so it serves a value cached by
+// storeDirtyMax rather than walking the dirty set under a lock.
 func (s *BaseRoSnapshots) DirtySegmentsMax(t snaptype.Enum) uint64 {
+	u, ok := s.dirtyMaxByType[t]
+	if !ok {
+		return 0
+	}
+	return u.Load()
+}
+
+// storeDirtyMax refreshes the cache for t. Must be called with dirtyLock held, from the
+// single publish point every dirty mutation funnels through.
+func (s *BaseRoSnapshots) storeDirtyMax(t snaptype.Enum) {
+	u, ok := s.dirtyMaxByType[t]
+	if !ok {
+		return
+	}
+	dirty := s.dirty[t]
+	if dirty == nil {
+		u.Store(0)
+		return
+	}
 	var _max uint64
-	s.WalkDirtySegments(t, func(sn *DirtySegment) bool {
-		if sn.to > 0 && sn.to-1 > _max {
-			_max = sn.to - 1
+	dirty.Walk(func(segments []*DirtySegment) bool {
+		for _, sn := range segments {
+			if sn.to > 0 && sn.to-1 > _max {
+				_max = sn.to - 1
+			}
 		}
 		return true
 	})
-	return _max
+	u.Store(_max)
 }
 
 func (s *BaseRoSnapshots) DownloadComplete() {
@@ -860,6 +886,7 @@ func (s *BaseRoSnapshots) recalcVisibleFiles(alignMin bool, retired retiredSegme
 	maxVisibleBlocks := make([]uint64, 0, len(s.types))
 
 	for _, t := range s.enums {
+		s.storeDirtyMax(t)
 		newVisibleSegments := RecalcVisibleSegments(s.dirty[t])
 		visible[t] = newVisibleSegments
 		var to uint64
@@ -1072,6 +1099,17 @@ func (s *BaseRoSnapshots) visibleIdxAvailability(segtype snaptype.Enum) (maxVisi
 	}
 
 	return
+}
+
+// VisibleSegmentsMaxTo is the exclusive upper bound of the last visible segment of segtype.
+// A generation's segment ranges never change after publish, so this needs no reader pin —
+// which matters for callers on a per-request path, where releasing a pin can take dirtyLock.
+func (s *BaseRoSnapshots) VisibleSegmentsMaxTo(segtype snaptype.Enum) uint64 {
+	visibleFiles := s.visible.Load().segments[segtype]
+	if len(visibleFiles) == 0 {
+		return 0
+	}
+	return visibleFiles[len(visibleFiles)-1].to
 }
 
 func (s *BaseRoSnapshots) Ls() {
@@ -1364,12 +1402,6 @@ func (s *BaseRoSnapshots) detachNotInList(protect []string) retiredSegments {
 		detached = append(detached, toDelete...)
 	}
 	return detached
-}
-
-// CloseSegmentsNotInList closes and drops tree segments whose file name is not
-// in protectFiles.
-func CloseSegmentsNotInList(tree *btree.BTreeG[*DirtySegment], protectFiles map[string]struct{}) {
-	closeAndDropNotProtected(tree, protectFiles, (*DirtySegment).FileName)
 }
 
 func closeAndDropNotProtected(tree *btree.BTreeG[*DirtySegment], protectFiles map[string]struct{}, nameOf func(*DirtySegment) string) {

--- a/db/snapshotsync/snapshots_test.go
+++ b/db/snapshotsync/snapshots_test.go
@@ -1402,6 +1402,26 @@ func TestDirtySegmentsMaxCountsUnindexedTail(t *testing.T) {
 	require.Equal(uint64(30_000-1), s.DirtySegmentsMax(snaptype2.Enums.Headers))
 }
 
+// DirtySegmentsMax is served from a cache, so every path that mutates the dirty set has to
+// refresh it — a stale max would let the archive backfill stop short of history it still needs.
+func TestDirtySegmentsMaxFollowsRetire(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlCrit)
+	dir, require := t.TempDir(), require.New(t)
+	cfg := ethconfig.BlocksFreezing{ChainName: networkname.Mainnet}
+
+	for i := range uint64(3) {
+		createTestSegmentFile(t, i*10_000, (i+1)*10_000, snaptype2.Enums.Headers, dir, version.V1_0, logger)
+	}
+	s := NewBaseRoSnapshots(cfg, dir, []snaptype.Type{snaptype2.Headers}, snaptype2.Headers, false, logger)
+	defer s.Close()
+	require.NoError(s.OpenFolder())
+	require.Equal(uint64(30_000-1), s.DirtySegmentsMax(snaptype2.Enums.Headers))
+
+	tail := snaptype.SegmentFileName(version.V1_0, 20_000, 30_000, snaptype2.Enums.Headers)
+	require.NoError(s.retireFiles(mvcc.RetireReasonMerged, tail))
+	require.Equal(uint64(20_000-1), s.DirtySegmentsMax(snaptype2.Enums.Headers))
+}
+
 // An index builder needs the dumped-but-unindexed segments, which the visible set hides
 // and DirtySegmentsMax only summarizes into one number.
 func TestWalkDirtySegments(t *testing.T) {


### PR DESCRIPTION
Review follow-up to #22944 — items from https://github.com/erigontech/erigon/pull/22944#issuecomment-5212416068. Stacked on it, merge that first.

Two matter:

- `DirtySegmentsMax` walked the dirty btree under a lock on every call, ~1.3k beacon segments on mainnet, and `SegmentsMax` sits in the per-block `SetOnNewBlock` callback. Now a cached atomic per type, refreshed in `recalcVisibleFiles` — the one place every dirty mutation funnels through.
- `FrozenBlobs` took a `View`, so `releaseVisible` → `reclaimRetired` grabbed `dirtyLock`'s write lock on every call. It reads only `VisibleSegment.to`, which nothing mutates after publish, so it now reads the published generation with no lock.

Rest: delete the dead `CloseSegmentsNotInList`, per-entry cancellation in the torrent scan, one label for an unreadable data file, `gctx` naming, and the preverified filter names what it dropped.

Not here: closing the embedding shadow set structurally, which needs the base to stop calling its own `OpenFolder`.

