### PR TITLE
execution/commitment: bound keysCount in Fuzz_ProcessUpdates_ArbitraryUpdateCount2

### DIFF
--- a/execution/commitment/hex_patricia_hashed_fuzz_test.go
+++ b/execution/commitment/hex_patricia_hashed_fuzz_test.go
@@ -82,6 +82,11 @@ func Fuzz_ProcessUpdates_ArbitraryUpdateCount2(f *testing.F) {
 	f.Add(uint16(100), uint32(1), uint32(2))
 
 	f.Fuzz(func(t *testing.T, keysCount uint16, ks, us uint32) {
+		// The top of the uint16 range costs ~40s per input and trips the
+		// fuzzer's hang detector, spending the budget on timeouts instead of
+		// tree shapes. Clamp rather than skip so every input stays a case.
+		keysCount %= 4096
+
 		keysSeed := rand.New(rand.NewSource(int64(ks)))
 		updateSeed := rand.New(rand.NewSource(int64(us)))
 


### PR DESCRIPTION
The target takes `keysCount` straight from a `uint16` with no bound, so one input can build 65535 keys. That costs **40.77s**, well past the fuzzer's 10s hang detector — libafl reported the same hanging input twice inside a 32s run and exited 1, spending the budget on timeouts instead of tree shapes.

Clamping to 4096 keeps every input a valid case — no skip, nothing discarded — and keeps real tree depth.

## Measured

Stock `go test`, replaying a seed corpus entry per row:

| keysCount | before | after |
|---|---|---|
| 100 | 3.81s (incl. build) | — |
| 1,000 | 1.55s | — |
| 8,000 | 3.99s | — |
| **65,535** | **40.77s** | **2.59s** |

gosentry/libafl, same target on the same host:

| | result |
|---|---|
| before | `FAIL` at 31.979s, 2 hang reports, `objectives: 0` |
| after | 2m38s, **0 hangs**, corpus grows to 180 over 2329 executions |

## Sibling targets

The other count-taking targets in this package already bound their input, so this one was the outlier:

| target | param | bound |
|---|---|---|
| `Fuzz_ProcessUpdates_ArbitraryUpdateCount2` | `uint16` | **none** — this PR |
| `Fuzz_HexPatriciaHashed_DeferredMatchesEager` | `uint8` | `> 64` skipped |
| `FuzzParallelEquivalence` | `uint16` | `> 512` skipped |
| `Fuzz_HexPatriciaHashed_ReviewKeys` | `uint64` | `kc > 10e9` |

`ReviewKeys` is worth a second look by whoever owns it, but not in this PR: at the cost measured above, 10e9 keys is roughly 190 years, so that guard bounds nothing in practice — though its 100k-key seed suggests it is meant to be a deliberately slow test rather than a fast fuzz loop. Separately, it calls `testing.Short()`, which panics under gosentry (`Short called before Parse`, from `testing.LibAFLInit`) and makes the run report `ok` after **0 executions** — a tooling bug I am reporting upstream, affecting this target and `FuzzOnNewBlocks`.