### PR TITLE
common/dbg: disable adaptive trunk-pin by default

### DIFF
--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -135,7 +135,7 @@ var (
 	UseTxDependencies    = EnvBool("USE_TX_DEPENDENCIES", false)
 	UseStateCache        = EnvBool("USE_STATE_CACHE", true)
 	UseCodeStore         = EnvBool("USE_CODE_STORE", true)
-	DisableAdaptivePin   = EnvBool("DISABLE_ADAPTIVE_PIN", false)
+	DisableAdaptivePin   = EnvBool("DISABLE_ADAPTIVE_PIN", true)
 	AssertStateCache     = EnvBool("ASSERT_STATE_CACHE", false)
 	ReadAhead            = EnvBool("READ_AHEAD", true)
 	// FilesAsyncIO warms cold state .kv pages via io_uring before the mmap read, so


### PR DESCRIPTION
Cherry-pick of #22990 to `main`.

Flips `DISABLE_ADAPTIVE_PIN` to default `true`, so `Aggregator.openFolder` no longer builds the `AdaptivePinController` and no trunk preload runs.

The controller's promote/extend preloads run inline from `SharedDomains.Commit` — under the controller mutex and inside the still-open write tx — so their cost (per-contract `TblCommitmentVals` cursor scan into a Go map, per-wave frontier sort, sequential `GetLatest` per key) lands on the block-commit critical path.

`DISABLE_ADAPTIVE_PIN=false` re-enables it.