### PR TITLE
.github/actions: retry Go module downloads

### DIFF
--- a/.github/actions/cleanup-erigon/action.yml
+++ b/.github/actions/cleanup-erigon/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Check for existing module cache entry
       id: modcache-probe
-      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_MODCACHE != '' && env.ERIGON_CI_MODCACHE_KEY != '' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_MODCACHE_COMPLETE == 'true' && env.ERIGON_CI_MODCACHE != '' && env.ERIGON_CI_MODCACHE_KEY != '' }}
       continue-on-error: true
       uses: actions/cache/restore@v5
       with:
@@ -40,7 +40,7 @@ runs:
         lookup-only: true
 
     - uses: ./.github/actions/save-mod-cache
-      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_MODCACHE != '' && env.ERIGON_CI_MODCACHE_KEY != '' && steps.modcache-probe.outputs.cache-hit != 'true' }}
+      if: ${{ always() && github.event_name != 'merge_group' && env.ERIGON_CI_MODCACHE_COMPLETE == 'true' && env.ERIGON_CI_MODCACHE != '' && env.ERIGON_CI_MODCACHE_KEY != '' && steps.modcache-probe.outputs.cache-hit != 'true' }}
       with:
         modcache-path: ${{ env.ERIGON_CI_MODCACHE }}
         key: ${{ env.ERIGON_CI_MODCACHE_KEY }}

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -270,6 +270,23 @@ runs:
       shell: bash
       run: echo "ERIGON_CI_MODCACHE_KEY=${{ steps.restore-mod-cache.outputs.primary-key }}" >> "$GITHUB_ENV"
 
+    - name: Download Go modules
+      shell: bash
+      env:
+        GOPROXY: 'https://proxy.golang.org|direct'
+      run: |
+        for attempt in 1 2 3; do
+          if go mod download; then
+            echo "ERIGON_CI_MODCACHE_COMPLETE=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            exit 1
+          fi
+          echo "go mod download failed (attempt $attempt), retrying..."
+          sleep $((attempt * 15))
+        done
+
     - id: restore-build-cache
       uses: ./.github/actions/restore-build-cache
       with:


### PR DESCRIPTION
## Summary

- prefetch Go modules with three attempts and bounded backoff
- fall back to direct module retrieval after any public proxy error
- publish the module cache only after dependency prefetch succeeds

## Motivation

[Cache-warming job 94641079118](https://github.com/erigontech/erigon/actions/runs/31759001894/job/94641079118) failed while downloading `github.com/klauspost/compress@v1.19.1`: the connection from the GitHub-hosted runner to the Go proxy's Google storage backend was reset.

The cleanup action then saved the incomplete module cache because module-cache publication runs under `always()`. The successful serial sibling later found that immutable cache key and could not replace it with its complete cache.

This change makes dependency acquisition the retry boundary instead of retrying compilation or tests. A completion marker allows later test failures to retain a valid module cache while preventing failed downloads from publishing partial entries.

Cache-key consolidation is intentionally out of scope for this focused reliability fix.

## Validation

- `actionlint -shellcheck '' --ignore '"workspace" is not defined in object type' --ignore 'unexpected key "queue" for "concurrency" section'`
- `zizmor` 1.26.1 strict composite-action parsing; no new findings compared with the base branch
- `shellcheck -s bash` on the new retry block
- `GOPROXY='https://proxy.golang.org|direct' go mod download`
- `make lint` (three clean passes)
- `make erigon integration`

This is a CI-only composite-action change, so TDD does not apply.
