### PR TITLE
db/state: merge commitment shards during the rebuild

### DIFF
--- a/db/state/rebuild_merge.go
+++ b/db/state/rebuild_merge.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"context"
+
+	"github.com/erigontech/erigon/db/kv"
+)
+
+// keepCommitmentMergeOnly holds every domain but commitment. A rebuild shard runs
+// inside a range-scoped iterator over the accounts and storage files, so those must
+// keep the layout they were opened with until the range ends.
+func keepCommitmentMergeOnly(r *Ranges) {
+	for id := range r.domain {
+		if kv.Domain(id) != kv.CommitmentDomain {
+			r.domain[id] = DomainRanges{}
+		}
+	}
+	for i := range r.invertedIndex {
+		r.invertedIndex[i] = nil
+	}
+}
+
+// mergeCommitmentStep collapses the shard files a rebuild has produced so far.
+// Every shard opens the commitment files of the shards before it, so left flat the
+// per-key lookup cost grows with the shard count and the range degrades to
+// quadratic. Merging only commitment is what makes this safe to call mid-range.
+func (a *Aggregator) mergeCommitmentStep(ctx context.Context, toTxNum uint64) (somethingDone bool, err error) {
+	aggTx := a.BeginFilesRo()
+	defer aggTx.Close()
+	mxRunningMerges.Inc()
+	defer mxRunningMerges.Dec()
+
+	// Referencing ties the accounts/storage/commitment ranges together, and holding
+	// the other two would stall the merge anyway.
+	if a.referencesInCommitmentBranches() || aggTx.commitmentVisibleFilesReferenced() {
+		return false, nil
+	}
+
+	r := aggTx.findMergeRange(toTxNum, a.StepSize(), a.StepsInFrozenFile())
+	keepCommitmentMergeOnly(r)
+	if !r.any() {
+		// Reclaims the inputs of earlier merges, which stay pinned for as long as a
+		// range-scoped reader still references them.
+		a.cleanAfterMerge(nil)
+		return false, nil
+	}
+
+	outs, err := aggTx.filesInRange(r)
+	if err != nil {
+		return false, err
+	}
+
+	in, err := aggTx.mergeFiles(ctx, outs, r)
+	if err != nil {
+		in.Close()
+		return true, err
+	}
+	a.integrateMergedDirtyFiles(in)
+	return true, nil
+}

--- a/db/state/rebuild_merge_test.go
+++ b/db/state/rebuild_merge_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/db/kv"
+)
+
+func mergeableRange(name kv.Domain, from, to uint64) DomainRanges {
+	return DomainRanges{
+		name:    name,
+		values:  MergeRange{name: name.String(), needMerge: true, from: from, to: to},
+		history: HistoryRanges{history: MergeRange{needMerge: true, from: from, to: to}},
+		aggStep: 1,
+	}
+}
+
+// A rebuild shard runs inside a range-scoped iterator over the accounts and
+// storage files, so only commitment may collapse underneath it.
+func TestKeepCommitmentMergeOnly(t *testing.T) {
+	t.Parallel()
+
+	r := &Ranges{}
+	r.domain[kv.AccountsDomain] = mergeableRange(kv.AccountsDomain, 0, 100)
+	r.domain[kv.StorageDomain] = mergeableRange(kv.StorageDomain, 0, 100)
+	r.domain[kv.CodeDomain] = mergeableRange(kv.CodeDomain, 0, 100)
+	r.domain[kv.CommitmentDomain] = mergeableRange(kv.CommitmentDomain, 0, 100)
+	r.invertedIndex[0] = NewMergeRange("logaddrs", true, 0, 100)
+
+	require.True(t, r.any())
+	keepCommitmentMergeOnly(r)
+
+	require.True(t, r.domain[kv.CommitmentDomain].any(), "commitment must stay mergeable")
+	require.False(t, r.domain[kv.AccountsDomain].any(), "accounts must be held")
+	require.False(t, r.domain[kv.StorageDomain].any(), "storage must be held")
+	require.False(t, r.domain[kv.CodeDomain].any(), "code must be held")
+	for i, ii := range r.invertedIndex {
+		require.Nilf(t, ii, "inverted index %d must be held", i)
+	}
+}
+
+func TestKeepCommitmentMergeOnlyNothingToDo(t *testing.T) {
+	t.Parallel()
+
+	r := &Ranges{}
+	r.domain[kv.AccountsDomain] = mergeableRange(kv.AccountsDomain, 0, 100)
+
+	keepCommitmentMergeOnly(r)
+	require.False(t, r.any(), "with no commitment range there is nothing left to merge")
+}

