### PR TITLE
docs(site): forward-port version resolution and retarget docs automation

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -243,6 +243,8 @@ jobs:
           ARCHIVE_LABEL: ${{ steps.plan.outputs.archive_label }}
           # docs:version loads docusaurus.config.ts, whose release lookup now
           # fails closed; without a token it runs on the anonymous rate limit.
+          # This job's write scope reaches that config, accepted because the
+          # workflow is dispatch-only so the ref is maintainer-chosen.
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -236,16 +236,28 @@ jobs:
         with:
           python-version: '3.11'
 
+      # Docusaurus config runs branch-controlled JS (config + plugins) and needs
+      # an authenticated call for its release lookup. Mint a read-only token for
+      # it rather than handing it this job's contents:write GITHUB_TOKEN.
+      - name: Generate read-only token for docs build
+        id: docs_token
+        if: steps.plan.outputs.outcome == 'proceed'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          repositories: "erigon"
+          permission-contents: read
+
       - name: Snapshot outgoing docs and capture full versioned state
         if: steps.plan.outputs.outcome == 'proceed'
         working-directory: outgoing/docs/site
         env:
           ARCHIVE_LABEL: ${{ steps.plan.outputs.archive_label }}
-          # docs:version loads docusaurus.config.ts, whose release lookup now
-          # fails closed; without a token it runs on the anonymous rate limit.
-          # This job's write scope reaches that config, accepted because the
-          # workflow is dispatch-only so the ref is maintainer-chosen.
-          GITHUB_TOKEN: ${{ github.token }}
+          # docs:version loads docusaurus.config.ts, whose release lookup fails
+          # closed; without a token it runs on the anonymous rate limit. Use the
+          # read-only token so branch-controlled config never sees write scope.
+          GITHUB_TOKEN: ${{ steps.docs_token.outputs.token }}
         run: |
           set -euo pipefail
           npm ci
@@ -278,7 +290,9 @@ jobs:
         if: steps.plan.outputs.outcome == 'proceed'
         working-directory: incoming/docs/site
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # Same reasoning as the snapshot step: `npm run build` loads the same
+          # branch-controlled config, so it gets the read-only token too.
+          GITHUB_TOKEN: ${{ steps.docs_token.outputs.token }}
         run: |
           set -euo pipefail
           src="$RUNNER_TEMP/versioned-state"

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -241,6 +241,9 @@ jobs:
         working-directory: outgoing/docs/site
         env:
           ARCHIVE_LABEL: ${{ steps.plan.outputs.archive_label }}
+          # docs:version loads docusaurus.config.ts, whose release lookup now
+          # fails closed; without a token it runs on the anonymous rate limit.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           npm ci

--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -99,6 +99,13 @@ jobs:
         if: steps.guard.outputs.present == 'true'
         working-directory: docs/site
 
+      # Release selection (src/releases.js) orders by semantic version because
+      # the GitHub API orders by publish date; the unit tests pin that so a
+      # back-port cannot silently regress the version in the install snippets.
+      - run: npm test
+        if: steps.guard.outputs.present == 'true'
+        working-directory: docs/site
+
       - run: npm run build
         if: steps.guard.outputs.present == 'true'
         working-directory: docs/site

--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -98,3 +98,7 @@ jobs:
       - run: npm run build
         if: steps.guard.outputs.present == 'true'
         working-directory: docs/site
+        env:
+          # Version resolution fails the build rather than publishing a
+          # placeholder, so it must not run against the anonymous rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -7,6 +7,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Callers grant actions/pull-requests write and reusable jobs inherit it,
+    # so pin this one down before the build step gets a token.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/docs-version-bump.yml
+++ b/.github/workflows/docs-version-bump.yml
@@ -81,14 +81,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Docusaurus config runs branch-controlled JS (config + plugins) and needs
+      # an authenticated call for its release lookup. Mint a read-only token for
+      # it rather than handing it this job's contents:write GITHUB_TOKEN.
+      - name: Generate read-only token for docs build
+        id: docs_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  ## v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          repositories: "erigon"
+          permission-contents: read
+
       - name: Snapshot current docs as ${{ inputs.archive_version }}
         env:
           ARCHIVE_VERSION: ${{ inputs.archive_version }}
