### PR TITLE
cmd/rpctest: split wide eth_getLogs filters in invariantsEthGetLogs

### DIFF
--- a/cmd/rpctest/main.go
+++ b/cmd/rpctest/main.go
@@ -64,6 +64,7 @@ func main() {
 		visitAllPages     bool
 		additionalParams  string
 		failFast          bool
+		queryLimit        int
 	)
 	withErigonUrl := func(cmd *cobra.Command) {
 		cmd.Flags().StringVar(&erigonURL, "erigonUrl", "http://localhost:8545", "Erigon rpcdaemon url")
@@ -102,6 +103,10 @@ func main() {
 	}
 	withFailFast := func(cmd *cobra.Command) {
 		cmd.Flags().BoolVar(&failFast, "failFast", false, "Fail fast")
+	}
+	withQueryLimit := func(cmd *cobra.Command) {
+		cmd.Flags().IntVar(&queryLimit, "queryLimit", utils.RpcLogQueryLimit.Value,
+			"Max addresses or topic alternatives per eth_getLogs request, wider filters are split. Must match the server's --"+utils.RpcLogQueryLimit.Name+" (<=0 = unlimited)")
 	}
 	with := func(cmd *cobra.Command, opts ...func(*cobra.Command)) {
 		for i := range opts {
@@ -307,13 +312,13 @@ func main() {
 		Short: "",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := rpctest.EthGetLogsInvariants(cmd.Context(), erigonURL, gethURL, needCompare, blockFrom, blockTo, latest, failFast)
+			err := rpctest.EthGetLogsInvariants(cmd.Context(), erigonURL, gethURL, needCompare, blockFrom, blockTo, latest, failFast, queryLimit)
 			if err != nil {
 				logger.Error(err.Error())
 			}
 		},
 	}
-	with(ethGetLogsInvariantsCmd, withErigonUrl, withGethUrl, withNeedCompare, withBlockNum, withRecord, withErrorFile, withLatest, withFailFast)
+	with(ethGetLogsInvariantsCmd, withErigonUrl, withGethUrl, withNeedCompare, withBlockNum, withRecord, withErrorFile, withLatest, withFailFast, withQueryLimit)
 
 	var benchOverlayGetLogsCmd = &cobra.Command{
 		Use:   "benchOverlayGetLogs",

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -35,6 +35,10 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
+// maxTopicPositions is how many topic positions a log filter can have, fixed by the
+// LOG0..LOG4 opcodes.
+const maxTopicPositions = 4
+
 // BenchEthGetLogs compares response of Erigon with Geth
 // but also can be used for comparing RPCDaemon with Geth or infura
 // parameters:
@@ -210,13 +214,13 @@ func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCo
 			}
 
 			sawAddr := map[common.Address]struct{}{}
-			topicsByPos := [4]map[common.Hash]struct{}{{}, {}, {}, {}}
+			topicsByPos := [maxTopicPositions]map[common.Hash]struct{}{{}, {}, {}, {}}
 			if baseOK {
 				for i := range resp.Result {
 					l := &resp.Result[i]
 					sawAddr[l.Address] = struct{}{}
 					for pos, t := range l.Topics {
-						if pos < 4 {
+						if pos < maxTopicPositions {
 							topicsByPos[pos][t] = struct{}{}
 						}
 					}

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -19,6 +19,7 @@ package rpctest
 import (
 	"context"
 	"fmt"
+	"iter"
 	"maps"
 	"math/rand"
 	"slices"
@@ -132,7 +133,10 @@ func BenchEthGetLogs(erigonURL, gethURL string, needCompare bool, blockFrom uint
 	return nil
 }
 
-func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCompare bool, blockFrom, blockTo uint64, latest, failFast bool) error {
+// EthGetLogsInvariants checks that logs found by a block-wide eth_getLogs are also found
+// when the same block is queried by address or by topic. queryLimit is the server's
+// --rpc.logs.querylimit: filters wider than that are split into several requests.
+func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCompare bool, blockFrom, blockTo uint64, latest, failFast bool, queryLimit int) error {
 	setRoutes(erigonURL, gethURL)
 
 	reqGen := &RequestGenerator{}
@@ -220,27 +224,33 @@ func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCo
 			}
 
 			if len(sawAddr) > 0 {
-				resp = EthGetLogs{}
-				res = reqGen.Erigon("eth_getLogs", reqGen.getLogsForAddresses(bn, bn, slices.Collect(maps.Keys(sawAddr))), &resp)
+				var addrLogs []Log
 				addrOK := true
-				if res.Err != nil {
-					if failFast {
-						return fmt.Errorf("could not get eth_getLogs by address (Erigon): %v", res.Err)
+				for batch := range batches(slices.Collect(maps.Keys(sawAddr)), queryLimit) {
+					var batchResp EthGetLogs
+					res = reqGen.Erigon("eth_getLogs", reqGen.getLogsForAddresses(bn, bn, batch), &batchResp)
+					if res.Err != nil {
+						if failFast {
+							return fmt.Errorf("could not get eth_getLogs by address (Erigon): %v", res.Err)
+						}
+						log.Error("[ethGetLogsInvariants] could not get eth_getLogs by address", "blockNum", bn, "error", res.Err.Error())
+						addrOK = false
+						break
 					}
-					log.Error("[ethGetLogsInvariants] could not get eth_getLogs by address", "blockNum", bn, "error", res.Err.Error())
-					addrOK = false
-				}
-				if resp.Error != nil {
-					if failFast {
-						return fmt.Errorf("error getting eth_getLogs by address (Erigon): %d %s", resp.Error.Code, resp.Error.Message)
+					if batchResp.Error != nil {
+						if failFast {
+							return fmt.Errorf("error getting eth_getLogs by address (Erigon): %d %s", batchResp.Error.Code, batchResp.Error.Message)
+						}
+						log.Error("[ethGetLogsInvariants] error getting eth_getLogs by address", "blockNum", bn, "error", batchResp.Error.Code, "message", batchResp.Error.Message)
+						addrOK = false
+						break
 					}
-					log.Error("[ethGetLogsInvariants] error getting eth_getLogs by address", "blockNum", bn, "error", resp.Error.Code, "message", resp.Error.Message)
-					addrOK = false
+					addrLogs = append(addrLogs, batchResp.Result...)
 				}
 
 				if addrOK {
 					for k := range sawAddr {
-						logs := filterLogsByAddr(resp.Result, k)
+						logs := filterLogsByAddr(addrLogs, k)
 						if len(logs) == 0 {
 							if failFast {
 								return fmt.Errorf("eth_getLogs: at blockNum=%d and addr %x not indexed", bn, k)
@@ -263,35 +273,43 @@ func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCo
 				if len(topicsAtPos) == 0 {
 					continue
 				}
-				filter := make([][]common.Hash, pos+1)
-				filter[pos] = slices.Collect(maps.Keys(topicsAtPos))
-
-				resp = EthGetLogs{}
-				res = reqGen.Erigon("eth_getLogs", reqGen.getLogsForTopics(bn, bn, filter), &resp)
-				if res.Err != nil {
-					if failFast {
-						return fmt.Errorf("could not get logs by topics pos %d (Erigon): %v", pos, res.Err)
-					}
-					log.Error("[ethGetLogsInvariants] could not get logs by topics (Erigon)", "blockNum", bn, "pos", pos, "error", res.Err.Error())
-					continue
-				}
-				if resp.Error != nil {
-					if failFast {
-						return fmt.Errorf("error getting logs by topics pos %d (Erigon): %d %s", pos, resp.Error.Code, resp.Error.Message)
-					}
-					log.Error("[ethGetLogsInvariants] error getting logs by topics (Erigon)", "blockNum", bn, "pos", pos, "error", resp.Error.Code, "message", resp.Error.Message)
-					continue
-				}
-
 				logsByTopic := make(map[common.Hash][]Log, len(topicsAtPos))
-				for i := range resp.Result {
-					l := &resp.Result[i]
-					if pos < len(l.Topics) {
-						t := l.Topics[pos]
-						if _, ok := topicsAtPos[t]; ok {
-							logsByTopic[t] = append(logsByTopic[t], *l)
+				posOK := true
+				for batch := range batches(slices.Collect(maps.Keys(topicsAtPos)), queryLimit) {
+					filter := make([][]common.Hash, pos+1)
+					filter[pos] = batch
+
+					var batchResp EthGetLogs
+					res = reqGen.Erigon("eth_getLogs", reqGen.getLogsForTopics(bn, bn, filter), &batchResp)
+					if res.Err != nil {
+						if failFast {
+							return fmt.Errorf("could not get logs by topics pos %d (Erigon): %v", pos, res.Err)
+						}
+						log.Error("[ethGetLogsInvariants] could not get logs by topics (Erigon)", "blockNum", bn, "pos", pos, "error", res.Err.Error())
+						posOK = false
+						break
+					}
+					if batchResp.Error != nil {
+						if failFast {
+							return fmt.Errorf("error getting logs by topics pos %d (Erigon): %d %s", pos, batchResp.Error.Code, batchResp.Error.Message)
+						}
+						log.Error("[ethGetLogsInvariants] error getting logs by topics (Erigon)", "blockNum", bn, "pos", pos, "error", batchResp.Error.Code, "message", batchResp.Error.Message)
+						posOK = false
+						break
+					}
+
+					for i := range batchResp.Result {
+						l := &batchResp.Result[i]
+						if pos < len(l.Topics) {
+							t := l.Topics[pos]
+							if _, ok := topicsAtPos[t]; ok {
+								logsByTopic[t] = append(logsByTopic[t], *l)
+							}
 						}
 					}
+				}
+				if !posOK {
+					continue
 				}
 
 				for k := range topicsAtPos {
@@ -438,6 +456,15 @@ func BenchEthGetLogsRandomBlock(erigonURL string, concurentRequests int) error {
 			m.Unlock()
 		}(bn, time.Now())
 	}
+}
+
+// batches splits s into slices of at most limit elements, so that one eth_getLogs request
+// stays within the server's --rpc.logs.querylimit. limit<=0 means unlimited: one batch.
+func batches[T any](s []T, limit int) iter.Seq[[]T] {
+	if limit <= 0 {
+		limit = max(len(s), 1)
+	}
+	return slices.Chunk(s, limit)
 }
 
 func filterLogsByAddr(logs []Log, addr common.Address) (filtered []Log) {

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -214,7 +214,10 @@ func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCo
 			}
 
 			sawAddr := map[common.Address]struct{}{}
-			topicsByPos := [maxTopicPositions]map[common.Hash]struct{}{{}, {}, {}, {}}
+			var topicsByPos [maxTopicPositions]map[common.Hash]struct{}
+			for i := range topicsByPos {
+				topicsByPos[i] = map[common.Hash]struct{}{}
+			}
 			if baseOK {
 				for i := range resp.Result {
 					l := &resp.Result[i]
@@ -228,33 +231,25 @@ func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCo
 			}
 
 			if len(sawAddr) > 0 {
-				var addrLogs []Log
-				addrOK := true
-				for batch := range batches(slices.Collect(maps.Keys(sawAddr)), queryLimit) {
-					var batchResp EthGetLogs
-					res = reqGen.Erigon("eth_getLogs", reqGen.getLogsForAddresses(bn, bn, batch), &batchResp)
-					if res.Err != nil {
-						if failFast {
-							return fmt.Errorf("could not get eth_getLogs by address (Erigon): %v", res.Err)
+				logsByAddr := make(map[common.Address][]Log, len(sawAddr))
+				err := getLogsBatched(reqGen, slices.Collect(maps.Keys(sawAddr)), queryLimit,
+					func(batch []common.Address) string { return reqGen.getLogsForAddresses(bn, bn, batch) },
+					func(logs []Log) {
+						for i := range logs {
+							l := &logs[i]
+							if _, ok := sawAddr[l.Address]; ok {
+								logsByAddr[l.Address] = append(logsByAddr[l.Address], *l)
+							}
 						}
-						log.Error("[ethGetLogsInvariants] could not get eth_getLogs by address", "blockNum", bn, "error", res.Err.Error())
-						addrOK = false
-						break
+					})
+				if err != nil {
+					if failFast {
+						return fmt.Errorf("eth_getLogs by address (Erigon): %w", err)
 					}
-					if batchResp.Error != nil {
-						if failFast {
-							return fmt.Errorf("error getting eth_getLogs by address (Erigon): %d %s", batchResp.Error.Code, batchResp.Error.Message)
-						}
-						log.Error("[ethGetLogsInvariants] error getting eth_getLogs by address", "blockNum", bn, "error", batchResp.Error.Code, "message", batchResp.Error.Message)
-						addrOK = false
-						break
-					}
-					addrLogs = append(addrLogs, batchResp.Result...)
-				}
-
-				if addrOK {
+					log.Error("[ethGetLogsInvariants] eth_getLogs by address (Erigon)", "blockNum", bn, "error", err.Error())
+				} else {
 					for k := range sawAddr {
-						logs := filterLogsByAddr(addrLogs, k)
+						logs := logsByAddr[k]
 						if len(logs) == 0 {
 							if failFast {
 								return fmt.Errorf("eth_getLogs: at blockNum=%d and addr %x not indexed", bn, k)
@@ -278,41 +273,28 @@ func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCo
 					continue
 				}
 				logsByTopic := make(map[common.Hash][]Log, len(topicsAtPos))
-				posOK := true
-				for batch := range batches(slices.Collect(maps.Keys(topicsAtPos)), queryLimit) {
-					filter := make([][]common.Hash, pos+1)
-					filter[pos] = batch
-
-					var batchResp EthGetLogs
-					res = reqGen.Erigon("eth_getLogs", reqGen.getLogsForTopics(bn, bn, filter), &batchResp)
-					if res.Err != nil {
-						if failFast {
-							return fmt.Errorf("could not get logs by topics pos %d (Erigon): %v", pos, res.Err)
-						}
-						log.Error("[ethGetLogsInvariants] could not get logs by topics (Erigon)", "blockNum", bn, "pos", pos, "error", res.Err.Error())
-						posOK = false
-						break
-					}
-					if batchResp.Error != nil {
-						if failFast {
-							return fmt.Errorf("error getting logs by topics pos %d (Erigon): %d %s", pos, batchResp.Error.Code, batchResp.Error.Message)
-						}
-						log.Error("[ethGetLogsInvariants] error getting logs by topics (Erigon)", "blockNum", bn, "pos", pos, "error", batchResp.Error.Code, "message", batchResp.Error.Message)
-						posOK = false
-						break
-					}
-
-					for i := range batchResp.Result {
-						l := &batchResp.Result[i]
-						if pos < len(l.Topics) {
-							t := l.Topics[pos]
-							if _, ok := topicsAtPos[t]; ok {
-								logsByTopic[t] = append(logsByTopic[t], *l)
+				err := getLogsBatched(reqGen, slices.Collect(maps.Keys(topicsAtPos)), queryLimit,
+					func(batch []common.Hash) string {
+						filter := make([][]common.Hash, pos+1)
+						filter[pos] = batch
+						return reqGen.getLogsForTopics(bn, bn, filter)
+					},
+					func(logs []Log) {
+						for i := range logs {
+							l := &logs[i]
+							if pos < len(l.Topics) {
+								t := l.Topics[pos]
+								if _, ok := topicsAtPos[t]; ok {
+									logsByTopic[t] = append(logsByTopic[t], *l)
+								}
 							}
 						}
+					})
+				if err != nil {
+					if failFast {
+						return fmt.Errorf("eth_getLogs by topics pos %d (Erigon): %w", pos, err)
 					}
-				}
-				if !posOK {
+					log.Error("[ethGetLogsInvariants] eth_getLogs by topics (Erigon)", "blockNum", bn, "pos", pos, "error", err.Error())
 					continue
 				}
 
@@ -462,21 +444,28 @@ func BenchEthGetLogsRandomBlock(erigonURL string, concurentRequests int) error {
 	}
 }
 
+// getLogsBatched sends one eth_getLogs per batch of at most queryLimit filter entries and
+// feeds every response to collect. On error what collect already gathered is incomplete,
+// so the caller must discard it.
+func getLogsBatched[T any](reqGen *RequestGenerator, keys []T, queryLimit int, request func(batch []T) string, collect func(logs []Log)) error {
+	for batch := range batches(keys, queryLimit) {
+		var resp EthGetLogs
+		if res := reqGen.Erigon("eth_getLogs", request(batch), &resp); res.Err != nil {
+			return fmt.Errorf("could not get logs: %w", res.Err)
+		}
+		if resp.Error != nil {
+			return fmt.Errorf("error getting logs: %d %s", resp.Error.Code, resp.Error.Message)
+		}
+		collect(resp.Result)
+	}
+	return nil
+}
+
 // batches splits s into slices of at most limit elements, so that one eth_getLogs request
-// stays within the server's --rpc.logs.querylimit. limit<=0 means unlimited: one batch.
+// stays within the server's --rpc.logs.querylimit. limit<=0 disables splitting.
 func batches[T any](s []T, limit int) iter.Seq[[]T] {
 	if limit <= 0 {
 		limit = max(len(s), 1)
 	}
 	return slices.Chunk(s, limit)
-}
-
-func filterLogsByAddr(logs []Log, addr common.Address) (filtered []Log) {
-	for i := range logs {
-		l := &logs[i]
-		if l.Address == addr {
-			filtered = append(filtered, *l)
-		}
-	}
-	return
 }

--- a/cmd/rpctest/rpctest/request_generator_test.go
+++ b/cmd/rpctest/rpctest/request_generator_test.go
@@ -17,11 +17,18 @@
 package rpctest
 
 import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/hexutil"
 )
 
 func MockRequestGenerator(reqId int) *RequestGenerator {
@@ -531,4 +538,100 @@ func TestRequestGenerator_getLogsForTopics(t *testing.T) {
 		got := reqGen.getLogsForTopics(100, 100, tc.topics)
 		require.Equal(t, tc.expected, got)
 	}
+}
+
+// TestEthGetLogsInvariants_WideFilters pins that a block with more distinct addresses or
+// topics than the server's query limit is still checked, by splitting the filter over
+// several requests.
+func TestEthGetLogsInvariants_WideFilters(t *testing.T) {
+	const (
+		queryLimit = 100
+		logCount   = 250
+		blockNum   = 1
+	)
+
+	sig := common.BigToHash(big.NewInt(1))
+	logs := make([]Log, logCount)
+	for i := range logs {
+		logs[i] = Log{
+			Address:     common.BigToAddress(big.NewInt(int64(i + 1))),
+			Topics:      []common.Hash{sig, sig, common.BigToHash(big.NewInt(int64(i + 2)))},
+			BlockNumber: blockNum,
+			Index:       hexutil.Uint(i),
+		}
+	}
+
+	srv := fakeLogsServer(t, logs, queryLimit)
+	err := EthGetLogsInvariants(t.Context(), srv.URL, "", false, blockNum, blockNum+1, false, true, queryLimit)
+	require.NoError(t, err)
+}
+
+// fakeLogsServer serves eth_blockNumber and eth_getLogs over logs, rejecting filters with
+// more than queryLimit addresses or topic alternatives at one position - the way rpcdaemon
+// does for --rpc.logs.querylimit.
+func fakeLogsServer(t *testing.T, logs []Log, queryLimit int) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+			Params []struct {
+				Address []common.Address `json:"address"`
+				Topics  [][]common.Hash  `json:"topics"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decoding request: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		if req.Method == "eth_blockNumber" {
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%d,"result":"0x%x"}`, req.ID, 1_000_000)
+			return
+		}
+
+		crit := req.Params[0]
+		tooWide := len(crit.Address) > queryLimit
+		for _, alternatives := range crit.Topics {
+			tooWide = tooWide || len(alternatives) > queryLimit
+		}
+		if tooWide {
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%d,"error":{"code":-32602,"message":"query exceeds the maximum of %d addresses or topics per search position"}}`, req.ID, queryLimit)
+			return
+		}
+
+		result := []Log{}
+		for i := range logs {
+			if logMatchesFilter(&logs[i], crit.Address, crit.Topics) {
+				result = append(result, logs[i])
+			}
+		}
+		resp, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result})
+		if err != nil {
+			t.Errorf("encoding response: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(resp) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func logMatchesFilter(l *Log, addresses []common.Address, topics [][]common.Hash) bool {
+	if len(addresses) > 0 && !slices.Contains(addresses, l.Address) {
+		return false
+	}
+	for pos, alternatives := range topics {
+		if len(alternatives) == 0 {
+			continue
+		}
+		if pos >= len(l.Topics) || !slices.Contains(alternatives, l.Topics[pos]) {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/rpctest/rpctest/request_generator_test.go
+++ b/cmd/rpctest/rpctest/request_generator_test.go
@@ -577,8 +577,10 @@ func fakeLogsServer(t *testing.T, logs []Log, queryLimit int) *httptest.Server {
 			ID     int    `json:"id"`
 			Method string `json:"method"`
 			Params []struct {
-				Address []common.Address `json:"address"`
-				Topics  [][]common.Hash  `json:"topics"`
+				FromBlock hexutil.Uint64   `json:"fromBlock"`
+				ToBlock   hexutil.Uint64   `json:"toBlock"`
+				Address   []common.Address `json:"address"`
+				Topics    [][]common.Hash  `json:"topics"`
 			} `json:"params"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -593,6 +595,11 @@ func fakeLogsServer(t *testing.T, logs []Log, queryLimit int) *httptest.Server {
 			return
 		}
 
+		if len(req.Params) == 0 {
+			t.Errorf("no params in %s request", req.Method)
+			http.Error(w, "no params", http.StatusBadRequest)
+			return
+		}
 		crit := req.Params[0]
 		tooWide := len(crit.Address) > queryLimit
 		for _, alternatives := range crit.Topics {
@@ -605,8 +612,12 @@ func fakeLogsServer(t *testing.T, logs []Log, queryLimit int) *httptest.Server {
 
 		result := []Log{}
 		for i := range logs {
-			if logMatchesFilter(&logs[i], crit.Address, crit.Topics) {
-				result = append(result, logs[i])
+			l := &logs[i]
+			if l.BlockNumber < crit.FromBlock || l.BlockNumber > crit.ToBlock {
+				continue
+			}
+			if logMatchesFilter(l, crit.Address, crit.Topics) {
+				result = append(result, *l)
 			}
 		}
 		resp, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result})
@@ -623,6 +634,9 @@ func fakeLogsServer(t *testing.T, logs []Log, queryLimit int) *httptest.Server {
 
 func logMatchesFilter(l *Log, addresses []common.Address, topics [][]common.Hash) bool {
 	if len(addresses) > 0 && !slices.Contains(addresses, l.Address) {
+		return false
+	}
+	if len(topics) > len(l.Topics) {
 		return false
 	}
 	for pos, alternatives := range topics {


### PR DESCRIPTION
`invariantsEthGetLogs` builds the by-address and by-topic queries from everything seen in the block. When a block has more than `--rpc.logs.querylimit` (default 1000) distinct addresses, or distinct topics at one position, the server rejects the request and the block is not checked:

```
go run ./cmd/rpctest invariantsEthGetLogs --erigonUrl=http://localhost:8549 --blockFrom=25636108 --blockTo=25636118
EROR [ethGetLogsInvariants] error getting logs by topics (Erigon) blockNum=25636114 pos=2 error=-32602 message="query exceeds the maximum of 1000 addresses or topics per search position"
```

Such filters are now sent in several requests and the results merged. Batch size comes from a new `--queryLimit` flag, default 1000 = the server's default; set it to match a server that runs a different limit, or to <=0 for a server with the limit off.

Test in `request_generator_test.go`: a fake rpcdaemon that enforces the limit over a block with 250 distinct addresses and 250 distinct topics at position 2. It fails with the -32602 above when the filter is not split.