### PR TITLE
docs: measure Sepolia, Hoodi and Chiado disk usage in all three pruning modes

### DIFF
--- a/docs/site/docs/get-started/hardware-requirements.mdx
+++ b/docs/site/docs/get-started/hardware-requirements.mdx
@@ -90,29 +90,29 @@ _Current Disk Usage measured as of {/* ds-date:gnosis */}2026-07-21{/* ds:end */
 <TabItem value="sepolia" label="Sepolia">
 | **Pruning Mode**  | **Current Disk Usage** |
 | -------------- | ---------------------- |
-| Archive        | {/* ds:sepolia:archive */}1.10 TB{/* ds:end */} |
-| Full (Default) | -                      |
-| Minimal        | -                      |
+| Archive        | {/* ds:sepolia:archive */}1.04 TB{/* ds:end */} |
+| Full (Default) | {/* ds:sepolia:full */}238.71 GB{/* ds:end */} |
+| Minimal        | {/* ds:sepolia:minimal */}218.06 GB{/* ds:end */} |
 
-_Current Disk Usage measured as of {/* ds-date:sepolia */}2026-07-29{/* ds:end */}; usage grows over time as the chain grows. Execution layer only. Archive is the only mode measured for Sepolia. Measured on a v3.6 archive node, so treat it as indicative here._
+_Current Disk Usage measured as of {/* ds-date:sepolia */}2026-08-05{/* ds:end */}; usage grows over time as the chain grows. Measured on v3.5.4; the Archive figure was taken a day later, on 2026-08-06._
 </TabItem>
 <TabItem value="hoodi" label="Hoodi">
 | **Pruning Mode**  | **Current Disk Usage** |
 | -------------- | ---------------------- |
-| Archive        | {/* ds:hoodi:archive */}133.73 GB{/* ds:end */} |
-| Full (Default) | -                      |
-| Minimal        | -                      |
+| Archive        | {/* ds:hoodi:archive */}115.85 GB{/* ds:end */} |
+| Full (Default) | {/* ds:hoodi:full */}48.36 GB{/* ds:end */} |
+| Minimal        | {/* ds:hoodi:minimal */}45.61 GB{/* ds:end */} |
 
-_Current Disk Usage measured as of {/* ds-date:hoodi */}2026-07-29{/* ds:end */}; usage grows over time as the chain grows. Execution layer only. Archive is the only mode measured for Hoodi. Measured on a v3.6 archive node, so treat it as indicative here._
+_Current Disk Usage measured as of {/* ds-date:hoodi */}2026-08-04{/* ds:end */}; usage grows over time as the chain grows. Measured on v3.5.4._
 </TabItem>
 <TabItem value="chiado" label="Chiado">
 | **Pruning Mode**  | **Current Disk Usage** |
 | -------------- | ---------------------- |
-| Archive        | {/* ds:chiado:archive */}29.64 GB{/* ds:end */} |
-| Full (Default) | -                      |
-| Minimal        | -                      |
+| Archive        | {/* ds:chiado:archive */}26.95 GB{/* ds:end */} |
+| Full (Default) | {/* ds:chiado:full */}13.32 GB{/* ds:end */} |
+| Minimal        | {/* ds:chiado:minimal */}13.16 GB{/* ds:end */} |
 
-_Current Disk Usage measured as of {/* ds-date:chiado */}2026-07-29{/* ds:end */}; usage grows over time as the chain grows. Execution layer only. Archive is the only mode measured for Chiado. Measured on a v3.6 archive node, so treat it as indicative here._
+_Current Disk Usage measured as of {/* ds-date:chiado */}2026-08-07{/* ds:end */}; usage grows over time as the chain grows. Measured on v3.5.4. Minimal and Full are near-identical on Chiado: the chain is young enough that pruning has little history to remove._
 </TabItem>
 </Tabs>
 

--- a/docs/site/src/data/disk-sizes.json
+++ b/docs/site/src/data/disk-sizes.json
@@ -43,25 +43,61 @@
     },
     "sepolia": {
       "archive": {
-        "bytes": 1095748761644,
-        "display": "1.10 TB",
-        "measured_at": "2026-07-29",
+        "bytes": 1044192616448,
+        "display": "1.04 TB",
+        "measured_at": "2026-08-06",
+        "source": "manual"
+      },
+      "full": {
+        "bytes": 238706274304,
+        "display": "238.71 GB",
+        "measured_at": "2026-08-05",
+        "source": "manual"
+      },
+      "minimal": {
+        "bytes": 218055909376,
+        "display": "218.06 GB",
+        "measured_at": "2026-08-05",
         "source": "manual"
       }
     },
     "hoodi": {
       "archive": {
-        "bytes": 133727771520,
-        "display": "133.73 GB",
-        "measured_at": "2026-07-29",
+        "bytes": 115852066816,
+        "display": "115.85 GB",
+        "measured_at": "2026-08-04",
+        "source": "manual"
+      },
+      "full": {
+        "bytes": 48357707776,
+        "display": "48.36 GB",
+        "measured_at": "2026-08-04",
+        "source": "manual"
+      },
+      "minimal": {
+        "bytes": 45606547456,
+        "display": "45.61 GB",
+        "measured_at": "2026-08-04",
         "source": "manual"
       }
     },
     "chiado": {
       "archive": {
-        "bytes": 29643543816,
-        "display": "29.64 GB",
-        "measured_at": "2026-07-29",
+        "bytes": 26946150400,
+        "display": "26.95 GB",
+        "measured_at": "2026-08-07",
+        "source": "manual"
+      },
+      "full": {
+        "bytes": 13315887104,
+        "display": "13.32 GB",
+        "measured_at": "2026-08-07",
+        "source": "manual"
+      },
+      "minimal": {
+        "bytes": 13163872256,
+        "display": "13.16 GB",
+        "measured_at": "2026-08-07",
         "source": "manual"
       }
     }

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -132,31 +132,31 @@ _Current Disk Usage measured as of 2026-07-21; usage grows over time as the chai
 
 | **Pruning Mode**  | **Current Disk Usage** |
 | -------------- | ---------------------- |
