### PR TITLE
[r3.6] calcState: skip the commitment calculator's dead baseline read

### DIFF
--- a/execution/stagedsync/calc_state.go
+++ b/execution/stagedsync/calc_state.go
@@ -69,6 +69,11 @@ func (r *calcDomainReader) ReadAccountStorage(addr accounts.Address, key account
 	return val, true, nil
 }
 
+// accountBaselineReader supplies an address's pre-write account fields.
+type accountBaselineReader interface {
+	ReadAccountData(addr accounts.Address) (*accounts.Account, error)
+}
+
 // storageEnumerator lists every persisted storage slot under an address.
 type storageEnumerator interface {
 	EachStorageSlot(addr accounts.Address, fn func(key accounts.StorageKey) error) error
@@ -87,7 +92,7 @@ type calcState struct {
 	storageDirty map[accounts.Address]map[accounts.StorageKey]bool
 
 	// domainReader provides lazy-load from the domain via asOfStateReader.
-	domainReader *calcDomainReader
+	domainReader accountBaselineReader
 
 	// storageEnum enumerates an account's persisted storage subtree for
 	// self-destruct; nil disables the on-disk subtree wipe.
@@ -121,8 +126,17 @@ func newCalcState(reader *asOfStateReader, logger log.Logger, logPrefix string) 
 	}
 }
 
+// writesCoverBaseline reports whether writes set every field ensureAccount would
+// lazy-load, making the domain read dead. Normalize fills all three for every
+// address it does not drop, so this holds for all but self-destructed ones.
+func writesCoverBaseline(writes *state.WriteSet, addr accounts.Address) bool {
+	return writes.Has(state.WriteHeader{Address: addr, Path: state.BalancePath}) &&
+		writes.Has(state.WriteHeader{Address: addr, Path: state.NoncePath}) &&
+		writes.Has(state.WriteHeader{Address: addr, Path: state.CodeHashPath})
+}
+
 // ensureAccount returns the account state, lazy-loading from domain on first touch.
