### PR TITLE
execution/builder: keep payload commitment on the builder snapshot

### DIFF
--- a/execution/builder/builder.go
+++ b/execution/builder/builder.go
@@ -106,6 +106,11 @@ func (b *Builder) PendingBlockCh() chan *types.Block {
 	return b.pendingBlockCh
 }
 
+func newBuilderSharedDomains(ctx context.Context, tx kv.TemporalTx, logger log.Logger) (*execctx.SharedDomains, error) {
+	return execctx.NewSharedDomains(ctx, tx, logger,
+		execctx.WithoutDeferredBranchUpdates(), execctx.WithoutSharedBranchCache(), execctx.WithSequentialCommitment())
+}
+
 // Build satisfies BlockBuilderFunc. Pass b.Build directly to ExecModule.
 func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *types.BlockWithReceipts, err error) {
 	defer func() {
@@ -145,7 +150,7 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 		}
 	}
 
-	sd, err := execctx.NewSharedDomains(b.ctx, compositeTx, b.logger, execctx.WithoutDeferredBranchUpdates(), execctx.WithoutSharedBranchCache())
+	sd, err := newBuilderSharedDomains(b.ctx, compositeTx, b.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -155,9 +160,7 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 		sd.SetParent(parentSD)
 	}
 
-	// Wire the parallel commitment trie's context factory. Values still resolve
-	// through the sd/parent mem-batch overlay chain; b.db only backs the fresh
-	// per-worker readers. Mirrors exec3; no-op for the sequential trie.
+	// The sequential trie only uses this DB for best-effort page-cache warmup.
 	sd.EnableParaTrieDB(b.db)
 
 	executionAt, err := stages.GetStageProgress(compositeTx, stages.Execution)

--- a/execution/builder/builder_test.go
+++ b/execution/builder/builder_test.go
@@ -25,8 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
+	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/execution/builder/buildercfg"
+	"github.com/erigontech/erigon/execution/commitment"
 	"github.com/erigontech/erigon/execution/types"
 )
 
@@ -68,4 +72,22 @@ func TestBuilder_PendingBlockCh(t *testing.T) {
 	ch := b.PendingBlockCh()
 	require.NotNil(t, ch)
 	require.Equal(t, ch, b.PendingBlockCh(), "must return the same channel on repeated calls")
+}
+
+func TestBuilderSharedDomainsUsesSequentialCommitment(t *testing.T) {
+	original := statecfg.ExperimentalParallelCommitment
+	statecfg.ExperimentalParallelCommitment = true
+	t.Cleanup(func() { statecfg.ExperimentalParallelCommitment = original })
+
+	db := temporaltest.NewTestDB(t, datadir.New(t.TempDir()))
+	tx, err := db.BeginTemporalRo(t.Context())
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	sd, err := newBuilderSharedDomains(t.Context(), tx, log.New())
+	require.NoError(t, err)
+	defer sd.Close()
+	sd.EnableParaTrieDB(db)
+
+	require.Equal(t, commitment.VariantHexPatriciaTrie, sd.GetCommitmentCtx().Trie().Variant())
 }


### PR DESCRIPTION
Relates to #22209.

Split from #22198 after #22617 landed the independent builder `BranchCache` isolation and closed #22152. This is an interim mitigation and does not close #22209.

## Problem

With experimental parallel commitment enabled, a payload build starts from its own read snapshot but parallel trie workers open fresh temporal read transactions while folding the root. #22354 pins their aggregator file generation, but their MDBX transaction can still observe a newer committed head. If FCU advances during a build, the fold can combine the builder overlay with current-head values.

## Change

Create the builder `SharedDomains` with `WithSequentialCommitment()`. Payload commitment reads therefore stay on the builder transaction and overlay. `EnableParaTrieDB` remains enabled for best-effort page-cache warmup, which does not compute the root.

The proper fix remains binding parallel worker reads to the complete caller snapshot as tracked by #22209. After that lands, builders can use parallel commitment again.

## TDD

Red: `TestBuilderSharedDomainsUsesSequentialCommitment` enabled experimental parallel commitment and observed `hex-parallel-patricia-hashed`.

Green: adding the builder-only sequential option changed the observed variant to `hex-patricia-hashed`.

## Verification

- `go test ./execution/builder -count=1`
- `go test ./execution/execmodule -run TestAssembleBlockWithConcurrentSiblingCommit -count=1`
- `make lint` passed three times
- `make erigon integration`