### PR TITLE
execution/commitment: small cleanups in the parallel trie core

### DIFF
--- a/execution/commitment/parallel_mount.go
+++ b/execution/commitment/parallel_mount.go
@@ -70,11 +70,8 @@ func (hph *HexPatriciaHashed) mountTo(root *HexPatriciaHashed, nibble int) {
 	hph.mountedNib = nibble
 	hph.mounted = true
 	hph.mountWall = root.currentKeyLen + 1
-	for row := 0; row <= hph.activeRows; row++ {
-		for nib := range len(hph.grid[row]) {
-			hph.grid[row][nib] = root.grid[row][nib]
-		}
-	}
+	n := hph.activeRows + 1
+	copy(hph.grid[:n], root.grid[:n])
 }
 
 // processMounted folds each touched root-child subtree concurrently, stitches the resulting cells back into the base row, and folds the base up to the root.

--- a/execution/commitment/parallel_update.go
+++ b/execution/commitment/parallel_update.go
@@ -40,7 +40,7 @@ func (a *plainKeyArena) intern(b []byte) []byte {
 	return a.buf[off : off+len(b) : off+len(b)]
 }
 
-func (a *plainKeyArena) reset() { a.buf = nil }
+func (a *plainKeyArena) reset() { a.buf = a.buf[:0] }
 
 // parallelUpdate owns the per-batch state that drives parallel commitment.
 // Insert calls must be serialized by the caller.

--- a/execution/commitment/prefix_trie.go
+++ b/execution/commitment/prefix_trie.go
@@ -16,7 +16,11 @@
 
 package commitment
 
-import "math/bits"
+import (
+	"math/bits"
+
+	"github.com/erigontech/erigon/execution/commitment/nibbles"
+)
 
 const prefixSlabSize = 16384
 
@@ -110,16 +114,6 @@ func (t *prefixTrie) Reset() {
 	t.root = t.arena.allocNode()
 }
 
-func commonPrefixLen(a, b []byte) int {
-	n := min(len(b), len(a))
-	for i := range n {
-		if a[i] != b[i] {
-			return i
-		}
-	}
-	return n
-}
-
 // Insert adds hashedKey (nibble form), recording plainKey and optional update (nil = re-read from ctx) at its terminating node.
 // Re-inserting merges updates copy-on-write so a snapshot of the old update stays intact; plainKey backing must outlive the trie.
 func (t *prefixTrie) Insert(hashedKey, plainKey []byte, update *Update) (isNew bool) {
@@ -135,7 +129,7 @@ func (t *prefixTrie) Insert(hashedKey, plainKey []byte, update *Update) (isNew b
 		t.visited = append(t.visited, node)
 
 		remain := hashedKey[keyOffset:]
-		m := commonPrefixLen(remain, node.ext)
+		m := nibbles.CommonPrefixLen(remain, node.ext)
 
 		if m < len(node.ext) {
 			// Partial match: split the node at position m.


### PR DESCRIPTION
Three shape fixes in the parallel trie core. No measurable throughput effect — 500K-StorageHeavy/ModeParallel-w18 goes 150.1m → 147.8m sec/op, p=0.109, inside the noise band. Landing them as cleanup, not as a perf change.

## Changes

- `plainKeyArena.reset` dropped its backing array instead of truncating it, so the first interned key of every block re-allocated a 64KB chunk. Every sibling reset in the package keeps capacity — `deferredCombined[:0]`, the HashSort arena ring, `prefixArena.resetArena` keeping slab 0.
- `mountTo` copied the mounted grid rows with a nested per-cell loop while the six field copies directly above it use `copy()`. A row is a plain `[16]cell`, so one bulk copy of `activeRows+1` rows is the same operation.
- `prefix_trie.go` carried its own `commonPrefixLen`, behaviourally identical to `nibbles.CommonPrefixLen`, which the same package already imports and calls from `hex_patricia_hashed.go`. The `nibbles` package exists specifically to stop this primitive being duplicated.