### PR TITLE
[r3.6] execution/stagedsync: hand the trace sets to the apply result instead of copying

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -2920,8 +2919,8 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 			applyResult := txResult{
 				blockNum:              be.blockNum,
 				blockHash:             be.blockHash,
-				traceFroms:            map[accounts.Address]struct{}{},
-				traceTos:              map[accounts.Address]struct{}{},
+				traceFroms:            result.TraceFroms,
+				traceTos:              result.TraceTos,
 				txNum:                 task.Version().TxNum,
 				rules:                 task.Rules(),
 				cumulativeBlobGasUsed: result.cumulativeBlobGasUsed,
@@ -2948,8 +2947,6 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				pe.executedGas.Add(int64(applyResult.blockGasUsed))
 			}
 
-			maps.Copy(applyResult.traceFroms, result.TraceFroms)
-			maps.Copy(applyResult.traceTos, result.TraceTos)
 			be.cntFinalized++
 			be.publishTasks.markComplete(tx)
 


### PR DESCRIPTION
Cherry-pick of #23092 to release/3.6. Applied cleanly.

Every premise the change rests on was re-checked against this branch rather than assumed from main:

- `Worker` has no `CallTracer` field; the tracer is a local in `RunTxTaskNoLock` built per transaction (`execution/exec/state.go:533`), handing its maps to the result at 561-562.
- `TxResult` is not pooled — the only `sync.Pool` in `txtask.go` is `queuePool`.
- `applyLogsAndTraces4` only ranges over the two maps.
- `finalizedResults[tx-1]` is read again at 2747, but only for `.Receipt`.
- The block-end result at 3131 already assigns the maps directly.

Green: `execution/stagedsync`, `execution/tests`, `rpc/jsonrpc`.
