### PR TITLE
ci: retry Kurtosis CLI installation

### DIFF
--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -516,13 +516,19 @@ jobs:
           docker save "${KURTOSIS_PYTHON_IMAGE}" -o /tmp/docker-cache/python.tar
 
       - name: Install Kurtosis CLI and start engine
-        # The engine otherwise bootstraps inside `kurtosis run`, mid-action,
-        # where a registry blip fails the whole test step. Start it here from
-        # the pre-loaded images, with cheap retries.
+        # The action cannot retry setup after it starts, so prepare the CLI
+        # and engine here with bounded backoff.
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt-get update
-          sudo apt-get install -y "kurtosis-cli=${KURTOSIS_VERSION}"
+          for n in 1 2 3; do
+            if sudo apt-get update \
+              && sudo apt-get install -y "kurtosis-cli=${KURTOSIS_VERSION}"; then
+              break
+            fi
+            echo "Kurtosis CLI install failed (attempt $n of 3)"
+            if [ "$n" -eq 3 ]; then exit 1; fi
+            sleep $((10 * n))
+          done
           kurtosis analytics disable
           for n in 1 2 3; do
             if kurtosis engine start; then exit 0; fi

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -344,13 +344,19 @@ jobs:
           path: /tmp/docker-cache
           key: docker-cl-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}
       - name: Install Kurtosis CLI and start engine
-        # The engine otherwise bootstraps inside `kurtosis run`, mid-action,
-        # where a registry blip fails the whole test step. Start it here from
-        # the pre-loaded images, with cheap retries.
+        # The action cannot retry setup after it starts, so prepare the CLI
+        # and engine here with bounded backoff.
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt-get update
-          sudo apt-get install -y kurtosis-cli=${KURTOSIS_VERSION}
+          for n in 1 2 3; do
+            if sudo apt-get update \
+              && sudo apt-get install -y "kurtosis-cli=${KURTOSIS_VERSION}"; then
+              break
+            fi
+            echo "Kurtosis CLI install failed (attempt $n of 3)"
+            if [ "$n" -eq 3 ]; then exit 1; fi
+            sleep $((10 * n))
+          done
           kurtosis analytics disable
           for n in 1 2 3; do
             if kurtosis engine start; then exit 0; fi


### PR DESCRIPTION
## Problem

The merge-group run for #23271 failed before any Kurtosis test ran. The `assertoor_glamsterdam_serial_test` runner timed out while refreshing `apt.fury.io`; `apt-get update` continued with a warning, then `apt-get install` failed because `kurtosis-cli` was unavailable.

The workflow already retried engine startup, but CLI installation had only one attempt. A transient package-repository failure therefore failed `ci-gate` and removed the PR from the merge queue.

Root-cause job: https://github.com/erigontech/erigon/actions/runs/31792302050/job/94743279070

## Fix

- Retry the complete `apt-get update` and pinned `kurtosis-cli` installation pair up to three times.
- Use 10- and 20-second backoff delays between attempts.
- Apply the same behavior to the Assertoor and GLOAS Kurtosis workflows.
- Preserve a hard failure after the third attempt so a persistent setup problem still blocks the gate.

The update and install commands are retried together because APT may return success from the update while reporting an unavailable repository as a warning; the following install is the command that exposes the failure.

## Validation

- `actionlint .github/workflows/test-kurtosis-assertoor.yml .github/workflows/test-kurtosis-gloas.yml`
- `make lint` repeatedly, all clean
- `make erigon integration`

No TDD cycle: this is a mechanical CI workflow change with no application behavior change.
