### PR TITLE
p2p/enode: fix flaky TestFairMixRemoveSource

### DIFF
--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/erigontech/erigon/p2p/enr"
@@ -160,31 +161,36 @@ func TestFairMixEmpty(t *testing.T) {
 
 // This test checks closing a source while Next runs.
 func TestFairMixRemoveSource(t *testing.T) {
-	mix := NewFairMix(1 * time.Second)
-	source := make(blockingIter)
-	mix.AddSource(source)
+	synctest.Test(t, func(t *testing.T) {
+		mix := NewFairMix(1 * time.Second)
+		defer mix.Close()
+		source := make(blockingIter)
+		mix.AddSource(source)
 
-	sig := make(chan *Node)
-	go func() {
-		<-sig
-		mix.Next()
-		sig <- mix.Node()
-	}()
+		sig := make(chan *Node)
+		go func() {
+			mix.Next()
+			sig <- mix.Node()
+		}()
 
-	sig <- nil
-	runtime.Gosched()
-	source.Close()
+		// Pin the interleaving: Next must be parked on the blocking source before it
+		// is closed, and must have dropped it before the replacement is added.
+		// Otherwise Next returns a node without ever deleting the dead source.
+		synctest.Wait()
+		source.Close()
+		synctest.Wait()
 
-	wantNode := testNode(0, 0)
-	mix.AddSource(CycleNodes([]*Node{wantNode}))
-	n := <-sig
+		wantNode := testNode(0, 0)
+		mix.AddSource(CycleNodes([]*Node{wantNode}))
+		n := <-sig
 
-	if len(mix.sources) != 1 {
-		t.Fatalf("have %d sources, want one", len(mix.sources))
-	}
-	if n != wantNode {
-		t.Fatalf("mixer returned wrong node")
-	}
+		if len(mix.sources) != 1 {
+			t.Fatalf("have %d sources, want one", len(mix.sources))
+		}
+		if n != wantNode {
+			t.Fatalf("mixer returned wrong node")
+		}
+	})
 }
 
 type blockingIter chan struct{}


### PR DESCRIPTION
`TestFairMixRemoveSource` fails intermittently with `have 2 sources, want one` (issue #15019). It kicked #23053 out of the merge queue today — the merge-queue `ci-gate` named it as the only root cause.

## Why it flakes

`FairMix.Next` selects on the picked source's channel and on a timer set to the mixer timeout — 1 second in this test. Only the channel arm removes an ended source:

```go
select {
case n, ok := <-source.next:
	if ok { ... return true }
	m.deleteSource(source)   // <- the only path that drops a dead source
case <-timeout:
	source.timeout /= 2
	return m.nextFromAny()   // <- returns a node, drops nothing
}
```

On a loaded CI runner a whole second can pass before `Next` observes the closed source, the timer arm wins, and the dead source stays in the mix.

A second interleaving has the same effect and does not involve the timer at all: if the replacement source is added before `Next` picks anything, `pickSource` returns the replacement (`m.last = (0+1) % 2` = index 1), `Next` returns its node, and the dead source is never visited. `runtime.Gosched()` is a scheduling hint, not a barrier, so nothing ruled either case out.

## Fix

Run the test in a `synctest` bubble and use `synctest.Wait()` as the barrier the test always needed — it returns once every other goroutine in the bubble is durably blocked:

- first `Wait()` — `Next` is parked on the blocking source, so closing it cannot race with the timer;
- second `Wait()` — the closed source has been dropped and `Next` has fallen through to `nextFromAny`, so the replacement cannot be picked first.

`mix.Close()` is now deferred: a bubble requires its goroutines to exit, and the test previously leaked the source goroutines.

Test-only change; `FairMix` itself is untouched. The timeout fallback path keeps its own coverage in `TestFairMixNextFromAll`.

## Verification

Cutting the mixer timeout to `1 * time.Nanosecond` stands in for an arbitrarily slow runner and makes the old failure deterministic:

```
# before, NewFairMix(1 * time.Nanosecond)
go test ./p2p/enode/ -run TestFairMixRemoveSource -count=20
--- FAIL: TestFairMixRemoveSource (0.00s)
    iter_test.go:183: have 2 sources, want one          20/20 fail

# after, same 1ns timeout
go test ./p2p/enode/ -run TestFairMixRemoveSource -count=500
ok  	github.com/erigontech/erigon/p2p/enode	0.478s     500/500 pass
```

At the real 1s timeout: `-count=500` green, `go test -race ./p2p/enode/ -count=3` green, `-run TestFairMix -count=100` green.

Closes #15019.
