### PR TITLE
db/recsplit/eliasfano32: let the fuzzer pick the input size

### DIFF
--- a/db/recsplit/eliasfano32/elias_fano_fuzz_test.go
+++ b/db/recsplit/eliasfano32/elias_fano_fuzz_test.go
@@ -32,13 +32,6 @@ func FuzzSingleEliasFano(f *testing.F) {
 		if len(in) == 0 {
 			t.Skip()
 		}
-		// The fuzzing engine hands the input as a read-only buffer; clone it
-		// before growing so the appends below never write into that buffer.
-		in = bytes.Clone(in)
-		for len(in) < int(2*superQ) { // make input large enough to trigger supreQ jump logic
-			in = append(in, in...)
-		}
-
 		// Treat each byte of the sequence as difference between previous value and the next
 		count := len(in)
 		keys := make([]uint64, count+1)
@@ -119,13 +112,6 @@ func FuzzDoubleEliasFano(f *testing.F) {
 		if len(in) == 0 {
 			t.Skip()
 		}
-		// The fuzzing engine hands the input as a read-only buffer; clone it
-		// before growing so the appends below never write into that buffer.
-		in = bytes.Clone(in)
-		for len(in) < int(2*superQ) { // make input large enough to trigger supreQ jump logic
-			in = append(in, in...)
-		}
-
 		var ef DoubleEliasFano
 		// Treat each byte of the sequence as difference between previous value and the next
 		numBuckets := len(in) / 2
@@ -150,8 +136,9 @@ func FuzzDoubleEliasFano(f *testing.F) {
 		if !ef1.build() || !ef2.build() || !ef.build(cumKeys, position) {
 			return
 		}
-		// Try to read from ef
-		for bucket := range numBuckets {
+		// Try to read from ef. Index numBuckets is the last one the structure
+		// holds; only Get3 stops short, since it also reads cumKeys[bucket+1].
+		for bucket := range numBuckets + 1 {
 			cumKey, bitPos := ef.Get2(uint64(bucket))
 			if cumKey != cumKeys[bucket] {
 				t.Fatalf("bucket %d: cumKey from EF = %d, expected %d", bucket, cumKey, cumKeys[bucket])

--- a/db/recsplit/eliasfano32/elias_fano_test.go
+++ b/db/recsplit/eliasfano32/elias_fano_test.go
@@ -493,6 +493,64 @@ func TestSearchUpperReverseNoSolution(t *testing.T) {
 	require.False(t, it.HasNext(), "no element <= 1 should be found when EF starts at 1_000_000")
 }
 
+// A jump lookup adds a per-superQ base to a per-q offset inside that block, and
+// both terms are nonzero only from index superQ+q on.
+const jumpTestCount = superQ + q + 2
+
+func requireFullJumpReach(t *testing.T, maxIdx uint64) {
+	t.Helper()
+	require.NotZero(t, maxIdx/superQ, "max read index %d never leaves the first superQ block", maxIdx)
+	require.NotZero(t, (maxIdx%superQ)/q, "max read index %d has a zero offset inside its superQ block", maxIdx)
+}
+
+func increasingSeq(n, stride uint64) []uint64 {
+	seq := make([]uint64, n)
+	var acc uint64
+	for i := range seq {
+		acc += 1 + (uint64(i)*stride)%251
+		seq[i] = acc
+	}
+	return seq
+}
+
+func TestEliasFanoGetAcrossSuperQJump(t *testing.T) {
+	keys := increasingSeq(jumpTestCount, 7)
+	requireFullJumpReach(t, uint64(len(keys)-1))
+
+	ef := NewEliasFano(uint64(len(keys)), keys[len(keys)-1])
+	for _, k := range keys {
+		ef.AddOffset(k)
+	}
+	ef.Build()
+
+	for i, want := range keys {
+		require.Equal(t, want, ef.Get(uint64(i)), "Get(%d)", i)
+	}
+}
+
+func TestDoubleEliasFanoGetAcrossSuperQJump(t *testing.T) {
+	cumKeys := increasingSeq(jumpTestCount+1, 7)
+	position := increasingSeq(jumpTestCount+1, 13)
+	numBuckets := uint64(len(cumKeys) - 1)
+	// Get3 reads cumKeys[bucket+1], so it stops one bucket short of Get2.
+	requireFullJumpReach(t, numBuckets-1)
+
+	var ef DoubleEliasFano
+	ef.Build(cumKeys, position)
+
+	for bucket := range numBuckets + 1 {
+		cumKey, bitPos := ef.Get2(bucket)
+		require.Equal(t, cumKeys[bucket], cumKey, "Get2(%d) cumKeys", bucket)
+		require.Equal(t, position[bucket], bitPos, "Get2(%d) position", bucket)
+	}
+	for bucket := range numBuckets {
+		cumKey, cumKeysNext, bitPos := ef.Get3(bucket)
+		require.Equal(t, cumKeys[bucket], cumKey, "Get3(%d) cumKeys", bucket)
+		require.Equal(t, cumKeys[bucket+1], cumKeysNext, "Get3(%d) cumKeysNext", bucket)
+		require.Equal(t, position[bucket], bitPos, "Get3(%d) position", bucket)
+	}
+}
+
 func TestEliasFano(t *testing.T) {
 	offsets := []uint64{1, 4, 6, 8, 10, 14, 16, 19, 22, 34, 37, 39, 41, 43, 48, 51, 54, 58, 62}
 	count := uint64(len(offsets))


### PR DESCRIPTION
Both fuzz targets padded every input up to `2*superQ` (32KB, `superQ = 1<<14`), so each execution built and fully traversed a 32k-element structure — and no small input could exist, because the padding loop ran unconditionally.

The padding also missed what it was aiming at. What selects the jump path is the largest index the read loops hand to `Get`/`Get2`/`Get3`, not the byte count, and a jump lookup needs `superQ+q` = 16640 before both of its terms — the per-superQ base and the per-q offset inside that block — are nonzero:

| target | max read index | needed | 32KB input gives |
| --- | --- | --- | --- |
| Single | `len(in)` | 16640 | 32768 — 2x more than needed |
| Double, `Get2` | `len(in)/2 - 1` | 16640 | 16383 — never reaches it |
| Double, `Get3` | `len(in)/2 - 1` | 16640 | 16383 — never reaches it |

So the Double target built the second superQ block (`build` loops `i <= numBuckets`) and never read it back, while the Single target paid twice over for the one it did read.

## A plain test instead of padding

`elias_fano_test.go` gets two tests that build `superQ+q+2` entries and read every index back:

- `TestEliasFanoGetAcrossSuperQJump` — `Get` over all indices
- `TestDoubleEliasFanoGetAcrossSuperQJump` — `Get2` over `[0, numBuckets]`, `Get3` over `[0, numBuckets-1]`

`requireFullJumpReach` asserts the max index really does have a nonzero superQ base *and* a nonzero offset inside that block, so the coverage cannot lapse silently if the constants move. Both tests together take ~40ms and run on every `go test ./...`.

`DoubleEliasFano` had no coverage outside the fuzz target at any index before this — the `Test` functions in the package are all single-EliasFano, and `Get2`/`Get3` appear elsewhere only in benchmarks.

Mutation check: zeroing the per-superQ base (`jump := 0*ef.jump[jumpSuperQ] + …`) in `upper()` and `get2()` fails both new tests at index 16384. Without them that mutation is caught only by `TestEliasFanoSeek` and `TestEliasFanoSeekPositionLarge`, both single-EliasFano; the `DoubleEliasFano` half goes unnoticed.

## The targets no longer pad at all

60s per target from a clean corpus, one worker, on an idle 16-core EPYC 4344P:

| target | main | this PR |
| --- | --- | --- |
| `FuzzSingleEliasFano` | 89,521 execs (1,487/s) | **8,965,322 execs (159,305/s)** |
| `FuzzDoubleEliasFano` | 67,386 execs (1,112/s) | **7,810,317 execs (130,435/s)** |

No padding constant, no fuzz argument, no corpus migration — the eight committed corpus entries stay exactly as they are.

One assertion widened while there: the `Get2`/`ef1`/`ef2` loop in the Double target now runs to `numBuckets` inclusive, so `cumKeys[numBuckets]` and `position[numBuckets]` are verified. `Get3` still stops at `numBuckets-1`, since it reads `cumKeys[bucket+1]`.
