### PR TITLE
execution/types: migrate txJSON and JsonAuthorization to hexutil.U256

### DIFF
--- a/execution/types/transaction_marshalling.go
+++ b/execution/types/transaction_marshalling.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/big"
 
 	"github.com/holiman/uint256"
 	"github.com/valyala/fastjson"
@@ -38,24 +37,24 @@ type txJSON struct {
 
 	// Common transaction fields:
 	Nonce                *hexutil.Uint64 `json:"nonce"`
-	GasPrice             *hexutil.Big    `json:"gasPrice"`
-	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
-	MaxPriorityFeePerGas *hexutil.Big    `json:"maxPriorityFeePerGas"`
+	GasPrice             *hexutil.U256   `json:"gasPrice"`
+	MaxFeePerGas         *hexutil.U256   `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *hexutil.U256   `json:"maxPriorityFeePerGas"`
 	Gas                  *hexutil.Uint64 `json:"gas"`
-	Value                *hexutil.Big    `json:"value"`
+	Value                *hexutil.U256   `json:"value"`
 	Data                 *hexutil.Bytes  `json:"input"`
-	V                    *hexutil.Big    `json:"v"`
-	R                    *hexutil.Big    `json:"r"`
-	S                    *hexutil.Big    `json:"s"`
+	V                    *hexutil.U256   `json:"v"`
+	R                    *hexutil.U256   `json:"r"`
+	S                    *hexutil.U256   `json:"s"`
 	To                   *common.Address `json:"to"`
 
 	// Access list transaction fields:
-	ChainID        *hexutil.Big         `json:"chainId,omitempty"`
+	ChainID        *hexutil.U256        `json:"chainId,omitempty"`
 	AccessList     *AccessList          `json:"accessList,omitempty"`
 	Authorizations *[]JsonAuthorization `json:"authorizationList,omitempty"`
 
 	// Blob transaction fields:
-	MaxFeePerBlobGas    *hexutil.Big  `json:"maxFeePerBlobGas,omitempty"`
+	MaxFeePerBlobGas    *hexutil.U256 `json:"maxFeePerBlobGas,omitempty"`
 	BlobVersionedHashes []common.Hash `json:"blobVersionedHashes,omitempty"`
 	// Blob wrapper fields:
 	Blobs       Blobs     `json:"blobs,omitempty"`
@@ -67,22 +66,22 @@ type txJSON struct {
 }
 
 type JsonAuthorization struct {
-	ChainID hexutil.Big    `json:"chainId"`
+	ChainID hexutil.U256   `json:"chainId"`
 	Address common.Address `json:"address"`
 	Nonce   hexutil.Uint64 `json:"nonce"`
 	YParity hexutil.Uint64 `json:"yParity"`
-	R       hexutil.Big    `json:"r"`
-	S       hexutil.Big    `json:"s"`
+	R       hexutil.U256   `json:"r"`
+	S       hexutil.U256   `json:"s"`
 }
 
 func (a JsonAuthorization) FromAuthorization(authorization Authorization) JsonAuthorization {
-	a.ChainID = hexutil.Big(*authorization.ChainID.ToBig())
+	a.ChainID = hexutil.U256(authorization.ChainID)
 	a.Address = authorization.Address
 	a.Nonce = (hexutil.Uint64)(authorization.Nonce)
 
 	a.YParity = (hexutil.Uint64)(authorization.YParity)
-	a.R = hexutil.Big(*authorization.R.ToBig())
-	a.S = hexutil.Big(*authorization.S.ToBig())
+	a.R = hexutil.U256(authorization.R)
+	a.S = hexutil.U256(authorization.S)
 	return a
 }
 
@@ -90,27 +89,15 @@ func (a JsonAuthorization) ToAuthorization() (Authorization, error) {
 	auth := Authorization{
 		Address: a.Address,
 		Nonce:   a.Nonce.Uint64(),
+		ChainID: uint256.Int(a.ChainID),
+		R:       uint256.Int(a.R),
+		S:       uint256.Int(a.S),
 	}
-	chainId, overflow := uint256.FromBig((*big.Int)(&a.ChainID))
-	if overflow {
-		return auth, errors.New("chainId in authorization does not fit in 256 bits")
-	}
-	auth.ChainID = *chainId
 	yParity := a.YParity.Uint64()
 	if yParity >= 1<<8 {
 		return auth, errors.New("y parity in authorization does not fit in 8 bits")
 	}
 	auth.YParity = uint8(yParity)
-	r, overflow := uint256.FromBig((*big.Int)(&a.R))
-	if overflow {
-		return auth, errors.New("r in authorization does not fit in 256 bits")
-	}
-	auth.R = *r
-	s, overflow := uint256.FromBig((*big.Int)(&a.S))
-	if overflow {
-		return auth, errors.New("s in authorization does not fit in 256 bits")
-	}
-	auth.S = *s
 	return auth, nil
 }
 
@@ -121,15 +108,15 @@ func (tx *LegacyTx) MarshalJSON() ([]byte, error) {
 	enc.Type = hexutil.Uint64(tx.Type())
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
 	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
-	enc.GasPrice = (*hexutil.Big)(tx.GasPrice.ToBig())
-	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
+	enc.GasPrice = (*hexutil.U256)(&tx.GasPrice)
+	enc.Value = (*hexutil.U256)(&tx.Value)
 	enc.Data = (*hexutil.Bytes)(&tx.Data)
 	enc.To = tx.To
-	enc.V = (*hexutil.Big)(tx.V.ToBig())
-	enc.R = (*hexutil.Big)(tx.R.ToBig())
-	enc.S = (*hexutil.Big)(tx.S.ToBig())
+	enc.V = (*hexutil.U256)(&tx.V)
+	enc.R = (*hexutil.U256)(&tx.R)
+	enc.S = (*hexutil.U256)(&tx.S)
 	if tx.Protected() {
-		enc.ChainID = (*hexutil.Big)(tx.GetChainID().ToBig())
+		enc.ChainID = (*hexutil.U256)(tx.GetChainID())
 	}
 	return json.Marshal(&enc)
 }
@@ -139,17 +126,17 @@ func (tx *AccessListTx) MarshalJSON() ([]byte, error) {
 	// These are set for all txn types.
 	enc.Hash = tx.Hash()
 	enc.Type = hexutil.Uint64(tx.Type())
-	enc.ChainID = (*hexutil.Big)(tx.ChainID.ToBig())
+	enc.ChainID = (*hexutil.U256)(&tx.ChainID)
 	enc.AccessList = &tx.AccessList
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
 	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
-	enc.GasPrice = (*hexutil.Big)(tx.GasPrice.ToBig())
-	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
+	enc.GasPrice = (*hexutil.U256)(&tx.GasPrice)
+	enc.Value = (*hexutil.U256)(&tx.Value)
 	enc.Data = (*hexutil.Bytes)(&tx.Data)
 	enc.To = tx.To
-	enc.V = (*hexutil.Big)(tx.V.ToBig())
-	enc.R = (*hexutil.Big)(tx.R.ToBig())
-	enc.S = (*hexutil.Big)(tx.S.ToBig())
+	enc.V = (*hexutil.U256)(&tx.V)
+	enc.R = (*hexutil.U256)(&tx.R)
+	enc.S = (*hexutil.U256)(&tx.S)
 	return json.Marshal(&enc)
 }
 
@@ -158,18 +145,18 @@ func (tx *DynamicFeeTransaction) MarshalJSON() ([]byte, error) {
 	// These are set for all txn types.
 	enc.Hash = tx.Hash()
 	enc.Type = hexutil.Uint64(tx.Type())
-	enc.ChainID = (*hexutil.Big)(tx.ChainID.ToBig())
+	enc.ChainID = (*hexutil.U256)(&tx.ChainID)
 	enc.AccessList = &tx.AccessList
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
 	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
-	enc.MaxFeePerGas = (*hexutil.Big)(tx.FeeCap.ToBig())
-	enc.MaxPriorityFeePerGas = (*hexutil.Big)(tx.TipCap.ToBig())
-	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
+	enc.MaxFeePerGas = (*hexutil.U256)(&tx.FeeCap)
+	enc.MaxPriorityFeePerGas = (*hexutil.U256)(&tx.TipCap)
+	enc.Value = (*hexutil.U256)(&tx.Value)
 	enc.Data = (*hexutil.Bytes)(&tx.Data)
 	enc.To = tx.To
-	enc.V = (*hexutil.Big)(tx.V.ToBig())
-	enc.R = (*hexutil.Big)(tx.R.ToBig())
-	enc.S = (*hexutil.Big)(tx.S.ToBig())
+	enc.V = (*hexutil.U256)(&tx.V)
+	enc.R = (*hexutil.U256)(&tx.R)
+	enc.S = (*hexutil.U256)(&tx.S)
 	return json.Marshal(&enc)
 }
 
@@ -178,19 +165,19 @@ func toBlobTxJSON(tx *BlobTx) *txJSON {
 	// These are set for all txn types.
 	enc.Hash = tx.Hash()
 	enc.Type = hexutil.Uint64(tx.Type())
-	enc.ChainID = (*hexutil.Big)(tx.ChainID.ToBig())
+	enc.ChainID = (*hexutil.U256)(&tx.ChainID)
 	enc.AccessList = &tx.AccessList
 	enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
 	enc.Gas = (*hexutil.Uint64)(&tx.GasLimit)
-	enc.MaxFeePerGas = (*hexutil.Big)(tx.FeeCap.ToBig())
-	enc.MaxPriorityFeePerGas = (*hexutil.Big)(tx.TipCap.ToBig())
-	enc.Value = (*hexutil.Big)(tx.Value.ToBig())
+	enc.MaxFeePerGas = (*hexutil.U256)(&tx.FeeCap)
+	enc.MaxPriorityFeePerGas = (*hexutil.U256)(&tx.TipCap)
+	enc.Value = (*hexutil.U256)(&tx.Value)
 	enc.Data = (*hexutil.Bytes)(&tx.Data)
 	enc.To = tx.To
-	enc.V = (*hexutil.Big)(tx.V.ToBig())
-	enc.R = (*hexutil.Big)(tx.R.ToBig())
-	enc.S = (*hexutil.Big)(tx.S.ToBig())
-	enc.MaxFeePerBlobGas = (*hexutil.Big)(tx.MaxFeePerBlobGas.ToBig())
+	enc.V = (*hexutil.U256)(&tx.V)
+	enc.R = (*hexutil.U256)(&tx.R)
+	enc.S = (*hexutil.U256)(&tx.S)
+	enc.MaxFeePerBlobGas = (*hexutil.U256)(&tx.MaxFeePerBlobGas)
 	enc.BlobVersionedHashes = tx.GetBlobHashes()
 	return &enc
 }
@@ -280,11 +267,7 @@ func (tx *LegacyTx) UnmarshalJSON(input []byte) error {
 	if dec.GasPrice == nil {
 		return errors.New("missing required field 'gasPrice' in transaction")
 	}
-	gasPrice, overflow := uint256.FromBig(dec.GasPrice.ToInt())
-	if overflow {
-		return errors.New("'gasPrice' in transaction does not fit in 256 bits")
-	}
-	tx.GasPrice = *gasPrice
+	tx.GasPrice = uint256.Int(*dec.GasPrice)
 	if dec.Gas == nil {
 		return errors.New("missing required field 'gas' in transaction")
 	}
@@ -292,11 +275,7 @@ func (tx *LegacyTx) UnmarshalJSON(input []byte) error {
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' in transaction")
 	}
-	val, overflow := uint256.FromBig(dec.Value.ToInt())
-	if overflow {
-		return errors.New("'value' in transaction does not fit in 256 bits")
-	}
-	tx.Value = *val
+	tx.Value = uint256.Int(*dec.Value)
 	if dec.Data == nil {
 		return errors.New("missing required field 'input' in transaction")
 	}
@@ -304,27 +283,15 @@ func (tx *LegacyTx) UnmarshalJSON(input []byte) error {
 	if dec.V == nil {
 		return errors.New("missing required field 'v' in transaction")
 	}
-	overflow = tx.V.SetFromBig(dec.V.ToInt())
-	if overflow {
-		return errors.New("dec.V higher than 2^256-1")
-	}
+	tx.V = uint256.Int(*dec.V)
 	if dec.R == nil {
 		return errors.New("missing required field 'r' in transaction")
 	}
-	overflow = tx.R.SetFromBig(dec.R.ToInt())
-	if overflow {
-		return errors.New("dec.R higher than 2^256-1")
-	}
+	tx.R = uint256.Int(*dec.R)
 	if dec.S == nil {
 		return errors.New("missing required field 's' in transaction")
 	}
-	overflow = tx.S.SetFromBig(dec.S.ToInt())
-	if overflow {
-		return errors.New("dec.S higher than 2^256-1")
-	}
-	if overflow {
-		return errors.New("'s' in transaction does not fit in 256 bits")
-	}
+	tx.S = uint256.Int(*dec.S)
 	withSignature := !tx.V.IsZero() || !tx.R.IsZero() || !tx.S.IsZero()
 	if withSignature {
 		if err := sanityCheckSignature(&tx.V, &tx.R, &tx.S, true); err != nil {
@@ -346,11 +313,7 @@ func (tx *AccessListTx) UnmarshalJSON(input []byte) error {
 	if dec.ChainID == nil {
 		return errors.New("missing required field 'chainId' in transaction")
 	}
-	chainID, overflow := uint256.FromBig(dec.ChainID.ToInt())
-	if overflow {
-		return errors.New("'chainId' in transaction does not fit in 256 bits")
-	}
-	tx.ChainID = *chainID
+	tx.ChainID = uint256.Int(*dec.ChainID)
 	if dec.To != nil {
 		tx.To = dec.To
 	}
@@ -361,11 +324,7 @@ func (tx *AccessListTx) UnmarshalJSON(input []byte) error {
 	if dec.GasPrice == nil {
 		return errors.New("missing required field 'gasPrice' in transaction")
 	}
-	gasPrice, overflow := uint256.FromBig(dec.GasPrice.ToInt())
-	if overflow {
-		return errors.New("'gasPrice' in transaction does not fit in 256 bits")
-	}
-	tx.GasPrice = *gasPrice
+	tx.GasPrice = uint256.Int(*dec.GasPrice)
 	if dec.Gas == nil {
 		return errors.New("missing required field 'gas' in transaction")
 	}
@@ -373,11 +332,7 @@ func (tx *AccessListTx) UnmarshalJSON(input []byte) error {
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' in transaction")
 	}
-	val, overflow := uint256.FromBig(dec.Value.ToInt())
-	if overflow {
-		return errors.New("'value' in transaction does not fit in 256 bits")
-	}
-	tx.Value = *val
+	tx.Value = uint256.Int(*dec.Value)
 	if dec.Data == nil {
 		return errors.New("missing required field 'input' in transaction")
 	}
@@ -385,24 +340,15 @@ func (tx *AccessListTx) UnmarshalJSON(input []byte) error {
 	if dec.V == nil {
 		return errors.New("missing required field 'v' in transaction")
 	}
-	overflow = tx.V.SetFromBig(dec.V.ToInt())
-	if overflow {
-		return errors.New("dec.V higher than 2^256-1")
-	}
+	tx.V = uint256.Int(*dec.V)
 	if dec.R == nil {
 		return errors.New("missing required field 'r' in transaction")
 	}
-	overflow = tx.R.SetFromBig(dec.R.ToInt())
-	if overflow {
-		return errors.New("dec.R higher than 2^256-1")
-	}
+	tx.R = uint256.Int(*dec.R)
 	if dec.S == nil {
 		return errors.New("missing required field 's' in transaction")
 	}
-	overflow = tx.S.SetFromBig(dec.S.ToInt())
-	if overflow {
-		return errors.New("dec.S higher than 2^256-1")
-	}
+	tx.S = uint256.Int(*dec.S)
 	withSignature := !tx.V.IsZero() || !tx.R.IsZero() || !tx.S.IsZero()
 	if withSignature {
 		if err := sanityCheckSignature(&tx.V, &tx.R, &tx.S, false); err != nil {
@@ -420,11 +366,7 @@ func (tx *DynamicFeeTransaction) unmarshalJson(dec txJSON) error {
 	if dec.ChainID == nil {
 		return errors.New("missing required field 'chainId' in transaction")
 	}
-	chainID, overflow := uint256.FromBig(dec.ChainID.ToInt())
-	if overflow {
-		return errors.New("'chainId' in transaction does not fit in 256 bits")
-	}
-	tx.ChainID = *chainID
+	tx.ChainID = uint256.Int(*dec.ChainID)
 	if dec.To != nil {
 		tx.To = dec.To
 	}
@@ -432,19 +374,14 @@ func (tx *DynamicFeeTransaction) unmarshalJson(dec txJSON) error {
 		return errors.New("missing required field 'nonce' in transaction")
 	}
 	tx.Nonce = uint64(*dec.Nonce)
-	if dec.GasPrice == nil {
-		return errors.New("missing required field 'gasPrice' in transaction")
+	if dec.MaxPriorityFeePerGas == nil {
+		return errors.New("missing required field 'maxPriorityFeePerGas' in transaction")
 	}
-	tipCap, overflow := uint256.FromBig(dec.MaxPriorityFeePerGas.ToInt())
-	if overflow {
-		return errors.New("'tip' in transaction does not fit in 256 bits")
+	tx.TipCap = uint256.Int(*dec.MaxPriorityFeePerGas)
+	if dec.MaxFeePerGas == nil {
+		return errors.New("missing required field 'maxFeePerGas' in transaction")
 	}
-	tx.TipCap = *tipCap
-	feeCap, overflow := uint256.FromBig(dec.MaxFeePerGas.ToInt())
-	if overflow {
-		return errors.New("'feeCap' in transaction does not fit in 256 bits")
-	}
-	tx.FeeCap = *feeCap
+	tx.FeeCap = uint256.Int(*dec.MaxFeePerGas)
 	if dec.Gas == nil {
 		return errors.New("missing required field 'gas' in transaction")
 	}
@@ -452,11 +389,7 @@ func (tx *DynamicFeeTransaction) unmarshalJson(dec txJSON) error {
 	if dec.Value == nil {
 		return errors.New("missing required field 'value' in transaction")
 	}
-	val, overflow := uint256.FromBig(dec.Value.ToInt())
-	if overflow {
-		return errors.New("'value' in transaction does not fit in 256 bits")
-	}
-	tx.Value = *val
+	tx.Value = uint256.Int(*dec.Value)
 	if dec.Data == nil {
 		return errors.New("missing required field 'input' in transaction")
 	}
@@ -464,27 +397,15 @@ func (tx *DynamicFeeTransaction) unmarshalJson(dec txJSON) error {
 	if dec.V == nil {
 		return errors.New("missing required field 'v' in transaction")
 	}
-	overflow = tx.V.SetFromBig(dec.V.ToInt())
-	if overflow {
-		return errors.New("dec.V higher than 2^256-1")
-	}
+	tx.V = uint256.Int(*dec.V)
 	if dec.R == nil {
 		return errors.New("missing required field 'r' in transaction")
 	}
-	overflow = tx.R.SetFromBig(dec.R.ToInt())
-	if overflow {
-		return errors.New("dec.R higher than 2^256-1")
-	}
+	tx.R = uint256.Int(*dec.R)
 	if dec.S == nil {
 		return errors.New("missing required field 's' in transaction")
 	}
-	overflow = tx.S.SetFromBig(dec.S.ToInt())
-	if overflow {
-		return errors.New("dec.S higher than 2^256-1")
-	}
-	if overflow {
-		return errors.New("'s' in transaction does not fit in 256 bits")
-	}
+	tx.S = uint256.Int(*dec.S)
 	withSignature := !tx.V.IsZero() || !tx.R.IsZero() || !tx.S.IsZero()
 	if withSignature {
 		if err := sanityCheckSignature(&tx.V, &tx.R, &tx.S, false); err != nil {
@@ -512,6 +433,9 @@ func (tx *SetCodeTransaction) UnmarshalJSON(input []byte) error {
 	if err := tx.unmarshalJson(dec); err != nil {
 		return err
 	}
+	if dec.Authorizations == nil {
+		return errors.New("missing required field 'authorizationList' in transaction")
+	}
 	auths := *dec.Authorizations
 	tx.Authorizations = make([]Authorization, len(auths))
 	for i := range auths {
@@ -538,11 +462,7 @@ func UnmarshalBlobTxJSON(input []byte) (Transaction, error) {
 	if dec.ChainID == nil {
 		return nil, errors.New("missing required field 'chainId' in transaction")
 	}
-	chainID, overflow := uint256.FromBig(dec.ChainID.ToInt())
-	if overflow {
-		return nil, errors.New("'chainId' in transaction does not fit in 256 bits")
-	}
-	tx.ChainID = *chainID
+	tx.ChainID = uint256.Int(*dec.ChainID)
 	if dec.To != nil {
 		tx.To = dec.To
 	}
@@ -550,16 +470,14 @@ func UnmarshalBlobTxJSON(input []byte) (Transaction, error) {
 		return nil, errors.New("missing required field 'nonce' in transaction")
 	}
 	tx.Nonce = uint64(*dec.Nonce)
-	tipCap, overflow := uint256.FromBig(dec.MaxPriorityFeePerGas.ToInt())
-	if overflow {
-		return nil, errors.New("'tip' in transaction does not fit in 256 bits")
+	if dec.MaxPriorityFeePerGas == nil {
+		return nil, errors.New("missing required field 'maxPriorityFeePerGas' in transaction")
 	}
-	tx.TipCap = *tipCap
-	feeCap, overflow := uint256.FromBig(dec.MaxFeePerGas.ToInt())
-	if overflow {
-		return nil, errors.New("'feeCap' in transaction does not fit in 256 bits")
+	tx.TipCap = uint256.Int(*dec.MaxPriorityFeePerGas)
+	if dec.MaxFeePerGas == nil {
+		return nil, errors.New("missing required field 'maxFeePerGas' in transaction")
 	}
-	tx.FeeCap = *feeCap
+	tx.FeeCap = uint256.Int(*dec.MaxFeePerGas)
 	if dec.Gas == nil {
 		return nil, errors.New("missing required field 'gas' in transaction")
 	}
@@ -567,11 +485,7 @@ func UnmarshalBlobTxJSON(input []byte) (Transaction, error) {
 	if dec.Value == nil {
 		return nil, errors.New("missing required field 'value' in transaction")
 	}
-	val, overflow := uint256.FromBig(dec.Value.ToInt())
-	if overflow {
-		return nil, errors.New("'value' in transaction does not fit in 256 bits")
-	}
-	tx.Value = *val
+	tx.Value = uint256.Int(*dec.Value)
 	if dec.Data == nil {
 		return nil, errors.New("missing required field 'input' in transaction")
 	}
@@ -581,11 +495,7 @@ func UnmarshalBlobTxJSON(input []byte) (Transaction, error) {
 		return nil, errors.New("missing required field 'maxFeePerBlobGas' in transaction")
 	}
 
-	maxFeePerBlobGas, overflow := uint256.FromBig(dec.MaxFeePerBlobGas.ToInt())
-	if overflow {
-		return nil, errors.New("'maxFeePerBlobGas' in transaction does not fit in 256 bits")
-	}
-	tx.MaxFeePerBlobGas = *maxFeePerBlobGas
+	tx.MaxFeePerBlobGas = uint256.Int(*dec.MaxFeePerBlobGas)
 
 	if dec.BlobVersionedHashes != nil {
 		tx.BlobVersionedHashes = dec.BlobVersionedHashes
@@ -596,24 +506,15 @@ func UnmarshalBlobTxJSON(input []byte) (Transaction, error) {
 	if dec.V == nil {
 		return nil, errors.New("missing required field 'v' in transaction")
 	}
-	overflow = tx.V.SetFromBig(dec.V.ToInt())
-	if overflow {
-		return nil, errors.New("dec.V higher than 2^256-1")
-	}
+	tx.V = uint256.Int(*dec.V)
 	if dec.R == nil {
 		return nil, errors.New("missing required field 'r' in transaction")
 	}
-	overflow = tx.R.SetFromBig(dec.R.ToInt())
-	if overflow {
-		return nil, errors.New("dec.R higher than 2^256-1")
-	}
+	tx.R = uint256.Int(*dec.R)
 	if dec.S == nil {
 		return nil, errors.New("missing required field 's' in transaction")
 	}
-	overflow = tx.S.SetFromBig(dec.S.ToInt())
-	if overflow {
-		return nil, errors.New("dec.S higher than 2^256-1")
-	}
+	tx.S = uint256.Int(*dec.S)
 
 	withSignature := !tx.V.IsZero() || !tx.R.IsZero() || !tx.S.IsZero()
 	if withSignature {

--- a/execution/types/transaction_test.go
+++ b/execution/types/transaction_test.go
@@ -876,3 +876,35 @@ func TestTypedTxEmptyToErrorMessage(t *testing.T) {
 		})
 	}
 }
+
+// A typed transaction whose JSON omits a fee field the decoder reads must be
+// rejected, not panic. The dynamic-fee decoder guarded 'gasPrice' but then read
+// 'maxFeePerGas'/'maxPriorityFeePerGas', and the blob decoder guarded neither.
+func TestUnmarshalTransactionFromJSONMissingFields(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		json string
+	}{
+		{"dynamicFee without maxFeePerGas", `{"type":"0x2","chainId":"0x1","nonce":"0x1","maxPriorityFeePerGas":"0x1","gas":"0x5208","value":"0x0","input":"0x","v":"0x0","r":"0x0","s":"0x0"}`},
+		{"dynamicFee without maxPriorityFeePerGas", `{"type":"0x2","chainId":"0x1","nonce":"0x1","maxFeePerGas":"0x1","gas":"0x5208","value":"0x0","input":"0x","v":"0x0","r":"0x0","s":"0x0"}`},
+		{"blob without maxFeePerGas", `{"type":"0x3","chainId":"0x1","nonce":"0x1","maxPriorityFeePerGas":"0x1","gas":"0x5208","value":"0x0","input":"0x","maxFeePerBlobGas":"0x1","v":"0x0","r":"0x0","s":"0x0"}`},
+		{"blob without maxPriorityFeePerGas", `{"type":"0x3","chainId":"0x1","nonce":"0x1","maxFeePerGas":"0x1","gas":"0x5208","value":"0x0","input":"0x","maxFeePerBlobGas":"0x1","v":"0x0","r":"0x0","s":"0x0"}`},
+		{"setCode without authorizationList", `{"type":"0x4","chainId":"0x1","nonce":"0x1","maxFeePerGas":"0x1","maxPriorityFeePerGas":"0x1","gas":"0x5208","value":"0x0","input":"0x","v":"0x0","r":"0x0","s":"0x0"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := UnmarshalTransactionFromJSON([]byte(tc.json))
+			assert.Error(t, err)
+		})
+	}
+}
+
+// A type-2 transaction carries no 'gasPrice' field, so its absence must not be
+// an error.
+func TestUnmarshalDynamicFeeTransactionFromJSONWithoutGasPrice(t *testing.T) {
+	t.Parallel()
+	const txJSON = `{"type":"0x2","chainId":"0x1","nonce":"0x1","maxFeePerGas":"0x3b9aca00","maxPriorityFeePerGas":"0x1","gas":"0x5208","value":"0x0","input":"0x","v":"0x0","r":"0x0","s":"0x0"}`
+	txn, err := UnmarshalTransactionFromJSON([]byte(txJSON))
+	assert.NoError(t, err)
+	assert.Equal(t, uint256.NewInt(1_000_000_000), txn.GetFeeCap())
+}

