### PR TITLE
[r3.5] cl/beacon: handle empty Fulu builder response

### DIFF
--- a/cl/beacon/builder/client_test.go
+++ b/cl/beacon/builder/client_test.go
@@ -334,6 +334,62 @@ func TestSubmitBlindedBlocks(t *testing.T) {
 	})
 }
 
+func TestSubmitBlindedBlocksFulu(t *testing.T) {
+	ctx := context.Background()
+	expectPath := mockUrl.JoinPath("/eth/v2/builder/blinded_blocks").String()
+	block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	block.Block.SetVersion(clparams.FuluVersion)
+
+	t.Run("empty accepted response", func(t *testing.T) {
+		mockHttpClient := &http.Client{
+			Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+				require.Equal(t, expectPath, req.URL.String())
+				require.Equal(t, http.MethodPost, req.Method)
+				require.Equal(t, clparams.FuluVersion.String(), req.Header.Get("Eth-Consensus-Version"))
+				return &http.Response{
+					StatusCode: http.StatusAccepted,
+					Body:       io.NopCloser(bytes.NewReader(nil)),
+					Request:    req.Clone(context.Background()),
+				}, nil
+			}),
+		}
+		builderClient := &builderClient{
+			httpClient:   mockHttpClient,
+			url:          mockUrl,
+			beaconConfig: mockBeaconConfig,
+		}
+
+		payload, bundle, requests, err := builderClient.SubmitBlindedBlocks(ctx, block)
+		require.NoError(t, err)
+		require.Nil(t, payload)
+		require.Nil(t, bundle)
+		require.Nil(t, requests)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		mockHttpClient := &http.Client{
+			Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(bytes.NewBufferString("builder error")),
+					Request:    req.Clone(context.Background()),
+				}, nil
+			}),
+		}
+		builderClient := &builderClient{
+			httpClient:   mockHttpClient,
+			url:          mockUrl,
+			beaconConfig: mockBeaconConfig,
+		}
+
+		payload, bundle, requests, err := builderClient.SubmitBlindedBlocks(ctx, block)
+		require.Error(t, err)
+		require.Nil(t, payload)
+		require.Nil(t, bundle)
+		require.Nil(t, requests)
+	})
+}
+
 func newBytes48FromString(s string) common.Bytes48 {
 	bytes := common.Hex2Bytes(s)
 	var b common.Bytes48

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -62,8 +62,6 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
-	"github.com/erigontech/erigon/execution/protocol/params"
-	"github.com/erigontech/erigon/execution/rlp"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
@@ -1401,23 +1399,73 @@ func (a *ApiHandler) PostEthV2BlindedBlocks(w http.ResponseWriter, r *http.Reque
 	return resp, err
 }
 
+func validateBlindedBlockRequest(block *cltypes.SignedBlindedBeaconBlock, version clparams.StateVersion) error {
+	if version < clparams.BellatrixVersion {
+		return errors.New("blinded blocks are unsupported before Bellatrix")
+	}
+	if block == nil || block.Block == nil {
+		return errors.New("missing block")
+	}
+	if block.Block.Body == nil {
+		return errors.New("missing block body")
+	}
+	if block.Block.Body.ExecutionPayload == nil {
+		return errors.New("missing execution payload header")
+	}
+	return nil
+}
+
+func validateBuilderPayload(blockPayload *cltypes.Eth1Block, executionRequests *cltypes.ExecutionRequests, expectedVersion clparams.StateVersion) error {
+	if blockPayload == nil {
+		return errors.New("builder returned nil execution payload")
+	}
+	if blockPayload.Version() != expectedVersion {
+		return fmt.Errorf("builder execution payload version mismatch: got %s, expected %s", blockPayload.Version(), expectedVersion)
+	}
+	if blockPayload.Extra == nil {
+		return errors.New("builder execution payload missing extra data")
+	}
+	if blockPayload.Transactions == nil {
+		return errors.New("builder execution payload missing transactions")
+	}
+	if expectedVersion.AfterOrEqual(clparams.CapellaVersion) && blockPayload.Withdrawals == nil {
+		return errors.New("builder execution payload missing withdrawals")
+	}
+	if expectedVersion.AfterOrEqual(clparams.ElectraVersion) && executionRequests == nil {
+		return errors.New("builder response missing execution requests")
+	}
+	return nil
+}
+
 func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request, apiVersion int) (*beaconhttp.BeaconResponse, error) {
 	ethVersion := r.Header.Get("Eth-Consensus-Version")
 	version, err := a.parseEthConsensusVersion(ethVersion, apiVersion)
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
+	if version >= clparams.GloasVersion {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, cltypes.ErrGloasCannotBlind)
+	}
+	defer r.Body.Close()
+	contentType, err := requestContentType(r)
+	if err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusUnsupportedMediaType, err)
+	}
+	if contentType != "application/json" && contentType != "application/octet-stream" {
+		return nil, beaconhttp.NewEndpointError(http.StatusUnsupportedMediaType, fmt.Errorf("unsupported content type: %s", contentType))
+	}
+	isJSON := contentType == "application/json"
 
 	// todo: broadcast_validation
 
 	signedBlindedBlock := cltypes.NewSignedBlindedBeaconBlock(a.beaconChainCfg, version)
 	signedBlindedBlock.Block.SetVersion(version)
 	b, err := io.ReadAll(r.Body)
