### PR TITLE
[r3.6] execution: BlockStateCache lock-free committed storage + non-quadratic held-back retry reinsertion

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3292,20 +3292,13 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 			return 0
 		}
 		budget := pe.in.Capacity() - pe.in.NewTasksLen()
-		var holdBack sort.IntSlice
-		for {
-			nextTx := be.execTasks.minPending()
-			if nextTx < 0 {
-				break
-			}
+		be.execTasks.dispatchPending(func(nextTx int) dispatchAction {
 			incarnation := be.txIncarnations[nextTx]
-			// A fresh tx needs a free input-channel slot. If none, leave it in
-			// pending (peek, don't take): taking then re-inserting the lowest
-			// index at the front would be O(pending) shift churn per call.
+			// A fresh tx needs a free input-channel slot. With none, stop: it is
+			// the lowest pending, so nothing after it dispatches this pass either.
 			if incarnation == 0 && budget <= 0 {
-				break
+				return dispatchStop
 			}
-			be.execTasks.takeNextPending()
 			execTask := be.tasks[nextTx]
 			isNextValidated := nextTx == maxValidated+1
 
@@ -3322,8 +3315,7 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 							}
 							return state.VersionInvalid
 						}, false, "") != state.VersionValid {
-					holdBack = append(holdBack, nextTx)
-					continue
+					return dispatchHold
 				}
 			}
 
@@ -3338,8 +3330,7 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 			if incarnation == 0 {
 				tv.version = execTask.Version()
 				if !pe.in.TryAdd(tv) {
-					holdBack = append(holdBack, nextTx)
-					break
+					return dispatchHoldStop
 				}
 				budget--
 			} else {
@@ -3362,10 +3353,8 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 			}
 			be.cntExec++
 			dispatched++
-		}
-		for _, tx := range holdBack {
-			be.execTasks.pushPending(tx)
-		}
+			return dispatchConsume
+		})
 		return dispatched
 	}
 

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1688,3 +1688,142 @@ func TestParallelFinalizeMissingPrevReceiptErrors(t *testing.T) {
 	assert.ErrorContains(err, "missing finalized receipt for tx 1")
 	assert.Nil(res)
 }
+
+func TestDispatchPendingCompaction(t *testing.T) {
+	cases := []struct {
+		name       string
+		pending    []int
+		decide     func(tx int) dispatchAction
+		wantPend   []int
+		wantInProg []int
+	}{
+		{
+			name:    "mix hold/consume then stop",
+			pending: []int{0, 1, 2, 3, 4, 5, 6, 7},
+			decide: func(tx int) dispatchAction {
+				switch tx {
+				case 1, 3:
+					return dispatchHold
+				case 5:
+					return dispatchStop
+				default:
+					return dispatchConsume
+				}
+			},
+			wantPend:   []int{1, 3, 5, 6, 7},
+			wantInProg: []int{0, 1, 2, 3, 4},
+		},
+		{
+			name:    "hold-stop when input is full",
+			pending: []int{0, 1, 2, 3},
+			decide: func(tx int) dispatchAction {
+				if tx == 1 {
+					return dispatchHoldStop
+				}
+				return dispatchConsume
+			},
+			wantPend:   []int{1, 2, 3},
+			wantInProg: []int{0, 1},
+		},
+		{
+			name:       "all consumed",
+			pending:    []int{0, 1, 2},
+			decide:     func(int) dispatchAction { return dispatchConsume },
+			wantPend:   []int{},
+			wantInProg: []int{0, 1, 2},
+		},
+		{
+			name:       "stop immediately leaves pending untouched",
+			pending:    []int{0, 1, 2},
+			decide:     func(int) dispatchAction { return dispatchStop },
+			wantPend:   []int{0, 1, 2},
+			wantInProg: []int{},
+		},
+		{
+			name:       "all held",
+			pending:    []int{0, 1, 2},
+			decide:     func(int) dispatchAction { return dispatchHold },
+			wantPend:   []int{0, 1, 2},
+			wantInProg: []int{0, 1, 2},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &execStatusList{pending: append([]int{}, tc.pending...)}
+			m.dispatchPending(tc.decide)
+			require.Equal(t, tc.wantPend, m.pending, "pending")
+
+			gotInProg := map[int]bool{}
+			for i, v := range m.inProgress {
+				if v {
+					gotInProg[i] = true
+				}
+			}
+			wantInProg := map[int]bool{}
+			for _, v := range tc.wantInProg {
+				wantInProg[v] = true
+			}
+			require.Equal(t, wantInProg, gotInProg, "inProgress")
+			require.Equal(t, len(tc.wantInProg), m.inProgressCnt, "inProgressCnt")
+		})
+	}
+}
+
+// dispatchPending must produce the same result on a slice whose start and
+// capacity have drifted through takeNextPending as on a fresh one.
+func TestDispatchPendingOnDriftedSlice(t *testing.T) {
+	m := &execStatusList{}
+	for i := range 10 {
+		m.pushPending(i)
+	}
+	m.takeNextPending()
+	m.takeNextPending()
+	m.dispatchPending(func(tx int) dispatchAction {
+		switch tx {
+		case 3, 4:
+			return dispatchHold
+		case 7:
+			return dispatchStop
+		default:
+			return dispatchConsume
+		}
+	})
+	require.Equal(t, []int{3, 4, 7, 8, 9}, m.pending)
+}
+
+// BenchmarkDispatchPendingCompaction holds back and dispatches a fixed prefix in
+// front of a growing suffix. The compaction never touches the suffix, so the
+// time stays flat as the suffix grows.
+func BenchmarkDispatchPendingCompaction(b *testing.B) {
+	const held, consumed = 8, 8
+	prefix := held + consumed
+	decide := func(tx int) dispatchAction {
+		switch {
+		case tx < held:
+			return dispatchHold
+		case tx < prefix:
+			return dispatchConsume
+		default:
+			return dispatchStop
+		}
+	}
+	for _, suffix := range []int{1024, 4096, 16384, 65536} {
+		total := prefix + suffix
+		base := make([]int, total)
+		for i := range base {
+			base[i] = i
+		}
+		buf := make([]int, total)
+		b.Run(fmt.Sprintf("suffix=%d", suffix), func(b *testing.B) {
+			m := &execStatusList{}
+			m.ensureLen(total)
+			copy(buf, base) // dispatchPending only rewrites the prefix, so the suffix stays valid
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				copy(buf[:prefix], base[:prefix])
+				m.pending = buf
+				m.dispatchPending(decide)
+			}
+		})
+	}
+}

