### PR TITLE
docs: correct five flag defaults and the dead beaconstate.info endpoint

### DIFF
--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -68,22 +68,22 @@ These flags cover the general behavior and configuration of the Erigon client.
 
 These flags are mainly for dev networks, testing, or specialized block-production setups.
 
-* `--allow-insecure-unlock`: Allows insecure account unlocking when account-related RPCs are exposed by HTTP. Use only on trusted networks.
+* `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
   * Default: `false`
-* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator; enables PoS dev mode.
+* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
   * Default: `devnet`
-* `--dev-validator-count value`: Number of validators for PoS dev mode.
+* `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
   * Default: `64`
-* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode.
+* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
   * Default: `6`
 * `--miner.gaslimit value`: Target gas limit for mined blocks.
-  * Default: `0`
-* `--miner.extradata value`: Block extra data set by the miner; defaults to the client version string.
-  * Default: client version string
+  * Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
+* `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
+  * Default: the client version string
 * `--experimental.bal`: Generates block access lists.
   * Default: `false`
 * `--experimental.always-generate-changesets`: Overrides changeset generation logic.
-  * Default: `false`
+  * Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
 * `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
   * Default: `false`
 
@@ -103,7 +103,7 @@ These flags control database performance and memory usage. See [Database](/funda
   * Default: `2`
 * `--batchSize value`: Sets the batch size for the execution stage.
   * Default: `512M`
-* `--etl.bufferSize value`: Buffer size for ETL operations.
+* `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
   * Default: `256MB`
 * `--bodies.cache value`: Sets the size limit for the block bodies cache.
   * Default: `268435456`

--- a/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl.mdx
+++ b/docs/site/docs/get-started/easy-nodes/how-to-run-an-ethereum-node/ethereum-with-an-external-cl.mdx
@@ -63,8 +63,8 @@ scheduled forks, not after.
     ./prysm.sh beacon-chain \
     --execution-endpoint http://localhost:8551 \
     --mainnet --jwt-secret=<your-datadir>/jwt.hex \
-    --checkpoint-sync-url=https://beaconstate.info \
-    --genesis-beacon-api-url=https://beaconstate.info
+    --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+    --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
     ```
 </TabItem>
 <TabItem value="lighthouse" label="Lighthouse">

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -1057,8 +1057,8 @@ scheduled forks, not after.
     ./prysm.sh beacon-chain \
     --execution-endpoint http://localhost:8551 \
     --mainnet --jwt-secret=<your-datadir>/jwt.hex \
-    --checkpoint-sync-url=https://beaconstate.info \
-    --genesis-beacon-api-url=https://beaconstate.info
+    --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+    --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
     ```
 
 1.  Start Erigon adding the `--externalcl` flag:
@@ -2102,22 +2102,22 @@ These flags cover the general behavior and configuration of the Erigon client.
 
 These flags are mainly for dev networks, testing, or specialized block-production setups.
 
-* `--allow-insecure-unlock`: Allows insecure account unlocking when account-related RPCs are exposed by HTTP. Use only on trusted networks.
+* `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
   * Default: `false`
-* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator; enables PoS dev mode.
+* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
   * Default: `devnet`
-* `--dev-validator-count value`: Number of validators for PoS dev mode.
+* `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
   * Default: `64`
-* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode.
+* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
   * Default: `6`
 * `--miner.gaslimit value`: Target gas limit for mined blocks.
-  * Default: `0`
-* `--miner.extradata value`: Block extra data set by the miner; defaults to the client version string.
-  * Default: client version string
+  * Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
+* `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
+  * Default: the client version string
 * `--experimental.bal`: Generates block access lists.
   * Default: `false`
 * `--experimental.always-generate-changesets`: Overrides changeset generation logic.
-  * Default: `false`
+  * Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
 * `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
   * Default: `false`
 
@@ -2137,7 +2137,7 @@ These flags control database performance and memory usage. See [Database](/funda
   * Default: `2`
 * `--batchSize value`: Sets the batch size for the execution stage.
   * Default: `512M`
-* `--etl.bufferSize value`: Buffer size for ETL operations.
+* `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
   * Default: `256MB`
 * `--bodies.cache value`: Sets the size limit for the block bodies cache.
   * Default: `268435456`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1057,8 +1057,8 @@ scheduled forks, not after.
     ./prysm.sh beacon-chain \
     --execution-endpoint http://localhost:8551 \
     --mainnet --jwt-secret=<your-datadir>/jwt.hex \
-    --checkpoint-sync-url=https://beaconstate.info \
-    --genesis-beacon-api-url=https://beaconstate.info
+    --checkpoint-sync-url=https://mainnet.checkpoint.sigp.io \
+    --genesis-beacon-api-url=https://mainnet.checkpoint.sigp.io
     ```
 
 1.  Start Erigon adding the `--externalcl` flag:
@@ -2102,22 +2102,22 @@ These flags cover the general behavior and configuration of the Erigon client.
 
 These flags are mainly for dev networks, testing, or specialized block-production setups.
 
-* `--allow-insecure-unlock`: Allows insecure account unlocking when account-related RPCs are exposed by HTTP. Use only on trusted networks.
+* `--allow-insecure-unlock`: Accepted for go-ethereum CLI compatibility but currently has **no effect** — the flag is registered and settable, yet nothing in the codebase reads it and Erigon exposes no account-unlocking RPC.
   * Default: `false`
-* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator; enables PoS dev mode.
+* `--dev-validator-seed value`: Deterministic BLS key seed for the embedded dev validator. Read only in PoS dev mode, which is selected by `--chain dev`; on any other chain the flag does nothing.
   * Default: `devnet`
-* `--dev-validator-count value`: Number of validators for PoS dev mode.
+* `--dev-validator-count value`: Number of validators for PoS dev mode (`--chain dev`).
   * Default: `64`
-* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode.
+* `--dev.slot-time value`: Slot duration in seconds for PoS dev mode (`--chain dev`). Values below `2` are silently raised to `2`.
   * Default: `6`
 * `--miner.gaslimit value`: Target gas limit for mined blocks.
-  * Default: `0`
-* `--miner.extradata value`: Block extra data set by the miner; defaults to the client version string.
-  * Default: client version string
+  * Default: unset — the target falls back to the chain configuration's default block gas limit, or `60000000` where the chain config does not set one. An explicit `0` is ignored rather than applied as a zero limit, so the flag only takes effect when set to a positive value.
+* `--miner.extradata value`: Block extra data set by the miner. Values longer than 32 bytes are silently truncated.
+  * Default: the client version string
 * `--experimental.bal`: Generates block access lists.
   * Default: `false`
 * `--experimental.always-generate-changesets`: Overrides changeset generation logic.
-  * Default: `false`
+  * Default: `false`, derived as the inverse of the `BATCH_COMMITMENTS` environment variable (itself `true` by default). Running with `BATCH_COMMITMENTS=false` therefore flips this default to `true` unless the flag is passed explicitly.
 * `--chaos.monkey`: Testing-only flag that enables spontaneous network, consensus, and other failures.
   * Default: `false`
 
@@ -2137,7 +2137,7 @@ These flags control database performance and memory usage. See [Database](/funda
   * Default: `2`
 * `--batchSize value`: Sets the batch size for the execution stage.
   * Default: `512M`
-* `--etl.bufferSize value`: Buffer size for ETL operations.
+* `--etl.bufferSize value`: Buffer size for ETL operations. Also settable through the `ETL_OPTIMAL` environment variable.
   * Default: `256MB`
 * `--bodies.cache value`: Sets the size limit for the block bodies cache.
   * Default: `268435456`


### PR DESCRIPTION
## Why

Two unrelated docs defects on `release/3.6`, both found by the w33 weekly routine.

## 1. A dead checkpoint-sync endpoint

The Prysm example passed `--checkpoint-sync-url=https://beaconstate.info`. That host **no longer resolves** — its NS records still delegate to bunny.net, but there is no A, AAAA or CNAME record, so the documented command fails at DNS before it reaches the network. Confirmed by authoritative query to `kiki.bunny.net` (NOERROR, zero answers).

Replaced with `https://mainnet.checkpoint.sigp.io`, which the **Lighthouse example on this same page already used** and which is on the [eth-clients checkpoint-sync list](https://github.com/eth-clients/checkpoint-sync-endpoints) the surrounding prose links to. The dead host is still listed upstream, so that list is itself stale.

Note this was not a markdown link — it was a flag value inside a fenced command, so a link checker that only inspects `[text](url)` pairs never sees it.

## 2. Five wrong flag defaults in the dev-helpers section

Two adversarial review passes (GPT-5.5 and Fable) were run over the w33 diffs before pushing, and falsified five statements in the CLI reference. Each was re-verified against `origin/release/3.6` source:

| Documented | What the source says |
|---|---|
| `--miner.gaslimit` default `0` | applied only when set **and** non-zero (`cmd/utils/flags.go`); `setDefaultMinerGasLimit` (`node/eth/backend.go`) then fills an unset limit from the chain config's default block gas limit, falling back to `60_000_000`. "Default: 0" reads as a zero gas target, which never happens |
| `--experimental.always-generate-changesets` default `false` | derived as `!dbg.BatchCommitments` (`node/ethconfig/config.go:93`); `BATCH_COMMITMENTS` defaults true, so the documented `false` is environment-dependent, not fixed |
| "Allows insecure account unlocking when account-related RPCs are exposed by HTTP" | **the flag does nothing.** `--allow-insecure-unlock` is registered in `node/cli/default_flags.go` but read nowhere in the tree, and Erigon exposes no account-unlocking RPC. Documenting it as a security-relevant toggle is actively misleading |
| `--dev-validator-seed` "enables PoS dev mode" | `setDevnetEthConfig` is reached only via `case networkname.Dev`, so `--chain dev` selects dev mode and the seed is merely read inside it. Setting it on any other chain does nothing. `--dev-validator-count` and `--dev.slot-time` are now marked as `--chain dev` options for the same reason |
| `--dev.slot-time` | values below `2` are **silently raised** to `2`, not rejected |

These entries arrived in #22939 and the same text is on `release/3.5` and `main`, so the identical corrections ship in the sibling PRs — the three branches stay in step.

Also added: `--miner.extradata` is truncated to 32 bytes, and `--etl.bufferSize` is settable via the `ETL_OPTIMAL` environment variable.

## Testing

- `cd docs/site && npm ci && npm run build` ✅
- `python3 docs/site/scripts/generate-llms.py --check` ✅ (artifacts regenerated and committed)
- Every claim verified against `origin/release/3.6` source, not against `main` and not from a `Usage` string

Part of the w33 weekly docs routine. Sibling PRs cover `release/3.5` and `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
