### PR TITLE
[r3.6] execution/stagedsync: reclaim superseded fee-merge write sets off the apply loop

### DIFF
--- a/execution/stagedsync/exec3_fee_merge_temp_test.go
+++ b/execution/stagedsync/exec3_fee_merge_temp_test.go
@@ -59,6 +59,7 @@ func TestRecordFeeMergeReleasesSupersededTemp(t *testing.T) {
 	// superseded and reclaimed.
 	temp2 := feeMergeTestWrites(t, addr, 3)
 	be.recordFeeMerge(0, temp1, temp2)
+	awaitMapReleases()
 	require.Same(t, temp2, be.feeMergeTemp[0])
 	require.Equal(t, 0, temp1.Count(), "superseded fee-merge temp must be released")
 	require.Equal(t, 1, temp2.Count())
@@ -68,6 +69,7 @@ func TestRecordFeeMergeReleasesSupersededTemp(t *testing.T) {
 	txOut2 := feeMergeTestWrites(t, addr, 4)
 	temp3 := feeMergeTestWrites(t, addr, 5)
 	be.recordFeeMerge(0, txOut2, temp3)
+	awaitMapReleases()
 	require.Same(t, temp3, be.feeMergeTemp[0])
 	require.Equal(t, 1, txOut2.Count(), "TxOut must survive the fee merge")
 	require.Equal(t, 1, temp2.Count(), "a temp that is not prev must not be released")
@@ -90,6 +92,7 @@ func TestRecordFeeMergeReleaseKeepsSharedWrites(t *testing.T) {
 	merged := temp1.MergeInto(tipWrites)
 	require.Same(t, tipWrites, merged)
 	be.recordFeeMerge(0, temp1, merged)
+	awaitMapReleases()
 
 	require.Equal(t, 0, temp1.Count())
 	vw, ok := merged.GetBalance(shared)

--- a/execution/stagedsync/exec3_fee_merge_temp_test.go
+++ b/execution/stagedsync/exec3_fee_merge_temp_test.go
@@ -59,7 +59,7 @@ func TestRecordFeeMergeReleasesSupersededTemp(t *testing.T) {
 	// superseded and reclaimed.
 	temp2 := feeMergeTestWrites(t, addr, 3)
 	be.recordFeeMerge(0, temp1, temp2)
-	awaitMapReleases()
+	be.awaitMapReleases()
 	require.Same(t, temp2, be.feeMergeTemp[0])
 	require.Equal(t, 0, temp1.Count(), "superseded fee-merge temp must be released")
 	require.Equal(t, 1, temp2.Count())
@@ -69,7 +69,7 @@ func TestRecordFeeMergeReleasesSupersededTemp(t *testing.T) {
 	txOut2 := feeMergeTestWrites(t, addr, 4)
 	temp3 := feeMergeTestWrites(t, addr, 5)
 	be.recordFeeMerge(0, txOut2, temp3)
-	awaitMapReleases()
+	be.awaitMapReleases()
 	require.Same(t, temp3, be.feeMergeTemp[0])
 	require.Equal(t, 1, txOut2.Count(), "TxOut must survive the fee merge")
 	require.Equal(t, 1, temp2.Count(), "a temp that is not prev must not be released")
@@ -92,7 +92,7 @@ func TestRecordFeeMergeReleaseKeepsSharedWrites(t *testing.T) {
 	merged := temp1.MergeInto(tipWrites)
 	require.Same(t, tipWrites, merged)
 	be.recordFeeMerge(0, temp1, merged)
-	awaitMapReleases()
+	be.awaitMapReleases()
 
 	require.Equal(t, 0, temp1.Count())
 	vw, ok := merged.GetBalance(shared)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2452,10 +2452,43 @@ func (be *blockExecutor) invalidBlockResult(err error) *blockResult {
 // so pooling prev's maps leaves the writes merged now holds intact.
 func (be *blockExecutor) recordFeeMerge(tx int, prev, merged *state.WriteSet) {
 	if temp := be.feeMergeTemp[tx]; temp != nil && temp == prev && merged != temp {
-		temp.ReleaseMaps()
+		queueMapRelease(temp)
 	}
 	be.feeMergeTemp[tx] = merged
 }
+
+// Reclaiming a superseded write set is not free: ReleaseMaps clears every map
+// before pooling it, which is O(entries), and a superseded fee-merge set holds
+// the transaction's whole write set. Keep that off the apply loop, which is the
+// serial stage the workers wait behind.
+var (
+	mapReleases     = make(chan *state.WriteSet, 4096)
+	mapReleaseStart sync.Once
+	mapReleasing    sync.WaitGroup
+)
+
+func queueMapRelease(ws *state.WriteSet) {
+	mapReleaseStart.Do(func() {
+		go func() {
+			for w := range mapReleases {
+				w.ReleaseMaps()
+				mapReleasing.Done()
+			}
+		}()
+	})
+	mapReleasing.Add(1)
+	select {
+	case mapReleases <- ws:
+	default:
+		// A full queue means the releaser is behind; reclaiming inline costs
+		// less than letting the apply loop block on it.
+		ws.ReleaseMaps()
+		mapReleasing.Done()
+	}
+}
+
+// awaitMapReleases waits for queued reclamation to finish. Tests only.
+func awaitMapReleases() { mapReleasing.Wait() }
 
 // tooManyRetries returns an invalid-block result when tx has exceeded its
 // retry budget, otherwise nil. origin may be nil (validator-invalid path)

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -2269,6 +2269,8 @@ type blockExecutor struct {
 	// recorded set is some execResult's TxOut, which stays live.
 	feeMergeTemp map[int]*state.WriteSet
 
+	mapReleasing sync.WaitGroup
+
 	// settledInput[tx]==true marks a task that was dispatched when every
 	// preceding task had already validated — so it executed against fully
 	// settled MVCC state, with no lower-indexed worker still in flight.
@@ -2452,43 +2454,44 @@ func (be *blockExecutor) invalidBlockResult(err error) *blockResult {
 // so pooling prev's maps leaves the writes merged now holds intact.
 func (be *blockExecutor) recordFeeMerge(tx int, prev, merged *state.WriteSet) {
 	if temp := be.feeMergeTemp[tx]; temp != nil && temp == prev && merged != temp {
-		queueMapRelease(temp)
+		be.queueMapRelease(temp)
 	}
 	be.feeMergeTemp[tx] = merged
 }
 
-// Reclaiming a superseded write set is not free: ReleaseMaps clears every map
-// before pooling it, which is O(entries), and a superseded fee-merge set holds
-// the transaction's whole write set. Keep that off the apply loop, which is the
-// serial stage the workers wait behind.
+// ReleaseMaps clears every map before pooling it, which is O(entries), and a
+// superseded fee-merge set holds the whole tx's writes. Keep it off the apply
+// loop, which is the serial stage the workers wait behind.
+type mapRelease struct {
+	ws      *state.WriteSet
+	pending *sync.WaitGroup
+}
+
 var (
-	mapReleases     = make(chan *state.WriteSet, 4096)
+	mapReleases     = make(chan mapRelease, 4096)
 	mapReleaseStart sync.Once
-	mapReleasing    sync.WaitGroup
 )
 
-func queueMapRelease(ws *state.WriteSet) {
+func (be *blockExecutor) queueMapRelease(ws *state.WriteSet) {
 	mapReleaseStart.Do(func() {
 		go func() {
-			for w := range mapReleases {
-				w.ReleaseMaps()
-				mapReleasing.Done()
+			for r := range mapReleases {
+				r.ws.ReleaseMaps()
+				r.pending.Done()
 			}
 		}()
 	})
-	mapReleasing.Add(1)
+	be.mapReleasing.Add(1)
 	select {
-	case mapReleases <- ws:
+	case mapReleases <- mapRelease{ws, &be.mapReleasing}:
 	default:
-		// A full queue means the releaser is behind; reclaiming inline costs
-		// less than letting the apply loop block on it.
+		// Releaser is behind; inline costs less than blocking the apply loop.
 		ws.ReleaseMaps()
-		mapReleasing.Done()
+		be.mapReleasing.Done()
 	}
 }
 
-// awaitMapReleases waits for queued reclamation to finish. Tests only.
-func awaitMapReleases() { mapReleasing.Wait() }
+func (be *blockExecutor) awaitMapReleases() { be.mapReleasing.Wait() }
 
 // tooManyRetries returns an invalid-block result when tx has exceeded its
 // retry budget, otherwise nil. origin may be nil (validator-invalid path)


### PR DESCRIPTION
<img width="2129" height="233" alt="Screenshot 2026-08-07 at 22 45 47" src="https://github.com/user-attachments/assets/2c563bbf-3f19-47f8-8a43-1c14934ae640" />


Remove `WriteSet.ReleaseMaps` from hot-path (`processResults`)
- `clear()` of map is not free in Go
- we call `ReleaseMaps` method for every txn (plus we can have 40% re-exec rate) - and inside `WriteSet` we have many maps (each need to clear, and iterate, and send to own sync.Pool - i don't want to change it in 3.6)

solved by: non-blocking send to 1-goroutine

