### PR TITLE
execution: block read aheader to return blocks with bals

### DIFF
--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -29,6 +29,7 @@ type BlockReadAheader struct {
 	headers *lru.Cache[common.Hash, *types.Header]
 	bodies  *lru.Cache[common.Hash, *types.Body]
 	senders *lru.Cache[common.Hash, []byte] // just do raw senders
+	bals    *lru.Cache[common.Hash, []byte]
 
 	// this is for warming state
 	warming atomic.Bool // only one warmBody can run at a time
@@ -56,10 +57,15 @@ func NewBlockReadAheader() *BlockReadAheader {
 	if err != nil {
 		panic(err)
 	}
+	bals, err := lru.New[common.Hash, []byte](4)
+	if err != nil {
+		panic(err)
+	}
 	return &BlockReadAheader{
 		headers: headers,
 		bodies:  bodies,
 		senders: senders,
+		bals:    bals,
 	}
 }
 
@@ -137,6 +143,13 @@ func (bra *BlockReadAheader) AddSenders(senders []byte, blockHash common.Hash) {
 		return
 	}
 	bra.senders.Add(blockHash, bytes.Clone(senders))
+}
+
+func (bra *BlockReadAheader) AddBlockAccessList(bal []byte, blockHash common.Hash) {
+	if len(bal) == 0 {
+		return
+	}
+	bra.bals.Add(blockHash, bal)
 }
 
 // warmBody warms state for all transactions in a body using multiple workers.
@@ -330,7 +343,8 @@ func (bra *BlockReadAheader) ReadBlockWithSenders(blockHash common.Hash) (*types
 		sendersAddresses = append(sendersAddresses, common.BytesToAddress(senders[i:i+length.Addr]))
 	}
 	body.SendersToTxs(sendersAddresses)
