### PR TITLE
common, rpc, execution: replace Hash.Big with Hash.U256 and migrate the getProof quantities

### DIFF
--- a/common/hash.go
+++ b/common/hash.go
@@ -24,6 +24,8 @@ import (
 	"math/rand/v2"
 	"reflect"
 
+	"github.com/holiman/uint256"
+
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/length"
 )
@@ -62,8 +64,15 @@ func (h Hash) Cmp(other Hash) int {
 	return bytes.Compare(h[:], other[:])
 }
 
-// Big converts a hash to a big integer.
-func (h Hash) Big() *big.Int { return new(big.Int).SetBytes(h[:]) }
+// U256 converts a hash to a 256-bit integer. Returned by value so the
+// conversion allocates nothing; take its address when a pointer is needed.
+func (h Hash) U256() (u uint256.Int) {
+	u.SetBytes32(h[:])
+	return u
+}
+
+// U256ToHash sets the byte representation of u to hash.
+func U256ToHash(u uint256.Int) Hash { return Hash(u.Bytes32()) }
 
 // Hex converts a hash to a hex string.
 func (h Hash) Hex() string { return hexutil.Encode(h[:]) }

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -28,6 +28,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/hexutil"
 )
 
 func TestBytesConversion(t *testing.T) {
@@ -537,6 +541,32 @@ func TestHash_Format(t *testing.T) {
 			if tt.out != tt.want {
 				t.Errorf("%s does not render as expected:\n got %s\nwant %s", tt.name, tt.out, tt.want)
 			}
+		})
+	}
+}
+
+// TestHashU256MatchesBigIntBehaviour pins U256/U256ToHash to the big.Int
+// conversion they replace: same value from the same 32 bytes, same hex
+// rendering, and a lossless round-trip back to the hash.
+func TestHashU256MatchesBigIntBehaviour(t *testing.T) {
+	hashes := []Hash{
+		{},
+		BytesToHash([]byte{1}),
+		BytesToHash([]byte{0xff}),
+		HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+		HexToHash("0x00000000000000000000000000000000000000000000000000000000ffffffff"),
+		HexToHash("0x760c4460e5336ac9bbd87952a3c7ec4363fc0a97bd31c86430806e287b437fd1"),
+		HexToHash("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+	}
+	for _, h := range hashes {
+		t.Run(h.Hex(), func(t *testing.T) {
+			want := new(big.Int).SetBytes(h[:]) // what Hash.Big did
+			u := h.U256()
+
+			require.Equal(t, want.String(), u.Dec(), "same integer value")
+			require.Equal(t, hexutil.EncodeBig(want), u.Hex(), "same hex rendering")
+			require.Equal(t, h, U256ToHash(u), "round-trip back to the hash")
+			require.Equal(t, BytesToHash(want.Bytes()), U256ToHash(u), "same as BigToHash")
 		})
 	}
 }

--- a/execution/commitment/trie/retain_list.go
+++ b/execution/commitment/trie/retain_list.go
@@ -24,7 +24,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/big"
 	"sort"
 
 	"github.com/holiman/uint256"
@@ -177,7 +176,7 @@ func (pr *DefaultProofRetainer) ProofElement(prefix []byte) *proofElement {
 func (pr *DefaultProofRetainer) ProofResult() (*accounts.AccProofResult, error) {
 	result := &accounts.AccProofResult{
 		Address:  pr.addr,
-		Balance:  (*hexutil.Big)(pr.acc.Balance.ToBig()),
+		Balance:  (*hexutil.U256)(new(uint256.Int).Set(&pr.acc.Balance)),
 		Nonce:    hexutil.Uint64(pr.acc.Nonce),
 		CodeHash: pr.acc.CodeHash.Value(),
 	}
@@ -209,7 +208,7 @@ func (pr *DefaultProofRetainer) ProofResult() (*accounts.AccProofResult, error) 
 			// chooses 'empty' as it seems more consistent and it is expected that
 			// provers will treat the EmptyRoot as a special case and ignore the proof
 			// bytes.
-			result.StorageProof[i].Value = (*hexutil.Big)(new(big.Int))
+			result.StorageProof[i].Value = new(hexutil.U256)
 			result.StorageProof[i].Proof = make([]hexutil.Bytes, 0)
 			continue
 		}
@@ -225,14 +224,14 @@ func (pr *DefaultProofRetainer) ProofResult() (*accounts.AccProofResult, error) 
 			}
 
 			if pe.storageValue != nil && bytes.Equal(pe.storageKey, hexKey[2*(length.Hash+length.Incarnation):]) {
-				result.StorageProof[i].Value = (*hexutil.Big)(pe.storageValue.ToBig())
+				result.StorageProof[i].Value = (*hexutil.U256)(new(uint256.Int).Set(pe.storageValue))
 			}
 
 			result.StorageProof[i].Proof = append(result.StorageProof[i].Proof, pe.proof.Bytes())
 		}
 
 		if result.StorageProof[i].Value == nil {
-			result.StorageProof[i].Value = (*hexutil.Big)(new(big.Int))
+			result.StorageProof[i].Value = new(hexutil.U256)
 		}
 	}
 

