### PR TITLE
calcState: skip the commitment calculator's dead baseline read

### DIFF
--- a/execution/stagedsync/calc_state.go
+++ b/execution/stagedsync/calc_state.go
@@ -69,6 +69,11 @@ func (r *calcDomainReader) ReadAccountStorage(addr accounts.Address, key account
 	return val, true, nil
 }
 
+// accountBaselineReader supplies an address's pre-write account fields.
+type accountBaselineReader interface {
+	ReadAccountData(addr accounts.Address) (*accounts.Account, error)
+}
+
 // storageEnumerator lists every persisted storage slot under an address.
 type storageEnumerator interface {
 	EachStorageSlot(addr accounts.Address, fn func(key accounts.StorageKey) error) error
@@ -87,7 +92,7 @@ type calcState struct {
 	storageDirty map[accounts.Address]map[accounts.StorageKey]bool
 
 	// domainReader provides lazy-load from the domain via asOfStateReader.
-	domainReader *calcDomainReader
+	domainReader accountBaselineReader
 
 	// storageEnum is a test injection point; production leaves it nil. The
 	// self-destruct path no longer reads it — the account delete collapses the
@@ -121,8 +126,17 @@ func newCalcState(reader *asOfStateReader, logger log.Logger, logPrefix string) 
 	}
 }
 
+// writesCoverBaseline reports whether writes set every field ensureAccount would
+// lazy-load, making the domain read dead. Normalize fills all three for every
+// address it does not drop, so this holds for all but self-destructed ones.
+func writesCoverBaseline(writes *state.WriteSet, addr accounts.Address) bool {
+	return writes.Has(state.WriteHeader{Address: addr, Path: state.BalancePath}) &&
+		writes.Has(state.WriteHeader{Address: addr, Path: state.NoncePath}) &&
+		writes.Has(state.WriteHeader{Address: addr, Path: state.CodeHashPath})
+}
+
 // ensureAccount returns the account state, lazy-loading from domain on first touch.
