### PR TITLE
execution/commitment: pass the leaf value to completeLeafHash without boxing it

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -730,7 +730,7 @@ func (cell *cell) accountForHashing(buffer []byte, storageRootHash common.Hash) 
 	return pos
 }
 
-func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key []byte, compact0 byte, ni int, val rlp.RlpSerializable, singleton bool) ([]byte, error) {
+func completeLeafHash[V rlp.RlpSerializable](hph *HexPatriciaHashed, buf []byte, compactLen int, key []byte, compact0 byte, ni int, val V, singleton bool) ([]byte, error) {
 	// Compute the total length of binary representation
 	var kp, kl int
 	if compactLen > 1 {
@@ -761,7 +761,6 @@ func (hph *HexPatriciaHashed) completeLeafHash(buf []byte, compactLen int, key [
 	canEmbed := !singleton && totalLen+pl < length.Hash
 	var writer io.Writer
 	if canEmbed {
-		//hph.byteArrayWriter.Setup(buf)
 		hph.auxBuffer.Reset()
 		writer = hph.auxBuffer
 	} else {
@@ -799,10 +798,10 @@ func (hph *HexPatriciaHashed) leafHashWithKeyVal(buf, key []byte, val rlp.RlpSer
 	} else {
 		compact0 = 0x20
 	}
-	return hph.completeLeafHash(buf, compactLen, key, compact0, ni, val, singleton)
+	return completeLeafHash(hph, buf, compactLen, key, compact0, ni, val, singleton)
 }
 
-func (hph *HexPatriciaHashed) accountLeafHashWithKey(buf, key []byte, val rlp.RlpSerializable) ([]byte, error) {
+func (hph *HexPatriciaHashed) accountLeafHashWithKey(buf, key []byte, val rlp.RlpEncodedBytes) ([]byte, error) {
 	// Write key
 	var compactLen int
 	var ni int
@@ -822,7 +821,7 @@ func (hph *HexPatriciaHashed) accountLeafHashWithKey(buf, key []byte, val rlp.Rl
 			ni = 1
 		}
 	}
-	return hph.completeLeafHash(buf, compactLen, key, compact0, ni, val, true)
+	return completeLeafHash(hph, buf, compactLen, key, compact0, ni, val, true)
 }
 
 func (hph *HexPatriciaHashed) extensionHash(key []byte, hash []byte) (common.Hash, error) {

--- a/execution/commitment/leaf_hash_test.go
+++ b/execution/commitment/leaf_hash_test.go
@@ -116,7 +116,7 @@ func TestCompleteLeafHashMatchesPerByteHeader(t *testing.T) {
 			var val rlp.RlpSerializable
 			if tc.account {
 				val = rlp.RlpEncodedBytes(accountVal)
-				got, err = hph.accountLeafHashWithKey(nil, tc.key, val)
+				got, err = hph.accountLeafHashWithKey(nil, tc.key, rlp.RlpEncodedBytes(accountVal))
 			} else {
 				storage := rlp.RlpSerializableBytes(storageVal)
 				val = storage
@@ -165,7 +165,7 @@ func TestCompleteLeafHashAllKeyLengths(t *testing.T) {
 				var val rlp.RlpSerializable
 				if account {
 					val = rlp.RlpEncodedBytes(accountVal)
-					got, err = hph.accountLeafHashWithKey(nil, key, val)
+					got, err = hph.accountLeafHashWithKey(nil, key, rlp.RlpEncodedBytes(accountVal))
 				} else {
 					storage := rlp.RlpSerializableBytes(storageVal)
 					val = storage


### PR DESCRIPTION
`leafHashWithKeyVal` converted its `rlp.RlpSerializableBytes` to `completeLeafHash`'s `rlp.RlpSerializable` parameter on every leaf — one `convTslice` each, 10.7% of allocations in the fold benchmark's profile. The buffers inside `completeLeafHash` were already fine; only the value handoff allocated.

`completeLeafHash` becomes generic over `rlp.RlpSerializable`, so the slice header passes by value. Methods cannot take type params, so it is now a free function. `accountLeafHashWithKey` stays a method and takes `rlp.RlpEncodedBytes` directly — that is the only type it was ever called with, and naming it turns a wrongly double-prefixed account value into a compile error rather than a wrong state root.

Pure refactor with no behavior change, so no new test — the existing leaf-hash differential tests are the safety net.

BenchmarkHexPatriciaHashedFold, count=12 benchtime=300x:

| | main | PR |
|---|---|---|
| allocs/op | 1171.0 | 1057.0 (-9.7%) |
| B/op | 55.36Ki | 52.68Ki (-4.8%) |
| sec/op | 180.7µ | 175.3µ (~, p=0.114) |