### PR TITLE
execution/commitment: size keyArena chunks from the subtree key count

### DIFF
--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -601,15 +601,22 @@ func childForNib(root *prefixNode, nib byte) (*prefixNode, bool) {
 }
 
 // keyArena copies walk-path nibbles into chunked backing buffers so each
-// collected key gets a stable slice without one allocation per key.
-type keyArena struct{ buf []byte }
+// collected key gets a stable slice without one allocation per key. remaining
+// is the caller's expected key count; without it a subtree far smaller than a
+// chunk still burns a whole chunk, and most subtrees are.
+type keyArena struct {
+	buf       []byte
+	remaining int
+}
 
 const keyArenaChunk = 64 * 1024
 
 func (a *keyArena) copy(hk []byte) []byte {
 	if len(hk) > cap(a.buf)-len(a.buf) {
-		a.buf = make([]byte, 0, max(keyArenaChunk, len(hk)))
+		want := len(hk) * max(a.remaining, 1)
+		a.buf = make([]byte, 0, max(min(want, keyArenaChunk), len(hk)))
 	}
+	a.remaining--
 	start := len(a.buf)
 	a.buf = append(a.buf, hk...)
 	return a.buf[start:len(a.buf):len(a.buf)]

--- a/execution/commitment/streaming_commitment_test.go
+++ b/execution/commitment/streaming_commitment_test.go
@@ -951,3 +951,45 @@ func whaleFullCollapseCorpus() (pk [][]byte, upds []Update, k2 [][]byte, u2 []Up
 	}
 	return pk, upds, k2, u2
 }
+
+func TestKeyArena_ChunkSizedFromRemaining(t *testing.T) {
+	const keyLen = 144
+
+	t.Run("small subtree does not burn a full chunk", func(t *testing.T) {
+		const keys = 32
+		arena := keyArena{remaining: keys}
+		for range keys {
+			arena.copy(make([]byte, keyLen))
+		}
+		require.Equal(t, keys*keyLen, cap(arena.buf))
+	})
+
+	t.Run("large subtree still caps at one chunk", func(t *testing.T) {
+		arena := keyArena{remaining: 10 * keyArenaChunk / keyLen}
+		arena.copy(make([]byte, keyLen))
+		require.Equal(t, keyArenaChunk, cap(arena.buf))
+	})
+
+	t.Run("oversized key gets its own backing", func(t *testing.T) {
+		arena := keyArena{remaining: 4}
+		got := arena.copy(make([]byte, 2*keyArenaChunk))
+		require.Len(t, got, 2*keyArenaChunk)
+		require.Equal(t, 2*keyArenaChunk, cap(arena.buf))
+	})
+
+	t.Run("copies stay stable across a chunk swap", func(t *testing.T) {
+		arena := keyArena{remaining: 2}
+		first := arena.copy(bytes.Repeat([]byte{0xAA}, keyLen))
+		for i := range 8 {
+			arena.copy(bytes.Repeat([]byte{byte(i)}, keyLen))
+		}
+		require.Equal(t, bytes.Repeat([]byte{0xAA}, keyLen), first)
+	})
+
+	t.Run("unhinted arena falls back to one key per chunk growth", func(t *testing.T) {
+		var arena keyArena
+		got := arena.copy(make([]byte, keyLen))
+		require.Len(t, got, keyLen)
+		require.Equal(t, keyLen, cap(arena.buf))
+	})
+}

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -307,7 +307,7 @@ func newDeferredStorageWorker(ctx context.Context, accountKeyLen int16, cfg Trie
 // nibbles off the reused walk path but leaves plainKey/update aliased.
 func collectSubtreeKeys(node *prefixNode, path []byte) []touchedKey {
 	out := make([]touchedKey, 0, node.subtreeCount)
-	var arena keyArena
+	arena := keyArena{remaining: int(node.subtreeCount)}
 	_ = dfsSubtree(node, path, func(hk, pk []byte, upd *Update) error {
 		out = append(out, touchedKey{hk: arena.copy(hk), pk: pk, upd: upd})
 		return nil


### PR DESCRIPTION
`keyArena.copy` allocated a flat 64KB chunk whenever the current one could not fit the next key. `collectSubtreeKeys` builds a fresh arena per first-nibble child of every deep-folded account, and those groups are mostly far smaller than a chunk, so each burned 64KB to hold ~13KB of nibbles. On `Benchmark_Commitment_DirectVsParallel/500K-StorageHeavy` that one line was 2.96GB of 5.83GB total allocated (50.6% of the alloc_space profile), ~93% of it never written.

## Changes

Size the chunk from the caller's remaining key count, still clamped to `keyArenaChunk`, so large groups behave exactly as before. `collectSubtreeKeys` passes `node.subtreeCount`, which it already has.

500K-StorageHeavy, Apple M5 Max (18 cores), `-benchtime=3x -count=8`:

| workers | sec/op | | B/op | |
|---|---|---|---|---|
| w1 | 213.3m → 194.5m | −8.8% | 1268.5Mi → 315.5Mi | −75.1% |
| w4 | 150.8m → 116.8m | −22.5% | 1262.7Mi → 314.8Mi | −75.1% |
| w8 | 148.0m → 109.5m | −26.1% | 1264.2Mi → 313.8Mi | −75.2% |
| w18 | 150.1m → 108.8m | −27.5% | 1276.9Mi → 313.0Mi | −75.5% |

All p=0.000, n=8. `Benchmark_DeepStorageWhale` unchanged. Re-profiling after the change drops `keyArena.copy` to 6.1%; what remains above it is benchmark harness, not production code.