### PR TITLE
mmap: modernize, drop the `*[MaxMapSize]byte` handle, remove `unsafe` use

### DIFF
--- a/common/mmap/mmap_unix.go
+++ b/common/mmap/mmap_unix.go
@@ -24,14 +24,11 @@ import (
 	"os"
 	"reflect"
 	"syscall"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 
 	_ "github.com/erigontech/erigon/common/race"
 )
-
-const MaxMapSize = 0xFFFFFFFFFFFF
 
 var osPageSize = uintptr(os.Getpagesize())
 
@@ -50,21 +47,18 @@ func pageAligned(m []byte) []byte {
 	return m[skip : len(m)-trim]
 }
 
-func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
-	// Map the data file to memory.
-	mmapHandle1, err := unix.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+func Mmap(f *os.File, size int) ([]byte, error) {
+	m, err := unix.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
 	// Advise the kernel that the mmap is accessed randomly.
-	err = unix.Madvise(mmapHandle1, syscall.MADV_RANDOM)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
-		return nil, nil, fmt.Errorf("madvise: %w", err)
+	// Ignore not implemented error in kernel because it still works.
+	if err := unix.Madvise(m, syscall.MADV_RANDOM); err != nil && !errors.Is(err, syscall.ENOSYS) {
+		_ = unix.Munmap(m)
+		return nil, fmt.Errorf("madvise: %w", err)
 	}
-	mmapHandle2 := (*[MaxMapSize]byte)(unsafe.Pointer(&mmapHandle1[0]))
-	return mmapHandle1, mmapHandle2, nil
+	return m, nil
 }
 
 func madvise(m []byte, advice int) error {
@@ -81,13 +75,11 @@ func MadviseNormal(m []byte) error     { return madvise(m, syscall.MADV_NORMAL) 
 func MadviseWillNeed(m []byte) error   { return madvise(m, syscall.MADV_WILLNEED) }
 func MadviseRandom(m []byte) error     { return madvise(m, syscall.MADV_RANDOM) }
 
-// munmap unmaps a DB's data file from memory.
-func Munmap(mmapHandle1 []byte, _ *[MaxMapSize]byte) error {
-	// Ignore the unmap if we have no mapped data.
-	if mmapHandle1 == nil {
+// Munmap accepts only the slice returned by Mmap: a re-slice has a different
+// base address and length, which munmap(2) rejects.
+func Munmap(m []byte) error {
+	if len(m) == 0 {
 		return nil
 	}
-	// Unmap using the original byte slice.
-	err := unix.Munmap(mmapHandle1)
-	return err
+	return unix.Munmap(m)
 }

--- a/common/mmap/mmap_windows.go
+++ b/common/mmap/mmap_windows.go
@@ -23,31 +23,27 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const MaxMapSize = 0xFFFFFFFFFFFF
-
-func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
+func Mmap(f *os.File, size int) ([]byte, error) {
 	// Open a file mapping handle.
-	sizelo := uint32(size >> 32)
-	sizehi := uint32(size) & 0xffffffff
-	h, errno := windows.CreateFileMapping(windows.Handle(f.Fd()), nil, windows.PAGE_READONLY, sizelo, sizehi, nil)
+	maxSizeHigh := uint32(size >> 32)
+	maxSizeLow := uint32(size) & 0xffffffff
+	h, errno := windows.CreateFileMapping(windows.Handle(f.Fd()), nil, windows.PAGE_READONLY, maxSizeHigh, maxSizeLow, nil)
 	if h == 0 {
-		return nil, nil, os.NewSyscallError("CreateFileMapping", errno)
+		return nil, os.NewSyscallError("CreateFileMapping", errno)
 	}
 
-	// Create the memory map.
+	// Create the memory map. The view keeps the section alive, so the mapping
+	// handle is closed either way.
 	addr, errno := windows.MapViewOfFile(h, windows.FILE_MAP_READ, 0, 0, uintptr(size))
 	if addr == 0 {
-		return nil, nil, os.NewSyscallError("MapViewOfFile", errno)
+		_ = windows.CloseHandle(h)
+		return nil, os.NewSyscallError("MapViewOfFile", errno)
 	}
-
-	// Close mapping handle.
 	if err := windows.CloseHandle(h); err != nil {
-		return nil, nil, os.NewSyscallError("CloseHandle", err)
+		return nil, os.NewSyscallError("CloseHandle", err)
 	}
 
-	// Convert to a byte array.
-	mmapHandle2 := ((*[MaxMapSize]byte)(unsafe.Pointer(addr)))
-	return mmapHandle2[:size], mmapHandle2, nil
+	return unsafe.Slice((*byte)(unsafe.Pointer(addr)), size), nil
 }
 
 func MadviseSequential(mmapHandle1 []byte) error { return nil }
@@ -55,12 +51,14 @@ func MadviseNormal(mmapHandle1 []byte) error     { return nil }
 func MadviseWillNeed(mmapHandle1 []byte) error   { return nil }
 func MadviseRandom(mmapHandle1 []byte) error     { return nil }
 
-func Munmap(_ []byte, mmapHandle2 *[MaxMapSize]byte) error {
-	if mmapHandle2 == nil {
+// Munmap accepts only the slice returned by Mmap: UnmapViewOfFile needs the
+// base address of the view, which a re-slice no longer carries.
+func Munmap(m []byte) error {
+	if len(m) == 0 {
 		return nil
 	}
 
-	addr := (uintptr)(unsafe.Pointer(&mmapHandle2[0]))
+	addr := uintptr(unsafe.Pointer(&m[0]))
 	if err := windows.UnmapViewOfFile(addr); err != nil {
 		return os.NewSyscallError("UnmapViewOfFile", err)
 	}

--- a/common/mmap/residency_linux_test.go
+++ b/common/mmap/residency_linux_test.go
@@ -49,9 +49,9 @@ func TestResidencyProbe(t *testing.T) {
 	require.NoError(t, f.Sync())
 	require.NoError(t, unix.Fadvise(int(f.Fd()), 0, int64(len(data)), unix.FADV_DONTNEED))
 
-	m, h2, err := Mmap(f, len(data))
+	m, err := Mmap(f, len(data))
 	require.NoError(t, err)
-	defer Munmap(m, h2)
+	defer Munmap(m)
 
 	res, err := Resident(m)
 	require.NoError(t, err)

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -40,11 +40,10 @@ type dataProvider interface {
 }
 
 type fileDataProvider struct {
-	file        *os.File
-	mmapReader  *mmapBytesReader       // zero-copy reader over mmap'd data
-	mmapData    []byte                 // mmap'd file content
-	mmapHandle2 *[mmap.MaxMapSize]byte // pointer handle for cleanup
-	wg          *errgroup.Group
+	file       *os.File
+	mmapReader *mmapBytesReader // zero-copy reader over mmap'd data
+	mmapData   []byte           // mmap'd file content
+	wg         *errgroup.Group
 }
 
 // mmapBytesReader tracks position for reading from mmap'd data
@@ -144,7 +143,7 @@ func (p *fileDataProvider) initMmap() error {
 	if fi.Size() == 0 {
 		return io.EOF
 	}
-	p.mmapData, p.mmapHandle2, err = mmap.Mmap(p.file, int(fi.Size()))
+	p.mmapData, err = mmap.Mmap(p.file, int(fi.Size()))
 	if err != nil {
 		return fmt.Errorf("mmap failed: %w", err)
 	}
@@ -197,9 +196,8 @@ func (p *fileDataProvider) Dispose() {
 	p.Wait()
 
 	if p.mmapData != nil {
-		_ = mmap.Munmap(p.mmapData, p.mmapHandle2)
+		_ = mmap.Munmap(p.mmapData)
 		p.mmapData = nil
-		p.mmapHandle2 = nil
 		p.mmapReader = nil
 	}
 

--- a/db/etl/read_bench_test.go
+++ b/db/etl/read_bench_test.go
@@ -141,7 +141,7 @@ func openMmap(b *testing.B, fname string) ([]byte, *os.File) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	data, _, err := mmap.Mmap(f, int(fi.Size()))
+	data, err := mmap.Mmap(f, int(fi.Size()))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -76,7 +76,6 @@ var IncompatibleErr = errors.New("incompatible. can re-build such files by comma
 type Index struct {
 	offsetEf           *eliasfano32.EliasFano
 	f                  *os.File
-	mmapHandle2        *[mmap.MaxMapSize]byte // mmap handle for windows (this is used to close mmap)
 	filePath, fileName string
 
 	grData      []uint64
@@ -140,7 +139,7 @@ func OpenIndex(indexFilePath string) (_ *Index, err error) {
 	}
 	idx.size = stat.Size()
 	idx.modTime = stat.ModTime()
-	if idx.mmapHandle1, idx.mmapHandle2, err = mmap.Mmap(idx.f, int(idx.size)); err != nil {
+	if idx.mmapHandle1, err = mmap.Mmap(idx.f, int(idx.size)); err != nil {
 		return nil, err
 	}
 	idx.data = idx.mmapHandle1[:idx.size]
@@ -393,7 +392,7 @@ func (idx *Index) Close() {
 	if idx == nil || idx.f == nil {
 		return
 	}
-	if err := mmap.Munmap(idx.mmapHandle1, idx.mmapHandle2); err != nil {
+	if err := mmap.Munmap(idx.mmapHandle1); err != nil {
 		log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", idx.FileName(), "stack", dbg.Stack())
 	}
 	if err := idx.f.Close(); err != nil {

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -889,11 +889,11 @@ func (rs *RecSplit) buildOffsetEf() (retErr error) {
 	}
 
 	mmapSize := int(rs.keysAdded * 8)
-	mmapHandle1, mmapHandle2, err := mmap.Mmap(rs.offsetFile, mmapSize)
+	mmapHandle1, err := mmap.Mmap(rs.offsetFile, mmapSize)
 	if err != nil {
 		return fmt.Errorf("mmap offset file: %w", err)
 	}
-	defer mmap.Munmap(mmapHandle1, mmapHandle2)
+	defer mmap.Munmap(mmapHandle1)
 
 	data := mmapHandle1[:mmapSize]
 	for i := uint64(0); i < rs.keysAdded; i++ {

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -168,7 +168,6 @@ func (e ErrCompressedFileCorrupted) Is(err error) bool {
 // Decompressor provides access to the superstrings in a file produced by a compressor
 type Decompressor struct {
 	f                   *os.File
-	mmapHandle2         *[mmap.MaxMapSize]byte // mmap handle for windows (this is used to close mmap)
 	dict                *patternTable
 	posDict             *posTable
 	patArena            *patternArena // arena keeping all pattern table allocations alive
@@ -249,7 +248,7 @@ func NewDecompressorWithMetadata(compressedFilePath string, hasMetadata bool) (*
 	}
 
 	d.modTime = stat.ModTime()
-	if d.mmapHandle1, d.mmapHandle2, err = mmap.Mmap(d.f, int(d.size)); err != nil {
+	if d.mmapHandle1, err = mmap.Mmap(d.f, int(d.size)); err != nil {
 		return nil, err
 	}
 	// read patterns from file
@@ -578,7 +577,7 @@ func (d *Decompressor) Close() {
 		rb.stop() // join the refresh goroutine before munmap so no mincore touches freed memory
 		d.residency.Store(nil)
 	}
-	if err := mmap.Munmap(d.mmapHandle1, d.mmapHandle2); err != nil {
+	if err := mmap.Munmap(d.mmapHandle1); err != nil {
 		log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", d.FileName(), "stack", dbg.Stack())
 	}
 	if err := d.f.Close(); err != nil {
@@ -681,7 +680,6 @@ func (d *Decompressor) MadvWillNeed() *Decompressor {
 type SequentialView struct {
 	d           *Decompressor
 	mmapHandle1 []byte
-	mmapHandle2 *[mmap.MaxMapSize]byte
 	data        []byte // words data region from the sequential mmap
 }
 
@@ -694,7 +692,7 @@ func (d *Decompressor) OpenSequentialView(separateReadahead bool) (*SequentialVi
 	if !separateReadahead {
 		return &SequentialView{d: d, data: d.data[d.wordsStart:]}, nil
 	}
-	h1, h2, err := mmap.Mmap(d.f, int(d.size))
+	h1, err := mmap.Mmap(d.f, int(d.size))
 	if err != nil {
 		return nil, err
 	}
@@ -709,7 +707,7 @@ func (d *Decompressor) OpenSequentialView(separateReadahead bool) (*SequentialVi
 	headerSize := d.size - int64(len(d.data))
 	wordsFileOffset := headerSize + int64(d.wordsStart)
 	return &SequentialView{
-		d: d, mmapHandle1: h1, mmapHandle2: h2,
+		d: d, mmapHandle1: h1,
 		data: h1[wordsFileOffset:d.size],
 	}, nil
 }
@@ -736,7 +734,7 @@ func (v *SequentialView) Close() {
 	if v == nil || v.mmapHandle1 == nil {
 		return
 	}
-	_ = mmap.Munmap(v.mmapHandle1, v.mmapHandle2)
+	_ = mmap.Munmap(v.mmapHandle1)
 	v.mmapHandle1 = nil
 	v.data = nil
 }


### PR DESCRIPTION
`Mmap` returned a second handle, `*[MaxMapSize]byte`, next to the mapped slice, and every caller stored it in a struct field only to hand it back to `Munmap`. It exists because `MapViewOfFile` returns a raw address and pre-1.17 Go had no `unsafe.Slice`, so casting to a huge array pointer was the only way to build a slice over it. On unix the handle was never used at all — `func Munmap(mmapHandle1 []byte, _ *[MaxMapSize]byte) error`.

```go
-func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error)
-func Munmap(mmapHandle1 []byte, _ *[MaxMapSize]byte) error
+func Mmap(f *os.File, size int) ([]byte, error)
+func Munmap(m []byte) error
```

Removes the `mmapHandle2` field from `seg.Decompressor`, `seg.SequentialView`, `recsplit.Index` and `etl.fileDataProvider`, and the `MaxMapSize` constant.

Two fixes fall out:

- Windows mappings had `cap == MaxMapSize` (256 TB), since the slice came from `hugeArray[:size]`. A reslice past `len` read outside the mapping instead of panicking. `unsafe.Slice` gives `cap == len`. Latent — no caller reslices past `len` today.
- Error-path leaks: unix leaked the mapping when `madvise` failed, Windows leaked the `CreateFileMapping` handle when `MapViewOfFile` failed.

Everything else is unchanged: same prot/flags, same `MADV_RANDOM` on the full mapping, same `ENOSYS` tolerance.
