### PR TITLE
ci: cache Kurtosis helper images

### DIFF
--- a/.github/workflows/cache-warming-kurtosis-cl-images.yml
+++ b/.github/workflows/cache-warming-kurtosis-cl-images.yml
@@ -13,9 +13,9 @@ name: Cache Warming — Kurtosis CL images
 #   - schedule (daily) -> safety net if LRU-evicted
 #   - workflow_dispatch -> manual (use once to bootstrap)
 #
-# The cache key is derived from the pinned image versions: the kurtosis-infra and
-# eth2-val-tools tags in test-kurtosis-assertoor.yml plus the CL / assertoor tags it
-# reads from the kurtosis .io files — hence the paths filter covers both.
+# The cache key is derived from the pinned third-party tags in
+# test-kurtosis-assertoor.yml plus the CL / assertoor tags it reads from the
+# kurtosis .io files — hence the paths filter covers both.
 
 on:
   push:

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -33,10 +33,11 @@ env:
   BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
   # eth2-val-tools is the validator-keystore generator pulled during `kurtosis run`;
   # it publishes only :latest, so the cache serves the `latest` digest from the last
-  # warm rather than tracking live `latest`. (genesis-generator is pulled live: its
-  # version is the ethereum-package default, which varies per ethereum_package_branch,
-  # so it isn't cached here.)
+  # warm rather than tracking live `latest`.
   ETH2_VAL_TOOLS_IMAGE: "protolambda/eth2-val-tools:latest"
+  GENESIS_GENERATOR_IMAGE: "ethpandaops/ethereum-genesis-generator:4.0.4"
+  CAPLIN_GENESIS_GENERATOR_IMAGE: "ethpandaops/ethereum-genesis-generator:3.3.7"
+  KURTOSIS_PYTHON_IMAGE: "python:3.11-alpine"
 
 on:
   workflow_dispatch:
@@ -228,7 +229,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
           lookup-only: true
 
       - name: Pull third-party containers
@@ -258,6 +259,9 @@ jobs:
           pull "${KURTOSIS_TRAEFIK_IMAGE}"
           pull "${KURTOSIS_ALPINE_IMAGE}"
           pull "${ETH2_VAL_TOOLS_IMAGE}"
+          pull "${GENESIS_GENERATOR_IMAGE}"
+          pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
+          pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
           docker save "${TEKU_IMAGE}" -o /tmp/docker-cache/teku.tar
@@ -273,13 +277,16 @@ jobs:
           docker save "${KURTOSIS_TRAEFIK_IMAGE}" -o /tmp/docker-cache/traefik.tar
           docker save "${KURTOSIS_ALPINE_IMAGE}" -o /tmp/docker-cache/alpine.tar
           docker save "${ETH2_VAL_TOOLS_IMAGE}" -o /tmp/docker-cache/eth2-val-tools.tar
+          docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
+          docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
+          docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Save third-party containers to cache
         if: steps.cache-cl-images.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
 
       - name: Check whether buildkit image is already cached
         id: cache-buildkit-image
@@ -435,7 +442,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /tmp/docker-cache
-          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}
+          key: docker-cl-${{ env.LIGHTHOUSE_IMAGE }}-${{ env.LIGHTHOUSE_VC_IMAGE }}-${{ env.TEKU_IMAGE }}-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}-${{ env.ASSERTOOR_PECTRA_IMAGE }}-${{ env.ASSERTOOR_GLAMSTERDAM_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.CAPLIN_GENESIS_GENERATOR_IMAGE }}-${{ env.KURTOSIS_PYTHON_IMAGE }}
 
       - name: Load cached containers into daemon
         if: steps.cache-cl-images.outputs.cache-hit == 'true'
@@ -455,6 +462,9 @@ jobs:
           docker load -i /tmp/docker-cache/traefik.tar
           docker load -i /tmp/docker-cache/alpine.tar
           docker load -i /tmp/docker-cache/eth2-val-tools.tar
+          docker load -i /tmp/docker-cache/genesis-generator.tar
+          docker load -i /tmp/docker-cache/caplin-genesis-generator.tar
+          docker load -i /tmp/docker-cache/python.tar
 
       - name: Pull third-party containers and save to cache
         if: steps.cache-cl-images.outputs.cache-hit != 'true'
@@ -483,6 +493,9 @@ jobs:
           pull "${KURTOSIS_TRAEFIK_IMAGE}"
           pull "${KURTOSIS_ALPINE_IMAGE}"
           pull "${ETH2_VAL_TOOLS_IMAGE}"
+          pull "${GENESIS_GENERATOR_IMAGE}"
+          pull "${CAPLIN_GENESIS_GENERATOR_IMAGE}"
+          pull "${KURTOSIS_PYTHON_IMAGE}"
           docker save "${LIGHTHOUSE_IMAGE}" -o /tmp/docker-cache/lighthouse.tar
           docker save "${LIGHTHOUSE_VC_IMAGE}" -o /tmp/docker-cache/lighthouse-vc.tar
           docker save "${TEKU_IMAGE}" -o /tmp/docker-cache/teku.tar
@@ -498,6 +511,9 @@ jobs:
           docker save "${KURTOSIS_TRAEFIK_IMAGE}" -o /tmp/docker-cache/traefik.tar
           docker save "${KURTOSIS_ALPINE_IMAGE}" -o /tmp/docker-cache/alpine.tar
           docker save "${ETH2_VAL_TOOLS_IMAGE}" -o /tmp/docker-cache/eth2-val-tools.tar
+          docker save "${GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/genesis-generator.tar
+          docker save "${CAPLIN_GENESIS_GENERATOR_IMAGE}" -o /tmp/docker-cache/caplin-genesis-generator.tar
+          docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Install Kurtosis CLI and start engine
         # The engine otherwise bootstraps inside `kurtosis run`, mid-action,
@@ -506,7 +522,7 @@ jobs:
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt-get update
-          sudo apt-get install -y kurtosis-cli=${KURTOSIS_VERSION}
+          sudo apt-get install -y "kurtosis-cli=${KURTOSIS_VERSION}"
           kurtosis analytics disable
           for n in 1 2 3; do
             if kurtosis engine start; then exit 0; fi


### PR DESCRIPTION
for https://github.com/erigontech/erigon/issues/22377#issuecomment-5207151274

## Summary

- cache the Ethereum genesis generator used by the regular and Pectra Kurtosis suites
- cache the Caplin genesis generator and Kurtosis Python helper image
- include the new image tags in the existing cache key and warm/load paths

## Why

Kurtosis CI can fail during otherwise healthy runs when Docker Hub times out while pulling package helper images. The existing third-party cache covered the clients and Kurtosis infrastructure but omitted these helper images. This change extends that cache without changing its structure or retry behavior.

## Validation

- `actionlint .github/workflows/test-kurtosis-assertoor.yml .github/workflows/cache-warming-kurtosis-cl-images.yml`
- parsed both workflows with `yq`
- `git diff --check`
- `make erigon integration`
- `make lint`: fast pass clean; full scan stops on the pre-existing `node/gdbme/gdbme_darwin.go:103` gocritic finding, which is unchanged from `main`
