### PR TITLE
cmd/rpctest: extract latestBlockNumber helper

### DIFF
--- a/cmd/rpctest/rpctest/bench1.go
+++ b/cmd/rpctest/rpctest/bench1.go
@@ -46,21 +46,16 @@ func Bench1(erigonURL, gethURL string, needCompare bool, fullTest bool, blockFro
 	defer close(resultsCh)
 	go vegetaWrite(false, []string{"eth_getBlockByNumber", "debug_storageRangeAt"}, resultsCh)
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	resultsCh <- res
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
+	fmt.Printf("Last block: %d\n", lastBlock)
 	prevBn := blockFrom
 	storageCounter := 0
+	var res CallResult
 	for bn := blockFrom; bn <= blockTo; bn++ {
 		var b EthBlockByNumber
 		res = reqGen.Erigon("eth_getBlockByNumber", reqGen.getBlockByNumber(bn, true /* withTxs */), &b)

--- a/cmd/rpctest/rpctest/bench2.go
+++ b/cmd/rpctest/rpctest/bench2.go
@@ -25,26 +25,20 @@ import (
 
 func Bench2(erigon_url string) error {
 
-	req_id := 0
-	req_id++
-	blockNumTemplate := `{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":%d}`
-	var blockNumber EthBlockNumber
-	if err := post(client, erigon_url, fmt.Sprintf(blockNumTemplate, req_id), &blockNumber); err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", err)
+	setRoutes(erigon_url, "")
+	reqGen := &RequestGenerator{}
+
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	lastBlock := blockNumber.Number
 	fmt.Printf("Last block: %d\n", lastBlock)
-	firstBn := 1720000 - 2
+	firstBn := uint64(1720000 - 2)
 	prevBn := firstBn
-	for bn := firstBn; bn <= int(lastBlock); bn++ {
-		req_id++
-		blockByNumTemplate := `{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x%x",true],"id":%d}` //nolint
+	for bn := firstBn; bn <= lastBlock; bn++ {
 		var b EthBlockByNumber
-		if err := post(client, erigon_url, fmt.Sprintf(blockByNumTemplate, bn, req_id), &b); err != nil {
-			return fmt.Errorf("Could not retrieve block %d: %v\n", bn, err)
+		if res := reqGen.Erigon("eth_getBlockByNumber", reqGen.getBlockByNumber(bn, true /* withTxs */), &b); res.Err != nil {
+			return fmt.Errorf("Could not retrieve block %d: %v\n", bn, res.Err)
 		}
 		if b.Error != nil {
 			fmt.Printf("Error retrieving block: %d %s\n", b.Error.Code, b.Error.Message)
@@ -54,15 +48,12 @@ func Bench2(erigon_url string) error {
 			txn := &b.Result.Transactions[i]
 			if txn.To != nil && txn.Gas.ToInt().Uint64() > 21000 {
 				// Request storage range
-				// blockHash common.Hash, txIndex int, contractAddress common.Address, keyStart hexutil.Bytes, maxResult int
-				req_id++
-				storageRangeTemplate := `{"jsonrpc":"2.0","method":"debug_storageRangeAt","params":["0x%x", %d,"0x%x","0x%x",%d],"id":%d}` //nolint
 				sm := make(map[common.Hash]storageEntry)
 				nextKey := &common.Hash{}
 				for nextKey != nil {
 					var sr DebugStorageRange
-					if err := post(client, erigon_url, fmt.Sprintf(storageRangeTemplate, b.Result.Hash, i, txn.To, *nextKey, 1024, req_id), &sr); err != nil {
-						return fmt.Errorf("Could not get storageRange: %x: %v\n", txn.Hash, err)
+					if res := reqGen.Erigon("debug_storageRangeAt", reqGen.storageRangeAt(b.Result.Hash, i, txn.To, *nextKey), &sr); res.Err != nil {
+						return fmt.Errorf("Could not get storageRange: %x: %v\n", txn.Hash, res.Err)
 					}
 					if sr.Error != nil {
 						fmt.Printf("Error getting storageRange: %d %s\n", sr.Error.Code, sr.Error.Message)
@@ -88,11 +79,9 @@ func Bench2(erigon_url string) error {
 
 		if prevBn < bn && bn%1000 == 0 {
 			// Checking modified accounts
-			req_id++
-			accountRangeTemplate := `{"jsonrpc":"2.0","method":"debug_getModifiedAccountsByNumber","params":[%d, %d],"id":%d}` //nolint
 			var ma DebugModifiedAccounts
-			if err := post(client, erigon_url, fmt.Sprintf(accountRangeTemplate, prevBn, bn, req_id), &ma); err != nil {
-				return fmt.Errorf("Could not get modified accounts: %v\n", err)
+			if res := reqGen.Erigon("debug_getModifiedAccountsByNumber", reqGen.getModifiedAccountsByNumber(prevBn, bn), &ma); res.Err != nil {
+				return fmt.Errorf("Could not get modified accounts: %v\n", res.Err)
 			}
 			if ma.Error != nil {
 				return fmt.Errorf("Error getting modified accounts: %d %s\n", ma.Error.Code, ma.Error.Message)

--- a/cmd/rpctest/rpctest/bench6.go
+++ b/cmd/rpctest/rpctest/bench6.go
@@ -24,31 +24,20 @@ import (
 
 func Bench6(erigon_url string) error {
 
-	req_id := 0
+	setRoutes(erigon_url, "")
+	reqGen := &RequestGenerator{}
 
-	req_id++
-	template := `
-{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":%d}
-`
-	var blockNumber EthBlockNumber
-	if err := post(client, erigon_url, fmt.Sprintf(template, req_id), &blockNumber); err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	lastBlock := blockNumber.Number
 	fmt.Printf("Last block: %d\n", lastBlock)
 	accounts := make(map[common.Address]struct{})
-	firstBn := 100000
-	for bn := firstBn; bn <= int(lastBlock); bn++ {
-		req_id++
-		template := `
-{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x%x",true],"id":%d}
-`
+	firstBn := uint64(100000)
+	for bn := firstBn; bn <= lastBlock; bn++ {
 		var b EthBlockByNumber
-		if err := post(client, erigon_url, fmt.Sprintf(template, bn, req_id), &b); err != nil {
-			return fmt.Errorf("Could not retrieve block %d: %v\n", bn, err)
+		if res := reqGen.Erigon("eth_getBlockByNumber", reqGen.getBlockByNumber(bn, true /* withTxs */), &b); res.Err != nil {
+			return fmt.Errorf("Could not retrieve block %d: %v\n", bn, res.Err)
 		}
 		if b.Error != nil {
 			fmt.Printf("Error retrieving block: %d %s\n", b.Error.Code, b.Error.Message)
@@ -60,14 +49,10 @@ func Bench6(erigon_url string) error {
 			if txn.To != nil {
 				accounts[*txn.To] = struct{}{}
 			}
-			req_id++
-			template = `
-{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["%s"],"id":%d}
-`
 			var receipt EthReceipt
-			if err := post(client, erigon_url, fmt.Sprintf(template, txn.Hash, req_id), &receipt); err != nil {
-				printRPCRequest(client, erigon_url, fmt.Sprintf(template, txn.Hash, req_id))
-				return fmt.Errorf("Count not get receipt: %s: %v\n", txn.Hash, err)
+			if res := reqGen.Erigon("eth_getTransactionReceipt", reqGen.getTransactionReceipt(txn.Hash), &receipt); res.Err != nil {
+				printRPCRequest(client, erigon_url, res.RequestBody)
+				return fmt.Errorf("Count not get receipt: %s: %v\n", txn.Hash, res.Err)
 			}
 			if receipt.Error != nil {
 				return fmt.Errorf("Error getting receipt: %d %s\n", receipt.Error.Code, receipt.Error.Message)

--- a/cmd/rpctest/rpctest/bench9.go
+++ b/cmd/rpctest/rpctest/bench9.go
@@ -28,21 +28,16 @@ import (
 func Bench9(erigonURL, gethURL string, needCompare, latest bool) error {
 	setRoutes(erigonURL, gethURL)
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	lastBlock := blockNumber.Number
 	fmt.Printf("Last block: %d\n", lastBlock)
+	var res CallResult
 	// Go back 256 blocks
-	bn := uint64(lastBlock) - 256
+	bn := lastBlock - 256
 	zeroAddr := common.Address{}
 	page := zeroAddr[:]
 

--- a/cmd/rpctest/rpctest/bench_blockbynumber.go
+++ b/cmd/rpctest/rpctest/bench_blockbynumber.go
@@ -24,19 +24,15 @@ import (
 func BenchEthGetBlockByNumber(erigonURL string) error {
 	setRoutes(erigonURL, erigonURL)
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
-	for bn := uint64(0); bn <= uint64(blockNumber.Number)/2; bn++ {
+	fmt.Printf("Last block: %d\n", lastBlock)
+	var res CallResult
+	for bn := uint64(0); bn <= lastBlock/2; bn++ {
 
 		res = reqGen.Erigon2("eth_getBlockByNumber", reqGen.getBlockByNumber(bn, false /* withTxs */))
 		if res.Err != nil {
@@ -49,7 +45,7 @@ func BenchEthGetBlockByNumber(erigonURL string) error {
 			return fmt.Errorf("empty result: %s\n", res.Response)
 		}
 
-		bn1 := uint64(blockNumber.Number) - bn
+		bn1 := lastBlock - bn
 		res = reqGen.Erigon2("eth_getBlockByNumber", reqGen.getBlockByNumber(bn1, false /* withTxs */))
 		if res.Err != nil {
 			return fmt.Errorf("Could not retrieve block (Erigon) %d: %v\n", bn1, res.Err)

--- a/cmd/rpctest/rpctest/bench_debugTrace.go
+++ b/cmd/rpctest/rpctest/bench_debugTrace.go
@@ -175,17 +175,11 @@ func BenchDebugTraceCall(erigonURL, gethURL string, needCompare bool, blockFrom 
 
 	reqGen := &RequestGenerator{}
 
-	var res CallResult
-
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
+	fmt.Printf("Last block: %d\n", lastBlock)
 
 	var nBlocks = 0
 	var nTransactions = 0

--- a/cmd/rpctest/rpctest/bench_ethgetBalance.go
+++ b/cmd/rpctest/rpctest/bench_ethgetBalance.go
@@ -45,13 +45,8 @@ func BenchEthGetBalance(erigonURL, gethURL string, needCompare bool, blockFrom u
 		go vegetaWrite(true, []string{"eth_getBalance"}, resultsCh)
 	}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
-	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
+	if _, err := reqGen.latestBlockNumber(); err != nil {
+		return err
 	}
 	for bn := blockFrom; bn <= blockTo; bn++ {
 
@@ -117,15 +112,9 @@ func BenchEthGetBalanceRandomAccount(erigonURL string, concurentRequests int) er
 
 	reqGen := &RequestGenerator{}
 
-	var res CallResult
-
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
-	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
 
 	latencyLen := 1000
@@ -174,11 +163,11 @@ func BenchEthGetBalanceRandomAccount(erigonURL string, concurentRequests int) er
 
 	for {
 		bn := uint64(rand.Intn(
-			int(blockNumber.Number.Uint64()),
+			int(lastBlock),
 		))
 
 		var b EthBlockByNumber
-		res = reqGen.Erigon("eth_getBlockByNumber", reqGen.getBlockByNumber(bn, true /* withTxs */), &b)
+		res := reqGen.Erigon("eth_getBlockByNumber", reqGen.getBlockByNumber(bn, true /* withTxs */), &b)
 		if res.Err != nil {
 			return fmt.Errorf("Could not retrieve block (Erigon) %d: %v\n", bn, res.Err)
 		}
@@ -196,7 +185,7 @@ func BenchEthGetBalanceRandomAccount(erigonURL string, concurentRequests int) er
 			go func(account common.Address, bn uint64, launchedAt time.Time) {
 				var balance EthBalance
 
-				res = reqGen.Erigon("eth_getBalance", reqGen.getBalance(account, bn), &balance)
+				res := reqGen.Erigon("eth_getBalance", reqGen.getBalance(account, bn), &balance)
 				if res.Err != nil {
 					panic(fmt.Errorf("Could not get account balance (Erigon): %v\n", res.Err))
 				}

--- a/cmd/rpctest/rpctest/bench_ethgetlogs.go
+++ b/cmd/rpctest/rpctest/bench_ethgetlogs.go
@@ -63,18 +63,14 @@ func BenchEthGetLogs(erigonURL, gethURL string, needCompare bool, blockFrom uint
 		go vegetaWrite(true, []string{"debug_getModifiedAccountsByNumber", "eth_getLogs"}, resultsCh)
 	}
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
+	fmt.Printf("Last block: %d\n", lastBlock)
+	var res CallResult
 
 	prevBn := blockFrom
 	rnd := rand.New(rand.NewSource(42)) // nolint:gosec
@@ -145,15 +141,10 @@ func EthGetLogsInvariants(ctx context.Context, erigonURL, gethURL string, needCo
 
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res := reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("could not get block number: %v", res.Err)
+	latestBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("error getting block number: %d %s", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	latestBlock := blockNumber.Number.Uint64()
 	log.Info("[ethGetLogsInvariants] starting", "blockFrom", blockFrom, "blockTo", blockTo, "latestBlock", latestBlock)
 	if blockFrom > latestBlock {
 		return fmt.Errorf("fromBlock(%d) > latestBlock(%d)", blockFrom, latestBlock)
@@ -353,15 +344,9 @@ func BenchEthGetLogsRandomBlock(erigonURL string, concurentRequests int) error {
 
 	reqGen := &RequestGenerator{}
 
-	var res CallResult
-
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
-	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
 
 	latencyLen := 1000
@@ -413,7 +398,7 @@ func BenchEthGetLogsRandomBlock(erigonURL string, concurentRequests int) error {
 
 	for {
 		bn := uint64(rand.Intn(
-			int(blockNumber.Number.Uint64()),
+			int(lastBlock),
 		))
 
 		reqQueue <- struct{}{}

--- a/cmd/rpctest/rpctest/bench_overlaygetlogs.go
+++ b/cmd/rpctest/rpctest/bench_overlaygetlogs.go
@@ -45,18 +45,14 @@ func BenchOverlayGetLogs(erigonURL string, needCompare bool, blockFrom uint64, b
 		go vegetaWrite(true, []string{"debug_getModifiedAccountsByNumber", "eth_getLogs"}, resultsCh)
 	}
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
+	fmt.Printf("Last block: %d\n", lastBlock)
+	var res CallResult
 
 	prevBn := blockFrom
 	rnd := rand.New(rand.NewSource(42)) // nolint:gosec

--- a/cmd/rpctest/rpctest/bench_traceblock.go
+++ b/cmd/rpctest/rpctest/bench_traceblock.go
@@ -33,18 +33,13 @@ func BenchTraceBlock(erigonURL, oeURL string, needCompare bool, blockFrom uint64
 	}
 	defer cleanup()
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
+	fmt.Printf("Last block: %d\n", lastBlock)
 	for bn := blockFrom; bn <= blockTo; bn++ {
 		_, skip, err := fetchBlock(reqGen, bn, false, nil)
 		if err != nil {

--- a/cmd/rpctest/rpctest/bench_tracecall.go
+++ b/cmd/rpctest/rpctest/bench_tracecall.go
@@ -35,15 +35,11 @@ func BenchTraceCall(erigonURL, oeURL string, needCompare bool, blockFrom uint64,
 
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res := reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
+	fmt.Printf("Last block: %d\n", lastBlock)
 	for bn := blockFrom; bn <= blockTo; bn++ {
 
 		b, _, err := fetchBlock(reqGen, bn, false, nil)

--- a/cmd/rpctest/rpctest/bench_tracecallmany.go
+++ b/cmd/rpctest/rpctest/bench_tracecallmany.go
@@ -36,18 +36,13 @@ func BenchTraceCallMany(erigonURL, oeURL string, needCompare bool, blockFrom uin
 	}
 	defer cleanup()
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
+	fmt.Printf("Last block: %d\n", lastBlock)
 	for bn := blockFrom; bn <= blockTo; bn++ {
 		b, skip, err := fetchBlock(reqGen, bn, false, nil)
 		if err != nil {

--- a/cmd/rpctest/rpctest/bench_tracefilter.go
+++ b/cmd/rpctest/rpctest/bench_tracefilter.go
@@ -36,18 +36,14 @@ func BenchTraceFilter(erigonURL, oeURL string, needCompare bool, blockFrom uint6
 	}
 	defer cleanup()
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
+	fmt.Printf("Last block: %d\n", lastBlock)
+	var res CallResult
 	rnd := rand.New(rand.NewSource(42)) // nolint:gosec
 	prevBn := blockFrom
 	for bn := blockFrom + 100; bn < blockTo; bn += 100 {

--- a/cmd/rpctest/rpctest/bench_txreceipts.go
+++ b/cmd/rpctest/rpctest/bench_txreceipts.go
@@ -43,18 +43,13 @@ func BenchTxReceipt(erigonURL, gethURL string, needCompare bool, blockFrom uint6
 		go vegetaWrite(true, []string{"eth_getTransactionReceipt"}, resultsCh)
 	}
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
-	}
-	fmt.Printf("Last block: %d\n", blockNumber.Number)
+	fmt.Printf("Last block: %d\n", lastBlock)
 	for bn := blockFrom; bn <= blockTo; bn++ {
 		b, skip, err := fetchBlock(reqGen, bn, false, nil)
 		if err != nil {
@@ -96,21 +91,16 @@ func BenchBlockReceipts(erigonURL, gethURL string, needCompare bool, blockFrom u
 		go vegetaWrite(true, []string{"eth_getBlockReceipts"}, resultsCh)
 	}
 
-	var res CallResult
 	reqGen := &RequestGenerator{}
 
-	var blockNumber EthBlockNumber
-	res = reqGen.Erigon("eth_blockNumber", reqGen.blockNumber(), &blockNumber)
-	if res.Err != nil {
-		return fmt.Errorf("Could not get block number: %v\n", res.Err)
-	}
-	if blockNumber.Error != nil {
-		return fmt.Errorf("Error getting block number: %d %s\n", blockNumber.Error.Code, blockNumber.Error.Message)
+	lastBlock, err := reqGen.latestBlockNumber()
+	if err != nil {
+		return err
 	}
 	logEvery := time.NewTicker(logInterval)
 	defer logEvery.Stop()
 
-	log.Info("starting", "last_block", blockNumber.Number, "from", blockNumber, "to", blockTo)
+	log.Info("starting", "last_block", lastBlock, "from", blockFrom, "to", blockTo)
 	for bn := blockFrom; bn <= blockTo; bn++ {
 		request := reqGen.getBlockReceipts(bn)
 		errCtx := fmt.Sprintf("block %d", bn)

--- a/cmd/rpctest/rpctest/request_generator.go
+++ b/cmd/rpctest/rpctest/request_generator.go
@@ -377,3 +377,14 @@ func (g *RequestGenerator) Geth2(method, body string) CallResult {
 func (g *RequestGenerator) Erigon2(method, body string) CallResult {
 	return g.call2(Erigon, method, body)
 }
+
+func (g *RequestGenerator) latestBlockNumber() (uint64, error) {
+	var blockNumber EthBlockNumber
+	if res := g.Erigon("eth_blockNumber", g.blockNumber(), &blockNumber); res.Err != nil {
+		return 0, fmt.Errorf("could not get block number: %v", res.Err)
+	}
+	if blockNumber.Error != nil {
+		return 0, fmt.Errorf("error getting block number: %d %s", blockNumber.Error.Code, blockNumber.Error.Message)
+	}
+	return uint64(blockNumber.Number), nil
+}


### PR DESCRIPTION
Replace 18 copy-pasted `eth_blockNumber` fetch+check blocks across 16 bench files with a single `RequestGenerator.latestBlockNumber() (uint64, error)` method. `Bench2` and `Bench6` are also moved from raw JSON templates to the existing `RequestGenerator` builders (identical wire format), so each function uses one request mechanism.

Pure refactor, no TDD cycle; verified with `go test ./cmd/rpctest/...` and `make lint`.