### PR TITLE
apply `go fix`

### DIFF
--- a/common/log/v3/log_test.go
+++ b/common/log/v3/log_test.go
@@ -581,17 +581,18 @@ func TestCallerStackHandler(t *testing.T) {
 		t.Fatalf("Wrong context value type, got %T expected string", r.Ctx[1])
 	}
 
-	exp := "["
+	var exp strings.Builder
+	exp.WriteString("[")
 	for i, line := range lines {
 		if i > 0 {
-			exp += " "
+			exp.WriteString(" ")
 		}
-		exp += fmt.Sprint(file, ":", line)
+		exp.WriteString(fmt.Sprint(file, ":", line))
 	}
-	exp += "]"
+	exp.WriteString("]")
 
-	if s != exp {
-		t.Fatalf("Wrong context value, got %s expected string matching %s", s, exp)
+	if s != exp.String() {
+		t.Fatalf("Wrong context value, got %s expected string matching %s", s, exp.String())
 	}
 }
 

--- a/execution/protocol/rules/aura/aura.go
+++ b/execution/protocol/rules/aura/aura.go
@@ -193,7 +193,7 @@ func (e *EpochManager) zoomToAfter(chain rules.ChainHeaderReader, er *NonTransac
 		e.finalityChecker = NewRollingFinality(epochSet)
 		if proof.SignalNumber >= DEBUG_LOG_FROM {
 			fmt.Printf("new rolling finality: %d\n", proof.SignalNumber)
-			for i := 0; i < len(epochSet); i++ {
+			for i := range epochSet {
 				fmt.Printf("\t%x\n", epochSet[i])
 			}
 		}

--- a/node/app/event/eventbus_test.go
+++ b/node/app/event/eventbus_test.go
@@ -173,9 +173,7 @@ func TestSubcribeOnceAsync(t *testing.T) {
 		t.Fail()
 	}
 
-	var cb func(a int, out *[]int)
-
-	if bus.HasCallback(reflect.TypeOf(cb)) {
+	if bus.HasCallback(reflect.TypeFor[func(a int, out *[]int)]()) {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
`go fix ./...` reports exactly three suggested fixes across the repo, applied here verbatim.

| file | fix |
| --- | --- |
| `execution/protocol/rules/aura/aura.go` | `for i := 0; i < len(epochSet); i++` → `for i := range epochSet` |
| `common/log/v3/log_test.go` | string `+=` in a loop → `strings.Builder` |
| `node/app/event/eventbus_test.go` | `reflect.TypeOf(cb)` on a declared var → `reflect.TypeFor[...]()` |

Only the aura change is production, and it is inside a `fmt.Printf` block gated on `DEBUG_LOG_FROM`.

`make lint` does not report these even though `modernize` is enabled repo-wide (the only exclusion is `_grpc.pb.go`): golangci-lint bundles its own analyzer set, which lags the one shipped with the toolchain. So `go fix -diff ./...` is worth running periodically — it sees fixes our lint structurally cannot.