--- a/db/state/rebuild_shard_merge_test.go
+++ b/db/state/rebuild_shard_merge_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/empty"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/rawdbv3"
+	"github.com/erigontech/erigon/db/kv/temporal"
+	"github.com/erigontech/erigon/db/state"
+	"github.com/erigontech/erigon/execution/commitment"
+	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+)
+
+// A range wider than one shard is rebuilt in several shards, each made visible
+// before the next starts, with commitment merges running between them. The root
+// must come out where the forward run left it regardless of that reshuffling.
+func TestAggregator_RebuildCommitmentAcrossMergedShards(t *testing.T) {
+	if testing.Short() {
+		t.Skip("long-running test")
+	}
+
+	// 257 steps collate into a 256-step file: four shards, so a merged file lands
+	// while shards are still being built and later ones read it. Keys must outnumber
+	// steps or the shard loop divides by a zero keys-per-step. Branch transform off:
+	// referencing pins the accounts, storage and commitment ranges together, and a
+	// mid-range commitment merge stands down.
+	const stepSize = uint64(2)
+	const txCount = int(stepSize) * 257
+
+	db, agg := testDbAggregatorWithNoFiles(t, txCount, &testAggConfig{
+		stepSize:                         stepSize,
+		disableCommitmentBranchTransform: true,
+	})
+	require.NoError(t, agg.BuildFiles(uint64(txCount)))
+
+	var rootInFiles []byte
+	var fPaths []string
+	{
+		tx, err := db.BeginTemporalRw(t.Context())
+		require.NoError(t, err)
+		defer tx.Rollback()
+		ac := state.AggTx(tx)
+
+		stateVal, ok, _, _, _ := ac.DebugGetLatestFromFiles(kv.CommitmentDomain, commitmentdb.KeyCommitmentState, math.MaxUint64)
+		require.True(t, ok)
+		rootInFiles, _, _, err = commitment.HexTrieExtractStateRoot(stateVal)
+		require.NoError(t, err)
+
+		var widest uint64
+		for _, f := range ac.Files(kv.AccountsDomain) {
+			if steps := (f.EndRootNum() - f.StartRootNum()) / stepSize; steps > widest {
+				widest = steps
+			}
+		}
+		require.Greaterf(t, widest, uint64(commitment.DefaultRebuildShardMaxSteps),
+			"the widest range must exceed one shard, or the rebuild never shards and this proves nothing")
+
+		for _, f := range ac.Files(kv.CommitmentDomain) {
+			fPaths = append(fPaths, f.Fullpath())
+		}
+		tx.Rollback()
+		agg.Close()
+	}
+
+	agg = testAgg(t, db, agg.Dirs(), stepSize, log.New())
+	db, err := temporal.New(db, agg, nil)
+	require.NoError(t, err)
+	defer db.Close()
+
+	rwTx, err := db.BeginRw(t.Context())
+	require.NoError(t, err)
+	defer rwTx.Rollback()
+	buckets, err := rwTx.ListTables()
+	require.NoError(t, err)
+	for _, b := range buckets {
+		if strings.Contains(strings.ToLower(b), kv.CommitmentDomain.String()) {
+			require.NoError(t, rwTx.ClearTable(b))
+		}
+	}
+	require.NoError(t, rwTx.Commit())
+
+	for _, fn := range fPaths {
+		if strings.Contains(fn, kv.CommitmentDomain.String()) {
+			require.NoError(t, dir.RemoveFile(fn))
+		}
+	}
+	require.NoError(t, agg.OpenFolder())
+
+	finalRoot, err := state.RebuildCommitmentFiles(t.Context(), db, &rawdbv3.TxNums, log.New(), false)
+	require.NoError(t, err)
+	require.NotEmpty(t, finalRoot)
+	require.NotEqual(t, empty.RootHash[:], finalRoot)
+	require.Equal(t, rootInFiles, finalRoot)
+}

--- a/db/state/squeeze.go
+++ b/db/state/squeeze.go
@@ -1084,6 +1084,16 @@ func RebuildCommitmentFiles(ctx context.Context, rwDb kv.TemporalRwDB, txNumsRea
 			a.dirtyFilesLock.Unlock()
 			rwTx.Rollback()
 
+			for {
+				smthDone, err := a.mergeCommitmentStep(ctx, rangeToTxNum)
+				if err != nil {
+					return nil, err
+				}
+				if !smthDone {
+					break
+				}
+			}
+
 			if shardTo+shardStepsSize > lastShard && shardStepsSize > 1 {
 				shardStepsSize /= 2
 			}


### PR DESCRIPTION
A commitment rebuild splits a file range into shards, makes each finished shard visible, and merges them only once the whole range is done. Every shard therefore runs against all of its predecessors, and per-key lookup cost grows with the visible file count.

Measured on a mainnet `0-8192` range, 13.99M keys per shard throughout: 2m24s for the first shard, 14m00s for the 37th, a least-squares fit of +22.9s per additional file, with the visible count climbing 1:1 with the shard index.

Rebuilt with this change, the count follows the merge cascade instead — log2(shards), 4 by shard 15 against 15 — and the same work runs 1.43x faster at equal key position, holding between 1.43x and 1.75x across shards 8 to 15.

This lowers the constant rather than removing the growth. Per-shard cost still rises in both runs: the merged file keeps getting larger, and its merge I/O overlaps the next shard. Do not read an endpoint projection into the 1.43x. Those runs rebuilt a binary trie, but the cost sits in the domain file lookup and does not depend on the trie engine.

## Changes

`mergeCommitmentStep` collapses shard files as they land.

It merges commitment only. The shard loop holds accounts and storage `FileStream`s open for the range's lifetime, so merging those would collate files out from under the iterator driving the rebuild. It also declines when referencing ties accounts, storage and commitment to a common range, where commitment cannot advance alone.

Superseded inputs stay on disk until the range-scoped reader releases them, so peak disk within a range is unchanged.

The existing rebuild test collates 31 steps, whose widest range is 16 — under one shard, so it never sharded. The added test collates 257 steps into a 256-step range, four shards, and asserts the rebuilt root against the forward run's.