-          # docs:version loads docusaurus.config.ts, whose release lookup now
-          # fails closed; without a token it runs on the anonymous rate limit.
-          # This job's write scope reaches that config, accepted because the
-          # workflow is dispatch-only so the ref is maintainer-chosen.
-          GITHUB_TOKEN: ${{ github.token }}
+          # docs:version loads docusaurus.config.ts, whose release lookup fails
+          # closed; without a token it runs on the anonymous rate limit. Use the
+          # read-only token so branch-controlled config never sees write scope.
+          GITHUB_TOKEN: ${{ steps.docs_token.outputs.token }}
         run: npx docusaurus docs:version "$ARCHIVE_VERSION"
 
       - name: Bump current version label to ${{ inputs.new_label }}
@@ -118,7 +129,9 @@ jobs:
       - name: Verify build
         run: npm run build
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same reasoning as the snapshot step: `npm run build` loads the same
+          # branch-controlled config, so it gets the read-only token too.
+          GITHUB_TOKEN: ${{ steps.docs_token.outputs.token }}
 
       - name: Open pull request
         env:

--- a/.github/workflows/docs-version-bump.yml
+++ b/.github/workflows/docs-version-bump.yml
@@ -86,6 +86,8 @@ jobs:
           ARCHIVE_VERSION: ${{ inputs.archive_version }}
           # docs:version loads docusaurus.config.ts, whose release lookup now
           # fails closed; without a token it runs on the anonymous rate limit.
+          # This job's write scope reaches that config, accepted because the
+          # workflow is dispatch-only so the ref is maintainer-chosen.
           GITHUB_TOKEN: ${{ github.token }}
         run: npx docusaurus docs:version "$ARCHIVE_VERSION"
 

--- a/.github/workflows/docs-version-bump.yml
+++ b/.github/workflows/docs-version-bump.yml
@@ -12,12 +12,9 @@ run-name: "Docs Version Bump — archive ${{ inputs.archive_version }}, publish 
 # artifacts, verifies the build, and opens a PR.
 #
 # NOTE on {ERIGON_VERSION} injection: the remark plugin
-# (src/remark/version-replace.js) currently special-cases specific archived
-# versions by path (e.g. version-v3.3), rather than resolving generically from
-# versions.json. Until that plugin is made generic, adding a new archived
-# version whose pages contain {ERIGON_VERSION} placeholders may require a
-# matching case in version-replace.js (and/or docusaurus.config.ts) by hand —
-# review the diff this workflow produces before merging.
+# (src/remark/version-replace.js) resolves every archived version generically
+# from versions.json, keyed off the version-vX.Y path segment, so a new archive
+# needs no hand-written case there or in docusaurus.config.ts.
 #
 # NOTE: this does NOT move the Pages deploy trigger. If the docs deploy still
 # lives on a per-release branch (docs-deploy.yml), update that branch separately.
@@ -87,6 +84,9 @@ jobs:
       - name: Snapshot current docs as ${{ inputs.archive_version }}
         env:
           ARCHIVE_VERSION: ${{ inputs.archive_version }}
+          # docs:version loads docusaurus.config.ts, whose release lookup now
+          # fails closed; without a token it runs on the anonymous rate limit.
+          GITHUB_TOKEN: ${{ github.token }}
         run: npx docusaurus docs:version "$ARCHIVE_VERSION"
 
       - name: Bump current version label to ${{ inputs.new_label }}

--- a/.github/workflows/update-disk-sizes.yml
+++ b/.github/workflows/update-disk-sizes.yml
@@ -4,9 +4,9 @@ name: Docs - Update disk sizes
 # Archive sizes are not handled here: they are read manually from the Grafana
 # dashboard and committed by hand in a dedicated monthly PR.
 # Downloads the disk-usage artifacts, updates docs/site/src/data/disk-sizes.json,
-# and opens (or updates) a draft PR against a pinned base branch (release/3.5).
+# and opens (or updates) a draft PR against a pinned base branch (release/3.6).
 on:
-  # zizmor: ignore[dangerous-triggers] no checkout of triggering run's head; BASE_BRANCH is pinned to release/3.5 for workflow_run events
+  # zizmor: ignore[dangerous-triggers] no checkout of triggering run's head; BASE_BRANCH is pinned to release/3.6 for workflow_run events
   workflow_run:
     workflows:
       - "QA - Sync from scratch (minimal node)"
@@ -25,7 +25,7 @@ on:
         description: "Base branch to update"
         required: true
         # Official docs branch — bump at each release cutover (e.g. 3.5 → 3.6).