--- a/execution/commitment/trie/retain_list_test.go
+++ b/execution/commitment/trie/retain_list_test.go
@@ -159,6 +159,6 @@ func TestProofRetainerConstruction(t *testing.T) {
 		defer func() { pr.proofs[4].storageValue = oldKey }()
 		accProof, err := pr.ProofResult()
 		require.NoError(t, err)
-		require.Equal(t, &hexutil.Big{}, accProof.StorageProof[0].Value)
+		require.Equal(t, &hexutil.U256{}, accProof.StorageProof[0].Value)
 	})
 }

--- a/execution/engineapi/engineapitester/mock_cl.go
+++ b/execution/engineapi/engineapitester/mock_cl.go
@@ -19,7 +19,6 @@ package engineapitester
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"strings"
 	"time"
 
@@ -68,8 +67,8 @@ func NewMockCl(logger log.Logger, elClient *engineapi.JsonRpcClient, genesis *ty
 		state: &MockClState{
 			ParentElBlock:     genesis.Hash(),
 			ParentElTimestamp: genesis.Time(),
-			ParentClBlockRoot: big.NewInt(999_999_999),
-			ParentRandao:      big.NewInt(0),
+			ParentClBlockRoot: *uint256.NewInt(999_999_999),
+			ParentRandao:      uint256.Int{},
 		},
 	}
 	for _, opt := range opts {
@@ -122,7 +121,7 @@ func (cl *MockCl) StartBuilding(ctx context.Context, opts ...BlockBuildingOption
 			return nil, enginetypes.PayloadAttributes{}, fmt.Errorf("start building: wait error: %w", err)
 		}
 	}
