### PR TITLE
[r3.6] execution: build payloads until the slot they are for

### DIFF
--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -37,7 +37,7 @@ type BlockBuilder struct {
 	err       error
 }
 
-func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTimeSecs uint64) *BlockBuilder {
+func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime time.Duration) *BlockBuilder {
 	builder := new(BlockBuilder)
 	builder.syncCond = sync.NewCond(new(sync.Mutex))
 	terminated := make(chan struct{})
@@ -73,7 +73,7 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTimeSecs
 	}()
 
 	go func() {
-		timer := time.NewTimer(time.Duration(maxBuildTimeSecs) * time.Second)
+		timer := time.NewTimer(maxBuildTime)
 		defer timer.Stop()
 		select {
 		case <-timer.C:

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -19,6 +19,7 @@ package execmodule
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/holiman/uint256"
 
@@ -37,6 +38,26 @@ func (e *ExecModule) checkWithdrawalsPresence(time uint64, withdrawals []*types.
 		return &rpc.InvalidParamsError{Message: "missing withdrawals list"}
 	}
 	return nil
+}
+
+// buildDuration returns how long a payload builder may run before it stops itself.
+//
+// A consensus layer may send payload attributes well ahead of the slot the payload is for and then
+// call getPayload against the cached payload id, without sending fresh attributes. A builder that
+// stops before that slot hands back a payload missing every transaction that arrived in between, so
+// build until shortly into the target slot, derived from the payload's own timestamp. The floor
+// leaves a late request no worse off than a fixed budget; the cap stops an implausible timestamp
+// from pinning a builder and its resources.
+func buildDuration(payloadTimestamp uint64, now time.Time, secondsPerSlot uint64) time.Duration {
+	slot := time.Duration(secondsPerSlot) * time.Second
+	// Reject beyond the cap horizon before converting: a large enough timestamp overflows
+	// time.Unix and lands in the past, which would take the floor instead of the cap.
+	horizon := now.Add(2 * slot)
+	if payloadTimestamp > uint64(max(horizon.Unix(), 0)) {
+		return 2 * slot
+	}
+	d := time.Unix(int64(payloadTimestamp), 0).Add(slot / 3).Sub(now)
+	return min(max(d, slot/4), 2*slot)
 }
 
 func (e *ExecModule) evictOldBuilders() {
@@ -74,7 +95,7 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Paramete
 	params.PayloadId = e.nextPayloadId
 	e.lastParameters = params
 
-	e.builders[e.nextPayloadId] = builder.NewBlockBuilder(e.builderFunc, params, e.config.SecondsPerSlot()/4)
+	e.builders[e.nextPayloadId] = builder.NewBlockBuilder(e.builderFunc, params, buildDuration(params.Timestamp, time.Now(), e.config.SecondsPerSlot()))
 	e.logger.Info("[ForkChoiceUpdated] BlockBuilder added", "payload", e.nextPayloadId)
 
 	return AssembleBlockResult{PayloadID: e.nextPayloadId}, nil

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execmodule
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDuration(t *testing.T) {
+	const ethereum, gnosis = uint64(12), uint64(5)
+	slotStart := time.Unix(1_700_000_000, 0)
+	payloadTimestamp := uint64(slotStart.Unix())
+
+	for _, tc := range []struct {
+		name           string
+		secondsPerSlot uint64
+		sentAt         time.Time
+		want           time.Duration
+	}{
+		// A consensus layer sends payload attributes ahead of the slot and then calls getPayload
+		// without refreshing, so the builder has to survive until that slot however early it was asked.
+		{"attributes well before the slot", ethereum, slotStart.Add(-8 * time.Second), 12 * time.Second},
+		{"attributes shortly before the slot", ethereum, slotStart.Add(-4 * time.Second), 8 * time.Second},
+		{"attributes at production time", ethereum, slotStart.Add(400 * time.Millisecond), 3600 * time.Millisecond},
+
+		// A request arriving too late to leave a useful window still gets the old fixed budget,
+		// so late proposals are no worse off than before.
+		{"very late request floors", ethereum, slotStart.Add(3900 * time.Millisecond), 3 * time.Second},
+
+		// Bounds scale with the chain rather than assuming 12s slots.
+		{"short slots, attributes before the slot", gnosis, slotStart.Add(-4 * time.Second), 4*time.Second + 5*time.Second/3},
+		{"short slots, late request floors", gnosis, slotStart.Add(2 * time.Second), 1250 * time.Millisecond},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, buildDuration(payloadTimestamp, tc.sentAt, tc.secondsPerSlot))
+		})
+	}
+}
+
+func TestBuildDurationCapsAbsurdTimestamp(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	farFuture := uint64(now.Add(time.Hour).Unix())
+
+	// A bogus timestamp must not pin a builder, and its resources, indefinitely.
+	require.Equal(t, 24*time.Second, buildDuration(farFuture, now, 12))
+}
+
+func TestBuildDurationCapsOverflowingTimestamp(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	// Beyond int64 seconds the conversion wraps into the past, which would collapse the budget to
+	// the floor instead of the cap.
+	require.Equal(t, 24*time.Second, buildDuration(math.MaxUint64, now, 12))
+}


### PR DESCRIPTION
Cherry-pick of #23098 to release/3.6.

## r3.6-specific adaptations

`NewBlockBuilder` differs on this branch: it uses `syncCond` and a `terminated` channel where main uses a `done` channel, and `Stop()` takes no context. Only the signature change (`maxBuildTimeSecs uint64` → `maxBuildTime time.Duration`) was applied — the branch's own builder internals are untouched. `buildDuration` and its tests are byte-identical to #23098.
