### PR TITLE
execution/state: retain definitive account reads for validation

### DIFF
--- a/execution/state/eip8246_selfdestruct_test.go
+++ b/execution/state/eip8246_selfdestruct_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -11,6 +12,17 @@ import (
 	"github.com/erigontech/erigon/execution/tracing"
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
+
+type publishOnAccountRead struct {
+	StateReader
+	once    sync.Once
+	publish func()
+}
+
+func (r *publishOnAccountRead) ReadAccountData(accounts.Address) (*accounts.Account, error) {
+	r.once.Do(r.publish)
+	return nil, nil
+}
 
 // EIP-8246 removes the SELFDESTRUCT balance burn, leaving a destroyed account
 // alive as a balance-only account. These tests cover that behavior inside
@@ -57,6 +69,53 @@ func TestEIP8246_PreservedSD_ReadsAsEmptyCodeAccountInLaterTx(t *testing.T) {
 	exists, err := tx1.Exist(addr)
 	require.NoError(t, err)
 	require.True(t, exists, "the preserved account still exists")
+}
+
+func TestEIP8246_DefinitiveAbsenceSurvivesLaterAccountReconstruction(t *testing.T) {
+	addr := accounts.InternAddress(common.HexToAddress("0x8246F"))
+	preserved := *uint256.NewInt(1_000_000)
+	priorTx := Version{TxIndex: 0}
+
+	vm := NewVersionMap(nil)
+	vm.WriteBalance(addr, priorTx, preserved, true)
+
+	published := &WriteSet{}
+	published.SetSelfDestruct(addr, &VersionedWrite[bool]{
+		WriteHeader: WriteHeader{Address: addr, Path: SelfDestructPath, Version: priorTx},
+		Val:         true,
+	})
+	published.SetBalance(addr, &VersionedWrite[uint256.Int]{
+		WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Version: priorTx},
+		Val:         preserved,
+	})
+	published.SetIncarnation(addr, &VersionedWrite[uint64]{
+		WriteHeader: WriteHeader{Address: addr, Path: IncarnationPath, Version: priorTx},
+	})
+
+	reader := &publishOnAccountRead{
+		StateReader: NewNoopReader(),
+		publish:     func() { vm.FlushVersionedWrites(published, true, "") },
+	}
+	ibs := New(reader)
+	defer ibs.Close()
+	ibs.SetTxContext(1, 1)
+	ibs.SetVersionMap(vm)
+	ibs.SetNoMaterialize(true)
+	ibs.eip8246 = true
+	ibs.eip161 = true
+
+	empty, err := ibs.Empty(addr)
+	require.NoError(t, err)
+	require.True(t, empty, "the forced publication occurs after this attempt reads the address as absent")
+	require.NoError(t, ibs.CreateAccount(addr, true))
+	balance, err := ibs.GetBalance(addr)
+	require.NoError(t, err)
+	require.Equal(t, preserved, balance)
+
+	io := NewVersionedIO(2)
+	io.RecordReads(Version{TxIndex: 1}, ibs.VersionedReads())
+	require.Equal(t, VersionInvalid, vm.ValidateVersion(1, io, validateEqualVersion, true, false, false, ""),
+		"the consumed absence must invalidate even if a later read reconstructs the published account")
 }
 
 // The block assembler runs every tx on one shared IBS (no per-tx Reset).

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -2969,6 +2969,12 @@ func (sdb *IntraBlockState) accountRead(addr accounts.Address, account *accounts
 			// synthetic tx-reads source into validation, which rejects it.
 			return
 		}
+		// Reconciliation may replace only the provisional nil probe made by
+		// this account load. A definitive read may already have affected EVM
+		// behavior and must remain in the read set for commit-time validation.
+		if previous, ok := sdb.versionedReads.GetAddress(addr); ok && previous.Source != ProvisionalRead {
+			return
+		}
 		data := *account
 		// Demote a sub-field MapRead promotion when AddressPath itself has no cell,
 		// or the validator non-converges on its recursive AddressPath check.


### PR DESCRIPTION
## Problem

During parallel execution, an account load can overlap publication of an earlier transaction. `Empty` may first observe that the target is absent and use that result to charge Amsterdam new-account state gas. A later operation in the same execution attempt can reconstruct the account from newly published EIP-8246 state.

The regression was introduced by #22190, which added provisional account reads and recorded-read reconciliation for BAL-driven parallel execution.

The reconstruction previously replaced the earlier definitive `AddressPath` read. Commit-time validation then lost the observation that affected gas accounting, so it could accept the stale attempt instead of retrying it.

## Fix

Keep the first definitive address read for an execution attempt. Account-load reconciliation may replace only its own provisional nil probe; it cannot erase a definitive observation that may already have affected EVM behavior.

This lets optimistic-concurrency validation detect the newly published account, reject the stale attempt, and retry it against a consistent state view.

## Testing

The new deterministic regression publishes the earlier transaction between the initial address probe and the storage fallback. Before the production change, the test failed because validation returned `VersionValid`; with the fix, it returns `VersionInvalid`.

- `go test ./execution/state -count=1`
- `go test -race ./execution/state -run '^TestEIP8246_DefinitiveAbsenceSurvivesLaterAccountReconstruction$' -count=100`
- `ERIGON_COMMITMENT_PARALLEL=false go test ./execution/engineapi -run '^TestEngineApiEIP8246PreservedBalanceSurvivesCreate2Recreate$' -count=100`
- `ERIGON_COMMITMENT_PARALLEL=false go test -race ./execution/engineapi -run '^TestEngineApiEIP8246PreservedBalanceSurvivesCreate2Recreate$' -count=100`
- `make lint`
- `make erigon integration`
- `make test-short`