-func (cs *calcState) ensureAccount(addr accounts.Address) *calcAccountState {
+func (cs *calcState) ensureAccount(addr accounts.Address, writes *state.WriteSet) *calcAccountState {
 	if acc, ok := cs.accounts[addr]; ok {
 		return acc
 	}
@@ -130,7 +144,7 @@ func (cs *calcState) ensureAccount(addr accounts.Address) *calcAccountState {
 	acc := &calcAccountState{
 		CodeHash: empty.CodeHash,
 	}
-	if cs.domainReader != nil {
+	if cs.domainReader != nil && !writesCoverBaseline(writes, addr) {
 		dbAcc, err := cs.domainReader.ReadAccountData(addr)
 		if err != nil {
 			// Sticky — recorded so the next compute fails fast instead of
@@ -164,7 +178,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 	for addr, vw := range writes.SelfDestructs() {
 		sdThisCall[addr] = vw.Val
 		if vw.Val {
-			acc := cs.ensureAccount(addr)
+			acc := cs.ensureAccount(addr, writes)
 			acc.Deleted = true
 			acc.dirty = true
 			cs.deleteStorageSubtree(addr)
@@ -174,7 +188,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		return nonZero || !sdThisCall[addr]
 	}
 	for addr, vw := range writes.Balances() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.Balance = vw.Val
 		acc.dirty = true
 		if clearsDeleted(addr, !acc.Balance.IsZero()) {
@@ -182,7 +196,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		}
 	}
 	for addr, vw := range writes.Nonces() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.Nonce = vw.Val
 		acc.dirty = true
 		if clearsDeleted(addr, acc.Nonce != 0) {
@@ -190,7 +204,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		}
 	}
 	for addr, vw := range writes.CodeHashes() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.CodeHash = vw.Val.Value()
 		acc.dirty = true
 		if clearsDeleted(addr, vw.Val.Value() != empty.CodeHash) {
@@ -198,7 +212,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		}
 	}
 	for addr, vw := range writes.Codes() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.CodeHash = vw.Val.Hash.Value()
 		acc.dirty = true
 		if clearsDeleted(addr, vw.Val.Len() > 0) {
@@ -206,7 +220,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		}
 	}
 	for addr, vw := range writes.Incarnations() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.Incarnation = vw.Val
 		acc.dirty = true
 	}

--- a/execution/stagedsync/calc_state_test.go
+++ b/execution/stagedsync/calc_state_test.go
@@ -264,6 +264,126 @@ func TestApplyWrites_BalancePathClearsDeleted(t *testing.T) {
 	assert.Equal(t, uint64(42), acc.Balance.Uint64())
 }
 
+// countingBaselineReader counts calcState's baseline reads.
+type countingBaselineReader struct {
+	reads int
+	acc   *accounts.Account
+}
+
+func (r *countingBaselineReader) ReadAccountData(accounts.Address) (*accounts.Account, error) {
+	r.reads++
+	return r.acc, nil
+}
+
+// TestApplyWrites_SkipsBaselineReadWhenWritesCoverAccount: writes carrying
+// balance, nonce and codeHash overwrite every field the baseline read supplies.
+func TestApplyWrites_SkipsBaselineReadWhenWritesCoverAccount(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xe1})
+	reader := &countingBaselineReader{acc: &accounts.Account{
+		Nonce:   7,
+		Balance: *uint256.NewInt(99),
+	}}
+	cs := newTestCalcState()
+	cs.domainReader = reader
+
+	codeHash := accounts.InternCodeHash(common.Hash{0xab})
+	writes := newWS().
+		bal(addr, state.Version{}, *uint256.NewInt(5)).
+		nonce(addr, state.Version{}, 3).
+		codeHash(addr, state.Version{}, codeHash).
+		build()
+	cs.ApplyWrites(writes, false)
+
+	assert.Equal(t, 0, reader.reads, "writes cover balance/nonce/codeHash — the baseline read is dead")
+
+	acc, ok := cs.accounts[addr]
+	require.True(t, ok)
+	assert.Equal(t, uint64(5), acc.Balance.Uint64())
+	assert.Equal(t, uint64(3), acc.Nonce)
+	assert.Equal(t, [32]byte(common.Hash{0xab}), acc.CodeHash)
+}
+
+// TestApplyWrites_ReadsBaselineWhenWritesIncomplete: a missing field must still
+// load, else it would flush as zero.
+func TestApplyWrites_ReadsBaselineWhenWritesIncomplete(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xe2})
+	reader := &countingBaselineReader{acc: &accounts.Account{
+		Nonce:   7,
+		Balance: *uint256.NewInt(99),
+	}}
+	cs := newTestCalcState()
+	cs.domainReader = reader
+
+	writes := newWS().bal(addr, state.Version{}, *uint256.NewInt(5)).build()
+	cs.ApplyWrites(writes, false)
+
+	assert.Equal(t, 1, reader.reads, "nonce and codeHash are not in the writes — they must come from the domain")
+
+	acc, ok := cs.accounts[addr]
+	require.True(t, ok)
+	assert.Equal(t, uint64(5), acc.Balance.Uint64(), "the write wins over the baseline")
+	assert.Equal(t, uint64(7), acc.Nonce, "the untouched nonce comes from the baseline")
+}
+
+// TestApplyWrites_ReadsBaselineForSelfDestruct: Normalize drops the SD'd
+// address's nonce/codeHash, and an EIP-8246 residual balance revives the
+// account — which then flushes those baseline fields.
+func TestApplyWrites_ReadsBaselineForSelfDestruct(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xe3})
+	reader := &countingBaselineReader{acc: &accounts.Account{
+		Nonce:   7,
+		Balance: *uint256.NewInt(99),
+	}}
+	cs := newTestCalcState()
+	cs.domainReader = reader
+
+	writes := newWS().
+		selfDestruct(addr, state.Version{}, true).
+		bal(addr, state.Version{}, *uint256.NewInt(42)).
+		build()
+	cs.ApplyWrites(writes, true /*eip8246*/)
+
+	assert.Equal(t, 1, reader.reads, "a self-destructed address has no nonce/codeHash write to cover it")
+
+	acc, ok := cs.accounts[addr]
+	require.True(t, ok)
+	assert.False(t, acc.Deleted, "a non-zero residual balance revives the account")
+	assert.Equal(t, uint64(7), acc.Nonce, "the revived account keeps its baseline nonce")
+}
+
+// TestNormalizeCoversBaseline pins the coupling the skip relies on: Normalize
+// fills all three fields whatever the raw write set held. If this stops
+// holding, the skip silently stops firing.
+func TestNormalizeCoversBaseline(t *testing.T) {
+	balanceOnly := accounts.InternAddress([20]byte{0xf1})
+	storageOnly := accounts.InternAddress([20]byte{0xf2})
+	slot := accounts.InternKey(common.Hash{0x01})
+
+	raw := newWS().
+		bal(balanceOnly, state.Version{}, *uint256.NewInt(11)).
+		stor(storageOnly, slot, state.Version{}, *uint256.NewInt(22)).
+		build()
+
+	// Non-empty pre-block account, else EIP-161 removal strips the fields.
+	reader := &everyAddrReader{acc: &accounts.Account{Nonce: 7}}
+	norm, err := raw.Normalize(state.NewVersionMap(nil), 0, 0, reader, nil,
+		true /*emptyRemoval*/, false /*isAura*/, false /*eip8246*/)
+	require.NoError(t, err)
+
+	assert.True(t, writesCoverBaseline(norm, balanceOnly), "a balance-only write comes out with nonce and codeHash filled")
+	assert.True(t, writesCoverBaseline(norm, storageOnly), "a storage-only address gets its account fields filled too")
+}
+
+// everyAddrReader serves the same pre-block account for every address.
+type everyAddrReader struct {
+	preBlockReader
+	acc *accounts.Account
+}
+
+func (r *everyAddrReader) ReadAccountData(accounts.Address) (*accounts.Account, error) {
+	return r.acc, nil
+}
+
 // preBlockReader is a minimal StateReader stub for the integration test
 // below — returns the configured pre-block account for a single address.
 type preBlockReader struct {


### PR DESCRIPTION
The commitment calculator lazy-loads an account from the domain the first time
it touches an address (`calcState.ensureAccount` -> `GetAsOf`), to supply the
fields a tx did not write. On the per-tx path it never needs to: `Normalize`
already fills balance, nonce and codeHash for every address it does not drop,
so all three loaded fields are overwritten by the write loops immediately after.

This skips the read when the write set carries all three. The check is three map
lookups on the miss path only, and it is self-verifying rather than trusting
`Normalize` — where the fields are absent, the read still happens:

- self-destructed addresses (`Normalize` drops their nonce/codeHash, and under
  EIP-8246 a non-zero residual balance revives the account, which then flushes
  the baseline nonce/codeHash)
- EIP-161 empty-account removals (`DeleteAccountFields` strips them)
- the BAL fold path, which builds its write set straight from the block access
  list and so carries only changed fields

## Numbers

From a 300s mainnet CPU profile (850s of samples):

| | cum | share of `ApplyWrites` |
|---|---|---|
| `ApplyWrites` | 6.82s | — |
| ├ `ensureAccount` | 4.45s | 65% |
| └ `ReadAccountData` -> `asOfStateReader.Read` | 3.79s | **56%** |

That is 0.45% of total execution CPU, plus one `accounts.Account` allocation per
first touch. Not yet measured end-to-end — the domain read is often a cold
snapshot seek, so wall-clock may move more than the CPU share suggests. Draft
until an A/B on n5 confirms it.

## Side effect

`ensureAccount` was the only reason `cs.accounts` needed to survive across
blocks. With the read gone on the per-tx path, its cross-block cache role
largely disappears, which makes the map (currently unbounded for the lifetime of
a batch, and uncounted by `--batchSize`) much cheaper to bound or drop. Separate
change.

`calcState.domainReader` becomes a one-method interface so a test can count the
reads.