### PR TITLE
all: add Kibi/Mebi/Gibi/Tebi and use them for byte sizes

### DIFF
--- a/cl/clparams/config.go
+++ b/cl/clparams/config.go
@@ -123,11 +123,11 @@ const CustomNetwork NetworkType = -1
 const (
 	MaxDialTimeout               = 15 * time.Second
 	VersionLength  int           = 4
-	MaxChunkSize   uint64        = 15 * 1024 * 1024
+	MaxChunkSize   uint64        = 15 * common.Mebi
 	ReqTimeout     time.Duration = 5 * time.Second
 	RespTimeout    time.Duration = 10 * time.Second
 	// ExecutionPayload transactions bounds from consensus specs.
-	MaxBytesPerTransactionDefault    uint64 = 1 << 30
+	MaxBytesPerTransactionDefault    uint64 = common.Gibi
 	MaxTransactionsPerPayloadDefault uint64 = 1 << 20
 )
 

--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -481,7 +481,7 @@ func executionPayloadToEth1Block(ep *engine_types.ExecutionPayload, version clpa
 		block.SlotNumber = uint64(*ep.SlotNumber)
 	}
 	if ep.BlockAccessList != nil && len(*ep.BlockAccessList) > 0 {
-		maxBytes := uint64(1073741824) // MAX_BYTES_PER_TRANSACTION default
+		maxBytes := uint64(common.Gibi) // MAX_BYTES_PER_TRANSACTION default
 		if beaconCfg != nil {
 			maxBytes = beaconCfg.MaxBytesPerTransaction
 		}

--- a/cl/phase1/network/gossip/gossip_manager_test.go
+++ b/cl/phase1/network/gossip/gossip_manager_test.go
@@ -114,11 +114,11 @@ func (s *newPubsubValidatorTestSuite) SetupTest() {
 		beaconConfig,
 		networkConfig,
 		s.mockClock,
-		false,                        // subscribeAll
-		0,                            // activeIndicies
-		datasize.ByteSize(1024*1024), // maxInboundTrafficPerPeer
-		datasize.ByteSize(1024*1024), // maxOutboundTrafficPerPeer
-		false,                        // adaptableTrafficRequirements
+		false,       // subscribeAll
+		0,           // activeIndicies
+		datasize.MB, // maxInboundTrafficPerPeer
+		datasize.MB, // maxOutboundTrafficPerPeer
+		false,       // adaptableTrafficRequirements
 	)
 }
 
@@ -419,11 +419,11 @@ func (s *subscribeUpcomingTopicsTestSuite) SetupTest() {
 		beaconConfig,
 		networkConfig,
 		s.mockClock,
-		false,                        // subscribeAll
-		0,                            // activeIndicies
-		datasize.ByteSize(1024*1024), // maxInboundTrafficPerPeer
-		datasize.ByteSize(1024*1024), // maxOutboundTrafficPerPeer
-		false,                        // adaptableTrafficRequirements
+		false,       // subscribeAll
+		0,           // activeIndicies
+		datasize.MB, // maxInboundTrafficPerPeer
+		datasize.MB, // maxOutboundTrafficPerPeer
+		false,       // adaptableTrafficRequirements
 	)
 }
 

--- a/cl/sentinel/communication/topics_test.go
+++ b/cl/sentinel/communication/topics_test.go
@@ -24,10 +24,12 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
 )
 
 func TestMaxWireResponseBytes(t *testing.T) {
-	const rawItem = 15 * 1024 * 1024
+	const rawItem = 15 * common.Mebi
 	perItem := uint64(snappy.MaxEncodedLen(rawItem)) + reqRespChunkFraming
 
 	// A realistic count multiplies out exactly.
@@ -59,7 +61,7 @@ func TestMaxWireResponseBytesBoundsStreamEncoding(t *testing.T) {
 		}
 	}
 	// tiny inputs, a blob sidecar (~129 KiB), 1 MiB, and the spec per-chunk maximum.