--- a/execution/types/transaction_test.go
+++ b/execution/types/transaction_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
@@ -877,9 +878,8 @@ func TestTypedTxEmptyToErrorMessage(t *testing.T) {
 	}
 }
 
-// A typed transaction whose JSON omits a fee field the decoder reads must be
-// rejected, not panic. The dynamic-fee decoder guarded 'gasPrice' but then read
-// 'maxFeePerGas'/'maxPriorityFeePerGas', and the blob decoder guarded neither.
+// Typed-transaction JSON that omits a field the decoder dereferences must be
+// rejected, not panic.
 func TestUnmarshalTransactionFromJSONMissingFields(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -905,7 +905,7 @@ func TestUnmarshalDynamicFeeTransactionFromJSONWithoutGasPrice(t *testing.T) {
 	t.Parallel()
 	const txJSON = `{"type":"0x2","chainId":"0x1","nonce":"0x1","maxFeePerGas":"0x3b9aca00","maxPriorityFeePerGas":"0x1","gas":"0x5208","value":"0x0","input":"0x","v":"0x0","r":"0x0","s":"0x0"}`
 	txn, err := UnmarshalTransactionFromJSON([]byte(txJSON))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint256.NewInt(1_000_000_000), txn.GetFeeCap())
 }
 


### PR DESCRIPTION
Replaces `*hexutil.Big` with `hexutil.U256` on `txJSON` and `JsonAuthorization`. Every quantity is already a `uint256.Int` on the transaction — the `big.Int` existed only to satisfy the type. Marshal now aliases the field instead of allocating, removing up to nine `big.Int` allocations per encoded transaction.