--- a/execution/stagedsync/exec3_status.go
+++ b/execution/stagedsync/exec3_status.go
@@ -59,16 +59,45 @@ func (m *execStatusList) takeNextPending() int {
 
 	x := m.pending[0]
 	m.pending = m.pending[1:]
-	m.ensureLen(x)
-	if !m.inProgress[x] {
-		m.inProgress[x] = true
-		m.inProgressCnt++
-	}
-	if x < m.minInProgressHint {
-		m.minInProgressHint = x
-	}
+	m.setInProgress(x)
 
 	return x
+}
+
+type dispatchAction uint8
+
+const (
+	dispatchStop     dispatchAction = iota // leave tx and the rest in pending, end the pass
+	dispatchConsume                        // tx dispatched: drop it from pending
+	dispatchHold                           // tx held back: keep it in pending
+	dispatchHoldStop                       // hold tx back, then end the pass
+)
+
+// dispatchPending walks pending front-to-back, dispatching or holding each tx
+// per decide. Held-back txs are compacted ahead of the suffix in O(consumed
+// prefix): the suffix is never moved and nothing is allocated, and the compacted
+// prefix stays sorted below the suffix, so it needs no re-sort or dedup.
+func (m *execStatusList) dispatchPending(decide func(tx int) dispatchAction) {
+	read, write := 0, 0
+	for read < len(m.pending) {
+		act := decide(m.pending[read])
+		if act == dispatchStop {
+			break
+		}
+		m.setInProgress(m.pending[read])
+		if act == dispatchHold || act == dispatchHoldStop {
+			m.pending[write] = m.pending[read]
+			write++
+		}
+		read++
+		if act == dispatchHoldStop {
+			break
+		}
+	}
+	if write > 0 {
+		copy(m.pending[read-write:read], m.pending[:write])
+	}
+	m.pending = m.pending[read-write:]
 }
 
 func (m execStatusList) maxComplete() int {

--- a/execution/state/block_cache_committed_storage_test.go
+++ b/execution/state/block_cache_committed_storage_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types/accounts"
+)
+
+// BenchmarkCommittedStorage prices the committed-storage cache path that every
+// block worker hits on SLOAD. Run with -cpu=1,8,16 to see behaviour under the
+// contention the parallel executor actually produces.
+func BenchmarkCommittedStorage(b *testing.B) {
+	const nAddrs, nKeys = 64, 64
+	addrs := make([]accounts.Address, nAddrs)
+	keys := make([]accounts.StorageKey, nKeys)
+	for i := range addrs {
+		addrs[i] = accounts.InternAddress(common.Address{byte(i), byte(i >> 8)})
+	}
+	for i := range keys {
+		keys[i] = accounts.InternKey(common.Hash{byte(i), byte(i >> 8)})
+	}
+	val := []byte{1, 2, 3, 4}
+
+	// Warm read: all keys pre-filled, workers only read (the SLOAD cache-hit hot path).
+	b.Run("read_warm", func(b *testing.B) {
+		c := NewBlockStateCache()
+		for _, a := range addrs {
+			for _, k := range keys {
+				c.PutCommittedStorage(a, k, val)
+			}
+		}
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				c.GetCommittedStorage(addrs[i&(nAddrs-1)], keys[(i*7)&(nKeys-1)])
+				i++
+			}
+		})
+	})
+
+	// Read-through fill: first touch misses then fills (the profiled PutCommittedStorage
+	// contention), subsequent touches hit.
+	b.Run("fill_read", func(b *testing.B) {
+		c := NewBlockStateCache()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				a, k := addrs[i&(nAddrs-1)], keys[(i*7)&(nKeys-1)]
+				if _, ok := c.GetCommittedStorage(a, k); !ok {
+					c.PutCommittedStorage(a, k, val)
+				}
+				i++
+			}
+		})
+	})
+}
+
+// committedStorage is a write-once, immutable pre-block view backed by a
+// lock-free sync.Map. These pin the value semantics the reader relies on — in
+// particular a cached empty slot (ok=true, nil value) must stay distinct from
+// an uncached miss (ok=false).
+func TestBlockStateCache_CommittedStorage_Semantics(t *testing.T) {
+	t.Parallel()
+
+	cache := NewBlockStateCache()
+	addr := accounts.InternAddress(common.HexToAddress("0xc0ffee"))
+	key := accounts.InternKey(common.Hash{0x22})
+
+	got, ok := cache.GetCommittedStorage(addr, key)
+	require.False(t, ok, "uncached slot must miss")
+	require.Nil(t, got)
+
+	cache.PutCommittedStorage(addr, key, []byte{0x01, 0x02})
+	got, ok = cache.GetCommittedStorage(addr, key)
+	require.True(t, ok)
+	require.Equal(t, []byte{0x01, 0x02}, got)
+
+	emptyKey := accounts.InternKey(common.Hash{0x33})
+	cache.PutCommittedStorage(addr, emptyKey, nil)
+	got, ok = cache.GetCommittedStorage(addr, emptyKey)
+	require.True(t, ok, "a cached empty slot must report ok=true, not a miss")
+	require.Nil(t, got)
+
+	got, ok = cache.GetCurrentStorage(addr, key)
+	require.True(t, ok, "GetCurrentStorage must fall back to committed when unwritten")
+	require.Equal(t, []byte{0x01, 0x02}, got)
+}
+
+// All worker goroutines of a block share one cache and read committed storage
+// concurrently; the lock-free path must be race-free and never lose a value.
+func TestBlockStateCache_CommittedStorage_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	const nAddrs, nKeys = 8, 32
+	addrList := make([]accounts.Address, nAddrs)
+	keyList := make([]accounts.StorageKey, nKeys)
+	for i := range addrList {
+		addrList[i] = accounts.InternAddress(common.Address{byte(i + 1)})
+	}
+	for i := range keyList {
+		keyList[i] = accounts.InternKey(common.Hash{byte(i + 1)})
+	}
+	// write-once value, deterministic in (addr,key) so reads can be checked.
+	val := func(ai, ki int) []byte { return []byte{byte(ai + 1), byte(ki + 1)} }
+
+	cache := NewBlockStateCache()
+	var wg sync.WaitGroup
+	for g := range 16 {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range 2000 {
+				ai := (g + i) % nAddrs
+				ki := (g*7 + i) % nKeys
+				a, k := addrList[ai], keyList[ki]
+				cache.PutCommittedStorage(a, k, val(ai, ki))
+				if got, ok := cache.GetCommittedStorage(a, k); ok {
+					require.Equal(t, val(ai, ki), got)
+				}
+				cache.GetCurrentStorage(a, k)
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -1057,7 +1057,9 @@ type BlockStateCache struct {
 	// committed holds pre-block state, lazily populated on first read.
 	// These values are returned by CachedReaderV3 for GetCommittedState.
 	committedAccounts map[accounts.Address]*accounts.Account
-	committedStorage  map[accounts.Address]map[accounts.StorageKey][]byte
+	// committedStorage is write-once-per-key (an immutable pre-block view), so it
+	// is a sync.Map for lock-free reads off the shared mu hot path.
+	committedStorage sync.Map // committedStorageKey -> []byte (nil slice = cached empty slot)
 
 	// current holds the latest state including intra-block writes.
 	// Updated by WriteAccount/WriteStorage. Read by block finalize.
@@ -1084,6 +1086,12 @@ type BlockStateCache struct {
 	// commitment-domain reads) that ask for state at an intra-block
 	// txNum.
 	writeLog []bcWriteOp
+}
+
+// committedStorageKey is the sync.Map key for BlockStateCache.committedStorage.
+type committedStorageKey struct {
+	addr accounts.Address
+	key  accounts.StorageKey
 }
 
 // bcOpKind enumerates the operations recorded in BlockStateCache.writeLog.
@@ -1113,7 +1121,6 @@ type bcWriteOp struct {
 func NewBlockStateCache() *BlockStateCache {
 	return &BlockStateCache{
 		committedAccounts: make(map[accounts.Address]*accounts.Account),
-		committedStorage:  make(map[accounts.Address]map[accounts.StorageKey][]byte),
 		currentAccounts:   make(map[accounts.Address][]byte),
 		currentStorage:    make(map[accounts.Address]map[accounts.StorageKey][]byte),
 		currentCode:       make(map[accounts.Address][]byte),
@@ -1139,27 +1146,16 @@ func (c *BlockStateCache) PutCommittedAccount(addr accounts.Address, acc *accoun
 
 // GetCommittedStorage returns the pre-block storage value, or (nil, false) if not cached.
 func (c *BlockStateCache) GetCommittedStorage(addr accounts.Address, key accounts.StorageKey) ([]byte, bool) {
-	c.mu.RLock()
-	slots, addrOk := c.committedStorage[addr]
-	if !addrOk {
-		c.mu.RUnlock()
+	v, ok := c.committedStorage.Load(committedStorageKey{addr: addr, key: key})
+	if !ok {
 		return nil, false
 	}
-	val, ok := slots[key]
-	c.mu.RUnlock()
-	return val, ok
+	return v.([]byte), true
 }
 
 // PutCommittedStorage caches a pre-block storage value. nil = empty slot.
 func (c *BlockStateCache) PutCommittedStorage(addr accounts.Address, key accounts.StorageKey, val []byte) {
-	c.mu.Lock()
-	slots, ok := c.committedStorage[addr]
-	if !ok {
-		slots = make(map[accounts.StorageKey][]byte)
-		c.committedStorage[addr] = slots
-	}
-	slots[key] = val
-	c.mu.Unlock()
+	c.committedStorage.Store(committedStorageKey{addr: addr, key: key}, val)
 }
 
 // --- Current (write buffer) methods ---
@@ -1279,14 +1275,10 @@ func (c *BlockStateCache) GetCurrentStorage(addr accounts.Address, key accounts.
 			return val, true
 		}
 	}
-	// Fall back to committed.
-	if slots, ok := c.committedStorage[addr]; ok {
-		if val, ok := slots[key]; ok {
-			c.mu.RUnlock()
-			return val, true
-		}
-	}
 	c.mu.RUnlock()
+	if v, ok := c.committedStorage.Load(committedStorageKey{addr: addr, key: key}); ok {
+		return v.([]byte), true
+	}
 	return nil, false
 }
 


### PR DESCRIPTION
Cherry-pick of #23134 and #23236 to release/3.6.

## r3.6-specific adaptations

- **#23134** — `main` had already converted `BlockStateCache.committedAccounts` to a `sync.Map` in an earlier PR; release/3.6 still has it as a plain map. Only `committedStorage` is converted here, which is all #23134 itself changed. `committedAccounts` and its `mu`-guarded accessors are left as they are on release/3.6.
- **#23236** — release/3.6's `VersionMap.ValidateVersion` takes two fewer arguments (no `IsEIP161Enabled` / `IsAura`). The call site keeps the release/3.6 signature; only the control-flow change (`holdBack` slice append → `return dispatchHold`) is taken.
- **#23236** — the conflict region in `exec3_parallel_test.go` also contained `TestNextResult_NilVsEmptyRecordForkAware`, which belongs to a different `main` PR and is not on release/3.6. It was dropped; only `TestDispatchPendingCompaction` and `TestDispatchPendingOnDriftedSlice` are taken. The resulting diff matches upstream #23236 exactly at 184 insertions / 27 deletions.
