### PR TITLE
execution/commitment: lower deepStorageThreshold to 128

### DIFF
--- a/execution/commitment/deepfold_singleslot_reexpand_regression_test.go
+++ b/execution/commitment/deepfold_singleslot_reexpand_regression_test.go
@@ -37,7 +37,7 @@ import (
 func TestDeepFold_SingleSlotCollapseThenDeepReexpand(t *testing.T) {
 	t.Parallel()
 
-	const seed = 900 // < deepStorageThreshold: batch 1 and the batch-2 collapse both stream
+	const seed = 100 // < deepStorageThreshold: batch 1 and the batch-2 collapse both stream
 	addr, _, _, _, wk1, wu1, groups := whaleByNibble(seed)
 	a := hex.EncodeToString(addr)
 

--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -16,7 +16,8 @@ import (
 var cmtTiming = os.Getenv("ERIGON_CMT_TIMING") == "1"
 
 // deepStorageThreshold is the touched-slot count above which an account's storage subtree folds concurrently instead of streaming through its worker.
-const deepStorageThreshold = 1_000
+// Set below the common hot-contract straggler size (~150 touched slots) so those subtrees fold in parallel rather than serializing through one nibble worker.
+const deepStorageThreshold = 128
 
 // unfoldRootWall unfolds base at the root until row 0 forms the top-nibble mount wall,
 // consuming at most one nibble per step: a restored root extension sharing the probe's


### PR DESCRIPTION
## What

Lower `deepStorageThreshold` **1000 → 128** in the parallel-commitment para-trie.

## Why

The para-trie folds an account's storage subtree concurrently only when its touched-slot count exceeds `deepStorageThreshold`; otherwise the subtree streams serially through its top-nibble worker. At the old threshold of 1000, the common hot-contract stragglers (USDT/USDC-class, ~150 touched slots) and even 600–700-slot whales stayed under it — so they serialized through one worker and dominated commitment wall time. **128** folds those subtrees in parallel while still skipping genuinely small accounts.

The straggler that drives this appears in **~78% of tip blocks** (median ~145 touched slots), so the win applies to the majority of blocks, with the largest absolute gains on the tail whale blocks.

## Measurements

Replayed mainnet blocks via `loop_newpayload` (re-run block N against N-1 state, rolled back with no persist — deterministic, real latest-path reads). Sample whale block 25723772 (~672-key single-nibble storage straggler), critical-nibble `workerWall`:

| regime | threshold 1000 | threshold 128 |
|---|---|---|
| warm | ~35ms | ~16ms |
| cold (drop_caches every run) | ~730ms | ~500ms |

Root unchanged across every sampled block/config.

A grid over the fold-concurrency budget (`maxFoldConcurrency`, 1×→8× GOMAXPROCS) showed **no effect** warm or cold — the critical path is a single whale's storage subtree, so the fold budget can't help it — so that knob is left unchanged and this PR is threshold-only. Full per-tier grid chart (memory × core count) posted in a comment below.

## Tests

`deepfold_singleslot_reexpand`'s streaming-collapse seed is lowered (900 → 100) to stay below the new threshold so it still exercises the stream-then-deep-fold transition. Full `execution/commitment` + `db/state/execctx` commitment tests pass; `make lint` clean.

## Live tip validation

Live validation at chain tip on a **64 GB memory-constrained machine** (the standard tip perf-reference tier) is running — it will confirm 0 wrong roots over a sustained at-tip window and measure the at-tip commit improvement. Results posted here.
