### PR TITLE
build(deps): bump nanoid from 3.3.16 to 3.3.18 in /docs/site

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -14514,9 +14514,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes the open Dependabot alert for `nanoid` — GHSA-2v37-7h3g-55p8 / CVE-2026-67213 (high): a custom generator loops indefinitely when called with `size: 0`. Fixed upstream in 3.3.17; this takes 3.3.18, the current 3.x release.

Dependabot has not opened this one itself in the four days since the alert appeared, so it is done by hand.

Lockfile-only. `postcss` requires `^3.3.16`, so the transitive bump needs no parent update — the diff is the three `nanoid` lines and nothing else in the tree moves.

Verified locally: `npm ci`, `npm run typecheck` and `npm run build` all pass in `docs/site`, and `npm audit` no longer lists `nanoid`.

### Remaining npm alerts are not fixable yet

The other two open alerts are both `image-size` 2.0.2 — GHSA-5p2g-fcmc-qvqq (JXL/HEIF) and GHSA-w3rx-r6r6-pgpr (ICNS). There is no upgrade path: `image-size@latest` **is** 2.0.2, and every `@docusaurus/mdx-loader` from 3.9.0 to 3.10.2 pins `image-size: ^2.0.2`, so neither a direct bump nor a Docusaurus bump helps. Because of that `^2.0.2` range, a future 2.0.3 will be picked up by the weekly Dependabot npm job with no config change. Tracked separately.
