### PR TITLE
docs: August 2026 w33 — CLI reference gaps on release/3.5, dead checkpoint endpoint

### DIFF
--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -64,6 +64,29 @@ These flags cover the general behavior and configuration of the Erigon client.
 * `--keep.stored.chain.config`: Avoids overriding the chain configuration already stored in the database.
   * Default: `false`
 
+### Development, testing, and block-production helpers
+
+These flags are mainly for dev networks, testing, or specialized block-production setups.
+
+* `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
+  * Default: `false`
+* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
+  * Default: `devnet`
+* `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
+  * Default: `64`
+* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
+  * Default: `6`
+* `--miner.gaslimit value`: Target gas limit for mined blocks.
+  * Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
+* `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
+  * Default: the client version string
+* `--experimental.bal`: Generates block access lists.
+  * Default: `false`
+* `--experimental.always-generate-changesets`: Overrides changeset generation logic.
+  * Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
+* `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
+  * Default: `false`
+
 ### Database and Caching
 
 These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
@@ -80,6 +103,8 @@ These flags control database performance and memory usage. See [Database](/funda
   * Default: `2`
 * `--batchSize value`: Sets the batch size for the execution stage.
   * Default: `512M`
+* `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
+  * Default: `256MB`
 * `--bodies.cache value`: Sets the size limit for the block bodies cache.
   * Default: `268435456`
 * `--state.cache value`: Sets the amount of data to store in the StateCache.
@@ -451,6 +476,11 @@ Flags for configuring the parallel block execution engine.
   * Default: `true`
 * `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
   * Default: `true`
+
+**Commitment-trie construction.** The following flag changes how the commitment (state-root) trie is computed during execution. It defaults off and is intended for comparing root hashes against a sequential sync before enabling broadly.
+
+* `--experimental.concurrent-commitment` (experimental): Compute the commitment trie concurrently instead of sequentially. Also applies when rebuilding commitment from existing state.
+  * Default: `false`
 
 ### Caplin (Consensus Layer)
 

--- a/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl.mdx
+++ b/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl.mdx
@@ -63,8 +63,8 @@ scheduled forks, not after.
     ./prysm.sh beacon-chain \
     --execution-endpoint http://localhost:8551 \
     --mainnet --jwt-secret=<your-datadir>/jwt.hex \
-    --checkpoint-sync-url=https://beaconstate.info \
-    --genesis-beacon-api-url=https://beaconstate.info
+    --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+    --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
     ```
 </TabItem>
 <TabItem value="lighthouse" label="Lighthouse">

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -1131,8 +1131,8 @@ scheduled forks, not after.
     ./prysm.sh beacon-chain \
     --execution-endpoint http://localhost:8551 \
     --mainnet --jwt-secret=<your-datadir>/jwt.hex \
-    --checkpoint-sync-url=https://beaconstate.info \
-    --genesis-beacon-api-url=https://beaconstate.info
+    --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+    --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
     ```
 
 1.  Start Erigon adding the `--externalcl` flag:
@@ -2154,6 +2154,29 @@ These flags cover the general behavior and configuration of the Erigon client.
 * `--keep.stored.chain.config`: Avoids overriding the chain configuration already stored in the database.
   * Default: `false`
 
+### Development, testing, and block-production helpers
+
+These flags are mainly for dev networks, testing, or specialized block-production setups.
+
+* `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
+  * Default: `false`
+* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
+  * Default: `devnet`
+* `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
+  * Default: `64`
+* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
+  * Default: `6`
+* `--miner.gaslimit value`: Target gas limit for mined blocks.
+  * Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
+* `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
+  * Default: the client version string
+* `--experimental.bal`: Generates block access lists.
+  * Default: `false`
+* `--experimental.always-generate-changesets`: Overrides changeset generation logic.
+  * Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
+* `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
+  * Default: `false`
+
 ### Database and Caching
 
 These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
@@ -2170,6 +2193,8 @@ These flags control database performance and memory usage. See [Database](/funda
   * Default: `2`
 * `--batchSize value`: Sets the batch size for the execution stage.
   * Default: `512M`
+* `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
+  * Default: `256MB`
 * `--bodies.cache value`: Sets the size limit for the block bodies cache.
   * Default: `268435456`
 * `--state.cache value`: Sets the amount of data to store in the StateCache.
@@ -2541,6 +2566,11 @@ Flags for configuring the parallel block execution engine.
   * Default: `true`
 * `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
   * Default: `true`
+
+**Commitment-trie construction.** The following flag changes how the commitment (state-root) trie is computed during execution. It defaults off and is intended for comparing root hashes against a sequential sync before enabling broadly.
+
+* `--experimental.concurrent-commitment` (experimental): Compute the commitment trie concurrently instead of sequentially. Also applies when rebuilding commitment from existing state.
+  * Default: `false`
 
 ### Caplin (Consensus Layer)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1131,8 +1131,8 @@ scheduled forks, not after.
     ./prysm.sh beacon-chain \
     --execution-endpoint http://localhost:8551 \
     --mainnet --jwt-secret=<your-datadir>/jwt.hex \
-    --checkpoint-sync-url=https://beaconstate.info \
-    --genesis-beacon-api-url=https://beaconstate.info
+    --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+    --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
     ```
 
 1.  Start Erigon adding the `--externalcl` flag:
@@ -2154,6 +2154,29 @@ These flags cover the general behavior and configuration of the Erigon client.
 * `--keep.stored.chain.config`: Avoids overriding the chain configuration already stored in the database.
   * Default: `false`
 
+### Development, testing, and block-production helpers
+
+These flags are mainly for dev networks, testing, or specialized block-production setups.
+
+* `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
+  * Default: `false`
+* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
+  * Default: `devnet`
+* `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
+  * Default: `64`
+* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
+  * Default: `6`
+* `--miner.gaslimit value`: Target gas limit for mined blocks.
+  * Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
+* `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
+  * Default: the client version string
+* `--experimental.bal`: Generates block access lists.
+  * Default: `false`
+* `--experimental.always-generate-changesets`: Overrides changeset generation logic.
+  * Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
+* `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
+  * Default: `false`
+
 ### Database and Caching
 
 These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
@@ -2170,6 +2193,8 @@ These flags control database performance and memory usage. See [Database](/funda
   * Default: `2`
 * `--batchSize value`: Sets the batch size for the execution stage.
   * Default: `512M`
+* `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
+  * Default: `256MB`
 * `--bodies.cache value`: Sets the size limit for the block bodies cache.
   * Default: `268435456`
 * `--state.cache value`: Sets the amount of data to store in the StateCache.
@@ -2541,6 +2566,11 @@ Flags for configuring the parallel block execution engine.
   * Default: `true`
 * `--exec.state-cache`: Enable the executor's domain-shared read cache. Equivalent to `USE_STATE_CACHE=true`. Disable for cold-read performance measurements.
   * Default: `true`
+
+**Commitment-trie construction.** The following flag changes how the commitment (state-root) trie is computed during execution. It defaults off and is intended for comparing root hashes against a sequential sync before enabling broadly.
+
+* `--experimental.concurrent-commitment` (experimental): Compute the commitment trie concurrently instead of sequentially. Also applies when rebuilding commitment from existing state.
+  * Default: `false`
 
 ### Caplin (Consensus Layer)
 


### PR DESCRIPTION
## Why

The `release/3.5` CLI reference was missing **11 registered flags**. All 11 are already documented on `release/3.6` and `main` — #22938 and #22939 added them on 2026-08-01 — but neither had a `release/3.5` counterpart. Since `docs.erigon.tech` publishes from `release/3.5` only, the deployed docs were the sole place carrying the gap.

The flags: `--allow-insecure-unlock`, `--chaos.monkey`, `--dev-validator-count`, `--dev-validator-seed`, `--dev.slot-time`, `--etl.bufferSize`, `--experimental.always-generate-changesets`, `--experimental.bal`, `--experimental.concurrent-commitment`, `--miner.extradata`, `--miner.gaslimit`.

Each is registered in `node/cli/default_flags.go` on this branch and appeared in no page under `docs/site/docs`.

## Not a copy of the 3.6 text

Ten entries are based on the wording merged in #22939, but every default was re-read from `release/3.5` source. The eleventh, `--experimental.concurrent-commitment`, exists **only on this branch** — it was renamed to `--experimental.parallel-commitment` for 3.6 — so its entry is written from 3.5 source directly.

Then two adversarial review passes (GPT-5.5 and Fable) were run against the diff before pushing, and **five statements in the merged 3.6 wording turned out to be false**. Each was re-checked against source before rewriting:

| Statement in the 3.6 text | What the source says |
|---|---|
| `--miner.gaslimit` default `0` | `cmd/utils/flags.go` applies it only when set **and** non-zero; `setDefaultMinerGasLimit` (`node/eth/backend.go`) then fills an unset limit from the chain config's default block gas limit, falling back to `60_000_000` |
| `--experimental.always-generate-changesets` default `false` | derived as `!dbg.BatchCommitments` (`node/ethconfig/config.go:93`); `BATCH_COMMITMENTS` defaults true, so under `BATCH_COMMITMENTS=false` the default flips |
| "Allows insecure account unlocking" | **the flag does nothing** — registered, but read nowhere in the tree on 3.5, 3.6 or main, and Erigon exposes no account-unlocking RPC |
| `--dev-validator-seed` "enables PoS dev mode" | `setDevnetEthConfig` is reached only via `case networkname.Dev`, so `--chain dev` selects dev mode; the seed is merely read inside it |
| `--dev.slot-time` "minimum 2" | values below `2` are **silently raised** to `2`, not rejected |

Because all five are equally wrong on `release/3.6` and `main`, the same corrections ship there in the sibling PRs rather than leaving the three branches to diverge.

Also noted: `--miner.extradata` is truncated to 32 bytes, and `--etl.bufferSize` is settable via the `ETL_OPTIMAL` environment variable.

## Dead checkpoint-sync endpoint

The Prysm example passed `--checkpoint-sync-url=https://beaconstate.info`. That host **no longer resolves** — its NS records still delegate to bunny.net, but there is no A, AAAA or CNAME record, so the documented command fails at DNS before it reaches the network. Confirmed by authoritative query to `kiki.bunny.net` (NOERROR, zero answers).

Replaced with `https://mainnet.checkpoint.sigp.io`, which the **Lighthouse example on this same page already used** and which is on the [eth-clients checkpoint-sync list](https://github.com/eth-clients/checkpoint-sync-endpoints) the surrounding prose links to. Worth noting the dead host is still listed upstream, so that list is itself stale.

The frozen `versioned_docs/version-v3.3` and `version-v3.4` snapshots carry the same dead URL. Left alone deliberately — they are archived releases, and the routine restricts edits to `docs/site/docs/`.

## Testing

- `cd docs/site && npm ci && npm run build` ✅
- `python3 docs/site/scripts/generate-llms.py --check` ✅ (artifacts regenerated and committed)
- Every default and behaviour claim verified against `origin/release/3.5` source, never against 3.6/main or a `--help` string

Part of the w33 weekly docs routine. Sibling PRs cover `main` and `release/3.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
