### PR TITLE
db/integrity, execution/commitment: guard IsComplete against short branch buffers

### DIFF
--- a/db/integrity/commitment_integrity.go
+++ b/db/integrity/commitment_integrity.go
@@ -1364,6 +1364,10 @@ func checkStateCorrespondenceBase(ctx context.Context, file state.VisibleFile, s
 
 		branchData := commitment.BranchData(branchValue)
 
+		if branchData.IsTombstone() {
+			continue // tombstones kept across merges, not corruption
+		}
+
 		// Check completeness
 		if !branchData.IsComplete() {
 			touchMap := uint16(0)
@@ -1573,6 +1577,9 @@ func checkStateCorrespondenceReverse(ctx context.Context, file state.VisibleFile
 		branchKeys++
 
 		branchData := commitment.BranchData(branchValue)
+		if branchData.IsTombstone() {
+			continue
+		}
 
 		if !branchData.IsComplete() {
 			touchMap := uint16(0)

--- a/execution/commitment/commitment.go
+++ b/execution/commitment/commitment.go
@@ -690,8 +690,11 @@ func (branchData BranchData) ChildCount() int {
 	return bits.OnesCount16(binary.BigEndian.Uint16(branchData[2:4]))
 }
 
+// IsTombstone checks if given branch a domain's tombstone (will be removed on next .kv merge)
+func (branchData BranchData) IsTombstone() bool { return len(branchData) == 0 }
+
 func (branchData BranchData) String() string {
-	if len(branchData) == 0 {
+	if branchData.IsTombstone() {
 		return ""
 	}
 	touchMap := binary.BigEndian.Uint16(branchData[0:])
@@ -916,6 +919,9 @@ func (branchData BranchData) ReplacePlainKeys(newData []byte, fn func(key []byte
 // touch - whether this child has been modified or deleted in this branchData (corresponding bit in touchMap is set)
 // after - whether after this branchData application, the child is present in the tree or not (corresponding bit in afterMap is set)
 func (branchData BranchData) IsComplete() bool {
+	if len(branchData) < 4 {
+		return false
+	}
 	touchMap := binary.BigEndian.Uint16(branchData[0:])
 	afterMap := binary.BigEndian.Uint16(branchData[2:])
 	return ^touchMap&afterMap == 0
@@ -1023,7 +1029,7 @@ func (branchData BranchData) decodeCells() (touchMap, afterMap uint16, row [16]*
 }
 
 func (branchData BranchData) Validate(branchKey []byte) error {
-	if len(branchData) == 0 {
+	if branchData.IsTombstone() {
 		return nil
 	}
 	_, afterMap, row, err := branchData.decodeCells()

--- a/execution/commitment/commitment_test.go
+++ b/execution/commitment/commitment_test.go
@@ -462,6 +462,29 @@ func TestBranchData_ChildCount(t *testing.T) {
 	require.Equal(t, 3, buf.ChildCount())
 }
 
+func TestBranchData_IsComplete(t *testing.T) {
+	t.Parallel()
+
+	// Buffers shorter than the 4-byte touchMap+afterMap header are not complete
+	// and must not panic. Empty values are deletion tombstones kept across merges.
+	require.False(t, BranchData(nil).IsComplete())
+	require.False(t, BranchData{}.IsComplete())
+	require.False(t, BranchData{0x00}.IsComplete())
+	require.False(t, BranchData{0xff, 0xff, 0x00}.IsComplete())
+
+	// Every child present in afterMap is also covered by touchMap -> complete.
+	complete := make(BranchData, 4)
+	binary.BigEndian.PutUint16(complete[0:], 0xffff)
+	binary.BigEndian.PutUint16(complete[2:], 0b0000_0000_0000_0111)
+	require.True(t, complete.IsComplete())
+
+	// afterMap references a child missing from touchMap -> incomplete.
+	incomplete := make(BranchData, 4)
+	binary.BigEndian.PutUint16(incomplete[0:], 0b0000_0000_0000_0001)
+	binary.BigEndian.PutUint16(incomplete[2:], 0b0000_0000_0000_0011)
+	require.False(t, incomplete.IsComplete())
+}
+
 func TestBranchData_MergeHexBranchesEmptyBranches(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Forward-port of #22712, which merged to `release/3.6` only — the fix never landed on main.

`BranchData.IsComplete()` reads the 4-byte touchMap/afterMap header without a length check, so `seg integrity --check=StateVerify` panics with `index out of range [1] with length 0` on the zero-length commitment branch values that domain merges keep as deletion tombstones.

- `IsComplete()` returns `false` below 4 bytes, matching the guard idiom already used by `ChildCount`/`String`.
- The two StateVerify call sites skip empty (tombstone) branches instead of flagging them as corruption. The hash-verify sites already `continue` on `!IsComplete()`, so they are correct once it is panic-safe.

`TestBranchData_IsComplete` reproduces the panic on main without the guard.

Refs #21993.