### PR TITLE
[r3.6] txnprovider/txpool: reject trailing bytes after blob tx wrapper

### DIFF
--- a/txnprovider/txpool/pool_txn_parser.go
+++ b/txnprovider/txpool/pool_txn_parser.go
@@ -225,6 +225,9 @@ func (ctx *TxnParseContext) ParseTransaction(payload []byte, pos int, slot *TxnS
 		if err != nil {
 			return 0, fmt.Errorf("%w: blob wrapper list: %s", ErrParseTxn, err) //nolint
 		}
+		if wrapperListPos+wrapperListLen != len(txBytes) {
+			return 0, fmt.Errorf("%w: trailing bytes after blobs wrapper", ErrParseTxn)
+		}
 
 		// Parse the inner tx_payload_body (first element of the wrapper list).
 		innerBodyPos, innerBodyLen, err := rlp.ParseList(txBytes, wrapperListPos)

--- a/txnprovider/txpool/pool_txn_parser_test.go
+++ b/txnprovider/txpool/pool_txn_parser_test.go
@@ -565,6 +565,22 @@ func TestParseTransactionRejectsBlobCommitmentCountMismatch(t *testing.T) {
 	require.ErrorContains(t, err, "fewer commitments than blobs")
 }
 
+func TestParseTransactionsRejectsTrailingBlobWrapperBytes(t *testing.T) {
+	chainID := uint256.NewInt(5)
+	wrapper := types.MakeV1WrappedBlobTxn(chainID)
+
+	wrapperBuf := &bytes.Buffer{}
+	require.NoError(t, wrapper.MarshalBinaryWrapped(wrapperBuf))
+	malformed := append(wrapperBuf.Bytes(), 0x80)
+	packet := EncodeTransactions([][]byte{malformed}, nil)
+
+	ctx := NewTxnParseContext(*chainID)
+	ctx.WithSender(false)
+	var slots TxnSlots
+	_, err := ParseTransactions(packet, 0, ctx, &slots, nil)
+	require.ErrorContains(t, err, "trailing bytes after blobs wrapper")
+}
+
 func TestSetCodeAuthSignatureRecover(t *testing.T) {
 	txnRlpHex := testdata.ValidSetCodeTxn1
 	// For authorizationList[0] in the above :-


### PR DESCRIPTION
Cherry-pick of #23295 to release/3.6.

Depends on #23295 (still in draft) landing on `main` first.