-	return types.NewBlockFromStorage(header.Hash(), header, body.Transactions, body.Uncles, body.Withdrawals, nil), true
+	bal, _ := bra.bals.Get(blockHash)
+	return types.NewBlockFromStorage(header.Hash(), header, body.Transactions, body.Uncles, body.Withdrawals, bal), true
 }
 
 func BlocksReadAhead(ctx context.Context, workers int, db kv.RoDB, engine rules.Engine, blockReader dbservices.FullBlockReader) (chan uint64, context.CancelFunc) {

--- a/execution/exec/blocks_read_ahead.go
+++ b/execution/exec/blocks_read_ahead.go
@@ -145,7 +145,7 @@ func (bra *BlockReadAheader) AddSenders(senders []byte, blockHash common.Hash) {
 	bra.senders.Add(blockHash, bytes.Clone(senders))
 }
 
-func (bra *BlockReadAheader) AddBlockAccessList(bal []byte, blockHash common.Hash) {
+func (bra *BlockReadAheader) AddBlockAccessList(blockHash common.Hash, bal []byte) {
 	if len(bal) == 0 {
 		return
 	}

--- a/execution/exec/blocks_read_ahead_test.go
+++ b/execution/exec/blocks_read_ahead_test.go
@@ -17,6 +17,7 @@
 package exec
 
 import (
+	"context"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -59,8 +60,8 @@ func TestBlockReadAheaderCarriesBlockAccessList(t *testing.T) {
 	blockHash := header.Hash()
 	bal := []byte{0xc0}
 	sender := common.Address{1}
-	bra.AddHeaderAndBody(nil, nil, header, body)
-	bra.AddBlockAccessList(bal, blockHash)
+	bra.AddHeaderAndBody(context.Background(), nil, header, body)
+	bra.AddBlockAccessList(blockHash, bal)
 	bra.AddSenders(sender[:], blockHash)
 	block, ok := bra.ReadBlockWithSenders(blockHash)
 	require.True(t, ok)

--- a/execution/exec/blocks_read_ahead_test.go
+++ b/execution/exec/blocks_read_ahead_test.go
@@ -20,11 +20,14 @@ import (
 	"testing"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/cache"
+	"github.com/erigontech/erigon/execution/types"
 )
 
 // stubTemporalGetter stands in for the committed-state read view a warmup
@@ -47,6 +50,21 @@ func (s stubTemporalGetter) StepsInFiles(...kv.Domain) kv.Step { return 0 }
 func newTestStateCache() *cache.StateCache {
 	b := 1 * datasize.MB
 	return cache.NewStateCache(b, b, b, b)
+}
+
+func TestBlockReadAheaderCarriesBlockAccessList(t *testing.T) {
+	bra := NewBlockReadAheader()
+	header := &types.Header{Number: *uint256.NewInt(1)}
+	body := &types.Body{Transactions: []types.Transaction{types.NewTransaction(0, common.Address{}, new(uint256.Int), 0, new(uint256.Int), nil)}}
+	blockHash := header.Hash()
+	bal := []byte{0xc0}
+	sender := common.Address{1}
+	bra.AddHeaderAndBody(nil, nil, header, body)
+	bra.AddBlockAccessList(bal, blockHash)
+	bra.AddSenders(sender[:], blockHash)
+	block, ok := bra.ReadBlockWithSenders(blockHash)
+	require.True(t, ok)
+	require.Equal(t, bal, block.BlockAccessList())
 }
 
 // seedFill places an entry with an exact txNum stamp through the public fill

--- a/execution/execmodule/inserters.go
+++ b/execution/execmodule/inserters.go
@@ -128,30 +128,30 @@ func (e *ExecModule) InsertBlocks(ctx context.Context, blocks []*types.Block) (E
 		metrics.UpdateBlockConsumerBodyDownloadDelay(header.Time, height, e.logger)
 
 		// Sum TDs.
-		hash := header.Hash()
+		blockHash := header.Hash()
 		var td uint256.Int
 		if _, overflow := td.AddOverflow(parentTd, &header.Difficulty); overflow {
-			return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: TD overflows uint256 at height %d hash %x", height, hash)
+			return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: TD overflows uint256 at height %d hash %x", height, blockHash)
 		}
 		if err := rawdb.WriteHeader(blockOverlay, header); err != nil {
 			return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: writeHeader: %s", err)
 		}
-		if err := rawdb.WriteTd(blockOverlay, hash, height, td); err != nil {
+		if err := rawdb.WriteTd(blockOverlay, blockHash, height, td); err != nil {
 			return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: writeTd: %s", err)
 		}
-		if _, err := rawdb.WriteRawBodyIfNotExists(blockOverlay, hash, height, body); err != nil {
+		if _, err := rawdb.WriteRawBodyIfNotExists(blockOverlay, blockHash, height, body); err != nil {
 			return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: writeBody: %s", err)
 		}
 		if blockAccessList := block.BlockAccessList(); len(blockAccessList) > 0 {
 			if header.BlockAccessListHash == nil {
 				return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: block access list provided without hash for block %d", height)
 			}
-			if err := rawdb.WriteBlockAccessListBytes(blockOverlay, hash, height, blockAccessList); err != nil {
+			if err := rawdb.WriteBlockAccessListBytes(blockOverlay, blockHash, height, blockAccessList); err != nil {
 				return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: writeBlockAccessList, block %d: %s", height, err)
 			}
-			e.readAheader.AddBlockAccessList(blockAccessList, hash)
+			e.readAheader.AddBlockAccessList(blockHash, blockAccessList)
 		}
-		e.logger.Trace("Inserted block", "hash", hash, "number", header.Number)
+		e.logger.Trace("Inserted block", "hash", blockHash, "number", header.Number)
 	}
 
 	// On ChainTip - store blocks in Overlay

--- a/execution/execmodule/inserters.go
+++ b/execution/execmodule/inserters.go
@@ -149,6 +149,7 @@ func (e *ExecModule) InsertBlocks(ctx context.Context, blocks []*types.Block) (E
 			if err := rawdb.WriteBlockAccessListBytes(blockOverlay, hash, height, blockAccessList); err != nil {
 				return 0, fmt.Errorf("ethereumExecutionModule.InsertBlocks: writeBlockAccessList, block %d: %s", height, err)
 			}
+			e.readAheader.AddBlockAccessList(blockAccessList, hash)
 		}
 		e.logger.Trace("Inserted block", "hash", hash, "number", header.Number)
 	}

--- a/execution/stagedsync/exec3_bal_test.go
+++ b/execution/stagedsync/exec3_bal_test.go
@@ -27,19 +27,21 @@ func TestBlockAccessListBytes(t *testing.T) {
 	tests := []struct {
 		name      string
 		hash      *common.Hash
+		blockBAL  []byte
 		storedBAL []byte
 		wantBAL   []byte
 		wantReads int
 	}{
 		{name: "missing commitment"},
 		{name: "empty commitment", hash: &empty.BlockAccessListHash},
+		{name: "carried BAL", hash: &nonEmptyBALHash, blockBAL: storedBAL, wantBAL: storedBAL},
 		{name: "non-empty commitment", hash: &nonEmptyBALHash, storedBAL: storedBAL, wantBAL: storedBAL, wantReads: 1},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			getter := &countingBlockAccessListGetter{data: test.storedBAL}
-			block := types.NewBlockFromStorage(common.Hash{}, &types.Header{BlockAccessListHash: test.hash}, nil, nil, nil, nil)
+			block := types.NewBlockFromStorage(common.Hash{}, &types.Header{BlockAccessListHash: test.hash}, nil, nil, nil, test.blockBAL)
 
 			got, err := blockAccessListBytes(getter, block, 1)
 			if err != nil {


### PR DESCRIPTION
fixes a regression introduced in https://github.com/erigontech/erigon/pull/23060
in exec we read block from read aheader first to avoid db lookup and get it from memory instead, then fall back to db if not there
the read aheader was returning that block with bal=nil, causing an unnecessary db lookup for the BAL at tip
this fixes that