### PR TITLE
db/downloader: disable uTP to prevent peer-triggered abort

### DIFF
--- a/db/downloader/downloadercfg/downloadercfg.go
+++ b/db/downloader/downloadercfg/downloadercfg.go
@@ -139,6 +139,7 @@ func defaultTorrentClientConfig() *torrent.ClientConfig {
 
 	// enable dht. TODO: We want DHT.
 	torrentConfig.NoDHT = true
+	torrentConfig.DisableUTP = true
 
 	torrentConfig.Seed = true
 	torrentConfig.UpnpID += " leecher"

--- a/db/downloader/downloadercfg/downloadercfg_test.go
+++ b/db/downloader/downloadercfg/downloadercfg_test.go
@@ -1,0 +1,12 @@
+package downloadercfg
+
+import (
+	"testing"
+
+	"github.com/go-quicktest/qt"
+)
+
+func TestDefaultTorrentClientConfigDisablesUTP(t *testing.T) {
+	cfg := defaultTorrentClientConfig()
+	qt.Check(t, qt.IsTrue(cfg.DisableUTP))
+}


### PR DESCRIPTION
## Summary

- disable uTP for the in-process snapshot downloader
- retain TCP peer transport, tracker discovery, and webseeds
- add a regression test for the safe default

## Rationale

go-libutp v1.5.0 passes the peer-controlled reply_micro field into native delay averaging. A half-range value can violate a live assertion and abort Erigon. Upstream has no fixed release, so disabling uTP at the downloader configuration boundary removes the native UDP packet path while preserving TCP downloads and seeding.

Fixes erigontech/security#78

## Testing

- regression test failed before the production change and passed after it
- go test ./db/downloader/downloadercfg -count=1
- make lint (three clean runs)
- make erigon integration