### PR TITLE
execution/commitment, common/maphash: close the pinned-entry counter race and keep the deep probe lock-free

### DIFF
--- a/common/maphash/maphash.go
+++ b/common/maphash/maphash.go
@@ -65,6 +65,14 @@ func (m *Map[V]) ReplaceIfPresent(key []byte, value V) bool {
 	return ok
 }
 
+// LoadAndStore stores value and returns the previous one, loaded reporting
+// prior presence. Probing with a separate Get first races a concurrent delete,
+// so external counters must key off loaded.
+func (m *Map[V]) LoadAndStore(key []byte, value V) (previous V, loaded bool) {
+	h := Hash(key)
+	return m.m.LoadAndStore(h, value)
+}
+
 // Delete removes a key from the map.
 func (m *Map[V]) Delete(key []byte) {
 	h := Hash(key)

--- a/common/maphash/maphash_test.go
+++ b/common/maphash/maphash_test.go
@@ -204,6 +204,33 @@ func TestMapOverwrite(t *testing.T) {
 	}
 }
 
+// The bool reports presence, not insertion; callers count entries off it.
+func TestMapReplaceIfPresent(t *testing.T) {
+	SetSeed(42)
+	m := NewMap[string]()
+
+	if m.ReplaceIfPresent([]byte("absent"), "v") {
+		t.Error("ReplaceIfPresent on an absent key must report false")
+	}
+	if _, ok := m.Get([]byte("absent")); ok {
+		t.Error("ReplaceIfPresent must not insert")
+	}
+	if m.Len() != 0 {
+		t.Errorf("expected len 0, got %d", m.Len())
+	}
+
+	m.Set([]byte("key"), "first")
+	if !m.ReplaceIfPresent([]byte("key"), "second") {
+		t.Error("ReplaceIfPresent on a present key must report true")
+	}
+	if v, ok := m.Get([]byte("key")); !ok || v != "second" {
+		t.Errorf("expected (second, true), got (%s, %v)", v, ok)
+	}
+	if m.Len() != 1 {
+		t.Errorf("expected len 1, got %d", m.Len())
+	}
+}
+
 func TestMapEmptyKey(t *testing.T) {
 	SetSeed(42)
 	m := NewMap[int]()

--- a/execution/commitment/adaptive_pin_test.go
+++ b/execution/commitment/adaptive_pin_test.go
@@ -18,6 +18,7 @@ package commitment
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -136,8 +137,11 @@ func TestRecordPreload_RecordsElapsedAndBytes(t *testing.T) {
 			if got := mxPreloadBytesTotal.GetValue() - bytesBefore; got != tc.wantBytes {
 				t.Errorf("commitment_trunk_preload_bytes_total advanced by %v, want %v", got, tc.wantBytes)
 			}
-			const ulpSlack = 1e-9 // differencing a float64 accumulator lands just under
-			if got := mxPreloadDurationSecondsTotal.GetValue() - secondsBefore; got+ulpSlack < elapsed.Seconds() {
+			// Differencing a growing accumulator loses up to half an ULP of its
+			// magnitude, so a constant slack stops covering it as the total rises.
+			secondsAfter := mxPreloadDurationSecondsTotal.GetValue()
+			slack := math.Nextafter(secondsAfter, math.Inf(1)) - secondsAfter
+			if got := secondsAfter - secondsBefore; got+slack < elapsed.Seconds() {
 				t.Errorf("commitment_trunk_preload_duration_seconds_total advanced by %v, want >= %v", got, elapsed.Seconds())
 			}
 		})

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -256,11 +256,8 @@ func adaptiveTrunkDepth(active int64) uint8 {
 	return trunkDepthShallow
 }
 
-// slot returns the fixed-array slot for a nibble path of length 0-3 (and length
-// 4 when the depth-4 array is present, i.e. the account trunk), or nil when the
-// path is deeper — the caller then uses deep (storage) or the tail (account).
 // slot returns the cell for an n-nibble path, nil when that depth has no
-// resident tier and the caller must use deep.
+// resident tier and the caller must use deep (storage) or the tail (account).
 func (t *trunk) slot(path *[4]byte, n int, forWrite bool) *atomic.Pointer[branchCacheEntry] {
 	switch n {
 	case 0:
@@ -429,7 +426,9 @@ func (c *BranchCache) trunkSlot(prefix []byte, forWrite bool) *atomic.Pointer[br
 // the caller falls through to the tail. nibBuf is caller-owned scratch —
 // storageRoute cannot inline, so a local would escape.
 func (c *BranchCache) storageRoute(prefix []byte, create bool, nibBuf *[4]byte) (st *trunk, n int, ok bool) {
-	if len(prefix) < 33 {
+	// A terminator adds a nibble storageNibbles does not count, so the depth would
+	// be one short and route to a neighbouring slot. Refusing sends it to the tail.
+	if len(prefix) < 33 || prefix[0]&0x20 != 0 {
 		return nil, 0, false
 	}
 	// Both decodes stay behind this check; ahead of it they are pure cost.
@@ -492,11 +491,9 @@ func ContractHashFromPrefix(prefix []byte) (hash [32]byte, ok bool) {
 
 // storageNibbles decodes the storage nibbles after the 64-nibble account hash,
 // matching nibbles.CompactToHex(prefix)[64:]. Only the first 4 are written; n is
-// the true count. Assumes no terminator flag, which holds for traversal paths.
+// the true count. Undefined for terminator-flagged prefixes; storageRoute
+// rejects those before calling.
 func storageNibbles(prefix []byte, nib *[4]byte) (n int) {
-	if len(prefix) < 33 {
-		return 0
-	}
 	off := 2
 	if prefix[0]&0x10 != 0 { // odd: the account hash starts at the low nibble of byte 0
 		off = 1
@@ -640,7 +637,9 @@ func (c *BranchCache) store(prefix []byte, entry *branchCacheEntry) {
 					return
 				}
 			}
-		} else if st.deep.ReplaceIfPresent(prefix, entry) {
+		} else if _, present := st.deep.Get(prefix); present && st.deep.ReplaceIfPresent(prefix, entry) {
+			// Get is lock-free; ReplaceIfPresent locks the bucket even on a miss,
+			// and the miss is the common case here.
 			return
 		}
 	}
@@ -669,17 +668,17 @@ func (c *BranchCache) PinEntry(prefix []byte, data []byte, step, txN uint64) {
 		c.tailForWrite().Add(maphash.Hash(prefix), entry)
 		return
 	}
+	// Eviction takes no put stripe, so publish and read the prior occupancy in one
+	// step — a separate check would let an eviction land in between and lose a count.
 	if slot := st.slot(&nibBuf, n, true); slot != nil {
-		if slot.Load() == nil {
+		if slot.Swap(entry) == nil {
 			c.pinnedEntries.Add(1)
 		}
-		slot.Store(entry)
 		return
 	}
-	if _, exists := st.deep.Get(prefix); !exists {
+	if _, loaded := st.deep.LoadAndStore(prefix, entry); !loaded {
 		c.pinnedEntries.Add(1)
 	}
-	st.deep.Set(prefix, entry)
 }
 
 // PinnedCount returns the number of currently pinned storage-trunk entries.

--- a/execution/commitment/branch_cache_test.go
+++ b/execution/commitment/branch_cache_test.go
@@ -60,6 +60,48 @@ func TestBranchCache_AccountTrunkRouting(t *testing.T) {
 	require.False(t, ok, "trunk entry with txN=100 must drop at unwind floor 60")
 }
 
+// A pin that checked occupancy before writing could skip its +1 while a racing
+// Invalidate's -1 still lands, leaving PinnedCount below the resident count.
+func TestBranchCache_PinnedCountSurvivesConcurrentInvalidate(t *testing.T) {
+	newPrefix := func(contract byte, storageNibbles int) []byte {
+		p := make([]byte, 33+(storageNibbles+1)/2)
+		if storageNibbles%2 == 1 {
+			p[0] = 0x10
+		}
+		p[1] = contract
+		for i := 2; i < len(p); i++ {
+			p[i] = byte(i * 3)
+		}
+		return p
+	}
+
+	// The window only opens on an already-occupied slot, hence the pin per round.
+	for _, storageNibbles := range []int{0, 6} {
+		t.Run(fmt.Sprintf("depth%d", storageNibbles), func(t *testing.T) {
+			prefix := newPrefix(1, storageNibbles)
+
+			for range 20000 {
+				c := NewBranchCache(100)
+				c.PinEntry(prefix, []byte("v0"), 0, 100)
+
+				var wg sync.WaitGroup
+				wg.Go(func() { c.PinEntry(prefix, []byte("v1"), 0, 100) })
+				wg.Go(func() { c.Invalidate(prefix) })
+				wg.Wait()
+
+				_, _, resident := c.Get(prefix)
+				want := 0
+				if resident {
+					want = 1
+				}
+				require.Equalf(t, want, c.PinnedCount(),
+					"PinnedCount must match residency (resident=%v)", resident)
+				c.Close()
+			}
+		})
+	}
+}
+
 // TestBranchCache_StorageTrunkPin verifies PinEntry routes a storage-trunk
 // prefix (>= 64 nibbles) into its per-contract storage trunk, is served from
 // the pinned tier, counts toward PinnedCount, and honors the unwind model.
@@ -488,6 +530,28 @@ func TestStorageNibbles_MatchesReference(t *testing.T) {
 	}
 }
 
+// Terminator-flagged keys must be refused a trunk route, not routed one slot short.
+func TestBranchCache_StorageRouteRejectsTerminator(t *testing.T) {
+	prefix := make([]byte, 34)
+	for i := 1; i < len(prefix); i++ {
+		prefix[i] = byte(i)
+	}
+	for _, flag := range []byte{0x20, 0x30} {
+		prefix[0] = flag
+		c := NewBranchCache(100)
+		var nibBuf [4]byte
+		_, _, routed := c.storageRoute(prefix, true, &nibBuf)
+		require.Falsef(t, routed, "terminator-flagged prefix (%#x) must fall through to the tail", flag)
+
+		// Still cached, just on the slower tier — a refused route is not a drop.
+		c.PinEntry(prefix, []byte("v"), 0, 100)
+		got, _, ok := c.Get(prefix)
+		require.Truef(t, ok, "terminator-flagged prefix (%#x) must still round-trip", flag)
+		require.Equal(t, []byte("v"), got)
+		c.Close()
+	}
+}
+
 // TestBranchCache_StorageRoute_ZeroAlloc verifies storageRoute's account-hash
 // and storage-nibble decode no longer pay the CompactToHex + packed-key
 // allocations on a storage-tier lookup, for both odd and even flag parity.
@@ -514,41 +578,47 @@ func TestBranchCache_StorageRoute_ZeroAlloc(t *testing.T) {
 			_, _, _ = c.storageRoute(prefix, false, &nibBuf)
 		})
 		require.Zerof(t, allocs, "storageRoute must not allocate on a storage-tier lookup, prefix0=%#x", prefix[0])
+
+		// create=true reaches LoadOrStore; if that ever retained the key, escape
+		// analysis would heap-promote the 32-byte hash on both routes.
+		allocs = testing.AllocsPerRun(1000, func() {
+			var nibBuf [4]byte
+			_, _, _ = c.storageRoute(prefix, true, &nibBuf)
+		})
+		require.Zerof(t, allocs, "storageRoute must not allocate routing to a resident contract, prefix0=%#x", prefix[0])
 	}
 }
 
 // A right-nibbles/wrong-count decode routes the pin and the read to different
 // depths — a permanent miss the reference comparison cannot see.
 func TestBranchCache_StorageTrunkRoundTripAcrossDepths(t *testing.T) {
-	for _, oddFlag := range []bool{false, true} {
-		for storLen := range 9 {
-			// storLen storage nibbles after 64 account nibbles, in compact form.
-			total := 64 + storLen
-			if oddFlag {
-				total++
-			}
-			prefix := make([]byte, total/2+1)
-			if oddFlag {
-				prefix[0] = 0x10
-			}
-			for i := 1; i < len(prefix); i++ {
-				prefix[i] = byte(i*11 + storLen)
-			}
+	for depth := range 9 {
+		// The parity of 64+depth fixes the compact odd flag: one encoding per depth.
+		total := 64 + depth
+		oddFlag := total%2 == 1
+		prefix := make([]byte, total/2+1)
+		if oddFlag {
+			prefix[0] = 0x10
+		}
+		for i := 1; i < len(prefix); i++ {
+			prefix[i] = byte(i*11 + depth)
+		}
 
+		t.Run(fmt.Sprintf("depth%d", depth), func(t *testing.T) {
 			c := NewBranchCache(100)
-			want := fmt.Sprintf("d%d-%v", storLen, oddFlag)
+			defer c.Close() // a require failure here must not leak activeBranchCaches
+			want := fmt.Sprintf("d%d", depth)
 			c.PinEntry(prefix, []byte(want), 0, 100)
 
 			got, _, ok := c.Get(prefix)
-			require.Truef(t, ok, "pinned entry must read back, storLen=%d odd=%v", storLen, oddFlag)
+			require.Truef(t, ok, "pinned entry must read back, depth=%d", depth)
 			require.Equal(t, want, string(got))
-			require.Equalf(t, 1, c.PinnedCount(), "storLen=%d odd=%v", storLen, oddFlag)
+			require.Equalf(t, 1, c.PinnedCount(), "depth=%d", depth)
 
 			c.Invalidate(prefix)
 			_, _, ok = c.Get(prefix)
-			require.Falsef(t, ok, "invalidated entry must be gone, storLen=%d odd=%v", storLen, oddFlag)
-			require.Zerof(t, c.PinnedCount(), "storLen=%d odd=%v", storLen, oddFlag)
-			c.Close()
-		}
+			require.Falsef(t, ok, "invalidated entry must be gone, depth=%d", depth)
+			require.Zerof(t, c.PinnedCount(), "depth=%d", depth)
+		})
 	}
 }

--- a/p2p/protocols/eth/protocol_test.go
+++ b/p2p/protocols/eth/protocol_test.go
@@ -412,15 +412,13 @@ func TestHashOrNumberEncodeRLPPointerIsAllocFree(t *testing.T) {
 	}
 	valueAllocs := testing.AllocsPerRun(200, mustEncode(hn.Hash))
 	pointerAllocs := testing.AllocsPerRun(200, mustEncode(&hn.Hash))
-	if !race.Enabled {
-		t.Logf("allocs/op: byValue=%v byPointer=%v", valueAllocs, pointerAllocs)
-		if pointerAllocs >= valueAllocs {
-			t.Errorf("pointer form should allocate less: value=%v pointer=%v", valueAllocs, pointerAllocs)
-		}
-		// encBuffer is pooled, and sync.Pool drops values under the race detector.
-		//goland:noinspection GoBoolExpressions
-		if pointerAllocs != 0 {
-			t.Errorf("pointer form should not allocate, got %v", pointerAllocs)
-		}
+	t.Logf("allocs/op: byValue=%v byPointer=%v", valueAllocs, pointerAllocs)
+	if pointerAllocs >= valueAllocs {
+		t.Errorf("pointer form should allocate less: value=%v pointer=%v", valueAllocs, pointerAllocs)
+	}
+	// encBuffer is pooled, and sync.Pool drops values under the race detector.
+	//goland:noinspection GoBoolExpressions
+	if !race.Enabled && pointerAllocs != 0 {
+		t.Errorf("pointer form should not allocate, got %v", pointerAllocs)
 	}
 }


### PR DESCRIPTION
Follow-up to #23189, addressing its review. Two of these are bugs that predate that PR.

## Changes

**`PinEntry` counter race.** `PinEntry` publishes under a put stripe; `Invalidate` and the stale-read path evict without one. An eviction landing between `PinEntry`'s occupancy check and its store skips the `+1` while the `-1` still applies, so `PinnedCount()` drifts permanently below the resident count and the just-invalidated prefix is served again. Both tiers now publish and read prior occupancy in one step — `atomic.Pointer.Swap` for the fixed slots, a new `maphash.LoadAndStore` for the deep tier. New test fails on the old code with `resident=true` but `PinnedCount()==0`.

**Deep-tier probe contention.** `maphash.ReplaceIfPresent` calls `xsync.Map.Compute`, which passes `noLoadOp` to `doCompute` and therefore skips the lock-free pre-scan and takes `rootb.mu.Lock()` unconditionally (xsync v4.5.0 `map.go:546,598,628`). The old `Get` used `Load`, lock-free. The deep miss is the common case on that path — those prefixes fall through to the tail — so the miss must not take the bucket mutex while already holding a put stripe. Restores the lock-free `Get` probe and calls `ReplaceIfPresent` only on a hit. `Invalidate`'s `LoadAndDelete` keeps the pre-scan (`map.go:620`) and needs no probe.

**Terminator-flagged prefixes.** `storageNibbles` derives the storage depth from the `0x10` flag alone. For a `0x20` prefix `CompactToHex` yields `2*len-1` nibbles, so the true count is `2*len-65` where it computes `2*len-66` — one short, routing to a neighbouring slot. `TestStorageNibbles_MatchesReference` masks the terminator away, so the oracle could not see it. `storageRoute` now refuses those keys; they cache on the tail instead, slower but never wrong.

**Test fixes.** `c.Close()` was not deferred in the depth round-trip, so one `require` failure leaked `activeBranchCaches` for every later iteration — past `trunkInstanceDepthThreshold` that returns `trunkDepthShallow` for every subsequent `BranchCache`, so d3/d4 stop being allocated and unrelated tests start failing. `storLen` was not the storage-nibble count it named (`storLen=0, odd=true` is 1 nibble), so failure messages reported the wrong depth. The preload-duration slack was the constant `1e-9` where the error is half an ULP of a growing global accumulator: 27/200 failures at `-count=200`, 0/200 after. `ReplaceIfPresent` had no direct test of its present-after-the-operation contract. The zero-alloc route test covered only `create=false`.