-	defer r.Body.Close()
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
-	if r.Header.Get("Content-Type") == "application/json" {
+	if isJSON {
+		signedBlindedBlock.Block.Body.ExecutionPayload = nil
 		if err := json.Unmarshal(b, signedBlindedBlock); err != nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 		}
@@ -1426,6 +1474,12 @@ func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request
 			return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 		}
 	}
+	if err := validateBlindedBlockRequest(signedBlindedBlock, version); err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
+	}
+	if isJSON {
+		signedBlindedBlock.Block.SetVersion(version)
+	}
 	// submit and unblind the signedBlindedBlock
 	blockPayload, blobsBundle, executionRequests, err := a.builderClient.SubmitBlindedBlocks(r.Context(), signedBlindedBlock)
 	if err != nil {
@@ -1433,21 +1487,11 @@ func (a *ApiHandler) publishBlindedBlocks(w http.ResponseWriter, r *http.Request
 	}
 
 	if signedBlindedBlock.Version().AfterOrEqual(clparams.FuluVersion) {
-		requestsList := cltypes.GetExecutionRequestsList(a.beaconChainCfg, executionRequests)
-		requestsHash := cltypes.ComputeExecutionRequestHash(requestsList)
-		header, err := blockPayload.RlpHeader(&signedBlindedBlock.Block.ParentRoot, requestsHash)
-		if err != nil {
-			return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
-		}
-		rawBlock := types.RawBlock{Header: header, Body: blockPayload.Body()}
-		blockRlpSize := rawBlock.EncodingSize()
-		blockRlpSize += rlp.ListPrefixLen(blockRlpSize)
-		if blockRlpSize > params.MaxRlpBlockSize {
-			return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("block payload rlp size exceeds the limit: %d > %d", blockRlpSize, params.MaxRlpBlockSize))
-		}
-
 		log.Info("Successfully submitted blinded block", "block_num", signedBlindedBlock.Block.Body.ExecutionPayload.BlockNumber, "api_version", apiVersion)
 		return newBeaconResponse(nil), nil
+	}
+	if err := validateBuilderPayload(blockPayload, executionRequests, version); err != nil {
+		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
 	}
 
 	signedBlock, err := signedBlindedBlock.Unblind(blockPayload)

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -19,17 +19,23 @@ package handler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"math/big"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
+	builder_mock "github.com/erigontech/erigon/cl/beacon/builder/mock_services"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
+	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
@@ -73,6 +79,244 @@ func TestBlockBuilderWindowGloas(t *testing.T) {
 	// Attestation deadline is 3s; polling stops a quarter of it (750ms) earlier, at 2.25s.
 	require.Equal(t, slotStart.Add(2250*time.Millisecond).Add(-minPayloadPollingWindow), window.firstGetAt)
 	require.Equal(t, slotStart.Add(2250*time.Millisecond), window.pollUntil)
+}
+
+func TestPublishBlindedBlocksRejectsGloas(t *testing.T) {
+	_, _, _, _, _, h, _, _, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), true)
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(nil))
+	req.Header.Set("Eth-Consensus-Version", clparams.GloasVersion.String())
+
+	_, err := h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), cltypes.ErrGloasCannotBlind.Error())
+}
+
+func TestPublishBlindedBlocksRejectsPreBellatrix(t *testing.T) {
+	for _, version := range []clparams.StateVersion{clparams.Phase0Version, clparams.AltairVersion} {
+		t.Run(version.String(), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			h := &ApiHandler{
+				beaconChainCfg: &clparams.MainnetBeaconConfig,
+				builderClient:  builder_mock.NewMockBuilderClient(ctrl),
+			}
+			block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, version)
+			body, err := json.Marshal(block)
+			require.NoError(t, err)
+			req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Eth-Consensus-Version", version.String())
+
+			_, err = h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+			require.ErrorContains(t, err, "blinded blocks are unsupported before Bellatrix")
+		})
+	}
+
+	require.NoError(t, validateBlindedBlockRequest(
+		cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.BellatrixVersion),
+		clparams.BellatrixVersion,
+	))
+}
+
+func TestPublishBlindedBlocksRejectsUnsupportedContentType(t *testing.T) {
+	h := &ApiHandler{beaconChainCfg: &clparams.MainnetBeaconConfig}
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", nil)
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Eth-Consensus-Version", clparams.FuluVersion.String())
+
+	_, err := h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+	endpointErr, ok := err.(*beaconhttp.EndpointError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnsupportedMediaType, endpointErr.Code)
+	require.ErrorContains(t, err, "unsupported content type")
+}
+
+func TestPublishBlindedBlocksAcceptsEmptyFuluBuilderResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	builderClient := builder_mock.NewMockBuilderClient(ctrl)
+	builderClient.EXPECT().SubmitBlindedBlocks(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, block *cltypes.SignedBlindedBeaconBlock) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *cltypes.ExecutionRequests, error) {
+			require.Equal(t, cltypes.NewEth1Header(clparams.FuluVersion).EncodingSizeSSZ(), block.Block.Body.ExecutionPayload.EncodingSizeSSZ())
+			return nil, nil, nil, nil
+		},
+	)
+	h := &ApiHandler{
+		beaconChainCfg: &clparams.MainnetBeaconConfig,
+		builderClient:  builderClient,
+	}
+	block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+	body, err := json.Marshal(block)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Eth-Consensus-Version", clparams.FuluVersion.String())
+
+	resp, err := h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestPublishBlindedBlocksRejectsMissingPreFuluPayload(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	builderClient := builder_mock.NewMockBuilderClient(ctrl)
+	builderClient.EXPECT().SubmitBlindedBlocks(gomock.Any(), gomock.Any()).Return(nil, nil, nil, nil)
+	h := &ApiHandler{
+		beaconChainCfg: &clparams.MainnetBeaconConfig,
+		builderClient:  builderClient,
+	}
+	block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.ElectraVersion)
+	body, err := json.Marshal(block)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Eth-Consensus-Version", clparams.ElectraVersion.String())
+
+	_, err = h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+	require.ErrorContains(t, err, "builder returned nil execution payload")
+}
+
+func TestPublishBlindedBlocksRejectsMalformedRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		mutate     func(*cltypes.SignedBlindedBeaconBlock)
+		mutateJSON func(*testing.T, []byte) []byte
+		wantErr    string
+	}{
+		{
+			name: "missing block",
+			mutate: func(block *cltypes.SignedBlindedBeaconBlock) {
+				block.Block = nil
+			},
+			wantErr: "missing block",
+		},
+		{
+			name: "missing body",
+			mutate: func(block *cltypes.SignedBlindedBeaconBlock) {
+				block.Block.Body = nil
+			},
+			wantErr: "missing block body",
+		},
+		{
+			name: "null execution payload header",
+			mutate: func(block *cltypes.SignedBlindedBeaconBlock) {
+				block.Block.Body.ExecutionPayload = nil
+			},
+			mutateJSON: func(t *testing.T, body []byte) []byte {
+				var request map[string]any
+				require.NoError(t, json.Unmarshal(body, &request))
+				message := request["message"].(map[string]any)
+				blockBody := message["body"].(map[string]any)
+				blockBody["execution_payload_header"] = nil
+				encoded, err := json.Marshal(request)
+				require.NoError(t, err)
+				return encoded
+			},
+			wantErr: "missing execution payload header",
+		},
+		{
+			name: "omitted execution payload header",
+			mutate: func(block *cltypes.SignedBlindedBeaconBlock) {
+				block.Block.Body.ExecutionPayload = nil
+			},
+			wantErr: "missing execution payload header",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			builderClient := builder_mock.NewMockBuilderClient(ctrl)
+			h := &ApiHandler{
+				beaconChainCfg: &clparams.MainnetBeaconConfig,
+				builderClient:  builderClient,
+			}
+			block := cltypes.NewSignedBlindedBeaconBlock(&clparams.MainnetBeaconConfig, clparams.FuluVersion)
+			tc.mutate(block)
+			body, err := json.Marshal(block)
+			require.NoError(t, err)
+			if tc.mutateJSON != nil {
+				body = tc.mutateJSON(t, body)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/eth/v2/beacon/blinded_blocks", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Eth-Consensus-Version", clparams.FuluVersion.String())
+
+			_, err = h.publishBlindedBlocks(httptest.NewRecorder(), req, 2)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestValidateBuilderPayload(t *testing.T) {
+	validPayload := func(version clparams.StateVersion) *cltypes.Eth1Block {
+		payload := cltypes.NewEth1Block(version, &clparams.MainnetBeaconConfig)
+		payload.Extra = solid.NewExtraData()
+		payload.Transactions = &solid.TransactionsSSZ{}
+		if version.AfterOrEqual(clparams.CapellaVersion) {
+			payload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(clparams.MainnetBeaconConfig.MaxWithdrawalsPerPayload), 44)
+		}
+		return payload
+	}
+	validBellatrix := validPayload(clparams.BellatrixVersion)
+	require.NoError(t, validateBuilderPayload(validBellatrix, nil, clparams.BellatrixVersion))
+
+	for _, tc := range []struct {
+		name    string
+		payload *cltypes.Eth1Block
+		version clparams.StateVersion
+		wantErr string
+	}{
+		{name: "missing payload", version: clparams.BellatrixVersion, wantErr: "nil execution payload"},
+		{
+			name: "missing extra data",
+			payload: func() *cltypes.Eth1Block {
+				payload := validPayload(clparams.BellatrixVersion)
+				payload.Extra = nil
+				return payload
+			}(),
+			version: clparams.BellatrixVersion,
+			wantErr: "missing extra data",
+		},
+		{
+			name: "missing transactions",
+			payload: func() *cltypes.Eth1Block {
+				payload := validPayload(clparams.BellatrixVersion)
+				payload.Transactions = nil
+				return payload
+			}(),
+			version: clparams.BellatrixVersion,
+			wantErr: "missing transactions",
+		},
+		{
+			name: "missing withdrawals",
+			payload: func() *cltypes.Eth1Block {
+				payload := validPayload(clparams.CapellaVersion)
+				payload.Withdrawals = nil
+				return payload
+			}(),
+			version: clparams.CapellaVersion,
+			wantErr: "missing withdrawals",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.ErrorContains(t, validateBuilderPayload(tc.payload, nil, tc.version), tc.wantErr)
+		})
+	}
+}
+
+func TestValidateBuilderPayloadRejectsOlderResponseVersion(t *testing.T) {
+	payload := cltypes.NewEth1Block(clparams.BellatrixVersion, &clparams.MainnetBeaconConfig)
+	payload.Extra = solid.NewExtraData()
+	payload.Transactions = &solid.TransactionsSSZ{}
+
+	require.ErrorContains(t, validateBuilderPayload(payload, nil, clparams.ElectraVersion), "version mismatch")
+}
+
+func TestValidateBuilderPayloadRejectsMissingElectraExecutionRequests(t *testing.T) {
+	payload := cltypes.NewEth1Block(clparams.ElectraVersion, &clparams.MainnetBeaconConfig)
+	payload.Extra = solid.NewExtraData()
+	payload.Transactions = &solid.TransactionsSSZ{}
+	payload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(clparams.MainnetBeaconConfig.MaxWithdrawalsPerPayload), 44)
+
+	require.ErrorContains(t, validateBuilderPayload(payload, nil, clparams.ElectraVersion), "missing execution requests")
+	require.NoError(t, validateBuilderPayload(payload, cltypes.NewExecutionRequests(&clparams.MainnetBeaconConfig), clparams.ElectraVersion))
 }
 
 func TestBlockBuilderWindowLateStartKeepsPublicationMargin(t *testing.T) {

--- a/cl/beacon/handler/epbs.go
+++ b/cl/beacon/handler/epbs.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strconv"
 
@@ -31,6 +32,21 @@ import (
 	"github.com/erigontech/erigon/cl/pool"
 	"github.com/erigontech/erigon/common"
 )
+
+func requestContentType(r *http.Request) (string, error) {
+	contentTypeHeader := r.Header.Get("Content-Type")
+	if contentTypeHeader == "" {
+		return "application/json", nil
+	}
+	contentType, _, err := mime.ParseMediaType(contentTypeHeader)
+	if err != nil {
+		return "", fmt.Errorf("unsupported content type: %s", contentTypeHeader)
+	}
+	if contentType == "" {
+		return "application/json", nil
+	}
+	return contentType, nil
+}
 
 // ---- PTC Duties ----
 


### PR DESCRIPTION
Cherry-pick of #22606 to release/3.5.

Addresses #22598 on the 3.5 line. That issue was closed in July once the fix landed on `release/3.6` (#22606) and `main` (#22653), but the backport to `release/3.5` never happened — so current stable still panics on every Fulu blinded block submission.

`cl/beacon/builder/client.go` returns `nil, nil, nil, nil` after a successful Fulu submission, because Builder API v2 answers `202 Accepted` with no body — the relay publishes the block rather than returning the payload. `publishBlindedBlocks` then called `blockPayload.RlpHeader(...)` on that nil.

Confirmed on a mainnet validator running v3.5.4:

```
http: panic serving ...: runtime error: invalid memory address or nil pointer dereference
cl/cltypes.(*Eth1Block).RlpHeader(0x0, ...)
        cl/cltypes/eth1_block.go:463
cl/beacon/handler.(*ApiHandler).publishBlindedBlocks(...)
        cl/beacon/handler/block_production.go:1449
```

The beacon router installs no `middleware.Recoverer`, so `net/http` handles the panic: it writes the trace to stderr and drops the connection. The validator client sees only a transport error, and nothing appears in the Erigon log. Blocks still reach the chain because the relay publishes them, but the proposer gets no success signal, and a genuine relay failure is indistinguishable from success.

The removed `MaxRlpBlockSize` check went with it, as upstream. It ran after the relay had already published, so rejecting there could not prevent anything.

## r3.5-specific adaptations

- Added `requestContentType` to `cl/beacon/handler/epbs.go`, copied verbatim. Upstream gets it from #22091, a Gloas feature PR that is not on this branch.
- `cltypes.NewExecutionRequestsWithVersion` does not exist here, so the test uses `NewExecutionRequests`.
- `NewBlindedBeaconBody` on this branch hardcodes `Version: 0` and ignores its `version` argument (fixed upstream in #22091). The builder-client test therefore calls `SetVersion` explicitly, mirroring what `publishBlindedBlocks` already does in production. Production routing is unaffected, which is why the panic above reached the Fulu path at all.

## Testing

`make lint` clean over two runs. `go test ./cl/beacon/handler/ ./cl/beacon/builder/...` passes, including the new `TestPublishBlindedBlocksAcceptsEmptyFuluBuilderResponse`, which fails on this branch without the fix.
