### PR TITLE
node: stream one-shot gzip responses above the pool cap

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -180,6 +180,13 @@ func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "invalid host specified", http.StatusForbidden)
 }
 
+// maxBufferedGzipSize is the point above which a one-shot response stops
+// accumulating and switches to the streaming path. Past pool.MaxBufferCap the
+// buffer can no longer be returned to its pool, so holding the whole response
+// only to compute an exact Content-Length costs a multi-MB allocation per
+// request. net/http drops the header above 2KB for the same reason.
+const maxBufferedGzipSize = pool.MaxBufferCap
+
 // minGzipBodySize is the minimum response body size to compress. Responses
 // smaller than this are sent as-is: gzip framing overhead would exceed savings.
 const minGzipBodySize = 1024
@@ -249,6 +256,9 @@ func (w *gzipResponseWriter) WriteHeader(status int) {
 }
 
 func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	if w.gzw == nil && w.buf.Len()+len(b) > maxBufferedGzipSize {
+		w.Flush()
+	}
 	if w.gzw != nil {
 		gzipStreamingInBytes.AddInt(len(b))
 		return w.gzw.Write(b)

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -256,8 +256,11 @@ func (w *gzipResponseWriter) WriteHeader(status int) {
 }
 
 func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	// Switch on the write that would exceed the cap, so a single oversized
+	// write streams rather than growing the buffer past it. Only the mode
+	// switch: flushing here would emit an empty sync block before any data.
 	if w.gzw == nil && w.buf.Len()+len(b) > maxBufferedGzipSize {
-		w.Flush()
+		w.switchToStreaming()
 	}
 	if w.gzw != nil {
 		gzipStreamingInBytes.AddInt(len(b))
@@ -267,21 +270,29 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 }
 
 // Flush switches to streaming gzip on first call; subsequent calls flush incrementally.
-func (w *gzipResponseWriter) Flush() {
-	if w.gzw == nil {
-		w.ResponseWriter.Header().Set("Content-Encoding", "gzip")
-		w.ResponseWriter.Header().Del("Content-Length")
-		if w.status != 0 {
-			w.ResponseWriter.WriteHeader(w.status)
-		}
-		w.gzw = gzStreamPool.Get().(*gzip.Writer)
-		w.gzw.Reset(countingWriter{w: w.ResponseWriter, c: gzipStreamingOutBytes})
-		if w.buf.Len() > 0 {
-			gzipStreamingInBytes.AddInt(w.buf.Len())
-			_, _ = w.gzw.Write(w.buf.Bytes())
-			w.buf.Reset()
-		}
+// switchToStreaming activates the gzip stream and drains whatever is already
+// buffered. Content-Length is dropped here: past this point the body length is
+// not known before the headers go out.
+func (w *gzipResponseWriter) switchToStreaming() {
+	if w.gzw != nil {
+		return
 	}
+	w.ResponseWriter.Header().Set("Content-Encoding", "gzip")
+	w.ResponseWriter.Header().Del("Content-Length")
+	if w.status != 0 {
+		w.ResponseWriter.WriteHeader(w.status)
+	}
+	w.gzw = gzStreamPool.Get().(*gzip.Writer)
+	w.gzw.Reset(countingWriter{w: w.ResponseWriter, c: gzipStreamingOutBytes})
+	if w.buf.Len() > 0 {
+		gzipStreamingInBytes.AddInt(w.buf.Len())
+		_, _ = w.gzw.Write(w.buf.Bytes())
+		w.buf.Reset()
+	}
+}
+
+func (w *gzipResponseWriter) Flush() {
+	w.switchToStreaming()
 	_ = w.gzw.Flush()
 	if f, ok := w.ResponseWriter.(http.Flusher); ok {
 		f.Flush()

--- a/node/rpcstack_gzip_bench_test.go
+++ b/node/rpcstack_gzip_bench_test.go
@@ -375,3 +375,57 @@ func BenchmarkKlauspostGzipBestSpeed(b *testing.B) {
 func BenchmarkStdlibGzipBestSpeed(b *testing.B) {
 	benchmarkGzipHandler(b, getBenchPayload(b), newStdlibGzipHandler)
 }
+
+// syntheticBlockJSON builds a payload shaped like eth_getBlockByNumber output:
+// many repeated tx objects with high-entropy hex fields, so the compressor sees
+// realistic redundancy rather than a trivially compressible run.
+func syntheticBlockJSON(targetBytes int) []byte {
+	var b bytes.Buffer
+	b.WriteString(`{"jsonrpc":"2.0","id":1,"result":{"number":"0xc65d58","transactions":[`)
+	i := 0
+	for b.Len() < targetBytes {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"hash":"0x%064x","from":"0x%040x","to":"0x%040x","value":"0x%x","gas":"0x%x","input":"0x%0128x"}`,
+			i*2654435761, i*40503, i*2246822519, i*97, 21000+i, uint64(i)*11400714819323198485)
+		i++
+	}
+	b.WriteString(`]}}`)
+	return b.Bytes()
+}
+
+// BenchmarkGzipOneShotThroughput measures server throughput: concurrent clients,
+// unlike the sequential per-request loop in rpcstack_gzip_bench_test.go which
+// reports latency. -cpu controls the client concurrency.
+func BenchmarkGzipOneShotThroughput(b *testing.B) {
+	for _, size := range []int{16 << 10, 256 << 10, 2 << 20} {
+		payload := syntheticBlockJSON(size)
+		b.Run(fmt.Sprintf("payload=%dKB", len(payload)>>10), func(b *testing.B) {
+			handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(payload) //nolint:errcheck
+			}))
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			b.SetBytes(int64(len(payload)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				client := &http.Client{Transport: &http.Transport{DisableCompression: true, MaxIdleConnsPerHost: 64}}
+				for pb.Next() {
+					req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+					req.Header.Set("Accept-Encoding", "gzip")
+					resp, err := client.Do(req)
+					if err != nil {
+						b.Error(err)
+						return
+					}
+					io.Copy(io.Discard, resp.Body) //nolint:errcheck
+					resp.Body.Close()
+				}
+			})
+		})
+	}
+}

--- a/node/rpcstack_gzip_bench_test.go
+++ b/node/rpcstack_gzip_bench_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -518,5 +519,68 @@ func BenchmarkGzipStreamingThroughput(b *testing.B) {
 				})
 			}
 		}
+	}
+}
+
+// BenchmarkGzipPeakMemoryParallel reports peak live heap while many clients
+// request a large response at once. Per-request throughput hides this: the
+// one-shot path holds the whole uncompressed response per in-flight request,
+// so peak memory scales with concurrency, not with response size.
+func BenchmarkGzipPeakMemoryParallel(b *testing.B) {
+	for _, clients := range []int{8, 64} {
+		b.Run(fmt.Sprintf("clients=%d/payload=2MB", clients), func(b *testing.B) {
+			payload := syntheticBlockJSON(2 << 20)
+			srv := httptest.NewServer(newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(payload) //nolint:errcheck
+			})))
+			defer srv.Close()
+
+			var peak uint64
+			done := make(chan struct{})
+			var sampler sync.WaitGroup
+			sampler.Add(1)
+			go func() {
+				defer sampler.Done()
+				var ms runtime.MemStats
+				for {
+					select {
+					case <-done:
+						return
+					default:
+					}
+					runtime.ReadMemStats(&ms)
+					if ms.HeapInuse > atomic.LoadUint64(&peak) {
+						atomic.StoreUint64(&peak, ms.HeapInuse)
+					}
+				}
+			}()
+
+			runtime.GC()
+			b.ResetTimer()
+			var wg sync.WaitGroup
+			for range clients {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					c := &http.Client{Transport: &http.Transport{DisableCompression: true, MaxIdleConnsPerHost: 4}}
+					for range b.N {
+						req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+						req.Header.Set("Accept-Encoding", "gzip")
+						resp, err := c.Do(req)
+						if err != nil {
+							return
+						}
+						io.Copy(io.Discard, resp.Body) //nolint:errcheck
+						resp.Body.Close()
+					}
+				}()
+			}
+			wg.Wait()
+			b.StopTimer()
+			close(done)
+			sampler.Wait()
+			b.ReportMetric(float64(atomic.LoadUint64(&peak))/(1<<20), "peak-heap-MiB")
+		})
 	}
 }

--- a/node/rpcstack_gzip_bench_test.go
+++ b/node/rpcstack_gzip_bench_test.go
@@ -21,12 +21,15 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"github.com/erigontech/erigon/rpc/jsonstream"
+	jsoniter "github.com/json-iterator/go"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -427,5 +430,85 @@ func BenchmarkGzipOneShotThroughput(b *testing.B) {
 				}
 			})
 		})
+	}
+}
+
+// BenchmarkGzipStreamingThroughput drives the streaming path the way
+// debug_trace* does: a jsonstream writing through the gzip middleware. It
+// varies the jsoniter buffer, which is InitialBufferSize=4096 in production
+// (rpc/jsonstream/factory.go) -- on a several-hundred-MB trace that is tens of
+// thousands of write calls through the middleware.
+func BenchmarkGzipStreamingThroughput(b *testing.B) {
+	for _, bufSize := range []int{4096, 64 << 10, 256 << 10} {
+		for _, entries := range []int{2000, 60000} {
+			name := fmt.Sprintf("jsonbuf=%dKB/entries=%d", bufSize>>10, entries)
+			if bufSize < 1024 {
+				name = fmt.Sprintf("jsonbuf=%dB/entries=%d", bufSize, entries)
+			}
+			b.Run(name, func(b *testing.B) {
+				// Precomputed: formatting inside the write loop would make the
+				// benchmark measure fmt rather than the streaming path.
+				stackWords := make([]string, 64)
+				for i := range stackWords {
+					stackWords[i] = fmt.Sprintf("0x%064x", i*2654435761)
+				}
+				var wrote int64
+				handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					// Production enters streaming mode via the gzip hook before
+					// the first write; Flush is that same entry point.
+					w.(http.Flusher).Flush()
+
+					st := jsoniter.NewStream(jsoniter.ConfigDefault, w, bufSize)
+					stream := jsonstream.Wrap(st)
+					stream.WriteArrayStart()
+					for i := range entries {
+						if i > 0 {
+							stream.WriteMore()
+						}
+						stream.WriteObjectStart()
+						stream.WriteObjectField("pc")
+						stream.WriteInt(i)
+						stream.WriteMore()
+						stream.WriteObjectField("op")
+						stream.WriteString("SSTORE")
+						stream.WriteMore()
+						stream.WriteObjectField("stack")
+						stream.WriteString(stackWords[i%len(stackWords)])
+						stream.WriteObjectEnd()
+					}
+					stream.WriteArrayEnd()
+					stream.Flush() //nolint:errcheck
+					atomic.AddInt64(&wrote, int64(st.Buffered()))
+				}))
+				srv := httptest.NewServer(handler)
+				defer srv.Close()
+
+				// One warmup request to learn the uncompressed size for MB/s.
+				req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+				req.Header.Set("Accept-Encoding", "gzip")
+				if resp, err := (&http.Client{Transport: &http.Transport{DisableCompression: true}}).Do(req); err == nil {
+					io.Copy(io.Discard, resp.Body) //nolint:errcheck
+					resp.Body.Close()
+				}
+				b.SetBytes(int64(entries) * 96) // approx bytes of JSON per entry
+				b.ReportAllocs()
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					client := &http.Client{Transport: &http.Transport{DisableCompression: true, MaxIdleConnsPerHost: 64}}
+					for pb.Next() {
+						req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+						req.Header.Set("Accept-Encoding", "gzip")
+						resp, err := client.Do(req)
+						if err != nil {
+							b.Error(err)
+							return
+						}
+						io.Copy(io.Discard, resp.Body) //nolint:errcheck
+						resp.Body.Close()
+					}
+				})
+			})
+		}
 	}
 }

--- a/node/rpcstack_gzip_bench_test.go
+++ b/node/rpcstack_gzip_bench_test.go
@@ -402,7 +402,7 @@ func syntheticBlockJSON(targetBytes int) []byte {
 // unlike the sequential per-request loop in rpcstack_gzip_bench_test.go which
 // reports latency. -cpu controls the client concurrency.
 func BenchmarkGzipOneShotThroughput(b *testing.B) {
-	for _, size := range []int{16 << 10, 256 << 10, 2 << 20} {
+	for _, size := range []int{16 << 10, 256 << 10, 768 << 10, 2 << 20} {
 		payload := syntheticBlockJSON(size)
 		b.Run(fmt.Sprintf("payload=%dKB", len(payload)>>10), func(b *testing.B) {
 			handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/node/rpcstack_gzip_bench_test.go
+++ b/node/rpcstack_gzip_bench_test.go
@@ -439,76 +439,84 @@ func BenchmarkGzipOneShotThroughput(b *testing.B) {
 // (rpc/jsonstream/factory.go) -- on a several-hundred-MB trace that is tens of
 // thousands of write calls through the middleware.
 func BenchmarkGzipStreamingThroughput(b *testing.B) {
-	for _, bufSize := range []int{4096, 64 << 10, 256 << 10} {
-		for _, entries := range []int{2000, 60000} {
-			name := fmt.Sprintf("jsonbuf=%dKB/entries=%d", bufSize>>10, entries)
-			if bufSize < 1024 {
-				name = fmt.Sprintf("jsonbuf=%dB/entries=%d", bufSize, entries)
-			}
-			b.Run(name, func(b *testing.B) {
-				// Precomputed: formatting inside the write loop would make the
-				// benchmark measure fmt rather than the streaming path.
-				stackWords := make([]string, 64)
-				for i := range stackWords {
-					stackWords[i] = fmt.Sprintf("0x%064x", i*2654435761)
+	for _, gz := range []bool{false, true} {
+		for _, bufSize := range []int{4096, 256 << 10} {
+			for _, entries := range []int{2000, 60000} {
+				name := fmt.Sprintf("gzip=%v/jsonbuf=%dKB/entries=%d", gz, bufSize>>10, entries)
+				if bufSize < 1024 {
+					name = fmt.Sprintf("gzip=%v/jsonbuf=%dB/entries=%d", gz, bufSize, entries)
 				}
-				var wrote int64
-				handler := newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Set("Content-Type", "application/json")
-					// Production enters streaming mode via the gzip hook before
-					// the first write; Flush is that same entry point.
-					w.(http.Flusher).Flush()
-
-					st := jsoniter.NewStream(jsoniter.ConfigDefault, w, bufSize)
-					stream := jsonstream.Wrap(st)
-					stream.WriteArrayStart()
-					for i := range entries {
-						if i > 0 {
-							stream.WriteMore()
-						}
-						stream.WriteObjectStart()
-						stream.WriteObjectField("pc")
-						stream.WriteInt(i)
-						stream.WriteMore()
-						stream.WriteObjectField("op")
-						stream.WriteString("SSTORE")
-						stream.WriteMore()
-						stream.WriteObjectField("stack")
-						stream.WriteString(stackWords[i%len(stackWords)])
-						stream.WriteObjectEnd()
+				b.Run(name, func(b *testing.B) {
+					// Precomputed: formatting inside the write loop would make the
+					// benchmark measure fmt rather than the streaming path.
+					stackWords := make([]string, 64)
+					for i := range stackWords {
+						stackWords[i] = fmt.Sprintf("0x%064x", i*2654435761)
 					}
-					stream.WriteArrayEnd()
-					stream.Flush() //nolint:errcheck
-					atomic.AddInt64(&wrote, int64(st.Buffered()))
-				}))
-				srv := httptest.NewServer(handler)
-				defer srv.Close()
-
-				// One warmup request to learn the uncompressed size for MB/s.
-				req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
-				req.Header.Set("Accept-Encoding", "gzip")
-				if resp, err := (&http.Client{Transport: &http.Transport{DisableCompression: true}}).Do(req); err == nil {
-					io.Copy(io.Discard, resp.Body) //nolint:errcheck
-					resp.Body.Close()
-				}
-				b.SetBytes(int64(entries) * 96) // approx bytes of JSON per entry
-				b.ReportAllocs()
-				b.ResetTimer()
-				b.RunParallel(func(pb *testing.PB) {
-					client := &http.Client{Transport: &http.Transport{DisableCompression: true, MaxIdleConnsPerHost: 64}}
-					for pb.Next() {
-						req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
-						req.Header.Set("Accept-Encoding", "gzip")
-						resp, err := client.Do(req)
-						if err != nil {
-							b.Error(err)
-							return
+					var wrote int64
+					inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						// Production enters streaming mode via the gzip hook before
+						// the first write; Flush is that same entry point.
+						if f, ok := w.(http.Flusher); ok {
+							f.Flush()
 						}
+
+						st := jsoniter.NewStream(jsoniter.ConfigDefault, w, bufSize)
+						stream := jsonstream.Wrap(st)
+						stream.WriteArrayStart()
+						for i := range entries {
+							if i > 0 {
+								stream.WriteMore()
+							}
+							stream.WriteObjectStart()
+							stream.WriteObjectField("pc")
+							stream.WriteInt(i)
+							stream.WriteMore()
+							stream.WriteObjectField("op")
+							stream.WriteString("SSTORE")
+							stream.WriteMore()
+							stream.WriteObjectField("stack")
+							stream.WriteString(stackWords[i%len(stackWords)])
+							stream.WriteObjectEnd()
+						}
+						stream.WriteArrayEnd()
+						stream.Flush() //nolint:errcheck
+						atomic.AddInt64(&wrote, int64(st.Buffered()))
+					})
+					var handler http.Handler = inner
+					if gz {
+						handler = newGzipHandler(inner)
+					}
+					srv := httptest.NewServer(handler)
+					defer srv.Close()
+
+					// One warmup request to learn the uncompressed size for MB/s.
+					req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+					req.Header.Set("Accept-Encoding", "gzip")
+					if resp, err := (&http.Client{Transport: &http.Transport{DisableCompression: true}}).Do(req); err == nil {
 						io.Copy(io.Discard, resp.Body) //nolint:errcheck
 						resp.Body.Close()
 					}
+					b.SetBytes(int64(entries) * 96) // approx bytes of JSON per entry
+					b.ReportAllocs()
+					b.ResetTimer()
+					b.RunParallel(func(pb *testing.PB) {
+						client := &http.Client{Transport: &http.Transport{DisableCompression: true, MaxIdleConnsPerHost: 64}}
+						for pb.Next() {
+							req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+							req.Header.Set("Accept-Encoding", "gzip")
+							resp, err := client.Do(req)
+							if err != nil {
+								b.Error(err)
+								return
+							}
+							io.Copy(io.Discard, resp.Body) //nolint:errcheck
+							resp.Body.Close()
+						}
+					})
 				})
-			})
+			}
 		}
 	}
 }

--- a/node/rpcstack_gzip_handler_test.go
+++ b/node/rpcstack_gzip_handler_test.go
@@ -263,3 +263,34 @@ func TestGzipLargeResponseStreamsWithoutContentLength(t *testing.T) {
 		})
 	}
 }
+
+// A single write larger than the cap must stream rather than grow the buffer
+// past it: the threshold is checked against the incoming write, not only
+// against what is already buffered.
+func TestGzipSingleOversizedWriteStreams(t *testing.T) {
+	payload := bytes.Repeat([]byte(`{"k":"0123456789abcdef"},`), (8<<20)/25)
+	require.Greater(t, len(payload), maxBufferedGzipSize, "payload must exceed the cap in one write")
+
+	srv := httptest.NewServer(newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		n, err := w.Write(payload) // one Write call, nothing buffered before it
+		require.NoError(t, err)
+		require.Equal(t, len(payload), n)
+	})))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp, err := (&http.Client{Transport: &http.Transport{DisableCompression: true}}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+	require.Empty(t, resp.Header.Get("Content-Length"), "an oversized single write must stream")
+
+	zr, err := gzip.NewReader(resp.Body)
+	require.NoError(t, err)
+	got, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}

--- a/node/rpcstack_gzip_handler_test.go
+++ b/node/rpcstack_gzip_handler_test.go
@@ -220,3 +220,46 @@ func TestGzipResponseWriterFlushActivatesStreaming(t *testing.T) {
 	got := decompressGzip(t, rec.Body)
 	assert.Equal(t, []byte("pre-flush post-flush"), got)
 }
+
+// A response past maxBufferedGzipSize switches to the streaming path: it is
+// served chunked without Content-Length, the way net/http, nginx and Caddy all
+// frame a body whose size is not known before the headers go out. Smaller
+// responses keep the exact Content-Length.
+func TestGzipLargeResponseStreamsWithoutContentLength(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		size          int
+		wantStreaming bool
+	}{
+		{"under threshold keeps Content-Length", 64 << 10, false},
+		{"over threshold streams", maxBufferedGzipSize + (1 << 20), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := bytes.Repeat([]byte(`{"k":"0123456789abcdef"},`), tc.size/25)
+			srv := httptest.NewServer(newGzipHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(payload) //nolint:errcheck
+			})))
+			defer srv.Close()
+
+			req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+			req.Header.Set("Accept-Encoding", "gzip")
+			resp, err := (&http.Client{Transport: &http.Transport{DisableCompression: true}}).Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+			if tc.wantStreaming {
+				require.Empty(t, resp.Header.Get("Content-Length"), "streamed response must not declare a length")
+			} else {
+				require.NotEmpty(t, resp.Header.Get("Content-Length"), "buffered response must declare a length")
+			}
+
+			zr, err := gzip.NewReader(resp.Body)
+			require.NoError(t, err)
+			got, err := io.ReadAll(zr)
+			require.NoError(t, err)
+			require.Equal(t, payload, got, "decompressed body must be byte-identical")
+		})
+	}
+}


### PR DESCRIPTION
Fixes #23241.

The one-shot gzip path accumulates the **whole uncompressed response** so it can set an exact `Content-Length`. Past `pool.MaxBufferCap` (1 MB) that buffer can no longer be returned to its pool:

```go
func PutBuffer(b *bytes.Buffer) {
	if b.Cap() > MaxBufferCap { return }   // dropped, never pooled
	buffers.Put(b)
}
```

so every response over 1 MB allocates multiple MB and throws them away — `eth_getLogs` over wide ranges, large blocks, big traces.

## Change

Above the threshold, stop accumulating and hand off to the **existing** streaming path, which already deletes `Content-Length` and emits chunked. `Flush()` was complete; only an explicit hook ever triggered it, never size. Ten lines.

The threshold is `pool.MaxBufferCap` itself: above the point where a buffer can no longer be pooled, streaming is strictly better, so a buffer is never grown just to be discarded.

## Measured

Medians of 6 runs, 32 concurrent clients, all three configurations built and run on the same box. `main` is the current code; the other two differ only in the threshold constant.

| payload | main | **threshold = MaxBufferCap (this PR)** | threshold = MaxBufferCap/2 |
|---|---|---|---|
| 16 KB | 9,250 ns / 9,442 B | 9,298 ns / 9,558 B | 9,224 ns / 9,481 B |
| 256 KB | 20,800 ns / 8,858 B | 20,838 ns / 8,742 B | 21,040 ns / 8,854 B |
| 768 KB | 61,165 ns / 7,920 B | **60,474 ns / 7,904 B** | **72,276 ns** / 8,922 B |
| 2048 KB | 203,204 ns / **2,448,806 B** | 203,828 ns / **11,472 B** | 200,426 ns / 10,246 B |

Three things fall out:

- **The common path is untouched.** 16 KB and 256 KB are identical across all three configurations, which is the property that matters most — the overwhelming majority of RPC responses never reach the threshold.
- **Large responses stop producing garbage.** 2,448,806 to 11,472 B/op, roughly 213x less, with `ns/op` unchanged. The wall-clock is flat because allocating on a warm heap is cheap in a microbenchmark; the real cost of 2.4 MB per request is GC pressure under sustained load, which this cannot show.
- **The threshold is not arbitrary.** `MaxBufferCap/2` was measured too. It delivers the same win at 2 MB but costs **19% throughput in the 512 KB - 1 MB band** (72,276 vs 60,474 ns), because it streams payloads whose buffer is still poolable. `MaxBufferCap` is exactly the crossover where buffering stops being free: below it, buffering is cheaper than streaming; above it, the buffer cannot be pooled at all. The 768 KB payload exists in the benchmark specifically to expose that difference — without it, both thresholds measure identically.

### Peak memory under concurrency

Throughput was the wrong lens. `ns/op` is a wash (203,828 vs 203,204), because allocating on a warm heap is cheap in a microbenchmark. The cost shows up as peak live heap when many requests are in flight at once — each one holding its own full uncompressed response:

| concurrent clients | main | this PR | |
|---|---|---|---|
| 8 | 103.7 / 98.2 MiB | 34.8 / 33.9 MiB | 3x less |
| 64 | 310.6 / 296.4 MiB | 61.1 / 67.1 MiB | 4.7x less |

The scaling matters more than the ratio. From 8 to 64 clients **main grows ~3x** (101 to 303 MiB) because peak tracks concurrency times response size, while **this branch grows ~1.9x** (34 to 64 MiB) and what remains is pooled writer state rather than response-sized buffers. A node serving 64 concurrent wide `eth_getLogs` calls is exactly the case that never appears in a `ns/op` column.

`BenchmarkGzipPeakMemoryParallel` is included so this is reproducible rather than asserted.

### On the allocation figures

The `B/op` and `allocs/op` columns above come from `b.ReportAllocs()` on a benchmark that drives a real HTTP client in-process, so they count the **whole process**, not the code under test. A focused profile of the 2 MB case shows the gzip path accounting for **412 of 549,590 allocations (0.075%)** — all of it one-time compressor construction on pool misses:

```
$ go tool pprof -sample_index=alloc_objects -focus='gzhttp|compress/gzip|newGzipHandler'
    256  flate.newHuffmanEncoder
     51  flate.(*compressor).init
     37  flate.NewWriter
```

while the top of the unfiltered profile is the benchmark's own client and harness:

```
114691 20.87%  testing.(*B).RunParallel.func1
 32768  5.96%  net/http.(*Request).write
 18206  3.31%  net/http.ReadResponse
 16384  2.98%  syscall.anyToSockaddr
```

So **`allocs/op` should be disregarded** for every row: a larger payload means more client-side reads, which is what that counter was tracking. `B/op` survives only where the signal dwarfs the noise — main's 2,448,806 B/op at 2 MB is real, the 8-12 KB figures are at the noise floor and not meaningfully different from each other.

The peak-heap numbers are unaffected: they come from `runtime.ReadMemStats` sampled during the run, which measures live heap rather than per-op attribution.

## Precedent

This is what everything else does. `net/http` buffers `bufferBeforeChunkingSize = 2048`, sets `Content-Length` if the response fits and switches to chunked otherwise — so **the stdlib would already do this on its own**; the one-shot handler was overriding it. nginx (`gzip_buffers 32 4k`) and Caddy's `encode` behave the same way. And erigon already serves `debug_trace*` and `trace_filter` compressed with no `Content-Length` today, so no client can depend on it for large compressed bodies.

Chunked framing is HTTP/1.1-only; in HTTP/2 and HTTP/3 the framing layer delimits the body and `Content-Length` is optional metadata, so this is moot for h2/h3 clients.

## Tests and benchmark

`TestGzipLargeResponseStreamsWithoutContentLength` pins both sides of the threshold — under it keeps an exact `Content-Length`, over it must not declare one — and asserts the decompressed body is byte-identical in both cases.

`BenchmarkGzipOneShotThroughput` is added because the file had no way to measure this. The existing benchmarks are strictly sequential (`for i := 0; i < b.N; i++ { client.Do(req) }`), report `µs/req`, and their helper type is `latencyStats` — they measure latency and cannot answer a throughput question. The throughput claims in #22882 came from external `rpctest` runs, not from these.

Full `./node` suite is green.

## Not included

Two follow-ups from the issue, deliberately separate: restoring a bound and metrics for the compressor pool (#22882 replaced a bounded channel with unbounded `sync.Pool`s holding ~795 KiB writers), and the 4 KB `InitialBufferSize` on the streaming JSON path.


