### PR TITLE
[r3.6] execution/stagedsync: avoid quadratic held-back retry reinsertion

### DIFF
--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3292,20 +3292,13 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 			return 0
 		}
 		budget := pe.in.Capacity() - pe.in.NewTasksLen()
-		var holdBack sort.IntSlice
-		for {
-			nextTx := be.execTasks.minPending()
-			if nextTx < 0 {
-				break
-			}
+		be.execTasks.dispatchPending(func(nextTx int) dispatchAction {
 			incarnation := be.txIncarnations[nextTx]
-			// A fresh tx needs a free input-channel slot. If none, leave it in
-			// pending (peek, don't take): taking then re-inserting the lowest
-			// index at the front would be O(pending) shift churn per call.
+			// A fresh tx needs a free input-channel slot. With none, stop: it is
+			// the lowest pending, so nothing after it dispatches this pass either.
 			if incarnation == 0 && budget <= 0 {
-				break
+				return dispatchStop
 			}
-			be.execTasks.takeNextPending()
 			execTask := be.tasks[nextTx]
 			isNextValidated := nextTx == maxValidated+1
 
@@ -3322,8 +3315,7 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 							}
 							return state.VersionInvalid
 						}, false, "") != state.VersionValid {
-					holdBack = append(holdBack, nextTx)
-					continue
+					return dispatchHold
 				}
 			}
 
@@ -3338,8 +3330,7 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 			if incarnation == 0 {
 				tv.version = execTask.Version()
 				if !pe.in.TryAdd(tv) {
-					holdBack = append(holdBack, nextTx)
-					break
+					return dispatchHoldStop
 				}
 				budget--
 			} else {
@@ -3362,10 +3353,8 @@ func (be *blockExecutor) scheduleExecution(ctx context.Context, pe *parallelExec
 			}
 			be.cntExec++
 			dispatched++
-		}
-		for _, tx := range holdBack {
-			be.execTasks.pushPending(tx)
-		}
+			return dispatchConsume
+		})
 		return dispatched
 	}
 

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1688,3 +1688,142 @@ func TestParallelFinalizeMissingPrevReceiptErrors(t *testing.T) {
 	assert.ErrorContains(err, "missing finalized receipt for tx 1")
 	assert.Nil(res)
 }
+
+func TestDispatchPendingCompaction(t *testing.T) {
+	cases := []struct {
+		name       string
+		pending    []int
+		decide     func(tx int) dispatchAction
+		wantPend   []int
+		wantInProg []int
+	}{
+		{
+			name:    "mix hold/consume then stop",
+			pending: []int{0, 1, 2, 3, 4, 5, 6, 7},
+			decide: func(tx int) dispatchAction {
+				switch tx {
+				case 1, 3:
+					return dispatchHold
+				case 5:
+					return dispatchStop
+				default:
+					return dispatchConsume
+				}
+			},
+			wantPend:   []int{1, 3, 5, 6, 7},
+			wantInProg: []int{0, 1, 2, 3, 4},
+		},
+		{
+			name:    "hold-stop when input is full",
+			pending: []int{0, 1, 2, 3},
+			decide: func(tx int) dispatchAction {
+				if tx == 1 {
+					return dispatchHoldStop
+				}
+				return dispatchConsume
+			},
+			wantPend:   []int{1, 2, 3},
+			wantInProg: []int{0, 1},
+		},
+		{
+			name:       "all consumed",
+			pending:    []int{0, 1, 2},
+			decide:     func(int) dispatchAction { return dispatchConsume },
+			wantPend:   []int{},
+			wantInProg: []int{0, 1, 2},
+		},
+		{
+			name:       "stop immediately leaves pending untouched",
+			pending:    []int{0, 1, 2},
+			decide:     func(int) dispatchAction { return dispatchStop },
+			wantPend:   []int{0, 1, 2},
+			wantInProg: []int{},
+		},
+		{
+			name:       "all held",
+			pending:    []int{0, 1, 2},
+			decide:     func(int) dispatchAction { return dispatchHold },
+			wantPend:   []int{0, 1, 2},
+			wantInProg: []int{0, 1, 2},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &execStatusList{pending: append([]int{}, tc.pending...)}
+			m.dispatchPending(tc.decide)
+			require.Equal(t, tc.wantPend, m.pending, "pending")
+
+			gotInProg := map[int]bool{}
+			for i, v := range m.inProgress {
+				if v {
+					gotInProg[i] = true
+				}
+			}
+			wantInProg := map[int]bool{}
+			for _, v := range tc.wantInProg {
+				wantInProg[v] = true
+			}
+			require.Equal(t, wantInProg, gotInProg, "inProgress")
+			require.Equal(t, len(tc.wantInProg), m.inProgressCnt, "inProgressCnt")
+		})
+	}
+}
+
+// dispatchPending must produce the same result on a slice whose start and
+// capacity have drifted through takeNextPending as on a fresh one.
+func TestDispatchPendingOnDriftedSlice(t *testing.T) {
+	m := &execStatusList{}
+	for i := range 10 {
+		m.pushPending(i)
+	}
+	m.takeNextPending()
+	m.takeNextPending()
+	m.dispatchPending(func(tx int) dispatchAction {
+		switch tx {
+		case 3, 4:
+			return dispatchHold
+		case 7:
+			return dispatchStop
+		default:
+			return dispatchConsume
+		}
+	})
+	require.Equal(t, []int{3, 4, 7, 8, 9}, m.pending)
+}
+
+// BenchmarkDispatchPendingCompaction holds back and dispatches a fixed prefix in
+// front of a growing suffix. The compaction never touches the suffix, so the
+// time stays flat as the suffix grows.
+func BenchmarkDispatchPendingCompaction(b *testing.B) {
+	const held, consumed = 8, 8
+	prefix := held + consumed
+	decide := func(tx int) dispatchAction {
+		switch {
+		case tx < held:
+			return dispatchHold
+		case tx < prefix:
+			return dispatchConsume
+		default:
+			return dispatchStop
+		}
+	}
+	for _, suffix := range []int{1024, 4096, 16384, 65536} {
+		total := prefix + suffix
+		base := make([]int, total)
+		for i := range base {
+			base[i] = i
+		}
+		buf := make([]int, total)
+		b.Run(fmt.Sprintf("suffix=%d", suffix), func(b *testing.B) {
+			m := &execStatusList{}
+			m.ensureLen(total)
+			copy(buf, base) // dispatchPending only rewrites the prefix, so the suffix stays valid
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				copy(buf[:prefix], base[:prefix])
+				m.pending = buf
+				m.dispatchPending(decide)
+			}
+		})
+	}
+}

