### PR TITLE
mdbx: major release `0.14.3`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/holiman/bloomfilter/v2 => github.com/AskAlexSharov/bloomfilte
 require (
 	github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2
 	github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268
-	github.com/erigontech/mdbx-go v0.42.0
+	github.com/erigontech/mdbx-go v0.43.0
 	github.com/erigontech/secp256k1 v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2 h1:B
 github.com/erigontech/evmone_precompiles v0.0.0-20260414072133-b8b2bdc99de2/go.mod h1:WQvAqmoairhdM5RFNFDKK9oT6dzuZEbWMJH+ZdRTjP0=
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268 h1:NHl4+DjblLuHBJradIg9KriKmtByjRvLqLhkVODibac=
 github.com/erigontech/fastkeccak v0.1.1-0.20260408010752-08e7b6602268/go.mod h1:CwJFJVKFVWpQyKSfRrQyY56IqV16sR5xnQoFThGHiZA=
-github.com/erigontech/mdbx-go v0.42.0 h1:ZXQ0UqtxZLC/wDZJL4ACBLuNznD1vJQKhayp2HD1JH4=
-github.com/erigontech/mdbx-go v0.42.0/go.mod h1:Ps2n0MMTlU+BgecMWznc/Z7oGJWDJX/EQk+gUCTSaRo=
+github.com/erigontech/mdbx-go v0.43.0 h1:km4NnoGZ3zieFGWE9K1btMhRMnduZNybW7oebFg0ZWQ=
+github.com/erigontech/mdbx-go v0.43.0/go.mod h1:Ps2n0MMTlU+BgecMWznc/Z7oGJWDJX/EQk+gUCTSaRo=
 github.com/erigontech/secp256k1 v1.4.0 h1:kQLdnJ5jLqkDTBup9PpWirUZw1u2F/nHskQSKbKA4f0=
 github.com/erigontech/secp256k1 v1.4.0/go.mod h1:CnigLRUsfobnTYoUzwdT/De67fw9OhTA0KTkxa+svik=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=


### PR DESCRIPTION
## Summary

Upgrade `github.com/erigontech/mdbx-go` **v0.42.0 → [v0.43.0](https://github.com/erigontech/mdbx-go/releases/tag/v0.43.0)**, which vendors **libmdbx v0.14.2 → v0.14.3 "Китов" (Kitov)** (2026-08-09). go.mod/go.sum only — no Go API change, so no call sites move.

## libmdbx 0.14.2 → 0.14.3

**Data loss and hangs**
- **Copy without compaction produced a copy without payload.** A non-compacting `mdbx_env_copy` built the destination meta-pages from the empty model and never carried over the source tree roots or geometry, so the copy opened cleanly and read as an *empty database*. Verified fixed with a fill/copy/re-read probe over `MDBX_CP_DEFAULTS` and `MDBX_CP_FORCE_DYNAMIC_SIZE`: full payload against 0.14.3, empty database against 0.14.2.
- Lost table content after aborting a nested transaction that dropped the table.
- Infinite loop in `mdbx_txn_abort()` from a `memcmp()`/`memcpy()` typo.
- `env_owned_wrtxn()` bypassed locking under `MDBX_NOSTICKYTHREADS` — the mode mdbx-go always sets, so this one is on our path.
- Major typo in `latch_maindb_locked()`; missing `return` on an error path in `mdbx_cursor_bind()`.

**Spilling and cursors** — concentrated in large write transactions: committing a pure nested transaction that has spilled pages; leak of the spilled-pages list on nested-transaction abort; tracking and invalidation of the inner part of sibling cursors; the cursor stack reworked around a page `stash`; spilling and accounting corrected for `MDBX_AVOID_MSYNC=ON`.

**Leaks** — `mach_port_t` in `mdbx_get_sysraminfo()`, Windows section handle in `osal_mresize()`, table name in `dbi_open_locked()`, `cond_pair` in `copy_with_compacting()`.

**Windows** — `ERROR_LOCK_VIOLATION` during defrag in overlapped-I/O modes; lost global init and TLS destructors in MinGW static builds; MSVC C11-atomics workaround plus a guard against wrong codegen on non-x86.

## Behavior change worth knowing

Fixing the `env_owned_wrtxn()` locking bypass means the env functions that need the writer lock but take no txn — `SetFlags`, `SetOption`, `SetGeometry`, `Sync*`, `Stat`/`Info(nil)`, `Close` — now actually acquire that lock when the calling goroutine does not own the in-flight write transaction, instead of proceeding unlocked.

In `db/kv/mdbx` this is almost entirely a non-event: every `SetOption`/`SetGeometry` call runs during `Open` before any transaction exists, and the hot-path introspection (`MdbxTx.DBSize`, `Stat`, `Info`) already passes a live `tx`. The one txn-less call is `(*MdbxKV).DBSize()` → `env.Info(nil)` (single caller, `cl/phase1/.../persistent_block_collector.go`), which can now block for the duration of an in-flight write transaction rather than returning immediately. Worth keeping in mind if it ever shows up in a stall trace.

## Validation

- `go build ./...` and `go test ./db/kv/...` pass locally on darwin/arm64 with a fresh cgo rebuild.
- Upstream mdbx-go CI for this bump was green on Linux, macOS and Windows, including the `erigon make test-short` integration job.
