### PR TITLE
`db/seg` Huffman decode: byte-at-a-time bitstream read blocks BCE

### DIFF
--- a/db/seg/decompress.go
+++ b/db/seg/decompress.go
@@ -64,7 +64,7 @@ func (pt *patternTable) insertWord(cw *codeword) {
 
 // posEntry is one slot in a Huffman position table: bits>0 is a terminal
 // (pos is the decoded position); bits==0 is a subtable router (pos is the
-// child index in posArena.tables), valid on the posMask!=0 path only.
+// child index in posArena.tables).
 type posEntry struct {
 	pos  uint32
 	bits uint8
@@ -726,7 +726,6 @@ func (v *SequentialView) MakeGetter() *Getter {
 		g.posTables = v.d.posArena.tables
 	}
 	if v.d.posDict != nil {
-		g.posMask = v.d.posDict.mask
 		g.posEntries = v.d.posDict.entries
 	}
 	return g
@@ -747,7 +746,6 @@ type Getter struct {
 	dataP      uint64     // current byte offset in data
 	dataLen    uint64     // u64-typed len(data) to reduce amount of type-casting
 	dataBit    int        // bit offset within current byte (0-7)
-	posMask    uint16     // cached d.posDict.mask, avoids pointer chain on hot path
 	posEntries []posEntry // cached d.posDict.entries, avoids pointer chain on hot path
 	data       []byte
 	//less hot fields
@@ -779,21 +777,24 @@ func (g *Getter) nextPosClean() uint64 {
 }
 
 // nextPos reads the next position from the Huffman-coded bitstream.
-// It is structured to be inlinable: the subtable (deep-tree) case is pushed
-// into a separate //go:noinline helper so this function stays small.
+// Do NOT swap len(data)/len(entries) for g.dataLen/posTable.mask: prove cannot
+// relate a field to the slice it indexes, so the bounds checks come back and
+// the two stream bytes stop fusing into one 16-bit load.
 func (g *Getter) nextPos() uint64 {
-	if g.posMask == 0 {
-		return uint64(g.posEntries[0].pos)
+	entries := g.posEntries
+	if len(entries) <= 1 {
+		return uint64(entries[0].pos)
 	}
 	dataP := g.dataP
 	dataBit := uint(g.dataBit) & 7 // & 7 proves to compiler: 0 ≤ dataBit < 8, eliminating shift guards
 	data := g.data
-	code := uint16(data[dataP]) >> dataBit
-	if dataP+1 < g.dataLen {
-		code |= uint16(data[dataP+1]) << (8 - dataBit)
+	var code uint16
+	if dataP+1 < uint64(len(data)) {
+		code = (uint16(data[dataP]) | uint16(data[dataP+1])<<8) >> dataBit
+	} else {
+		code = uint16(data[dataP]) >> dataBit
 	}
-	code &= g.posMask
-	entry := g.posEntries[code]
+	entry := entries[int(code)&(len(entries)-1)]
 	l := uint(entry.bits)
 	if l == 0 {
 		return g.nextPosSubtable(entry.pos)
@@ -820,9 +821,11 @@ func (g *Getter) nextPosSubtable(tableIdx uint32) uint64 {
 		dataBit += 9
 		dataP += uint64(dataBit >> 3)
 		dataBit &= 7
-		code := uint16(data[dataP]) >> dataBit
-		if 8-dataBit < uint(table.bitLen) && dataP+1 < g.dataLen {
-			code |= uint16(data[dataP+1]) << (8 - dataBit)
+		var code uint16
+		if dataP+1 < uint64(len(data)) {
+			code = (uint16(data[dataP]) | uint16(data[dataP+1])<<8) >> dataBit
+		} else {
+			code = uint16(data[dataP]) >> dataBit
 		}
 		code &= table.mask
 		entry := table.entries[code]
@@ -848,9 +851,11 @@ func (g *Getter) nextPattern() []byte {
 	dataBit := uint(g.dataBit) & 7
 
 	for {
-		code := uint16(data[dataP]) >> dataBit
-		if 8-dataBit < uint(table.bitLen) && dataP+1 < g.dataLen {
-			code |= uint16(data[dataP+1]) << (8 - dataBit)
+		var code uint16
+		if dataP+1 < uint64(len(data)) {
+			code = (uint16(data[dataP]) | uint16(data[dataP+1])<<8) >> dataBit
+		} else {
+			code = uint16(data[dataP]) >> dataBit
 		}
 		code &= (uint16(1) << table.bitLen) - 1
 
@@ -894,7 +899,6 @@ func (d *Decompressor) MakeGetter() *Getter {
 		g.posTables = d.posArena.tables
 	}
 	if d.posDict != nil {
-		g.posMask = d.posDict.mask
 		g.posEntries = d.posDict.entries
 	}
 	return g


### PR DESCRIPTION
problem: `db/seg` Huffman decode reads the bitstream one byte at a time — the cached `Getter.dataLen` / `posTable.mask` fields stop the compiler from eliminating the bounds checks
solution: bound the stream reads by `len(data)` and mask the table by `len(entries)-1`, so the checks go away and both stream bytes fuse into one 16-bit load

-----

`nextPos`, `nextPosSubtable` and `nextPattern` each read 2 stream bytes and OR them together. `prove` cannot relate a struct field to the slice it guards, so both accesses kept a bounds check. Guarding on `len(data)` drops the second one, which lets the load-combining rules fire: the pair becomes a single `MOVWLZX` / `MOVHU` plus a shift. On amd64 it also removes a variable-shift shuffle through `CX`.

Same shape for the position table: `entries[int(code)&(len(entries)-1)]` behind the existing single-entry guard is in-bounds by construction, since `len(entries) == mask+1` (`posArena.allocTable`). `Getter.posMask` is then dead and removed.

`Getter.dataLen` looks dead too, but stays: it is adjacent to `dataP`, so `HasNext` loads both in one instruction. Removing it costs `Skip` 12 percentage points.

```
DecompressNextBuf-16           17.86n → 16.09n   -9.94%
DecompressNextHeap-16          24.36n → 23.54n   -3.41%
DecompressSkip/skip-16         59.96m → 54.52m   -9.08%
MatchCmp/MatchCmp_hit-16       64.51n → 57.07n  -11.53%
MatchCmp/MatchCmp_miss-16      42.90n → 36.88n  -14.05%
MatchCmp/Next_buf_reuse-16     61.46n → 54.13n  -11.93%
MatchCmp/MatchPrefix_hit-16    62.67n → 56.28n  -10.20%
MatchCmp/MatchPrefix_miss-16   16.54n → 14.52n  -12.21%
geomean                                         -10.34%
```
