### PR TITLE
rpc: fix parity_listStorageKeys state version and gate eth_getProof on execution

### DIFF
--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -437,6 +437,13 @@ func (api *APIImpl) GetProof(ctx context.Context, address common.Address, storag
 		return nil, err
 	}
 
+	// A canonical hash exists for blocks the header stage has downloaded but
+	// execution has not reached; the commitment history getProof needs is only
+	// written by execution.
+	if err := rpchelper.CheckBlockExecuted(roTx, uint64(requestedBlockNr)); err != nil {
+		return nil, err
+	}
+
 	err = api.BaseAPI.checkPruneHistory(ctx, roTx, uint64(requestedBlockNr))
 	if err != nil {
 		return nil, err

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -432,7 +432,9 @@ func (api *APIImpl) GetProof(ctx context.Context, address common.Address, storag
 	}
 	defer roTx.Rollback()
 
-	requestedBlockNr, _, _, err := rpchelper.GetCanonicalBlockNumber(ctx, blockNrOrHash, roTx, api._blockReader, api.filters)
+	// nil filters: the gate below and the commitment-history reads both go through
+	// this plain roTx, so the tag has to resolve on that same committed view.
+	requestedBlockNr, _, _, err := rpchelper.GetCanonicalBlockNumber(ctx, blockNrOrHash, roTx, api._blockReader, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/parity_api.go
+++ b/rpc/jsonrpc/parity_api.go
@@ -75,7 +75,9 @@ func (api *ParityAPIImpl) ListStorageKeys(ctx context.Context, account common.Ad
 	}
 
 	bn := rawdb.ReadCurrentBlockNumber(tx)
-	minTxNum, err := api._txNumReader.Min(ctx, tx, *bn)
+	// Min(bn+1) is the first txNum past bn — the state the latest-state account
+	// read above sees. Min(bn) would scan storage as of the end of bn-1.
+	minTxNum, err := api._txNumReader.Min(ctx, tx, *bn+1)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/jsonrpc/parity_api.go
+++ b/rpc/jsonrpc/parity_api.go
@@ -75,6 +75,9 @@ func (api *ParityAPIImpl) ListStorageKeys(ctx context.Context, account common.Ad
 	}
 
 	bn := rawdb.ReadCurrentBlockNumber(tx)
+	if bn == nil {
+		return nil, errors.New("current block number not found")
+	}
 	// Min(bn+1) is the first txNum past bn — the state the latest-state account
 	// read above sees. Min(bn) would scan storage as of the end of bn-1.
 	minTxNum, err := api._txNumReader.Min(ctx, tx, *bn+1)


### PR DESCRIPTION
Two state-version bugs in the RPC layer, both independent of each other and of the view-consistency work in #22533.

`parity_listStorageKeys` reads the account with a latest-state reader — the state after head block `bn` — but scanned its storage at `Min(bn)`, the first txNum of `bn`, which is the state after `bn-1`. The account and its storage therefore came from different blocks: a slot written in the head block was missing from the listing, and a slot deleted in it was still listed. `state.Dumper`, the equivalent path, uses `Min(blockNumber+1)`.

`eth_getProof` resolved a block by canonical hash alone. Canonical hashes exist for blocks the header stage has downloaded but execution has not reached, so a request for one walked the history path and surfaced a `PrunedError` or a root-hash mismatch instead of reporting that the block is not executed yet.

## Changes

- `parity_api.go` — `Min(bn)` → `Min(bn+1)` so the storage scan matches the account read.
- `eth_call.go` — gate `GetProof` on `rpchelper.CheckBlockExecuted` after resolution.