### PR TITLE
p2p/protocols/eth, execution/rlp: measure EncodeRLP itself, skip alloc assertions under -race

### DIFF
--- a/common/crypto/sha256_test.go
+++ b/common/crypto/sha256_test.go
@@ -117,11 +117,11 @@ func TestSha256Repeatable(t *testing.T) {
 // Joins too large for the stack buffer take the pooled scratch buffer, which keeps
 // them allocation-free too.
 func TestSha256JoinedPathAllocFree(t *testing.T) {
-	// sync.Pool deliberately drops values under the race detector, so the pooled path
-	// always allocates there and can't be measured.
+	// sync.Pool drops a random quarter of the values put back under the race detector,
+	// so the pooled path is not reliably allocation-free there.
 	//goland:noinspection GoBoolExpressions
 	if race.Enabled {
-		t.Skip("sync.Pool does not pool under -race")
+		t.Skip("sync.Pool does not pool reliably under -race")
 	}
 	big, extra := bytesOfLen(4096, 7), bytesOfLen(32, 8)
 	if n := testing.AllocsPerRun(200, func() { crypto.Sha256(big, extra) }); n != 0 {

--- a/execution/rlp/encode_test.go
+++ b/execution/rlp/encode_test.go
@@ -608,28 +608,30 @@ func TestEncodeValueAndPointerAgree(t *testing.T) {
 // fields of a value boxed into an interface are not addressable, so every [N]byte
 // field costs a reflect.New copy that the pointer form avoids entirely.
 func TestEncodePointerAvoidsByteArrayCopies(t *testing.T) {
+	// encBuffer is pooled, and sync.Pool deliberately drops values under the race
+	// detector, so the pooled path always allocates there and can't be measured.
+	//goland:noinspection GoBoolExpressions
+	if race.Enabled {
+		t.Skip("sync.Pool does not pool under -race")
+	}
+
 	v := ptrTestOuter{Inners: []*ptrTestInner{{}}, Payload: make([]byte, 64)}
 
-	// Panic rather than drop the error: a failing Encode would otherwise report a
-	// misleadingly low allocation count. The panic path never runs when it succeeds.
-	mustEncode := func(val any) func() {
-		return func() {
+	allocsPerEncode := func(val any) float64 {
+		return testing.AllocsPerRun(200, func() {
 			if err := Encode(io.Discard, val); err != nil {
-				panic(err)
+				t.Fatal(err)
 			}
-		}
+		})
 	}
-	byValue := testing.AllocsPerRun(200, mustEncode(v))
-	byPointer := testing.AllocsPerRun(200, mustEncode(&v))
+	byValue := allocsPerEncode(v)
+	byPointer := allocsPerEncode(&v)
 	t.Logf("allocs/op: byValue=%v byPointer=%v", byValue, byPointer)
 
 	if byValue <= byPointer {
 		t.Errorf("expected the value form to allocate more than the pointer form, got value=%v pointer=%v", byValue, byPointer)
 	}
-	// encBuffer comes from a sync.Pool, which deliberately drops values under the
-	// race detector, so only the relative comparison above holds there.
-	//goland:noinspection GoBoolExpressions
-	if !race.Enabled && byPointer != 0 {
+	if byPointer != 0 {
 		t.Errorf("pointer form should not allocate, got %v allocs/op", byPointer)
 	}
 }

--- a/execution/rlp/encode_test.go
+++ b/execution/rlp/encode_test.go
@@ -608,13 +608,6 @@ func TestEncodeValueAndPointerAgree(t *testing.T) {
 // fields of a value boxed into an interface are not addressable, so every [N]byte
 // field costs a reflect.New copy that the pointer form avoids entirely.
 func TestEncodePointerAvoidsByteArrayCopies(t *testing.T) {
-	// encBuffer is pooled, and sync.Pool deliberately drops values under the race
-	// detector, so the pooled path always allocates there and can't be measured.
-	//goland:noinspection GoBoolExpressions
-	if race.Enabled {
-		t.Skip("sync.Pool does not pool under -race")
-	}
-
 	v := ptrTestOuter{Inners: []*ptrTestInner{{}}, Payload: make([]byte, 64)}
 
 	allocsPerEncode := func(val any) float64 {
@@ -631,7 +624,12 @@ func TestEncodePointerAvoidsByteArrayCopies(t *testing.T) {
 	if byValue <= byPointer {
 		t.Errorf("expected the value form to allocate more than the pointer form, got value=%v pointer=%v", byValue, byPointer)
 	}
-	if byPointer != 0 {
+	// encBuffer is pooled, and sync.Pool drops a random quarter of the values put
+	// back under the race detector, so the pooled path is not reliably zero there.
+	// The relative check above survives: its gap is the two reflect.New copies,
+	// which the pool does not touch.
+	//goland:noinspection GoBoolExpressions
+	if !race.Enabled && byPointer != 0 {
 		t.Errorf("pointer form should not allocate, got %v allocs/op", byPointer)
 	}
 }

--- a/p2p/protocols/eth/protocol_test.go
+++ b/p2p/protocols/eth/protocol_test.go
@@ -401,6 +401,11 @@ func TestHashOrNumberEncodeRLPPointerIsAllocFree(t *testing.T) {
 		t.Fatalf("value=%x pointer=%x", byValue.Bytes(), byPointer.Bytes())
 	}
 
+	//goland:noinspection GoBoolExpressions
+	if race.Enabled {
+		return
+	}
+
 	// Panic rather than drop the error: a failing Encode would otherwise report a
 	// misleadingly low allocation count. The panic path never runs when it succeeds.
 	mustEncode := func(val any) func() {
@@ -416,9 +421,7 @@ func TestHashOrNumberEncodeRLPPointerIsAllocFree(t *testing.T) {
 	if pointerAllocs >= valueAllocs {
 		t.Errorf("pointer form should allocate less: value=%v pointer=%v", valueAllocs, pointerAllocs)
 	}
-	// encBuffer is pooled, and sync.Pool drops values under the race detector.
-	//goland:noinspection GoBoolExpressions
-	if !race.Enabled && pointerAllocs != 0 {
+	if pointerAllocs != 0 {
 		t.Errorf("pointer form should not allocate, got %v", pointerAllocs)
 	}
 }

--- a/p2p/protocols/eth/protocol_test.go
+++ b/p2p/protocols/eth/protocol_test.go
@@ -385,8 +385,10 @@ func BenchmarkHashOrNumberEncodeRLP(b *testing.B) {
 	})
 }
 
-// TestHashOrNumberEncodeRLPPointerIsAllocFree pins the allocation win the pointer
-// form gives, and that both forms still produce identical bytes.
+// TestHashOrNumberEncodeRLPPointerIsAllocFree pins both EncodeRLP branches: the
+// hash branch encodes through a pointer and allocates nothing, the number branch
+// boxes a uint64 into any and allocates once above the runtime's 0-255 cache. It
+// also pins that the hash branch still produces the same bytes as the value form.
 func TestHashOrNumberEncodeRLPPointerIsAllocFree(t *testing.T) {
 	hn := &HashOrNumber{Hash: common.Hash{1, 2, 3}}
 
@@ -401,11 +403,12 @@ func TestHashOrNumberEncodeRLPPointerIsAllocFree(t *testing.T) {
 		t.Fatalf("value=%x pointer=%x", byValue.Bytes(), byPointer.Bytes())
 	}
 
-	// encBuffer is pooled, and sync.Pool deliberately drops values under the race
-	// detector, so the pooled path always allocates there and can't be measured.
+	// encBuffer is pooled, and sync.Pool drops a random quarter of the values put
+	// back under the race detector. That is enough to move mallocs/runs across the
+	// 0/1 truncation boundary in AllocsPerRun and flake the assertions below.
 	//goland:noinspection GoBoolExpressions
 	if race.Enabled {
-		t.Skip("sync.Pool does not pool under -race")
+		t.Skip("sync.Pool does not pool reliably under -race")
 	}
 
 	allocsPerEncode := func(encode func(io.Writer) error) float64 {
@@ -417,8 +420,26 @@ func TestHashOrNumberEncodeRLPPointerIsAllocFree(t *testing.T) {
 	}
 	valueAllocs := allocsPerEncode(func(w io.Writer) error { return rlp.Encode(w, hn.Hash) })
 	pointerAllocs := allocsPerEncode(hn.EncodeRLP)
-	t.Logf("allocs/op: byValue=%v byPointer=%v", valueAllocs, pointerAllocs)
+	t.Logf("hash branch allocs/op: byValue=%v byPointer=%v", valueAllocs, pointerAllocs)
 	if pointerAllocs != 0 {
-		t.Errorf("EncodeRLP should not allocate, got %v (value form: %v)", pointerAllocs, valueAllocs)
+		t.Errorf("EncodeRLP hash branch should not allocate, got %v (value form: %v)", pointerAllocs, valueAllocs)
+	}
+
+	// Boxing hn.Number into any allocates unless the runtime's staticuint64s cache
+	// serves it. Upper bounds rather than exact counts, so an encoder improvement
+	// does not turn the build red.
+	for _, tc := range []struct {
+		number    uint64
+		maxAllocs float64
+	}{
+		{number: 255, maxAllocs: 0},
+		{number: 256, maxAllocs: 1},
+	} {
+		byNumber := &HashOrNumber{Number: tc.number}
+		got := allocsPerEncode(byNumber.EncodeRLP)
+		t.Logf("number branch %d: allocs/op=%v", tc.number, got)
+		if got > tc.maxAllocs {
+			t.Errorf("EncodeRLP number branch %d allocs = %v, want <= %v", tc.number, got, tc.maxAllocs)
+		}
 	}
 }

--- a/p2p/protocols/eth/protocol_test.go
+++ b/p2p/protocols/eth/protocol_test.go
@@ -394,34 +394,31 @@ func TestHashOrNumberEncodeRLPPointerIsAllocFree(t *testing.T) {
 	if err := rlp.Encode(&byValue, hn.Hash); err != nil {
 		t.Fatal(err)
 	}
-	if err := rlp.Encode(&byPointer, &hn.Hash); err != nil {
+	if err := hn.EncodeRLP(&byPointer); err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(byValue.Bytes(), byPointer.Bytes()) {
 		t.Fatalf("value=%x pointer=%x", byValue.Bytes(), byPointer.Bytes())
 	}
 
+	// encBuffer is pooled, and sync.Pool deliberately drops values under the race
+	// detector, so the pooled path always allocates there and can't be measured.
 	//goland:noinspection GoBoolExpressions
 	if race.Enabled {
-		return
+		t.Skip("sync.Pool does not pool under -race")
 	}
 
-	// Panic rather than drop the error: a failing Encode would otherwise report a
-	// misleadingly low allocation count. The panic path never runs when it succeeds.
-	mustEncode := func(val any) func() {
-		return func() {
-			if err := rlp.Encode(io.Discard, val); err != nil {
-				panic(err)
+	allocsPerEncode := func(encode func(io.Writer) error) float64 {
+		return testing.AllocsPerRun(200, func() {
+			if err := encode(io.Discard); err != nil {
+				t.Fatal(err)
 			}
-		}
+		})
 	}
-	valueAllocs := testing.AllocsPerRun(200, mustEncode(hn.Hash))
-	pointerAllocs := testing.AllocsPerRun(200, mustEncode(&hn.Hash))
+	valueAllocs := allocsPerEncode(func(w io.Writer) error { return rlp.Encode(w, hn.Hash) })
+	pointerAllocs := allocsPerEncode(hn.EncodeRLP)
 	t.Logf("allocs/op: byValue=%v byPointer=%v", valueAllocs, pointerAllocs)
-	if pointerAllocs >= valueAllocs {
-		t.Errorf("pointer form should allocate less: value=%v pointer=%v", valueAllocs, pointerAllocs)
-	}
 	if pointerAllocs != 0 {
-		t.Errorf("pointer form should not allocate, got %v", pointerAllocs)
+		t.Errorf("EncodeRLP should not allocate, got %v (value form: %v)", pointerAllocs, valueAllocs)
 	}
 }


### PR DESCRIPTION
Failing job: https://github.com/erigontech/erigon/actions/runs/31759617298/job/94643013852

```
--- FAIL: TestHashOrNumberEncodeRLPPointerIsAllocFree (0.00s)
    protocol_test.go:415: allocs/op: byValue=1 byPointer=1
    protocol_test.go:417: pointer form should allocate less: value=1 pointer=1
```

`sync.Pool` drops a random quarter of the values put back under the race detector, so the pooled path is not reliably allocation-free there. With a gap of 1 that is enough to move `mallocs/runs` across the 0/1 truncation boundary in `AllocsPerRun`, which is what the job above hit. `TestHashOrNumberEncodeRLPPointerIsAllocFree` now skips as a whole under `-race`, with `t.Skip` rather than a bare `return` so `go test -race -v` shows that the assertions did not run.

## The test was not measuring what it was named for

It re-derived the pointer expression by hand instead of calling `HashOrNumber.EncodeRLP`, so reverting `protocol.go:212` to the value form — the regression the test exists to pin — left the numbers byte-identical and nothing in the package caught it. The measurement now goes through the method:

| `protocol.go:212` | allocs/op | result |
| --- | --- | --- |
| `rlp.Encode(w, &hn.Hash)` (current) | byValue=2 byPointer=0 | PASS |
| `rlp.Encode(w, hn.Hash)` (reverted) | byValue=2 byPointer=2 | FAIL |

`byValue` reads 2 rather than 1 because boxing the `[32]byte` into `any` now happens inside the measured closure instead of once at closure-construction time.

## Both branches, not one

`EncodeRLP` picks between a hash and a number, and only the hash branch was covered. The number branch boxes a `uint64` into `any`, which allocates unless the runtime's `staticuint64s` cache serves it — so every real block number pays 1 alloc/op:

```
number branch 255: allocs/op=0
number branch 256: allocs/op=1
hash branch:       allocs/op=0
```

Both are pinned as upper bounds rather than exact counts, so an encoder improvement does not turn the build red.

Also here: the relative `pointer < value` check is gone from this test, since it is unreachable once the pointer form is asserted to allocate zero. `t.Fatal` replaces `panic` inside the closure — `AllocsPerRun` calls `f()` on the calling goroutine, so the panic took down the whole package binary instead of failing one test.

## Siblings

`execution/rlp/encode_test.go` ran the same comparison over the same pooled `encBuffer` with no gate at all. It keeps its relative assertion under `-race` — that gap is two `reflect.New` copies, which the pool does not touch, and it holds 60/60 race runs — and gates only the absolute `byPointer != 0` check, which is the one on the truncation boundary.

`common/crypto/sha256_test.go` is where the "deliberately drops values ... always allocates there" wording came from. It is corrected there as well, so the three sites now describe the actual 1-in-4 mechanism.
