### PR TITLE
db/seg: reclaim Compressor pattern workers in Close

### DIFF
--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -108,6 +108,7 @@ type Compressor struct {
 	Cfg
 	ctx              context.Context
 	wg               *sync.WaitGroup
+	stopWorkersOnce  sync.Once
 	superstrings     chan []uint16
 	uncompressedFile *RawWordsFile
 	tmpDir           string // temporary directory to use for ETL when building dictionary
@@ -199,7 +200,15 @@ func NewCompressor(ctx context.Context, logPrefix, outputFile, tmpDir string, cf
 	return cc, nil
 }
 
+func (c *Compressor) stopWorkers() {
+	c.stopWorkersOnce.Do(func() {
+		close(c.superstrings)
+		c.wg.Wait()
+	})
+}
+
 func (c *Compressor) Close() {
+	c.stopWorkers()
 	c.uncompressedFile.CloseAndRemove()
 	for _, collector := range c.suffixCollectors {
 		collector.Close()
@@ -307,8 +316,7 @@ func (c *Compressor) Compress() error {
 	if len(c.superstring) > 0 {
 		c.superstrings <- c.superstring
 	}
-	close(c.superstrings)
-	c.wg.Wait()
+	c.stopWorkers()
 
 	cf, err := dir.CreateTemp(c.outputFile)
 	if err != nil {
@@ -948,6 +956,7 @@ func NewRawWordsFile(filePath string) (*RawWordsFile, error) {
 	}
 	return &RawWordsFile{filePath: filePath, f: f, w: bufiopool.Writer(f), buf: make([]byte, 128)}, nil
 }
+
 func OpenRawWordsFile(filePath string) (*RawWordsFile, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -955,9 +964,11 @@ func OpenRawWordsFile(filePath string) (*RawWordsFile, error) {
 	}
 	return &RawWordsFile{filePath: filePath, f: f, w: bufiopool.Writer(f), buf: make([]byte, 128)}, nil
 }
+
 func (f *RawWordsFile) Flush() error {
 	return f.w.Flush()
 }
+
 func (f *RawWordsFile) Close() {
 	if f.w != nil {
 		f.w.Flush() //nolint:errcheck
@@ -967,10 +978,12 @@ func (f *RawWordsFile) Close() {
 		f.f = nil
 	}
 }
+
 func (f *RawWordsFile) CloseAndRemove() {
 	f.Close()
 	dir2.RemoveFile(f.filePath) //nolint:errcheck
 }
+
 func (f *RawWordsFile) Append(v []byte) error {
 	f.count++
 	// For compressed words, the length prefix is shifted to make lowest bit zero
@@ -985,6 +998,7 @@ func (f *RawWordsFile) Append(v []byte) error {
 	}
 	return nil
 }
+
 func (f *RawWordsFile) AppendUncompressed(v []byte) error {
 	f.count++
 	// For uncompressed words, the length prefix is shifted to make lowest bit one

--- a/db/seg/compress_test.go
+++ b/db/seg/compress_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -423,4 +424,28 @@ func TestCompressSamplingCoversWholeFile(t *testing.T) {
 	require.Greater(t, full, uint64(1))
 	require.Equal(t, full, windowCount(4))
 	require.Equal(t, full, windowCount(8))
+}
+
+// Close must reclaim the pattern workers NewCompressor started. A caller that
+// gives up between NewCompressor and Compress leaks one goroutine per worker,
+// each pinning its suffix-array buffers, for the lifetime of the parent context.
+func TestCompressorCloseReleasesWorkers(t *testing.T) {
+	logger := log.New()
+	tmpDir := t.TempDir()
+	c, err := NewCompressor(t.Context(), t.Name(), filepath.Join(tmpDir, "compressed"), tmpDir, DefaultCfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	require.NoError(t, c.AddWord([]byte("word")))
+
+	c.Close()
+
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close() returned while pattern workers are still running")
+	}
 }


### PR DESCRIPTION
Fixes #23223.

`NewCompressor` starts `cfg.Workers` goroutines blocked on the superstring channel. Only `Compress` ended that stream — `close(c.superstrings)` + `c.wg.Wait()` lived inside it — so any caller returning between `NewCompressor` and `Compress` abandoned one goroutine per worker for the lifetime of the parent context. The worker's only exits are `ctx.Done()` and channel close, so for a background job that means process lifetime.

Each abandoned worker pins its `sa`/`inv`/`lcp` `[]int32` at the high-water mark (they grow by `cap` and are never released), plus the `saisBuf` it took from `saisBufPool` — its `defer saisBufPool.Put` never runs, so the pool loses the buffer permanently — plus whatever is still buffered in the channel.

## Reaching it

`DumpBlobSidecarsRange` has **ten** `return` paths between `defer sn.Close()` and `sn.Compress()`. `antiquateBlobs` only logs its error and `retirementLoop` re-enters every 12s, so a persistent data condition leaks on every tick. The reported Gnosis archive node was OOM-killed at `alloc=58.7GB` on a 64GB host after ~328 attempts over 65 minutes, which matches the 12s period exactly.

This is not blob-specific: **20 call sites** construct a `Compressor`, including domain collate/merge and block retirement, which cannot be disabled in production.

## Fix

```go
func (c *Compressor) stopWorkers() {
	c.stopWorkersOnce.Do(func() {
		close(c.superstrings)
		c.wg.Wait()
	})
}
```

`Close` calls it **before** closing the collectors. That ordering also fixes the second defect in the same function: `Close` called `collector.Close()` on the etl collectors while a worker could still be writing into them. `Compress` uses the same helper in place of its inline close-and-wait, and the `sync.Once` keeps the ordinary `Compress` → deferred `Close` sequence from double-closing the channel.

## Test

`TestCompressorCloseReleasesWorkers` builds a compressor, adds a word, calls `Close` without `Compress`, and waits on the worker group. On current `main` it fails — `Close() returned while pattern workers are still running` — and passes here. The context stays live for the assertion, so it pins `Close`'s own behaviour rather than context cancellation cleaning up behind it.

`db/seg` is green.

## Worth a reviewer's opinion

On the abandon path the buffered superstrings are worthless — the output file is being removed — but closing the channel makes the workers drain and suffix-sort them before exiting, so `Close` now costs that work instead of leaking it. Cancelling a per-compressor context would let them exit immediately. I kept the close-and-wait shape because it is the minimal correct fix and matches the issue; happy to add the cancel if the drain cost matters at the collate/merge call sites.

## Backport

`Close` is byte-identical on `release/3.4`, `release/3.5` and `release/3.6`, so all three want this. Say the word and I will open them.