-        default: "release/3.5"
+        default: "release/3.6"
       prune_mode:
         description: "Prune mode measured in that run"
         required: true
@@ -99,7 +99,7 @@ jobs:
             printf 'prune_mode=%s\n' "$MODE" >> "$GITHUB_OUTPUT"
             printf 'source_run_id=%s\n' "$WORKFLOW_RUN_ID" >> "$GITHUB_OUTPUT"
             # Official docs branch — bump at each release cutover (e.g. 3.5 → 3.6).
-            printf 'base_branch=release/3.5\n' >> "$GITHUB_OUTPUT"
+            printf 'base_branch=release/3.6\n' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Generate GitHub App token

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -16,7 +16,23 @@ npm run typecheck # TypeScript check without emit
 
 ## Deployment
 
-Deployment is handled automatically by the `docs-deploy.yml` workflow, which lives on the release branches and publishes only from the one named by the `DOCS_DEPLOY_BRANCH` repository variable — every other ref builds and skips. Changing that variable is the whole cutover; the workflow is intentionally not present on `main`. Do not use manual `yarn deploy` — it is not configured for this site.
+Deployment is handled automatically by the `docs-deploy.yml` workflow, which lives on the release branches and publishes only from the one named by the `DOCS_DEPLOY_BRANCH` repository variable — every other ref builds and skips. The workflow is intentionally not present on `main`. Do not use manual `yarn deploy` — it is not configured for this site.
+
+### Cutting over to a new branch
+
+Two steps, not one: GitHub emits no event when a repository variable changes, so
+setting it starts nothing.
+
+1. Set `DOCS_DEPLOY_BRANCH` to the new branch (Settings → Secrets and variables →
+   Actions → Variables).
+2. Dispatch the deploy against that branch:
+   `gh workflow run docs-deploy.yml --ref <branch>` — or push any `docs/site/**`
+   change to it.
+
+Skipping step 2 is not fatal, only slow: `docs-deploy-cron.yml` on `main` wakes
+at 06:20 UTC and dispatches whichever branch the variable names, so production
+would otherwise stay on the previous branch for up to 24 hours. That cron reads
+the same variable, so step 1 is the only place the branch is named.
 
 ## Disk size data flow
 

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -1,6 +1,6 @@
 # Erigon Documentation Site
 
