### PR TITLE
execution: fix flaky TestExecModuleProducesE2Snapshots

### DIFF
--- a/execution/execmodule/exec_module_snapshots_test.go
+++ b/execution/execmodule/exec_module_snapshots_test.go
@@ -17,6 +17,7 @@
 package execmodule_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -33,7 +34,8 @@ import (
 )
 
 func TestExecModuleProducesE2Snapshots(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
 	retireStep := uint64(10)
 	chainLen := int(retireStep) + 2
 	emt := execmoduletester.New(
@@ -42,6 +44,7 @@ func TestExecModuleProducesE2Snapshots(t *testing.T) {
 		execmoduletester.WithE2RetireStep(retireStep),
 		execmoduletester.WithMaxReorgDepth(1),
 	)
+	require.NoError(t, emt.WaitForBlockRetirement(ctx))
 	cp, err := emt.GenerateChain(chainLen, func(i int, gen *blockgen.BlockGen) {
 		tx, err := types.SignTx(
 			types.NewTransaction(
@@ -59,26 +62,17 @@ func TestExecModuleProducesE2Snapshots(t *testing.T) {
 		gen.AddTx(tx)
 	})
 	require.NoError(t, err)
-	retirementDoneSub, retirementDoneSubClose := emt.Notifications.Events.AddRetirementDoneSubscription()
-	t.Cleanup(retirementDoneSubClose)
 	status, err := emt.InsertBlocks(ctx, cp.Blocks)
 	require.NoError(t, err)
 	require.Equal(t, execmodule.ExecutionStatusSuccess, status)
 	result, err := emt.UpdateForkChoice(ctx, cp.Blocks[len(cp.Blocks)-2].Header())
 	require.NoError(t, err)
 	require.Equal(t, execmodule.ExecutionStatusSuccess, result.Status)
+	require.NoError(t, emt.WaitForBlockRetirement(ctx))
 	result, err = emt.UpdateForkChoice(ctx, cp.TopBlock.Header())
 	require.NoError(t, err)
 	require.Equal(t, execmodule.ExecutionStatusSuccess, result.Status)
-	// wait for 2 retirement loops to be done since there are 2 UFCs
-	timeoutC := time.After(time.Minute)
-	for range 2 {
-		select {
-		case <-retirementDoneSub:
-		case <-timeoutC:
-			t.Fatal("retirement done timed out")
-		}
-	}
+	require.NoError(t, emt.WaitForBlockRetirement(ctx))
 	err = emt.BlockSnapshots.OpenFolder()
 	require.NoError(t, err)
 	require.Equal(t, uint64(9), emt.BlockSnapshots.BlocksAvailable())

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -130,7 +130,6 @@ type ExecModuleTester struct {
 	StateCache      *execmodule.Cache
 	retirementStart chan bool
 	retirementDone  chan struct{}
-	retirementWg    sync.WaitGroup
 
 	Notifications      *shards.Notifications
 	stateChangesClient StateChangesClient
@@ -584,10 +583,6 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 
 	if tb != nil {
 		tb.Cleanup(mock.Close)
-		tb.Cleanup(func() {
-			// Wait for all the background snapshot retirements launched by any stages2.StageLoopIteration to finish
-			mock.retirementWg.Wait()
-		})
 	}
 
 	// Committed genesis will be shared between download and mock sentry
@@ -899,6 +894,24 @@ func (emt *ExecModuleTester) UpdateForkChoice(ctx context.Context, header *types
 		}
 		return result, result.Status == execmodule.ExecutionStatusBusy, nil
 	})
+}
+
+func (emt *ExecModuleTester) WaitForBlockRetirement(ctx context.Context) error {
+	select {
+	case started := <-emt.retirementStart:
+		if !started {
+			return nil
+		}
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for block retirement start: %w", ctx.Err())
+	}
+
+	select {
+	case <-emt.retirementDone:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for block retirement completion: %w", ctx.Err())
+	}
 }
 
 func (emt *ExecModuleTester) InsertValidateAndUfc1By1(ctx context.Context, blocks []*types.Block) error {

--- a/node/gdbme/gdbme_darwin.go
+++ b/node/gdbme/gdbme_darwin.go
@@ -95,12 +95,11 @@ quit
 	}
 }
 
-// formatArgsForLLDB
 func formatArgsForLLDB(args []string) string {
 	var formattedArgs []string
 	for _, arg := range args {
 		if strings.Contains(arg, " ") {
-			formattedArgs = append(formattedArgs, fmt.Sprintf(`"%s"`, arg)) // Экранируем пробелы
+			formattedArgs = append(formattedArgs, fmt.Sprintf("%q", arg))
 		} else {
 			formattedArgs = append(formattedArgs, arg)
 		}


### PR DESCRIPTION
fixes https://github.com/erigontech/erigon/actions/runs/31178327105/job/92865344740
issue is I assumed there can be 2 retirement events to wait for for the 2 fcus in the test, however there are 3 (one after the genesis generation) and that caused the flakiness
instead switched to explicit "wait for retirement event" after each expected event so it is clearer