Continues the sweep in #23216 (`eth_`/`erigon_` getters), #23220 (`CallArgs`/`BlockOverrides`) and #23230 (`Hash.Big`, `eth_getProof`). No file overlap with any of them.

## Wire compatibility

Marshal output is unchanged — verified byte-identical against `main` for all five transaction types and `JsonAuthorization`, over `0`, `1`, max `uint64`, the 2^64 boundary and 2^256-1.

Which inputs decode is unchanged too, and more strongly than in the earlier PRs: `Big.UnmarshalText` and `U256.UnmarshalText` share `checkNumberText` and *both* reject inputs over 64 nibbles with `ErrBig256Range`. `checkNumberText` also requires the `0x` prefix, so neither accepts a negative. No JSON that used to decode is now rejected, and none that used to be rejected now decodes.

The **error text for malformed input does change**, as in the earlier PRs: both types wrap the failure in a `json.UnmarshalTypeError` carrying their own `reflect.Type`, so the trailing type name differs. `Value` — which says what was wrong — is identical:

| input | before | after |
|---|---|---|
| `"0xzz"` | `json: cannot unmarshal invalid hex string into Go value of type *hexutil.Big` | `… of type *hexutil.U256` |
| `1` | `json: cannot unmarshal non-string into Go value of type *hexutil.Big` | `… of type *hexutil.U256` |
| `"1"` | `json: cannot unmarshal hex string without 0x prefix into Go value of type *hexutil.Big` | `… of type *hexutil.U256` |
| 65+ nibbles | `json: cannot unmarshal hex number > 256 bits into Go value of type *hexutil.Big` | `… of type *hexutil.U256` |