-	parentBeaconBlockRoot := common.BigToHash(cl.state.ParentClBlockRoot)
+	parentBeaconBlockRoot := common.U256ToHash(cl.state.ParentClBlockRoot)
 	slotNumber := cl.state.NextSlotNumber()
 	withdrawals := make([]*types.Withdrawal, 0)
 	if options.withdrawals != nil {
@@ -130,7 +129,7 @@ func (cl *MockCl) StartBuilding(ctx context.Context, opts ...BlockBuildingOption
 	}
 	payloadAttributes := enginetypes.PayloadAttributes{
 		Timestamp:             hexutil.Uint64(timestamp),
-		PrevRandao:            common.BigToHash(cl.state.ParentRandao),
+		PrevRandao:            common.U256ToHash(cl.state.ParentRandao),
 		SuggestedFeeRecipient: cl.suggestedFeeRecipient,
 		Withdrawals:           withdrawals,
 		ParentBeaconBlockRoot: &parentBeaconBlockRoot,
@@ -262,8 +261,10 @@ func (cl *MockCl) UpdateForkChoice(ctx context.Context, p *MockClPayload) error 
 	// move forward
 	cl.state.ParentElBlock = head
 	cl.state.ParentElTimestamp = p.ExecutionPayload.Timestamp.Uint64()
-	cl.state.ParentClBlockRoot = new(big.Int).Add(p.ParentBeaconBlockRoot.Big(), big.NewInt(1))
-	cl.state.ParentRandao = new(big.Int).Add(p.ExecutionPayload.PrevRandao.Big(), big.NewInt(1))
+	cl.state.ParentClBlockRoot = p.ParentBeaconBlockRoot.U256()
+	cl.state.ParentClBlockRoot.AddUint64(&cl.state.ParentClBlockRoot, 1)
+	cl.state.ParentRandao = p.ExecutionPayload.PrevRandao.U256()
+	cl.state.ParentRandao.AddUint64(&cl.state.ParentRandao, 1)
 	return nil
 }
 
@@ -351,8 +352,8 @@ type MockClPayload struct {
 type MockClState struct {
 	ParentElBlock     common.Hash
 	ParentElTimestamp uint64
-	ParentClBlockRoot *big.Int
-	ParentRandao      *big.Int
+	ParentClBlockRoot uint256.Int
+	ParentRandao      uint256.Int
 	SlotNumber        uint64
 }
 

--- a/execution/types/accounts/account_proof.go
+++ b/execution/types/accounts/account_proof.go
@@ -25,7 +25,7 @@ import (
 type AccProofResult struct {
 	Address      common.Address    `json:"address"`
 	AccountProof []hexutil.Bytes   `json:"accountProof"`
-	Balance      *hexutil.Big      `json:"balance"`
+	Balance      *hexutil.U256     `json:"balance"`
 	CodeHash     common.Hash       `json:"codeHash"`
 	Nonce        hexutil.Uint64    `json:"nonce"`
 	StorageHash  common.Hash       `json:"storageHash"`
@@ -33,6 +33,6 @@ type AccProofResult struct {
 }
 type StorProofResult struct {
 	Key   string          `json:"key"`
-	Value *hexutil.Big    `json:"value"`
+	Value *hexutil.U256   `json:"value"`
 	Proof []hexutil.Bytes `json:"proof"`
 }

--- a/execution/types/block_access_list_canon_test.go
+++ b/execution/types/block_access_list_canon_test.go
@@ -69,8 +69,8 @@ func TestDecodeMinimalHashRejectsNonCanonical(t *testing.T) {
 		if err != nil {
 			t.Fatalf("input %s: canonical key must decode, got %v", c.hex, err)
 		}
-		if got := h.Big().Uint64(); got != c.want {
-			t.Fatalf("input %s: got key %d, want %d", c.hex, got, c.want)
+		if u := h.U256(); u.Uint64() != c.want {
+			t.Fatalf("input %s: got key %d, want %d", c.hex, u.Uint64(), c.want)
 		}
 	}
 }

--- a/rpc/jsonrpc/eth_call.go
+++ b/rpc/jsonrpc/eth_call.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"unsafe"
 
+	"github.com/holiman/uint256"
 	"google.golang.org/grpc"
 
 	"github.com/erigontech/erigon/common"
@@ -416,6 +417,14 @@ type StorageKeysInfo struct {
 	KeyLength int
 }
 
+func (s StorageKeysInfo) EncodeKey() string {
+	if s.KeyLength == 32 {
+		return hexutil.Encode(s.Hash[:])
+	}
+	u := s.Hash.U256()
+	return u.Hex()
+}
+
 // GetProof implements eth_getProof; historical blocks are supported as far back as the commitment history allows.
 func (api *APIImpl) GetProof(ctx context.Context, address common.Address, storageKeys []hexutil.Bytes, blockNrOrHashArg *rpc.BlockNumberOrHash) (*accounts.AccProofResult, error) {
 	blockNrOrHash := orLatest(blockNrOrHashArg)
@@ -460,22 +469,6 @@ func (api *APIImpl) GetProof(ctx context.Context, address common.Address, storag
 }
 
 func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address common.Address, storageKeys []StorageKeysInfo, blockNrOrHash rpc.BlockNumberOrHash, logger log.Logger) (*accounts.AccProofResult, error) {
-
-	// Output key encoding is a bit special: if the input was a 32-byte hash, it is
-	// returned as such. Otherwise, we apply the QUANTITY encoding mandated by the
-	// JSON-RPC spec for getProof. This behavior exists to preserve backwards
-	// compatibility with older client versions.
-	getKey := func(storageKey StorageKeysInfo) string {
-		var outputKey string
-
-		if storageKey.KeyLength != 32 {
-			outputKey = hexutil.EncodeBig(storageKey.Hash.Big())
-		} else {
-			outputKey = hexutil.Encode(storageKey.Hash[:])
-		}
-		return outputKey
-	}
-
 	tx, err := api.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
@@ -536,7 +529,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 	// set initial response fields
 	proof := &accounts.AccProofResult{
 		Address:      address,
-		Balance:      new(hexutil.Big),
+		Balance:      new(hexutil.U256),
 		Nonce:        hexutil.Uint64(0),
 		CodeHash:     common.Hash{},
 		StorageHash:  common.Hash{},
@@ -555,8 +548,8 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 	if acc == nil {
 		for i, storageKey := range storageKeys {
 			proof.StorageProof[i] = accounts.StorProofResult{
-				Key:   getKey(storageKey),
-				Value: new(hexutil.Big),
+				Key:   storageKey.EncodeKey(),
+				Value: new(hexutil.U256),
 				Proof: []hexutil.Bytes{},
 			}
 		}
@@ -567,7 +560,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 		return proof, nil
 	}
 
-	proof.Balance = (*hexutil.Big)(acc.Balance.ToBig())
+	proof.Balance = (*hexutil.U256)(new(uint256.Int).Set(&acc.Balance))
 	proof.Nonce = hexutil.Uint64(acc.Nonce)
 	proof.CodeHash = acc.CodeHash.Value()
 	proof.StorageHash = acc.Root
@@ -601,11 +594,11 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		proof.StorageProof[i].Key = getKey(storageKey)
+		proof.StorageProof[i].Key = storageKey.EncodeKey()
 		// if we have simple non contract account just set values directly without requesting any key proof
 		if proof.StorageHash.Cmp(common.BytesToHash(empty.RootHash[:])) == 0 {
 			proof.StorageProof[i].Proof = []hexutil.Bytes{}
-			proof.StorageProof[i].Value = new(hexutil.Big)
+			proof.StorageProof[i].Value = new(hexutil.U256)
 			continue
 		}
 
@@ -626,7 +619,7 @@ func (api *APIImpl) getProof(ctx context.Context, roTx kv.TemporalTx, address co
 		if err != nil {
 			logger.Warn(fmt.Sprintf("couldn't read account storage for the address %s\n", address.String()))
 		}
-		proof.StorageProof[i].Value = (*hexutil.Big)(res.ToBig())
+		proof.StorageProof[i].Value = (*hexutil.U256)(&res)
 
 		// 0x80 represents RLP encoding of an empty proof slice
 		proof.StorageProof[i].Proof = []hexutil.Bytes{[]byte{0x80}}

--- a/rpc/jsonrpc/eth_call_test.go
+++ b/rpc/jsonrpc/eth_call_test.go
@@ -431,7 +431,7 @@ func TestGetProof(t *testing.T) {
 						continue
 					}
 					found = true
-					require.Equal(t, tt.stateVal, (*big.Int)(storageProof.Value).Uint64())
+					require.Equal(t, tt.stateVal, (*uint256.Int)(storageProof.Value).Uint64())
 					err = trie.VerifyStorageProof(proof.StorageHash, storageProof)
 					require.NoError(t, err)
 				}


### PR DESCRIPTION
Continues the `hexutil.Big` -> uint256 work (#23216, #23220) into `common.Hash` and `eth_getProof`.

- `Hash.Big` -> `Hash.U256`, returned by value so the conversion allocates nothing. `U256ToHash` is the reverse. All three in-tree callers migrated, so `Big` is deleted — say the word if you would rather keep it as exported API.
- `AccProofResult.Balance` and `StorProofResult.Value` -> `*hexutil.U256`.
- `MockClState.ParentClBlockRoot` / `ParentRandao` -> `uint256.Int`.
- getProof key encoding moves from an anonymous closure onto `StorageKeysInfo.EncodeKey`, so the 32-byte-vs-QUANTITY rule lives with the type.

Wire format is unchanged: `hexutil.U256` encodes byte-identically to `hexutil.Big` for every value both can hold, and a hash is never negative. `TestHashU256MatchesBigIntBehaviour` pins value, hex rendering and round-trip against the old `big.Int` conversion.

Writers copy where the source is owned elsewhere (the trie account, the retainer's proof element) and alias only fresh locals.