-	for _, raw := range []int{1, 100, 4096, 131928, 1 << 20, 15 * 1024 * 1024} {
+	for _, raw := range []int{1, 100, 4096, 131928, 1 << 20, 15 * common.Mebi} {
 		payload := make([]byte, raw)
 		fill(payload)
 

--- a/cl/sentinel/httpreqresp/server.go
+++ b/cl/sentinel/httpreqresp/server.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/sentinel/communication"
+	"github.com/erigontech/erigon/common"
 )
 
 const (
@@ -51,7 +52,7 @@ const (
 	maxResponseChunks = 1024
 	// maxSingleObjectResponse bounds single-chunk protocols (status, ping, metadata,
 	// goodbye, light-client singles), whose responses are at most tens of KiB.
-	maxSingleObjectResponse = 1024 * 1024
+	maxSingleObjectResponse = common.Mebi
 )
 
 // maxMultiChunkResponse is the on-wire MAX_REQUEST_BLOCKS × MAX_CHUNK_SIZE ceiling: the backstop a

--- a/cl/sentinel/httpreqresp/server_test.go
+++ b/cl/sentinel/httpreqresp/server_test.go
@@ -34,13 +34,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/cl/sentinel/communication"
+	"github.com/erigontech/erigon/common"
 )
 
 func TestMaxResponseBodySize(t *testing.T) {
 	// Drive the cap off communication.AllProtocols, the single source of truth for response-size
 	// classification, so a protocol added there is automatically covered here.
 	ceiling := maxMultiChunkResponse
-	const budget = 5 * 1024 * 1024
+	const budget = 5 * common.Mebi
 	for _, p := range communication.AllProtocols {
 		if !p.MultiChunk {
 			// Single-object protocols ignore the caller's byte budget.
@@ -263,7 +264,7 @@ func fetchPeerResponse(t *testing.T, topic string, payloadSize int, maxResponseB
 		if _, err := s.Write([]byte{0x00}); err != nil {
 			return
 		}
-		buf := make([]byte, 1024*1024)
+		buf := make([]byte, common.Mebi)
 		for sent := 0; sent < payloadSize; {
 			chunk := buf
 			if remaining := payloadSize - sent; remaining < len(chunk) {
@@ -346,7 +347,7 @@ func TestResponseBodyRejectedOnFlood(t *testing.T) {
 	require.Equal(t, "0", code, "a compliant response carries the peer's success code")
 	require.Len(t, body, 1000, "a compliant single-object response must pass through in full")
 
-	const floodSize = 40 * 1024 * 1024 // well above the single-object cap
+	const floodSize = 40 * common.Mebi // well above the single-object cap
 	_, _, body, err = fetchPeerResponse(t, communication.StatusProtocolV1, floodSize, 0)
 	require.ErrorIs(t, err, ErrResponseTooLarge,
 		"a single-object flood must surface an explicit too-large error, not be truncated and accepted")
@@ -376,7 +377,7 @@ func TestSingleChunkEmptyCloseReturnsBadRequest(t *testing.T) {
 // ceiling — so a missing budget can never let a flooding peer drive an OOM. A budgeted multi-chunk
 // response above the single-object cap still passes; see TestMultiChunkResponseRejectedOverByteBudget.
 func TestMultiChunkResponseCappedWithoutBudget(t *testing.T) {
-	const floodSize = 5 * 1024 * 1024 // above the single-object cap
+	const floodSize = 5 * common.Mebi // above the single-object cap
 	_, _, body, err := fetchPeerResponse(t, communication.BeaconBlocksByRangeProtocolV2, floodSize, 0)
 	require.ErrorIs(t, err, ErrResponseTooLarge,
 		"an unbudgeted multi-chunk response over the single-object cap must be rejected, not streamed toward the ceiling")
@@ -388,15 +389,15 @@ func TestMultiChunkResponseCappedWithoutBudget(t *testing.T) {
 // full, a flood beyond it surfaces ErrResponseTooLarge (not truncated, and not clamped to the
 // single-object cap).
 func TestMultiChunkResponseRejectedOverByteBudget(t *testing.T) {
-	const budget = 8 * 1024 * 1024
+	const budget = 8 * common.Mebi
 
-	const okSize = 4 * 1024 * 1024 // within the budget
+	const okSize = 4 * common.Mebi // within the budget
 	status, _, body, err := fetchPeerResponse(t, communication.BeaconBlocksByRangeProtocolV2, okSize, budget)
 	require.NoError(t, err, "a response within the budget must stream through without error")
 	require.Equal(t, http.StatusOK, status)
 	require.EqualValues(t, okSize, len(body), "a response within the budget must pass through in full")
 
-	const floodSize = 40 * 1024 * 1024 // > budget, < the ceiling
+	const floodSize = 40 * common.Mebi // > budget, < the ceiling
 	_, _, body, err = fetchPeerResponse(t, communication.BeaconBlocksByRangeProtocolV2, floodSize, budget)
 	require.ErrorIs(t, err, ErrResponseTooLarge,
 		"a multi-chunk response over the byte budget must be rejected")

--- a/cmd/rpcdaemon/rpcdaemontest/test_util.go
+++ b/cmd/rpcdaemon/rpcdaemontest/test_util.go
@@ -440,7 +440,7 @@ func CreateTestGrpcConn(t *testing.T, m *execmoduletester.ExecModuleTester) (con
 		m.BlockReader, nil, log.New(), builder.NewLatestBlockBuiltStore(), nil))
 	txpoolproto.RegisterTxpoolServer(server, m.TxPoolGrpcServer)
 	txpoolproto.RegisterMiningServer(server, privateapi.NewMiningServer(ctx, &IsMiningMock{}, ethashApi, m.Log))
-	listener := bufconn.Listen(1024 * 1024)
+	listener := bufconn.Listen(common.Mebi)
 
 	dialer := func() func(context.Context, string) (net.Conn, error) {
 		go func() {

--- a/cmd/rpctest/rpctest/account_range_verify.go
+++ b/cmd/rpctest/rpctest/account_range_verify.go
@@ -66,8 +66,8 @@ func CompareAccountRange(logger log.Logger, erigonURL, gethURL, tmpDataDir, geth
 	var client = &http.Client{
 		Timeout: time.Minute * 60,
 		Transport: &http.Transport{
-			MaxResponseHeaderBytes: 256 * 1024 * 1024,
-			ReadBufferSize:         64 * 1024 * 1024,
+			MaxResponseHeaderBytes: 256 * common.Mebi,
+			ReadBufferSize:         64 * common.Mebi,
 			DialContext: (&net.Dialer{
 				//Timeout:   60 * time.Minute,
 				KeepAlive: 60 * time.Minute,

--- a/cmd/rpctest/rpctest/replay.go
+++ b/cmd/rpctest/rpctest/replay.go
@@ -22,6 +22,8 @@ import (
 	"os"
 
 	"github.com/valyala/fastjson"
+
+	"github.com/erigontech/erigon/common"
 )
 
 func Replay(erigonURL string, recordFile string) error {
@@ -33,7 +35,7 @@ func Replay(erigonURL string, recordFile string) error {
 	}
 	defer f.Close()
 	s := bufio.NewScanner(f)
-	var buf [64 * 1024 * 1024]byte // 64 Mb line buffer
+	var buf [64 * common.Mebi]byte // 64 Mb line buffer
 	s.Buffer(buf[:], len(buf))
 	var res CallResult
 	reqGen := &RequestGenerator{}

--- a/cmd/rpctest/rpctest/request_generator.go
+++ b/cmd/rpctest/rpctest/request_generator.go
@@ -324,8 +324,8 @@ var client = &http.Client{
 		MaxIdleConnsPerHost: 600,
 		MaxConnsPerHost:     600,
 		IdleConnTimeout:     90 * time.Second,
-		ReadBufferSize:      64 * 1024,
-		WriteBufferSize:     16 * 1024,
+		ReadBufferSize:      64 * common.Kibi,
+		WriteBufferSize:     16 * common.Kibi,
 	},
 	Timeout: 600 * time.Second, // Per-request timeout
 }

--- a/cmd/utils/app/snapshots_cmd_test.go
+++ b/cmd/utils/app/snapshots_cmd_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -1052,16 +1053,16 @@ func TestDUFormatHuman(t *testing.T) {
 		DetectedMode: "archive",
 		BlockRange:   [2]uint64{0, 21500000},
 		StepRange:    [2]uint64{0, 2048},
-		TotalBytes:   1024 * 1024 * 1024 * 100, // 100 GB
+		TotalBytes:   100 * common.Gibi, // 100 GB
 		TotalFiles:   500,
 		Categories: map[string]duCategoryStat{
-			duCatDomains: {Bytes: 50 * 1024 * 1024 * 1024, Files: 200},
-			duCatHistory: {Bytes: 30 * 1024 * 1024 * 1024, Files: 150},
-			duCatBlocks:  {Bytes: 20 * 1024 * 1024 * 1024, Files: 150},
+			duCatDomains: {Bytes: 50 * common.Gibi, Files: 200},
+			duCatHistory: {Bytes: 30 * common.Gibi, Files: 150},
+			duCatBlocks:  {Bytes: 20 * common.Gibi, Files: 150},
 		},
 		Estimates: []duEstimate{
-			{Mode: "archive", TotalBytes: 100 * 1024 * 1024 * 1024, Delta: 0, BlocksDesc: "all blocks", HistoryDesc: "all history"},
-			{Mode: "full", TotalBytes: 80 * 1024 * 1024 * 1024, Delta: -20 * 1024 * 1024 * 1024, BlocksDesc: "all blocks", HistoryDesc: "last 100.000"},
+			{Mode: "archive", TotalBytes: 100 * common.Gibi, Delta: 0, BlocksDesc: "all blocks", HistoryDesc: "all history"},
+			{Mode: "full", TotalBytes: 80 * common.Gibi, Delta: -20 * common.Gibi, BlocksDesc: "all blocks", HistoryDesc: "last 100.000"},
 		},
 	}
 

--- a/cmd/utils/flags/flags.go
+++ b/cmd/utils/flags/flags.go
@@ -31,6 +31,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/urfave/cli/v3"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/math"
 )
 
@@ -176,7 +177,7 @@ func DBPageSizeFlagUnmarshal(cliCtx *cli.Command, flagName, flagUsage string) da
 		panic(err)
 	}
 	sz := pageSize.Bytes()
-	if !isPowerOfTwo(sz) || sz < 256 || sz > 64*1024 {
+	if !isPowerOfTwo(sz) || sz < 256 || sz > 64*common.Kibi {
 		panic(fmt.Errorf("invalid --%s: %d, see: %s", flagName, sz, flagUsage))
 	}
 	return pageSize

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -24,7 +24,7 @@ import (
 )
 
 func ByteCount(b uint64) string {
-	const unit = 1024
+	const unit = Kibi
 	if b < unit {
 		return fmt.Sprintf("%dB", b)
 	}

--- a/common/bytesize.go
+++ b/common/bytesize.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+// Binary multipliers for byte sizes. They are untyped on purpose: array
+// lengths, buffer sizes and consensus parameters need a plain int, which is
+// where datasize.ByteSize does not fit.
+const (
+	Kibi = 1 << 10
+	Mebi = 1 << 20
+	Gibi = 1 << 30
+	Tebi = 1 << 40
+)

--- a/common/crypto/crypto.go
+++ b/common/crypto/crypto.go
@@ -82,7 +82,7 @@ var joinBufPool = sync.Pool{
 
 // joinBufKeepCap bounds what a join returns to the pool, so one outsized call
 // does not pin a large buffer per processor for the process lifetime.
-const joinBufKeepCap = 64 * 1024
+const joinBufKeepCap = 64 * common.Kibi
 
 type HashFunc func(data []byte, extras ...[]byte) common.Hash
 

--- a/common/dbg/experiments.go
+++ b/common/dbg/experiments.go
@@ -201,7 +201,7 @@ func DirtySpace() uint64 {
 		if v != "" {
 			i := MustParseInt(v)
 			log.Info("[Experiment]", "MDBX_DIRTY_SPACE_MB", i)
-			dirtySace = uint64(i * 1024 * 1024)
+			dirtySace = uint64(i * common.Mebi)
 		}
 	})
 	return dirtySace

--- a/common/size.go
+++ b/common/size.go
@@ -47,17 +47,17 @@ func formatStorageSize(s StorageSize, addSpace bool) string {
 	unit := "B"
 
 	switch {
-	case s >= 1099511627776:
-		value /= 1099511627776
+	case s >= Tebi:
+		value /= Tebi
 		unit = "TiB"
-	case s >= 1073741824:
-		value /= 1073741824
+	case s >= Gibi:
+		value /= Gibi
 		unit = "GiB"
-	case s >= 1048576:
-		value /= 1048576
+	case s >= Mebi:
+		value /= Mebi
 		unit = "MiB"
-	case s >= 1024:
-		value /= 1024
+	case s >= Kibi:
+		value /= Kibi
 		unit = "KiB"
 	}
 

--- a/db/datastruct/existence/existence_filter.go
+++ b/db/datastruct/existence/existence_filter.go
@@ -26,6 +26,7 @@ import (
 
 	bloomfilter "github.com/holiman/bloomfilter/v2"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/db/datastruct/fusefilter"
@@ -162,7 +163,7 @@ func OpenFilter(filePath string, _ bool) (idx *Filter, err error) {
 
 	if isBloomMagic(peek[:]) {
 		filter := new(bloomfilter.Filter)
-		_, err = filter.UnmarshalFromReaderNoVerify(bufio.NewReaderSize(f, 1*1024*1024))
+		_, err = filter.UnmarshalFromReaderNoVerify(bufio.NewReaderSize(f, common.Mebi))
 		if err != nil {
 			return nil, fmt.Errorf("OpenFilter: %w, %s", err, fileName)
 		}

--- a/db/downloader/bt_peer_discovery_test.go
+++ b/db/downloader/bt_peer_discovery_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/p2p/enode"
 	"github.com/erigontech/erigon/p2p/enr"
@@ -136,7 +137,7 @@ func newTestClientConfig(t *testing.T, dataDir string) *torrent.ClientConfig {
 func buildTestMetainfo(t *testing.T, dir, filename string) metainfo.MetaInfo {
 	t.Helper()
 	info := metainfo.Info{
-		PieceLength: 256 * 1024,
+		PieceLength: 256 * common.Kibi,
 	}
 	err := info.BuildFromFilePath(filepath.Join(dir, filename))
 	require.NoError(t, err)

--- a/db/downloader/downloadercfg/downloadercfg.go
+++ b/db/downloader/downloadercfg/downloadercfg.go
@@ -39,6 +39,7 @@ import (
 	"github.com/anacrolix/torrent"
 	pp "github.com/anacrolix/torrent/peer_protocol"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
@@ -48,11 +49,11 @@ import (
 // DefaultPieceSize - Erigon serves many big files, bigger pieces will reduce
 // amount of network announcements, but can't go over 2Mb. TODO: This is definitely not true.
 // see https://wiki.theory.org/BitTorrentSpecification#Metainfo_File_Structure
-const DefaultPieceSize = 2 * 1024 * 1024
+const DefaultPieceSize = 2 * common.Mebi
 
 // DefaultNetworkChunkSize - how much data request per 1 network call to peer.
 // BitTorrent client default: 16Kb
-var NetworkChunkSize pp.Integer = 256 << 10 // 256 KiB
+var NetworkChunkSize pp.Integer = 256 * common.Kibi // 256 KiB
 
 func init() {
 	s := os.Getenv("DOWNLOADER_NETWORK_CHUNK_SIZE")

--- a/db/etl/etl_test.go
+++ b/db/etl/etl_test.go
@@ -730,7 +730,7 @@ func TestSortable(t *testing.T) {
 }
 
 func TestSortableBufferStableSort(t *testing.T) {
-	buf := NewSortableBuffer(256 * 1024 * 1024)
+	buf := NewSortableBuffer(256 * common.Mebi)
 
 	// Need enough duplicates to trigger pdqsort's partitioning (not just insertion sort).
 	// Insert 1000 entries under each of 4 duplicate keys, interleaved with unique keys.
@@ -764,7 +764,7 @@ func TestSortableBufferStableSort(t *testing.T) {
 }
 
 func TestSortableBufferNilAndEmptyKeys(t *testing.T) {
-	buf := NewSortableBuffer(256 * 1024)
+	buf := NewSortableBuffer(256 * common.Kibi)
 
 	buf.Put([]byte{0x01}, []byte("normal"))
 	buf.Put(nil, []byte("nil-key"))
@@ -1100,7 +1100,7 @@ func BenchmarkSortableBufferSort(b *testing.B) {
 	const valLen = 64
 
 	makeBuffer := func(n int, sorted bool) *sortableBuffer {
-		buf := NewSortableBuffer(256 * 1024 * 1024)
+		buf := NewSortableBuffer(256 * common.Mebi)
 		buf.Prealloc(n, n*(keyLen+valLen))
 		key := make([]byte, keyLen)
 		val := make([]byte, valLen)
@@ -1159,7 +1159,7 @@ func BenchmarkSortableBufferPutSort(b *testing.B) {
 			b.ReportAllocs()
 			key := make([]byte, keyLen)
 			val := make([]byte, valLen)
-			buf := NewSortableBuffer(256 * 1024 * 1024)
+			buf := NewSortableBuffer(256 * common.Mebi)
 			buf.Prealloc(tc.count, tc.count*(keyLen+valLen))
 			for b.Loop() {
 				buf.Reset()
@@ -1198,7 +1198,7 @@ func BenchmarkSortableBufferPutSortLoad(b *testing.B) {
 			b.ReportAllocs()
 			key := make([]byte, keyLen)
 			val := make([]byte, valLen)
-			buf := NewSortableBuffer(256 * 1024 * 1024)
+			buf := NewSortableBuffer(256 * common.Mebi)
 			buf.Prealloc(tc.count, tc.count*(keyLen+valLen))
 			for b.Loop() {
 				buf.Reset()
@@ -1241,7 +1241,7 @@ func BenchmarkSortableBufferPutOnly(b *testing.B) {
 			b.ReportAllocs()
 			key := make([]byte, keyLen)
 			val := make([]byte, valLen)
-			buf := NewSortableBuffer(256 * 1024 * 1024)
+			buf := NewSortableBuffer(256 * common.Mebi)
 			buf.Prealloc(tc.count, tc.count*(keyLen+valLen))
 			for b.Loop() {
 				buf.Reset()
@@ -1279,7 +1279,7 @@ func BenchmarkSortableBufferInmemLoadOnly(b *testing.B) {
 			b.ReportAllocs()
 			key := make([]byte, keyLen)
 			val := make([]byte, valLen)
-			buf := NewSortableBuffer(256 * 1024 * 1024)
+			buf := NewSortableBuffer(256 * common.Mebi)
 			buf.Prealloc(tc.count, tc.count*(keyLen+valLen))
 			for i := range tc.count {
 				if tc.sorted {

--- a/db/etl/read_bench_test.go
+++ b/db/etl/read_bench_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/mmap"
 )
 
@@ -34,7 +35,7 @@ func readFieldU16(m *mmapBytesReader) ([]byte, error) {
 // BenchmarkSequentialRead compares mmap vs bufio for sequential reads of length-prefixed records
 // from a 128MB file. Compares native16 (current format) vs native32 length encoding.
 func BenchmarkSequentialRead(b *testing.B) {
-	const fileSize = 128 * 1024 * 1024 // 128MB
+	const fileSize = 128 * common.Mebi // 128MB
 
 	for _, valSize := range []int{32, 128, 1024} {
 		name := fmt.Sprintf("val%d", valSize)

--- a/db/integrity/torrent_verify_test.go
+++ b/db/integrity/torrent_verify_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	dir2 "github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
 )
@@ -38,7 +39,7 @@ func writeTorrentPair(t *testing.T, dir, name string, corrupt bool) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(dataPath), 0o755))
 	require.NoError(t, os.WriteFile(dataPath, bytes.Repeat([]byte{0xAA}, 1024), 0o644))
 
-	info := metainfo.Info{PieceLength: 16 * 1024}
+	info := metainfo.Info{PieceLength: 16 * common.Kibi}
 	require.NoError(t, info.BuildFromFilePath(dataPath))
 	infoBytes, err := bencode.Marshal(info)
 	require.NoError(t, err)

--- a/db/kv/mdbx/kv_abstract_test.go
+++ b/db/kv/mdbx/kv_abstract_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -157,7 +158,7 @@ func TestRemoteKvVersion(t *testing.T) {
 	logger := log.New()
 	dirs := datadir.New(t.TempDir())
 	writeDB := temporaltest.NewTestDB(t, dirs)
-	conn := bufconn.Listen(1024 * 1024)
+	conn := bufconn.Listen(common.Mebi)
 	grpcServer := grpc.NewServer()
 	go func() {
 		remoteproto.RegisterKVServer(grpcServer, remotedbserver.NewKvServer(ctx, writeDB, nil, nil, nil, logger))
@@ -201,7 +202,7 @@ func TestRemoteKvRange(t *testing.T) {
 	dirs := datadir.New(t.TempDir())
 	writeDB := temporaltest.NewTestDB(t, dirs)
 	ctx := t.Context()
-	grpcServer, conn := grpc.NewServer(), bufconn.Listen(1024*1024)
+	grpcServer, conn := grpc.NewServer(), bufconn.Listen(common.Mebi)
 	go func() {
 		kvServer := remotedbserver.NewKvServer(ctx, writeDB, nil, nil, nil, logger)
 		remoteproto.RegisterKVServer(grpcServer, kvServer)
@@ -339,7 +340,7 @@ func setupDatabases(t *testing.T, logger log.Logger) (writeDBs []kv.TemporalRwDB
 		//mdbx.New(dbcfg.ChainDB, logger).InMem(t, "").MustOpen(), // for remote db
 	}
 
-	conn := bufconn.Listen(1024 * 1024)
+	conn := bufconn.Listen(common.Mebi)
 
 	grpcServer := grpc.NewServer()
 	f2 := func() {

--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -33,6 +33,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dir"
 	dir2 "github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -422,7 +423,7 @@ func (c *Compressor) fsync(f *os.File) error {
 // superstringLimit limits how large can one "superstring" get before it is processed
 // CompressorSequential allocates 7 bytes for each uint of superstringLimit. For example,
 // superstingLimit 16m will result in 112Mb being allocated for various arrays
-const superstringLimit = 16 * 1024 * 1024
+const superstringLimit = 16 * common.Mebi
 
 type DictionaryBuilder struct {
 	lastWord      []byte
@@ -1008,7 +1009,7 @@ func (f *RawWordsFile) ForEach(walker func(v []byte, compressed bool) error) err
 	}
 	r := bufiopool.Reader(f.f)
 	defer bufiopool.PutReader(r)
-	buf := make([]byte, 16*1024)
+	buf := make([]byte, 16*common.Kibi)
 	l, e := binary.ReadUvarint(r)
 	for ; e == nil; l, e = binary.ReadUvarint(r) {
 		// extract lowest bit of length prefix as "uncompressed" flag and shift to obtain correct length

--- a/db/seg/parallel_compress.go
+++ b/db/seg/parallel_compress.go
@@ -699,7 +699,7 @@ func compressWithPatternCandidates(ctx context.Context, trace bool, cfg Cfg, log
 	hc.w = cw
 	r := bufiopool.Reader(intermediateFile)
 	defer bufiopool.PutReader(r)
-	copyNBuf := make([]byte, 32*1024)
+	copyNBuf := make([]byte, 32*common.Kibi)
 
 	var l uint64
 	var e error

--- a/db/state/changeset/state_changeset.go
+++ b/db/state/changeset/state_changeset.go
@@ -317,7 +317,7 @@ func deserializeKeys(in []byte) [kv.DomainLen][]kv.DomainEntryDiff {
 }
 
 const DiffChunkKeyLen = 48
-const DiffChunkLen = 4*1024 - 32
+const DiffChunkLen = 4*common.Kibi - 32
 
 type threadSafeBuf struct {
 	b []byte

--- a/db/state/changeset/state_changeset_test.go
+++ b/db/state/changeset/state_changeset_test.go
@@ -200,7 +200,7 @@ func BenchmarkSerializeDiffSet(b *testing.B) {
 		})
 	}
 
-	out := make([]byte, 0, 128*1024)
+	out := make([]byte, 0, 128*common.Kibi)
 	b.ResetTimer()
 	b.ReportAllocs()
 

--- a/diagnostics/mem/mem_linux.go
+++ b/diagnostics/mem/mem_linux.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/shirou/gopsutil/v4/process"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/diagnostics/metrics"
 )
 
@@ -60,7 +61,7 @@ func ReadVirtualMemStats() (process.MemoryMapsStat, error) {
 		field := val.Field(i)
 
 		if field.Kind() == reflect.Uint64 {
-			field.SetUint(field.Interface().(uint64) * 1024)
+			field.SetUint(field.Interface().(uint64) * common.Kibi)
 		}
 	}
 

--- a/execution/cache/cache_test.go
+++ b/execution/cache/cache_test.go
@@ -295,7 +295,7 @@ func TestCodeCache_AddrCapacityLimit(t *testing.T) {
 		return []byte{0x60, byte(i >> 8), byte(i)}
 	}
 
-	c := closeOnCleanup(t, NewCodeCache(1024*1024, 1024*28)) // 1MB code, ~1024 addr LRU entries
+	c := closeOnCleanup(t, NewCodeCache(common.Mebi, 28*common.Kibi)) // 1MB code, ~1024 addr LRU entries
 	for i := range 1100 {
 		c.Put(wideAddr(i), wideCode(i), 0)
 	}
@@ -329,7 +329,7 @@ func TestCodeCache_AddrCapacityLimit(t *testing.T) {
 func TestCodeCache_CodeCapacityLimit(t *testing.T) {
 	// Tiny byte budget → a 1-entry code layer cap. Successive distinct codes
 	// LRU-evict the coldest rather than freezing the layer.
-	c := closeOnCleanup(t, NewCodeCache(25, 1024*1024)) // 25 bytes code, 1MB addr
+	c := closeOnCleanup(t, NewCodeCache(25, common.Mebi)) // 25 bytes code, 1MB addr
 
 	c.Put(makeAddr(1), makeCode(1), 0)
 	c.Put(makeAddr(2), makeCode(2), 0)
@@ -395,7 +395,7 @@ func TestCodeCache_PrintStatsAndReset_NoOps(t *testing.T) {
 }
 
 func TestCodeCache_GetMissingCode(t *testing.T) {
-	c := closeOnCleanup(t, NewCodeCache(1024*1024, 1024*1024)) // 1MB each
+	c := closeOnCleanup(t, NewCodeCache(common.Mebi, common.Mebi)) // 1MB each
 
 	// Manually set addr mapping without code (simulates capacity limit scenario)
 	addr := makeAddr(1)

--- a/execution/cache/code_cache.go
+++ b/execution/cache/code_cache.go
@@ -51,7 +51,7 @@ const (
 	// the resident-code skew (hot contracts run 10-24 KB) rather than the raw
 	// average so the cap keeps RAM near the budget instead of several × over; the
 	// persistent (MDBX-backed) cold tier backstops entries the tighter cap evicts.
-	avgCodeEntryBytes = 12 * 1024
+	avgCodeEntryBytes = 12 * common.Kibi
 	// codeSizeEntryBytes is the resident cost of one size-layer slot (freelru
 	// element holding size/keyHash/txNum/epoch), used to map the size-layer entry
 	// ceiling to an envelope byte budget.
@@ -658,9 +658,9 @@ func (c *CodeCache) PrintStatsAndReset() {
 		"code_hit_rate", codeHitRate,
 		"addr_entries", c.addrToHash.Len(),
 		"code_entries", c.CodeLen(),
-		"addr_size_mb", addrSizeB/(1024*1024),
+		"addr_size_mb", addrSizeB/common.Mebi,
 		"addr_usage_pct", addrUsagePct,
-		"code_size_mb", codeSizeB/(1024*1024),
+		"code_size_mb", codeSizeB/common.Mebi,
 		"code_usage_pct", codeUsagePct,
 	)
 }

--- a/execution/cache/code_store.go
+++ b/execution/cache/code_store.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/maypok86/otter/v2"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 )
 
@@ -54,8 +55,8 @@ func (s *CodeStore) Stats() (memHits, tableHits, misses uint64) {
 }
 
 const (
-	DefaultCodeStoreMemBytes   = 256 * 1024 * 1024
-	DefaultCodeStoreTableBytes = 1024 * 1024 * 1024
+	DefaultCodeStoreMemBytes   = 256 * common.Mebi
+	DefaultCodeStoreTableBytes = common.Gibi
 )
 
 func NewCodeStore(memCapBytes, tableCapBytes uint64) *CodeStore {

--- a/execution/cache/generic_cache.go
+++ b/execution/cache/generic_cache.go
@@ -26,6 +26,7 @@ import (
 	"github.com/c2h5oh/datasize"
 	"github.com/elastic/go-freelru"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/cachebudget"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/maphash"
@@ -566,7 +567,7 @@ func (c *GenericCache[T]) PrintStatsAndReset(name string) {
 		"hits", hits, "misses", misses, "hit_rate", hitRate,
 		"inserts", inserts, "evictions", evictions, "dropped", dropped,
 		"stale_evicted", staleEvicted, "epoch", c.coh.Epoch(),
-		"entries", c.data.Load().Len(), "size_mb", sizeBytes/(1024*1024),
+		"entries", c.data.Load().Len(), "size_mb", sizeBytes/common.Mebi,
 		"capacity_mb", int64(c.capacityB/datasize.MB), "usage_pct", usagePct,
 	)
 }

--- a/execution/commitment/adaptive_pin.go
+++ b/execution/commitment/adaptive_pin.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 )
 
@@ -43,9 +44,9 @@ func DefaultAdaptivePinControllerConfig() AdaptivePinControllerConfig {
 		PromoteThresholdMisses:    100,
 		MaxPromotedContracts:      4,
 		DemoteCooldownBlocks:      5,
-		InitialViewBudgetBytes:    4 * 1024 * 1024,
-		ExtensionBudgetBytes:      8 * 1024 * 1024,
-		PerContractMaxBudgetBytes: 32 * 1024 * 1024,
+		InitialViewBudgetBytes:    4 * common.Mebi,
+		ExtensionBudgetBytes:      8 * common.Mebi,
+		PerContractMaxBudgetBytes: 32 * common.Mebi,
 	}
 }
 

--- a/execution/commitment/branch_cache.go
+++ b/execution/commitment/branch_cache.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/maphash"
 	"github.com/erigontech/erigon/execution/cache/coherence"
@@ -830,6 +831,6 @@ func (c *BranchCache) Stats() string {
 		kh, km, pct(kh, km),
 		ph, pm, pct(ph, pm), int(c.pinnedEntries.Load()),
 		th, tm, pct(th, tm), c.tailLen(),
-		float64(bb)/1024/1024, c.staleEvicted.Load(),
+		float64(bb)/common.Mebi, c.staleEvicted.Load(),
 	)
 }

--- a/execution/commitment/parallel_update.go
+++ b/execution/commitment/parallel_update.go
@@ -18,6 +18,8 @@ package commitment
 
 import (
 	"sync"
+
+	"github.com/erigontech/erigon/common"
 )
 
 // plainKeyArena hands out stable plainKey copies; a full chunk is replaced, not
@@ -26,7 +28,7 @@ type plainKeyArena struct {
 	buf []byte
 }
 
-const plainKeyArenaChunk = 64 * 1024
+const plainKeyArenaChunk = 64 * common.Kibi
 
 func (a *plainKeyArena) intern(b []byte) []byte {
 	if len(b) > plainKeyArenaChunk {

--- a/execution/commitment/prefix_trie.go
+++ b/execution/commitment/prefix_trie.go
@@ -19,11 +19,12 @@ package commitment
 import (
 	"math/bits"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/commitment/nibbles"
 )
 
 const prefixSlabSize = 16384
-const prefixExtChunkSize = 64 * 1024
+const prefixExtChunkSize = 64 * common.Kibi
 
 // prefixNode is a path-compressed prefix-trie node keyed on nibbles (each ext byte is one nibble 0x00..0x0F).
 // children is dense: len == popcount(bitmap). subtreeCount is the number of distinct keys in the

--- a/execution/commitment/streaming_commitment.go
+++ b/execution/commitment/streaming_commitment.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/db/kv"
 )
 
@@ -609,7 +610,7 @@ type keyArena struct {
 	remaining int
 }
 
-const keyArenaChunk = 64 * 1024
+const keyArenaChunk = 64 * common.Kibi
 
 func (a *keyArena) copy(hk []byte) []byte {
 	if len(hk) > cap(a.buf)-len(a.buf) {

--- a/execution/commitment/trie/hasher.go
+++ b/execution/commitment/trie/hasher.go
@@ -38,7 +38,7 @@ type hasher struct {
 
 	valueNodesRlpEncoded bool
 	prefixBuf            [8]byte
-	buffers              [1024 * 1024]byte
+	buffers              [common.Mebi]byte
 }
 
 const rlpPrefixLength = 4

--- a/execution/engineapi/engine_server_getblobs_bench_test.go
+++ b/execution/engineapi/engine_server_getblobs_bench_test.go
@@ -129,7 +129,7 @@ func BenchmarkEngineGetBlobsV3(b *testing.B) {
 			respBytes, err := getBlobsRaw()
 			require.NoError(b, err)
 			require.Greater(b, respBytes, minRespBytes, "response must carry the blobs")
-			b.Logf("getBlobsV3 over JSON-RPC: %d blobs, %d cell proofs/blob, ~%d KiB response (client decode excluded)", len(tc.hashes), params.CellsPerExtBlob, respBytes/1024)
+			b.Logf("getBlobsV3 over JSON-RPC: %d blobs, %d cell proofs/blob, ~%d KiB response (client decode excluded)", len(tc.hashes), params.CellsPerExtBlob, respBytes/common.Kibi)
 
 			b.SetBytes(respBytes)
 			b.ReportAllocs()

--- a/execution/engineapi/engine_server_getpayload_bench_test.go
+++ b/execution/engineapi/engine_server_getpayload_bench_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/jwt"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/testlog"
@@ -144,7 +145,7 @@ func BenchmarkEngineGetPayloadWithBlobs(b *testing.B) {
 
 	respBytes, err := getPayloadRaw()
 	require.NoError(b, err)
-	b.Logf("%s over JSON-RPC: %d blobs in bundle, ~%d KiB response (client decode excluded)", method, len(built.BlobsBundle.Blobs), respBytes/1024)
+	b.Logf("%s over JSON-RPC: %d blobs in bundle, ~%d KiB response (client decode excluded)", method, len(built.BlobsBundle.Blobs), respBytes/common.Kibi)
 
 	b.SetBytes(respBytes)
 	b.ReportAllocs()

--- a/execution/engineapi/engineapitester/engine_x_leak_test.go
+++ b/execution/engineapi/engineapitester/engine_x_leak_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/common/testlog"
 	"github.com/erigontech/erigon/execution/engineapi/engineapitester"
@@ -131,7 +132,7 @@ func printSample(t *testing.T, iter int) {
 		vmKb/1024/1024,
 		mapsLines,
 		runtime.NumGoroutine(),
-		ms.HeapAlloc/(1024*1024),
+		ms.HeapAlloc/common.Mebi,
 	)
 }
 

--- a/execution/protocol/params/protocol.go
+++ b/execution/protocol/params/protocol.go
@@ -146,10 +146,10 @@ const (
 	ElasticityMultiplier               = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
 	InitialBaseFee                     = 1000000000 // Initial base fee for EIP-1559 blocks.
 
-	MaxCodeSize              = 24 * 1024                // Maximum bytecode to permit for a contract
-	MaxCodeSizeAhmedabad     = 32 * 1024                // Maximum bytecode to permit for a contract post Ahmedabad hard fork (bor / polygon pos) (32KB)
+	MaxCodeSize              = 24 * common.Kibi         // Maximum bytecode to permit for a contract
+	MaxCodeSizeAhmedabad     = 32 * common.Kibi         // Maximum bytecode to permit for a contract post Ahmedabad hard fork (bor / polygon pos) (32KB)
 	MaxInitCodeSize          = 2 * MaxCodeSize          // Maximum initcode to permit in a creation transaction and create instructions
-	MaxCodeSizeAmsterdam     = 64 * 1024                // EIP-7954: Increase Maximum Contract Size
+	MaxCodeSizeAmsterdam     = 64 * common.Kibi         // EIP-7954: Increase Maximum Contract Size
 	MaxInitCodeSizeAmsterdam = 2 * MaxCodeSizeAmsterdam // EIP-7954: Increase Maximum Contract Size
 
 	// Precompiled contract gas prices

--- a/execution/protocol/rules/ethash/algorithm_test.go
+++ b/execution/protocol/rules/ethash/algorithm_test.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 
 	"github.com/erigontech/erigon/common/length"
@@ -64,7 +65,7 @@ func TestCacheGeneration(t *testing.T) {
 		cache []byte
 	}{
 		{
-			size:  1024,
+			size:  common.Kibi,
 			epoch: 0,
 			cache: hexutil.MustDecode("0x" +
 				"7ce2991c951f7bf4c4c1bb119887ee07871eb5339d7b97b8588e85c742de90e5bafd5bbe6ce93a134fb6be9ad3e30db99d9528a2ea7846833f52e9ca119b6b54" +
@@ -85,7 +86,7 @@ func TestCacheGeneration(t *testing.T) {
 				"845f64fd8324bb85312979dead74f764c9677aab89801ad4f927f1c00f12e28f22422bb44200d1969d9ab377dd6b099dc6dbc3222e9321b2c1e84f8e2f07731c"),
 		},
 		{
-			size:  1024,
+			size:  common.Kibi,
 			epoch: 1,
 			cache: hexutil.MustDecode("0x" +
 				"1f56855d59cc5a085720899b4377a0198f1abe948d85fe5820dc0e346b7c0931b9cde8e541d751de3b2b3275d0aabfae316209d5879297d8bd99f8a033c9d4df" +
@@ -128,8 +129,8 @@ func TestDatasetGeneration(t *testing.T) {
 	}{
 		{
 			epoch:       0,
-			cacheSize:   1024,
-			datasetSize: 32 * 1024,
+			cacheSize:   common.Kibi,
+			datasetSize: 32 * common.Kibi,
 			dataset: hexutil.MustDecode("0x" +
 				"4bc09fbd530a041dd2ec296110a29e8f130f179c59d223f51ecce3126e8b0c74326abc2f32ccd9d7f976bd0944e3ccf8479db39343cbbffa467046ca97e2da63" +
 				"da5f9d9688c7c33ab7b8aace570e422fa48b24659b72fc534669209d66389ca15b099c5604601e7581488e3bd6925cec0f12d465f8004d4fa84793f8e1e46a1b" +
@@ -666,10 +667,10 @@ func TestDatasetGeneration(t *testing.T) {
 // datasets.
 func TestHashimoto(t *testing.T) {
 	// Create the verification cache and mining dataset
-	cache := make([]uint32, 1024/4)
+	cache := make([]uint32, common.Kibi/4)
 	generateCache(cache, 0, make([]byte, 32))
 
-	dataset := make([]uint32, 32*1024/4)
+	dataset := make([]uint32, 32*common.Kibi/4)
 	generateDataset(dataset, 0, cache)
 
 	// Create a block to verify
@@ -679,7 +680,7 @@ func TestHashimoto(t *testing.T) {
 	wantDigest := hexutil.MustDecode("0xe4073cffaef931d37117cefd9afd27ea0f1cad6a981dd2605c4a1ac97c519800")
 	wantResult := hexutil.MustDecode("0xd3539235ee2e6f8db665c0a72169f55b7f6c605712330b778ec3944f0eb5a557")
 
-	digest, result := hashimotoLight(32*1024, cache, hash, nonce)
+	digest, result := hashimotoLight(32*common.Kibi, cache, hash, nonce)
 	if !bytes.Equal(digest, wantDigest) {
 		t.Errorf("light hashimoto digest mismatch: have %x, want %x", digest, wantDigest)
 	}

--- a/execution/protocol/rules/ethash/ethash.go
+++ b/execution/protocol/rules/ethash/ethash.go
@@ -37,6 +37,7 @@ import (
 	"github.com/edsrzf/mmap-go"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	dir2 "github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -359,7 +360,7 @@ func (d *dataset) generate(dir string, limit int, lock bool, test bool) {
 		seed := seedHash(d.epoch*epochLength + 1)
 		if test {
 			csize = 1024
-			dsize = 32 * 1024
+			dsize = 32 * common.Kibi
 		}
 		// If we don't store anything on disk, generate and return
 		if dir == "" {

--- a/execution/protocol/rules/ethash/rules.go
+++ b/execution/protocol/rules/ethash/rules.go
@@ -375,7 +375,7 @@ func (ethash *Ethash) verifySeal(header *types.Header, fulldag bool) error { //n
 
 		size := datasetSize(number)
 		if ethash.config.PowMode == ethashcfg.ModeTest {
-			size = 32 * 1024
+			size = 32 * common.Kibi
 		}
 		digest, result = hashimotoLight(size, cache.cache, sealHash[:], header.Nonce.Uint64())
 

--- a/execution/state/log_arena.go
+++ b/execution/state/log_arena.go
@@ -50,7 +50,7 @@ const (
 	// Slots the arena keeps between resets. The run is a block for a caller that
 	// resets per block, so this is bounded by the memory it costs rather than by
 	// a transaction's budget: 32KB of pointers, holding the p99 block of 1706.
-	maxRetainedLogSlots = 32 * 1024 / 8
+	maxRetainedLogSlots = 32 * common.Kibi / 8
 )
 
 // logArena owns a block's log entries and recycles them through a pool, so what

--- a/execution/state/log_arena_test.go
+++ b/execution/state/log_arena_test.go
@@ -388,7 +388,7 @@ func BenchmarkLogEmitWorstCaseTx(b *testing.B) {
 		ibs.Reset()
 	}
 	b.ReportMetric(float64(len(ibs.logs.pool)), "pooled")
-	b.ReportMetric(float64(ibs.logs.poolBytes)/1024, "poolKB")
+	b.ReportMetric(float64(ibs.logs.poolBytes)/common.Kibi, "poolKB")
 }
 
 // Blocks whose transactions each emit a 64KB log — the shape an attack sends.
@@ -398,7 +398,7 @@ func BenchmarkLogEmitLargeDataPerTx(b *testing.B) {
 	log := &types.Log{
 		Address: common.HexToAddress("0x1"),
 		Topics:  []common.Hash{common.HexToHash("0xaa")},
-		Data:    bytes.Repeat([]byte{0x11}, 64*1024+1),
+		Data:    bytes.Repeat([]byte{0x11}, 64*common.Kibi+1),
 	}
 	for _, txs := range []int{16, 100} {
 		b.Run(fmt.Sprintf("txs=%d", txs), func(b *testing.B) {
@@ -468,7 +468,7 @@ func BenchmarkLogEmitShiftingShape(b *testing.B) {
 	entries, slotCap, dataBytes := retainedLogs(ibs)
 	b.ReportMetric(float64(slotCap), "slots")
 	b.ReportMetric(float64(entries), "entries")
-	b.ReportMetric(float64(dataBytes)/1024, "retainedKB")
+	b.ReportMetric(float64(dataBytes)/common.Kibi, "retainedKB")
 }
 
 func BenchmarkLogEmitAndResetPerTx(b *testing.B) {
@@ -706,5 +706,5 @@ func TestArenaRetentionStaysBounded(t *testing.T) {
 	require.LessOrEqual(t, ibs.logs.poolBytes, maxPooledLogBytes, "pooled Data")
 
 	held := slotBytes + len(ibs.logs.pool)*304 + ibs.logs.poolBytes
-	require.Less(t, held, 3<<20, "an arena holds %dKB after mixed traffic", held/1024)
+	require.Less(t, held, 3*common.Mebi, "an arena holds %dKB after mixed traffic", held/common.Kibi)
 }

--- a/execution/tracing/tracers/util.go
+++ b/execution/tracing/tracers/util.go
@@ -22,10 +22,12 @@ import (
 	"math"
 
 	"github.com/holiman/uint256"
+
+	"github.com/erigontech/erigon/common"
 )
 
 const (
-	memoryPadLimit = 1024 * 1024
+	memoryPadLimit = common.Mebi
 )
 
 // GetMemoryCopyPadded returns offset + size as a new slice.

--- a/execution/types/block.go
+++ b/execution/types/block.go
@@ -627,7 +627,7 @@ func (h *Header) SanityCheck() error {
 	if diffLen := h.Difficulty.BitLen(); diffLen > 192 {
 		return fmt.Errorf("too large block difficulty: bitlen %d", diffLen)
 	}
-	if eLen := len(h.Extra); eLen > 100*1024 {
+	if eLen := len(h.Extra); eLen > 100*common.Kibi {
 		return fmt.Errorf("too large block extradata: size %d", eLen)
 	}
 	if h.BaseFee != nil {

--- a/execution/types/rlp_fuzzer_test.go
+++ b/execution/types/rlp_fuzzer_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/holiman/uint256"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/rlp"
 )
 
@@ -51,7 +52,7 @@ func FuzzRLP(f *testing.F) {
 }
 
 func fuzzRlp(t *testing.T, input []byte) {
-	if len(input) == 0 || len(input) > 500*1024 {
+	if len(input) == 0 || len(input) > 500*common.Kibi {
 		return
 	}
 	rlp.Split(input)

--- a/execution/vm/benchmark/bench_interpreter_test.go
+++ b/execution/vm/benchmark/bench_interpreter_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/vm"
 	"github.com/erigontech/erigon/execution/vm/program"
 )
@@ -174,8 +175,8 @@ func formatGas(gas uint64) string {
 
 func formatSize(size int) string {
 	switch {
-	case size >= 1024:
-		return fmt.Sprintf("%dKB", size/1024)
+	case size >= common.Kibi:
+		return fmt.Sprintf("%dKB", size/common.Kibi)
 	default:
 		return fmt.Sprintf("%dB", size)
 	}

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -85,7 +85,7 @@ var LightClientGPO = gaspricecfg.Config{
 var Defaults = Config{
 	Sync: Sync{
 		ExecWorkerCount:            dbg.Exec3Workers, //only half of CPU, other half will spend for snapshots build/merge/prune
-		BodyCacheLimit:             256 * 1024 * 1024,
+		BodyCacheLimit:             256 * common.Mebi,
 		BodyDownloadTimeoutSeconds: 2,
 		//LoopBlockLimit:             100_000,
 		ParallelStateFlushing:    true,

--- a/node/rpcstack_gzip_bench_test.go
+++ b/node/rpcstack_gzip_bench_test.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/erigontech/erigon/common"
 )
 
 const rpcEndpoint = "http://localhost:8545"
@@ -156,7 +158,7 @@ func measureHandlerLatency(t testing.TB, payload []byte, wrap func(http.Handler)
 		resp.Body.Close()
 		latencies = append(latencies, time.Since(start))
 	}
-	return computeStats(latencies, len(payload)/1024)
+	return computeStats(latencies, len(payload)/common.Kibi)
 }
 
 // measureRPCLatency measures end-to-end latency of a real rpcdaemon at endpoint.
@@ -185,7 +187,7 @@ func measureRPCLatency(t testing.TB, endpoint, blockTag string) latencyStats {
 		data, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if i == 0 {
-			payloadKB = len(data) / 1024
+			payloadKB = len(data) / common.Kibi
 		}
 	}
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/event"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -48,7 +49,7 @@ var (
 const (
 	baseProtocolVersion    = 5
 	baseProtocolLength     = uint64(16)
-	baseProtocolMaxMsgSize = 2 * 1024
+	baseProtocolMaxMsgSize = 2 * common.Kibi
 
 	snappyProtocolVersion = 5
 

--- a/p2p/protocols/eth/handler.go
+++ b/p2p/protocols/eth/handler.go
@@ -33,7 +33,7 @@ const (
 	// It is a soft, per-block-boundary limit: once the running total exceeds this
 	// threshold the server stops adding more blocks, but the current block is
 	// still included in full. Used by all protocol versions (eth/68–70).
-	softResponseLimit = 2 * 1024 * 1024
+	softResponseLimit = 2 * common.Mebi
 
 	// Eth70ResponseSizeLimit is the hard, per-receipt limit introduced in eth/70.
 	// Unlike softResponseLimit, it can cut a block's receipt list short (setting

--- a/p2p/protocols/eth/handlers_test.go
+++ b/p2p/protocols/eth/handlers_test.go
@@ -321,7 +321,7 @@ func TestAnswerGetReceiptsQueryCacheOnly70_LastBlockIncomplete(t *testing.T) {
 	// Create receipts with large log data to force truncation
 	var bigReceipts types.Receipts
 	for i := range 20 {
-		bigReceipts = append(bigReceipts, makeReceipt(uint64(i+1)*100, 1024*1024)) // 1MB log data each
+		bigReceipts = append(bigReceipts, makeReceipt(uint64(i+1)*100, common.Mebi)) // 1MB log data each
 	}
 	getter := &mockReceiptsGetter{
 		cached: map[common.Hash]types.Receipts{
@@ -363,7 +363,7 @@ func TestAnswerGetReceiptsQueryCacheOnly70_MultipleBlocksTruncatesLast(t *testin
 	// Second block: very large receipts that force truncation
 	var bigReceipts types.Receipts
 	for i := range 20 {
-		bigReceipts = append(bigReceipts, makeReceipt(uint64(i+1)*100, 1024*1024))
+		bigReceipts = append(bigReceipts, makeReceipt(uint64(i+1)*100, common.Mebi))
 	}
 	getter := &mockReceiptsGetter{
 		cached: map[common.Hash]types.Receipts{
@@ -624,7 +624,7 @@ func TestAnswerGetBlockAccessListsQuery_SoftSizeLimit(t *testing.T) {
 	// Each BAL just over 1 MiB so that three of them exceed softResponseLimit (2 MiB)
 	// but the first two plus the current entry still trigger the break after the
 	// second full BAL is appended.
-	balSize := 1024*1024 + 1
+	balSize := common.Mebi + 1
 	big := make([]byte, balSize)
 	for i := range big {
 		big[i] = byte(i)

--- a/p2p/protocols/eth/protocol.go
+++ b/p2p/protocols/eth/protocol.go
@@ -53,7 +53,7 @@ var ProtocolToString = map[uint]string{
 const ProtocolName = "eth"
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
-const maxMessageSize = 10 * 1024 * 1024
+const maxMessageSize = 10 * common.Mebi
 const ProtocolMaxMsgSize = maxMessageSize
 
 var ProtocolLengths = map[uint]uint64{ETH68: 17, ETH69: 18, ETH70: 18, ETH71: 20}

--- a/p2p/protocols/wit/protocol.go
+++ b/p2p/protocols/wit/protocol.go
@@ -31,13 +31,13 @@ var ProtocolVersions = []uint{WIT1}
 var ProtocolLengths = map[uint]uint64{WIT1: 4}
 
 // MaxMessageSize is the maximum cap on the size of a protocol message.
-const MaxMessageSize = 16 * 1024 * 1024
+const MaxMessageSize = 16 * common.Mebi
 
 // Witness Response constants
 const (
-	PageSize                       = 15 * 1024 * 1024  // 15 MB
-	MaximumCachedWitnessOnARequest = 200 * 1024 * 1024 // 200 MB, the maximum amount of memory a request can demand while getting witness
-	MaximumResponseSize            = 16 * 1024 * 1024  // 16 MB, helps to fast fail check
+	PageSize                       = 15 * common.Mebi  // 15 MB
+	MaximumCachedWitnessOnARequest = 200 * common.Mebi // 200 MB, the maximum amount of memory a request can demand while getting witness
+	MaximumResponseSize            = 16 * common.Mebi  // 16 MB, helps to fast fail check
 
 	// MaxWitnessPages caps the TotalPages a peer may advertise in a response. A
 	// legitimate witness fits in MaximumCachedWitnessOnARequest bytes split into

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	maxRequestContentLength = 1024 * 1024 * 32 // 32MB
+	maxRequestContentLength = 32 * common.Mebi // 32MB
 	contentType             = "application/json"
 	jwtTokenExpiry          = 60 * time.Second
 )

--- a/rpc/jsonrpc/witness_cache.go
+++ b/rpc/jsonrpc/witness_cache.go
@@ -25,19 +25,16 @@ import (
 	"github.com/erigontech/erigon/common"
 )
 
-const (
-	witnessCacheMaxBlocks = 96
-	bytesPerMB            = 1024 * 1024
-)
+const witnessCacheMaxBlocks = 96
 
 // witnessCacheMaxBytes converts a MB byte-cap to bytes, clamping to avoid int
 // overflow on 32-bit builds or absurd values. 0 stays 0 (byte cap disabled).
 func witnessCacheMaxBytes(mb uint) int {
-	const maxMB = uint(math.MaxInt / bytesPerMB)
+	const maxMB = uint(math.MaxInt / common.Mebi)
 	if mb > maxMB {
 		mb = maxMB
 	}
-	return int(mb) * bytesPerMB
+	return int(mb) * common.Mebi
 }
 
 // witnessResultCache maps a canonical block hash to its pre-marshaled legacy-mode

--- a/rpc/mcp/handlers_logs.go
+++ b/rpc/mcp/handlers_logs.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/erigontech/erigon/common"
 )
 
 // logTools implements the logs_* tool handlers.
@@ -168,8 +170,8 @@ func readLogTail(filename string, lines int, filter string) ([]string, error) {
 	scanner := bufio.NewScanner(file)
 
 	// Increase buffer size for long log lines
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	buf := make([]byte, 0, 64*common.Kibi)
+	scanner.Buffer(buf, common.Mebi)
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -200,8 +202,8 @@ func readLogHead(filename string, lines int, filter string) ([]string, error) {
 	scanner := bufio.NewScanner(file)
 
 	// Increase buffer size for long log lines
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	buf := make([]byte, 0, 64*common.Kibi)
+	scanner.Buffer(buf, common.Mebi)
 
 	count := 0
 	for scanner.Scan() && count < lines {
@@ -231,8 +233,8 @@ func grepLog(filename, pattern string, maxLines int, caseInsensitive bool) ([]st
 	scanner := bufio.NewScanner(file)
 
 	// Increase buffer size for long log lines
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	buf := make([]byte, 0, 64*common.Kibi)
+	scanner.Buffer(buf, common.Mebi)
 
 	searchPattern := pattern
 	if caseInsensitive {
@@ -279,8 +281,8 @@ func getLogStats(filename string) (map[string]any, error) {
 	var infoLines int
 
 	scanner := bufio.NewScanner(file)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	buf := make([]byte, 0, 64*common.Kibi)
+	scanner.Buffer(buf, common.Mebi)
 
 	for scanner.Scan() {
 		totalLines++
@@ -303,7 +305,7 @@ func getLogStats(filename string) (map[string]any, error) {
 	stats := map[string]any{
 		"file_name":    filepath.Base(filename),
 		"file_size":    fileInfo.Size(),
-		"file_size_mb": float64(fileInfo.Size()) / (1024 * 1024),
+		"file_size_mb": float64(fileInfo.Size()) / common.Mebi,
 		"modified":     fileInfo.ModTime().Format("2006-01-02 15:04:05"),
 		"total_lines":  totalLines,
 		"error_lines":  errorLines,

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -34,6 +34,7 @@ import (
 	"github.com/coder/websocket"
 	mapset "github.com/deckarep/golang-set/v2"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/kv"
 )
@@ -41,7 +42,7 @@ import (
 const (
 	wsPingInterval     = 60 * time.Second
 	wsPingWriteTimeout = 5 * time.Second
-	wsMessageSizeLimit = 32 * 1024 * 1024
+	wsMessageSizeLimit = 32 * common.Mebi
 )
 
 // WebsocketHandler returns a handler that serves JSON-RPC to WebSocket connections.

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -65,7 +65,7 @@ import (
 // txMaxBroadcastSize is the max size of a transaction that will be broadcast.
 // All transactions with a higher size will be announced and need to be fetched
 // by the peer.
-const txMaxBroadcastSize = 4 * 1024
+const txMaxBroadcastSize = 4 * common.Kibi
 
 // Pool is interface for the transaction pool
 // This interface exists for the convenience of testing, and not yet because
@@ -1329,7 +1329,7 @@ func (p *TxPool) ValidateSerializedTxn(serializedTxn []byte) error {
 		// takes up based on its size. The slots are used as DoS protection, ensuring
 		// that validating a new transaction remains a constant operation (in reality
 		// O(maxslots), where max slots are 4 currently).
-		txnSlotSize = 32 * 1024
+		txnSlotSize = 32 * common.Kibi
 
 		// txnMaxSize is the maximum size a single transaction can have. This field has
 		// non-trivial consequences: larger transactions are significantly harder and
@@ -1338,7 +1338,7 @@ func (p *TxPool) ValidateSerializedTxn(serializedTxn []byte) error {
 		txnMaxSize = 4 * txnSlotSize // 128KB
 
 		// Should be enough for a transaction with 6 blobs
-		blobTxnMaxSize = 1024 * 1024
+		blobTxnMaxSize = common.Mebi
 	)
 	txnType, err := PeekTransactionType(serializedTxn)
 	if err != nil {
@@ -2354,7 +2354,7 @@ func (p *TxPool) Run(ctx context.Context) error {
 					continue
 				}
 				writeToDBBytesCounter.SetUint64(written)
-				p.logger.Debug("[txpool] Commit", "written_kb", written/1024, "in", time.Since(t))
+				p.logger.Debug("[txpool] Commit", "written_kb", written/common.Kibi, "in", time.Since(t))
 			}
 		case <-dormancySweep.C:
 			if p.Started() {

--- a/txnprovider/txpool/send.go
+++ b/txnprovider/txpool/send.go
@@ -24,6 +24,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/node/gointerfaces/sentryproto"
 	"github.com/erigontech/erigon/p2p/sentry/libsentry"
@@ -51,7 +52,7 @@ func NewSend(ctx context.Context, sentryClients []sentryproto.SentryClient, logg
 const (
 	// This is the target size for the packs of transactions or announcements. A
 	// pack can get larger than this if a single transactions exceeds this size.
-	p2pTxPacketLimit = 100 * 1024
+	p2pTxPacketLimit = 100 * common.Kibi
 )
 
 func (f *Send) notifyTests() {


### PR DESCRIPTION
Closes #14688.

Adds Kibi/Mebi/Gibi/Tebi to package common and uses them for byte sizes.
They're untyped because array lengths and constants like MaxCodeSize need
a plain int, which datasize.ByteSize isn't. Where the value is already a
datasize.ByteSize, I used datasize's own constant.

No values change. The 1024s that mean counts are left alone, and so are
the shift forms, except the line from your example and two that sit next
to a conversion. It's a mechanical pass, so I didn't add tests.

Happy to take the shifts too, here or in a separate PR, whichever you
prefer.
