### PR TITLE
cl: reuse one converter between consensus and execution withdrawals

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -2592,9 +2592,9 @@ func (a *ApiHandler) cacheExecutionBody(payload *cltypes.Eth1Block) {
 	}
 	var ws []*types.Withdrawal
 	if payload.Withdrawals != nil && payload.Withdrawals.Len() > 0 {
-		consensusWithdrawals := make([]*cltypes.Withdrawal, 0, payload.Withdrawals.Len())
-		payload.Withdrawals.Range(func(_ int, w *cltypes.Withdrawal, _ int) bool {
-			consensusWithdrawals = append(consensusWithdrawals, w)
+		consensusWithdrawals := make([]*cltypes.Withdrawal, payload.Withdrawals.Len())
+		payload.Withdrawals.Range(func(idx int, w *cltypes.Withdrawal, _ int) bool {
+			consensusWithdrawals[idx] = w
 			return true
 		})
 		ws = cltypes.ConvertConsensusWithdrawalsToExecutionWithdrawals(consensusWithdrawals)

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -2591,16 +2591,13 @@ func (a *ApiHandler) cacheExecutionBody(payload *cltypes.Eth1Block) {
 		})
 	}
 	var ws []*types.Withdrawal
-	if payload.Withdrawals != nil {
-		payload.Withdrawals.Range(func(idx int, w *cltypes.Withdrawal, total int) bool {
-			ws = append(ws, &types.Withdrawal{
-				Index:     w.Index,
-				Validator: w.Validator,
-				Address:   w.Address,
-				Amount:    w.Amount,
-			})
+	if payload.Withdrawals != nil && payload.Withdrawals.Len() > 0 {
+		consensusWithdrawals := make([]*cltypes.Withdrawal, 0, payload.Withdrawals.Len())
+		payload.Withdrawals.Range(func(_ int, w *cltypes.Withdrawal, _ int) bool {
+			consensusWithdrawals = append(consensusWithdrawals, w)
 			return true
 		})
+		ws = cltypes.ConvertConsensusWithdrawalsToExecutionWithdrawals(consensusWithdrawals)
 	}
 	a.blockReader.CacheBlockBody(payload.BlockNumber, rawTxs, ws)
 }

--- a/cl/cltypes/withdrawal.go
+++ b/cl/cltypes/withdrawal.go
@@ -87,6 +87,16 @@ func convertExecutionWithdrawalsToConsensusWithdrawals(executionWithdrawal []*ty
 	return ret
 }
 
+// ConvertConsensusWithdrawalsToExecutionWithdrawals is the single crossing point between the two
+// representations, so callers building the same list cannot drift apart.
+func ConvertConsensusWithdrawalsToExecutionWithdrawals(consensusWithdrawals []*Withdrawal) []*types.Withdrawal {
+	ret := make([]*types.Withdrawal, len(consensusWithdrawals))
+	for i, w := range consensusWithdrawals {
+		ret[i] = convertConsensusWithdrawalToExecutionWithdrawal(w)
+	}
+	return ret
+}
+
 // ExpectedWithdrawals represents the expected withdrawals for a beacon state
 type ExpectedWithdrawals struct {
 	Withdrawals                      []*Withdrawal `json:"withdrawals"`

--- a/cl/cltypes/withdrawal.go
+++ b/cl/cltypes/withdrawal.go
@@ -87,8 +87,9 @@ func convertExecutionWithdrawalsToConsensusWithdrawals(executionWithdrawal []*ty
 	return ret
 }
 
-// ConvertConsensusWithdrawalsToExecutionWithdrawals is the single crossing point between the two
-// representations, so callers building the same list cannot drift apart.
+// ConvertConsensusWithdrawalsToExecutionWithdrawals converts a withdrawal list to its execution
+// representation, in order and with no shared pointers. The result is never nil, which matters
+// because the execution layer rejects a nil list and an empty one under opposite conditions.
 func ConvertConsensusWithdrawalsToExecutionWithdrawals(consensusWithdrawals []*Withdrawal) []*types.Withdrawal {
 	ret := make([]*types.Withdrawal, len(consensusWithdrawals))
 	for i, w := range consensusWithdrawals {

--- a/cl/cltypes/withdrawal_test.go
+++ b/cl/cltypes/withdrawal_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package cltypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+func TestConvertConsensusWithdrawalsToExecutionWithdrawals(t *testing.T) {
+	t.Parallel()
+
+	source := []*Withdrawal{
+		{Index: 1, Validator: 10, Address: common.Address{0xaa}, Amount: 100},
+		{Index: 2, Validator: 20, Address: common.Address{0xbb}, Amount: 200},
+	}
+
+	converted := ConvertConsensusWithdrawalsToExecutionWithdrawals(source)
+
+	require.Equal(t, []*types.Withdrawal{
+		{Index: 1, Validator: 10, Address: common.Address{0xaa}, Amount: 100},
+		{Index: 2, Validator: 20, Address: common.Address{0xbb}, Amount: 200},
+	}, converted)
+
+	// The execution layer owns its copy: mutating the source afterwards must not reach it.
+	source[0].Amount = 999
+	require.Equal(t, uint64(100), converted[0].Amount)
+}
+
+func TestConvertConsensusWithdrawalsToExecutionWithdrawalsNeverReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	// A nil list and an empty one are rejected by the execution layer under opposite conditions,
+	// so an absent input must not become an absent list.
+	require.NotNil(t, ConvertConsensusWithdrawalsToExecutionWithdrawals(nil))
+	require.Empty(t, ConvertConsensusWithdrawalsToExecutionWithdrawals(nil))
+	require.NotNil(t, ConvertConsensusWithdrawalsToExecutionWithdrawals([]*Withdrawal{}))
+}

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -14,6 +14,7 @@ import (
 	"github.com/erigontech/erigon/cl/beacon/beaconevents"
 	"github.com/erigontech/erigon/cl/beacon/synced_data"
 	"github.com/erigontech/erigon/cl/clparams"
+	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/monitor"
 	"github.com/erigontech/erigon/cl/monitor/shuffling_metrics"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
@@ -30,7 +31,6 @@ import (
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
-	"github.com/erigontech/erigon/execution/types"
 )
 
 // computeAndNotifyServicesOfNewForkChoice calculates the new head of the fork choice and notifies relevant services.
@@ -251,19 +251,11 @@ func emitNextPaylodAttributesEvent(cfg *Cfg, headSlot uint64, headRoot common.Ha
 		log.Warn("failed to get proposer index", "err", err)
 		return err
 	}
-	withdrawals := []*types.Withdrawal{}
 	expWithdrawals, err := state.GetExpectedWithdrawals(s, epoch)
 	if err != nil {
 		return err
 	}
-	for _, w := range expWithdrawals.Withdrawals {
-		withdrawals = append(withdrawals, &types.Withdrawal{
-			Amount:    w.Amount,
-			Index:     w.Index,
-			Validator: w.Validator,
-			Address:   w.Address,
-		})
-	}
+	withdrawals := cltypes.ConvertConsensusWithdrawalsToExecutionWithdrawals(expWithdrawals.Withdrawals)
 	payloadAttributes := engine_types.PayloadAttributes{
 		Timestamp:             hexutil.Uint64(headPayloadHeader.Time + cfg.beaconCfg.SecondsPerSlot),
 		PrevRandao:            randaoMix,


### PR DESCRIPTION
Split out of #23105, which grew too large to review in one piece. This is the mechanical, behaviour-neutral part.

The conversion between `cltypes.Withdrawal` and `types.Withdrawal` was hand-written at each call site. `cl/cltypes/withdrawal.go` already had a private singular converter, so this exports a plural one and uses it in the two places that built the list by hand: the payload-attributes emitter in the forkchoice stage, and `cacheExecutionBody`.

No behaviour change. Both sites produce the same slice as before, including whether it comes back nil — `cacheExecutionBody` keeps returning nil for an empty withdrawals list rather than an empty slice.

Part of a series splitting #23105 into reviewable units. The remaining parts follow separately; this one stands alone and depends on nothing else in the series.
