### PR TITLE
txnprovider/txpool: reject trailing bytes after blob tx wrapper

### DIFF
--- a/txnprovider/txpool/pool_txn_parser.go
+++ b/txnprovider/txpool/pool_txn_parser.go
@@ -224,6 +224,9 @@ func (ctx *TxnParseContext) ParseTransaction(payload []byte, pos int, slot *TxnS
 		if err != nil {
 			return 0, fmt.Errorf("%w: blob wrapper list: %s", ErrParseTxn, err) //nolint
 		}
+		if wrapperListPos+wrapperListLen != len(txBytes) {
+			return 0, fmt.Errorf("%w: trailing bytes after blobs wrapper", ErrParseTxn)
+		}
 
 		// Parse the inner tx_payload_body (first element of the wrapper list).
 		innerBodyPos, innerBodyLen, err := rlp.ParseList(txBytes, wrapperListPos)

--- a/txnprovider/txpool/pool_txn_parser_test.go
+++ b/txnprovider/txpool/pool_txn_parser_test.go
@@ -565,6 +565,22 @@ func TestParseTransactionRejectsBlobCommitmentCountMismatch(t *testing.T) {
 	require.ErrorContains(t, err, "fewer commitments than blobs")
 }
 
+func TestParseTransactionsRejectsTrailingBlobWrapperBytes(t *testing.T) {
+	chainID := uint256.NewInt(5)
+	wrapper := types.MakeV1WrappedBlobTxn(chainID)
+
+	wrapperBuf := &bytes.Buffer{}
+	require.NoError(t, wrapper.MarshalBinaryWrapped(wrapperBuf))
+	malformed := append(wrapperBuf.Bytes(), 0x80)
+	packet := EncodeTransactions([][]byte{malformed}, nil)
+
+	ctx := NewTxnParseContext(*chainID)
+	ctx.WithSender(false)
+	var slots TxnSlots
+	_, err := ParseTransactions(packet, 0, ctx, &slots, nil)
+	require.ErrorContains(t, err, "trailing bytes after blobs wrapper")
+}
+
 func TestSetCodeAuthSignatureRecover(t *testing.T) {
 	txnRlpHex := testdata.ValidSetCodeTxn1
 	// For authorizationList[0] in the above :-


### PR DESCRIPTION
## Problem

Fixes a txpool denial-of-service reported via the bounty program (ethereum-bounty/erigon#30, private tracker).

Erigon's zero-copy parser for wrapped (version-1) type-3 blob transactions (`ParseTransaction` in `txnprovider/txpool/pool_txn_parser.go`) checks that the wrapper's elements end exactly where the wrapper list header declares, but never that the wrapper list ends at the end of the enveloped transaction bytes.

A single `0x80` byte appended after an otherwise valid wrapper is therefore accepted:

- every wrapper-relative check (blobs, commitments, proofs, `wp == wrapperListPos+wrapperListLen`) passes, because the tail lies outside all of them;
- `slot.IDHash` is keccak of the canonical inner body, so the entry deduplicates as a normal, valid blob tx;
- `slot.Rlp` stores the full tail-bearing bytes, and that is what gets served to peers on `GET_POOLED_TRANSACTIONS`.

The wrapper path does decode the inner tx via the strict decoder, but only over the reconstructed inner body — so it bypasses the strict decoder's own trailing-byte check that the non-wrapper path (`decodeTxn(txBytes)`) gets for free. The bad bytes surface later: on a local payload build, `ProvideTxns` strictly re-decodes `slot.Rlp` and fails with `trailing bytes after rlp encoded transaction`, aborting the whole `engine_getPayloadV5` call. The entry stays pending, so every subsequent build fails identically until the pool is cleared — and because Erigon re-announces the entry, a second Erigon node can pull a byte-identical copy and be poisoned too.

## Fix

Add the missing companion boundary check right after the wrapper list header is parsed: the wrapper list must end at `len(txBytes)`. This rejects the input at parse time, so it never enters the pool or gets re-gossiped. A client must not admit and re-gossip an encoding it cannot itself decode.

```go
if wrapperListPos+wrapperListLen != len(txBytes) {
    return 0, fmt.Errorf("%w: trailing bytes after blobs wrapper", ErrParseTxn)
}
```

## Test

`TestParseTransactionsRejectsTrailingBlobWrapperBytes` builds a valid v1 wrapped blob tx, appends one `0x80` byte, and asserts the parser rejects it. Verified red→green: without the fix the parser accepts the malformed tx (test fails, "an error is expected but got nil"); with the fix it returns `trailing bytes after blobs wrapper`.

## Notes / possible follow-up

Out of scope for this PR, but noted: `ProvideTxns` returns `nil, err` on the first entry that fails to decode, so one undecodable entry fails the entire transaction set for that build rather than being dropped. This parse-time fix stops such an entry from entering the pool in the first place; hardening `ProvideTxns` to skip or evict an individual undecodable entry would be additional defense-in-depth.
