### PR TITLE
chaindata: pageSize 16kb -> 4kb

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -849,7 +849,7 @@ var (
 	}
 	DbPageSizeFlag = cli.StringFlag{
 		Name:  "db.pagesize",
-		Usage: "DB is split to 'pages' of fixed size. Can't change DB creation. Must be power of 2 and '256b <= pagesize <= 64kb'. Default: equal to OperationSystem's pageSize. Bigger pageSize causing: 1. More writes to disk during commit 2. Smaller b-tree high 3. Less fragmentation 4. Less overhead on 'free-pages list' maintenance (a bit faster Put/Commit) 5. If expecting DB-size > 8Tb then set pageSize >= 8Kb",
+		Usage: "DB is split to 'pages' of fixed size. Can't change after DB creation. Must be power of 2 and '256b <= pagesize <= 64kb'. Bigger pageSize causing: 1. More writes to disk during commit 2. Smaller b-tree high 3. Less fragmentation 4. Less overhead on 'free-pages list' maintenance (a bit faster Put/Commit) 5. If expecting DB-size > 8Tb then set pageSize >= 8Kb",
 		Value: ethconfig.DefaultChainDBPageSize.String(),
 	}
 	DbSizeLimitFlag = cli.StringFlag{

--- a/db/kv/mdbx/kv_mdbx.go
+++ b/db/kv/mdbx/kv_mdbx.go
@@ -99,7 +99,7 @@ func New(label kv.Label, log log.Logger) MdbxOpts {
 		bucketsCfg: WithChaindataTables,
 		flags:      mdbx.NoReadahead | mdbx.Durable,
 		log:        log,
-		pageSize:   DefaultPageSize(),
+		pageSize:   defaultPageSize(),
 
 		mapSize:         DefaultMapSize,
 		growthStep:      DefaultGrowthStep,
@@ -289,7 +289,7 @@ func (opts MdbxOpts) Open(ctx context.Context) (_ kv.RwDB, err error) {
 		//   - after they will require rwtx-lock, which is not acceptable in ACCEDEE mode.
 		pageSize := opts.pageSize
 		if pageSize == 0 {
-			pageSize = DefaultPageSize()
+			pageSize = defaultPageSize()
 		}
 		var dirtySpace uint64
 		if opts.dirtySpace > 0 {

--- a/db/kv/mdbx/kv_mdbx.go
+++ b/db/kv/mdbx/kv_mdbx.go
@@ -257,6 +257,12 @@ func (opts MdbxOpts) Open(ctx context.Context) (_ kv.RwDB, err error) {
 		}
 	}
 
+	requestedPageSize := opts.pageSize
+	if requestedPageSize == 0 {
+		requestedPageSize = defaultPageSize()
+	}
+	var dirtySpace uint64
+
 	// erigon using big transactions
 	// increase "page measured" options. need do it after env.Open() because default are depend on pageSize known only after env.Open()
 	if !opts.HasFlag(mdbx.Readonly) {
@@ -287,11 +293,6 @@ func (opts MdbxOpts) Open(ctx context.Context) (_ kv.RwDB, err error) {
 		// before env.Open() we don't know real pageSize. but will be implemented soon: https://gitflic.ru/project/erthink/libmdbx/issue/15
 		// but we want call all `SetOption` before env.Open(), because:
 		//   - after they will require rwtx-lock, which is not acceptable in ACCEDEE mode.
-		pageSize := opts.pageSize
-		if pageSize == 0 {
-			pageSize = defaultPageSize()
-		}
-		var dirtySpace uint64
 		if opts.dirtySpace > 0 {
 			dirtySpace = opts.dirtySpace
 		} else {
@@ -307,7 +308,7 @@ func (opts MdbxOpts) Open(ctx context.Context) (_ kv.RwDB, err error) {
 			}
 		}
 		//can't use real pagesize here - it will be known only after env.Open()
-		if err := env.SetOption(mdbx.OptTxnDpLimit, dirtySpace/pageSize.Bytes()); err != nil {
+		if err := env.SetOption(mdbx.OptTxnDpLimit, dirtySpace/requestedPageSize.Bytes()); err != nil {
 			return nil, err
 		}
 
@@ -331,6 +332,15 @@ func (opts MdbxOpts) Open(ctx context.Context) (_ kv.RwDB, err error) {
 
 	opts.pageSize = datasize.ByteSize(in.PageSize)
 	opts.mapSize = datasize.ByteSize(in.MapSize)
+
+	// OptTxnDpLimit counts pages, but the budget we want is a byte one. mdbx keeps the pageSize of
+	// an existing db, so a stale limit would scale the dirty-page memory by the size ratio.
+	// Accede must stay lock-free here - SetOption after Open takes the rwtx-lock.
+	if dirtySpace > 0 && opts.pageSize != requestedPageSize && !opts.HasFlag(mdbx.Accede) {
+		if err := env.SetOption(mdbx.OptTxnDpLimit, dirtySpace/opts.pageSize.Bytes()); err != nil {
+			return nil, fmt.Errorf("%w, label: %s", err, opts.label)
+		}
+	}
 	if opts.label == dbcfg.ChainDB {
 		opts.log.Info("[db] open", "label", opts.label, "sizeLimit", opts.mapSize, "pageSize", opts.pageSize)
 	} else {

--- a/db/kv/mdbx/kv_mdbx_test.go
+++ b/db/kv/mdbx/kv_mdbx_test.go
@@ -1237,3 +1237,28 @@ func TestAutoRemove(t *testing.T) {
 		require.DirExists(t, dbPath)
 	})
 }
+
+func TestTxnDpLimitFromRealPageSize(t *testing.T) {
+	path := t.TempDir()
+	logger := log.New()
+	const dirtySpace = uint64(1 * datasize.GB)
+
+	open := func(requestedPageSize datasize.ByteSize) kv.RwDB {
+		return mdbx.New(dbcfg.ChainDB, logger).Path(path).
+			PageSize(requestedPageSize).DirtySpace(dirtySpace).MapSize(16 * datasize.GB).MustOpen()
+	}
+
+	db := open(16 * datasize.KB)
+	require.Equal(t, 16*datasize.KB, db.PageSize())
+	db.Close()
+
+	// mdbx keeps the page size of an existing db, so the dirty-page limit must
+	// follow the real page size - not the requested one
+	db = open(4 * datasize.KB)
+	defer db.Close()
+	require.Equal(t, 16*datasize.KB, db.PageSize())
+
+	dpLimit, err := db.(*mdbx.MdbxKV).Env().GetOption(mdbxgo.OptTxnDpLimit)
+	require.NoError(t, err)
+	require.Equal(t, dirtySpace/db.PageSize().Bytes(), dpLimit)
+}

--- a/db/kv/mdbx/util.go
+++ b/db/kv/mdbx/util.go
@@ -50,7 +50,7 @@ func RecordSummaries(dbLabel kv.Label, latency mdbx.CommitLatency) error {
 	return nil
 }
 
-func DefaultPageSize() datasize.ByteSize {
+func defaultPageSize() datasize.ByteSize {
 	osPageSize := os.Getpagesize()
 	if osPageSize < 4096 { // reduce further may lead to errors (because some data is just big)
 		osPageSize = 4096

--- a/db/state/changeset/state_changeset.go
+++ b/db/state/changeset/state_changeset.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/kv/dbutils"
 	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/node/ethconfig"
 )
 
 type StateChangeSet struct {
@@ -317,7 +318,10 @@ func deserializeKeys(in []byte) [kv.DomainLen][]kv.DomainEntryDiff {
 }
 
 const DiffChunkKeyLen = 48
-const DiffChunkLen = 4*1024 - 32
+
+// DiffChunkLen keeps 2 chunks inline in one mdbx leaf page - values bigger than half a page go to
+// overflow pages, which cost extra FreeList maintenance. See TestNoOverflowPages.
+const DiffChunkLen = int(ethconfig.DefaultChainDBPageSize)/2 - DiffChunkKeyLen - 32
 
 type threadSafeBuf struct {
 	b []byte
@@ -396,7 +400,7 @@ func ReadDiffSet(tx kv.Tx, blockNumber uint64, blockHash common.Hash) ([kv.Domai
 	}
 
 	key := make([]byte, 48)
-	val := make([]byte, 0, DiffChunkLen*chunkCount)
+	val := make([]byte, 0, DiffChunkLen*int(chunkCount))
 	for i := range chunkCount {
 		binary.BigEndian.PutUint64(key, blockNumber)
 		copy(key[8:], blockHash[:])

--- a/db/state/history.go
+++ b/db/state/history.go
@@ -45,6 +45,7 @@ import (
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/db/version"
+	"github.com/erigontech/erigon/node/ethconfig"
 )
 
 type History struct {
@@ -384,6 +385,10 @@ func (h *History) Scan(ctx context.Context, toTxNum uint64) error {
 	return nil
 }
 
+// mdbx keeps a dupsort value as a key of the nested tree, so it is capped by keysize_max(pageSize),
+// which is pageSize/2 - 26. Here that budget is shared with the 8-byte txNum prefix.
+const maxHistoryValLen = int(ethconfig.DefaultChainDBPageSize)/2 - 26 - 8
+
 func (w *historyBufferedWriter) AddPrevValue(k []byte, txNum uint64, original []byte) (err error) {
 	if w.discard {
 		return nil
@@ -423,8 +428,8 @@ func (w *historyBufferedWriter) AddPrevValue(k []byte, txNum uint64, original []
 	historyVal := historyKey[lk:]
 	invIdxVal := historyKey[:lk]
 
-	if len(original) > 2048 {
-		log.Error("History value is too large while largeValues=false", "h", w.historyValsTable, "histo", string(w.historyKey[:lk]), "len", len(original), "max", len(w.historyKey)-8-len(k))
+	if len(original) > maxHistoryValLen {
+		log.Error("History value is too large while largeValues=false", "h", w.historyValsTable, "histo", string(w.historyKey[:lk]), "len", len(original), "max", maxHistoryValLen)
 		panic("History value is too large while largeValues=false")
 	}
 

--- a/db/state/history_test.go
+++ b/db/state/history_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/erigontech/erigon/db/seg"
 	"github.com/erigontech/erigon/db/state/statecfg"
 	"github.com/erigontech/erigon/execution/commitment/commitmentdb"
+	"github.com/erigontech/erigon/node/ethconfig"
 )
 
 func testDbAndHistory(tb testing.TB, largeValues bool, logger log.Logger) (kv.RwDB, *History) {
@@ -2537,4 +2538,22 @@ func BenchmarkRangeAsOf_MultiFile(b *testing.B) {
 		}
 		it.Close()
 	}
+}
+
+func TestMaxHistoryValLen(t *testing.T) {
+	db := mdbx.New(dbcfg.ChainDB, log.New()).InMem(t.TempDir()).
+		PageSize(ethconfig.DefaultChainDBPageSize).
+		WithTableCfg(func(kv.TableCfg) kv.TableCfg {
+			return kv.TableCfg{kv.TblAccountHistoryVals: kv.TableCfgItem{Flags: kv.DupSort}}
+		}).MustOpen()
+	defer db.Close()
+
+	// historyLargeValues=false stores txNum+value as one dupsort value
+	put := func(valLen int) error {
+		return db.Update(t.Context(), func(tx kv.RwTx) error {
+			return tx.Put(kv.TblAccountHistoryVals, []byte("key"), make([]byte, 8+valLen))
+		})
+	}
+	require.NoError(t, put(maxHistoryValLen))
+	require.Error(t, put(maxHistoryValLen+1))
 }

--- a/docs/site/docs/fundamentals/configuring-erigon.mdx
+++ b/docs/site/docs/fundamentals/configuring-erigon.mdx
@@ -92,7 +92,7 @@ These flags are mainly for dev networks, testing, or specialized block-productio
 These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
 
 * `--db.pagesize value`: Sets the fixed page size for the database.
-  * Default: `16KB`
+  * Default: `4KB`
 * `--db.size.limit value`: Sets a runtime limit on the chaindata database size.
   * Default: `1TB`
 * `--db.writemap`: Enables `WRITE_MAP` for fast database writes.

--- a/docs/site/help-center/known-issues.mdx
+++ b/docs/site/help-center/known-issues.mdx
@@ -70,4 +70,4 @@ vm.max_map_count = 16777216
 
 The `--db.pagesize` flag sets the MDBX page size and **must be chosen before the first sync**. It cannot be changed on an existing database without deleting the datadir and re-syncing from scratch. See [Configuring Erigon](/fundamentals/configuring-erigon) for all database flags.
 
-The default page size is `16KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](/fundamentals/performance-tricks) and [Optimizing Storage](/fundamentals/optimizing-storage) for further tuning options.
+The default page size is `4KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](/fundamentals/performance-tricks) and [Optimizing Storage](/fundamentals/optimizing-storage) for further tuning options.

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2125,7 +2125,7 @@ These flags are mainly for dev networks, testing, or specialized block-productio
 These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
 
 * `--db.pagesize value`: Sets the fixed page size for the database.
-  * Default: `16KB`
+  * Default: `4KB`
 * `--db.size.limit value`: Sets a runtime limit on the chaindata database size.
   * Default: `1TB`
 * `--db.writemap`: Enables `WRITE_MAP` for fast database writes.
@@ -8212,7 +8212,7 @@ vm.max_map_count = 16777216
 
 The `--db.pagesize` flag sets the MDBX page size and **must be chosen before the first sync**. It cannot be changed on an existing database without deleting the datadir and re-syncing from scratch. See [Configuring Erigon](/fundamentals/configuring-erigon) for all database flags.
 
-The default page size is `16KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](/fundamentals/performance-tricks) and [Optimizing Storage](/fundamentals/optimizing-storage) for further tuning options.
+The default page size is `4KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](/fundamentals/performance-tricks) and [Optimizing Storage](/fundamentals/optimizing-storage) for further tuning options.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2125,7 +2125,7 @@ These flags are mainly for dev networks, testing, or specialized block-productio
 These flags control database performance and memory usage. See [Database](/fundamentals/database) for the on-disk layout.
 
 * `--db.pagesize value`: Sets the fixed page size for the database.
-  * Default: `16KB`
+  * Default: `4KB`
 * `--db.size.limit value`: Sets a runtime limit on the chaindata database size.
   * Default: `1TB`
 * `--db.writemap`: Enables `WRITE_MAP` for fast database writes.
@@ -8212,7 +8212,7 @@ vm.max_map_count = 16777216
 
 The `--db.pagesize` flag sets the MDBX page size and **must be chosen before the first sync**. It cannot be changed on an existing database without deleting the datadir and re-syncing from scratch. See [Configuring Erigon](/fundamentals/configuring-erigon) for all database flags.
 
-The default page size is `16KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](/fundamentals/performance-tricks) and [Optimizing Storage](/fundamentals/optimizing-storage) for further tuning options.
+The default page size is `4KB`. For cloud drives or any storage with high sequential I/O latency, a larger page size (e.g. `--db.pagesize=64kb`) reduces database fragmentation and improves I/O efficiency. See [Performance Tricks](/fundamentals/performance-tricks) and [Optimizing Storage](/fundamentals/optimizing-storage) for further tuning options.
 
 ---
 

--- a/node/ethconfig/config.go
+++ b/node/ethconfig/config.go
@@ -117,7 +117,7 @@ var Defaults = Config{
 	WarmupKzgCtxOnInit: true,
 }
 
-const DefaultChainDBPageSize = 16 * datasize.KB
+const DefaultChainDBPageSize = 4 * datasize.KB
 
 func init() {
 	home := os.Getenv("HOME")


### PR DESCRIPTION
`DefaultChainDBPageSize` 16kb -> 4kb, and `DiffChunkLen` now derives from it at compile time instead of hardcoding `4*1024 - 32`.

The old `DiffChunkLen` formula (`pageSize - 32`) does not describe "fits inline in a leaf page". mdbx stores a value inline only if `NODESIZE(8) + keylen + vallen <= leaf_nodemax`, where `leaf_nodemax = EVEN_FLOOR((pageSize-20)/2) - 2` - half a page, because a leaf must hold at least 2 nodes. At 16kb the old 4064 passed by luck (4064 < 8180); at 4kb it exceeds 2036 and every chunk becomes an overflow page. `TestNoOverflowPages` goes red on it. New formula `pageSize/2 - DiffChunkKeyLen - 32` gives 1968 at 4kb and 8112 at 16kb, both inline.

`ChangeSets3` chunks go 4064 -> 1968 bytes, so its row count roughly doubles. The knob that touches is `pruneDiffsLimit = 200_000` in `stage_execute.go` - rows per prune call, now covering half as many blocks.

Existing databases keep their page size: mdbx ignores it after DB creation, so this affects new datadirs only. `DiffChunkLen` is write-side only - `ReadDiffSet` takes `chunkCount` from the db and `deserializeKeys` parses by length prefixes - so rows written at 4064 stay readable.

txpool stays at 16kb: `txpoolcfg.MdbxPageSize` is never fed from `--db.pagesize`, so the explicit `PageSize(16 * datasize.KB)` in `assemble.go` wins.

`mdbx.DefaultPageSize()` had no callers outside its package - made private, logic unchanged. `--db.pagesize` usage text dropped the false "Default: equal to OperationSystem's pageSize".

`OptTxnDpLimit` counts pages, but the budget it expresses is a byte one, so it has to follow the real pageSize. mdbx keeps the pageSize of an existing db, and erigon computed the limit from the *requested* one before `env.Open()`. So every existing 16kb chaindata opened by this binary got `1gb/4kb = 262144` pages of 16kb = **4gb** of dirty pages before spilling, instead of 1gb. Now recomputed after Open when the two differ - skipped under Accede, where `SetOption` would take the rwtx-lock. `TestTxnDpLimitFromRealPageSize` pins it.

Measured the 4x longer dirty-page list on n5 (EPYC 4344P, 62gb ram), mdbx-only bench: 5gb table, `dirtySpace`=1gb, 100k keys per tx, 10 iterations x 3 counts.

| workload | 16kb | 4kb | delta |
|---|---|---|---|
| 100k random updates / tx | 150.25 ms | 139.11 ms | **-7.4%** |
| 100k sequential appends / tx | 44.88 ms | 47.75 ms | **+6.4%** |

No pathology from the longer DPL. Random writes get *faster* at 4kb - the same 1gb of dirty space now holds 262144 pages instead of 65536, so 4x more random updates fit before mdbx starts spilling. Appends pay ~6% for 4x more DPL entries at the same byte volume. Commit itself is not where the cost lands: 0.06-0.10 ms on the random arm, because mdbx spills during `Put` once `dp_limit` is crossed.

Caveats: the working set is fully page-cached, and the key/value shape (8b key, 100b value) is not erigon's domain layout. A real exec A/B over identical snapshots has not been run.
