### PR TITLE
cl/beacon: publish fork-choice head before state copy

### DIFF
--- a/cl/beacon/handler/attestation_rewards.go
+++ b/cl/beacon/handler/attestation_rewards.go
@@ -92,7 +92,7 @@ func (a *ApiHandler) PostEthV1BeaconRewardsAttestations(w http.ResponseWriter, r
 	if err != nil {
 		return nil, err
 	}
-	_, headSlot, statusCode, err := a.getHead()
+	_, headSlot, statusCode, err := a.getSelectedHead()
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(statusCode, err)
 	}

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -376,11 +376,11 @@ func (a *ApiHandler) GetEthV1ValidatorAttestationData(
 		return newBeaconResponse(attestationData), nil
 	}
 
-	if err := a.syncedData.ViewHeadState(func(headState *state.CachingBeaconState) error {
+	if err := a.viewHeadStateWithIdentity(func(headState *state.CachingBeaconState, headRoot common.Hash, _ uint64) error {
 		attestationData, err = a.attestationProducer.ProduceAndCacheAttestationData(
 			tx,
 			headState,
-			a.syncedData.HeadRoot(),
+			headRoot,
 			*slot,
 		)
 
@@ -457,18 +457,14 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 		}
 	}
 
-	baseBlockRoot := a.syncedData.HeadRoot()
-	if baseBlockRoot == (common.Hash{}) {
-		return nil, beaconhttp.NewEndpointError(
-			http.StatusServiceUnavailable,
-			errors.New("node is syncing"),
-		)
-	}
-
 	start := time.Now()
 
-	var baseState *state.CachingBeaconState
-	if err := a.syncedData.ViewHeadState(func(headState *state.CachingBeaconState) error {
+	var (
+		baseBlockRoot common.Hash
+		baseState     *state.CachingBeaconState
+	)
+	if err := a.viewHeadStateWithIdentity(func(headState *state.CachingBeaconState, root common.Hash, _ uint64) error {
+		baseBlockRoot = root
 		baseState, err = headState.Copy()
 		if err != nil {
 			return err
@@ -2112,30 +2108,53 @@ func (a *ApiHandler) storeBlockAndBlobs(
 	if err := a.forkchoiceStore.OnBlock(ctx, block, true, false, false); err != nil {
 		return err
 	}
-	finalizedHash := a.forkchoiceStore.GetFinalizedExecutionHash(a.forkchoiceStore.FinalizedCheckpoint().Root)
-	safeHash := a.forkchoiceStore.GetFinalizedExecutionHash(a.forkchoiceStore.JustifiedCheckpoint().Root)
-	if _, err := a.engine.ForkChoiceUpdate(ctx, finalizedHash, safeHash, a.forkchoiceStore.GetEth1Hash(blockRoot), nil, block.Version()); err != nil {
-		return err
-	}
-	headState, err := a.forkchoiceStore.GetStateAtBlockRoot(blockRoot, false)
+	headRoot, headSlot, headState, err := a.selectedHeadState(blockRoot)
 	if err != nil {
 		return err
 	}
-	if headState == nil {
-		return errors.New("failed to get head state")
+	finalizedHash := a.forkchoiceStore.GetFinalizedExecutionHash(a.forkchoiceStore.FinalizedCheckpoint().Root)
+	safeHash := a.forkchoiceStore.GetFinalizedExecutionHash(a.forkchoiceStore.JustifiedCheckpoint().Root)
+	headVersion := a.beaconChainCfg.GetCurrentStateVersion(headSlot / a.beaconChainCfg.SlotsPerEpoch)
+	if _, err := a.engine.ForkChoiceUpdate(ctx, finalizedHash, safeHash, a.forkchoiceStore.GetEth1Hash(headRoot), nil, headVersion); err != nil {
+		return err
 	}
 
 	if err := a.indiciesDB.View(ctx, func(tx kv.Tx) error {
-		_, err := a.attestationProducer.ProduceAndCacheAttestationData(tx, headState, blockRoot, block.Block.Slot)
+		_, err := a.attestationProducer.ProduceAndCacheAttestationData(tx, headState, headRoot, block.Block.Slot)
 		return err
 	}); err != nil {
 		return err
 	}
-	if err := a.syncedData.OnHeadStateWithBlockRoot(headState, blockRoot); err != nil {
+	if err := a.syncedData.OnHeadStateWithBlockRoot(headState, headRoot); err != nil {
 		return fmt.Errorf("failed to update synced data: %w", err)
 	}
 
 	return nil
+}
+
+func (a *ApiHandler) selectedHeadState(auxiliaryRoot common.Hash) (common.Hash, uint64, *state.CachingBeaconState, error) {
+	auxiliaryState, err := a.forkchoiceStore.GetStateAtBlockRoot(auxiliaryRoot, false)
+	if err != nil {
+		return common.Hash{}, 0, nil, err
+	}
+	if auxiliaryState == nil {
+		return common.Hash{}, 0, nil, errors.New("failed to get head state")
+	}
+	headRoot, headSlot, err := a.forkchoiceStore.GetHead(auxiliaryState)
+	if err != nil {
+		return common.Hash{}, 0, nil, err
+	}
+	if headRoot == auxiliaryRoot {
+		return headRoot, headSlot, auxiliaryState, nil
+	}
+	headState, err := a.forkchoiceStore.GetStateAtBlockRoot(headRoot, false)
+	if err != nil {
+		return common.Hash{}, 0, nil, err
+	}
+	if headState == nil {
+		return common.Hash{}, 0, nil, errors.New("failed to get selected head state")
+	}
+	return headRoot, headSlot, headState, nil
 }
 
 type attestationCandidate struct {

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -2138,7 +2138,7 @@ func (a *ApiHandler) selectedHeadState(auxiliaryRoot common.Hash) (common.Hash, 
 		return common.Hash{}, 0, nil, err
 	}
 	if auxiliaryState == nil {
-		return common.Hash{}, 0, nil, errors.New("failed to get head state")
+		return common.Hash{}, 0, nil, fmt.Errorf("failed to get auxiliary state for root %s", auxiliaryRoot)
 	}
 	headRoot, headSlot, err := a.forkchoiceStore.GetHead(auxiliaryState)
 	if err != nil {
@@ -2152,7 +2152,7 @@ func (a *ApiHandler) selectedHeadState(auxiliaryRoot common.Hash) (common.Hash, 
 		return common.Hash{}, 0, nil, err
 	}
 	if headState == nil {
-		return common.Hash{}, 0, nil, errors.New("failed to get selected head state")
+		return common.Hash{}, 0, nil, fmt.Errorf("failed to get selected head state for root %s", headRoot)
 	}
 	return headRoot, headSlot, headState, nil
 }

--- a/cl/beacon/handler/blocks.go
+++ b/cl/beacon/handler/blocks.go
@@ -39,7 +39,7 @@ func (a *ApiHandler) rootFromBlockId(ctx context.Context, tx kv.Tx, blockId *bea
 	switch {
 	case blockId.Head():
 		var statusCode int
-		root, _, statusCode, err = a.getHead()
+		root, _, statusCode, err = a.getSelectedHead()
 		if err != nil {
 			return common.Hash{}, beaconhttp.NewEndpointError(statusCode, err)
 		}

--- a/cl/beacon/handler/builder.go
+++ b/cl/beacon/handler/builder.go
@@ -43,9 +43,21 @@ func (a *ApiHandler) GetEth1V1BuilderStatesExpectedWithdrawals(w http.ResponseWr
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
+	if blockId.Head() {
+		response, _, err := a.memoizedExpectedWithdrawals(nil)
+		if err != nil {
+			return nil, err
+		}
+		return response, nil
+	}
 	root, httpStatus, err := a.blockRootFromStateId(ctx, tx, blockId)
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(httpStatus, err)
+	}
+	if response, matched, err := a.memoizedExpectedWithdrawals(&root); err != nil {
+		return nil, err
+	} else if matched {
+		return response, nil
 	}
 	isOptimistic := a.forkchoiceStore.IsRootOptimistic(root)
 	slot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, root)
@@ -57,25 +69,6 @@ func (a *ApiHandler) GetEth1V1BuilderStatesExpectedWithdrawals(w http.ResponseWr
 	}
 	if a.beaconChainCfg.GetCurrentStateVersion(*slot/a.beaconChainCfg.SlotsPerEpoch) < clparams.CapellaVersion {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, errors.New("the specified state is not a capella state"))
-	}
-	headRoot, _, statusCode, err := a.getHead()
-	if err != nil {
-		return nil, beaconhttp.NewEndpointError(statusCode, err)
-	}
-
-	if a.syncedData.Syncing() {
-		return nil, beaconhttp.NewEndpointError(http.StatusServiceUnavailable, errors.New("beacon node is syncing"))
-	}
-	if root == headRoot {
-		var expectedWithdrawals *cltypes.ExpectedWithdrawals
-		if err := a.syncedData.ViewHeadState(func(headState *state.CachingBeaconState) error {
-			var err error
-			expectedWithdrawals, err = state.GetExpectedWithdrawals(headState, state.Epoch(headState))
-			return err
-		}); err != nil {
-			return nil, err
-		}
-		return newBeaconResponse(expectedWithdrawals.Withdrawals).WithFinalized(false), nil
 	}
 	lookAhead := 1024
 	for currSlot := *slot + 1; currSlot < *slot+uint64(lookAhead); currSlot++ {
@@ -101,6 +94,29 @@ func (a *ApiHandler) GetEth1V1BuilderStatesExpectedWithdrawals(w http.ResponseWr
 	}
 
 	return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("state not found"))
+}
+
+func (a *ApiHandler) memoizedExpectedWithdrawals(requestedRoot *common.Hash) (*beaconhttp.BeaconResponse, bool, error) {
+	var response *beaconhttp.BeaconResponse
+	matched := false
+	err := a.viewHeadStateWithIdentity(func(headState *state.CachingBeaconState, root common.Hash, slot uint64) error {
+		if requestedRoot != nil && *requestedRoot != root {
+			return nil
+		}
+		matched = true
+		if a.beaconChainCfg.GetCurrentStateVersion(slot/a.beaconChainCfg.SlotsPerEpoch) < clparams.CapellaVersion {
+			return beaconhttp.NewEndpointError(http.StatusBadRequest, errors.New("the specified state is not a capella state"))
+		}
+		expectedWithdrawals, err := state.GetExpectedWithdrawals(headState, state.Epoch(headState))
+		if err != nil {
+			return err
+		}
+		response = newBeaconResponse(expectedWithdrawals.Withdrawals).
+			WithFinalized(false).
+			WithOptimistic(a.forkchoiceStore.IsRootOptimistic(root))
+		return nil
+	})
+	return response, matched, err
 }
 
 func (a *ApiHandler) PostEthV1BuilderRegisterValidator(w http.ResponseWriter, r *http.Request) (*beaconhttp.BeaconResponse, error) {

--- a/cl/beacon/handler/committees.go
+++ b/cl/beacon/handler/committees.go
@@ -25,6 +25,7 @@ import (
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	state_accessors "github.com/erigontech/erigon/cl/persistence/state"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/common"
 )
 
 type committeeResponse struct {
@@ -61,12 +62,63 @@ func (a *ApiHandler) getCommittees(w http.ResponseWriter, r *http.Request) (*bea
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
 
+	buildResponse := func(s *state.CachingBeaconState, epoch uint64) ([]*committeeResponse, error) {
+		if epoch > state.Epoch(s)+maxEpochsLookaheadForDuties {
+			return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("sync committees duties: epoch %d is too far in the future", epoch))
+		}
+		resp := make([]*committeeResponse, 0, a.beaconChainCfg.SlotsPerEpoch*a.beaconChainCfg.MaxCommitteesPerSlot)
+		committeeCount := s.CommitteeCount(epoch)
+		for currSlot := epoch * a.beaconChainCfg.SlotsPerEpoch; currSlot < (epoch+1)*a.beaconChainCfg.SlotsPerEpoch; currSlot++ {
+			if slotFilter != nil && currSlot != *slotFilter {
+				continue
+			}
+			for committeeIndex := range committeeCount {
+				if index != nil && committeeIndex != *index {
+					continue
+				}
+				data := &committeeResponse{Index: committeeIndex, Slot: currSlot}
+				idxs, err := s.GetBeaconCommitee(currSlot, committeeIndex)
+				if err != nil {
+					return nil, err
+				}
+				for _, idx := range idxs {
+					data.Validators = append(data.Validators, strconv.FormatUint(idx, 10))
+				}
+				resp = append(resp, data)
+			}
+		}
+		return resp, nil
+	}
+
+	if blockId.Head() {
+		var response *beaconhttp.BeaconResponse
+		err = a.viewHeadStateWithIdentity(func(s *state.CachingBeaconState, root common.Hash, slot uint64) error {
+			epoch := slot / a.beaconChainCfg.SlotsPerEpoch
+			if epochReq != nil {
+				epoch = *epochReq
+			}
+			if slotFilter != nil && !(epoch*a.beaconChainCfg.SlotsPerEpoch <= *slotFilter && *slotFilter < (epoch+1)*a.beaconChainCfg.SlotsPerEpoch) {
+				return beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("slot %d is not in epoch %d", *slotFilter, epoch))
+			}
+			resp, err := buildResponse(s, epoch)
+			if err != nil {
+				return err
+			}
+			response = newBeaconResponse(resp).
+				WithFinalized(slot <= a.forkchoiceStore.FinalizedSlot()).
+				WithOptimistic(a.forkchoiceStore.IsRootOptimistic(root))
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return response, nil
+	}
+
 	blockRoot, httpStatus, err := a.blockRootFromStateId(ctx, tx, blockId)
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(httpStatus, err)
 	}
-
-	isOptimistic := a.forkchoiceStore.IsRootOptimistic(blockRoot)
 	slotPtr, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, blockRoot)
 	if err != nil {
 		return nil, err
@@ -75,6 +127,7 @@ func (a *ApiHandler) getCommittees(w http.ResponseWriter, r *http.Request) (*bea
 		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("could not read block slot: %x", blockRoot))
 	}
 	slot := *slotPtr
+	isOptimistic := a.forkchoiceStore.IsRootOptimistic(blockRoot)
 	epoch := slot / a.beaconChainCfg.SlotsPerEpoch
 	if epochReq != nil {
 		epoch = *epochReq
@@ -83,41 +136,18 @@ func (a *ApiHandler) getCommittees(w http.ResponseWriter, r *http.Request) (*bea
 	if slotFilter != nil && !(epoch*a.beaconChainCfg.SlotsPerEpoch <= *slotFilter && *slotFilter < (epoch+1)*a.beaconChainCfg.SlotsPerEpoch) {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("slot %d is not in epoch %d", *slotFilter, epoch))
 	}
-	resp := make([]*committeeResponse, 0, a.beaconChainCfg.SlotsPerEpoch*a.beaconChainCfg.MaxCommitteesPerSlot)
 	isFinalized := slot <= a.forkchoiceStore.FinalizedSlot()
 	// s, cn := a.syncedData.HeadState()
 	// defer cn()
 
 	if a.forkchoiceStore.LowestAvailableSlot() <= slot {
 		// non-finality case
-		if err := a.syncedData.ViewHeadState(func(s *state.CachingBeaconState) error {
-			if epoch > state.Epoch(s)+maxEpochsLookaheadForDuties {
-				return beaconhttp.NewEndpointError(http.StatusBadRequest, fmt.Errorf("sync committees duties: epoch %d is too far in the future", epoch))
-			}
-			// get active validator indicies
-			committeeCount := s.CommitteeCount(epoch)
-			// now start obtaining the committees from the head state
-			for currSlot := epoch * a.beaconChainCfg.SlotsPerEpoch; currSlot < (epoch+1)*a.beaconChainCfg.SlotsPerEpoch; currSlot++ {
-				if slotFilter != nil && currSlot != *slotFilter {
-					continue
-				}
-				for committeeIndex := range committeeCount {
-					if index != nil && committeeIndex != *index {
-						continue
-					}
-					data := &committeeResponse{Index: committeeIndex, Slot: currSlot}
-					idxs, err := s.GetBeaconCommitee(currSlot, committeeIndex)
-					if err != nil {
-						return err
-					}
-					for _, idx := range idxs {
-						data.Validators = append(data.Validators, strconv.FormatUint(idx, 10))
-					}
-					resp = append(resp, data)
-				}
-			}
-			return nil
-		}); err != nil {
+		var resp []*committeeResponse
+		err = a.syncedData.ViewHeadState(func(s *state.CachingBeaconState) error {
+			resp, err = buildResponse(s, epoch)
+			return err
+		})
+		if err != nil {
 			return nil, err
 		}
 
@@ -143,6 +173,7 @@ func (a *ApiHandler) getCommittees(w http.ResponseWriter, r *http.Request) (*bea
 		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, fmt.Errorf("could not read randao mix: %v", err))
 	}
 
+	resp := make([]*committeeResponse, 0, a.beaconChainCfg.SlotsPerEpoch*a.beaconChainCfg.MaxCommitteesPerSlot)
 	for currSlot := epoch * a.beaconChainCfg.SlotsPerEpoch; currSlot < (epoch+1)*a.beaconChainCfg.SlotsPerEpoch; currSlot++ {
 		if slotFilter != nil && currSlot != *slotFilter {
 			continue

--- a/cl/beacon/handler/epbs.go
+++ b/cl/beacon/handler/epbs.go
@@ -204,7 +204,7 @@ func (a *ApiHandler) GetEthV1ValidatorPayloadAttestationData(w http.ResponseWrit
 	}
 
 	// Get the beacon block root for this slot from fork choice
-	headRoot, headSlot, _, err := a.getHead()
+	headRoot, headSlot, _, err := a.getSelectedHead()
 	if err != nil {
 		return nil, err
 	}
@@ -1050,7 +1050,7 @@ func (a *ApiHandler) GetEthV1ValidatorExecutionPayloadEnvelopeBySlot(w http.Resp
 func (a *ApiHandler) blockRootFromBlockId(blockId *beaconhttp.SegmentID) (common.Hash, error) {
 	switch {
 	case blockId.Head():
-		root, _, _, err := a.getHead()
+		root, _, _, err := a.getSelectedHead()
 		return root, err
 	case blockId.Finalized():
 		// Get finalized root from fork choice

--- a/cl/beacon/handler/forkchoice.go
+++ b/cl/beacon/handler/forkchoice.go
@@ -38,7 +38,7 @@ func (a *ApiHandler) GetEthV2DebugBeaconHeads(w http.ResponseWriter, r *http.Req
 			map[string]any{
 				"slot":                 strconv.FormatUint(slot, 10),
 				"root":                 root,
-				"execution_optimistic": false,
+				"execution_optimistic": a.forkchoiceStore.IsRootOptimistic(root),
 			},
 		},
 	), nil

--- a/cl/beacon/handler/forkchoice.go
+++ b/cl/beacon/handler/forkchoice.go
@@ -29,7 +29,7 @@ func (a *ApiHandler) GetEthV2DebugBeaconHeads(w http.ResponseWriter, r *http.Req
 	if a.syncedData.Syncing() {
 		return nil, beaconhttp.NewEndpointError(http.StatusServiceUnavailable, errors.New("beacon node is syncing"))
 	}
-	root, slot, statusCode, err := a.getHead()
+	root, slot, statusCode, err := a.getSelectedHead()
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(statusCode, err)
 	}

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -470,12 +470,12 @@ func (a *ApiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	a.mux.ServeHTTP(w, r)
 }
 
+// getHead resolves the head from fork choice, not from the memoized head state: the latter
+// only advances once the head state has been copied, so reading it hands out the parent root
+// for the whole duration of that copy.
 func (a *ApiHandler) getHead() (common.Hash, uint64, int, error) {
-	if a.enableMemoizedHeadState {
-		if a.syncedData.Syncing() {
-			return common.Hash{}, 0, http.StatusServiceUnavailable, errors.New("beacon node is syncing")
-		}
-		return a.syncedData.HeadRoot(), a.syncedData.HeadSlot(), 0, nil
+	if a.enableMemoizedHeadState && a.syncedData.Syncing() {
+		return common.Hash{}, 0, http.StatusServiceUnavailable, errors.New("beacon node is syncing")
 	}
 	blockRoot, blockSlot, err := a.forkchoiceStore.GetHead(nil)
 	if err != nil {

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -470,16 +470,39 @@ func (a *ApiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	a.mux.ServeHTTP(w, r)
 }
 
-// getHead resolves the head from fork choice, not from the memoized head state: the latter
-// only advances once the head state has been copied, so reading it hands out the parent root
-// for the whole duration of that copy.
-func (a *ApiHandler) getHead() (common.Hash, uint64, int, error) {
-	if a.enableMemoizedHeadState && a.syncedData.Syncing() {
-		return common.Hash{}, 0, http.StatusServiceUnavailable, errors.New("beacon node is syncing")
+func (a *ApiHandler) getStateHead() (common.Hash, uint64, int, error) {
+	if a.enableMemoizedHeadState {
+		blockRoot, blockSlot, ok := a.syncedData.StateHead()
+		if !ok {
+			return common.Hash{}, 0, http.StatusServiceUnavailable, errors.New("beacon node is syncing")
+		}
+		return blockRoot, blockSlot, 0, nil
 	}
 	blockRoot, blockSlot, err := a.forkchoiceStore.GetHead(nil)
 	if err != nil {
 		return common.Hash{}, 0, http.StatusInternalServerError, err
 	}
 	return blockRoot, blockSlot, 0, nil
+}
+
+func (a *ApiHandler) getSelectedHead() (common.Hash, uint64, int, error) {
+	if !a.enableMemoizedHeadState {
+		return a.getStateHead()
+	}
+	stateRoot, stateSlot, stateReady := a.syncedData.StateHead()
+	if !stateReady {
+		return common.Hash{}, 0, http.StatusServiceUnavailable, errors.New("beacon node is syncing")
+	}
+	if blockRoot, blockSlot, ok := a.syncedData.SelectedHead(); ok {
+		return blockRoot, blockSlot, 0, nil
+	}
+	return stateRoot, stateSlot, 0, nil
+}
+
+func (a *ApiHandler) viewHeadStateWithIdentity(fn synced_data.ViewHeadStateWithIdentityFn) error {
+	err := a.syncedData.ViewHeadStateWithIdentity(fn)
+	if errors.Is(err, synced_data.ErrNotSynced) {
+		return beaconhttp.NewEndpointError(http.StatusServiceUnavailable, err)
+	}
+	return err
 }

--- a/cl/beacon/handler/head_test.go
+++ b/cl/beacon/handler/head_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	sync_mock_services "github.com/erigontech/erigon/cl/beacon/synced_data/mock_services"
+	mock_services2 "github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
+	"github.com/erigontech/erigon/common"
+)
+
+// The memoized head state trails the fork choice head by however long it takes to copy
+// the head state, so resolving head from it hands out a stale root for the whole window.
+func TestGetHeadDoesNotTrailTheMemoizedHeadState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
+	syncedData.EXPECT().Syncing().Return(false).AnyTimes()
+	syncedData.EXPECT().HeadRoot().Return(common.Hash{0xbb}).AnyTimes()
+	syncedData.EXPECT().HeadSlot().Return(uint64(99)).AnyTimes()
+
+	fcu := mock_services2.NewForkChoiceStorageMock(t)
+	fcu.HeadVal = common.Hash{0xaa}
+	fcu.HeadSlotVal = 100
+
+	a := &ApiHandler{
+		enableMemoizedHeadState: true,
+		syncedData:              syncedData,
+		forkchoiceStore:         fcu,
+	}
+
+	root, slot, statusCode, err := a.getHead()
+	require.NoError(t, err)
+	require.Equal(t, 0, statusCode)
+	require.Equal(t, common.Hash{0xaa}, root)
+	require.Equal(t, uint64(100), slot)
+}
+
+func TestGetHeadReportsSyncing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
+	syncedData.EXPECT().Syncing().Return(true).AnyTimes()
+
+	a := &ApiHandler{
+		enableMemoizedHeadState: true,
+		syncedData:              syncedData,
+		forkchoiceStore:         mock_services2.NewForkChoiceStorageMock(t),
+	}
+
+	_, _, statusCode, err := a.getHead()
+	require.Error(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, statusCode)
+}

--- a/cl/beacon/handler/head_test.go
+++ b/cl/beacon/handler/head_test.go
@@ -186,6 +186,26 @@ func TestSelectedHeadStateUsesWinningSideBranch(t *testing.T) {
 	require.Same(t, selectedState, headState)
 }
 
+func TestSelectedHeadStateReportsMissingAuxiliaryRoot(t *testing.T) {
+	auxiliaryRoot := common.Hash{0xaa}
+	a := &ApiHandler{forkchoiceStore: mock_services2.NewForkChoiceStorageMock(t)}
+
+	_, _, _, err := a.selectedHeadState(auxiliaryRoot)
+	require.EqualError(t, err, "failed to get auxiliary state for root 0xaa00000000000000000000000000000000000000000000000000000000000000")
+}
+
+func TestSelectedHeadStateReportsMissingSelectedRoot(t *testing.T) {
+	auxiliaryRoot := common.Hash{0xaa}
+	selectedRoot := common.Hash{0xbb}
+	fcu := mock_services2.NewForkChoiceStorageMock(t)
+	fcu.HeadVal = selectedRoot
+	fcu.StateAtBlockRootVal[auxiliaryRoot] = state.New(&clparams.MainnetBeaconConfig)
+	a := &ApiHandler{forkchoiceStore: fcu}
+
+	_, _, _, err := a.selectedHeadState(auxiliaryRoot)
+	require.EqualError(t, err, "failed to get selected head state for root 0xbb00000000000000000000000000000000000000000000000000000000000000")
+}
+
 func TestMemoizedExpectedWithdrawalsMatchesExplicitHeadRoot(t *testing.T) {
 	cfg := clparams.MainnetBeaconConfig
 	cfg.AltairForkEpoch = 0

--- a/cl/beacon/handler/head_test.go
+++ b/cl/beacon/handler/head_test.go
@@ -17,25 +17,49 @@
 package handler
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/erigontech/erigon/cl/beacon/beaconhttp"
+	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	sync_mock_services "github.com/erigontech/erigon/cl/beacon/synced_data/mock_services"
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
 	mock_services2 "github.com/erigontech/erigon/cl/phase1/forkchoice/mock_services"
 	"github.com/erigontech/erigon/common"
 )
 
-// The memoized head state trails the fork choice head by however long it takes to copy
-// the head state, so resolving head from it hands out a stale root for the whole window.
-func TestGetHeadDoesNotTrailTheMemoizedHeadState(t *testing.T) {
+func TestGetSelectedHeadDoesNotTrailTheMemoizedHeadState(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
-	syncedData.EXPECT().Syncing().Return(false).AnyTimes()
-	syncedData.EXPECT().HeadRoot().Return(common.Hash{0xbb}).AnyTimes()
-	syncedData.EXPECT().HeadSlot().Return(uint64(99)).AnyTimes()
+	syncedData.EXPECT().StateHead().Return(common.Hash{0xbb}, uint64(99), true)
+	syncedData.EXPECT().SelectedHead().Return(common.Hash{0xaa}, uint64(100), true)
+
+	fcu := mock_services2.NewForkChoiceStorageMock(t)
+
+	a := &ApiHandler{
+		enableMemoizedHeadState: true,
+		syncedData:              syncedData,
+		forkchoiceStore:         fcu,
+	}
+
+	root, slot, statusCode, err := a.getSelectedHead()
+	require.NoError(t, err)
+	require.Equal(t, 0, statusCode)
+	require.Equal(t, common.Hash{0xaa}, root)
+	require.Equal(t, uint64(100), slot)
+}
+
+func TestGetStateHeadKeepsMemoizedStateIdentity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
+	syncedData.EXPECT().StateHead().Return(common.Hash{0xbb}, uint64(99), true)
 
 	fcu := mock_services2.NewForkChoiceStorageMock(t)
 	fcu.HeadVal = common.Hash{0xaa}
@@ -47,17 +71,18 @@ func TestGetHeadDoesNotTrailTheMemoizedHeadState(t *testing.T) {
 		forkchoiceStore:         fcu,
 	}
 
-	root, slot, statusCode, err := a.getHead()
+	root, slot, statusCode, err := a.getStateHead()
 	require.NoError(t, err)
 	require.Equal(t, 0, statusCode)
-	require.Equal(t, common.Hash{0xaa}, root)
-	require.Equal(t, uint64(100), slot)
+	require.Equal(t, common.Hash{0xbb}, root)
+	require.Equal(t, uint64(99), slot)
 }
 
-func TestGetHeadReportsSyncing(t *testing.T) {
+func TestGetSelectedHeadFallsBackToMemoizedStateIdentity(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
-	syncedData.EXPECT().Syncing().Return(true).AnyTimes()
+	syncedData.EXPECT().StateHead().Return(common.Hash{0xbb}, uint64(99), true)
+	syncedData.EXPECT().SelectedHead().Return(common.Hash{}, uint64(0), false)
 
 	a := &ApiHandler{
 		enableMemoizedHeadState: true,
@@ -65,7 +90,109 @@ func TestGetHeadReportsSyncing(t *testing.T) {
 		forkchoiceStore:         mock_services2.NewForkChoiceStorageMock(t),
 	}
 
-	_, _, statusCode, err := a.getHead()
+	root, slot, statusCode, err := a.getSelectedHead()
+	require.NoError(t, err)
+	require.Equal(t, 0, statusCode)
+	require.Equal(t, common.Hash{0xbb}, root)
+	require.Equal(t, uint64(99), slot)
+}
+
+func TestHeadBlockIDUsesSelectedHead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
+	syncedData.EXPECT().StateHead().Return(common.Hash{0xbb}, uint64(99), true)
+	syncedData.EXPECT().SelectedHead().Return(common.Hash{0xaa}, uint64(100), true)
+
+	fcu := mock_services2.NewForkChoiceStorageMock(t)
+	fcu.HeadVal = common.Hash{0xcc}
+	fcu.HeadSlotVal = 101
+	a := &ApiHandler{
+		enableMemoizedHeadState: true,
+		syncedData:              syncedData,
+		forkchoiceStore:         fcu,
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/eth/v1/beacon/blocks/head/root", nil)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("block_id", "head")
+	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
+	blockID, err := beaconhttp.BlockIdFromRequest(request)
+	require.NoError(t, err)
+
+	root, err := a.rootFromBlockId(request.Context(), nil, blockID)
+	require.NoError(t, err)
+	require.Equal(t, common.Hash{0xaa}, root)
+}
+
+func TestGetHeadReportsSyncing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
+	syncedData.EXPECT().StateHead().Return(common.Hash{}, uint64(0), false)
+
+	a := &ApiHandler{
+		enableMemoizedHeadState: true,
+		syncedData:              syncedData,
+		forkchoiceStore:         mock_services2.NewForkChoiceStorageMock(t),
+	}
+
+	_, _, statusCode, err := a.getStateHead()
 	require.Error(t, err)
 	require.Equal(t, http.StatusServiceUnavailable, statusCode)
+}
+
+func TestSelectedHeadStateUsesWinningSideBranch(t *testing.T) {
+	submittedRoot := common.Hash{0xaa}
+	selectedRoot := common.Hash{0xbb}
+	submittedState := state.New(&clparams.MainnetBeaconConfig)
+	selectedState := state.New(&clparams.MainnetBeaconConfig)
+	fcu := mock_services2.NewForkChoiceStorageMock(t)
+	fcu.HeadVal = selectedRoot
+	fcu.HeadSlotVal = 99
+	fcu.StateAtBlockRootVal[submittedRoot] = submittedState
+	fcu.StateAtBlockRootVal[selectedRoot] = selectedState
+	a := &ApiHandler{forkchoiceStore: fcu}
+
+	root, slot, headState, err := a.selectedHeadState(submittedRoot)
+	require.NoError(t, err)
+	require.Equal(t, selectedRoot, root)
+	require.Equal(t, uint64(99), slot)
+	require.Same(t, selectedState, headState)
+}
+
+func TestMemoizedExpectedWithdrawalsMatchesExplicitHeadRoot(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	headState := state.New(&cfg)
+	headState.SetVersion(clparams.CapellaVersion)
+	headRoot := common.Hash{0xaa}
+
+	ctrl := gomock.NewController(t)
+	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
+	syncedData.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).DoAndReturn(func(fn synced_data.ViewHeadStateWithIdentityFn) error {
+		return fn(headState, headRoot, 0)
+	})
+	a := &ApiHandler{
+		beaconChainCfg:  &cfg,
+		syncedData:      syncedData,
+		forkchoiceStore: mock_services2.NewForkChoiceStorageMock(t),
+	}
+
+	response, matched, err := a.memoizedExpectedWithdrawals(&headRoot)
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.NotNil(t, response)
+}
+
+func TestViewHeadStateWithIdentityReportsSyncing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
+	syncedData.EXPECT().ViewHeadStateWithIdentity(gomock.Any()).Return(synced_data.ErrNotSynced)
+	a := &ApiHandler{syncedData: syncedData}
+
+	err := a.viewHeadStateWithIdentity(func(*state.CachingBeaconState, common.Hash, uint64) error { return nil })
+	endpointErr, ok := err.(*beaconhttp.EndpointError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusServiceUnavailable, endpointErr.Code)
 }

--- a/cl/beacon/handler/head_test.go
+++ b/cl/beacon/handler/head_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -54,6 +55,32 @@ func TestGetSelectedHeadDoesNotTrailTheMemoizedHeadState(t *testing.T) {
 	require.Equal(t, 0, statusCode)
 	require.Equal(t, common.Hash{0xaa}, root)
 	require.Equal(t, uint64(100), slot)
+}
+
+func TestDebugBeaconHeadsReportsSelectedHeadOptimistic(t *testing.T) {
+	for _, optimistic := range []bool{false, true} {
+		t.Run(strconv.FormatBool(optimistic), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			syncedData := sync_mock_services.NewMockSyncedData(ctrl)
+			syncedData.EXPECT().Syncing().Return(false)
+			syncedData.EXPECT().StateHead().Return(common.Hash{0xbb}, uint64(99), true)
+			syncedData.EXPECT().SelectedHead().Return(common.Hash{0xaa}, uint64(100), true)
+
+			fcu := mock_services2.NewForkChoiceStorageMock(t)
+			fcu.IsRootOptimisticVal = optimistic
+			a := &ApiHandler{
+				enableMemoizedHeadState: true,
+				syncedData:              syncedData,
+				forkchoiceStore:         fcu,
+			}
+
+			response, err := a.GetEthV2DebugBeaconHeads(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/eth/v2/debug/beacon/heads", nil))
+			require.NoError(t, err)
+			heads := response.Data.([]any)
+			require.Len(t, heads, 1)
+			require.Equal(t, optimistic, heads[0].(map[string]any)["execution_optimistic"])
+		})
+	}
 }
 
 func TestGetStateHeadKeepsMemoizedStateIdentity(t *testing.T) {
@@ -124,7 +151,7 @@ func TestHeadBlockIDUsesSelectedHead(t *testing.T) {
 	require.Equal(t, common.Hash{0xaa}, root)
 }
 
-func TestGetHeadReportsSyncing(t *testing.T) {
+func TestGetStateHeadReportsSyncing(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	syncedData := sync_mock_services.NewMockSyncedData(ctrl)
 	syncedData.EXPECT().StateHead().Return(common.Hash{}, uint64(0), false)

--- a/cl/beacon/handler/headers.go
+++ b/cl/beacon/handler/headers.go
@@ -132,7 +132,7 @@ func (a *ApiHandler) getHeader(w http.ResponseWriter, r *http.Request) (*beaconh
 
 	return newBeaconResponse(&headerResponse{
 		Root:      root,
-		Canonical: canonicalRoot == root,
+		Canonical: blockId.Head() || canonicalRoot == root,
 		Header:    signedHeader,
 	}).WithFinalized(canonicalRoot == root && signedHeader.Header.Slot <= a.forkchoiceStore.FinalizedSlot()).
 		WithOptimistic(a.forkchoiceStore.IsRootOptimistic(root)), nil

--- a/cl/beacon/handler/headers_test.go
+++ b/cl/beacon/handler/headers_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
 )
 
 func TestGetHeadersIncludesFinalized(t *testing.T) {
@@ -134,4 +135,31 @@ func TestGetHeadersIncludesFinalized(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetHeadHeaderIsCanonicalBeforeDatabasePromotion(t *testing.T) {
+	db, blocks, _, _, _, handler, _, _, fcu, _ := setupTestingHandler(t, clparams.Phase0Version, log.Root(), false)
+	head := blocks[len(blocks)-1]
+	headRoot, err := head.Block.HashSSZ()
+	require.NoError(t, err)
+	fcu.HeadVal = headRoot
+	fcu.HeadSlotVal = head.Block.Slot
+
+	require.NoError(t, db.Update(context.Background(), func(tx kv.RwTx) error {
+		return beacon_indicies.TruncateCanonicalChain(context.Background(), tx, head.Block.Slot)
+	}))
+
+	server := httptest.NewServer(handler.mux)
+	defer server.Close()
+	resp, err := http.Get(server.URL + "/eth/v1/beacon/headers/head")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		Data headerResponse `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	require.Equal(t, common.Hash(headRoot), body.Data.Root)
+	require.True(t, body.Data.Canonical)
 }

--- a/cl/beacon/handler/states.go
+++ b/cl/beacon/handler/states.go
@@ -38,7 +38,7 @@ import (
 func (a *ApiHandler) blockRootFromStateId(ctx context.Context, tx kv.Tx, stateId *beaconhttp.SegmentID) (root common.Hash, httpStatusErr int, err error) {
 	switch {
 	case stateId.Head():
-		root, _, httpStatusErr, err = a.getHead()
+		root, _, httpStatusErr, err = a.getStateHead()
 		return
 	case stateId.Finalized():
 		root = a.forkchoiceStore.FinalizedCheckpoint().Root

--- a/cl/beacon/handler/validators.go
+++ b/cl/beacon/handler/validators.go
@@ -289,7 +289,6 @@ func (a *ApiHandler) writeValidatorsResponse(
 	validatorIds,
 	queryFilters []string,
 ) {
-	isOptimistic := a.forkchoiceStore.IsRootOptimistic(blockRoot)
 	filterIndicies, err := parseQueryValidatorIndicies(a.syncedData, validatorIds)
 	if err != nil {
 		beaconhttp.NewEndpointError(http.StatusBadRequest, err).WriteTo(w)
@@ -303,14 +302,15 @@ func (a *ApiHandler) writeValidatorsResponse(
 	}
 
 	if blockId.Head() { // Lets see if we point to head, if yes then we need to look at the head state we always keep.
-		if err := a.syncedData.ViewHeadState(func(s *state.CachingBeaconState) error {
-			responseValidators(w, filterIndicies, statusFilters, state.Epoch(s), s.Balances(), s.Validators(), false, isOptimistic)
+		if err := a.viewHeadStateWithIdentity(func(s *state.CachingBeaconState, root common.Hash, _ uint64) error {
+			responseValidators(w, filterIndicies, statusFilters, state.Epoch(s), s.Balances(), s.Validators(), false, a.forkchoiceStore.IsRootOptimistic(root))
 			return nil
 		}); err != nil {
 			beaconhttp.NewEndpointError(http.StatusServiceUnavailable, errors.New("node is not synced")).WriteTo(w)
 		}
 		return
 	}
+	isOptimistic := a.forkchoiceStore.IsRootOptimistic(blockRoot)
 	slot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, blockRoot)
 	if err != nil {
 		beaconhttp.NewEndpointError(http.StatusInternalServerError, err).WriteTo(w)
@@ -424,8 +424,6 @@ func (a *ApiHandler) GetEthV1BeaconStatesValidator(w http.ResponseWriter, r *htt
 		return nil, beaconhttp.NewEndpointError(httpStatus, err)
 	}
 
-	isOptimistic := a.forkchoiceStore.IsRootOptimistic(blockRoot)
-
 	validatorId, err := beaconhttp.StringFromRequest(r, "validator_id")
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
@@ -446,12 +444,12 @@ func (a *ApiHandler) GetEthV1BeaconStatesValidator(w http.ResponseWriter, r *htt
 			resp *beaconhttp.BeaconResponse
 			err  error
 		)
-		if err := a.syncedData.ViewHeadState(func(s *state.CachingBeaconState) error {
+		if err := a.viewHeadStateWithIdentity(func(s *state.CachingBeaconState, root common.Hash, _ uint64) error {
 			if s.ValidatorLength() <= int(validatorIndex) {
 				resp = newBeaconResponse([]int{}).WithFinalized(false)
 				return nil
 			}
-			resp, err = responseValidator(validatorIndex, state.Epoch(s), s.Balances(), s.Validators(), false, isOptimistic)
+			resp, err = responseValidator(validatorIndex, state.Epoch(s), s.Balances(), s.Validators(), false, a.forkchoiceStore.IsRootOptimistic(root))
 			return nil // return err later
 		}); err != nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusServiceUnavailable, errors.New("node is not synced"))
@@ -459,6 +457,7 @@ func (a *ApiHandler) GetEthV1BeaconStatesValidator(w http.ResponseWriter, r *htt
 
 		return resp, err
 	}
+	isOptimistic := a.forkchoiceStore.IsRootOptimistic(blockRoot)
 	slot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, blockRoot)
 	if err != nil {
 		return nil, err
@@ -552,18 +551,17 @@ func (a *ApiHandler) getValidatorBalances(ctx context.Context, w http.ResponseWr
 		return nil, beaconhttp.NewEndpointError(http.StatusBadRequest, err)
 	}
 
-	isOptimistic := a.forkchoiceStore.IsRootOptimistic(blockRoot)
-
 	if blockId.Head() { // Lets see if we point to head, if yes then we need to look at the head state we always keep.
 		var response *beaconhttp.BeaconResponse
-		if err := a.syncedData.ViewHeadState(func(s *state.CachingBeaconState) error {
-			response = responseValidatorsBalances(w, filterIndicies, s.Balances(), false, isOptimistic)
+		if err := a.viewHeadStateWithIdentity(func(s *state.CachingBeaconState, root common.Hash, _ uint64) error {
+			response = responseValidatorsBalances(w, filterIndicies, s.Balances(), false, a.forkchoiceStore.IsRootOptimistic(root))
 			return nil
 		}); err != nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusServiceUnavailable, errors.New("node is not synced"))
 		}
 		return response, nil
 	}
+	isOptimistic := a.forkchoiceStore.IsRootOptimistic(blockRoot)
 	slot, err := beacon_indicies.ReadBlockSlotByBlockRoot(tx, blockRoot)
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
@@ -805,16 +803,16 @@ func (a *ApiHandler) GetEthV1ValidatorIdentities(w http.ResponseWriter, r *http.
 	if err != nil {
 		return nil, beaconhttp.NewEndpointError(httpStatus, err)
 	}
-	isOptimistic := a.forkchoiceStore.IsRootOptimistic(blockRoot)
-
 	var (
-		validators  *solid.ValidatorSet
-		isFinalized bool
+		validators   *solid.ValidatorSet
+		isFinalized  bool
+		isOptimistic bool
 	)
 	if blockId.Head() {
 		// If we are looking at the head, we can just read the validators from the head state
-		if err := a.syncedData.ViewHeadState(func(s *state.CachingBeaconState) error {
+		if err := a.viewHeadStateWithIdentity(func(s *state.CachingBeaconState, root common.Hash, _ uint64) error {
 			validators = s.Validators()
+			isOptimistic = a.forkchoiceStore.IsRootOptimistic(root)
 			return nil
 		}); err != nil {
 			return nil, beaconhttp.NewEndpointError(http.StatusInternalServerError, err)
@@ -843,6 +841,7 @@ func (a *ApiHandler) GetEthV1ValidatorIdentities(w http.ResponseWriter, r *http.
 			}
 		}
 		isFinalized = *slot <= a.forkchoiceStore.FinalizedSlot()
+		isOptimistic = a.forkchoiceStore.IsRootOptimistic(blockRoot)
 	}
 	if validators == nil {
 		return nil, beaconhttp.NewEndpointError(http.StatusNotFound, errors.New("validators not found"))

--- a/cl/beacon/synced_data/interface.go
+++ b/cl/beacon/synced_data/interface.go
@@ -23,16 +23,20 @@ import (
 )
 
 type (
-	CancelFn        func()
-	ViewHeadStateFn func(headState *state.CachingBeaconState) error
+	CancelFn                    func()
+	ViewHeadStateFn             func(headState *state.CachingBeaconState) error
+	ViewHeadStateWithIdentityFn func(headState *state.CachingBeaconState, root common.Hash, slot uint64) error
 )
 
 //go:generate mockgen -typed=true -destination=./mock_services/synced_data_mock.go -package=mock_services . SyncedData
 type SyncedData interface {
+	SelectedHead() (common.Hash, uint64, bool)
+	StateHead() (common.Hash, uint64, bool)
 	OnHeadState(newState *state.CachingBeaconState) error
 	OnHeadStateWithBlockRoot(newState *state.CachingBeaconState, blockRoot common.Hash) error
 	UnsetHeadState()
 	ViewHeadState(fn ViewHeadStateFn) error
+	ViewHeadStateWithIdentity(fn ViewHeadStateWithIdentityFn) error
 	ViewPreviousHeadState(fn ViewHeadStateFn) error
 	Syncing() bool
 	HeadSlot() uint64

--- a/cl/beacon/synced_data/mock_services/synced_data_mock.go
+++ b/cl/beacon/synced_data/mock_services/synced_data_mock.go
@@ -311,6 +311,86 @@ func (c *MockSyncedDataOnHeadStateWithBlockRootCall) DoAndReturn(f func(*state.C
 	return c
 }
 
+// SelectedHead mocks base method.
+func (m *MockSyncedData) SelectedHead() (common.Hash, uint64, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectedHead")
+	ret0, _ := ret[0].(common.Hash)
+	ret1, _ := ret[1].(uint64)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
+}
+
+// SelectedHead indicates an expected call of SelectedHead.
+func (mr *MockSyncedDataMockRecorder) SelectedHead() *MockSyncedDataSelectedHeadCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectedHead", reflect.TypeOf((*MockSyncedData)(nil).SelectedHead))
+	return &MockSyncedDataSelectedHeadCall{Call: call}
+}
+
+// MockSyncedDataSelectedHeadCall wrap *gomock.Call
+type MockSyncedDataSelectedHeadCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockSyncedDataSelectedHeadCall) Return(arg0 common.Hash, arg1 uint64, arg2 bool) *MockSyncedDataSelectedHeadCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockSyncedDataSelectedHeadCall) Do(f func() (common.Hash, uint64, bool)) *MockSyncedDataSelectedHeadCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockSyncedDataSelectedHeadCall) DoAndReturn(f func() (common.Hash, uint64, bool)) *MockSyncedDataSelectedHeadCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// StateHead mocks base method.
+func (m *MockSyncedData) StateHead() (common.Hash, uint64, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StateHead")
+	ret0, _ := ret[0].(common.Hash)
+	ret1, _ := ret[1].(uint64)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
+}
+
+// StateHead indicates an expected call of StateHead.
+func (mr *MockSyncedDataMockRecorder) StateHead() *MockSyncedDataStateHeadCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateHead", reflect.TypeOf((*MockSyncedData)(nil).StateHead))
+	return &MockSyncedDataStateHeadCall{Call: call}
+}
+
+// MockSyncedDataStateHeadCall wrap *gomock.Call
+type MockSyncedDataStateHeadCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockSyncedDataStateHeadCall) Return(arg0 common.Hash, arg1 uint64, arg2 bool) *MockSyncedDataStateHeadCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockSyncedDataStateHeadCall) Do(f func() (common.Hash, uint64, bool)) *MockSyncedDataStateHeadCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockSyncedDataStateHeadCall) DoAndReturn(f func() (common.Hash, uint64, bool)) *MockSyncedDataStateHeadCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Syncing mocks base method.
 func (m *MockSyncedData) Syncing() bool {
 	m.ctrl.T.Helper()
@@ -498,6 +578,44 @@ func (c *MockSyncedDataViewHeadStateCall) Do(f func(synced_data.ViewHeadStateFn)
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockSyncedDataViewHeadStateCall) DoAndReturn(f func(synced_data.ViewHeadStateFn) error) *MockSyncedDataViewHeadStateCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ViewHeadStateWithIdentity mocks base method.
+func (m *MockSyncedData) ViewHeadStateWithIdentity(fn synced_data.ViewHeadStateWithIdentityFn) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ViewHeadStateWithIdentity", fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ViewHeadStateWithIdentity indicates an expected call of ViewHeadStateWithIdentity.
+func (mr *MockSyncedDataMockRecorder) ViewHeadStateWithIdentity(fn any) *MockSyncedDataViewHeadStateWithIdentityCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ViewHeadStateWithIdentity", reflect.TypeOf((*MockSyncedData)(nil).ViewHeadStateWithIdentity), fn)
+	return &MockSyncedDataViewHeadStateWithIdentityCall{Call: call}
+}
+
+// MockSyncedDataViewHeadStateWithIdentityCall wrap *gomock.Call
+type MockSyncedDataViewHeadStateWithIdentityCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockSyncedDataViewHeadStateWithIdentityCall) Return(arg0 error) *MockSyncedDataViewHeadStateWithIdentityCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockSyncedDataViewHeadStateWithIdentityCall) Do(f func(synced_data.ViewHeadStateWithIdentityFn) error) *MockSyncedDataViewHeadStateWithIdentityCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockSyncedDataViewHeadStateWithIdentityCall) DoAndReturn(f func(synced_data.ViewHeadStateWithIdentityFn) error) *MockSyncedDataViewHeadStateWithIdentityCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cl/beacon/synced_data/selected_head_test.go
+++ b/cl/beacon/synced_data/selected_head_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package synced_data
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/common"
+)
+
+func TestSelectedHeadLifecycle(t *testing.T) {
+	manager := NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+
+	_, _, ok := manager.SelectedHead()
+	require.False(t, ok)
+
+	root100 := common.Hash{0x10}
+	manager.OnSelectedHead(root100, 100)
+	root, slot, ok := manager.SelectedHead()
+	require.True(t, ok)
+	require.Equal(t, root100, root)
+	require.Equal(t, uint64(100), slot)
+
+	root99 := common.Hash{0x09}
+	manager.OnSelectedHead(root99, 99)
+	root, slot, ok = manager.SelectedHead()
+	require.True(t, ok)
+	require.Equal(t, root99, root)
+	require.Equal(t, uint64(99), slot)
+
+	manager.UnsetHeadState()
+	_, _, ok = manager.SelectedHead()
+	require.False(t, ok)
+}
+
+func TestSelectedHeadDisabled(t *testing.T) {
+	manager := NewSyncedDataManager(&clparams.MainnetBeaconConfig, false)
+	manager.OnSelectedHead(common.Hash{0x10}, 100)
+
+	_, _, ok := manager.SelectedHead()
+	require.False(t, ok)
+}
+
+func TestSelectedHeadRootAndSlotStayInOneGeneration(t *testing.T) {
+	manager := NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+	rootA := common.Hash{0xaa}
+	rootB := common.Hash{0xbb}
+	manager.OnSelectedHead(rootA, 100)
+
+	var writers sync.WaitGroup
+	writers.Go(func() {
+		for range 10_000 {
+			manager.OnSelectedHead(rootB, 99)
+			manager.OnSelectedHead(rootA, 100)
+		}
+	})
+
+	for range 10_000 {
+		root, slot, ok := manager.SelectedHead()
+		require.True(t, ok)
+		require.True(t, root == rootA && slot == 100 || root == rootB && slot == 99)
+	}
+	writers.Wait()
+}
+
+func TestStateHeadRootAndSlotStayInOneGeneration(t *testing.T) {
+	manager := NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+	rootA := common.Hash{0xaa}
+	rootB := common.Hash{0xbb}
+	manager.stateHead.Store(&headIdentity{root: rootA, slot: 100})
+
+	var writers sync.WaitGroup
+	writers.Go(func() {
+		for range 10_000 {
+			manager.stateHead.Store(&headIdentity{root: rootB, slot: 99})
+			manager.stateHead.Store(&headIdentity{root: rootA, slot: 100})
+		}
+	})
+
+	for range 10_000 {
+		root, slot, ok := manager.StateHead()
+		require.True(t, ok)
+		require.True(t, root == rootA && slot == 100 || root == rootB && slot == 99)
+	}
+	writers.Wait()
+}
+
+func TestViewHeadStateWithIdentityStaysInOneGeneration(t *testing.T) {
+	manager := NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+	manager.headState = state.New(&clparams.MainnetBeaconConfig)
+	manager.stateHead.Store(&headIdentity{root: common.Hash{0xaa}, slot: 100})
+	manager.headState.SetSlot(100)
+
+	var writers sync.WaitGroup
+	writers.Go(func() {
+		for range 10_000 {
+			manager.mu.Lock()
+			manager.headState.SetSlot(99)
+			manager.stateHead.Store(&headIdentity{root: common.Hash{0xbb}, slot: 99})
+			manager.mu.Unlock()
+
+			manager.mu.Lock()
+			manager.headState.SetSlot(100)
+			manager.stateHead.Store(&headIdentity{root: common.Hash{0xaa}, slot: 100})
+			manager.mu.Unlock()
+		}
+	})
+
+	for range 10_000 {
+		require.NoError(t, manager.ViewHeadStateWithIdentity(func(headState *state.CachingBeaconState, root common.Hash, slot uint64) error {
+			require.Equal(t, slot, headState.Slot())
+			require.True(t, root == (common.Hash{0xaa}) && slot == 100 || root == (common.Hash{0xbb}) && slot == 99)
+			return nil
+		}))
+	}
+	writers.Wait()
+}

--- a/cl/beacon/synced_data/selected_head_test.go
+++ b/cl/beacon/synced_data/selected_head_test.go
@@ -134,3 +134,17 @@ func TestViewHeadStateWithIdentityStaysInOneGeneration(t *testing.T) {
 	}
 	writers.Wait()
 }
+
+func TestViewHeadStateRejectsMissingStateAfterReadinessPublished(t *testing.T) {
+	manager := NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+	manager.stateHead.Store(&headIdentity{root: common.Hash{0xaa}, slot: 100})
+	called := false
+
+	err := manager.ViewHeadState(func(*state.CachingBeaconState) error {
+		called = true
+		return nil
+	})
+
+	require.ErrorIs(t, err, ErrNotSynced)
+	require.False(t, called)
+}

--- a/cl/beacon/synced_data/synced_data.go
+++ b/cl/beacon/synced_data/synced_data.go
@@ -41,8 +41,8 @@ type SyncedDataManager struct {
 	enabled bool
 	cfg     *clparams.BeaconChainConfig
 
-	headRoot atomic.Value
-	headSlot atomic.Uint64
+	selectedHead atomic.Pointer[headIdentity]
+	stateHead    atomic.Pointer[headIdentity]
 
 	headState         *state.CachingBeaconState
 	previousHeadState *state.CachingBeaconState
@@ -51,11 +51,34 @@ type SyncedDataManager struct {
 	mu         sync.RWMutex
 }
 
+type headIdentity struct {
+	root common.Hash
+	slot uint64
+}
+
 func NewSyncedDataManager(cfg *clparams.BeaconChainConfig, enabled bool) *SyncedDataManager {
 	return &SyncedDataManager{
 		enabled: enabled,
 		cfg:     cfg,
 	}
+}
+
+func (s *SyncedDataManager) OnSelectedHead(blockRoot common.Hash, blockSlot uint64) {
+	if !s.enabled {
+		return
+	}
+	s.selectedHead.Store(&headIdentity{root: blockRoot, slot: blockSlot})
+}
+
+func (s *SyncedDataManager) SelectedHead() (common.Hash, uint64, bool) {
+	if !s.enabled {
+		return common.Hash{}, 0, false
+	}
+	head := s.selectedHead.Load()
+	if head == nil {
+		return common.Hash{}, 0, false
+	}
+	return head.root, head.slot, true
 }
 
 // OnHeadState updates the current head state and tracks the previous state.
@@ -96,8 +119,7 @@ func (s *SyncedDataManager) OnHeadState(newState *state.CachingBeaconState) (err
 	if err != nil {
 		return err
 	}
-	s.headSlot.Store(newState.Slot())
-	s.headRoot.Store(blkRoot)
+	s.stateHead.Store(&headIdentity{root: blkRoot, slot: newState.Slot()})
 	return nil
 }
 
@@ -136,15 +158,13 @@ func (s *SyncedDataManager) OnHeadStateWithBlockRoot(newState *state.CachingBeac
 	if err != nil {
 		return err
 	}
-	s.headSlot.Store(newState.Slot())
-	s.headRoot.Store(blockRoot)
+	s.stateHead.Store(&headIdentity{root: blockRoot, slot: newState.Slot()})
 	return nil
 }
 
 // ViewHeadState allows safe, read-only access to the current head state.
 func (s *SyncedDataManager) ViewHeadState(fn ViewHeadStateFn) error {
-	_, synced := s.headRoot.Load().(common.Hash)
-	if !s.enabled || !synced {
+	if !s.enabled || s.stateHead.Load() == nil {
 		return ErrNotSynced
 	}
 	s.mu.RLock()
@@ -168,6 +188,16 @@ func (s *SyncedDataManager) ViewHeadState(fn ViewHeadStateFn) error {
 	return nil
 }
 
+func (s *SyncedDataManager) ViewHeadStateWithIdentity(fn ViewHeadStateWithIdentityFn) error {
+	return s.ViewHeadState(func(headState *state.CachingBeaconState) error {
+		head := s.stateHead.Load()
+		if head == nil {
+			return ErrNotSynced
+		}
+		return fn(headState, head.root, head.slot)
+	})
+}
+
 // ViewPreviousHeadState allows safe, read-only access to the previous head state.
 func (s *SyncedDataManager) ViewPreviousHeadState(fn ViewHeadStateFn) error {
 	s.mu.RLock()
@@ -179,26 +209,34 @@ func (s *SyncedDataManager) ViewPreviousHeadState(fn ViewHeadStateFn) error {
 }
 
 func (s *SyncedDataManager) Syncing() bool {
-	_, synced := s.headRoot.Load().(common.Hash)
-	return !synced
+	return s.stateHead.Load() == nil
 }
 
 func (s *SyncedDataManager) HeadSlot() uint64 {
-	if !s.enabled {
+	head := s.stateHead.Load()
+	if !s.enabled || head == nil {
 		return 0
 	}
-	return s.headSlot.Load()
+	return head.slot
 }
 
 func (s *SyncedDataManager) HeadRoot() common.Hash {
+	head := s.stateHead.Load()
+	if !s.enabled || head == nil {
+		return common.Hash{}
+	}
+	return head.root
+}
+
+func (s *SyncedDataManager) StateHead() (common.Hash, uint64, bool) {
 	if !s.enabled {
-		return common.Hash{}
+		return common.Hash{}, 0, false
 	}
-	root, ok := s.headRoot.Load().(common.Hash)
-	if !ok {
-		return common.Hash{}
+	head := s.stateHead.Load()
+	if head == nil {
+		return common.Hash{}, 0, false
 	}
-	return root
+	return head.root, head.slot, true
 }
 
 func (s *SyncedDataManager) CommitteeCount(epoch uint64) uint64 {
@@ -215,8 +253,8 @@ func (s *SyncedDataManager) UnsetHeadState() {
 	defer s.mu.Unlock()
 	s.accessLock.Lock()
 	defer s.accessLock.Unlock()
-	s.headRoot = atomic.Value{}
-	s.headSlot.Store(uint64(0))
+	s.stateHead.Store(nil)
+	s.selectedHead.Store(nil)
 	s.headState = nil
 	s.previousHeadState = nil
 }

--- a/cl/beacon/synced_data/synced_data.go
+++ b/cl/beacon/synced_data/synced_data.go
@@ -168,6 +168,10 @@ func (s *SyncedDataManager) ViewHeadState(fn ViewHeadStateFn) error {
 		return ErrNotSynced
 	}
 	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.stateHead.Load() == nil || s.headState == nil {
+		return ErrNotSynced
+	}
 	if dbg.CaplinSyncedDataMangerDeadlockDetection {
 		trace := dbg.Stack()
 		ch := make(chan struct{})
@@ -181,7 +185,6 @@ func (s *SyncedDataManager) ViewHeadState(fn ViewHeadStateFn) error {
 		}()
 		defer close(ch)
 	}
-	defer s.mu.RUnlock()
 	if err := fn(s.headState); err != nil {
 		return err
 	}

--- a/cl/phase1/forkchoice/fork_choice_test.go
+++ b/cl/phase1/forkchoice/fork_choice_test.go
@@ -122,6 +122,10 @@ func TestForkChoiceBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, headRoot, common.HexToHash("0xc9bd7bcb6dfa49dc4e5a67ca75e89062c36b5c300bc25a1b31db4e1a89306071"))
 	require.Equal(t, uint64(1), headSlot)
+	selectedRoot, selectedSlot, ok := sd.SelectedHead()
+	require.True(t, ok)
+	require.Equal(t, headRoot, selectedRoot)
+	require.Equal(t, headSlot, selectedSlot)
 	// process another tick and another block
 	store.OnTick(36)
 	require.NoError(t, store.OnBlock(ctx, block0xc2, false, true, false))
@@ -134,6 +138,10 @@ func TestForkChoiceBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), headSlot)
 	require.Equal(t, headRoot, common.HexToHash("0x744cc484f6503462f0f3a5981d956bf4fcb3e57ab8687ed006467e05049ee033"))
+	selectedRoot, selectedSlot, ok = sd.SelectedHead()
+	require.True(t, ok)
+	require.Equal(t, headRoot, selectedRoot)
+	require.Equal(t, headSlot, selectedSlot)
 	// last block
 	require.NoError(t, store.OnBlock(ctx, block0xd4, false, true, false))
 	require.Equal(t, uint64(36), store.Time())

--- a/cl/phase1/forkchoice/forkchoice_test.go
+++ b/cl/phase1/forkchoice/forkchoice_test.go
@@ -388,6 +388,9 @@ type getFinalizedExecutionHashForkGraph struct {
 	addChainSegmentStatus fork_graph.ChainSegmentInsertionResult
 	addChainSegmentErr    error
 	addChainSegmentCalled bool
+	anchorRoot            common.Hash
+	anchorSlot            uint64
+	currentJustified      solid.Checkpoint
 }
 
 func (g *getFinalizedExecutionHashForkGraph) AddChainSegment(*cltypes.SignedBeaconBlock, bool) (*state.CachingBeaconState, fork_graph.ChainSegmentInsertionResult, error) {
@@ -433,7 +436,7 @@ func (g *getFinalizedExecutionHashForkGraph) stateCopyModes() []bool {
 }
 
 func (g *getFinalizedExecutionHashForkGraph) GetCurrentJustifiedCheckpoint(common.Hash) (solid.Checkpoint, bool) {
-	panic("not used")
+	return g.currentJustified, true
 }
 
 func (g *getFinalizedExecutionHashForkGraph) GetFinalizedCheckpoint(common.Hash) (solid.Checkpoint, bool) {
@@ -449,11 +452,11 @@ func (g *getFinalizedExecutionHashForkGraph) MarkHeaderAsInvalid(common.Hash) {
 }
 
 func (g *getFinalizedExecutionHashForkGraph) AnchorSlot() uint64 {
-	panic("not used")
+	return g.anchorSlot
 }
 
 func (g *getFinalizedExecutionHashForkGraph) AnchorRoot() common.Hash {
-	panic("not used")
+	return g.anchorRoot
 }
 
 func (g *getFinalizedExecutionHashForkGraph) Prune(uint64) error {

--- a/cl/phase1/forkchoice/get_head.go
+++ b/cl/phase1/forkchoice/get_head.go
@@ -110,6 +110,7 @@ func (f *ForkChoiceStore) GetHead(auxilliaryState *state.CachingBeaconState) (co
 	f.mu.RLock()
 	if f.headHash != (common.Hash{}) {
 		headHash, headSlot := f.headHash, f.headSlot
+		f.publishSelectedHead(headHash, headSlot)
 		f.mu.RUnlock()
 		return headHash, headSlot, nil
 	}
@@ -124,7 +125,15 @@ func (f *ForkChoiceStore) GetHead(auxilliaryState *state.CachingBeaconState) (co
 	if _, hasJustified := f.forkGraph.GetHeader(justifiedCheckpoint.Root); !hasJustified {
 		log.Debug("GetHead: justified root not in fork graph, using anchor as head",
 			"justifiedRoot", justifiedCheckpoint.Root)
-		return f.forkGraph.AnchorRoot(), f.forkGraph.AnchorSlot(), nil
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if f.headHash != (common.Hash{}) {
+			f.publishSelectedHead(f.headHash, f.headSlot)
+			return f.headHash, f.headSlot, nil
+		}
+		headRoot, headSlot := f.forkGraph.AnchorRoot(), f.forkGraph.AnchorSlot()
+		f.publishSelectedHead(headRoot, headSlot)
+		return headRoot, headSlot, nil
 	}
 
 	currentEpoch := f.computeEpochAtSlot(f.Slot())
@@ -165,6 +174,7 @@ func (f *ForkChoiceStore) getHeadGloas() (common.Hash, uint64, error) {
 			f.headHash = head.Root
 			f.headSlot = slot
 			f.headPayloadStatus = head.PayloadStatus
+			f.publishSelectedHead(f.headHash, f.headSlot)
 			return f.headHash, f.headSlot, true, nil
 		}()
 		if err != nil {
@@ -292,6 +302,7 @@ func (f *ForkChoiceStore) getHead(auxilliaryState *state.CachingBeaconState) (co
 				return common.Hash{}, 0, errors.New("no slot for head is stored")
 			}
 			f.headSlot = header.Slot
+			f.publishSelectedHead(f.headHash, f.headSlot)
 			return f.headHash, f.headSlot, nil
 		}
 
@@ -315,6 +326,12 @@ func (f *ForkChoiceStore) getHead(auxilliaryState *state.CachingBeaconState) (co
 				maxWeight = weight
 			}
 		}
+	}
+}
+
+func (f *ForkChoiceStore) publishSelectedHead(root common.Hash, slot uint64) {
+	if f.syncedDataManager != nil {
+		f.syncedDataManager.OnSelectedHead(root, slot)
 	}
 }
 

--- a/cl/phase1/forkchoice/gloas_weight_tree_test.go
+++ b/cl/phase1/forkchoice/gloas_weight_tree_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
@@ -87,6 +88,83 @@ func TestSetUnequivocatingInvalidatesHeadCache(t *testing.T) {
 
 	require.Equal(t, common.Hash{}, f.headHash)
 	require.Equal(t, cltypes.PayloadStatusPending, f.headPayloadStatus)
+}
+
+func TestGetHeadPublishesCachedSelection(t *testing.T) {
+	manager := synced_data.NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+	manager.OnSelectedHead(common.Hash{0xaa}, 100)
+	store := &ForkChoiceStore{
+		headHash:          common.Hash{0xbb},
+		headSlot:          99,
+		syncedDataManager: manager,
+	}
+
+	root, slot, err := store.GetHead(nil)
+	require.NoError(t, err)
+	require.Equal(t, common.Hash{0xbb}, root)
+	require.Equal(t, uint64(99), slot)
+	selectedRoot, selectedSlot, ok := manager.SelectedHead()
+	require.True(t, ok)
+	require.Equal(t, root, selectedRoot)
+	require.Equal(t, slot, selectedSlot)
+}
+
+func TestGetHeadPublishesAnchorFallback(t *testing.T) {
+	manager := synced_data.NewSyncedDataManager(&clparams.MainnetBeaconConfig, true)
+	anchorRoot := common.Hash{0xaa}
+	store := &ForkChoiceStore{
+		beaconCfg:         &clparams.MainnetBeaconConfig,
+		forkGraph:         &getFinalizedExecutionHashForkGraph{anchorRoot: anchorRoot, anchorSlot: 10},
+		syncedDataManager: manager,
+	}
+	store.justifiedCheckpoint.Store(solid.Checkpoint{Root: common.Hash{0xbb}})
+
+	root, slot, err := store.GetHead(nil)
+	require.NoError(t, err)
+	require.Equal(t, anchorRoot, root)
+	require.Equal(t, uint64(10), slot)
+	selectedRoot, selectedSlot, ok := manager.SelectedHead()
+	require.True(t, ok)
+	require.Equal(t, root, selectedRoot)
+	require.Equal(t, slot, selectedSlot)
+}
+
+func TestGetHeadPublishesGloasSelection(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cfg.AltairForkEpoch = 0
+	cfg.BellatrixForkEpoch = 0
+	cfg.CapellaForkEpoch = 0
+	cfg.DenebForkEpoch = 0
+	cfg.ElectraForkEpoch = 0
+	cfg.FuluForkEpoch = 0
+	cfg.GloasForkEpoch = 0
+	manager := synced_data.NewSyncedDataManager(&cfg, true)
+	root := common.Hash{0xaa}
+	checkpoint := solid.Checkpoint{Root: root}
+	graph := &getFinalizedExecutionHashForkGraph{
+		headers: map[common.Hash]*cltypes.BeaconBlockHeader{
+			root: {Slot: 10},
+		},
+		blocks:           map[common.Hash]*cltypes.SignedBeaconBlock{},
+		currentJustified: checkpoint,
+	}
+	store := newGloasWeightTreeTestStore()
+	store.beaconCfg = &cfg
+	store.forkGraph = graph
+	store.syncedDataManager = manager
+	store.justifiedCheckpoint.Store(checkpoint)
+	store.finalizedCheckpoint.Store(solid.Checkpoint{})
+	store.proposerBoostRoot.Store(common.Hash{})
+	store.checkpointStates.Store(checkpoint, &checkpointState{beaconConfig: &cfg})
+
+	selectedRoot, selectedSlot, err := store.GetHead(nil)
+	require.NoError(t, err)
+	require.Equal(t, root, selectedRoot)
+	require.Equal(t, uint64(10), selectedSlot)
+	publishedRoot, publishedSlot, ok := manager.SelectedHead()
+	require.True(t, ok)
+	require.Equal(t, selectedRoot, publishedRoot)
+	require.Equal(t, selectedSlot, publishedSlot)
 }
 
 func TestSetUnequivocatingGrowsAmortized(t *testing.T) {


### PR DESCRIPTION
Fixes #23154.

## Problem

Beacon API `head` identity came from the memoized head state. That identity advances only after the new state has been copied, so block/root endpoints could return the parent for roughly 750 ms after fork choice had already selected the new head.

Calling `forkchoiceStore.GetHead(nil)` from public handlers avoids that lag, but it can perform expensive fork-choice/checkpoint-state work on a cache miss and can expose a selected root with the previous memoized state.

## Change

- Publish the selected `(root, slot)` from `ForkChoiceStore.GetHead` at the successful selection boundary, while the fork-choice lock still orders concurrent selections.
- Store selected-head and memoized-state identities as separate atomic pairs.
- Route identity-only `head` endpoints to selected head; state-backed endpoints continue using memoized state identity.
- Add an identity-aware state view so state, root, and slot are obtained from the same locked generation.
- Publish before EL notification/state copying, including cached, anchor fallback, pre-Gloas, Gloas, forward-sync, and local-block paths.
- Keep local side-branch submissions aligned with the actual selected root/state, and report head headers as canonical before canonical DB promotion completes.
- Report the selected root's fork-choice optimistic status from the debug heads endpoint.

Public read-only endpoints no longer invoke fork-choice computation when memoized head state is enabled.

## Trade-offs

- During the state-copy window, identity-only endpoints can report the newly selected root while state-backed endpoints still report the previous memoized state head. Each response remains internally consistent, but clients correlating separate endpoint responses can observe different heads.
- The selected identity is published before the EL fork-choice update. A head that EL later rejects can therefore be visible temporarily as execution optimistic until fork choice invalidates and replaces it.
- Local block submission resolves the actual selected root and state before notifying EL. A state lookup or replay, particularly after a side-branch submission, can therefore add latency to that notification.

## Testing

- `go test ./cl/beacon/handler -count=1`
- `go test ./cl/beacon/synced_data -count=1`
- `go test ./cl/phase1/forkchoice -count=1`
- `go test ./cl/phase1/stages -count=1`
- `go test -race ./cl/beacon/synced_data -run '^(TestSelectedHeadRootAndSlotStayInOneGeneration|TestStateHeadRootAndSlotStayInOneGeneration|TestViewHeadStateWithIdentityStaysInOneGeneration|TestViewHeadStateRejectsMissingStateAfterReadinessPublished)$' -count=1`
- `make lint`
- `make erigon integration`

Focused coverage includes lower-slot replacement, cache hit, checkpoint-sync anchor fallback, Gloas selection, local side-branch selection, root/slot generation coherence, explicit current-head state roots, cold-state 503 responses, optimistic debug-head metadata, and pre-commit canonical header responses.