-| Archive        | 1.10 TB |
-| Full (Default) | -                      |
-| Minimal        | -                      |
+| Archive        | 1.04 TB |
+| Full (Default) | 238.71 GB |
+| Minimal        | 218.06 GB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only. Archive is the only mode measured for Sepolia. Measured on a v3.6 archive node, so treat it as indicative here._
+_Current Disk Usage measured as of 2026-08-05; usage grows over time as the chain grows. Measured on v3.5.4; the Archive figure was taken a day later, on 2026-08-06._
 
 ### Hoodi
 
 | **Pruning Mode**  | **Current Disk Usage** |
 | -------------- | ---------------------- |
-| Archive        | 133.73 GB |
-| Full (Default) | -                      |
-| Minimal        | -                      |
+| Archive        | 115.85 GB |
+| Full (Default) | 48.36 GB |
+| Minimal        | 45.61 GB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only. Archive is the only mode measured for Hoodi. Measured on a v3.6 archive node, so treat it as indicative here._
+_Current Disk Usage measured as of 2026-08-04; usage grows over time as the chain grows. Measured on v3.5.4._
 
 ### Chiado
 
 | **Pruning Mode**  | **Current Disk Usage** |
 | -------------- | ---------------------- |
-| Archive        | 29.64 GB |
-| Full (Default) | -                      |
-| Minimal        | -                      |
+| Archive        | 26.95 GB |
+| Full (Default) | 13.32 GB |
+| Minimal        | 13.16 GB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only. Archive is the only mode measured for Chiado. Measured on a v3.6 archive node, so treat it as indicative here._
+_Current Disk Usage measured as of 2026-08-07; usage grows over time as the chain grows. Measured on v3.5.4. Minimal and Full are near-identical on Chiado: the chain is young enough that pruning has little history to remove._
 
 :::tip
 See also how you can [optimize storage](../fundamentals/optimizing-storage).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -132,31 +132,31 @@ _Current Disk Usage measured as of 2026-07-21; usage grows over time as the chai
 
 | **Pruning Mode**  | **Current Disk Usage** |
 | -------------- | ---------------------- |
-| Archive        | 1.10 TB |
-| Full (Default) | -                      |
-| Minimal        | -                      |
+| Archive        | 1.04 TB |
+| Full (Default) | 238.71 GB |
+| Minimal        | 218.06 GB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only. Archive is the only mode measured for Sepolia. Measured on a v3.6 archive node, so treat it as indicative here._
+_Current Disk Usage measured as of 2026-08-05; usage grows over time as the chain grows. Measured on v3.5.4; the Archive figure was taken a day later, on 2026-08-06._
 
 ### Hoodi
 
 | **Pruning Mode**  | **Current Disk Usage** |
 | -------------- | ---------------------- |
