### PR TITLE
execution/commitment: reuse a scratch buffer for HexToCompact on the fold path

### DIFF
--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -139,12 +139,13 @@ type HexPatriciaHashed struct {
 	rootPresent   bool
 	traceW        io.Writer // nil = disabled, non-nil = write trace output
 	ctx           PatriciaContext
-	hashAuxBuffer [128]byte           // buffer to compute cell hash or write hash-related things
-	cellHashBuf   common.Hash         // shared scratch buffer for hashKey calls (avoids per-cell allocation)
-	leafHashBuf   [33]byte            // shared scratch for leaf hash prefixing (avoids per-leaf escape)
-	leafRlpBuf    [maxLeafRlpLen]byte // shared scratch for a leaf's RLP list prefix + compact key
-	rlpPrefixBuf  [8]byte             // shared scratch for RlpSerializable length prefixes
-	auxBuffer     *bytes.Buffer       // auxiliary buffer used during branch updates encoding
+	hashAuxBuffer [128]byte              // buffer to compute cell hash or write hash-related things
+	cellHashBuf   common.Hash            // shared scratch buffer for hashKey calls (avoids per-cell allocation)
+	leafHashBuf   [33]byte               // shared scratch for leaf hash prefixing (avoids per-leaf escape)
+	leafRlpBuf    [maxLeafRlpLen]byte    // shared scratch for a leaf's RLP list prefix + compact key
+	rlpPrefixBuf  [8]byte                // shared scratch for RlpSerializable length prefixes
+	compactKeyBuf [maxCompactKeyLen]byte // shared scratch for HexToCompact on the fold/unfold path
+	auxBuffer     *bytes.Buffer          // auxiliary buffer used during branch updates encoding
 	branchEncoder *BranchEncoder
 
 	mounted    bool  // true if this trie is mounted to some root trie
@@ -322,11 +323,14 @@ const (
 	cellLoadStorage = loadFlags(2)
 )
 
+// maxCompactKeyLen bounds a compact-encoded (hex-prefix) key or branch prefix,
+// derived from the nibble array rather than from the shorter keys today's depth
+// arithmetic yields, so a caller slicing deeper cannot overflow the buffer.
+const maxCompactKeyLen = len(cell{}.hashedExtension)/2 + 1
+
 // maxLeafRlpLen bounds a leaf's assembled RLP header: list prefix (tag plus up to
-// 8 length bytes), key prefix byte, then the compact key. Derived from the nibble
-// array rather than from the shorter keys today's depth arithmetic yields, so a
-// caller slicing deeper cannot overflow the buffer.
-const maxLeafRlpLen = 9 + 1 + (len(cell{}.hashedExtension)/2 + 1)
+// 8 length bytes), key prefix byte, then the compact key.
+const maxLeafRlpLen = 9 + 1 + maxCompactKeyLen
 
 func (f loadFlags) String() string {
 	var b strings.Builder
@@ -1380,7 +1384,7 @@ func (hph *HexPatriciaHashed) PrintGrid() {
 // witnessMaterializeBranch decodes the branch stored at the given hashed-nibble prefix into
 // a trie.FullNode whose children are HashNodes. Mirrors unfoldBranchNode's branch decode.
 func (hph *HexPatriciaHashed) witnessMaterializeBranch(branchPrefix []byte, childDepth int16) (*trie.FullNode, error) {
-	compact := nibbles.HexToCompact(branchPrefix)
+	compact := nibbles.HexToCompactInto(hph.compactKeyBuf[:], branchPrefix)
 	branchData, err := hph.readBranchAndCheckForFlushing(compact)
 	if err != nil {
 		return nil, err
@@ -1450,7 +1454,7 @@ func (hph *HexPatriciaHashed) readBranchAndCheckForFlushing(prefix []byte) ([]by
 
 // unfoldBranchNode returns true if unfolding has been done
 func (hph *HexPatriciaHashed) unfoldBranchNode(row int, depth int16, deleted bool) error {
-	key := nibbles.HexToCompact(hph.currentKey[:hph.currentKeyLen])
+	key := nibbles.HexToCompactInto(hph.compactKeyBuf[:], hph.currentKey[:hph.currentKeyLen])
 	hph.metrics.BranchLoad(hph.currentKey[:hph.currentKeyLen])
 
 	branchData, err := hph.readBranchAndCheckForFlushing(key)
@@ -1991,7 +1995,7 @@ func (hph *HexPatriciaHashed) fold() error {
 
 	depth := hph.depths[row]
 
-	updateKey := nibbles.HexToCompact(hph.currentKey[:updateKeyLen])
+	updateKey := nibbles.HexToCompactInto(hph.compactKeyBuf[:], hph.currentKey[:updateKeyLen])
 	defer func() { hph.depthsToTxNum[depth] = 0 }()
 
 	if hph.traceW != nil {

--- a/execution/commitment/hex_patricia_hashed.go
+++ b/execution/commitment/hex_patricia_hashed.go
@@ -144,8 +144,12 @@ type HexPatriciaHashed struct {
 	leafHashBuf   [33]byte               // shared scratch for leaf hash prefixing (avoids per-leaf escape)
 	leafRlpBuf    [maxLeafRlpLen]byte    // shared scratch for a leaf's RLP list prefix + compact key
 	rlpPrefixBuf  [8]byte                // shared scratch for RlpSerializable length prefixes
-	compactKeyBuf [maxCompactKeyLen]byte // shared scratch for HexToCompact on the fold/unfold path
-	auxBuffer     *bytes.Buffer          // auxiliary buffer used during branch updates encoding
+	compactKeyBuf [maxCompactKeyLen]byte // shared scratch for HexToCompact on the read paths
+	// foldKeyBuf must stay separate from compactKeyBuf: fold's update key is still live
+	// when foldDelete runs the collapse tracer, and that callback is caller code free to
+	// re-enter a read path.
+	foldKeyBuf    [maxCompactKeyLen]byte
+	auxBuffer     *bytes.Buffer // auxiliary buffer used during branch updates encoding
 	branchEncoder *BranchEncoder
 
 	mounted    bool  // true if this trie is mounted to some root trie
@@ -1995,7 +1999,7 @@ func (hph *HexPatriciaHashed) fold() error {
 
 	depth := hph.depths[row]
 
-	updateKey := nibbles.HexToCompactInto(hph.compactKeyBuf[:], hph.currentKey[:updateKeyLen])
+	updateKey := nibbles.HexToCompactInto(hph.foldKeyBuf[:], hph.currentKey[:updateKeyLen])
 	defer func() { hph.depthsToTxNum[depth] = 0 }()
 
 	if hph.traceW != nil {

--- a/execution/commitment/nibbles/nibbles.go
+++ b/execution/commitment/nibbles/nibbles.go
@@ -33,10 +33,10 @@ func HexToCompact(hex []byte) []byte {
 	return HexToCompactInto(nil, hex)
 }
 
-// HexToCompactInto is HexToCompact but writes into dst's backing array when it
-// has enough capacity, returning dst re-sliced to the result; otherwise it
-// allocates, same as HexToCompact. The caller must not retain the result past
-// dst's next reuse.
+// HexToCompactInto is HexToCompact but writes into dst's backing array when it has
+// enough capacity, returning dst re-sliced to the result; otherwise it allocates and
+// the result is independent of dst. A result that aliases dst must not be retained
+// past dst's next reuse.
 func HexToCompactInto(dst, hex []byte) []byte {
 	terminator := byte(0)
 	if HasTerm(hex) {

--- a/execution/commitment/nibbles/nibbles.go
+++ b/execution/commitment/nibbles/nibbles.go
@@ -30,12 +30,26 @@ const Terminator byte = 0x10
 // as defined by the Ethereum Yellow Paper. The result is a fresh allocation the
 // caller owns and may retain.
 func HexToCompact(hex []byte) []byte {
+	return HexToCompactInto(nil, hex)
+}
+
+// HexToCompactInto is HexToCompact but writes into dst's backing array when it
+// has enough capacity, returning dst re-sliced to the result; otherwise it
+// allocates, same as HexToCompact. The caller must not retain the result past
+// dst's next reuse.
+func HexToCompactInto(dst, hex []byte) []byte {
 	terminator := byte(0)
 	if HasTerm(hex) {
 		terminator = 1
 		hex = hex[:len(hex)-1]
 	}
-	buf := make([]byte, len(hex)/2+1)
+	need := len(hex)/2 + 1
+	buf := dst
+	if cap(buf) < need {
+		buf = make([]byte, need)
+	} else {
+		buf = buf[:need]
+	}
 	buf[0] = terminator << 5 // the flag byte
 	if len(hex)&1 == 1 {
 		buf[0] |= 1 << 4 // odd flag

--- a/execution/commitment/nibbles/nibbles_test.go
+++ b/execution/commitment/nibbles/nibbles_test.go
@@ -209,3 +209,26 @@ func BenchmarkHexToKeybytes(b *testing.B) {
 		HexToKeybytes(testBytes)
 	}
 }
+
+func TestHexToCompactInto(t *testing.T) {
+	hex := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	want := HexToCompact(hex)
+
+	t.Run("dst large enough is reused", func(t *testing.T) {
+		dst := make([]byte, 64)
+		got := HexToCompactInto(dst, hex)
+		require.Equal(t, want, got)
+		require.Same(t, &dst[0], &got[0], "result must alias dst when capacity allows")
+	})
+
+	t.Run("dst too small allocates independently", func(t *testing.T) {
+		dst := make([]byte, 2)
+		got := HexToCompactInto(dst, hex)
+		require.Equal(t, want, got)
+		require.NotSame(t, &dst[0], &got[0], "result must not alias an undersized dst")
+	})
+
+	t.Run("nil dst matches HexToCompact", func(t *testing.T) {
+		require.Equal(t, want, HexToCompactInto(nil, hex))
+	})
+}

--- a/execution/commitment/streaming_deep_fold.go
+++ b/execution/commitment/streaming_deep_fold.go
@@ -64,7 +64,7 @@ func unfoldStorageBase(base *HexPatriciaHashed, accPrefix []byte) error {
 	}
 	base.touchMap[0], base.afterMap[0], base.branchBefore[0] = 0, 0, false
 
-	branch, err := base.branchFromCacheOrDB(nibbles.HexToCompact(accPrefix))
+	branch, err := base.branchFromCacheOrDB(nibbles.HexToCompactInto(base.compactKeyBuf[:], accPrefix))
 	if err != nil {
 		return err
 	}
@@ -275,7 +275,7 @@ func storageRootFromSingleChild(base *HexPatriciaHashed) (cell, error) {
 
 	// The prior on-disk branch at the account prefix, if any, is now an extension: no branch record.
 	if base.branchBefore[0] {
-		if err := base.collectDeleteUpdate(nibbles.HexToCompact(base.currentKey[:base.currentKeyLen]), 0); err != nil {
+		if err := base.collectDeleteUpdate(nibbles.HexToCompactInto(base.compactKeyBuf[:], base.currentKey[:base.currentKeyLen]), 0); err != nil {
 			return cell{}, err
 		}
 	}

--- a/execution/commitment/warmuper.go
+++ b/execution/commitment/warmuper.go
@@ -161,8 +161,9 @@ func (w *Warmuper) Start() {
 // If cache is enabled, the data is also stored in the cache for later use.
 func (w *Warmuper) warmupKey(trieCtx PatriciaContext, hashedKey []byte, startDepth int) {
 	depth := startDepth
+	var compactBuf [maxCompactKeyLen]byte
 	for depth <= len(hashedKey) && depth <= w.maxDepth {
-		prefix := nibbles.HexToCompact(hashedKey[:depth])
+		prefix := nibbles.HexToCompactInto(compactBuf[:], hashedKey[:depth])
 
 		// Check cache first, then fall back to DB
 		branchData, _, err := trieCtx.Branch(prefix)


### PR DESCRIPTION
`nibbles.HexToCompact` allocates a fresh slice on every call and sits on the fold/unfold hot path — once per trie row, not per key. Six call sites now write into a caller-owned scratch buffer instead.

## Changes
- `HexToCompactInto(dst, hex)` writes into `dst` when its capacity allows and falls back to allocating otherwise, so an undersized buffer loses the optimisation rather than panicking. `HexToCompact` delegates with `dst=nil`, leaving every retaining caller unchanged.
- Routed through a per-instance scratch: `fold`, `unfoldBranchNode`, `witnessMaterializeBranch`, both sites in `streaming_deep_fold.go`, and `Warmuper.warmupKey` (hoisted out of its descent loop).
- `fold`'s update key uses a buffer separate from the read paths. It is still live when `foldDelete` runs the collapse tracer, and `SetCollapseTracer` takes caller code that is free to re-enter a read path.
- Call sites whose result is retained past the call are deliberately left allocating.

## Notes
Apple M5 Max, go1.25.7, `-benchtime=200x -count=6`, benchstat:

| benchmark | allocs/op | B/op |
| --- | --- | --- |
| `HexPatriciaHashedFold` | 905 → 691 (−23.7%, p=0.002) | 50.5Ki → 46.5Ki (−7.9%) |
| `Commitment_SmallCounts` | −9% to −24% across all 20 sub-benchmarks, p=0.002 | −4.1% geomean |

`ns/op` is unchanged within noise; this reduces allocation and GC pressure, not wall clock. `KeyToHexNibbleHash`, which never calls `HexToCompact`, is flat as expected.
