### PR TITLE
[3.6] state_cache: 1g default for storage, 128mb defautl for accs, 32mb for codeHashes

### DIFF
--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -41,7 +41,7 @@ const (
 	// DefaultCodeCacheBytes is the byte limit for the code cache.
 	DefaultCodeCacheBytes = 512 * datasize.MB
 	// DefaultAddrCacheBytes is the byte limit for address cache (16 MB)
-	DefaultAddrCacheBytes = 16 * datasize.MB
+	DefaultAddrCacheBytes = 32 * datasize.MB
 	// DefaultCodeSizeCacheEntries is the max entry count for the size-only
 	// cache (code size answers without loading bytes for
 	// EXTCODESIZE / EXTCODEHASH callers).

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -32,11 +32,11 @@ import (
 
 const (
 	// DefaultAccountCacheBytes is the byte limit for the account cache.
-	DefaultAccountCacheBytes = 1 * datasize.GB
+	DefaultAccountCacheBytes = 150 * datasize.MB
 	// DefaultStorageCacheBytes is the byte limit for storage cache. 150 MB
 	// holds the hot storage working set with headroom so eviction pressure
 	// doesn't push the hot set out.
-	DefaultStorageCacheBytes = 150 * datasize.MB
+	DefaultStorageCacheBytes = 1 * datasize.GB
 
 	// Per-domain avg entry size used to translate the byte budget into the
 	// entry-count cap the underlying sharded LRU is sized against. Account

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -111,16 +111,20 @@ func newDomainCacheBytes(capacityBytes datasize.ByteSize, avgBytes uint32, mode 
 	}
 }
 
-// NewDefaultStateCache creates a new StateCache with the production byte budgets
-// (Account 1GB, Storage 150MB, Code 512MB, Addr 16MB). Harnesses that build
-// many short-lived ExecModules set a small ethconfig.Config.StateCacheBudget
-// instead.
+// NewDefaultStateCache creates a new StateCache with the production byte
+// budgets, each overridable by env (values parse as "150MB", "1GB") so a
+// sizing A/B needs no rebuild. Harnesses that build many short-lived
+// ExecModules set a small ethconfig.Config.StateCacheBudget instead.
+//
+// The budgets draw from one shared envelope (cachebudget.Global), so raising
+// them all at once buys nothing — a step that would overflow it is refused and
+// that cache stops growing.
 func NewDefaultStateCache() *StateCache {
 	return NewStateCache(
-		DefaultAccountCacheBytes,
-		DefaultStorageCacheBytes,
-		DefaultCodeCacheBytes,
-		DefaultAddrCacheBytes,
+		dbg.EnvDataSize("STATE_CACHE_ACCOUNT", DefaultAccountCacheBytes),
+		dbg.EnvDataSize("STATE_CACHE_STORAGE", DefaultStorageCacheBytes),
+		dbg.EnvDataSize("STATE_CACHE_CODE", DefaultCodeCacheBytes),
+		dbg.EnvDataSize("STATE_CACHE_ADDR", DefaultAddrCacheBytes),
 	)
 }
 

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -31,11 +31,7 @@ import (
 )
 
 const (
-	// DefaultAccountCacheBytes is the byte limit for the account cache.
 	DefaultAccountCacheBytes = 150 * datasize.MB
-	// DefaultStorageCacheBytes is the byte limit for storage cache. 150 MB
-	// holds the hot storage working set with headroom so eviction pressure
-	// doesn't push the hot set out.
 	DefaultStorageCacheBytes = 1 * datasize.GB
 
 	// Per-domain avg entry size used to translate the byte budget into the

--- a/execution/cache/state_cache.go
+++ b/execution/cache/state_cache.go
@@ -121,10 +121,10 @@ func newDomainCacheBytes(capacityBytes datasize.ByteSize, avgBytes uint32, mode 
 // that cache stops growing.
 func NewDefaultStateCache() *StateCache {
 	return NewStateCache(
-		dbg.EnvDataSize("STATE_CACHE_ACCOUNT", DefaultAccountCacheBytes),
+		dbg.EnvDataSize("STATE_CACHE_ACCOUNTS", DefaultAccountCacheBytes),
 		dbg.EnvDataSize("STATE_CACHE_STORAGE", DefaultStorageCacheBytes),
 		dbg.EnvDataSize("STATE_CACHE_CODE", DefaultCodeCacheBytes),
-		dbg.EnvDataSize("STATE_CACHE_ADDR", DefaultAddrCacheBytes),
+		dbg.EnvDataSize("STATE_CACHE_CODE_INDEX", DefaultAddrCacheBytes),
 	)
 }
 


### PR DESCRIPTION
added knobs: 
```
dbg.EnvDataSize("STATE_CACHE_ACCOUNTS", DefaultAccountCacheBytes),
dbg.EnvDataSize("STATE_CACHE_STORAGE", DefaultStorageCacheBytes),
dbg.EnvDataSize("STATE_CACHE_CODE", DefaultCodeCacheBytes),
dbg.EnvDataSize("STATE_CACHE_CODE_INDEX", DefaultAddrCacheBytes),
```

changed defaults: 
storage 128mb -> 1g
acc 1g -> 128mb
codeHash 16mb -> 32mb

Monitoring (yellow is `3.6` - our branch. green - `3.5`):
<img width="2540" height="919" alt="State Cache defaults" src="https://github.com/user-attachments/assets/ec4c1ea4-41f4-464d-b6d7-0953799c8676" />
