### PR TITLE
builder: cover Stop when completion and cancellation coincide

### DIFF
--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -136,6 +136,7 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 	select {
 	case <-b.done:
 	case <-ctx.Done():
+		// Completion may become ready while select chooses, so recheck before abandoning the result.
 		select {
 		case <-b.done:
 		default:

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -19,6 +19,7 @@ package builder
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -231,6 +232,49 @@ func TestBlockBuilderStopPrefersCompletedOutcomeOverCanceledCaller(t *testing.T)
 				require.Same(t, tc.result, got)
 			}
 		})
+	}
+}
+
+type completeOnDoneCheck struct {
+	context.Context
+	cancelled chan struct{}
+	complete  func()
+	once      sync.Once
+}
+
+func (c *completeOnDoneCheck) Done() <-chan struct{} {
+	c.once.Do(c.complete)
+	return c.cancelled
+}
+
+func (c *completeOnDoneCheck) Err() error { return context.Canceled }
+
+func TestBlockBuilderStopPrefersPayloadCompletedDuringSelection(t *testing.T) {
+	t.Parallel()
+
+	// Stop evaluates the builder channel before asking for the context channel. Completing in Done
+	// makes both cases ready before select chooses between them.
+	for range 100 {
+		done := make(chan struct{})
+		cancelled := make(chan struct{})
+		close(cancelled)
+		want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
+		builder := &BlockBuilder{done: done}
+		ctx := &completeOnDoneCheck{
+			Context:   t.Context(),
+			cancelled: cancelled,
+			complete: func() {
+				builder.mu.Lock()
+				builder.result = want
+				builder.state.Store(blockBuilderCompleted)
+				builder.mu.Unlock()
+				close(done)
+			},
+		}
+
+		result, err := builder.Stop(ctx)
+		require.NoError(t, err)
+		require.Same(t, want, result)
 	}
 }
 

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -19,7 +19,6 @@ package builder
 import (
 	"context"
 	"errors"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -235,44 +234,29 @@ func TestBlockBuilderStopPrefersCompletedOutcomeOverCanceledCaller(t *testing.T)
 	}
 }
 
-type completeOnDoneCheck struct {
-	context.Context
-	cancelled chan struct{}
-	complete  func()
-	once      sync.Once
-}
-
-func (c *completeOnDoneCheck) Done() <-chan struct{} {
-	c.once.Do(c.complete)
-	return c.cancelled
-}
-
-func (c *completeOnDoneCheck) Err() error { return context.Canceled }
-
 func TestBlockBuilderStopPrefersPayloadCompletedDuringSelection(t *testing.T) {
 	t.Parallel()
 
-	// Stop evaluates the builder channel before asking for the context channel. Completing in Done
-	// makes both cases ready before select chooses between them.
+	callerCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	want := &types.BlockWithReceipts{}
+
+	// Stop's select evaluates channel operands in source order before choosing a ready case.
+	// Completing the builder from the context's Done method makes both cases ready together.
 	for range 100 {
-		done := make(chan struct{})
-		cancelled := make(chan struct{})
-		close(cancelled)
-		want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
-		builder := &BlockBuilder{done: done}
-		ctx := &completeOnDoneCheck{
-			Context:   t.Context(),
-			cancelled: cancelled,
-			complete: func() {
+		builder := &BlockBuilder{done: make(chan struct{})}
+		stopCtx := &finishOnDoneContext{
+			Context: callerCtx,
+			finish: func() {
 				builder.mu.Lock()
 				builder.result = want
 				builder.state.Store(blockBuilderCompleted)
 				builder.mu.Unlock()
-				close(done)
+				close(builder.done)
 			},
 		}
 
-		result, err := builder.Stop(ctx)
+		result, err := builder.Stop(stopCtx)
 		require.NoError(t, err)
 		require.Same(t, want, result)
 	}


### PR DESCRIPTION
Adds focused regression coverage for the completion/cancellation handoff in `BlockBuilder.Stop`.

The test completes the builder while `Stop` evaluates the context's `Done` channel, making completion and cancellation ready together before the `select` chooses a case. Repeated attempts exercise that choice and verify that `Stop` returns the completed payload rather than the caller's cancellation.
