### PR TITLE
execution/execmodule: propagate canonicality lookup errors

### DIFF
--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -413,7 +413,14 @@ func (e *ExecModule) drainReadAhead() {
 
 func (e *ExecModule) unwindToCommonCanonical(sd *execctx.SharedDomains, tx kv.TemporalRwTx, header *types.Header) error {
 	currentHeader := header
-	for isCanonical, err := e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash()); !isCanonical && err == nil; isCanonical, err = e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash()) {
+	for {
+		isCanonical, err := e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash())
+		if err != nil {
+			return err
+		}
+		if isCanonical {
+			break
+		}
 		parentBlockHash, parentBlockNum := currentHeader.ParentHash, currentHeader.Number.Uint64()-1
 		currentHeader, err = e.getHeader(e.bacgroundCtx, tx, parentBlockHash, parentBlockNum)
 		if err != nil {

--- a/execution/execmodule/exec_module_internal_test.go
+++ b/execution/execmodule/exec_module_internal_test.go
@@ -17,13 +17,37 @@
 package execmodule
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
+	"github.com/erigontech/erigon/db/dbservices"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/execution/types"
 )
+
+type headerNumberErrorReader struct {
+	dbservices.FullBlockReader
+	err error
+}
+
+func (r headerNumberErrorReader) HeaderNumber(context.Context, kv.Getter, common.Hash) (*uint64, error) {
+	return nil, r.err
+}
+
+type emptyStageProgressTx struct {
+	kv.TemporalRwTx
+}
+
+func (emptyStageProgressTx) GetOne(string, []byte) ([]byte, error) {
+	return nil, nil
+}
 
 // The module is the one owner of the domain state cache: callers pass a byte
 // budget, never a constructed cache, so a disabled cache cannot be built
@@ -43,4 +67,17 @@ func TestNewDomainStateCacheRespectsUseStateCache(t *testing.T) {
 	scDefault := newDomainStateCache(0)
 	require.NotNil(t, scDefault, "zero budget means the production default, not no cache")
 	scDefault.Close()
+}
+
+func TestUnwindToCommonCanonicalReturnsCanonicalityError(t *testing.T) {
+	expectedErr := errors.New("canonicality read failed")
+	e := &ExecModule{
+		bacgroundCtx: t.Context(),
+		blockReader:  headerNumberErrorReader{err: expectedErr},
+	}
+	header := &types.Header{Number: *uint256.NewInt(0)}
+
+	err := e.unwindToCommonCanonical(nil, emptyStageProgressTx{}, header)
+
+	require.ErrorIs(t, err, expectedErr)
 }


### PR DESCRIPTION
## Problem

`unwindToCommonCanonical` stopped walking when `isCanonicalHash` returned an error, but the loop-scoped error was then discarded. Validation could continue with a header whose canonicality was unknown and use it as the unwind point.

## Solution

Check each canonicality result explicitly. Return lookup errors immediately and stop walking only after confirming that the current header is canonical.

## Testing

- `go test ./execution/execmodule -count=1`
- `make lint`
- `make erigon integration`