## 28 dead overflow checks removed

Because `Big` already rejected anything wider than 256 bits at decode, every `"does not fit in 256 bits"` branch behind it was unreachable. Two of them retested an `overflow` flag that the preceding block had already handled:

```go
overflow = tx.S.SetFromBig(dec.S.ToInt())
if overflow {
    return errors.New("dec.S higher than 2^256-1")
}
if overflow {   // <- same flag, second copy
    return errors.New("'s' in transaction does not fit in 256 bits")
}
```

## Three nil dereferences on the decode path

Found while converting the fee fields, since `(*uint256.Int)(dec.MaxFeePerGas)` panics on nil exactly where `uint256.FromBig(dec.MaxFeePerGas.ToInt())` did.

- `DynamicFeeTransaction.unmarshalJson` guarded `dec.GasPrice`, then read `dec.MaxPriorityFeePerGas` and `dec.MaxFeePerGas`. JSON carrying `gasPrice` but not `maxFeePerGas` panicked.
- `UnmarshalBlobTxJSON` guarded neither before reading both.
- `SetCodeTransaction.UnmarshalJSON` dereferences `*dec.Authorizations`. This one was unreachable only because the wrong `gasPrice` guard rejected the input first, so fixing the guard above exposes it.

Each now returns a `missing required field` error. Covered by `TestUnmarshalTransactionFromJSONMissingFields`, which panics on current `main`.

**One deliberate loosening:** a type-2 transaction carries no `gasPrice` field, so requiring it was wrong — geth requires `maxFeePerGas`/`maxPriorityFeePerGas` instead. Dynamic-fee JSON without `gasPrice` is now accepted (`TestUnmarshalDynamicFeeTransactionFromJSONWithoutGasPrice`). Say the word if you would rather keep the old requirement and fix only the panic.

## Reachability

`UnmarshalTransactionFromJSON` and the per-type `UnmarshalJSON` are exported but have no production RPC caller today — transactions reach the node as RLP. So these are decoder-hardening, not a live crash path.