-| Archive        | 133.73 GB |
-| Full (Default) | -                      |
-| Minimal        | -                      |
+| Archive        | 115.85 GB |
+| Full (Default) | 48.36 GB |
+| Minimal        | 45.61 GB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only. Archive is the only mode measured for Hoodi. Measured on a v3.6 archive node, so treat it as indicative here._
+_Current Disk Usage measured as of 2026-08-04; usage grows over time as the chain grows. Measured on v3.5.4._
 
 ### Chiado
 
 | **Pruning Mode**  | **Current Disk Usage** |
 | -------------- | ---------------------- |
-| Archive        | 29.64 GB |
-| Full (Default) | -                      |
-| Minimal        | -                      |
+| Archive        | 26.95 GB |
+| Full (Default) | 13.32 GB |
+| Minimal        | 13.16 GB |
 
-_Current Disk Usage measured as of 2026-07-29; usage grows over time as the chain grows. Execution layer only. Archive is the only mode measured for Chiado. Measured on a v3.6 archive node, so treat it as indicative here._
+_Current Disk Usage measured as of 2026-08-07; usage grows over time as the chain grows. Measured on v3.5.4. Minimal and Full are near-identical on Chiado: the chain is young enough that pruning has little history to remove._
 
 :::tip
 See also how you can [optimize storage](../fundamentals/optimizing-storage).


### PR DESCRIPTION
Stacked on #22919 — merge that first. The testnet tabs this fills in only exist on that branch, so basing here keeps the diff to a single commit.

## What this does

#22919 added Sepolia, Hoodi and Chiado tabs with an **Archive-only** figure measured on a **v3.6** node, footnoted as indicative, and `-` placeholders for Full and Minimal. This replaces all of it with a complete 3×3 matrix measured on **v3.5.4**, the series this branch deploys from.

| Tab | Archive | Full | Minimal |
| --- | --- | --- | --- |
| Sepolia | 1.10 → **1.04 TB** | – → **238.71 GB** | – → **218.06 GB** |
| Hoodi | 133.73 → **115.85 GB** | – → **48.36 GB** | – → **45.61 GB** |
| Chiado | 29.64 → **26.95 GB** | – → **13.32 GB** | – → **13.16 GB** |

## Provenance

Every cell comes from one sweep: one binary (`3.5.4-01a3ec91`), one measurement script, each node synced from scratch and confirmed holding the live tip before measuring (head age at confirmation 0.4–3.6 s). Values are whole-datadir minus `temp/` scratch — the same basis as the existing mainnet and Gnosis rows.

## Three things worth reviewer attention

**Archive figures all move down.** That is a change of measurement basis (v3.6 → v3.5.4, plus this script's whole-datadir-minus-temp), not chain shrinkage. Worth stating explicitly, since a shrinking archive would otherwise read as an error.

**`"Execution layer only"` was inaccurate and is dropped.** `caplin/` is 1.08 GB — 4% of the Chiado archive total — and it *is* inside the measured total. The figures are standard Erigon + embedded Caplin with only `--prune.mode` varied, which matches the section intro and the mainnet/Gnosis rows.

**Chiado Minimal and Full land within 0.16 GB.** This is real, not a copy-paste error: the chain is young enough that pruning has almost no history to remove. The tab now says so, to avoid it being read as evidence that pruning modes barely differ in general.

## Deliberately not included

Sync times were measured but are not published — they describe one host's disk and 88 Mbit link, not what a reader should expect.

The testnet tables stay at two columns. Mainnet and Gnosis carry "Disk Size (Recommended)" and RAM columns; disk was measured here, RAM was not, and inventing hardware recommendations seemed worse than omitting them. Happy to add them if maintainers want to set the values.

## Checks

- `render-disk-sizes.py --check` — OK, page matches `disk-sizes.json`
- `generate-llms.py --check` — OK, 4 files, 73 pages
- `python3 -m unittest discover docs/site/scripts` — 92 tests, OK
- `npm ci && npm run build` — clean, no broken links or anchors
- Rendered and verified on a local `npm run serve`: 5 tabs, 15 cells, 0 stale markers, 0 leftover placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFH8scMUyJQ8Pd8dMP7kMr