### PR TITLE
[r3.5] db/seg: reclaim Compressor pattern workers in Close

### DIFF
--- a/db/seg/compress.go
+++ b/db/seg/compress.go
@@ -110,6 +110,7 @@ type Compressor struct {
 	Cfg
 	ctx              context.Context
 	wg               *sync.WaitGroup
+	stopWorkersOnce  sync.Once
 	superstrings     chan []byte
 	uncompressedFile *RawWordsFile
 	tmpDir           string // temporary directory to use for ETL when building dictionary
@@ -197,7 +198,15 @@ func NewCompressor(ctx context.Context, logPrefix, outputFile, tmpDir string, cf
 	return cc, nil
 }
 
+func (c *Compressor) stopWorkers() {
+	c.stopWorkersOnce.Do(func() {
+		close(c.superstrings)
+		c.wg.Wait()
+	})
+}
+
 func (c *Compressor) Close() {
+	c.stopWorkers()
 	c.uncompressedFile.CloseAndRemove()
 	for _, collector := range c.suffixCollectors {
 		collector.Close()
@@ -320,8 +329,7 @@ func (c *Compressor) Compress() error {
 	if len(c.superstring) > 0 {
 		c.superstrings <- c.superstring
 	}
-	close(c.superstrings)
-	c.wg.Wait()
+	c.stopWorkers()
 
 	cf, err := dir.CreateTemp(c.outputFile)
 	if err != nil {
@@ -961,6 +969,7 @@ func NewRawWordsFile(filePath string) (*RawWordsFile, error) {
 	}
 	return &RawWordsFile{filePath: filePath, f: f, w: getBufioWriter(f), buf: make([]byte, 128)}, nil
 }
+
 func OpenRawWordsFile(filePath string) (*RawWordsFile, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -968,9 +977,11 @@ func OpenRawWordsFile(filePath string) (*RawWordsFile, error) {
 	}
 	return &RawWordsFile{filePath: filePath, f: f, w: getBufioWriter(f), buf: make([]byte, 128)}, nil
 }
+
 func (f *RawWordsFile) Flush() error {
 	return f.w.Flush()
 }
+
 func (f *RawWordsFile) Close() {
 	if f.w != nil {
 		f.w.Flush()
@@ -980,10 +991,12 @@ func (f *RawWordsFile) Close() {
 		f.f = nil
 	}
 }
+
 func (f *RawWordsFile) CloseAndRemove() {
 	f.Close()
 	dir2.RemoveFile(f.filePath)
 }
+
 func (f *RawWordsFile) Append(v []byte) error {
 	f.count++
 	// For compressed words, the length prefix is shifted to make lowest bit zero
@@ -998,6 +1011,7 @@ func (f *RawWordsFile) Append(v []byte) error {
 	}
 	return nil
 }
+
 func (f *RawWordsFile) AppendUncompressed(v []byte) error {
 	f.count++
 	// For uncompressed words, the length prefix is shifted to make lowest bit one

--- a/db/seg/compress_test.go
+++ b/db/seg/compress_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -385,5 +386,29 @@ func TestCompressNoWordPatterns(t *testing.T) {
 
 	if cs := checksum(file); cs != 1879837905 {
 		t.Errorf("fast-path output differs from main, checksum=%d", cs)
+	}
+}
+
+// Close must reclaim the pattern workers NewCompressor started. A caller that
+// gives up between NewCompressor and Compress leaks one goroutine per worker,
+// each pinning its suffix-array buffers, for the lifetime of the parent context.
+func TestCompressorCloseReleasesWorkers(t *testing.T) {
+	logger := log.New()
+	tmpDir := t.TempDir()
+	c, err := NewCompressor(t.Context(), t.Name(), filepath.Join(tmpDir, "compressed"), tmpDir, DefaultCfg, log.LvlDebug, logger)
+	require.NoError(t, err)
+	require.NoError(t, c.AddWord([]byte("word")))
+
+	c.Close()
+
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close() returned while pattern workers are still running")
 	}
 }


### PR DESCRIPTION
Cherry-pick of #23233 to `release/3.5`, fixing #23223 on the 3.5 line. `main` and `release/3.6` already have it (#23233, #23235); `Close()` was byte-identical on 3.5, so it leaks there too.

This is the OOM reported on a Gnosis archive node running `release/3.5`: 328 abandoned compressors over 65 minutes drove `alloc` to 58.7GB on a 64GB host.

## r3.5-specific adaptations

- `Compressor.superstrings` is `chan []byte` on this branch (the `[]uint16` superstring change is not backported), so the struct hunk keeps `[]byte` and only adds `stopWorkersOnce`.
- The upstream test hunk also carries `TestCompressSamplingCoversWholeFile` from #21806, which is not on 3.5 and references `superstringLimit`, a field this branch lacks. Only `TestCompressorCloseReleasesWorkers` is taken.

## Verification on this branch

The worker plumbing differs here — `wg.Add(workers)` plus `defer completion.Done()` rather than `wg.Go` — so the test was re-checked against 3.5 rather than assumed from main. It fails without the fix (`Close() returned while pattern workers are still running`, after the full 10s timeout) and passes with it.

`db/seg/...` green under `-race`; `db/state/...` and `db/snapshotsync/...` green; `make lint` clean; `make erigon` builds.