-func (cs *calcState) ensureAccount(addr accounts.Address) *calcAccountState {
+func (cs *calcState) ensureAccount(addr accounts.Address, writes *state.WriteSet) *calcAccountState {
 	if acc, ok := cs.accounts[addr]; ok {
 		return acc
 	}
@@ -130,7 +144,7 @@ func (cs *calcState) ensureAccount(addr accounts.Address) *calcAccountState {
 	acc := &calcAccountState{
 		CodeHash: empty.CodeHash,
 	}
-	if cs.domainReader != nil {
+	if cs.domainReader != nil && !writesCoverBaseline(writes, addr) {
 		dbAcc, err := cs.domainReader.ReadAccountData(addr)
 		if err != nil {
 			// Sticky — recorded so the next compute fails fast instead of
@@ -164,7 +178,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 	for addr, vw := range writes.SelfDestructs() {
 		sdThisCall[addr] = vw.Val
 		if vw.Val {
-			acc := cs.ensureAccount(addr)
+			acc := cs.ensureAccount(addr, writes)
 			acc.Deleted = true
 			acc.dirty = true
 			cs.deleteStorageSubtree(addr)
@@ -174,7 +188,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		return nonZero || !sdThisCall[addr]
 	}
 	for addr, vw := range writes.Balances() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.Balance = vw.Val
 		acc.dirty = true
 		if clearsDeleted(addr, !acc.Balance.IsZero()) {
@@ -182,7 +196,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		}
 	}
 	for addr, vw := range writes.Nonces() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.Nonce = vw.Val
 		acc.dirty = true
 		if clearsDeleted(addr, acc.Nonce != 0) {
@@ -190,7 +204,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		}
 	}
 	for addr, vw := range writes.CodeHashes() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.CodeHash = vw.Val.Value()
 		acc.dirty = true
 		if clearsDeleted(addr, vw.Val.Value() != empty.CodeHash) {
@@ -198,7 +212,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		}
 	}
 	for addr, vw := range writes.Codes() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.CodeHash = vw.Val.Hash.Value()
 		acc.dirty = true
 		if clearsDeleted(addr, vw.Val.Len() > 0) {
@@ -206,7 +220,7 @@ func (cs *calcState) ApplyWrites(writes *state.WriteSet, eip8246 bool) {
 		}
 	}
 	for addr, vw := range writes.Incarnations() {
-		acc := cs.ensureAccount(addr)
+		acc := cs.ensureAccount(addr, writes)
 		acc.Incarnation = vw.Val
 		acc.dirty = true
 	}

--- a/execution/stagedsync/calc_state_test.go
+++ b/execution/stagedsync/calc_state_test.go
@@ -278,6 +278,93 @@ func TestApplyWrites_BalancePathClearsDeleted(t *testing.T) {
 	assert.Equal(t, uint64(42), acc.Balance.Uint64())
 }
 
+// countingBaselineReader counts calcState's baseline reads.
+type countingBaselineReader struct {
+	reads int
+	acc   *accounts.Account
+}
+
+func (r *countingBaselineReader) ReadAccountData(accounts.Address) (*accounts.Account, error) {
+	r.reads++
+	return r.acc, nil
+}
+
+// TestApplyWrites_SkipsBaselineReadWhenWritesCoverAccount: writes carrying
+// balance, nonce and codeHash overwrite every field the baseline read supplies.
+func TestApplyWrites_SkipsBaselineReadWhenWritesCoverAccount(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xe1})
+	reader := &countingBaselineReader{acc: &accounts.Account{
+		Nonce:   7,
+		Balance: *uint256.NewInt(99),
+	}}
+	cs := newTestCalcState()
+	cs.domainReader = reader
+
+	codeHash := accounts.InternCodeHash(common.Hash{0xab})
+	writes := newWS().
+		bal(addr, state.Version{}, *uint256.NewInt(5)).
+		nonce(addr, state.Version{}, 3).
+		codeHash(addr, state.Version{}, codeHash).
+		build()
+	cs.ApplyWrites(writes, false)
+
+	assert.Equal(t, 0, reader.reads, "writes cover balance/nonce/codeHash — the baseline read is dead")
+
+	acc, ok := cs.accounts[addr]
+	require.True(t, ok)
+	assert.Equal(t, uint64(5), acc.Balance.Uint64())
+	assert.Equal(t, uint64(3), acc.Nonce)
+	assert.Equal(t, [32]byte(common.Hash{0xab}), acc.CodeHash)
+}
+
+// TestApplyWrites_ReadsBaselineWhenWritesIncomplete: a missing field must still
+// load, else it would flush as zero.
+func TestApplyWrites_ReadsBaselineWhenWritesIncomplete(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xe2})
+	reader := &countingBaselineReader{acc: &accounts.Account{
+		Nonce:   7,
+		Balance: *uint256.NewInt(99),
+	}}
+	cs := newTestCalcState()
+	cs.domainReader = reader
+
+	writes := newWS().bal(addr, state.Version{}, *uint256.NewInt(5)).build()
+	cs.ApplyWrites(writes, false)
+
+	assert.Equal(t, 1, reader.reads, "nonce and codeHash are not in the writes — they must come from the domain")
+
+	acc, ok := cs.accounts[addr]
+	require.True(t, ok)
+	assert.Equal(t, uint64(5), acc.Balance.Uint64(), "the write wins over the baseline")
+	assert.Equal(t, uint64(7), acc.Nonce, "the untouched nonce comes from the baseline")
+}
+
+// TestApplyWrites_ReadsBaselineForSelfDestruct: Normalize drops the SD'd
+// address's nonce/codeHash, and an EIP-8246 residual balance revives the
+// account — which then flushes those baseline fields.
+func TestApplyWrites_ReadsBaselineForSelfDestruct(t *testing.T) {
+	addr := accounts.InternAddress([20]byte{0xe3})
+	reader := &countingBaselineReader{acc: &accounts.Account{
+		Nonce:   7,
+		Balance: *uint256.NewInt(99),
+	}}
+	cs := newTestCalcState()
+	cs.domainReader = reader
+
+	writes := newWS().
+		selfDestruct(addr, state.Version{}, true).
+		bal(addr, state.Version{}, *uint256.NewInt(42)).
+		build()
+	cs.ApplyWrites(writes, true /*eip8246*/)
+
+	assert.Equal(t, 1, reader.reads, "a self-destructed address has no nonce/codeHash write to cover it")
+
+	acc, ok := cs.accounts[addr]
+	require.True(t, ok)
+	assert.False(t, acc.Deleted, "a non-zero residual balance revives the account")
+	assert.Equal(t, uint64(7), acc.Nonce, "the revived account keeps its baseline nonce")
+}
+
 // preBlockReader is a minimal StateReader stub for the integration test
 // below — returns the configured pre-block account for a single address.
 type preBlockReader struct {


### PR DESCRIPTION
Cherry-pick of #23210 to release/3.6.

## r3.6-specific adaptations

Dropped `TestNormalizeCoversBaseline` and its `everyAddrReader` helper. That test pins an assumption about `WriteSet.Normalize` — that the sets it produces satisfy the `writesCoverBaseline` guard — and `Normalize` does not exist on this branch (`execution/state/writeset_normalize.go` is main-only).

The production change is unaffected: `writesCoverBaseline` inspects the write set itself and only skips the read when every field `ensureAccount` would consult is already present, so the guard is self-checking rather than relying on a normalized input. Without `Normalize` upstream the skip simply fires less often here.

The three tests that pin the production behaviour are ported unchanged and pass: `TestApplyWrites_SkipsBaselineReadWhenWritesCoverAccount`, `TestApplyWrites_ReadsBaselineWhenWritesIncomplete`, `TestApplyWrites_ReadsBaselineForSelfDestruct`.

`execution/stagedsync/calc_state.go` applied with no conflicts.