### PR TITLE
rpc/jsonrpc: return hexutil.U256 from eth_getBalance

### DIFF
--- a/rpc/jsonrpc/eth_accounts.go
+++ b/rpc/jsonrpc/eth_accounts.go
@@ -19,7 +19,6 @@ package jsonrpc
 import (
 	"context"
 	"fmt"
-	"math/big"
 
 	"google.golang.org/grpc"
 
@@ -73,7 +72,7 @@ func (api *APIImpl) stateReaderAt(ctx context.Context, blockNrOrHash rpc.BlockNu
 }
 
 // GetBalance implements eth_getBalance. Returns the balance of an account for a given address.
-func (api *APIImpl) GetBalance(ctx context.Context, address common.Address, blockNrOrHashArg *rpc.BlockNumberOrHash) (*hexutil.Big, error) {
+func (api *APIImpl) GetBalance(ctx context.Context, address common.Address, blockNrOrHashArg *rpc.BlockNumberOrHash) (*hexutil.U256, error) {
 	blockNrOrHash := orLatest(blockNrOrHashArg)
 	tx, reader, err := api.stateReaderAt(ctx, blockNrOrHash)
 	if err != nil {
@@ -87,10 +86,10 @@ func (api *APIImpl) GetBalance(ctx context.Context, address common.Address, bloc
 	}
 	if acc == nil {
 		// Special case - non-existent account is assumed to have zero balance
-		return (*hexutil.Big)(big.NewInt(0)), nil
+		return new(hexutil.U256), nil
 	}
 
-	return (*hexutil.Big)(acc.Balance.ToBig()), nil
+	return (*hexutil.U256)(&acc.Balance), nil
 }
 
 // GetTransactionCount implements eth_getTransactionCount. Returns the number of transactions sent from an address (the nonce).

--- a/rpc/jsonrpc/eth_api.go
+++ b/rpc/jsonrpc/eth_api.go
@@ -99,7 +99,7 @@ type EthAPI interface {
 
 	// Account related (see ./eth_accounts.go)
 	Accounts(ctx context.Context) ([]common.Address, error)
-	GetBalance(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Big, error)
+	GetBalance(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.U256, error)
 	GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error)
 	GetStorageAt(ctx context.Context, address common.Address, index string, blockNrOrHash *rpc.BlockNumberOrHash) (string, error)
 	GetStorageValues(ctx context.Context, requests map[common.Address][]common.Hash, blockNrOrHash *rpc.BlockNumberOrHash) (map[common.Address][]hexutil.Bytes, error)


### PR DESCRIPTION
Second step of replacing `*hexutil.Big` with `hexutil.U256` on RPC quantity fields. Follows #23216 (independent — different lines, no conflict).

`Account.Balance` is already a `uint256.Int` value field, so `ToBig()` was a pure round-trip through `big.Int` on every balance query.

`hexutil.U256` is byte-identical on the wire for every value both types can represent — same `checkNumberText` on unmarshal, same lowercase no-leading-zero output, zero marshals as `0x0`. Pinned by `TestMarshalU256`. A balance can be neither negative nor above 256 bits, so the two representable ranges coincide here.

The non-existent-account branch now returns the `U256` zero value instead of `big.NewInt(0)`; both marshal to `"0x0"`.

### Aliasing

`&acc.Balance` is aliased rather than copied. That is safe on this path:

- every `ReadAccountData` implementation reachable from `stateReaderAt` allocates a fresh `accounts.Account` and returns `&a` — `CachedReader3` (`execution/state/cached_reader3.go`), `cachedHistoryReaderV3` cache-hit (`rpc/rpchelper/helper.go`), and the `HistoryReaderV3` fallback (`execution/state/history_reader_v3.go`). None is pooled or shared.
- `Balance` is a `uint256.Int` value field, not a slice, so it cannot alias tx-owned memory released by the deferred `Rollback`.

### Coverage

Unlike #23216, the rpc-tests corpus compares the result value here: 22 of the 29 `integration/mainnet/eth_getBalance` fixtures carry literal expected hex against historical blocks, including `0x0` (test_07, the zero branch) and 80-bit values past the first word (test_14 `0x37c81160f0c495451e16`, test_22 `0x131a841afc8bc9b52cdd`).