### PR TITLE
execution/stagedsync: drain block requests before the result that races them

### DIFF
--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -293,6 +293,7 @@ func (cc *commitmentCalculator) loop(ctx context.Context) {
 				in = nil
 				continue
 			}
+			reqs = cc.drainBlockRequests(ctx, reqs)
 			cc.handleMessage(ctx, result)
 		case req, ok := <-reqs:
 			if !ok {
@@ -300,6 +301,27 @@ func (cc *commitmentCalculator) loop(ctx context.Context) {
 				continue
 			}
 			cc.handleBlockRequest(ctx, req)
+		}
+	}
+}
+
+// drainBlockRequests handles every request already buffered, returning nil once
+// the channel is closed. The exec loop sends blockRequest(N) before dispatching
+// the exec that produces blockResult(N), so a result in hand means its own
+// request is already buffered — draining before handling the result restores the
+// send order that select's unordered pick between two ready channels loses.
+// Otherwise handleBlockRequest's drop-guard discards that request as stale and
+// maybeComputeAhead's contiguity chain never recovers for the rest of the batch.
+func (cc *commitmentCalculator) drainBlockRequests(ctx context.Context, reqs chan *blockRequest) chan *blockRequest {
+	for {
+		select {
+		case req, ok := <-reqs:
+			if !ok {
+				return nil
+			}
+			cc.handleBlockRequest(ctx, req)
+		default:
+			return reqs
 		}
 	}
 }
