### PR TITLE
execution/commitment: assemble the extension-node header before hashing it

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -60,6 +60,7 @@ type CollapseTracer func(hashedKeyPath, branchPrefix []byte)
 // witnessTracer receives canonical trie nodes as they are hashed during a
 // witness fold pass; nil on the normal commitment path.
 type witnessTracer interface {
+	// Neither slice may be retained: both are scratch buffers reused by the next node.
 	onNode(rlp, hash []byte)
 }
 
@@ -69,30 +70,30 @@ type witnessTracer interface {
 // so reset() only detaches the tracer.
 type witness struct {
 	tracer          witnessTracer
-	leafBuf         bytes.Buffer
+	nodeBuf         bytes.Buffer
 	branchBuf       bytes.Buffer
-	leafWriterCache io.Writer // keccak+leafBuf tee, built once per keccak
+	nodeWriterCache io.Writer // keccak+nodeBuf tee, built once per keccak
 }
 
 func (w *witness) active() bool { return w.tracer != nil }
 func (w *witness) reset()       { w.tracer = nil }
 
-// leafWriter tees the keccak stream into leafBuf so the leaf node bytes can be
-// emitted once the hash is read; without a tracer it returns keccak unchanged.
-func (w *witness) leafWriter(keccak io.Writer) io.Writer {
+// nodeWriter tees the keccak stream into nodeBuf so the node bytes can be emitted
+// once the hash is read; without a tracer it returns keccak unchanged.
+func (w *witness) nodeWriter(keccak io.Writer) io.Writer {
 	if w.tracer == nil {
 		return keccak
 	}
-	w.leafBuf.Reset()
-	if w.leafWriterCache == nil {
-		w.leafWriterCache = io.MultiWriter(keccak, &w.leafBuf)
+	w.nodeBuf.Reset()
+	if w.nodeWriterCache == nil {
+		w.nodeWriterCache = io.MultiWriter(keccak, &w.nodeBuf)
 	}
-	return w.leafWriterCache
+	return w.nodeWriterCache
 }
 
-func (w *witness) emitLeaf(hash []byte) {
+func (w *witness) emitNode(hash []byte) {
 	if w.tracer != nil {
-		w.tracer.onNode(w.leafBuf.Bytes(), hash)
+		w.tracer.onNode(w.nodeBuf.Bytes(), hash)
 	}
 }
 
@@ -139,10 +140,12 @@ type HexPatriciaHashed struct {
 	rootPresent   bool
 	traceW        io.Writer // nil = disabled, non-nil = write trace output
 	ctx           PatriciaContext
-	hashAuxBuffer [128]byte           // buffer to compute cell hash or write hash-related things
-	cellHashBuf   common.Hash         // shared scratch buffer for hashKey calls (avoids per-cell allocation)
-	leafHashBuf   [33]byte            // shared scratch for leaf hash prefixing (avoids per-leaf escape)
-	leafRlpBuf    [maxLeafRlpLen]byte // shared scratch for a leaf's RLP list prefix + compact key
+	hashAuxBuffer [128]byte   // buffer to compute cell hash or write hash-related things
+	cellHashBuf   common.Hash // shared scratch buffer for hashKey calls (avoids per-cell allocation)
+	// Scratch for the one node being hashed at a time: keccak and the witness writer are
+	// interfaces, so a local buffer handed to Write or Read is heap-pinned per call.
+	nodeHashBuf   [33]byte            // 0x80+32 tag followed by the node hash
+	nodeRlpBuf    [maxNodeRlpLen]byte // node's RLP list prefix, key prefix and compact key
 	rlpPrefixBuf  [8]byte             // shared scratch for RlpSerializable length prefixes
 	auxBuffer     *bytes.Buffer       // auxiliary buffer used during branch updates encoding
 	branchEncoder *BranchEncoder
@@ -322,11 +325,15 @@ const (
 	cellLoadStorage = loadFlags(2)
 )
 
-// maxLeafRlpLen bounds a leaf's assembled RLP header: list prefix (tag plus up to
-// 8 length bytes), key prefix byte, then the compact key. Derived from the nibble
-// array rather than from the shorter keys today's depth arithmetic yields, so a
-// caller slicing deeper cannot overflow the buffer.
-const maxLeafRlpLen = 9 + 1 + (len(cell{}.hashedExtension)/2 + 1)
+// maxNodeRlpLen bounds a node's assembled RLP header: list prefix (tag plus up to 8
+// length bytes), key prefix byte, the compact key, then a hash tag byte. Derived from
+// the nibble arrays rather than from the shorter keys today's depth arithmetic yields,
+// so a caller slicing deeper cannot overflow the buffer.
+const maxNodeRlpLen = 9 + 1 + (len(cell{}.hashedExtension)/2 + 1) + 1
+
+// Both key arrays a node header can be built from must fit; negative shifts fail the build.
+const _ = uint(maxNodeRlpLen - (9 + 1 + (len(cell{}.hashedExtension)/2 + 1) + 1))
+const _ = uint(maxNodeRlpLen - (9 + 1 + (len(cell{}.extension)/2 + 1) + 1))
 
 func (f loadFlags) String() string {
 	var b strings.Builder
@@ -731,32 +738,9 @@ func (cell *cell) accountForHashing(buffer []byte, storageRootHash common.Hash) 
 }
 
 func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key []byte, compact0 byte, ni int, val rlp.RlpSerializable, singleton bool) ([]byte, error) {
-	// Compute the total length of binary representation
-	var kp, kl int
-	if compactLen > 1 {
-		kp = 1
-		kl = compactLen
-	} else {
-		kl = 1
-	}
-
-	totalLen := kp + kl + val.DoubleRLPLen()
-	// The header (list prefix, key prefix, compact key) is assembled into one scratch
-	// buffer: passing per-write stack arrays to the io.Writer interface heap-allocates them.
-	header := hph.leafRlpBuf[:]
-	pl := rlp.EncodeListPrefixToBuf(totalLen, header)
-	n := pl
-	if kp > 0 {
-		header[n] = 0x80 + byte(compactLen)
-		n++
-	}
-	header[n] = compact0
-	n++
-	for i := 1; i < compactLen; i++ {
-		header[n] = key[ni]*16 + key[ni+1]
-		n++
-		ni += 2
-	}
+	totalLen := keyRlpLen(compactLen) + val.DoubleRLPLen()
+	n, pl := hph.assembleNodeHeader(totalLen, compactLen, key, compact0, ni)
+	header := hph.nodeRlpBuf[:]
 
 	canEmbed := !singleton && totalLen+pl < length.Hash
 	var writer io.Writer
@@ -766,7 +750,7 @@ func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key [
 		writer = hph.auxBuffer
 	} else {
 		hph.keccak.Reset()
-		writer = hph.witness.leafWriter(hph.keccak)
+		writer = hph.witness.nodeWriter(hph.keccak)
 	}
 	if _, err := writer.Write(header[:n]); err != nil {
 		return nil, err
@@ -777,12 +761,12 @@ func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key [
 	if canEmbed {
 		buf = hph.auxBuffer.Bytes()
 	} else {
-		hph.leafHashBuf[0] = 0x80 + length.Hash
-		if _, err := hph.keccak.Read(hph.leafHashBuf[1:]); err != nil {
+		hph.nodeHashBuf[0] = 0x80 + length.Hash
+		if _, err := hph.keccak.Read(hph.nodeHashBuf[1:]); err != nil {
 			return nil, err
 		}
-		buf = append(buf, hph.leafHashBuf[:]...)
-		hph.witness.emitLeaf(hph.leafHashBuf[1:])
+		buf = append(buf, hph.nodeHashBuf[:]...)
+		hph.witness.emitNode(hph.nodeHashBuf[1:])
 	}
 	return buf, nil
 }
@@ -803,97 +787,82 @@ func (hph *HexPatriciaHashed) leafHashWithKeyVal(buf, key []byte, val rlp.RlpSer
 }
 
 func (hph *HexPatriciaHashed) accountLeafHashWithKey(buf, key []byte, val rlp.RlpSerializable) ([]byte, error) {
-	// Write key
-	var compactLen int
-	var ni int
-	var compact0 byte
+	compactLen, compact0, ni := compactKeyParams(key)
+	return hph.completeLeafHash(buf, compactLen, key, compact0, ni, val, true)
+}
+
+// compactKeyParams applies the hex-prefix rule to a key that may or may not carry a
+// terminator. Storage leaves always carry one and use the shorter form inline.
+func compactKeyParams(key []byte) (compactLen int, compact0 byte, ni int) {
 	if nibbles.HasTerm(key) {
 		compactLen = (len(key)-1)/2 + 1
 		if len(key)&1 == 0 {
-			compact0 = 48 + key[0] // Odd (1<<4) + first nibble
-			ni = 1
-		} else {
-			compact0 = 32
+			return compactLen, 0x30 + key[0], 1
 		}
-	} else {
-		compactLen = len(key)/2 + 1
-		if len(key)&1 == 1 {
-			compact0 = terminatorHexByte + key[0] // Odd (1<<4) + first nibble
-			ni = 1
-		}
+		return compactLen, 0x20, 0
 	}
-	return hph.completeLeafHash(buf, compactLen, key, compact0, ni, val, true)
+	compactLen = len(key)/2 + 1
+	if len(key)&1 == 1 {
+		return compactLen, terminatorHexByte + key[0], 1
+	}
+	return compactLen, 0, 0
 }
 
 func (hph *HexPatriciaHashed) extensionHash(key []byte, hash []byte) (common.Hash, error) {
 	var hashBuf common.Hash
 
-	// Compute the total length of binary representation
-	var kp, kl int
-	// Write key
-	var compactLen int
-	var ni int
-	var compact0 byte
-	if nibbles.HasTerm(key) {
-		compactLen = (len(key)-1)/2 + 1
-		if len(key)&1 == 0 {
-			compact0 = 0x30 + key[0] // Odd: (3<<4) + first nibble
-			ni = 1
-		} else {
-			compact0 = 0x20
-		}
-	} else {
-		compactLen = len(key)/2 + 1
-		if len(key)&1 == 1 {
-			compact0 = 0x10 + key[0] // Odd: (1<<4) + first nibble
-			ni = 1
-		}
-	}
-	var keyPrefix [1]byte
-	if compactLen > 1 {
-		keyPrefix[0] = 0x80 + byte(compactLen)
-		kp = 1
-		kl = compactLen
-	} else {
-		kl = 1
-	}
-	totalLen := kp + kl + 33
-	var lenPrefix [4]byte
-	pt := rlp.EncodeListPrefixToBuf(totalLen, lenPrefix[:])
+	compactLen, compact0, ni := compactKeyParams(key)
+	n, _ := hph.assembleNodeHeader(keyRlpLen(compactLen)+length.Hash+1, compactLen, key, compact0, ni)
+	header := hph.nodeRlpBuf[:]
+	header[n] = 0x80 + length.Hash
+	n++
 
 	hph.keccak.Reset()
-	w := hph.witness.leafWriter(hph.keccak)
-	if _, err := w.Write(lenPrefix[:pt]); err != nil {
-		return hashBuf, err
-	}
-	if _, err := w.Write(keyPrefix[:kp]); err != nil {
-		return hashBuf, err
-	}
-	var b [1]byte
-	b[0] = compact0
-	if _, err := w.Write(b[:]); err != nil {
-		return hashBuf, err
-	}
-	for i := 1; i < compactLen; i++ {
-		b[0] = key[ni]*16 + key[ni+1]
-		if _, err := w.Write(b[:]); err != nil {
-			return hashBuf, err
-		}
-		ni += 2
-	}
-	b[0] = 0x80 + length.Hash
-	if _, err := w.Write(b[:]); err != nil {
+	w := hph.witness.nodeWriter(hph.keccak)
+	if _, err := w.Write(header[:n]); err != nil {
 		return hashBuf, err
 	}
 	if _, err := w.Write(hash); err != nil {
 		return hashBuf, err
 	}
-	// Replace previous hash with the new one
-	if _, err := hph.keccak.Read(hashBuf[:]); err != nil {
+	hph.nodeHashBuf[0] = 0x80 + length.Hash
+	if _, err := hph.keccak.Read(hph.nodeHashBuf[1:]); err != nil {
 		return hashBuf, err
 	}
-	hph.witness.emitLeaf(hashBuf[:])
+	copy(hashBuf[:], hph.nodeHashBuf[1:])
+	hph.witness.emitNode(hph.nodeHashBuf[1:])
 	return hashBuf, nil
+}
+
+// keyRlpLen is the encoded length of a compacted key: its optional prefix byte plus
+// the compact bytes themselves.
+func keyRlpLen(compactLen int) int {
+	if compactLen > 1 {
+		return 1 + compactLen
+	}
+	return 1
+}
+
+// assembleNodeHeader writes a node's RLP list prefix, key prefix and compact key into
+// nodeRlpBuf, returning the bytes written and the list-prefix length. One buffer rather
+// than a write per byte: the writer is an interface, so every stack array handed to it
+// would be heap-allocated.
+func (hph *HexPatriciaHashed) assembleNodeHeader(payloadLen, compactLen int, key []byte, compact0 byte, ni int) (n, prefixLen int) {
+	header := hph.nodeRlpBuf[:]
+	prefixLen = rlp.EncodeListPrefixToBuf(payloadLen, header)
+	n = prefixLen
+	if compactLen > 1 {
+		header[n] = 0x80 + byte(compactLen)
+		n++
+	}
+	header[n] = compact0
+	n++
+	for i := 1; i < compactLen; i++ {
+		header[n] = key[ni]*16 + key[ni+1]
+		n++
+		ni += 2
+	}
+	return n, prefixLen
 }
 
 func (hph *HexPatriciaHashed) computeCellHashLen(cell *cell, depth int16) int16 {

--- a/execution/commitment/leaf_hash_test.go
+++ b/execution/commitment/leaf_hash_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/length"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 	"github.com/erigontech/erigon/execution/rlp"
@@ -134,7 +135,7 @@ func TestCompleteLeafHashMatchesPerByteHeader(t *testing.T) {
 }
 
 // The table above pins named shapes; this sweeps every key length the nibble
-// arrays permit, so an undersized leafRlpBuf cannot pass by staying below the
+// arrays permit, so an undersized nodeRlpBuf cannot pass by staying below the
 // longest key the buffer is sized for.
 func TestCompleteLeafHashAllKeyLengths(t *testing.T) {
 	t.Parallel()
@@ -189,7 +190,7 @@ func TestCompleteLeafHashAllKeyLengths(t *testing.T) {
 // assembled in one buffer. It writes through the same witness wrapper production uses,
 // so enabling witness tracing cannot make the reference and the real path diverge.
 func referenceLeafHash(ref *HexPatriciaHashed, key []byte, val rlp.RlpSerializable, account, singleton bool) ([]byte, error) {
-	compactLen, compact0, ni := compactKeyParams(key, account)
+	compactLen, compact0, ni := referenceCompactKeyParams(key, account)
 	kp, kl := 0, 1
 	if compactLen > 1 {
 		kp, kl = 1, compactLen
@@ -203,7 +204,7 @@ func referenceLeafHash(ref *HexPatriciaHashed, key []byte, val rlp.RlpSerializab
 		writer = ref.auxBuffer
 	} else {
 		ref.keccak.Reset()
-		writer = ref.witness.leafWriter(ref.keccak)
+		writer = ref.witness.nodeWriter(ref.keccak)
 	}
 	if err := writeLeafHeaderPerByte(writer, totalLen, compactLen, key, compact0, ni); err != nil {
 		return nil, err
@@ -223,9 +224,9 @@ func referenceLeafHash(ref *HexPatriciaHashed, key []byte, val rlp.RlpSerializab
 	return hashBuf, nil
 }
 
-// compactKeyParams mirrors the compact-encoding decisions leafHashWithKeyVal and
+// referenceCompactKeyParams mirrors the compact-encoding decisions leafHashWithKeyVal and
 // accountLeafHashWithKey make before delegating to completeLeafHash.
-func compactKeyParams(key []byte, account bool) (compactLen int, compact0 byte, ni int) {
+func referenceCompactKeyParams(key []byte, account bool) (compactLen int, compact0 byte, ni int) {
 	if account {
 		if nibbles.HasTerm(key) {
 			compactLen = (len(key)-1)/2 + 1
@@ -245,4 +246,65 @@ func compactKeyParams(key []byte, account bool) (compactLen int, compact0 byte, 
 		return compactLen, 0x30 + key[0], 1
 	}
 	return compactLen, 0x20, 0
+}
+
+// The extension header is the leaf header plus a hash tag, assembled in the same
+// buffer, so it needs the same sweep over every key length the nibble arrays permit.
+func TestExtensionHashMatchesPerByteHeader(t *testing.T) {
+	t.Parallel()
+
+	hash := make([]byte, length.Hash)
+	for i := range hash {
+		hash[i] = byte(0xc0 + i)
+	}
+
+	for keyLen := 1; keyLen <= len(cell{}.hashedExtension); keyLen++ {
+		for _, terminated := range []bool{false, true} {
+			key := make([]byte, keyLen)
+			for i := range key {
+				key[i] = byte(i % 16)
+			}
+			if terminated {
+				key[keyLen-1] = terminatorHexByte
+			}
+
+			hph := NewHexPatriciaHashed(length.Addr, nil, TrieConfig{})
+			got, err := hph.extensionHash(key, hash)
+			require.NoError(t, err, "keyLen=%d terminated=%v", keyLen, terminated)
+
+			ref := NewHexPatriciaHashed(length.Addr, nil, TrieConfig{})
+			want, err := referenceExtensionHash(ref, key, hash)
+			require.NoError(t, err, "keyLen=%d terminated=%v", keyLen, terminated)
+			require.Equal(t, want, got, "keyLen=%d terminated=%v", keyLen, terminated)
+
+			ref.Release()
+			hph.Release()
+		}
+	}
+}
+
+// referenceExtensionHash reproduces extensionHash as it behaved before the header was
+// assembled in one buffer.
+func referenceExtensionHash(ref *HexPatriciaHashed, key, hash []byte) (common.Hash, error) {
+	var out common.Hash
+	compactLen, compact0, ni := referenceCompactKeyParams(key, true)
+	kp := 0
+	if compactLen > 1 {
+		kp = 1
+	}
+
+	ref.keccak.Reset()
+	w := ref.witness.nodeWriter(ref.keccak)
+	if err := writeLeafHeaderPerByte(w, kp+compactLen+length.Hash+1, compactLen, key, compact0, ni); err != nil {
+		return out, err
+	}
+	tag := [1]byte{0x80 + length.Hash}
+	if _, err := w.Write(tag[:]); err != nil {
+		return out, err
+	}
+	if _, err := w.Write(hash); err != nil {
+		return out, err
+	}
+	_, err := ref.keccak.Read(out[:])
+	return out, err
 }

--- a/execution/commitment/witness_tracer_test.go
+++ b/execution/commitment/witness_tracer_test.go
@@ -37,15 +37,15 @@ func (r *recordingTracer) onNode(rlp, hash []byte) {
 
 // Test_witness_capture exercises the witness helper directly: an inactive witness
 // passes the keccak writer through untouched and emits nothing, while an active one
-// tees leaf bytes through leafBuf and accumulates a branch from its prefix and slots.
+// tees node bytes through nodeBuf and accumulates a branch from its prefix and slots.
 func Test_witness_capture(t *testing.T) {
 	var w witness
 	var sink bytes.Buffer
 
 	// inactive: passthrough writer, emits are no-ops, no panic on nil tracer
 	require.False(t, w.active())
-	require.Same(t, &sink, w.leafWriter(&sink))
-	w.emitLeaf([]byte("x"))
+	require.Same(t, &sink, w.nodeWriter(&sink))
+	w.emitNode([]byte("x"))
 	w.beginBranch([]byte("y"))
 	w.writeBranch([]byte("z"))
 	w.emitBranch([]byte("w"))
@@ -54,9 +54,9 @@ func Test_witness_capture(t *testing.T) {
 	w.tracer = rec
 	require.True(t, w.active())
 
-	lw := w.leafWriter(&sink)
+	lw := w.nodeWriter(&sink)
 	_, _ = lw.Write([]byte("leaf-rlp"))
-	w.emitLeaf([]byte("leaf-hash"))
+	w.emitNode([]byte("leaf-hash"))
 
 	w.beginBranch([]byte("pre"))
 	w.writeBranch([]byte("-slot1"))


### PR DESCRIPTION
`extensionHash` wrote the list prefix, key prefix and compact key through the `io.Writer` interface one piece at a time — a byte per loop iteration. Every local it wrote from was heap-pinned: `hashBuf`, `keyPrefix`, `lenPrefix`, `b`.

Now the header is assembled into the scratch buffer `completeLeafHash` already uses and written once. Those buffers are not leaf-specific, so `leafRlpBuf`/`leafHashBuf` become `nodeRlpBuf`/`nodeHashBuf`, and the witness members that capture any non-branch node (`leafWriter`/`emitLeaf`/`leafBuf`) follow. No new fields on `HexPatriciaHashed`.

The header assembly and the hex-prefix rule are shared between the leaf and extension paths instead of copied. `TestExtensionHashMatchesPerByteHeader` pins the extension header against a per-byte reference across every key length, matching what the leaf path already had — it caught a real off-by-one while writing this. `maxNodeRlpLen` gets a compile-time bound check for both `cell.extension` and `cell.hashedExtension`.

Byte stream is unchanged, so hashes and witness output are identical. `onNode` now documents that neither slice may be retained.

BenchmarkHexPatriciaHashedFold, count=12 benchtime=300x:

| | main | PR |
|---|---|---|
| allocs/op | 1171.0 | 1141.0 (-2.6%) |
| B/op | 55.36Ki | 55.09Ki (-0.5%) |
| sec/op | 179.1µ | 176.5µ (~, p=0.319) |