-Built with [Docusaurus 3](https://docusaurus.io/). Deployed automatically to [docs.erigon.tech](https://docs.erigon.tech) via GitHub Actions on push to `release/3.5`.
+Built with [Docusaurus 3](https://docusaurus.io/). Deployed automatically to [docs.erigon.tech](https://docs.erigon.tech) via GitHub Actions on push to the branch named by the `DOCS_DEPLOY_BRANCH` repository variable.
 
 ## Local Development
 
@@ -16,7 +16,7 @@ npm run typecheck # TypeScript check without emit
 
 ## Deployment
 
-Deployment is handled automatically by the `docs-deploy.yml` workflow, which lives on the `release/3.5` branch (the deploy source) and runs on every push there. It is intentionally not present on `main`. Do not use manual `yarn deploy` — it is not configured for this site.
+Deployment is handled automatically by the `docs-deploy.yml` workflow, which lives on the release branches and publishes only from the one named by the `DOCS_DEPLOY_BRANCH` repository variable — every other ref builds and skips. Changing that variable is the whole cutover; the workflow is intentionally not present on `main`. Do not use manual `yarn deploy` — it is not configured for this site.
 
 ## Disk size data flow
 

--- a/docs/site/docs/fundamentals/modules/downloader.mdx
+++ b/docs/site/docs/fundamentals/modules/downloader.mdx
@@ -35,7 +35,7 @@ By referring to the embedded documentation file, you can gain a deeper understan
 
 ## Command line options
 
-To display available options for Downloader digit:
+To display available options for Downloader, run:
 
 ```bash
 ./build/bin/downloader --help

--- a/docs/site/docs/fundamentals/modules/sentry.mdx
+++ b/docs/site/docs/fundamentals/modules/sentry.mdx
@@ -67,7 +67,7 @@ For other information regarding Sentry functionality, configuration, and usage, 
 
 ### Command Line Options
 
-To display available options for Sentry digit:
+To display available options for Sentry, run:
 
 ```bash
 ./build/bin/sentry --help

--- a/docs/site/docs/fundamentals/modules/txpool.md
+++ b/docs/site/docs/fundamentals/modules/txpool.md
@@ -62,7 +62,7 @@ If Erigon is on a different device, add the flags `--pprof --pprof.addr 0.0.0.0`
 * `--txpool.disable`: This flag disables the internal transaction pool (TxPool) and block producer (default: `false`). When running the TxPool as a separate process, this flag is used to prevent the internal TxPool from interfering with the external one.
 * `--private.api.addr=localhost:9090`: This flag sets the address and port for the private API. The private API is used for internal communication between Erigon components (default: `127.0.0.1:9090`).
 * `--datadir=<your datadir>`: This flag specifies the data directory for Erigon. This is where Erigon stores its databases and other data.
-* `--http=false`: This flag disables the HTTP API server in Erigon (default: `true)`. When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
+* `--http=false`: This flag disables the HTTP API server in Erigon (default: `true`). When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
 * `--sentry.api.addr=localhost:9091`: This flag sets the address and port for the Sentry API. The Sentry API is used for communication between the TxPool and the Sentry.
 * `--txpool.api.addr=localhost:9094`: This flag sets the address and port for the TxPool API (default: use value of `--private.api.addr`). The TxPool API is used for communication between the TxPool and other Erigon components.
 * `--pprof`: Enable the pprof HTTP server (default: `false`)
@@ -70,7 +70,7 @@ If Erigon is on a different device, add the flags `--pprof --pprof.addr 0.0.0.0`
 
 ## Command Line Options
 
-To display available options for TxPool digit:
+To display available options for TxPool, run:
 
 ```bash
 ./build/bin/txpool --help

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -16,12 +16,13 @@ const currentDocsVersion = {
   badge: false,
 };
 
-// Releases carry a pre-release suffix without reliably setting the API's
-// `prerelease` flag, so tag shape is the load-bearing check. Semver identifiers
-// are arbitrary (-rc.1, -dev, -nightly), so reject any hyphen rather than a list.
-const PRERELEASE_TAG = /-/;
-
 type Release = {tag_name: string; prerelease: boolean; draft: boolean};
+
+// Stable-release selection lives in its own CommonJS module so its ordering
+// rules are testable without booting Docusaurus (src/releases.test.js). The
+// GitHub API orders releases by publish date, so every selector there sorts by
+// semantic version instead of trusting that order.
+const {installableVersion, latestStableInSeries} = require('./src/releases.js');
 
 function githubHeaders(): Record<string, string> {
   const headers: Record<string, string> = {Accept: 'application/vnd.github.v3+json'};
@@ -43,37 +44,6 @@ async function fetchReleases(): Promise<Release[]> {
     throw new Error(`Release lookup failed: ${res.status} ${res.statusText}.${hint}`);
   }
   return await res.json() as Release[];
-}
-
-const isStable = (r: Release) =>
-  !r.draft && !r.prerelease && !PRERELEASE_TAG.test(r.tag_name);
-
-// Scoped by series because the repo-wide "latest" is ordered by release date,
-// not by version, so a back-port or pre-release could win it.
-function stableInSeries(releases: Release[], series: string): Release | undefined {
-  return releases.find((r) => isStable(r) && r.tag_name.startsWith(`${series}.`));
-}
-
-function latestStableInSeries(releases: Release[], series: string): string {
-  const match = stableInSeries(releases, series);
-  if (!match) {
-    throw new Error(
-      `No stable ${series} release found in the newest 100 releases. ` +
-      'If that series predates the newest 100 releases, fetchReleases() needs pagination.',
-    );
-  }
-  return match.tag_name.replace(/^v/, '');
-}
-
-// Version pasted into the install commands. Falls back to the newest stable
-// release of any series while this one has none, since that is what a reader can
-// actually install; throwing is deliberate when nothing resolves at all.
-function installableVersion(releases: Release[], series: string): string {
-  const match = stableInSeries(releases, series) ?? releases.find(isStable);
-  if (!match) {
-    throw new Error('No stable release found in the newest 100 releases.');
-  }
-  return match.tag_name.replace(/^v/, '');
 }
 
 export default async function createConfig(): Promise<Config> {

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -17,8 +17,9 @@ const currentDocsVersion = {
 };
 
 // Releases carry a pre-release suffix without reliably setting the API's
-// `prerelease` flag, so tag shape is the load-bearing check.
-const PRERELEASE_TAG = /-(rc|alpha|beta|pre)/i;
+// `prerelease` flag, so tag shape is the load-bearing check. Semver identifiers
+// are arbitrary (-rc.1, -dev, -nightly), so reject any hyphen rather than a list.
+const PRERELEASE_TAG = /-/;
 
 type Release = {tag_name: string; prerelease: boolean; draft: boolean};
 

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -9,49 +9,78 @@ const versionReplace = require('./src/remark/version-replace.js');
 // below derives everything from this list, no per-version config edits required.
 const archivedVersions: string[] = require('./versions.json');
 
+// The docs series this branch publishes; also scopes the {ERIGON_VERSION}
+// lookup below. The `label: 'vX.Y'` literal is rewritten at each cutover.
+const currentDocsVersion = {
+  label: 'v3.6',
+  badge: false,
+};
+
+// Releases carry a pre-release suffix without reliably setting the API's
+// `prerelease` flag, so tag shape is the load-bearing check.
+const PRERELEASE_TAG = /-(rc|alpha|beta|pre)/i;
+
+type Release = {tag_name: string; prerelease: boolean; draft: boolean};
+
 function githubHeaders(): Record<string, string> {
   const headers: Record<string, string> = {Accept: 'application/vnd.github.v3+json'};
   if (process.env.GITHUB_TOKEN) headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
   return headers;
 }
 
-async function fetchLatestVersion(): Promise<string> {
-  try {
-    const res = await fetch(
-      'https://api.github.com/repos/erigontech/erigon/releases/latest',
-      {headers: githubHeaders()},
-    );
-    if (!res.ok) return 'latest';
-    const data = await res.json() as {tag_name?: string};
-    return data.tag_name?.replace(/^v/, '') ?? 'latest';
-  } catch {
-    return 'latest';
+// One page serves every series resolved below; 100 is the API maximum and must
+// stay wide enough to reach the oldest archived series.
+async function fetchReleases(): Promise<Release[]> {
+  const res = await fetch(
+    'https://api.github.com/repos/erigontech/erigon/releases?per_page=100',
+    {headers: githubHeaders()},
+  );
+  if (!res.ok) {
+    const hint = res.status === 403 || res.status === 429
+      ? ' Set GITHUB_TOKEN if this is rate limiting.'
+      : '';
+    throw new Error(`Release lookup failed: ${res.status} ${res.statusText}.${hint}`);
   }
+  return await res.json() as Release[];
 }
 
-async function fetchLatestSeriesVersion(prefix: string): Promise<string> {
-  try {
-    const res = await fetch(
-      'https://api.github.com/repos/erigontech/erigon/releases?per_page=50',
-      {headers: githubHeaders()},
+const isStable = (r: Release) =>
+  !r.draft && !r.prerelease && !PRERELEASE_TAG.test(r.tag_name);
+
+// Scoped by series because the repo-wide "latest" is ordered by release date,
+// not by version, so a back-port or pre-release could win it.
+function stableInSeries(releases: Release[], series: string): Release | undefined {
+  return releases.find((r) => isStable(r) && r.tag_name.startsWith(`${series}.`));
+}
+
+function latestStableInSeries(releases: Release[], series: string): string {
+  const match = stableInSeries(releases, series);
+  if (!match) {
+    throw new Error(
+      `No stable ${series} release found in the newest 100 releases. ` +
+      'If that series predates the newest 100 releases, fetchReleases() needs pagination.',
     );
-    if (!res.ok) return 'latest';
-    const releases = await res.json() as Array<{tag_name: string; prerelease: boolean}>;
-    const latest = releases.find((r) => !r.prerelease && r.tag_name.startsWith(prefix));
-    return latest?.tag_name.replace(/^v/, '') ?? 'latest';
-  } catch {
-    return 'latest';
   }
+  return match.tag_name.replace(/^v/, '');
+}
+
+// Version pasted into the install commands. Falls back to the newest stable
+// release of any series while this one has none, since that is what a reader can
+// actually install; throwing is deliberate when nothing resolves at all.
+function installableVersion(releases: Release[], series: string): string {
+  const match = stableInSeries(releases, series) ?? releases.find(isStable);
+  if (!match) {
+    throw new Error('No stable release found in the newest 100 releases.');
+  }
+  return match.tag_name.replace(/^v/, '');
 }
 
 export default async function createConfig(): Promise<Config> {
-  const [latestVersion, ...archivedVersionStrings] = await Promise.all([
-    fetchLatestVersion(),
-    ...archivedVersions.map((v) => fetchLatestSeriesVersion(`${v}.`)),
-  ]);
+  const releases = await fetchReleases();
+  const latestVersion = installableVersion(releases, currentDocsVersion.label);
   // Map each archived version id (e.g. "v3.4") to its latest patch release string.
   const versionStrings: Record<string, string> = Object.fromEntries(
-    archivedVersions.map((v, i) => [v, archivedVersionStrings[i]]),
+    archivedVersions.map((v) => [v, latestStableInSeries(releases, v)]),
   );
 
   return {
@@ -98,6 +127,13 @@ export default async function createConfig(): Promise<Config> {
               from: '/fundamentals/configuring-erigon/nat',
               to: '/fundamentals/nat',
             },
+            // The Polygon easy-node guide is removed: 3.1.* is the last series
+            // that officially supports Polygon. Inbound links land on the support
+            // statement; the guide itself is still readable in the v3.4 archive.
+            {
+              from: '/get-started/easy-nodes/how-to-run-a-polygon-node',
+              to: '/fundamentals/supported-networks',
+            },
           ],
         },
       ],
@@ -132,10 +168,7 @@ export default async function createConfig(): Promise<Config> {
           routeBasePath: '/',
           lastVersion: 'current',
           versions: {
-            current: {
-              label: 'v3.6',
-              badge: false,
-            },
+            current: currentDocsVersion,
           },
           remarkPlugins: [[versionReplace, {currentVersion: latestVersion, versionStrings}]],
           showLastUpdateTime: true,

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -13,6 +13,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
+    "test": "node --test src/*.test.js",
     "check:tsconfig": "node scripts/check-tsconfig-drift.mjs"
   },
   "dependencies": {

--- a/docs/site/src/releases.js
+++ b/docs/site/src/releases.js
@@ -1,0 +1,78 @@
+// Release selection for docusaurus.config.ts.
+//
+// Lives in its own module so the ordering rules below can be exercised without
+// booting Docusaurus: `node --test src/releases.test.js`.
+
+// Releases carry a pre-release suffix without reliably setting the API's
+// `prerelease` flag, so tag shape is the load-bearing check. Semver identifiers
+// are arbitrary (-rc.1, -dev, -nightly), so reject any hyphen rather than a list.
+const PRERELEASE_TAG = /-/;
+
+const isStable = (r) =>
+  !r.draft && !r.prerelease && !PRERELEASE_TAG.test(r.tag_name);
+
+// Numeric components of a tag; a missing component reads as 0 so "v3.6" orders
+// below "v3.6.1". Non-numeric junk also reads as 0 rather than NaN, which would
+// make the comparison non-transitive.
+function versionParts(tag) {
+  return tag.replace(/^v/, '').split('.').map((n) => {
+    const parsed = Number.parseInt(n, 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  });
+}
+
+// Descending semantic order. The API lists releases by publish date, so any
+// date-ordered pick is wrong the moment a back-port ships after a newer series
+// (v3.2.4 published after v3.3.0). Every selector below sorts rather than
+// taking the first match.
+function compareDesc(a, b) {
+  const left = versionParts(a.tag_name);
+  const right = versionParts(b.tag_name);
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    const diff = (right[i] ?? 0) - (left[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+// Highest stable release, optionally restricted to a subset.
+function highestStable(releases, predicate = () => true) {
+  return releases.filter((r) => isStable(r) && predicate(r)).sort(compareDesc)[0];
+}
+
+// The trailing dot keeps series "v3.6" from swallowing "v3.60.0".
+function stableInSeries(releases, series) {
+  return highestStable(releases, (r) => r.tag_name.startsWith(`${series}.`));
+}
+
+function latestStableInSeries(releases, series) {
+  const match = stableInSeries(releases, series);
+  if (!match) {
+    throw new Error(
+      `No stable ${series} release found in the newest 100 releases. ` +
+      'If that series predates the newest 100 releases, fetchReleases() needs pagination.',
+    );
+  }
+  return match.tag_name.replace(/^v/, '');
+}
+
+// Version pasted into the install commands. Falls back to the highest stable
+// release of any series while this one has none — with the sort above that is
+// the newest stable series, not whatever was published most recently. Throwing
+// is deliberate when nothing resolves at all.
+function installableVersion(releases, series) {
+  const match = stableInSeries(releases, series) ?? highestStable(releases);
+  if (!match) {
+    throw new Error('No stable release found in the newest 100 releases.');
+  }
+  return match.tag_name.replace(/^v/, '');
+}
+
+module.exports = {
+  isStable,
+  compareDesc,
+  highestStable,
+  stableInSeries,
+  latestStableInSeries,
+  installableVersion,
+};

--- a/docs/site/src/releases.test.js
+++ b/docs/site/src/releases.test.js
@@ -1,0 +1,63 @@
+// node --test src/releases.test.js
+//
+// Every case here is a list ordered the way the GitHub API returns it — by
+// publish date, newest first — so a selector that trusts that order fails.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  installableVersion,
+  latestStableInSeries,
+  stableInSeries,
+  highestStable,
+} = require('./releases.js');
+
+const rel = (tag, extra = {}) => ({tag_name: tag, prerelease: false, draft: false, ...extra});
+
+test('back-port published after a newer series does not win the fallback', () => {
+  // v3.2.4 shipped after v3.3.0, so it heads the API list.
+  const releases = [rel('v3.2.4'), rel('v3.3.0'), rel('v3.2.3')];
+  assert.equal(installableVersion(releases, 'v3.6'), '3.3.0');
+});
+
+test('back-port published after a newer patch does not win its own series', () => {
+  const releases = [rel('v3.4.3'), rel('v3.4.10'), rel('v3.4.9')];
+  assert.equal(latestStableInSeries(releases, 'v3.4'), '3.4.10');
+});
+
+test('patch components compare numerically, not lexically', () => {
+  const releases = [rel('v3.5.9'), rel('v3.5.10')];
+  assert.equal(latestStableInSeries(releases, 'v3.5'), '3.5.10');
+});
+
+test('the current series wins over a higher one when it has a stable release', () => {
+  const releases = [rel('v3.7.0'), rel('v3.6.1')];
+  assert.equal(installableVersion(releases, 'v3.6'), '3.6.1');
+});
+
+test('a series prefix does not swallow a longer numeric series', () => {
+  const releases = [rel('v3.60.0'), rel('v3.6.2')];
+  assert.equal(latestStableInSeries(releases, 'v3.6'), '3.6.2');
+  assert.equal(stableInSeries(releases, 'v3.6').tag_name, 'v3.6.2');
+});
+
+test('pre-release suffixes, prerelease flags and drafts are all rejected', () => {
+  const releases = [
+    rel('v3.7.0-rc.1'),
+    rel('v3.7.0-dev'),
+    rel('v3.6.9', {prerelease: true}),
+    rel('v3.6.8', {draft: true}),
+    rel('v3.6.2'),
+  ];
+  assert.equal(highestStable(releases).tag_name, 'v3.6.2');
+  assert.equal(installableVersion(releases, 'v3.6'), '3.6.2');
+});
+
+test('a missing series throws rather than silently resolving elsewhere', () => {
+  assert.throws(() => latestStableInSeries([rel('v3.6.2')], 'v3.3'), /No stable v3\.3 release/);
+});
+
+test('no stable release at all throws', () => {
+  assert.throws(() => installableVersion([rel('v3.7.0-rc.1')], 'v3.6'), /No stable release/);
+});

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -4426,7 +4426,7 @@ If Erigon is on a different device, add the flags `--pprof --pprof.addr 0.0.0.0`
 * `--txpool.disable`: This flag disables the internal transaction pool (TxPool) and block producer (default: `false`). When running the TxPool as a separate process, this flag is used to prevent the internal TxPool from interfering with the external one.
 * `--private.api.addr=localhost:9090`: This flag sets the address and port for the private API. The private API is used for internal communication between Erigon components (default: `127.0.0.1:9090`).
 * `--datadir=<your datadir>`: This flag specifies the data directory for Erigon. This is where Erigon stores its databases and other data.
-* `--http=false`: This flag disables the HTTP API server in Erigon (default: `true)`. When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
+* `--http=false`: This flag disables the HTTP API server in Erigon (default: `true`). When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
 * `--sentry.api.addr=localhost:9091`: This flag sets the address and port for the Sentry API. The Sentry API is used for communication between the TxPool and the Sentry.
 * `--txpool.api.addr=localhost:9094`: This flag sets the address and port for the TxPool API (default: use value of `--private.api.addr`). The TxPool API is used for communication between the TxPool and other Erigon components.
 * `--pprof`: Enable the pprof HTTP server (default: `false`)
@@ -4434,7 +4434,7 @@ If Erigon is on a different device, add the flags `--pprof --pprof.addr 0.0.0.0`
 
 ## Command Line Options
 
-To display available options for TxPool digit:
+To display available options for TxPool, run:
 
 ```bash
 ./build/bin/txpool --help
@@ -4558,7 +4558,7 @@ For other information regarding Sentry functionality, configuration, and usage, 
 
 ### Command Line Options
 
-To display available options for Sentry digit:
+To display available options for Sentry, run:
 
 ```bash
 ./build/bin/sentry --help
@@ -4650,7 +4650,7 @@ By referring to the embedded documentation file, you can gain a deeper understan
 
 ## Command line options
 
-To display available options for Downloader digit:
+To display available options for Downloader, run:
 
 ```bash
 ./build/bin/downloader --help

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4426,7 +4426,7 @@ If Erigon is on a different device, add the flags `--pprof --pprof.addr 0.0.0.0`
 * `--txpool.disable`: This flag disables the internal transaction pool (TxPool) and block producer (default: `false`). When running the TxPool as a separate process, this flag is used to prevent the internal TxPool from interfering with the external one.
 * `--private.api.addr=localhost:9090`: This flag sets the address and port for the private API. The private API is used for internal communication between Erigon components (default: `127.0.0.1:9090`).
 * `--datadir=<your datadir>`: This flag specifies the data directory for Erigon. This is where Erigon stores its databases and other data.
-* `--http=false`: This flag disables the HTTP API server in Erigon (default: `true)`. When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
+* `--http=false`: This flag disables the HTTP API server in Erigon (default: `true`). When running the TxPool as a separate process, this flag is used to prevent the internal HTTP server from interfering with the external TxPool.
 * `--sentry.api.addr=localhost:9091`: This flag sets the address and port for the Sentry API. The Sentry API is used for communication between the TxPool and the Sentry.
 * `--txpool.api.addr=localhost:9094`: This flag sets the address and port for the TxPool API (default: use value of `--private.api.addr`). The TxPool API is used for communication between the TxPool and other Erigon components.
 * `--pprof`: Enable the pprof HTTP server (default: `false`)
@@ -4434,7 +4434,7 @@ If Erigon is on a different device, add the flags `--pprof --pprof.addr 0.0.0.0`
 
 ## Command Line Options
 
-To display available options for TxPool digit:
+To display available options for TxPool, run:
 
 ```bash
 ./build/bin/txpool --help
@@ -4558,7 +4558,7 @@ For other information regarding Sentry functionality, configuration, and usage, 
 
 ### Command Line Options
 
-To display available options for Sentry digit:
+To display available options for Sentry, run:
 
 ```bash
 ./build/bin/sentry --help
@@ -4650,7 +4650,7 @@ By referring to the embedded documentation file, you can gain a deeper understan
 
 ## Command line options
 
-To display available options for Downloader digit:
+To display available options for Downloader, run:
 
 ```bash
 ./build/bin/downloader --help


### PR DESCRIPTION
Keeps `main` in sync with the deploy branch ahead of the 3.5 → 3.6 cutover.

- **Ports #23250/#23258** (series-scoped, fail-closed `{ERIGON_VERSION}` resolution). `main` did not have it, so any branch cut from `main` would revert to the repo-wide `/releases/latest` lookup and the fail-open `latest` placeholder.
- **Fallback for a series with no release yet**, so builds here don't depend on the next release landing first.
- **Carries the Polygon redirect forward** from `release/3.5` — its indexed URL would 404 once a branch cut from `main` publishes.
- **`GITHUB_TOKEN` for the docs-site build step**, so the now fail-closed lookup isn't subject to the anonymous rate limit on merge-queue runs.
- **Repoints `update-disk-sizes.yml` at `release/3.6`.** Only effective from this branch: `workflow_run` runs the default-branch copy. The file carries its own "bump at each release cutover" note.

**Verified:** 78/78 python guards OK, llms `--check` OK, `tsc` clean, build SUCCESS, resolves 3.5.5. `zizmor` clean. Config is byte-identical to the `release/3.6` companion.