@@ -453,11 +475,10 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 // BALDrivenCommitment is set, else incremental — then tries to compute the
 // block ahead of its result stream (maybeComputeAhead).
 func (cc *commitmentCalculator) handleBlockRequest(ctx context.Context, req *blockRequest) {
-	// Record the batch's first block before the drop-guard: if blockResult(n) is
-	// consumed before blockRequest(n) (the in/reqs select has no cross-channel
-	// ordering), a dropped first request must still set firstBlockNum to n rather
-	// than leave n+1 to claim it — else computeAheadGateOpen and the contiguity guard
-	// are both bypassed via n == firstBlockNum and n+1 computes ahead on a baseline missing n.
+	// Record the batch's first block before the drop-guard below: were the first
+	// request ever dropped, leaving n+1 to claim firstBlockNum would bypass
+	// computeAheadGateOpen's and the contiguity guard's n == firstBlockNum
+	// exception, letting n+1 compute ahead on a baseline missing n.
 	if !cc.hasFirstBlock {
 		cc.firstBlockNum = req.blockNum
 		cc.hasFirstBlock = true

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -305,13 +305,10 @@ func (cc *commitmentCalculator) loop(ctx context.Context) {
 	}
 }
 
-// drainBlockRequests handles every request already buffered, returning nil once
-// the channel is closed. The exec loop sends blockRequest(N) before dispatching
-// the exec that produces blockResult(N), so a result in hand means its own
-// request is already buffered — draining before handling the result restores the
-// send order that select's unordered pick between two ready channels loses.
-// Otherwise handleBlockRequest's drop-guard discards that request as stale and
-// maybeComputeAhead's contiguity chain never recovers for the rest of the batch.
+// drainBlockRequests handles every buffered request, returning nil once the
+// channel is closed. A block's request is always sent before the exec that
+// produces its result, so draining before handling a result keeps that order
+// past select, which would otherwise let the result drop the request as stale.
 func (cc *commitmentCalculator) drainBlockRequests(ctx context.Context, reqs chan *blockRequest) chan *blockRequest {
 	for {
 		select {

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -161,6 +161,11 @@ type commitmentCalculator struct {
 	lastComputedAheadBlock uint64
 	hasComputedAhead       bool
 
+	// computeAheadStopped marks that the contiguity guard has already rejected a
+	// block in this batch. The chain cannot re-anchor, so every later block hits
+	// the same guard — the drop to the incremental path is reported once.
+	computeAheadStopped bool
+
 	// signalCtx is the shared executor context carrying the stopCause. The
 	// calculator reads it (never its own compute ctx) to cap compute-ahead at the
 	// batch's coalesce block M — compute/publish run on the separate uncancelled
@@ -296,13 +301,19 @@ func (cc *commitmentCalculator) loop(ctx context.Context) {
 			reqs = cc.drainBlockRequests(ctx, reqs)
 			cc.handleMessage(ctx, result)
 		case req, ok := <-reqs:
-			if !ok {
-				reqs = nil
-				continue
-			}
-			cc.handleBlockRequest(ctx, req)
+			reqs = cc.acceptBlockRequest(ctx, reqs, req, ok)
 		}
 	}
+}
+
+// acceptBlockRequest handles a request received from reqs, returning the channel
+// to keep selecting on — nil once it is closed.
+func (cc *commitmentCalculator) acceptBlockRequest(ctx context.Context, reqs chan *blockRequest, req *blockRequest, ok bool) chan *blockRequest {
+	if !ok {
+		return nil
+	}
+	cc.handleBlockRequest(ctx, req)
+	return reqs
 }
 
 // drainBlockRequests handles every buffered request, returning nil once the
@@ -310,17 +321,15 @@ func (cc *commitmentCalculator) loop(ctx context.Context) {
 // produces its result, so draining before handling a result keeps that order
 // past select, which would otherwise let the result drop the request as stale.
 func (cc *commitmentCalculator) drainBlockRequests(ctx context.Context, reqs chan *blockRequest) chan *blockRequest {
-	for {
+	for reqs != nil {
 		select {
 		case req, ok := <-reqs:
-			if !ok {
-				return nil
-			}
-			cc.handleBlockRequest(ctx, req)
+			reqs = cc.acceptBlockRequest(ctx, reqs, req, ok)
 		default:
 			return reqs
 		}
 	}
+	return nil
 }
 
 // perBlockCompute reports whether the given block computes commitment at its
@@ -539,9 +548,25 @@ func (cc *commitmentCalculator) maybeComputeAhead(ctx context.Context, n uint64)
 		return
 	}
 	if n != cc.firstBlockNum && !(cc.hasComputedAhead && cc.lastComputedAheadBlock == n-1) {
+		cc.reportComputeAheadStopped(n)
 		return
 	}
 	cc.computeBlockFromBAL(ctx, pb)
+}
+
+// reportComputeAheadStopped logs the first block the contiguity guard rejects.
+// Compute-ahead never re-anchors within a batch, so this one line marks where the
+// whole remaining batch fell back to incremental commitment.
+func (cc *commitmentCalculator) reportComputeAheadStopped(n uint64) {
+	if cc.computeAheadStopped {
+		return
+	}
+	cc.computeAheadStopped = true
+	if cc.logger == nil {
+		return
+	}
+	cc.logger.Info("["+cc.logPrefix+"] BAL compute-ahead stopped, rest of batch computes incrementally",
+		"block", n, "lastComputedAhead", cc.lastComputedAheadBlock, "hasComputedAhead", cc.hasComputedAhead)
 }
 
 // computeBlockFromBAL computes block pb's commitment from its BAL, ahead of the

--- a/execution/stagedsync/committer.go
+++ b/execution/stagedsync/committer.go
@@ -366,11 +366,9 @@ func (cc *commitmentCalculator) handleMessage(ctx context.Context, msg applyResu
 		// the BAL (checkpointStepsFromBAL), computed while the domain sat exactly at
 		// each edge. Re-checkpointing here from the partially-accumulated cc.state
 		// on an already-advanced domain would let the last writer win and leave the
-		// step's commitment .kv inconsistent — so the incremental path is normally
-		// the sole checkpointer for a block. The in/reqs select has no cross-channel
-		// priority, so a late-consumed blockRequest can leave computedAhead[n] unset
-		// when this hook fires and let both paths checkpoint the same edge; that is
-		// benign — both emit identical values at the same txNum (idempotent).
+		// step's commitment .kv inconsistent — so exactly one of the two paths
+		// checkpoints a block. loop() drains a block's request before its results,
+		// so computedAhead[n] is already settled when this hook fires.
 		if !cc.computedAhead[r.blockNum] && cc.doms.IsUnfrozenStepEdge(cc.roTx, r.txNum) {
 			cc.computeStepBoundary(ctx, commitTarget{blockNum: r.blockNum, blockHash: r.blockHash, lastTxNum: r.txNum})
 		}

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -660,24 +660,33 @@ func TestComputeAhead_StepBoundaryCheckpointMidBlock(t *testing.T) {
 func TestLoop_BlockRequestBeatsSameNumberedResult(t *testing.T) {
 	defer func(p bool) { dbg.BALDrivenCommitment = p }(dbg.BALDrivenCommitment)
 	defer func(p bool) { dbg.IgnoreBAL = p }(dbg.IgnoreBAL)
+	defer func(p bool) { dbg.BatchCommitments = p }(dbg.BatchCommitments)
 	dbg.BALDrivenCommitment = true
 	dbg.IgnoreBAL = false
+	// Per-block mode would publish a second, incremental result per block and
+	// break the single-result assertion below.
+	dbg.BatchCommitments = true
 
+	// Each iteration logs its own expected wrong-root failure.
 	ctx := context.Background()
 	logger := log.New()
-	db, _, doms := setupStepTest(t)
-	rnd := rand.New(rand.NewSource(7))
+	logger.SetHandler(log.DiscardHandler())
+
+	// Each iteration is an independent coin flip on select's two-ready pick.
+	const iterations = uint64(200)
 
 	for _, tc := range []struct {
 		name       string
 		afterStart bool
-		iterations uint64
 	}{
-		{name: "buffered before start", iterations: 200},
-		{name: "delivered after start", afterStart: true, iterations: 2_000},
+		{name: "buffered before start"},
+		{name: "delivered after start", afterStart: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			for i := uint64(1); i <= tc.iterations; i++ {
+			// Own domains per subtest: block and txNum restart at 1.
+			db, _, doms := setupStepTest(t)
+			rnd := rand.New(rand.NewSource(7))
+			for i := uint64(1); i <= iterations; i++ {
 				in := make(chan applyResult, 4)
 				reqs := make(chan *blockRequest, 4)
 				out := make(chan commitmentResult, 4)

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -653,15 +653,10 @@ func TestComputeAhead_StepBoundaryCheckpointMidBlock(t *testing.T) {
 	requireBranchesConsistentWithAccounts(t, doms, tx, accountValues)
 }
 
-// TestLoop_BlockRequestBeatsSameNumberedResult pins the ordering loop() must
-// keep: blockRequest(N) is sent before the exec dispatch that produces
-// blockResult(N), so the request must always be handled first. select does not
-// preserve that across two channels, and handling the result first makes
-// handleBlockRequest drop the request as stale — after which maybeComputeAhead's
-// contiguity chain never recovers and the batch silently loses compute-ahead.
-// Both delivery orders are exercised: pre-buffered forces the two-ready-cases
-// pick every iteration, delivered-after-start forces the narrower window between
-// select's readiness poll and its park.
+// TestLoop_BlockRequestBeatsSameNumberedResult pins that loop() handles a block's
+// request before its own result, which select alone does not guarantee. The two
+// delivery orders hit different windows: pre-buffered makes both cases ready at
+// once, after-start races the send against select's readiness poll.
 func TestLoop_BlockRequestBeatsSameNumberedResult(t *testing.T) {
 	defer func(p bool) { dbg.BALDrivenCommitment = p }(dbg.BALDrivenCommitment)
 	defer func(p bool) { dbg.IgnoreBAL = p }(dbg.IgnoreBAL)
@@ -698,11 +693,8 @@ func TestLoop_BlockRequestBeatsSameNumberedResult(t *testing.T) {
 					NonceChanges: []*types.NonceChange{{Index: 0, Value: 1}},
 				}}
 
-				// stateRoot is deliberately wrong: computeBlockFromBAL's root check
-				// fails either way. Reaching that check at all — vs. the request
-				// being dropped before maybeComputeAhead ever calls
-				// computeBlockFromBAL — is exactly the property under test, and
-				// require.ErrorIs below tells the two outcomes apart.
+				// stateRoot is deliberately wrong, so a processed request publishes
+				// ErrWrongTrieRoot and a dropped one publishes nothing at all.
 				send := func() {
 					reqs <- &blockRequest{
 						blockNum:   i,
@@ -723,10 +715,8 @@ func TestLoop_BlockRequestBeatsSameNumberedResult(t *testing.T) {
 					cc.Start(ctx)
 				}
 
-				// Ranging over out blocks until loop() closes it, which only happens
-				// once in is fully drained and loop() returns — the same condition
-				// Stop() waits on, but without racing Stop()'s close(cc.done) against
-				// publish()'s own cc.out/cc.done select for a goroutine still in flight.
+				// Range rather than Stop() first: out closes only after loop() returns,
+				// and Stop()'s close(cc.done) would race an in-flight publish().
 				var results []commitmentResult
 				for res := range out {
 					results = append(results, res)

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -672,21 +672,24 @@ func TestLoop_BlockRequestBeatsSameNumberedResult(t *testing.T) {
 	logger := log.New()
 	logger.SetHandler(log.DiscardHandler())
 
-	// Each iteration is an independent coin flip on select's two-ready pick.
-	const iterations = uint64(200)
-
+	// Each iteration is an independent chance at select's two-ready pick, but the
+	// two orders are not equally likely to hit it: with the drain removed, the
+	// pre-buffered order catches within a handful of iterations while after-start
+	// averages ~40 and tails past 100, so it needs the larger count to keep a
+	// regression from slipping through.
 	for _, tc := range []struct {
 		name       string
 		afterStart bool
+		iterations uint64
 	}{
-		{name: "buffered before start"},
-		{name: "delivered after start", afterStart: true},
+		{name: "buffered before start", iterations: 200},
+		{name: "delivered after start", afterStart: true, iterations: 2_000},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Own domains per subtest: block and txNum restart at 1.
 			db, _, doms := setupStepTest(t)
 			rnd := rand.New(rand.NewSource(7))
-			for i := uint64(1); i <= iterations; i++ {
+			for i := uint64(1); i <= tc.iterations; i++ {
 				in := make(chan applyResult, 4)
 				reqs := make(chan *blockRequest, 4)
 				out := make(chan commitmentResult, 4)

--- a/execution/stagedsync/committer_step_boundary_test.go
+++ b/execution/stagedsync/committer_step_boundary_test.go
@@ -653,6 +653,95 @@ func TestComputeAhead_StepBoundaryCheckpointMidBlock(t *testing.T) {
 	requireBranchesConsistentWithAccounts(t, doms, tx, accountValues)
 }
 
+// TestLoop_BlockRequestBeatsSameNumberedResult pins the ordering loop() must
+// keep: blockRequest(N) is sent before the exec dispatch that produces
+// blockResult(N), so the request must always be handled first. select does not
+// preserve that across two channels, and handling the result first makes
+// handleBlockRequest drop the request as stale — after which maybeComputeAhead's
+// contiguity chain never recovers and the batch silently loses compute-ahead.
+// Both delivery orders are exercised: pre-buffered forces the two-ready-cases
+// pick every iteration, delivered-after-start forces the narrower window between
+// select's readiness poll and its park.
+func TestLoop_BlockRequestBeatsSameNumberedResult(t *testing.T) {
+	defer func(p bool) { dbg.BALDrivenCommitment = p }(dbg.BALDrivenCommitment)
+	defer func(p bool) { dbg.IgnoreBAL = p }(dbg.IgnoreBAL)
+	dbg.BALDrivenCommitment = true
+	dbg.IgnoreBAL = false
+
+	ctx := context.Background()
+	logger := log.New()
+	db, _, doms := setupStepTest(t)
+	rnd := rand.New(rand.NewSource(7))
+
+	for _, tc := range []struct {
+		name       string
+		afterStart bool
+		iterations uint64
+	}{
+		{name: "buffered before start", iterations: 200},
+		{name: "delivered after start", afterStart: true, iterations: 2_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for i := uint64(1); i <= tc.iterations; i++ {
+				in := make(chan applyResult, 4)
+				reqs := make(chan *blockRequest, 4)
+				out := make(chan commitmentResult, 4)
+				cc, err := newCommitmentCalculator(ctx, ctx, doms, db, &chain.Config{}, "test", logger, false, 1<<62, in, reqs, out)
+				require.NoError(t, err)
+				cc.hasFirstBlock = true
+				cc.firstBlockNum = i
+
+				addrBytes := make([]byte, length.Addr)
+				rnd.Read(addrBytes)
+				bal := types.BlockAccessList{{
+					Address:      accounts.InternAddress([20]byte(addrBytes)),
+					NonceChanges: []*types.NonceChange{{Index: 0, Value: 1}},
+				}}
+
+				// stateRoot is deliberately wrong: computeBlockFromBAL's root check
+				// fails either way. Reaching that check at all — vs. the request
+				// being dropped before maybeComputeAhead ever calls
+				// computeBlockFromBAL — is exactly the property under test, and
+				// require.ErrorIs below tells the two outcomes apart.
+				send := func() {
+					reqs <- &blockRequest{
+						blockNum:   i,
+						firstTxNum: i,
+						lastTxNum:  i,
+						stateRoot:  common.Hash{0xba, 0xd5, 0x00, 0x71},
+						bal:        bal,
+					}
+					in <- newTestBlockResult(i, common.Hash{0x01}, i, false)
+					close(reqs)
+					close(in)
+				}
+				if tc.afterStart {
+					cc.Start(ctx)
+					go send()
+				} else {
+					send()
+					cc.Start(ctx)
+				}
+
+				// Ranging over out blocks until loop() closes it, which only happens
+				// once in is fully drained and loop() returns — the same condition
+				// Stop() waits on, but without racing Stop()'s close(cc.done) against
+				// publish()'s own cc.out/cc.done select for a goroutine still in flight.
+				var results []commitmentResult
+				for res := range out {
+					results = append(results, res)
+				}
+				cc.Stop()
+
+				require.Len(t, results, 1,
+					"iteration %d: block %d's request was dropped by its own same-numbered result before compute-ahead could run", i, i)
+				require.ErrorIs(t, results[0].err, ErrWrongTrieRoot,
+					"iteration %d: block %d's request must be processed before its own result", i, i)
+			}
+		})
+	}
+}
+
 // feedBlock1Shadow builds a calculator, feeds block 1's n writes (seed 42) into
 // cc.state, marks the block computed-ahead with balRoots[1]=balRoot, then delivers
 // blockResult(1) with BAL_SHADOW_COMPUTE on so shadowCrossCheck recomputes the

--- a/execution/stagedsync/committer_test.go
+++ b/execution/stagedsync/committer_test.go
@@ -266,3 +266,41 @@ func TestComputeAheadCap_StopsComputeAhead(t *testing.T) {
 
 	assert.False(t, cc.computedAhead[5], "a compute-ahead past the coalesce block M must not run")
 }
+
+// TestContiguityGuard_ChainNeverRecovers pins that one block without a BAL ends
+// compute-ahead for the whole batch: the chain is anchored at the last block that
+// advanced the commitment domain, so every later block reads a stale baseline and
+// stays on the incremental path, however contiguous it is with its own predecessor.
+func TestContiguityGuard_ChainNeverRecovers(t *testing.T) {
+	defer func(prev bool) { dbg.BALDrivenCommitment = prev }(dbg.BALDrivenCommitment)
+	defer func(prev bool) { dbg.IgnoreBAL = prev }(dbg.IgnoreBAL)
+	dbg.BALDrivenCommitment = true
+	dbg.IgnoreBAL = false
+
+	ctx := context.Background()
+	cc := &commitmentCalculator{
+		signalCtx:     ctx,
+		pending:       map[uint64]*pendingBlock{},
+		computedAhead: map[uint64]bool{},
+		balRoots:      map[uint64][]byte{},
+		hasFirstBlock: true,
+		firstBlockNum: 5,
+		perBlockFrom:  1 << 62, // all blocks pre-window, so none owns a changeset
+		// Block 5 computed ahead, block 6 had no BAL and never advanced the domain.
+		hasComputedAhead:       true,
+		lastComputedAheadBlock: 5,
+		hasSeenBlockResult:     true,
+	}
+
+	for n := uint64(7); n <= 12; n++ {
+		cc.lastBlockResultSeen = n - 1 // gate open: only the contiguity guard may reject
+		cc.pending[n] = &pendingBlock{
+			req:  &blockRequest{blockNum: n, bal: make(types.BlockAccessList, 1)},
+			mode: calcModeBALDriven,
+		}
+		cc.maybeComputeAhead(ctx, n)
+		assert.False(t, cc.computedAhead[n], "block %d must not compute ahead across the gap at block 6", n)
+		assert.True(t, cc.computeAheadStopped, "the fall back to incremental must be reported at block %d", n)
+	}
+	assert.Equal(t, uint64(5), cc.lastComputedAheadBlock, "the chain must stay anchored at block 5")
+}


### PR DESCRIPTION
The exec loop sends `blockRequest(N)` before dispatching the exec that produces `blockResult(N)`, but the commitment calculator receives them on two channels and `select` does not preserve that order. When the result wins, `handleBlockRequest` drops the request as stale, and `maybeComputeAhead`'s contiguity chain never recovers — so one lost request silently drops the whole batch to incremental commitment.

Seen as `TestBALShadowCompute_MatchesIncremental` failing on `require.Positive(computedAhead)` in the sonar job, where whole-repo coverage runs make the loss likely enough to hit.

## Changes

- Drain the buffered requests before handling a dequeued result. A result in hand proves its own request is already buffered, so the drain is exhaustive rather than a timing bet.
- Regression test in both delivery orders. The orders do not hit the bad interleaving at the same rate: with the drain removed, over 12 runs, pre-buffered first catches it at a mean of 2.3 iterations, after-start at 39.5 with a tail to 110 — hence 200 and 2000 iterations respectively. The whole test costs 0.18s.
- Log once when the contiguity guard ends compute-ahead. The chain cannot re-anchor mid-batch, so a single block without a BAL sidecar drops every later block to the incremental path — previously with nothing in the log to say so.
- `loop()`'s request arm and the drain shared their body; both now go through `acceptBlockRequest`.

## What is left out

The contiguity chain still does not re-anchor after a gap — the fix here makes that visible, not recoverable. Re-anchoring needs a baseline read that does not depend on the prior block having advanced the commitment domain, which is a separate change.
