### PR TITLE
db/datastruct/btindex: skip EliasFano lookup on sequential cursor scan

### DIFF
--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -72,12 +72,15 @@ type Cursor struct {
 	value      []byte
 	d          uint64
 
-	// knownOffset is the offset of pair knownD, learned while reading the pair before
-	// it: pairs sit back to back in the .kv file, so reading one reveals where the next
-	// starts. Forward iteration then needs no EliasFano lookup. The zero value is valid
-	// - pair 0 always starts at offset 0.
-	knownD, knownOffset uint64
+	// known caches where one pair starts, learned while reading the pair before it:
+	// pairs sit back to back in the .kv file. Reading known.d then needs no EliasFano
+	// lookup. It stays a true fact about the file, so nothing has to invalidate it - a
+	// cursor reset elsewhere just fails the match and falls back to the lookup.
+	known pairStart
 }
+
+// pairStart is the offset at which pair d begins.
+type pairStart struct{ d, offset uint64 }
 
 func (c *Cursor) Close() {
 	if c == nil {
@@ -170,8 +173,8 @@ func (c *Cursor) readKV() error {
 		return errors.New("getter is nil")
 	}
 
-	offset := c.knownOffset
-	if c.knownD != c.d {
+	offset := c.known.offset
+	if c.known.d != c.d {
 		offset = c.ef.Get(c.d)
 	}
 	c.getter.Reset(offset)
@@ -182,8 +185,8 @@ func (c *Cursor) readKV() error {
 	if !c.getter.HasNext() {
 		return fmt.Errorf("pair %d/%d val not found, file: %s/%s", c.d, c.ef.Count(), c.getter.FileName(), c.getter.FileName())
 	}
-	c.value, c.knownOffset = c.getter.Next(nil) // if value is not compressed, we getting ptr to slice from mmap, may need to copy
-	c.knownD = c.d + 1
+	c.value, c.known.offset = c.getter.Next(nil) // if value is not compressed, we getting ptr to slice from mmap, may need to copy
+	c.known.d = c.d + 1
 	return nil
 }
 

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -71,6 +71,12 @@ type Cursor struct {
 	key        []byte
 	value      []byte
 	d          uint64
+
+	// knownOffset is the offset of pair knownD, learned while reading the pair before
+	// it: pairs sit back to back in the .kv file, so reading one reveals where the next
+	// starts. Forward iteration then needs no EliasFano lookup. The zero value is valid
+	// - pair 0 always starts at offset 0.
+	knownD, knownOffset uint64
 }
 
 func (c *Cursor) Close() {
@@ -164,7 +170,10 @@ func (c *Cursor) readKV() error {
 		return errors.New("getter is nil")
 	}
 
-	offset := c.ef.Get(c.d)
+	offset := c.knownOffset
+	if c.knownD != c.d {
+		offset = c.ef.Get(c.d)
+	}
 	c.getter.Reset(offset)
 	if !c.getter.HasNext() {
 		return fmt.Errorf("pair %d/%d key not found, file: %s/%s", c.d, c.ef.Count(), c.getter.FileName(), c.getter.FileName())
@@ -173,7 +182,8 @@ func (c *Cursor) readKV() error {
 	if !c.getter.HasNext() {
 		return fmt.Errorf("pair %d/%d val not found, file: %s/%s", c.d, c.ef.Count(), c.getter.FileName(), c.getter.FileName())
 	}
-	c.value, _ = c.getter.Next(nil) // if value is not compressed, we getting ptr to slice from mmap, may need to copy
+	c.value, c.knownOffset = c.getter.Next(nil) // if value is not compressed, we getting ptr to slice from mmap, may need to copy
+	c.knownD = c.d + 1
 	return nil
 }
 

--- a/db/datastruct/btindex/btree_index_scan_test.go
+++ b/db/datastruct/btindex/btree_index_scan_test.go
@@ -1,0 +1,110 @@
+package btindex
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/seg"
+)
+
+func openScanFixture(tb testing.TB, keyCount int, compressed seg.FileCompression) (*seg.Decompressor, *BtIndex) {
+	tb.Helper()
+	tmp := tb.TempDir()
+	logger := log.New()
+
+	dataPath := generateKV(tb, tmp, 52, 120, keyCount, logger, compressed)
+	indexPath := filepath.Join(tmp, filepath.Base(dataPath)+".bt")
+	buildBtreeIndex(tb, dataPath, indexPath, compressed, 1, logger, true)
+
+	kv, bt, err := OpenBtreeIndexAndDataFile(indexPath, dataPath, compressed, false)
+	require.NoError(tb, err)
+	tb.Cleanup(bt.Close)
+	tb.Cleanup(kv.Close)
+	return kv, bt
+}
+
+// TestCursor_ScanMatchesOrdinalLookup pins the forward-scan fast path: walking the
+// index with Next must yield exactly what an EliasFano lookup of each pair yields.
+func TestCursor_ScanMatchesOrdinalLookup(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		compressed seg.FileCompression
+	}{
+		{name: "uncompressed", compressed: seg.CompressNone},
+		{name: "compressed_keys", compressed: seg.CompressKeys},
+		{name: "compressed_kv", compressed: seg.CompressKeys | seg.CompressVals},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			const keyCount = 1000
+			kv, bt := openScanFixture(t, keyCount, tc.compressed)
+			getter := seg.NewReader(kv.MakeGetter(), tc.compressed)
+
+			cur, err := bt.Seek(getter, nil)
+			require.NoError(t, err)
+			defer cur.Close()
+
+			refGetter := seg.NewReader(kv.MakeGetter(), tc.compressed)
+			for di := range uint64(keyCount) {
+				wantK, wantV, _, err := bt.dataLookup(di, refGetter)
+				require.NoError(t, err)
+				require.Equalf(t, wantK, cur.Key(), "key at %d", di)
+				require.Equalf(t, wantV, cur.Value(), "value at %d", di)
+				require.Equal(t, di+1 < keyCount, cur.Next(), "Next at %d", di)
+			}
+		})
+	}
+}
+
+func BenchmarkCursorScan(b *testing.B) {
+	const keyCount = 100_000
+	kv, bt := openScanFixture(b, keyCount, seg.CompressKeys)
+	getter := seg.NewReader(kv.MakeGetter(), seg.CompressKeys)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		cur, err := bt.Seek(getter, nil)
+		require.NoError(b, err)
+		n := 1
+		for cur.Next() {
+			n++
+		}
+		require.Equal(b, keyCount, n)
+		cur.Close()
+	}
+}
+
+// TestCursor_ScanAfterSeek pins the same for a scan that starts in the middle, and
+// for a cursor taken from the pool after an earlier scan.
+func TestCursor_ScanAfterSeek(t *testing.T) {
+	t.Parallel()
+
+	const keyCount = 1000
+	compressed := seg.CompressKeys
+	kv, bt := openScanFixture(t, keyCount, compressed)
+	getter := seg.NewReader(kv.MakeGetter(), compressed)
+	refGetter := seg.NewReader(kv.MakeGetter(), compressed)
+
+	keys := make([][]byte, keyCount)
+	for di := range uint64(keyCount) {
+		k, _, _, err := bt.dataLookup(di, refGetter)
+		require.NoError(t, err)
+		keys[di] = append([]byte(nil), k...)
+	}
+
+	for _, from := range []int{0, 1, keyCount / 2, keyCount - 2} {
+		cur, err := bt.Seek(getter, keys[from])
+		require.NoError(t, err)
+		for di := from; di < keyCount; di++ {
+			require.Equalf(t, keys[di], cur.Key(), "from %d, key at %d", from, di)
+			require.Equal(t, di+1 < keyCount, cur.Next())
+		}
+		cur.Close() // back to the pool: the next Seek must not trust stale offsets
+	}
+}

