### PR TITLE
ci(docs): gate the docs deploy on DOCS_DEPLOY_BRANCH

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,7 +16,10 @@ permissions:
   id-token: write
 
 concurrency:
-  group: docs-pages
+  # Only the publishing branch joins the production group. Any other ref gets its
+  # own, because this group is evaluated before the build job's gate can skip it
+  # and would otherwise cancel a live deployment.
+  group: ${{ (github.ref_name == vars.DOCS_DEPLOY_BRANCH || github.ref == vars.DOCS_DEPLOY_BRANCH) && 'docs-pages' || format('docs-pages-idle-{0}', github.ref) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -24,7 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     # DOCS_DEPLOY_BRANCH is the single switch for which branch publishes, so this
     # branch stops publishing when it moves on, without deleting this file.
-    if: github.ref_name == vars.DOCS_DEPLOY_BRANCH
+    # Accepted either as a bare branch name or as a full refs/heads/ ref.
+    if: github.ref_name == vars.DOCS_DEPLOY_BRANCH || github.ref == vars.DOCS_DEPLOY_BRANCH
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # DOCS_DEPLOY_BRANCH is the single switch for which branch publishes, so this
+    # branch stops publishing when it moves on, without deleting this file.
+    if: github.ref_name == vars.DOCS_DEPLOY_BRANCH
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Replaces the hand-delete step of the cutover ritual. Merge **last**, after the variable points at `release/3.6`.

At each cutover this file has been hand-deleted from the outgoing branch so a later docs push couldn't redeploy over the new branch's site (`fbb7efd9b8` did this on `release/3.4`). Gating the build job on `DOCS_DEPLOY_BRANCH` achieves the same thing without deleting anything: this branch stops publishing the moment the variable moves on, and the variable becomes the single switch for which branch publishes.

The daily refresh (#23251) dispatches that same variable, so the gate and the dispatcher cannot disagree.

Three lines, no behaviour change while the variable still points here. `zizmor` output is identical to the unmodified file (one pre-existing low `artipacked`).