### PR TITLE
go.mod: update libsecp256k1 to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2
 	github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268
 	github.com/erigontech/mdbx-go v0.42.0
-	github.com/erigontech/secp256k1 v1.3.0
+	github.com/erigontech/secp256k1 v1.3.1-0.20260814111418-e0dee7431d97
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2
 	github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268
 	github.com/erigontech/mdbx-go v0.42.0
-	github.com/erigontech/secp256k1 v1.3.1-0.20260814111418-e0dee7431d97
+	github.com/erigontech/secp256k1 v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -332,8 +332,8 @@ github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268 h1:NHl4+Dj
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
 github.com/erigontech/mdbx-go v0.42.0 h1:ZXQ0UqtxZLC/wDZJL4ACBLuNznD1vJQKhayp2HD1JH4=
 github.com/erigontech/mdbx-go v0.42.0/go.mod h1:Ps2n0MMTlU+BgecMWznc/Z7oGJWDJX/EQk+gUCTSaRo=
-github.com/erigontech/secp256k1 v1.3.0 h1:lf/lNUBtgZ21yJjn1sYNkYnEy4bkZIcxvcEdlrHs14I=
-github.com/erigontech/secp256k1 v1.3.0/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
+github.com/erigontech/secp256k1 v1.3.1-0.20260814111418-e0dee7431d97 h1:5UXcOl85+/pGNs8XFc6HOJuZIHGRH8gGdT3YTJ7+f2Q=
+github.com/erigontech/secp256k1 v1.3.1-0.20260814111418-e0dee7431d97/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
 github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=

--- a/go.sum
+++ b/go.sum
@@ -332,8 +332,8 @@ github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268 h1:NHl4+Dj
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
 github.com/erigontech/mdbx-go v0.42.0 h1:ZXQ0UqtxZLC/wDZJL4ACBLuNznD1vJQKhayp2HD1JH4=
 github.com/erigontech/mdbx-go v0.42.0/go.mod h1:Ps2n0MMTlU+BgecMWznc/Z7oGJWDJX/EQk+gUCTSaRo=
-github.com/erigontech/secp256k1 v1.3.1-0.20260814111418-e0dee7431d97 h1:5UXcOl85+/pGNs8XFc6HOJuZIHGRH8gGdT3YTJ7+f2Q=
-github.com/erigontech/secp256k1 v1.3.1-0.20260814111418-e0dee7431d97/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
+github.com/erigontech/secp256k1 v1.4.0 h1:kQLdnJ5jLqkDTBup9PpWirUZw1u2F/nHskQSKbKA4f0=
+github.com/erigontech/secp256k1 v1.4.0/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
 github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=


### PR DESCRIPTION
Updates the bundled bitcoin-core/secp256k1 C library from v0.7.1 to v0.8.0 through [`erigontech/secp256k1` v1.4.0](https://github.com/erigontech/secp256k1/releases/tag/v1.4.0).

## Why it is low-risk

- The wrapper release replaces its vendored subtree with a tree that exactly matches upstream v0.8.0; fork-local wrapper code is unchanged.
- Erigon does not use the deprecated `secp256k1_context_no_precomp` and `secp256k1_schnorrsig_sign` symbols removed in v0.8.0.
- The wrapper Go module graph is unchanged, so this adds no transitive dependency updates.
- Upstream states that the remaining ABI is backward-compatible with v0.7.0 and v0.7.1.

Upstream v0.8.0 adds Silent Payments support and a SHA-256 compression callback, fixes EllSwift validation for out-of-range secret keys, and improves optimized field arithmetic. See the [upstream changelog](https://github.com/bitcoin-core/secp256k1/blob/v0.8.0/CHANGELOG.md#080---2026-08-03).

## Performance verification

The upstream changelog reports gains of up to about 11% for functions such as ECDSA verification with GCC and MSVC, while noting that Clang is largely unaffected. A/B benchmarks compared wrapper v1.3.0 with v1.4.0 on the identical Erigon commit using an Apple M2 Max, Apple Clang 17, Go 1.25.7, CGO, and `-test.cpu=1`. Each comparison used ten balanced samples and `benchstat` at alpha 0.05. Lower latency is better.

| Benchmark | v1.3.0 | v1.4.0 | Change | p-value |
|---|---:|---:|---:|---:|
| ECDSA verify | 20.42 µs | 20.29 µs | -0.6% | 0.436 |
| ECDSA verify, production `-O3` | 19.65 µs | 19.72 µs | +0.4% | 0.436 |
| ECDSA recovery | 24.38 µs | 24.33 µs | -0.2% | 0.796 |
| Authorization signer recovery | 24.51 µs | 24.69 µs | +0.7% | 0.853 |
| ECRECOVER precompile | 24.05 µs | 24.06 µs | +0.0% | 0.393 |
| Public-key decompression | 2.879 µs | 2.932 µs | +1.8% | 0.079 |

No latency difference is statistically significant, and allocation counts are unchanged. The results show no measurable performance benefit or regression in these Erigon paths on Apple Clang, consistent with the upstream qualification. This host does not test the separate GCC/MSVC performance claim.
