### PR TITLE
mmap: `mmap.Ro/Rw` typed objects

### DIFF
--- a/common/mmap/mapping.go
+++ b/common/mmap/mapping.go
@@ -41,7 +41,10 @@ func OpenRo(f *os.File, size int) (Ro, error) {
 	if err != nil {
 		return nil, err
 	}
-	_ = MadviseRandom(m)
+	if err := MadviseRandom(m); err != nil { // ENOSYS is already tolerated inside
+		_ = m.Unmap()
+		return nil, err
+	}
 	return Ro(m), nil
 }
 

--- a/common/mmap/mapping.go
+++ b/common/mmap/mapping.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package mmap
+
+import (
+	"fmt"
+	"os"
+
+	mmapgo "github.com/edsrzf/mmap-go"
+)
+
+// Ro is a read-only file mapping. Writing through it faults.
+type Ro []byte
+
+// Rw is a read-write file mapping. Changes reach the file lazily; call Sync to
+// force them out.
+type Rw []byte
+
+// OpenRo by-default sets MADV_RANDOM - because all files size >> RAM
+// mmap 1 file multiple times with different `madv` - is ok (Linux supports)
+// mmap 1 file-region multiple times with different `madv` - is ok (Linux supports)
+func OpenRo(f *os.File, size int) (Ro, error) {
+	if err := checkSize(f, size); err != nil {
+		return nil, err
+	}
+	m, err := mmapgo.MapRegion(f, size, mmapgo.RDONLY, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	_ = MadviseRandom(m)
+	return Ro(m), nil
+}
+
+func OpenRw(f *os.File, size int) (Rw, error) {
+	if err := checkSize(f, size); err != nil {
+		return nil, err
+	}
+	m, err := mmapgo.MapRegion(f, size, mmapgo.RDWR, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	return Rw(m), nil
+}
+
+// checkSize keeps both platforms alike: unix rejects size<=0 with EINVAL, while
+// Windows maps the whole file and returns a zero-length slice that Unmap skips,
+// leaking the view.
+func checkSize(f *os.File, size int) error {
+	if size <= 0 {
+		return fmt.Errorf("mmap %s: size must be positive, got %d", f.Name(), size)
+	}
+	return nil
+}
+
+// Unmap releases the mapping and nils m, so a use-after-unmap panics on a nil slice instead of
+// reading whatever the kernel put at that address next.
+func (m *Ro) Unmap() error {
+	if len(*m) == 0 {
+		*m = nil
+		return nil
+	}
+	return (*mmapgo.MMap)(m).Unmap()
+}
+
+func (m *Rw) Unmap() error {
+	if len(*m) == 0 {
+		*m = nil
+		return nil
+	}
+	return (*mmapgo.MMap)(m).Unmap()
+}
+
+func (m Rw) Sync() error { return mmapgo.MMap(m).Flush() }

--- a/common/mmap/mmap_unix.go
+++ b/common/mmap/mmap_unix.go
@@ -24,14 +24,11 @@ import (
 	"os"
 	"reflect"
 	"syscall"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 
 	_ "github.com/erigontech/erigon/common/race"
 )
-
-const MaxMapSize = 0xFFFFFFFFFFFF
 
 var osPageSize = uintptr(os.Getpagesize())
 
@@ -50,23 +47,6 @@ func pageAligned(m []byte) []byte {
 	return m[skip : len(m)-trim]
 }
 
-func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
-	// Map the data file to memory.
-	mmapHandle1, err := unix.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Advise the kernel that the mmap is accessed randomly.
-	err = unix.Madvise(mmapHandle1, syscall.MADV_RANDOM)
-	if err != nil && !errors.Is(err, syscall.ENOSYS) {
-		// Ignore not implemented error in kernel because it still works.
-		return nil, nil, fmt.Errorf("madvise: %w", err)
-	}
-	mmapHandle2 := (*[MaxMapSize]byte)(unsafe.Pointer(&mmapHandle1[0]))
-	return mmapHandle1, mmapHandle2, nil
-}
-
 func madvise(m []byte, advice int) error {
 	if aligned := pageAligned(m); len(aligned) > 0 {
 		if err := unix.Madvise(aligned, advice); err != nil && !errors.Is(err, syscall.ENOSYS) {
@@ -80,14 +60,3 @@ func MadviseSequential(m []byte) error { return madvise(m, syscall.MADV_SEQUENTI
 func MadviseNormal(m []byte) error     { return madvise(m, syscall.MADV_NORMAL) }
 func MadviseWillNeed(m []byte) error   { return madvise(m, syscall.MADV_WILLNEED) }
 func MadviseRandom(m []byte) error     { return madvise(m, syscall.MADV_RANDOM) }
-
-// munmap unmaps a DB's data file from memory.
-func Munmap(mmapHandle1 []byte, _ *[MaxMapSize]byte) error {
-	// Ignore the unmap if we have no mapped data.
-	if mmapHandle1 == nil {
-		return nil
-	}
-	// Unmap using the original byte slice.
-	err := unix.Munmap(mmapHandle1)
-	return err
-}

--- a/common/mmap/mmap_windows.go
+++ b/common/mmap/mmap_windows.go
@@ -16,53 +16,7 @@
 
 package mmap
 
-import (
-	"os"
-	"unsafe"
-
-	"golang.org/x/sys/windows"
-)
-
-const MaxMapSize = 0xFFFFFFFFFFFF
-
-func Mmap(f *os.File, size int) ([]byte, *[MaxMapSize]byte, error) {
-	// Open a file mapping handle.
-	sizelo := uint32(size >> 32)
-	sizehi := uint32(size) & 0xffffffff
-	h, errno := windows.CreateFileMapping(windows.Handle(f.Fd()), nil, windows.PAGE_READONLY, sizelo, sizehi, nil)
-	if h == 0 {
-		return nil, nil, os.NewSyscallError("CreateFileMapping", errno)
-	}
-
-	// Create the memory map.
-	addr, errno := windows.MapViewOfFile(h, windows.FILE_MAP_READ, 0, 0, uintptr(size))
-	if addr == 0 {
-		return nil, nil, os.NewSyscallError("MapViewOfFile", errno)
-	}
-
-	// Close mapping handle.
-	if err := windows.CloseHandle(h); err != nil {
-		return nil, nil, os.NewSyscallError("CloseHandle", err)
-	}
-
-	// Convert to a byte array.
-	mmapHandle2 := ((*[MaxMapSize]byte)(unsafe.Pointer(addr)))
-	return mmapHandle2[:size], mmapHandle2, nil
-}
-
 func MadviseSequential(mmapHandle1 []byte) error { return nil }
 func MadviseNormal(mmapHandle1 []byte) error     { return nil }
 func MadviseWillNeed(mmapHandle1 []byte) error   { return nil }
 func MadviseRandom(mmapHandle1 []byte) error     { return nil }
-
-func Munmap(_ []byte, mmapHandle2 *[MaxMapSize]byte) error {
-	if mmapHandle2 == nil {
-		return nil
-	}
-
-	addr := (uintptr)(unsafe.Pointer(&mmapHandle2[0]))
-	if err := windows.UnmapViewOfFile(addr); err != nil {
-		return os.NewSyscallError("UnmapViewOfFile", err)
-	}
-	return nil
-}

--- a/common/mmap/residency_linux_test.go
+++ b/common/mmap/residency_linux_test.go
@@ -49,9 +49,9 @@ func TestResidencyProbe(t *testing.T) {
 	require.NoError(t, f.Sync())
 	require.NoError(t, unix.Fadvise(int(f.Fd()), 0, int64(len(data)), unix.FADV_DONTNEED))
 
-	m, h2, err := Mmap(f, len(data))
+	m, err := OpenRo(f, len(data))
 	require.NoError(t, err)
-	defer Munmap(m, h2)
+	defer m.Unmap()
 
 	res, err := Resident(m)
 	require.NoError(t, err)

--- a/db/datastruct/btindex/btree_index.go
+++ b/db/datastruct/btindex/btree_index.go
@@ -26,12 +26,11 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/edsrzf/mmap-go"
-
 	"github.com/erigontech/erigon/common/background"
 	"github.com/erigontech/erigon/common/dbg"
 	"github.com/erigontech/erigon/common/dir"
 	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/common/mmap"
 	"github.com/erigontech/erigon/common/murmur3"
 	"github.com/erigontech/erigon/db/bufiopool"
 	"github.com/erigontech/erigon/db/datastruct/existence"
@@ -365,7 +364,7 @@ func (btw *BtIndexWriter) Close() {
 }
 
 type BtIndex struct {
-	m        mmap.MMap
+	m        mmap.Ro
 	data     []byte
 	ef       *eliasfano32.EliasFano
 	file     *os.File
@@ -505,10 +504,14 @@ func OpenBtreeIndexWithDecompressor(indexPath string, kvGetter *seg.Reader) (bt 
 		return idx, nil
 	}
 
-	idx.m, err = mmap.MapRegion(idx.file, int(idx.size), mmap.RDONLY, 0, 0)
+	idx.m, err = mmap.OpenRo(idx.file, int(idx.size))
 	if err != nil {
 		return nil, err
 	}
+	// Decoding below walks the whole node blob, so readahead pays off once. Lookups
+	// afterwards are scattered, hence OpenRo's MADV_RANDOM is restored on the way out.
+	_ = mmap.MadviseSequential(idx.m)
+	defer func() { _ = mmap.MadviseRandom(idx.m) }()
 	idx.data = idx.m[:idx.size]
 
 	var nodeOfftEF *eliasfano32.EliasFano

--- a/db/datastruct/fusefilter/fusefilter_reader.go
+++ b/db/datastruct/fusefilter/fusefilter_reader.go
@@ -10,10 +10,9 @@ import (
 
 	"github.com/FastFilter/xorfilter"
 	"github.com/c2h5oh/datasize"
-	"github.com/edsrzf/mmap-go"
 
 	"github.com/erigontech/erigon/common/dbg"
-	mm "github.com/erigontech/erigon/common/mmap"
+	"github.com/erigontech/erigon/common/mmap"
 )
 
 type Features uint32
@@ -33,8 +32,8 @@ type Reader struct {
 	keepInMem bool // keep it in mem insted of mmap
 
 	fileName string
-	f        *os.File
-	m        mmap.MMap
+	f        *os.File // non-nil only when this Reader mapped the file itself
+	m        []byte   // borrowed unless f != nil
 	features Features
 
 	version uint8
@@ -60,7 +59,7 @@ func NewReader(filePath string) (_ *Reader, err error) {
 		return nil, err
 	}
 	sz := int(st.Size())
-	m, err := mmap.MapRegion(f, sz, mmap.RDONLY, 0, 0)
+	m, err := mmap.OpenRo(f, sz)
 	if err != nil {
 		return nil, err
 	}
@@ -170,46 +169,49 @@ func (r *Reader) ForceInMem() datasize.ByteSize {
 }
 
 func (r *Reader) MadvWillNeed() {
-	if r == nil || r.f == nil || r.m == nil || len(r.m) == 0 || r.keepInMem {
+	if r == nil || r.f == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	if err := mm.MadviseWillNeed(r.m); err != nil {
+	if err := mmap.MadviseWillNeed(r.m); err != nil {
 		panic(err)
 	}
 }
 func (r *Reader) MadvNormal() {
-	if r == nil || r.f == nil || r.m == nil || len(r.m) == 0 || r.keepInMem {
+	if r == nil || r.f == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	if err := mm.MadviseNormal(r.m); err != nil {
+	if err := mmap.MadviseNormal(r.m); err != nil {
 		panic(err)
 	}
 }
 func (r *Reader) MadvRandom() {
-	if r == nil || r.f == nil || r.m == nil || len(r.m) == 0 || r.keepInMem {
+	if r == nil || r.f == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	if err := mm.MadviseRandom(r.m); err != nil {
+	if err := mmap.MadviseRandom(r.m); err != nil {
 		panic(err)
 	}
 }
 func (r *Reader) FileName() string           { return r.fileName }
 func (r *Reader) ContainsHash(v uint64) bool { return r.inner.Contains(v) }
 func (r *Reader) Close() {
-	if r == nil || r.f == nil {
+	if r == nil {
 		return
 	}
-	_ = r.m.Unmap() //nolint
-	_ = r.f.Close() //nolint
-	r.f = nil
+	if r.f != nil { // borrowed bytes are not ours to unmap
+		owned := mmap.Ro(r.m)
+		_ = owned.Unmap() //nolint
+		_ = r.f.Close()   //nolint
+		r.f, r.m = nil, nil
+	}
 }
 
 // ReaderSharded reads a sharded fusefilter (outer header version=1).
 // Only the shard matching keyHash >> 56 is checked on lookup.
 // shards is a value array (not pointer array) so ContainsHash needs only one pointer dereference.
 type ReaderSharded struct {
-	m         mmap.MMap // outer slice spanning header + all shard blobs, used for madvise
-	f         *os.File  // non-nil only when opened via NewReaderSharded(filePath)
+	m         []byte   // outer slice spanning header + all shard blobs, used for madvise
+	f         *os.File // non-nil only when opened via NewReaderSharded(filePath)
 	fileName  string
 	keepInMem bool // ForceInMem replaced m with an anonymous heap copy; skip madvise/munmap
 	shards    [256]Reader
@@ -230,7 +232,7 @@ func NewReaderSharded(filePath string) (_ *ReaderSharded, err error) {
 		return nil, err
 	}
 	sz := int(st.Size())
-	m, err := mmap.MapRegion(f, sz, mmap.RDONLY, 0, 0)
+	m, err := mmap.OpenRo(f, sz)
 	if err != nil {
 		return nil, err
 	}
@@ -253,14 +255,15 @@ func NewReaderSharded(filePath string) (_ *ReaderSharded, err error) {
 func (r *ReaderSharded) FileName() string { return r.fileName }
 
 func (r *ReaderSharded) Close() {
-	if r == nil || r.f == nil {
+	if r == nil {
 		return
 	}
-	if !r.keepInMem {
-		_ = r.m.Unmap() //nolint
+	if r.f != nil { // borrowed bytes are not ours to unmap
+		owned := mmap.Ro(r.m)
+		_ = owned.Unmap() //nolint
+		_ = r.f.Close()   //nolint
+		r.f, r.m = nil, nil
 	}
-	_ = r.f.Close() //nolint
-	r.f = nil
 }
 
 func NewReaderShardedOnBytes(m []byte, fName string) (*ReaderSharded, int, error) {
@@ -332,7 +335,7 @@ func (r *ReaderSharded) MadvWillNeed() {
 	if r == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	if err := mm.MadviseWillNeed(r.m); err != nil {
+	if err := mmap.MadviseWillNeed(r.m); err != nil {
 		panic(err)
 	}
 }
@@ -341,7 +344,7 @@ func (r *ReaderSharded) MadvNormal() {
 	if r == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	if err := mm.MadviseNormal(r.m); err != nil {
+	if err := mmap.MadviseNormal(r.m); err != nil {
 		panic(err)
 	}
 }
@@ -349,7 +352,7 @@ func (r *ReaderSharded) MadvRandom() {
 	if r == nil || len(r.m) == 0 || r.keepInMem {
 		return
 	}
-	if err := mm.MadviseRandom(r.m); err != nil {
+	if err := mmap.MadviseRandom(r.m); err != nil {
 		panic(err)
 	}
 }

--- a/db/datastruct/fusefilter/fusefilter_writer.go
+++ b/db/datastruct/fusefilter/fusefilter_writer.go
@@ -11,10 +11,10 @@ import (
 	"slices"
 	"unsafe"
 
-	"github.com/erigontech/erigon/common/dir"
-
 	"github.com/FastFilter/xorfilter"
-	"github.com/edsrzf/mmap-go"
+
+	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/mmap"
 )
 
 const bufSize = 4096
@@ -72,11 +72,12 @@ func (w *WriterOffHeap) build() (*xorfilter.BinaryFuse[uint8], error) {
 		return nil, err
 	}
 	sz := int(st.Size())
-	m, err := mmap.MapRegion(w.tmpFile, sz, mmap.RDONLY, 0, 0)
+	m, err := mmap.OpenRo(w.tmpFile, sz)
 	if err != nil {
 		return nil, fmt.Errorf("%s %w", w.tmpFilePath, err)
 	}
 	defer m.Unmap()
+	_ = mmap.MadviseSequential(m) // the whole temp file is read front-to-back below
 
 	keysHashes := castToArrU64(m[:sz])
 
@@ -276,7 +277,7 @@ func (w *WriterSharded) BuildTo(fw io.Writer) (int, error) {
 		return 0, fmt.Errorf("WriterSharded: no keys added")
 	}
 
-	m, err := mmap.MapRegion(w.tmpFile, sz, mmap.RDWR, 0, 0)
+	m, err := mmap.OpenRw(w.tmpFile, sz)
 	if err != nil {
 		return 0, fmt.Errorf("%s %w", w.tmpFilePath, err)
 	}

--- a/db/etl/dataprovider.go
+++ b/db/etl/dataprovider.go
@@ -40,11 +40,10 @@ type dataProvider interface {
 }
 
 type fileDataProvider struct {
-	file        *os.File
-	mmapReader  *mmapBytesReader       // zero-copy reader over mmap'd data
-	mmapData    []byte                 // mmap'd file content
-	mmapHandle2 *[mmap.MaxMapSize]byte // pointer handle for cleanup
-	wg          *errgroup.Group
+	file       *os.File
+	mmapReader *mmapBytesReader // zero-copy reader over mmap'd data
+	mmapData   mmap.Ro          // mmap'd file content
+	wg         *errgroup.Group
 }
 
 // mmapBytesReader tracks position for reading from mmap'd data
@@ -144,7 +143,7 @@ func (p *fileDataProvider) initMmap() error {
 	if fi.Size() == 0 {
 		return io.EOF
 	}
-	p.mmapData, p.mmapHandle2, err = mmap.Mmap(p.file, int(fi.Size()))
+	p.mmapData, err = mmap.OpenRo(p.file, int(fi.Size()))
 	if err != nil {
 		return fmt.Errorf("mmap failed: %w", err)
 	}
@@ -197,9 +196,8 @@ func (p *fileDataProvider) Dispose() {
 	p.Wait()
 
 	if p.mmapData != nil {
-		_ = mmap.Munmap(p.mmapData, p.mmapHandle2)
+		_ = p.mmapData.Unmap()
 		p.mmapData = nil
-		p.mmapHandle2 = nil
 		p.mmapReader = nil
 	}
 

--- a/db/etl/read_bench_test.go
+++ b/db/etl/read_bench_test.go
@@ -131,7 +131,7 @@ func createTestFileU32(b *testing.B, tmpdir string, keySize, valSize, fileSize i
 	return f.Name()
 }
 
-func openMmap(b *testing.B, fname string) ([]byte, *os.File) {
+func openMmap(b *testing.B, fname string) (mmap.Ro, *os.File) {
 	b.Helper()
 	f, err := os.Open(fname)
 	if err != nil {
@@ -153,6 +153,7 @@ func benchMmapU16(b *testing.B, fname string) {
 	b.Helper()
 	data, f := openMmap(b, fname)
 	defer f.Close()
+	defer data.Unmap() //nolint
 
 	m := &mmapBytesReader{data: data, pos: 0}
 	for {
@@ -169,6 +170,7 @@ func benchMmapU32(b *testing.B, fname string) {
 	b.Helper()
 	data, f := openMmap(b, fname)
 	defer f.Close()
+	defer data.Unmap() //nolint
 
 	pos := 0
 	for pos+4 <= len(data) {

--- a/db/etl/read_bench_test.go
+++ b/db/etl/read_bench_test.go
@@ -141,7 +141,7 @@ func openMmap(b *testing.B, fname string) ([]byte, *os.File) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	data, _, err := mmap.Mmap(f, int(fi.Size()))
+	data, err := mmap.OpenRo(f, int(fi.Size()))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/db/recsplit/eliasfano32/elias_fano.go
+++ b/db/recsplit/eliasfano32/elias_fano.go
@@ -27,13 +27,12 @@ import (
 	"unsafe"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/edsrzf/mmap-go"
-
-	"github.com/erigontech/erigon/db/recsplit/efcommon"
 
 	"github.com/erigontech/erigon/common/bitutil"
 	"github.com/erigontech/erigon/common/dir"
+	"github.com/erigontech/erigon/common/mmap"
 	"github.com/erigontech/erigon/db/kv/stream"
+	"github.com/erigontech/erigon/db/recsplit/efcommon"
 )
 
 // EliasFano algo overview https://www.antoniomallia.it/sorted-integers-compression-with-elias-fano-encoding.html
@@ -71,7 +70,7 @@ type EliasFano struct {
 // EliasFano so heap-backed EliasFano carries no extra overhead.
 type OffHeapBuilder struct {
 	*EliasFano
-	backingMmap mmap.MMap
+	backingMmap mmap.Rw
 	backingFile *os.File
 }
 
@@ -147,7 +146,7 @@ func NewEliasFanoOffHeap(count uint64, maxOffset uint64, tmpFilePath string) (_ 
 	if err := fallocate(f, sizeBytes); err != nil {
 		return nil, fmt.Errorf("pre-allocate ef tmp file: %w", err)
 	}
-	m, err := mmap.MapRegion(f, int(sizeBytes), mmap.RDWR, 0, 0)
+	m, err := mmap.OpenRw(f, int(sizeBytes))
 	if err != nil {
 		return nil, fmt.Errorf("mmap ef tmp file: %w", err)
 	}

--- a/db/recsplit/index.go
+++ b/db/recsplit/index.go
@@ -76,12 +76,11 @@ var IncompatibleErr = errors.New("incompatible. can re-build such files by comma
 type Index struct {
 	offsetEf           *eliasfano32.EliasFano
 	f                  *os.File
-	mmapHandle2        *[mmap.MaxMapSize]byte // mmap handle for windows (this is used to close mmap)
 	filePath, fileName string
 
 	grData      []uint64
-	data        []byte // slice of correct size for the index to work with
-	mmapHandle1 []byte // mmap handle for unix (this is used to close mmap)
+	data        []byte  // slice of correct size for the index to work with
+	mmapHandle1 mmap.Ro // mmap handle for unix (this is used to close mmap)
 	golombRice  []uint32
 
 	dataStructureVersion version.DataStructureVersion
@@ -140,7 +139,7 @@ func OpenIndex(indexFilePath string) (_ *Index, err error) {
 	}
 	idx.size = stat.Size()
 	idx.modTime = stat.ModTime()
-	if idx.mmapHandle1, idx.mmapHandle2, err = mmap.Mmap(idx.f, int(idx.size)); err != nil {
+	if idx.mmapHandle1, err = mmap.OpenRo(idx.f, int(idx.size)); err != nil {
 		return nil, err
 	}
 	idx.data = idx.mmapHandle1[:idx.size]
@@ -393,7 +392,7 @@ func (idx *Index) Close() {
 	if idx == nil || idx.f == nil {
 		return
 	}
-	if err := mmap.Munmap(idx.mmapHandle1, idx.mmapHandle2); err != nil {
+	if err := idx.mmapHandle1.Unmap(); err != nil {
 		log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", idx.FileName(), "stack", dbg.Stack())
 	}
 	if err := idx.f.Close(); err != nil {

--- a/db/recsplit/recsplit.go
+++ b/db/recsplit/recsplit.go
@@ -889,11 +889,11 @@ func (rs *RecSplit) buildOffsetEf() (retErr error) {
 	}
 
 	mmapSize := int(rs.keysAdded * 8)
-	mmapHandle1, mmapHandle2, err := mmap.Mmap(rs.offsetFile, mmapSize)
+	mmapHandle1, err := mmap.OpenRo(rs.offsetFile, mmapSize)
 	if err != nil {
 		return fmt.Errorf("mmap offset file: %w", err)
 	}
-	defer mmap.Munmap(mmapHandle1, mmapHandle2)
+	defer mmapHandle1.Unmap()
 
 	data := mmapHandle1[:mmapSize]
 	for i := uint64(0); i < rs.keysAdded; i++ {

--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -168,12 +168,11 @@ func (e ErrCompressedFileCorrupted) Is(err error) bool {
 // Decompressor provides access to the superstrings in a file produced by a compressor
 type Decompressor struct {
 	f                   *os.File
-	mmapHandle2         *[mmap.MaxMapSize]byte // mmap handle for windows (this is used to close mmap)
 	dict                *patternTable
 	posDict             *posTable
 	patArena            *patternArena // arena keeping all pattern table allocations alive
 	posArena            *posArena     // arena keeping all position table allocations alive
-	mmapHandle1         []byte        // mmap handle for unix (this is used to close mmap)
+	mmapHandle1         mmap.Ro       // mmap handle for unix (this is used to close mmap)
 	data                []byte        // slice of correct size for the decompressor to work with
 	wordsStart          uint64        // Offset of whether the superstrings actually start
 	size                int64
@@ -249,7 +248,7 @@ func NewDecompressorWithMetadata(compressedFilePath string, hasMetadata bool) (*
 	}
 
 	d.modTime = stat.ModTime()
-	if d.mmapHandle1, d.mmapHandle2, err = mmap.Mmap(d.f, int(d.size)); err != nil {
+	if d.mmapHandle1, err = mmap.OpenRo(d.f, int(d.size)); err != nil {
 		return nil, err
 	}
 	// read patterns from file
@@ -578,7 +577,7 @@ func (d *Decompressor) Close() {
 		rb.stop() // join the refresh goroutine before munmap so no mincore touches freed memory
 		d.residency.Store(nil)
 	}
-	if err := mmap.Munmap(d.mmapHandle1, d.mmapHandle2); err != nil {
+	if err := d.mmapHandle1.Unmap(); err != nil {
 		log.Log(dbg.FileCloseLogLevel, "unmap", "err", err, "file", d.FileName(), "stack", dbg.Stack())
 	}
 	if err := d.f.Close(); err != nil {
@@ -680,8 +679,7 @@ func (d *Decompressor) MadvWillNeed() *Decompressor {
 //	https://www.kernel.org/doc/html/latest/mm/page_reclaim.html
 type SequentialView struct {
 	d           *Decompressor
-	mmapHandle1 []byte
-	mmapHandle2 *[mmap.MaxMapSize]byte
+	mmapHandle1 mmap.Ro
 	data        []byte // words data region from the sequential mmap
 }
 
@@ -694,7 +692,7 @@ func (d *Decompressor) OpenSequentialView(separateReadahead bool) (*SequentialVi
 	if !separateReadahead {
 		return &SequentialView{d: d, data: d.data[d.wordsStart:]}, nil
 	}
-	h1, h2, err := mmap.Mmap(d.f, int(d.size))
+	h1, err := mmap.OpenRo(d.f, int(d.size))
 	if err != nil {
 		return nil, err
 	}
@@ -709,7 +707,7 @@ func (d *Decompressor) OpenSequentialView(separateReadahead bool) (*SequentialVi
 	headerSize := d.size - int64(len(d.data))
 	wordsFileOffset := headerSize + int64(d.wordsStart)
 	return &SequentialView{
-		d: d, mmapHandle1: h1, mmapHandle2: h2,
+		d: d, mmapHandle1: h1,
 		data: h1[wordsFileOffset:d.size],
 	}, nil
 }
@@ -736,7 +734,7 @@ func (v *SequentialView) Close() {
 	if v == nil || v.mmapHandle1 == nil {
 		return
 	}
-	_ = mmap.Munmap(v.mmapHandle1, v.mmapHandle2)
+	_ = v.mmapHandle1.Unmap()
 	v.mmapHandle1 = nil
 	v.data = nil
 }

--- a/db/seg/decompress_test.go
+++ b/db/seg/decompress_test.go
@@ -93,7 +93,7 @@ func TestNextReportsPackedLiteral(t *testing.T) {
 
 	require.Equal(t, word, got)
 	require.Equal(t, uint64(len(word)), literalLength)
-	require.Equal(t, word, d.mmapHandle1[literalOffset:literalOffset+literalLength])
+	require.Equal(t, word, []byte(d.mmapHandle1[literalOffset:literalOffset+literalLength]))
 }
 
 func TestDecompressSkip(t *testing.T) {

--- a/db/seg/literal_warm_linux_test.go
+++ b/db/seg/literal_warm_linux_test.go
@@ -54,9 +54,9 @@ func TestWarmLiteral(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, file.Sync())
 
-	mapping, mappingHandle, err := mmap.Mmap(file, len(payload))
+	mapping, err := mmap.OpenRo(file, len(payload))
 	require.NoError(t, err)
-	defer mmap.Munmap(mapping, mappingHandle)
+	defer mapping.Unmap()
 
 	region := mapping[:2*page]
 	require.NoError(t, unix.Madvise(mapping, unix.MADV_DONTNEED))


### PR DESCRIPTION
historically we used 2 libs for `mmap`. This pr dropping our - in favor of `mmap-go` lib.
But wrapping it to typed Ro/Rw objects.

---------

```go
type Ro []byte
type Rw []byte

func OpenRo(f *os.File, size int) (Ro, error)  // RDONLY + MADV_RANDOM
func OpenRw(f *os.File, size int) (Rw, error)

func (m *Ro) Unmap() error
func (m *Rw) Unmap() error
func (m Rw) Sync() error   // only on Rw
```

Not included: `execution/protocol/rules/ethash` still uses mmap-go directly. Its `memoryMapFile(file *os.File, write bool)` returns one type for both modes, so `Ro`/`Rw` forces it into two functions — separate change.
