### PR TITLE
execution/commitment: stop trace and branch-slot writes from heap-pinning locals

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -360,7 +360,14 @@ func (f loadFlags) addFlag(loadFlags loadFlags) loadFlags {
 
 var (
 	emptyRootHashBytes = empty.RootHash[:]
+	// Package-level because keccak2.Write is an interface call: a local copy would be
+	// heap-allocated on every hashed row.
+	emptyBranchSlotBytes = []byte{rlp.EmptyStringCode}
 )
+
+// traceHex hex-encodes b for a trace line without letting fmt box the slice, which would
+// pin its backing array to the heap on every call even when tracing is off.
+func traceHex(b []byte) string { return hex.EncodeToString(b) }
 
 func (cell *cell) hashAccKey(keccak keccak.KeccakState, depth int16, hashBuf []byte) error {
 	return hashKey(keccak, cell.accountAddr[:cell.accountAddrLen], cell.hashedExtension[:], depth, hashBuf)
@@ -980,7 +987,7 @@ func (hph *HexPatriciaHashed) witnessComputeCellHashWithStorage(cell *cell, dept
 			}
 			if singleton {
 				if hph.traceW != nil {
-					fmt.Fprintf(hph.traceW, "leafHashWithKeyVal(singleton) for [%x]=>[%x]\n", hashedKeyBuf[:64-hashedKeyOffset+1], cell.Storage[:cell.StorageLen])
+					fmt.Fprintf(hph.traceW, "leafHashWithKeyVal(singleton) for [%s]=>[%x]\n", traceHex(hashedKeyBuf[:64-hashedKeyOffset+1]), cell.Storage[:cell.StorageLen])
 				}
 				aux := hph.hashAuxBuffer[:0]
 				if aux, err = hph.leafHashWithKeyVal(aux, hashedKeyBuf[:64-hashedKeyOffset+1], cell.Storage[:cell.StorageLen], true); err != nil {
@@ -995,7 +1002,7 @@ func (hph *HexPatriciaHashed) witnessComputeCellHashWithStorage(cell *cell, dept
 				hadToReset.Add(1)
 			} else {
 				if hph.traceW != nil {
-					fmt.Fprintf(hph.traceW, "leafHashWithKeyVal for [%x]=>[%x] %v\n", hashedKeyBuf[:64-hashedKeyOffset+1], cell.Storage[:cell.StorageLen], cell.String())
+					fmt.Fprintf(hph.traceW, "leafHashWithKeyVal for [%s]=>[%x] %v\n", traceHex(hashedKeyBuf[:64-hashedKeyOffset+1]), cell.Storage[:cell.StorageLen], cell.String())
 				}
 				leafHash, err := hph.leafHashWithKeyVal(buf, hashedKeyBuf[:64-hashedKeyOffset+1], cell.Storage[:cell.StorageLen], false)
 				if err != nil {
@@ -1065,7 +1072,7 @@ func (hph *HexPatriciaHashed) witnessComputeCellHashWithStorage(cell *cell, dept
 		var valBuf [128]byte
 		valLen := cell.accountForHashing(valBuf[:], storageRootHash)
 		if hph.traceW != nil {
-			fmt.Fprintf(hph.traceW, "accountLeafHashWithKey for [%x]=>[%x]\n", hashedKeyBuf[:65-depth], rlp.RlpEncodedBytes(valBuf[:valLen]))
+			fmt.Fprintf(hph.traceW, "accountLeafHashWithKey for [%s]=>[%s]\n", traceHex(hashedKeyBuf[:65-depth]), traceHex(valBuf[:valLen]))
 		}
 		leafHash, err := hph.accountLeafHashWithKey(buf, hashedKeyBuf[:65-depth], rlp.RlpEncodedBytes(valBuf[:valLen]))
 		if err != nil {
@@ -1313,7 +1320,7 @@ func (hph *HexPatriciaHashed) needUnfolding(hashedKey []byte) int16 {
 
 	cpl := nibbles.CommonPrefixLen(hashedKey[depth:], cell.hashedExtension[:cell.hashedExtLen-1])
 	if hph.traceW != nil {
-		fmt.Fprintf(hph.traceW, "cpl=%d cell.hashedExtension=[%x] hashedKey[depth=%d:]=[%x]\n", cpl, cell.hashedExtension[:cell.hashedExtLen], depth, hashedKey[depth:])
+		fmt.Fprintf(hph.traceW, "cpl=%d cell.hashedExtension=[%x] hashedKey[depth=%d:]=[%s]\n", cpl, cell.hashedExtension[:cell.hashedExtLen], depth, traceHex(hashedKey[depth:]))
 	}
 	unfolding := clampToAccountBoundary(depth, int16(cpl+1))
 	if hph.traceW != nil && unfolding != int16(cpl+1) {
@@ -1469,7 +1476,7 @@ func (hph *HexPatriciaHashed) unfoldBranchNode(row int, depth int16, deleted boo
 		return nil
 	}
 	if len(branchData) == 0 {
-		log.Warn("got empty branch data during unfold", "key", hex.EncodeToString(key), "row", row, "depth", depth, "deleted", deleted)
+		log.Warn("got empty branch data during unfold", "key", traceHex(key), "row", row, "depth", depth, "deleted", deleted)
 		if hph.traceW != nil {
 			branchData, _ = hph.branchFromCacheOrDB(key)
 			fmt.Fprintf(hph.traceW, "unfoldBranchNode prefix '%x', nibbles [%x] depth %d row %d '%x' %s\n", key, hph.currentKey[:hph.currentKeyLen], depth, row, branchData, BranchData(branchData).String())
@@ -1728,61 +1735,22 @@ func (hph *HexPatriciaHashed) foldBranch(row int, nibble, upDepth, depth int16, 
 	return nil
 }
 
-// feedBranchHashesToKeccak iterates all 17 branch slots, computing cell hashes
-// for present cells via computeCellHash and writing 0x80 for empty slots into keccak2.
-// Used by the deferred encoding path where keccak2 feeding is done before encoding.
-func (hph *HexPatriciaHashed) feedBranchHashesToKeccak(row int, depth int16, emptyByte []byte) error {
-	for bitset, lastNib := hph.afterMap[row], 0; ; {
-		if bitset == 0 {
-			// Write remaining empty cells to keccak2
-			for i := lastNib; i < 17; i++ {
-				if _, err := hph.keccak2.Write(emptyByte); err != nil {
-					return err
-				}
-			}
-			break
-		}
-		bit := bitset & -bitset
-		nibble := bits.TrailingZeros16(bit)
-		// Write empty cells before this nibble
-		for i := lastNib; i < nibble; i++ {
-			if _, err := hph.keccak2.Write(emptyByte); err != nil {
-				return err
-			}
-		}
-		lastNib = nibble + 1
-
-		cell := &hph.grid[row][nibble]
-		cellHash, err := hph.computeCellHash(cell, depth, hph.hashAuxBuffer[:0])
-		if err != nil {
-			return err
-		}
-		if _, err := hph.keccak2.Write(cellHash); err != nil {
-			return err
-		}
-		bitset ^= bit
-	}
-	return nil
-}
-
 // hashRow performs a single pass over all 17 branch slots (16 nibbles + terminator),
 // feeding cell hashes to keccak2 for present cells (per afterMap) and writing 0x80
 // for empty slots. It simultaneously extracts cellEncodeData for each present cell.
-// This replaces the separate feedBranchHashesToKeccak + cellEncodeData extraction loop.
 func (hph *HexPatriciaHashed) hashRow(row int, depth int16) ([16]cellEncodeData, error) {
 	var cellData [16]cellEncodeData
-	b := [...]byte{0x80}
 	capture := hph.witness.active()
 
 	for bitset, lastNib := hph.afterMap[row], 0; ; {
 		if bitset == 0 {
 			// Write remaining empty cells to keccak2 (up to slot 16 inclusive = terminator)
 			for i := lastNib; i < 17; i++ {
-				if _, err := hph.keccak2.Write(b[:]); err != nil {
+				if _, err := hph.keccak2.Write(emptyBranchSlotBytes); err != nil {
 					return cellData, err
 				}
 				if capture {
-					hph.witness.writeBranch(b[:])
+					hph.witness.writeBranch(emptyBranchSlotBytes)
 				}
 			}
 			break
@@ -1792,11 +1760,11 @@ func (hph *HexPatriciaHashed) hashRow(row int, depth int16) ([16]cellEncodeData,
 
 		// Write empty cells before this nibble
 		for i := lastNib; i < nibble; i++ {
-			if _, err := hph.keccak2.Write(b[:]); err != nil {
+			if _, err := hph.keccak2.Write(emptyBranchSlotBytes); err != nil {
 				return cellData, err
 			}
 			if capture {
-				hph.witness.writeBranch(b[:])
+				hph.witness.writeBranch(emptyBranchSlotBytes)
 			}
 			if hph.traceW != nil {
 				fmt.Fprintf(hph.traceW, "  %x: empty(%d, %x, depth=%d)\n", i, row, i, depth)
@@ -2128,10 +2096,9 @@ func (hph *HexPatriciaHashed) detectCollapseBeforeDelete(hashedKey []byte) {
 	}
 
 	// collapse detected!
-	compact := NibblesToString(hashedKey)
 	if hph.traceW != nil {
 		fmt.Fprintf(hph.traceW, "[collapse] updateCell: hashedKey=%s (len=%d nibbles), deleted=true, activeRows=%d\n",
-			compact, len(hashedKey), hph.activeRows)
+			NibblesToString(hashedKey), len(hashedKey), hph.activeRows)
 	}
 
 	// Exactly 2 children in the parent row — one is on the delete path,
@@ -2161,10 +2128,9 @@ func (hph *HexPatriciaHashed) detectCollapseBeforeDelete(hashedKey []byte) {
 		copy(siblingPath[int(depth)+1:], siblingCell.hashedExtension[:siblingCell.hashedExtLen])
 	}
 
-	compactSibling := NibblesToString(siblingPath)
 	if hph.traceW != nil {
 		fmt.Fprintf(hph.traceW, "[collapse] found at parentRow=%d depth=%d: deleteNibble=%x, siblingNibble=%x, siblingPath=%s (len=%d), hashLen=%d, extLen=%d\n",
-			parentRow, depth, deleteNibble, siblingNibble, compactSibling, len(siblingPath), siblingCell.hashLen, siblingCell.hashedExtLen)
+			parentRow, depth, deleteNibble, siblingNibble, NibblesToString(siblingPath), len(siblingPath), siblingCell.hashLen, siblingCell.hashedExtLen)
 	}
 	hph.collapseTracer(siblingPath, bytes.Clone(hph.currentKey[:depth]))
 }
@@ -2185,10 +2151,9 @@ func (hph *HexPatriciaHashed) detectCascadingCollapseAtRow(row int) {
 		copy(siblingPath[int(depth)+1:], survivingCell.hashedExtension[:survivingCell.hashedExtLen])
 	}
 
-	compactSibling := NibblesToString(siblingPath)
 	if hph.traceW != nil {
 		fmt.Fprintf(hph.traceW, "[cascade-collapse] found at row=%d depth=%d: survivingNibble=%x, siblingPath=%s (len=%d), hashLen=%d, hashedExtLen=%d\n",
-			row, depth, survivingNibble, compactSibling, len(siblingPath), survivingCell.hashLen, survivingCell.hashedExtLen)
+			row, depth, survivingNibble, NibblesToString(siblingPath), len(siblingPath), survivingCell.hashLen, survivingCell.hashedExtLen)
 	}
 	hph.collapseTracer(siblingPath, bytes.Clone(hph.currentKey[:depth]))
 }

--- a/execution/commitment/hex_patricia_hashed_test.go
+++ b/execution/commitment/hex_patricia_hashed_test.go
@@ -1680,3 +1680,38 @@ func TestSetTraceWriter_BufferCapturesOutput(t *testing.T) {
 	require.True(t, strings.Contains(output, "fold ["),
 		"trace output should contain fold-related lines, got:\n%s", output)
 }
+
+// feedBranchHashesToKeccak is the per-slot reference hashRow replaced. It takes the
+// empty-slot byte as an argument so the comparison stays differential: the reference
+// spells the RLP empty string itself instead of reading the value under test.
+func (hph *HexPatriciaHashed) feedBranchHashesToKeccak(row int, depth int16, emptyByte []byte) error {
+	for bitset, lastNib := hph.afterMap[row], 0; ; {
+		if bitset == 0 {
+			for i := lastNib; i < 17; i++ {
+				if _, err := hph.keccak2.Write(emptyByte); err != nil {
+					return err
+				}
+			}
+			break
+		}
+		bit := bitset & -bitset
+		nibble := bits.TrailingZeros16(bit)
+		for i := lastNib; i < nibble; i++ {
+			if _, err := hph.keccak2.Write(emptyByte); err != nil {
+				return err
+			}
+		}
+		lastNib = nibble + 1
+
+		cell := &hph.grid[row][nibble]
+		cellHash, err := hph.computeCellHash(cell, depth, hph.hashAuxBuffer[:0])
+		if err != nil {
+			return err
+		}
+		if _, err := hph.keccak2.Write(cellHash); err != nil {
+			return err
+		}
+		bitset ^= bit
+	}
+	return nil
+}


### PR DESCRIPTION
`hashRow`'s `[1]byte{0x80}` escaped through the `keccak2.Write` interface call — one alloc per hashed row. It becomes a package-level value spelled `rlp.EmptyStringCode`.

Trace calls that pass a stack buffer as `%x` pin its backing array to the heap on every call, even with tracing off. `traceHex` hex-encodes instead. Verified with `-gcflags=-m`:
- `needUnfolding`: `leaking param: hashedKey` -> `does not escape`, which un-heaps `zero` in `unfoldRootWall`
- `witnessComputeCellHashWithStorage`: 128-byte `hashedKeyBuf` stays on the stack

The collapse detectors built a `NibblesToString` before checking `traceW`; that string now only forms when tracing is on.

`feedBranchHashesToKeccak` had no production caller left — it is the reference `Test_HexPatriciaHashed_hashRow` compares against — so it moves into the test file and keeps its own empty-slot literal. Otherwise reference and subject would read the same global and a wrong constant would go undetected; with the literal restored, setting `emptyBranchSlotBytes` to `0x81` fails the test.

BenchmarkHexPatriciaHashedFold, count=6:

| | main | PR |
|---|---|---|
| allocs/op | 1111.0 | 1008.0 (-9.3%) |
| B/op | 52.86Ki | 52.88Ki (~) |
| sec/op | 168.9µ | 171.6µ (~) |

Trace output is unchanged (`%x` on `[]byte` and `hex.EncodeToString` produce the same lowercase hex).