--- a/db/datastruct/btindex/btree_index_scan_test.go
+++ b/db/datastruct/btindex/btree_index_scan_test.go
@@ -61,6 +61,40 @@ func TestCursor_ScanMatchesOrdinalLookup(t *testing.T) {
 	}
 }
 
+// TestCursor_ScanWithSharedGetter pins why the cursor re-anchors the getter on every
+// read instead of assuming it is still where the previous read left it: one getter is
+// shared per file (DomainRoTx.reusableReader), so a point lookup - or anything an
+// IteratePrefix callback does - can reposition it between two Next calls.
+func TestCursor_ScanWithSharedGetter(t *testing.T) {
+	t.Parallel()
+
+	const keyCount = 1000
+	compressed := seg.CompressKeys
+	kv, bt := openScanFixture(t, keyCount, compressed)
+	getter := seg.NewReader(kv.MakeGetter(), compressed)
+	refGetter := seg.NewReader(kv.MakeGetter(), compressed)
+
+	keys := make([][]byte, keyCount)
+	for di := range uint64(keyCount) {
+		k, _, _, err := bt.dataLookup(di, refGetter)
+		require.NoError(t, err)
+		keys[di] = append([]byte(nil), k...)
+	}
+
+	cur, err := bt.Seek(getter, nil)
+	require.NoError(t, err)
+	defer cur.Close()
+	for di := range keyCount {
+		require.Equalf(t, keys[di], cur.Key(), "key at %d", di)
+
+		_, _, _, found, err := bt.Get(keys[(di*7+3)%keyCount], getter) // moves the shared getter
+		require.NoError(t, err)
+		require.True(t, found)
+
+		require.Equal(t, di+1 < keyCount, cur.Next(), "Next at %d", di)
+	}
+}
+
 func BenchmarkCursorScan(b *testing.B) {
 	const keyCount = 100_000
 	kv, bt := openScanFixture(b, keyCount, seg.CompressKeys)


### PR DESCRIPTION
`btindex.Cursor.readKV` asked EliasFano for the pair offset on every step. But `.kv` pairs are written back to back, and `Getter.Next` already returns the offset just past the value it read - which is exactly where the next pair starts. Cache it and reuse it when the cursor moves forward by one.

The cached `(index, offset)` stays a true fact about the file, so a cursor returning from the pool or reset elsewhere needs no invalidation - the cache is consulted only when the cached index matches the requested one.

The getter is still re-anchored on every read. One `seg.Reader` is shared per file (`DomainRoTx.reusableReader`), so a point lookup - or anything an `IteratePrefix` callback does - can move it between two `Next` calls; `TestCursor_ScanWithSharedGetter` pins that.

Sequential scan of one 100k-key `.bt` index:

```
go test ./db/datastruct/btindex/ -run XXX -bench BenchmarkCursorScan -benchtime 40x -count 20
```

```
              │    main     │                 PR                  │
              │   sec/op    │   sec/op     vs base                │
CursorScan-16   6.386m ± 2%   5.457m ± 1%  -14.55% (p=0.000 n=20)
```

The win is larger when several files are scanned at once, because the EF structures then compete for cache. Measured on a follow-up branch that benchmarks `IteratePrefix` over one account's storage (10k slots) in 5 `.kv` files:

```
                                      │    main     │                 PR                 │
                                      │   sec/op    │   sec/op     vs base               │
DomainIteratePrefix_5files-16           5.083m ± 2%   3.976m ± 1%  -21.77% (p=0.002 n=6)
DomainIteratePrefix_5files_1dbStep-16   6.616m ± 5%   5.423m ± 0%  -18.03% (p=0.002 n=6)
```