--- a/execution/stagedsync/exec3_status.go
+++ b/execution/stagedsync/exec3_status.go
@@ -59,16 +59,45 @@ func (m *execStatusList) takeNextPending() int {
 
 	x := m.pending[0]
 	m.pending = m.pending[1:]
-	m.ensureLen(x)
-	if !m.inProgress[x] {
-		m.inProgress[x] = true
-		m.inProgressCnt++
-	}
-	if x < m.minInProgressHint {
-		m.minInProgressHint = x
-	}
+	m.setInProgress(x)
 
 	return x
+}
+
+type dispatchAction uint8
+
+const (
+	dispatchStop     dispatchAction = iota // leave tx and the rest in pending, end the pass
+	dispatchConsume                        // tx dispatched: drop it from pending
+	dispatchHold                           // tx held back: keep it in pending
+	dispatchHoldStop                       // hold tx back, then end the pass
+)
+
+// dispatchPending walks pending front-to-back, dispatching or holding each tx
+// per decide. Held-back txs are compacted ahead of the suffix in O(consumed
+// prefix): the suffix is never moved and nothing is allocated, and the compacted
+// prefix stays sorted below the suffix, so it needs no re-sort or dedup.
+func (m *execStatusList) dispatchPending(decide func(tx int) dispatchAction) {
+	read, write := 0, 0
+	for read < len(m.pending) {
+		act := decide(m.pending[read])
+		if act == dispatchStop {
+			break
+		}
+		m.setInProgress(m.pending[read])
+		if act == dispatchHold || act == dispatchHoldStop {
+			m.pending[write] = m.pending[read]
+			write++
+		}
+		read++
+		if act == dispatchHoldStop {
+			break
+		}
+	}
+	if write > 0 {
+		copy(m.pending[read-write:read], m.pending[:write])
+	}
+	m.pending = m.pending[read-write:]
 }
 
 func (m execStatusList) maxComplete() int {


### PR DESCRIPTION
Cherry-pick of #23236 to release/3.6.

## r3.6-specific adaptations

- release/3.6's `VersionMap.ValidateVersion` takes two fewer arguments (no `IsEIP161Enabled` / `IsAura`). The call site keeps the release/3.6 signature; only the control-flow change (`holdBack` slice append → `return dispatchHold`) is taken.
- The conflict region in `exec3_parallel_test.go` also contained `TestNextResult_NilVsEmptyRecordForkAware`, which belongs to a different `main` PR and is not on release/3.6. It was dropped; only `TestDispatchPendingCompaction` and `TestDispatchPendingOnDriftedSlice` are taken. The resulting diff matches upstream #23236 exactly at 184 insertions / 27 deletions.
