### PR TITLE
execution/state: trim comments from 4489 to 763 lines

### DIFF
--- a/execution/state/access_list.go
+++ b/execution/state/access_list.go
@@ -25,34 +25,25 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// accessList tracks addresses and storage slots accessed during a transaction.
-// addresses maps each address to its index in slots (-1 if address-only, no slots).
-// This layout matches go-ethereum's design: the slots slice backing array is
-// reused across transactions via Reset, eliminating per-tx slot-map allocations.
+// accessList maps each address to its index in slots (-1 = address-only); the slots backing array is reused across transactions via Reset to avoid per-tx allocations.
 type accessList struct {
 	addresses map[accounts.Address]int
 	slots     []map[accounts.StorageKey]struct{}
 
-	// Memo of the last resolved (address -> slot set) and the last slot known
-	// warm within it: repeated AddSlot on the same addr skips the addresses
-	// lookup, and on the same (addr, slot) skips both map lookups.
-	// lastSlots == nil means no memo — lastAddr alone can't say, since its
-	// zero value NilAddress is a legal argument.
+	// Memo of the last resolved (addr -> slot set) and its last-known-warm slot, so repeated AddSlot on the same addr/slot skips the map lookups.
+	// lastSlots == nil means no memo; lastAddr alone can't say, since NilAddress is both a legal argument and that field's zero value.
 	lastAddr     accounts.Address
 	lastSlots    map[accounts.StorageKey]struct{}
 	lastWarmSlot accounts.StorageKey
 }
 
-// newAccessList creates a new accessList.
 func newAccessList() *accessList {
 	return &accessList{
 		addresses: make(map[accounts.Address]int),
 	}
 }
 
-// Reset clears the access list for reuse, keeping allocated memory.
-// The slots backing array is retained; cleared inner maps are reused by
-// subsequent AddSlot calls without new allocations.
+// Reset keeps the backing array and inner maps so subsequent AddSlot calls need no new allocations.
 func (al *accessList) Reset() {
 	for _, s := range al.slots {
 		clear(s)
@@ -68,14 +59,11 @@ func (al *accessList) dropMemo() {
 	al.lastWarmSlot = accounts.StorageKey{}
 }
 
-// ContainsAddress returns true if the address is in the access list.
 func (al *accessList) ContainsAddress(address accounts.Address) bool {
 	_, ok := al.addresses[address]
 	return ok
 }
 
-// Contains checks if a slot within an account is present in the access list, returning
-// separate flags for the presence of the account and the slot respectively.
 func (al *accessList) Contains(address accounts.Address, slot accounts.StorageKey) (addressPresent bool, slotPresent bool) {
 	if al.lastSlots != nil && al.lastAddr == address {
 		if slot == al.lastWarmSlot {
@@ -95,7 +83,6 @@ func (al *accessList) Contains(address accounts.Address, slot accounts.StorageKe
 	return true, slotPresent
 }
 
-// Copy creates an independent copy of an accessList.
 func (al *accessList) Copy() *accessList {
 	cp := &accessList{
 		addresses: maps.Clone(al.addresses),
@@ -107,8 +94,6 @@ func (al *accessList) Copy() *accessList {
 	return cp
 }
 
-// AddAddress adds an address to the access list, and returns 'true' if the operation
-// caused a change (addr was not previously in the list).
 func (al *accessList) AddAddress(address accounts.Address) bool {
 	if _, present := al.addresses[address]; present {
 		return false
@@ -117,18 +102,13 @@ func (al *accessList) AddAddress(address accounts.Address) bool {
 	return true
 }
 
-// AddSlot adds the specified (addr, slot) combo to the access list.
-// Return values are:
-// - address added
-// - slot added
-// For any 'true' value returned, a corresponding journal entry must be made.
+// AddSlot returns which of address/slot are newly added; the journal must record an entry for each true result.
 func (al *accessList) AddSlot(address accounts.Address, slot accounts.StorageKey) (addrChange bool, slotChange bool) {
 	if al.lastSlots != nil && al.lastAddr == address {
 		if slot == al.lastWarmSlot {
 			return false, false
 		}
-		// Probe-then-insert: a plain read on the warm case beats mapassign's
-		// write bookkeeping, and warm re-reads dominate cold inserts.
+		// probe-then-insert: a plain read on the warm case beats mapassign's write bookkeeping, since warm re-reads dominate cold inserts
 		if _, ok := al.lastSlots[slot]; ok {
 			al.lastWarmSlot = slot
 			return false, false
@@ -143,8 +123,6 @@ func (al *accessList) AddSlot(address accounts.Address, slot accounts.StorageKey
 func (al *accessList) addSlotSlow(address accounts.Address, slot accounts.StorageKey) (addrChange bool, slotChange bool) {
 	idx, addrPresent := al.addresses[address]
 	if !addrPresent || idx == -1 {
-		// Address not present, or addr present but no slots yet.
-		// Reuse a cleared slot map from the backing array if available.
 		newIdx := len(al.slots)
 		al.addresses[address] = newIdx
 		var slotmap map[accounts.StorageKey]struct{}
@@ -168,10 +146,7 @@ func (al *accessList) addSlotSlow(address accounts.Address, slot accounts.Storag
 	return false, true
 }
 
-// DeleteSlot removes an (address, slot)-tuple from the access list.
-// This operation needs to be performed in the same order as the addition happened.
-// This method is meant to be used by the journal, which maintains ordering of
-// operations.
+// DeleteSlot must be called in LIFO order matching the additions — it's meant for the journal's revert path only.
 func (al *accessList) DeleteSlot(address accounts.Address, slot accounts.StorageKey) {
 	idx, addrOk := al.addresses[address]
 	if !addrOk {
@@ -183,8 +158,7 @@ func (al *accessList) DeleteSlot(address accounts.Address, slot accounts.Storage
 	slotmap := al.slots[idx]
 	delete(slotmap, slot)
 	al.dropMemo()
-	// Since additions and rollbacks are always in LIFO order, when a slot map
-	// becomes empty it must be the last one appended — truncate the slice.
+	// LIFO order guarantees an emptied slot map is always the last one appended, so truncating the slice is safe.
 	if len(slotmap) == 0 {
 		if idx != len(al.slots)-1 {
 			panic("reverting slot change, LIFO violation: emptied slot map is not the last element")
@@ -194,10 +168,6 @@ func (al *accessList) DeleteSlot(address accounts.Address, slot accounts.Storage
 	}
 }
 
-// DeleteAddress removes an address from the access list. This operation
-// needs to be performed in the same order as the addition happened.
-// This method is meant to be used by the journal, which maintains ordering of
-// operations.
 func (al *accessList) DeleteAddress(address accounts.Address) {
 	idx, addrOk := al.addresses[address]
 	if !addrOk {

--- a/execution/state/access_list_test.go
+++ b/execution/state/access_list_test.go
@@ -30,7 +30,6 @@ import (
 
 func verifyAddrs(t *testing.T, s *IntraBlockState, astrings ...string) {
 	t.Helper()
-	// convert to common.Address form
 	addresses := make([]accounts.Address, 0, len(astrings))
 	var addressMap = make(map[accounts.Address]struct{})
 	for _, astring := range astrings {
@@ -38,13 +37,11 @@ func verifyAddrs(t *testing.T, s *IntraBlockState, astrings ...string) {
 		addresses = append(addresses, address)
 		addressMap[address] = struct{}{}
 	}
-	// Check that the given addresses are in the access list
 	for _, address := range addresses {
 		if !s.AddressInAccessList(address) {
 			t.Fatalf("expected %x to be in access list", address)
 		}
 	}
-	// Check that only the expected addresses are present in the acesslist
 	for address := range s.accessList.addresses {
 		if _, exist := addressMap[address]; !exist {
 			t.Fatalf("extra address %x in access list", address)
@@ -65,13 +62,11 @@ func verifySlots(t *testing.T, s *IntraBlockState, addrString string, slotString
 		slots = append(slots, s)
 		slotMap[s] = struct{}{}
 	}
-	// Check that the expected items are in the access list
 	for i, slot := range slots {
 		if _, slotPresent := s.SlotInAccessList(address, slot); !slotPresent {
 			t.Fatalf("input %d: scope missing slot %v (address %v)", i, slot, addrString)
 		}
 	}
-	// Check that no extra elements are in the access list
 	idx := s.accessList.addresses[address]
 	if idx >= 0 {
 		for s := range s.accessList.slots[idx] {
@@ -84,7 +79,6 @@ func verifySlots(t *testing.T, s *IntraBlockState, addrString string, slotString
 
 func TestAccessList(t *testing.T) {
 	t.Parallel()
-	// Some helpers
 	addr := func(a string) accounts.Address { return accounts.InternAddress(common.HexToAddress(a)) }
 	slot := func(s string) accounts.StorageKey { return accounts.InternKey(common.HexToHash(s)) }
 
@@ -98,9 +92,9 @@ func TestAccessList(t *testing.T) {
 
 	state.accessList.Reset()
 
-	state.AddAddressToAccessList(addr("aa"))          // 1
-	state.AddSlotToAccessList(addr("bb"), slot("01")) // 2,3
-	state.AddSlotToAccessList(addr("bb"), slot("02")) // 4
+	state.AddAddressToAccessList(addr("aa"))
+	state.AddSlotToAccessList(addr("bb"), slot("01"))
+	state.AddSlotToAccessList(addr("bb"), slot("02"))
 	verifyAddrs(t, state, "aa", "bb")
 	verifySlots(t, state, "bb", "01", "02")
 
@@ -121,10 +115,9 @@ func TestAccessList(t *testing.T) {
 	if exp, got := 4, state.journal.length(); exp != got {
 		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
 	}
-	// some new ones
-	state.AddSlotToAccessList(addr("bb"), slot("03")) // 5
-	state.AddSlotToAccessList(addr("aa"), slot("01")) // 6
-	state.AddSlotToAccessList(addr("cc"), slot("01")) // 7,8
+	state.AddSlotToAccessList(addr("bb"), slot("03"))
+	state.AddSlotToAccessList(addr("aa"), slot("01"))
+	state.AddSlotToAccessList(addr("cc"), slot("01"))
 	state.AddAddressToAccessList(addr("cc"))
 	if exp, got := 8, state.journal.length(); exp != got {
 		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
@@ -135,7 +128,6 @@ func TestAccessList(t *testing.T) {
 	verifySlots(t, state, "bb", "01", "02", "03")
 	verifySlots(t, state, "cc", "01")
 
-	// now start rolling back changes
 	state.journal.revert(state, 7)
 	if _, ok := state.SlotInAccessList(addr("cc"), slot("01")); ok {
 		t.Fatalf("slot present, expected missing")
@@ -243,14 +235,8 @@ func BenchmarkAccessListReset(b *testing.B) {
 	})
 }
 
-// BenchmarkAccessListSlots measures the per-opcode access-list traffic: every
-// SLOAD and SSTORE calls AddSlot, and a re-read of an already-warm slot is the
-// dominant case in storage-heavy contracts.
-//
-// runLen is how many consecutive storage ops target the same address before
-// execution moves to another one. A call frame only ever touches its own
-// storage, so runLen models frame length: 1 is a proxy chain doing one SLOAD
-// per frame, 64 is a loop inside a single contract.
+// BenchmarkAccessListSlots measures per-opcode access-list traffic (every SLOAD/SSTORE calls AddSlot).
+// runLen is how many consecutive ops hit the same address before moving on, modeling call-frame length.
 func BenchmarkAccessListSlots(b *testing.B) {
 	const nAddrs, nSlots = 4, 64
 	addrs := make([]accounts.Address, nAddrs)
@@ -283,8 +269,7 @@ func BenchmarkAccessListSlots(b *testing.B) {
 			}
 		})
 
-		// Same slot re-read for the whole run: a loop hammering one storage
-		// slot, the pattern SLOAD hot loops produce.
+		// re-reads the same slot for the whole run — the pattern a hot SLOAD loop produces
 		b.Run("warm-hit-hot/"+name, func(b *testing.B) {
 			al := populated()
 			b.ReportAllocs()
@@ -299,9 +284,7 @@ func BenchmarkAccessListSlots(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				// Walk all nAddrs*nSlots pairs exactly once per Reset window,
-				// keeping runs of runLen ops on one address. Deriving the slot
-				// from i alone would repeat 64 pairs four times instead.
+				// walks all nAddrs*nSlots pairs once per Reset window, keeping runs of runLen ops per address — deriving the slot from i alone would repeat pairs across runs
 				w := i % (nAddrs * nSlots)
 				if w == 0 {
 					al.Reset()
@@ -321,12 +304,8 @@ func BenchmarkAccessListSlots(b *testing.B) {
 	}
 }
 
-// TestAccessListMemoDroppedOnSlotMapReuse pins the memo invalidation in
-// DeleteSlot. Emptying a slot map truncates it out of al.slots and marks the
-// address slotless, so a surviving memo would send the next AddSlot into a
-// detached map — and hand that map, carrying the stray slot, to whichever
-// address claims the freed slot next. Reads go through the memo too, so the
-// damage only shows once another address has displaced it.
+// TestAccessListMemoDroppedOnSlotMapReuse pins that DeleteSlot drops the memo: emptying a slot map truncates it from al.slots, so a surviving memo would
+// send the next AddSlot into a detached map that a later address then inherits, stray slot included.
 func TestAccessListMemoDroppedOnSlotMapReuse(t *testing.T) {
 	t.Parallel()
 	addrA := accounts.InternAddress(common.HexToAddress("0xaa"))
@@ -336,10 +315,10 @@ func TestAccessListMemoDroppedOnSlotMapReuse(t *testing.T) {
 	slot3 := accounts.InternKey(common.HexToHash("0x03"))
 
 	al := newAccessList()
-	al.AddSlot(addrA, slot1) // populates the memo for A
+	al.AddSlot(addrA, slot1)
 	al.DeleteSlot(addrA, slot1)
-	al.AddSlot(addrA, slot2) // must re-establish A's slot map, not reuse the detached one
-	al.AddSlot(addrB, slot3) // displaces the memo, so the reads below take the slow path
+	al.AddSlot(addrA, slot2)
+	al.AddSlot(addrB, slot3)
 
 	addrPresent, slotPresent := al.Contains(addrA, slot2)
 	require.True(t, addrPresent)
@@ -349,9 +328,8 @@ func TestAccessListMemoDroppedOnSlotMapReuse(t *testing.T) {
 	require.False(t, leaked, "addrA's slot leaked into addrB's reused slot map")
 }
 
-// TestAccessListWarmSlotMemoDroppedOnDelete pins lastWarmSlot invalidation for
-// a DeleteSlot that leaves the slot map non-empty (no truncation): the reverted
-// slot must not keep reading as warm through the memo.
+// TestAccessListWarmSlotMemoDroppedOnDelete pins that DeleteSlot drops lastWarmSlot even when the slot map survives (no truncation), so the deleted
+// slot can't keep reading as warm through the memo.
 func TestAccessListWarmSlotMemoDroppedOnDelete(t *testing.T) {
 	t.Parallel()
 	addrA := accounts.InternAddress(common.HexToAddress("0xaa"))
@@ -360,7 +338,7 @@ func TestAccessListWarmSlotMemoDroppedOnDelete(t *testing.T) {
 
 	al := newAccessList()
 	al.AddSlot(addrA, slot1)
-	al.AddSlot(addrA, slot2) // memoizes slot2 as the last warm slot
+	al.AddSlot(addrA, slot2)
 	al.DeleteSlot(addrA, slot2)
 
 	_, slotPresent := al.Contains(addrA, slot2)
@@ -370,9 +348,7 @@ func TestAccessListWarmSlotMemoDroppedOnDelete(t *testing.T) {
 	require.True(t, slotChange, "re-adding a reverted slot must report a change for the journal")
 }
 
-// TestAccessListMemoOnEmptyList pins the empty and reset states: NilAddress is
-// the zero value of the memo's address field, so matching on the address alone
-// would let a list with no memo answer as if it had one.
+// TestAccessListMemoOnEmptyList pins that an empty or reset list must not answer from the memo: NilAddress is the zero value of the memo's address field, so matching on address alone would be wrong.
 func TestAccessListMemoOnEmptyList(t *testing.T) {
 	t.Parallel()
 	addrA := accounts.InternAddress(common.HexToAddress("0xaa"))
@@ -409,8 +385,7 @@ func TestAccessListMemoOnEmptyList(t *testing.T) {
 	}
 }
 
-// TestSlotKnownWarmOnEmptyAccessList pins the same invariant at the gas-charge
-// entry point: nothing is warm before anything is added.
+// TestSlotKnownWarmOnEmptyAccessList pins the same NilAddress zero-value trap at the gas-charge entry point.
 func TestSlotKnownWarmOnEmptyAccessList(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)

--- a/execution/state/account_lifecycle_test.go
+++ b/execution/state/account_lifecycle_test.go
@@ -25,11 +25,8 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// AccountLifecycle is the single revival definition the scattered consumers
-// (getVersionedAccount, versionedStateReader, validateReadImpl, the create
-// decision) converge onto. Pin it against the cases those sites currently
-// compute ad-hoc — including the same-tx metamorphic SD+CREATE2 that only the
-// AddressPath >= arm catches.
+// AccountLifecycle is the single revival definition other call sites replicate ad-hoc; the AddressPath >= arm
+// also catches same-tx metamorphic SD+CREATE2.
 func TestAccountLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -101,9 +98,7 @@ func TestAccountLifecycle(t *testing.T) {
 	})
 }
 
-// accountLifecycle layers the tx's own field-level SelfDestruct write over the
-// versionMap floor, without the stateObject. Pin the layering: own write wins
-// (true after same-tx SD, false after same-tx recreate); else the floor verdict.
+// accountLifecycle layers the tx's own SelfDestruct write over the versionMap floor: own write wins, else the floor verdict applies.
 func TestAccountLifecycle_LayersOwnTxWrites(t *testing.T) {
 	_, tx, domains := NewTestRwTx(t)
 
@@ -128,8 +123,8 @@ func TestAccountLifecycle_LayersOwnTxWrites(t *testing.T) {
 	t.Run("own-tx recreate (SD=false) wins", func(t *testing.T) {
 		ibs, vm := newIBS()
 		a := getAddress(2)
-		writeFor(vm, a, SelfDestructPath, accounts.NilKey, Version{TxIndex: 2}, true, true) // floor says destroyed
-		ownSD(ibs, a, false)                                                                // own recreate
+		writeFor(vm, a, SelfDestructPath, accounts.NilKey, Version{TxIndex: 2}, true, true)
+		ownSD(ibs, a, false)
 		require.False(t, ibs.accountLifecycle(a), "own recreate must override the floor destruct")
 	})
 	t.Run("no own write -> floor destroyed-no-revival", func(t *testing.T) {

--- a/execution/state/block_cache_committed_storage_test.go
+++ b/execution/state/block_cache_committed_storage_test.go
@@ -26,9 +26,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// BenchmarkCommittedStorage prices the committed-storage cache path that every
-// block worker hits on SLOAD. Run with -cpu=1,8,16 to see behaviour under the
-// contention the parallel executor actually produces.
+// Prices the committed-storage cache path every block worker hits on SLOAD; run with -cpu=1,8,16 to see contention behavior.
 func BenchmarkCommittedStorage(b *testing.B) {
 	const nAddrs, nKeys = 64, 64
 	addrs := make([]accounts.Address, nAddrs)
@@ -41,7 +39,6 @@ func BenchmarkCommittedStorage(b *testing.B) {
 	}
 	val := []byte{1, 2, 3, 4}
 
-	// Warm read: all keys pre-filled, workers only read (the SLOAD cache-hit hot path).
 	b.Run("read_warm", func(b *testing.B) {
 		c := NewBlockStateCache()
 		for _, a := range addrs {
@@ -59,8 +56,6 @@ func BenchmarkCommittedStorage(b *testing.B) {
 		})
 	})
 
-	// Read-through fill: first touch misses then fills (the profiled PutCommittedStorage
-	// contention), subsequent touches hit.
 	b.Run("fill_read", func(b *testing.B) {
 		c := NewBlockStateCache()
 		b.ResetTimer()
@@ -77,10 +72,7 @@ func BenchmarkCommittedStorage(b *testing.B) {
 	})
 }
 
-// committedStorage is a write-once, immutable pre-block view backed by a
-// lock-free sync.Map. These pin the value semantics the reader relies on — in
-// particular a cached empty slot (ok=true, nil value) must stay distinct from
-// an uncached miss (ok=false).
+// A cached empty slot (ok=true, nil) must stay distinct from an uncached miss (ok=false); GetCurrentStorage falls back to committed when unwritten.
 func TestBlockStateCache_CommittedStorage_Semantics(t *testing.T) {
 	t.Parallel()
 

--- a/execution/state/block_cache_multiblock_flush_test.go
+++ b/execution/state/block_cache_multiblock_flush_test.go
@@ -28,30 +28,8 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TestBlockStateCacheFlushClearsAcrossBlocks reproduces the trie-root race
-// at block 24839762 (EIP-7002 predeploy slots 0x01/0x03).
-//
-// The parallel executor reuses one BlockStateCache across all blocks in a
-// batch. When an early block's syscall writes value 0x01 to a storage slot
-// and a later block's syscall writes 0x00 (clearing it), Flush's dedup
-// compared the final value against `committedStorage[key]` — a lazily
-// populated pre-batch snapshot that was never refreshed. If the pre-batch
-// value happened to match the clearing value (both nil/zero), Flush
-// **skipped** the write, leaving sd.mem stuck at the earlier block's
-// stale 0x01. Subsequent commitment computation then saw value 0x01 for
-// that slot and produced a wrong trie root.
-//
-// The fix removes the stale-committed dedup skip in Flush.
-//
-// The test seeds a slot at pre-batch value 0x00 in the domain, then
-// simulates two block-level cache usages:
-//
-//	Block 1: SSTORE slot = 0x01, Flush → domain must hold 0x01
-//	Block 2: SSTORE slot = 0x00 (clear), Flush → domain must hold 0x00
-//
-// Pre-fix: block 2's Flush sees current==committed==nil and skips the
-// delete, so the domain still reads 0x01 afterwards. The test asserts
-// the domain is cleared — post-fix it passes.
+// Flush must not skip a delete because the pre-batch committedStorage
+// snapshot is stale: the final write for a key must always propagate.
 func TestBlockStateCacheFlushClearsAcrossBlocks(t *testing.T) {
 	t.Parallel()
 
@@ -64,18 +42,10 @@ func TestBlockStateCacheFlushClearsAcrossBlocks(t *testing.T) {
 	addrVal := addr.Value()
 	composite := append(append([]byte(nil), addrVal[:]...), slotVal[:]...)
 
-	// Share one cache across both blocks — this is the production pattern
-	// in exec3_parallel.go (one BlockStateCache per blockExecutor/batch).
 	cache := NewBlockStateCache()
 
-	// Block 1: syscall reads slot first (populating committedStorage with
-	// the pre-batch value, empty here), then writes 0x01, then Flush.
-	// The read is what CachedReaderV3.ReadAccountStorage does on first
-	// access — that's the production path that seeds committedStorage.
 	const block1TxNum uint64 = 100
 	domains.SetTxNum(block1TxNum)
-	// Simulate the first read — value is empty (pre-batch slot is zero).
-	// CachedReaderV3 caches this as committed[slot] = nil/empty.
 	cache.PutCommittedStorage(addr, slot, nil)
 	cache.WriteStorage(addr, slot, []byte{0x01}, block1TxNum)
 	require.NoError(t, cache.Flush(domains, tx))
@@ -85,11 +55,6 @@ func TestBlockStateCacheFlushClearsAcrossBlocks(t *testing.T) {
 	require.True(t, bytes.Equal(enc1, []byte{0x01}),
 		"after block 1 flush, domain should hold value 0x01, got %x", enc1)
 
-	// Block 2: syscall clears the slot back to 0x00. Prior to the fix the
-	// Flush dedup compared the (nil) cleared value against the stale
-	// `committedStorage[slot]` (still nil from a never-populated entry)
-	// and skipped the delete. After the fix the delete propagates and the
-	// domain no longer returns 0x01.
 	const block2TxNum uint64 = 200
 	domains.SetTxNum(block2TxNum)
 	cache.WriteStorage(addr, slot, nil, block2TxNum)
@@ -104,40 +69,13 @@ func TestBlockStateCacheFlushClearsAcrossBlocks(t *testing.T) {
 	)
 }
 
-// ctxFor satisfies the expectation that NewTestRwTx-backed code paths use a
-// valid context; kept as a small helper so the intent of the test above is
-// crisp even if the helper signature evolves.
 func ctxFor(t testing.TB) context.Context { //nolint:unused
 	t.Helper()
 	return context.Background()
 }
 
-// TestBlockStateCacheFlushPreservesPerTxHistory pins down the per-tx
-// history-granularity invariant: when multiple txs in one block write
-// to the same key (e.g. the coinbase, which receives a tip from every
-// tx), Flush must replay each write at its own per-tx txNum so the
-// AccountsDomain / StorageDomain history matches what the serial
-// executor (and main's parallel executor) produce by calling DomainPut
-// directly at per-tx txNum.
-//
-// Regression guard: an earlier version of Flush stamped every dirty
-// entry with the block's finalize txNum, collapsing per-tx history
-// entries into one. That broke intra-block GetAsOf reads —
-// silently — because end-of-block trie roots were unaffected and
-// only history-reading consumers (sd.GetAsOf at intra-block txNum,
-// the commitment domain's calculator, eth_getBalance at historic
-// blocks served via state replay) saw wrong values.
-//
-// The test seeds a coinbase-like account, pushes two writes at txNums
-// 3 and 5, Flushes, then asserts:
-//
-//	GetAsOf(addr, txNum=3)  → tx-3 post-state (V1)
-//	GetAsOf(addr, txNum=4)  → tx-3 post-state (V1, no write at txNum=4)
-//	GetAsOf(addr, txNum=5)  → tx-5 post-state (V2)
-//
-// With last-writer-wins stamping, GetAsOf(txNum=3) would return the
-// pre-block value (committed) because no history entry exists at
-// txNum=3 — the test catches that.
+// Flush must stamp each write at its own tx's txNum, not the block's
+// finalize txNum, so intra-block GetAsOf reads see per-tx history.
 func TestBlockStateCacheFlushPreservesPerTxHistory(t *testing.T) {
 	t.Parallel()
 
@@ -147,8 +85,6 @@ func TestBlockStateCacheFlushPreservesPerTxHistory(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xc0, 0x1b, 0xa5, 0xeb, 0xeb, 0xeb})
 	addrVal := addr.Value()
 
-	// Pre-block: account exists at the test's first txNum boundary with
-	// some baseline balance.
 	preAcc := accounts.NewAccount()
 	preAcc.Balance.SetUint64(1000)
 	preEnc := accounts.SerialiseV3(&preAcc)
@@ -159,30 +95,23 @@ func TestBlockStateCacheFlushPreservesPerTxHistory(t *testing.T) {
 	cache := NewBlockStateCache()
 	cache.PutCommittedAccount(addr, &preAcc)
 
-	// Tx 3 increments balance to 1100.
 	tx3Acc := accounts.NewAccount()
 	tx3Acc.Balance.SetUint64(1100)
 	tx3Enc := accounts.SerialiseV3(&tx3Acc)
 	cache.WriteAccount(addr, tx3Enc, 3)
 
-	// Tx 5 increments balance to 1300.
 	tx5Acc := accounts.NewAccount()
 	tx5Acc.Balance.SetUint64(1300)
 	tx5Enc := accounts.SerialiseV3(&tx5Acc)
 	cache.WriteAccount(addr, tx5Enc, 5)
 
-	// Block-end Flush.
 	domains.SetTxNum(5)
 	require.NoError(t, cache.Flush(domains, tx))
 
-	// GetLatest must reflect the final write.
 	latest, _, err := domains.GetLatest(kv.AccountsDomain, tx, addrVal[:])
 	require.NoError(t, err)
 	require.Equal(t, tx5Enc, latest, "latest should be the tx-5 value")
 
-	// GetAsOf at the per-tx txNums must reflect each tx's post-state.
-	// This requires the per-tx history entries to be present — which
-	// only happens if Flush emitted DomainPut at each per-tx txNum.
 	asOfTx3, ok, err := domains.GetAsOf(kv.AccountsDomain, addrVal[:], 4)
 	require.NoError(t, err)
 	require.True(t, ok, "GetAsOf at txNum=4 should find the tx-3 history entry")

--- a/execution/state/cached_reader.go
+++ b/execution/state/cached_reader.go
@@ -23,14 +23,11 @@ import (
 	"github.com/erigontech/erigon/node/shards"
 )
 
-// CachedReader is a wrapper for an instance of type StateReader
-// This wrapper only makes calls to the underlying reader if the item is not in the cache
 type CachedReader struct {
 	r     StateReader
 	cache *shards.StateCache
 }
 
-// NewCachedReader wraps a given state reader into the cached reader
 func NewCachedReader(r StateReader, cache *shards.StateCache) *CachedReader {
 	return &CachedReader{r: r, cache: cache}
 }
@@ -42,7 +39,6 @@ func (cr *CachedReader) SetTrace(trace bool, tracePrefix string) {
 func (cr *CachedReader) Trace() bool         { return cr.r.Trace() }
 func (cr *CachedReader) TracePrefix() string { return cr.r.TracePrefix() }
 
-// ReadAccountData is called when an account needs to be fetched from the state
 func (cr *CachedReader) ReadAccountData(address accounts.Address) (*accounts.Account, error) {
 	addrValue := address.Value()
 	if a, ok := cr.cache.GetAccount(addrValue[:]); ok {
@@ -60,12 +56,10 @@ func (cr *CachedReader) ReadAccountData(address accounts.Address) (*accounts.Acc
 	return a, nil
 }
 
-// ReadAccountDataForDebug is called when an account needs to be fetched from the state
 func (cr *CachedReader) ReadAccountDataForDebug(address accounts.Address) (*accounts.Account, error) {
 	return cr.ReadAccountData(address)
 }
 
-// ReadAccountStorage is called when a storage item needs to be fetched from the state
 func (cr *CachedReader) ReadAccountStorage(address accounts.Address, key accounts.StorageKey) (uint256.Int, bool, error) {
 	addrValue := address.Value()
 	keyValue := key.Value()
@@ -87,18 +81,11 @@ func (cr *CachedReader) ReadAccountStorage(address accounts.Address, key account
 }
 
 func (cr *CachedReader) HasStorage(address accounts.Address) (bool, error) {
-	// note: theoretically we could try to use the cache here using cr.cache.StorageTree
-	// to traverse the cached storage, however that will be only useful in case of a
-	// collision (ie creating an account which already has storage as per eip-7610) which
-	// in reality is very rare; for all the other most likely situations in which we query
-	// if an account has storage (and that account is newly created and doesn't have storage)
-	// the cache will say that there is no known storage in which case we will still need to
-	// check in the DB to be absolutely sure anyway (this deems such an "optimisation" useless)
+	// Cache-based traversal would only help the rare EIP-7610 collision case; the common
+	// case still needs a DB check, so this always delegates instead of consulting the cache.
 	return cr.r.HasStorage(address)
 }
 
-// ReadAccountCode is called when code of an account needs to be fetched from the state
-// Usually, one of (address;incarnation) or codeHash is enough to uniquely identify the code
 func (cr *CachedReader) ReadAccountCode(address accounts.Address) ([]byte, error) {
 	addrValue := address.Value()
 	if c, ok := cr.cache.GetCode(addrValue[:], 1); ok {
@@ -119,7 +106,6 @@ func (cr *CachedReader) ReadAccountCodeSize(address accounts.Address) (int, erro
 	return len(c), err
 }
 
-// ReadAccountIncarnation is called when incarnation of the account is required (to create and recreate contract)
 func (cr *CachedReader) ReadAccountIncarnation(address accounts.Address) (uint64, error) {
 	addrValue := address.Value()
 	deleted := cr.cache.GetDeletedAccount(addrValue[:])

--- a/execution/state/cached_reader3.go
+++ b/execution/state/cached_reader3.go
@@ -24,14 +24,11 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// CachedReader3 is a wrapper for an instance of type StateReader
-// This wrapper only makes calls to the underlying reader if the item is not in the cache
 type CachedReader3 struct {
 	cache kvcache.CacheView
 	db    kv.TemporalTx
 }
 
-// NewCachedReader3 wraps a given state reader into the cached reader
 func NewCachedReader3(cache kvcache.CacheView, tx kv.TemporalTx) *CachedReader3 {
 	return &CachedReader3{cache: cache, db: tx}
 }
@@ -40,7 +37,6 @@ func (r *CachedReader3) SetTrace(_ bool, _ string) {}
 func (r *CachedReader3) Trace() bool               { return false }
 func (r *CachedReader3) TracePrefix() string       { return "" }
 
-// ReadAccountData is called when an account needs to be fetched from the state
 func (r *CachedReader3) ReadAccountData(address accounts.Address) (*accounts.Account, error) {
 	addressValue := address.Value()
 	enc, err := r.cache.Get(addressValue[:])
@@ -57,8 +53,6 @@ func (r *CachedReader3) ReadAccountData(address accounts.Address) (*accounts.Acc
 	return &a, nil
 }
 
-// ReadAccountDataForDebug - is like ReadAccountData, but without adding key to `readList`.
-// Used to get `prev` account balance
 func (r *CachedReader3) ReadAccountDataForDebug(address accounts.Address) (*accounts.Account, error) {
 	return r.ReadAccountData(address)
 }

--- a/execution/state/cached_writer.go
+++ b/execution/state/cached_writer.go
@@ -23,13 +23,11 @@ import (
 	"github.com/erigontech/erigon/node/shards"
 )
 
-// CachedWriter is a wrapper for an instance of type StateWriter
 type CachedWriter struct {
 	w     StateWriter
 	cache *shards.StateCache
 }
 
-// NewCachedWriter wraps a given state writer into a cached writer
 func NewCachedWriter(w StateWriter, cache *shards.StateCache) *CachedWriter {
 	return &CachedWriter{w: w, cache: cache}
 }

--- a/execution/state/code_read_parallel_test.go
+++ b/execution/state/code_read_parallel_test.go
@@ -12,12 +12,9 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TestCodeReadParallel_NoMaterialize verifies that cold GetCode / GetCodeSize
-// reads on the parallel (versionMap) path return the committed code without
-// materializing/caching a stateObject.
 func TestCodeReadParallel_NoMaterialize(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xC0, 0xDE})
-	code := []byte{0x60, 0x01, 0x60, 0x02, 0x01} // PUSH1 1 PUSH1 2 ADD
+	code := []byte{0x60, 0x01, 0x60, 0x02, 0x01}
 
 	acc := accounts.NewAccount()
 	acc.Nonce = 1
@@ -39,29 +36,23 @@ func TestCodeReadParallel_NoMaterialize(t *testing.T) {
 	assert.Equal(t, len(code), sz, "cold GetCodeSize must return the committed size")
 	assert.Empty(t, ibs.stateObjects, "cold parallel GetCodeSize must not materialize a stateObject")
 
-	// Repeat reads hit the recorded ReadSet, still no materialization.
 	got2, err := ibs.GetCode(addr)
 	require.NoError(t, err)
 	assert.Equal(t, code, got2)
 	assert.Empty(t, ibs.stateObjects)
 }
 
-// TestCodeReadParallel_EmptyCodeHashIgnoresStaleCode pins the codeHash gate on
-// the cold parallel code read. When a 7702 delegation is cleared the account's
-// codeHash becomes empty, but the address-keyed CodeDomain keeps the stale
-// delegation bytes (code is never deleted, only the codeHash pointer). The read
-// must honour the empty codeHash and report no code — otherwise GetDelegatedDesignation
-// sees the stale delegation and a plain transfer to the EOA is charged as a call
-// to delegated code, running out of gas and flipping the receipt status.
+// Clearing a 7702 delegation empties the codeHash, but the address-keyed
+// CodeDomain still holds the stale delegation bytes — the read must honor the empty codeHash and report no code.
 func TestCodeReadParallel_EmptyCodeHashIgnoresStaleCode(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x30, 0x75, 0x76, 0xDd})
 	staleDelegation := types.AddressToDelegation(accounts.InternAddress([20]byte{0xfb, 0x77, 0x02}))
 
 	acc := accounts.NewAccount()
 	acc.Nonce = 594735
-	acc.CodeHash = accounts.EmptyCodeHash // delegation cleared: empty codehash...
+	acc.CodeHash = accounts.EmptyCodeHash
 
-	reader := &codeReader{addr: addr, account: &acc, code: staleDelegation} // ...but CodeDomain still holds the stale bytes
+	reader := &codeReader{addr: addr, account: &acc, code: staleDelegation}
 	ibs := NewWithVersionMap(reader, NewVersionMap(nil))
 	ibs.SetNoMaterialize(true)
 	ibs.SetTxContext(100, 5)
@@ -80,9 +71,8 @@ func TestCodeReadParallel_EmptyCodeHashIgnoresStaleCode(t *testing.T) {
 	assert.False(t, ok, "an empty-codehash account must not read as 7702-delegated")
 }
 
-// committedCodeIBS builds a noMaterialize IBS over one committed contract with
-// its CodePath read set warmed. accountHash, when set, makes the account record
-// disagree with the CodeDomain bytes.
+// committedCodeIBS builds a noMaterialize IBS over one committed contract;
+// accountHash, when set, makes the account record disagree with the CodeDomain bytes.
 func committedCodeIBS(tb testing.TB, codeLen int, accountHash *accounts.CodeHash) (*IntraBlockState, accounts.Address) {
 	tb.Helper()
 
@@ -113,8 +103,7 @@ func committedCodeIBS(tb testing.TB, codeLen int, accountHash *accounts.CodeHash
 	return ibs, addr
 }
 
-// BenchmarkGetStateObjectAfterCodeRead measures the rebuild every account-field
-// read falls through to. Cost growing with code size means the bytes are hashed.
+// Cost growing with code size means getStateObject's rebuild is hashing the code bytes.
 func BenchmarkGetStateObjectAfterCodeRead(b *testing.B) {
 	for _, codeLen := range []int{32, 1024, 24576} {
 		b.Run(fmt.Sprintf("code=%dB", codeLen), func(b *testing.B) {
@@ -129,9 +118,8 @@ func BenchmarkGetStateObjectAfterCodeRead(b *testing.B) {
 	}
 }
 
-// TestCommittedCodeHashComesFromAccountRecord pins the account record as the
-// authority for committed code. The CodeDomain is keyed by address, so it can
-// hold bytes the account no longer owns — a cleared 7702 delegation leaves them.
+// The account record is authoritative for committed code; CodeDomain (keyed
+// by address) can hold bytes a cleared 7702 delegation no longer owns.
 func TestCommittedCodeHashComesFromAccountRecord(t *testing.T) {
 	t.Run("account hash agrees with the bytes", func(t *testing.T) {
 		ibs, addr := committedCodeIBS(t, 4096, nil)
@@ -159,8 +147,7 @@ func TestCommittedCodeHashComesFromAccountRecord(t *testing.T) {
 	})
 }
 
-// TestPriorTxCodeWriteHashComesFromTheCell pins the cell as the authority for a
-// prior-tx code write, so its hash is used rather than derived from its bytes.
+// A prior-tx code write's cell hash is authoritative — not keccak(bytes).
 func TestPriorTxCodeWriteHashComesFromTheCell(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xC0, 0xDE})
 	priorCode := []byte{0xef, 0x01, 0x00, 0x11, 0x22, 0x33}
@@ -188,9 +175,8 @@ func TestPriorTxCodeWriteHashComesFromTheCell(t *testing.T) {
 	require.Equal(t, cellHash, so.data.CodeHash)
 }
 
-// TestPriorTxCodeWriteHashSurvivesReadSetHit pins the same authority once the
-// read is already recorded. A dirty address bypasses the read-once gate, so the
-// rebuild re-probes the version map and lands on the read-set hit instead.
+// The cell's hash stays authoritative even when a dirty address forces the
+// rebuild to re-probe and land on the cached read-set hit instead.
 func TestPriorTxCodeWriteHashSurvivesReadSetHit(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xC0, 0xDE})
 	priorCode := []byte{0xef, 0x01, 0x00, 0x11, 0x22, 0x33}

--- a/execution/state/code_size_test.go
+++ b/execution/state/code_size_test.go
@@ -33,14 +33,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestReproduceCrash pins that setting two storage keys non-zero, then clearing both in the same block, does not crash.
 func TestReproduceCrash(t *testing.T) {
 	t.Parallel()
-	// This example was taken from Ropsten contract that used to cause a crash
-	// it is created in the block 598915 and then there are 3 transactions modifying
-	// its storage in the same block:
-	// 1. Setting storageKey 1 to a non-zero value
-	// 2. Setting storageKey 2 to a non-zero value
-	// 3. Setting both storageKey1 and storageKey2 to zero values
 	value0 := uint256.NewInt(0)
 	contract := accounts.InternAddress(common.HexToAddress("0x71dd1027069078091B3ca48093B00E4735B20624"))
 	storageKey1 := accounts.InternKey(common.HexToHash("0x0e4c0e7175f9d22279a4f63ff74f7fa28b7a954a6454debaa62ce43dd9132541"))
@@ -56,23 +51,19 @@ func TestReproduceCrash(t *testing.T) {
 
 	intraBlockState := state.New(tsr)
 	defer intraBlockState.Close()
-	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, tsw); err != nil {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
-	// Start the 2nd transaction
 	intraBlockState.SetState(contract, storageKey1, *value1)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, tsw); err != nil {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
-	// Start the 3rd transaction
 	intraBlockState.AddBalance(contract, *uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
 	intraBlockState.SetState(contract, storageKey2, *value2)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, tsw); err != nil {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
-	// Start the 4th transaction - clearing both storage cells
 	intraBlockState.SubBalance(contract, *uint256.NewInt(1000000000), tracing.BalanceChangeUnspecified)
 	intraBlockState.SetState(contract, storageKey1, *value0)
 	intraBlockState.SetState(contract, storageKey2, *value0)
@@ -92,7 +83,6 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	r, tsw := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
 	intraBlockState := state.New(r)
 	defer intraBlockState.Close()
-	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 
 	oldCode := []byte{0x01, 0x02, 0x03, 0x04}
@@ -104,7 +94,6 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	}
 	rh1, err := sd.ComputeCommitment(context.Background(), tx, true, blockNum, txNum, "", nil)
 	require.NoError(t, err)
-	//t.Logf("stateRoot %x", rh1)
 
 	trieCode, tcErr := r.ReadAccountCode(contract)
 	require.NoError(t, tcErr, "you can receive the new code")
@@ -130,8 +119,6 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 func TestCacheCodeSizeSeparately(t *testing.T) {
 	t.Parallel()
 	contract := accounts.InternAddress(common.HexToAddress("0x71dd1027069078091B3ca48093B00E4735B20624"))
-	//root := common.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
-
 	_, tx, sd := state.NewTestRwTx(t)
 	blockNum, txNum := uint64(1), uint64(3)
 	_ = blockNum
@@ -140,7 +127,6 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 
 	intraBlockState := state.New(r)
 	defer intraBlockState.Close()
-	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 
 	code := []byte{0x01, 0x02, 0x03, 0x04}
@@ -166,7 +152,6 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 // TestCacheCodeSizeInTrie makes sure that we don't just read from the DB all the time
 func TestCacheCodeSizeInTrie(t *testing.T) {
 	t.Parallel()
-	//t.Skip("switch to TG state readers/writers")
 	contract := accounts.InternAddress(common.HexToAddress("0x71dd1027069078091B3ca48093B00E4735B20624"))
 	root := common.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
@@ -178,7 +163,6 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 
 	intraBlockState := state.New(r)
 	defer intraBlockState.Close()
-	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 
 	code := []byte{0x01, 0x02, 0x03, 0x04}

--- a/execution/state/code_trio_validation_test.go
+++ b/execution/state/code_trio_validation_test.go
@@ -24,24 +24,18 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// Code, CodeHash and CodeSize always co-write (one code change bumps all
-// three) and validate in the SAME value class: each carries a tiebreaker, so a
-// cold StorageRead that collides with a concurrent worker's Done flush stays
-// valid when the flushed value matches what was read, and invalidates when it
-// differs. The unification is deliberate: a value-matching collision is not a
-// real conflict, and re-executing on it costs determinism on the BAL-fed path.
+// Code, CodeHash and CodeSize co-write and validate under one tiebreaker: a cold read colliding with
+// a flush stays valid when the flushed value matches (a value-matching collision isn't a real conflict).
 func TestCodeTrio_ValidationClassAsymmetry(t *testing.T) {
 	t.Parallel()
 	addr := getAddress(80)
 	code := accounts.NewCode([]byte{0x60, 0x00, 0x60, 0x00, 0xf3})
 
 	vm := NewVersionMap(nil)
-	// A concurrent worker's Done flush of the trio lands at tx1.
 	vm.WriteCode(addr, Version{TxIndex: 1}, code, true)
 	vm.WriteCodeHash(addr, Version{TxIndex: 1}, code.Hash, true)
 	vm.WriteCodeSize(addr, Version{TxIndex: 1}, code.Len(), true)
 
-	// tx3's reads were served from storage (cold) and now collide with the flush.
 	readStorage := ReadHeader{Source: StorageRead, Version: Version{TxIndex: 3}}
 
 	ioHash := NewVersionedIO(4)

--- a/execution/state/contracts/gen.go
+++ b/execution/state/contracts/gen.go
@@ -16,49 +16,38 @@
 
 package contracts
 
-// changer.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build changer.sol
 //go:generate abigen -abi build/Changer.abi -bin build/Changer.bin -pkg contracts -type changer -out ./gen_changer.go
 
-// revive.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build revive.sol
 //go:generate abigen -abi build/Revive.abi -bin build/Revive.bin -pkg contracts -type revive -out ./gen_revive.go
 
-// selfdestruct.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build selfdestruct.sol
 //go:generate abigen -abi build/Selfdestruct.abi -bin build/Selfdestruct.bin -pkg contracts -type selfdestruct -out ./gen_selfdestruct.go
 
-// poly.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build poly.sol
 //go:generate abigen -abi build/Poly.abi -bin build/Poly.bin -pkg contracts -type poly -out ./gen_poly.go
 
-// revive2.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build revive2.sol
 //go:generate abigen -abi build/Revive2.abi -bin build/Revive2.bin -pkg contracts -type revive2 -out ./gen_revive2.go
 //go:generate abigen -abi build/Phoenix.abi -bin build/Phoenix.bin -pkg contracts -type phoenix -out ./gen_phoenix.go
 
-// disperse.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build disperse.sol
 //go:generate abigen -abi build/Disperse.abi -bin build/Disperse.bin -pkg contracts -type disperse -out ./gen_disperse.go
 
-// proxyfactory.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build proxyfactory.sol
 //go:generate abigen -abi build/Proxy.abi -bin build/Proxy.bin -pkg contracts -type proxy -out ./gen_proxy.go
 //go:generate abigen -abi build/ProxyFactory.abi -bin build/ProxyFactory.bin -pkg contracts -type proxyFactory -out ./gen_proxyfactory.go
 
-// statechurn.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build statechurn.sol
 //go:generate abigen -abi build/StateChurn.abi -bin build/StateChurn.bin -pkg contracts -type stateChurn -out ./gen_statechurn.go
 
-// observer.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build observer.sol
 //go:generate abigen -abi build/Observer.abi -bin build/Observer.bin -pkg contracts -type observer -out ./gen_observer.go
 
-// storeanddie.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build storeanddie.sol
 //go:generate abigen -abi build/StoreAndDie.abi -bin build/StoreAndDie.bin -pkg contracts -type storeAndDie -out ./gen_storeanddie.go
 
-// selfdestructfactory.sol
 //go:generate solc --allow-paths ., --abi --bin --overwrite --optimize -o build selfdestructfactory.sol
 //go:generate abigen -abi build/SelfDestructInConstructor.abi -bin build/SelfDestructInConstructor.bin -pkg contracts -type selfDestructInConstructor -out ./gen_selfdestructinconstructor.go
 //go:generate abigen -abi build/SelfDestructFactory.abi -bin build/SelfDestructFactory.bin -pkg contracts -type selfDestructFactory -out ./gen_selfdestructfactory.go

--- a/execution/state/create_absence_fork_test.go
+++ b/execution/state/create_absence_fork_test.go
@@ -25,15 +25,8 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TestCreateOverAbsenceConsumedBeforeDestructFlush pins the OCC invariant
-// that an execution which consumed an account's absence (e.g. for the
-// EIP-8037 new-account gas charge) must not silently adopt a destruct flushed
-// since: the attempt has to abort with ErrDependency or fail commit-time
-// validation, else its gas view forks from its state view. The
-// collisionCheckFirst variant interleaves the CREATE2 collision reads between
-// the probe and the account load — their destruct-wipe scan records a
-// SelfDestruct=true read that must not count as the absence having been
-// concluded from the destruct.
+// An OCC read that consumed an account's absence (e.g. the EIP-8037 new-account gas charge) must not silently
+// adopt a destruct flushed afterward: it must abort with ErrDependency or fail validation, or gas view forks from state view.
 func TestCreateOverAbsenceConsumedBeforeDestructFlush(t *testing.T) {
 	t.Parallel()
 	for _, collisionCheck := range []bool{false, true} {
@@ -55,22 +48,16 @@ func TestCreateOverAbsenceConsumedBeforeDestructFlush(t *testing.T) {
 
 			addr := getAddress(8246)
 
-			// tx1's gas probe consumes the account's absence before tx0 flushes.
 			empty, err := ibs.Empty(addr)
 			require.NoError(t, err)
 			require.True(t, empty)
 
-			// tx0's writes flush: CREATE2 whose constructor self-destructed to
-			// itself. EIP-8246 preserves the balance; the worker flush carries no
-			// AddressPath cell, so only the destruct probe can reveal the account
-			// to tx1.
 			writeFor(vm, addr, BalancePath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, *uint256.NewInt(1_000_000), true)
 			writeFor(vm, addr, NoncePath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, uint64(1), true)
 			writeFor(vm, addr, IncarnationPath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, uint64(0), true)
 			writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, true, true)
 			writeFor(vm, addr, CreateContractPath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, true, true)
 
-			// The CREATE2 flow re-reads the account it is about to create over.
 			diverged := false
 			func() {
 				defer func() {

--- a/execution/state/create_contract_path_test.go
+++ b/execution/state/create_contract_path_test.go
@@ -22,13 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CreateContractPath is not redundant with IncarnationPath: it is the signal a
-// contract (not a plain account) was created, and the apply path consumes it to
-// clear stale storage before re-creation (rw_v3 DomainDelPrefix, mirroring
-// Writer.CreateContract). This pins the distinct write-side signal — contract
-// creation records CreateContractPath, a plain account creation does not — so a
-// future "fold it into IncarnationPath" simplification can't silently drop the
-// storage-clear trigger.
+// CreateContractPath is not redundant with IncarnationPath: it signals contract (vs plain-account) creation
+// and drives the apply-side stale-storage clear before re-creation — don't fold it into IncarnationPath.
 func TestCreateContractPath_ContractOnlySignal(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)

--- a/execution/state/create_revert_versioned_test.go
+++ b/execution/state/create_revert_versioned_test.go
@@ -10,10 +10,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// createObjectChange.revert must drop the account-record cells that createObject
-// emitted (AddressPath/CodeHashPath) so a reverted creation leaves no versioned
-// write behind on the noMaterialize path — the journal keeps the write-set in
-// step on its own, without dirties re-processing.
+// Reverting a creation must drop the AddressPath/CodeHashPath cells createObject emitted — the journal alone keeps the write-set in step.
 func TestNoMaterialize_CreateRevertDropsCells(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress([20]byte{0xc0, 0x11})
@@ -36,11 +33,7 @@ func TestNoMaterialize_CreateRevertDropsCells(t *testing.T) {
 	require.False(t, exist, "the account must not exist after the creation is reverted")
 }
 
-// resetObjectChange.revert must restore, via restoreCreateFields, the
-// account-record cells the recreation overwrote. createObject stamps the
-// CodeHashPath to EmptyCodeHash, so a CreateAccount over a live contract clears
-// its code hash; reverting must bring the prior hash back on the noMaterialize
-// path (the journal keeps the write-set in step on its own).
+// Reverting a recreate over a live contract must restore the code hash that createObject's CodeHashPath=empty stamp overwrote.
 func TestNoMaterialize_RecreateRevertRestoresPrior(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress([20]byte{0xc0, 0x22})
@@ -56,7 +49,7 @@ func TestNoMaterialize_RecreateRevertRestoresPrior(t *testing.T) {
 	ibs.SetVersion(0)
 
 	snap := ibs.PushSnapshot()
-	require.NoError(t, ibs.CreateAccount(addr, true)) // stamps CodeHashPath -> empty
+	require.NoError(t, ibs.CreateAccount(addr, true))
 	ch, err := ibs.GetCodeHash(addr)
 	require.NoError(t, err)
 	require.Equal(t, accounts.EmptyCodeHash, ch, "recreation clears the code hash")

--- a/execution/state/database.go
+++ b/execution/state/database.go
@@ -30,10 +30,8 @@ import (
 )
 
 const (
-	//FirstContractIncarnation - first incarnation for contract accounts. After 1 it increases by 1.
 	FirstContractIncarnation = 1
-	//NonContractIncarnation incarnation for non contracts
-	NonContractIncarnation = 0
+	NonContractIncarnation   = 0
 )
 
 type StateReader interface {

--- a/execution/state/dump.go
+++ b/execution/state/dump.go
@@ -44,7 +44,6 @@ type Dumper struct {
 	txNumsReader rawdbv3.TxNumsReader
 }
 
-// DumpAccount represents tan account in the state.
 type DumpAccount struct {
 	Balance   string            `json:"balance"`
 	Nonce     uint64            `json:"nonce"`
@@ -52,57 +51,46 @@ type DumpAccount struct {
 	CodeHash  hexutil.Bytes     `json:"codeHash"`
 	Code      hexutil.Bytes     `json:"code,omitempty"`
 	Storage   map[string]string `json:"storage,omitempty"`
-	Address   *common.Address   `json:"address,omitempty"` // Address only present in iterative (line-by-line) mode
-	SecureKey *hexutil.Bytes    `json:"key,omitempty"`     // If we don't have address, we can output the key
+	Address   *common.Address   `json:"address,omitempty"`
+	SecureKey *hexutil.Bytes    `json:"key,omitempty"`
 }
 
-// Dump represents the full dump in a collected format, as one large map.
 type Dump struct {
 	Root     string                         `json:"root"`
 	Accounts map[common.Address]DumpAccount `json:"accounts"`
 }
 
-// iterativeDump is a 'collector'-implementation which dump output line-by-line iteratively.
 type iterativeDump struct {
 	*json.Encoder
 }
 
-// IteratorDump is an implementation for iterating over data.
 type IteratorDump struct {
 	Root     string                         `json:"root"`
 	Accounts map[common.Address]DumpAccount `json:"accounts"`
 	Next     []byte                         `json:"next,omitempty"` // nil if no more accounts
 }
 
-// DumpCollector interface which the state trie calls during iteration
 type DumpCollector interface {
-	// OnRoot is called with the state root
 	OnRoot(common.Hash)
-	// OnAccount is called once for each account in the trie
 	OnAccount(common.Address, DumpAccount)
 }
 
-// OnRoot implements DumpCollector interface
 func (d *Dump) OnRoot(root common.Hash) {
 	d.Root = fmt.Sprintf("%x", root)
 }
 
-// OnAccount implements DumpCollector interface
 func (d *Dump) OnAccount(addr common.Address, account DumpAccount) {
 	d.Accounts[addr] = account
 }
 
-// OnRoot implements DumpCollector interface
 func (d *IteratorDump) OnRoot(root common.Hash) {
 	d.Root = fmt.Sprintf("%x", root)
 }
 
-// OnAccount implements DumpCollector interface
 func (d *IteratorDump) OnAccount(addr common.Address, account DumpAccount) {
 	d.Accounts[addr] = account
 }
 
-// OnAccount implements DumpCollector interface
 func (d iterativeDump) OnAccount(addr common.Address, account DumpAccount) {
 	dumpAccount := &DumpAccount{
 		Balance:   account.Balance,
@@ -121,7 +109,6 @@ func (d iterativeDump) OnAccount(addr common.Address, account DumpAccount) {
 	_ = d.Encode(dumpAccount)
 }
 
-// OnRoot implements DumpCollector interface
 func (d iterativeDump) OnRoot(root common.Hash) {
 	//nolint:errcheck,errchkjson
 	_ = d.Encoder.Encode(struct {
@@ -150,7 +137,7 @@ func (d *Dumper) DumpToCollector(ctx context.Context, c DumpCollector, excludeCo
 		maxResults = kv.Unlim
 	}
 
-	c.OnRoot(emptyHash) // We do not calculate the root
+	c.OnRoot(emptyHash)
 
 	ttx := d.tx
 	txNum, err := d.txNumsReader.Min(ctx, ttx, d.blockNumber+1)
@@ -160,7 +147,7 @@ func (d *Dumper) DumpToCollector(ctx context.Context, c DumpCollector, excludeCo
 	txNumForStorage := txNum
 
 	var nextKey []byte
-	it, err := ttx.RangeAsOf(kv.AccountsDomain, startAddress[:], nil, txNum, order.Asc, kv.Unlim) //unlim because need skip empty vals
+	it, err := ttx.RangeAsOf(kv.AccountsDomain, startAddress[:], nil, txNum, order.Asc, kv.Unlim) // unlim: must skip empty (tombstoned) values before the maxResults cutoff applies
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +171,7 @@ func (d *Dumper) DumpToCollector(ctx context.Context, c DumpCollector, excludeCo
 		account := DumpAccount{
 			Balance:  acc.Balance.ToBig().String(),
 			Nonce:    acc.Nonce,
-			Root:     hexutil.Bytes(emptyHash[:]), // We cannot provide historical storage hash
+			Root:     hexutil.Bytes(emptyHash[:]),
 			CodeHash: hexutil.Bytes(empty.CodeHash[:]),
 			Storage:  make(map[string]string),
 		}
@@ -215,7 +202,7 @@ func (d *Dumper) DumpToCollector(ctx context.Context, c DumpCollector, excludeCo
 			if err := func() error {
 				t := trie.New(common.Hash{})
 				nextAcc, _ := kv.NextSubtree(addr[:])
-				r, err := ttx.RangeAsOf(kv.StorageDomain, addr[:], nextAcc, txNumForStorage, order.Asc, kv.Unlim) //unlim because need skip empty vals
+				r, err := ttx.RangeAsOf(kv.StorageDomain, addr[:], nextAcc, txNumForStorage, order.Asc, kv.Unlim)
 				if err != nil {
 					return fmt.Errorf("walking over storage for %x: %w", addr, err)
 				}
@@ -226,7 +213,7 @@ func (d *Dumper) DumpToCollector(ctx context.Context, c DumpCollector, excludeCo
 						return fmt.Errorf("walking over storage for %x: %w", addr, err)
 					}
 					if len(vs) == 0 {
-						continue // Skip deleted entries
+						continue
 					}
 					loc := k[20:]
 					account.Storage[common.BytesToHash(loc).String()] = common.Bytes2Hex(vs)
@@ -250,7 +237,6 @@ func (d *Dumper) DumpToCollector(ctx context.Context, c DumpCollector, excludeCo
 	return nextKey, nil
 }
 
-// RawDump returns the entire state an a single large object
 func (d *Dumper) RawDump(excludeCode, excludeStorage bool) Dump {
 	dump := &Dump{
 		Accounts: make(map[common.Address]DumpAccount),
@@ -260,7 +246,6 @@ func (d *Dumper) RawDump(excludeCode, excludeStorage bool) Dump {
 	return *dump
 }
 
-// Dump returns a JSON string representing the entire state as a single json-object
 func (d *Dumper) Dump(excludeCode, excludeStorage bool) []byte {
 	dump := d.RawDump(excludeCode, excludeStorage)
 	json, err := json.MarshalIndent(dump, "", "    ")
@@ -270,13 +255,11 @@ func (d *Dumper) Dump(excludeCode, excludeStorage bool) []byte {
 	return json
 }
 
-// IterativeDump dumps out accounts as json-objects, delimited by linebreaks on stdout
 func (d *Dumper) IterativeDump(excludeCode, excludeStorage bool, output *json.Encoder) {
 	//nolint:errcheck
 	d.DumpToCollector(context.Background(), iterativeDump{output}, excludeCode, excludeStorage, common.Address{}, 0)
 }
 
-// IteratorDump dumps out a batch of accounts starts with the given start key
 func (d *Dumper) IteratorDump(excludeCode, excludeStorage bool, start common.Address, maxResults int) (IteratorDump, error) {
 	iterator := &IteratorDump{
 		Accounts: make(map[common.Address]DumpAccount),
@@ -290,7 +273,6 @@ func (d *Dumper) DefaultRawDump() Dump {
 	return d.RawDump(false, false)
 }
 
-// DefaultDump returns a JSON string representing the state with the default params
 func (d *Dumper) DefaultDump() []byte {
 	return d.Dump(false, false)
 }

--- a/execution/state/eip161_ripemd_revert_test.go
+++ b/execution/state/eip161_ripemd_revert_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// emptyAccountReader serves one existing, already-empty account.
 type emptyAccountReader struct {
 	NoopReader
 	addr accounts.Address
@@ -44,13 +43,11 @@ func (r *emptyAccountReader) ReadAccountDataForDebug(address accounts.Address) (
 	return r.ReadAccountData(address)
 }
 
-// normalizeTouchThenRevert touches an already-empty account on the versioned
-// (parallel) path, reverts the transaction, and reports whether the normalized
-// write set sweeps the account under EIP-161.
+// normalizeTouchThenRevert touches an empty account, reverts it, and reports whether EIP-161 still sweeps the account.
 func normalizeTouchThenRevert(t *testing.T, addr accounts.Address) bool {
 	t.Helper()
 
-	empty := accounts.NewAccount() // balance 0, nonce 0, empty code hash
+	empty := accounts.NewAccount()
 	reader := &emptyAccountReader{addr: addr, acc: &empty}
 
 	vm := NewVersionMap(nil)
@@ -68,7 +65,7 @@ func normalizeTouchThenRevert(t *testing.T, addr accounts.Address) bool {
 	if writes == nil {
 		return false
 	}
-	normalized, err := writes.Normalize(vm, 0, 0, reader, nil, true /*emptyRemoval*/, false /*isAura*/, false)
+	normalized, err := writes.Normalize(vm, 0, 0, reader, nil, true, false, false)
 	require.NoError(t, err)
 	if normalized == nil {
 		return false
@@ -81,19 +78,8 @@ func normalizeTouchThenRevert(t *testing.T, addr accounts.Address) bool {
 	return false
 }
 
-// TestEIP161RipemdTouchSurvivesRevertOnVersionedPath pins RIPEMD-160's special
-// case on the parallel state path.
-//
-// touchAccount deliberately bumps ripemd's journal dirty count so a touch
-// outlives the reverting transaction, and serial therefore still sweeps the
-// account under EIP-161. The versioned path derives its write set from
-// versionedWrites, and reverting the touch's zero-balance write dropped that
-// sweep — so the account kept its trie leaf and mainnet's Spurious Dragon
-// clearing blocks re-executed to a wrong state root (first observed at block
-// 2,675,119).
-//
-// An ordinary account is the control: its reverted touch must NOT sweep, which
-// is what makes ripemd's exemption specific rather than a blanket rule.
+// RIPEMD-160 is specially exempted: its touch outlives a revert, so EIP-161
+// must still sweep it on the versioned path — unlike an ordinary account.
 func TestEIP161RipemdTouchSurvivesRevertOnVersionedPath(t *testing.T) {
 	t.Parallel()
 

--- a/execution/state/eip8246_selfdestruct_test.go
+++ b/execution/state/eip8246_selfdestruct_test.go
@@ -12,17 +12,9 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// EIP-8246 removes the SELFDESTRUCT balance burn, leaving a destroyed account
-// alive as a balance-only account. These tests cover that behavior inside
-// IntraBlockState: reconstructing a preserved account on the versioned-read
-// path, resetting the in-memory object at end-of-tx so the block assembler's
-// shared IBS carries the preserved balance into a later tx, and keeping the
-// re-created incarnation aligned across execution modes.
+// EIP-8246 removes SELFDESTRUCT's balance burn; these tests cover the resulting balance-only preserved account in IntraBlockState.
 
-// A destroyed-preserved contract's deployed code hash and nonce must not reach
-// a later tx. Extraction drops nonce/code/codeHash for self-destructed
-// accounts, so nothing in the version map carries them: GetCodeHash serves
-// EmptyCodeHash through the preserved-account reconstruction fallback.
+// A destroyed-preserved account's nonce and code hash must not reach a later tx: extraction drops both, so GetCodeHash falls back to EmptyCodeHash.
 func TestEIP8246_PreservedSD_ReadsAsEmptyCodeAccountInLaterTx(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x8246B"))
@@ -59,10 +51,7 @@ func TestEIP8246_PreservedSD_ReadsAsEmptyCodeAccountInLaterTx(t *testing.T) {
 	require.True(t, exists, "the preserved account still exists")
 }
 
-// The block assembler runs every tx on one shared IBS (no per-tx Reset).
-// After a balance-preserving SELFDESTRUCT is finalized, a later tx's CREATE2 at
-// the same address must carry the preserved balance — i.e. FinalizeTx must not
-// leave a stale selfdestructed marker on the in-memory object.
+// The block assembler shares one IBS across all txs (no per-tx Reset), so FinalizeTx must not leave a stale selfdestruct marker after a preserving SD.
 func TestEIP8246_FinalizeTx_PreservedBalanceCarriesToLaterTxCreate(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x8246C"))
@@ -77,7 +66,7 @@ func TestEIP8246_FinalizeTx_PreservedBalanceCarriesToLaterTxCreate(t *testing.T)
 	defer ibs.Close()
 
 	ibs.SetTxContext(1, 0)
-	_, err := ibs.Selfdestruct(addr, true /* preserveBalance */)
+	_, err := ibs.Selfdestruct(addr, true)
 	require.NoError(t, err)
 	require.NoError(t, ibs.FinalizeTx(rules, NewNoopWriter()))
 
@@ -88,22 +77,18 @@ func TestEIP8246_FinalizeTx_PreservedBalanceCarriesToLaterTxCreate(t *testing.T)
 	require.Equal(t, *uint256.NewInt(100), bal, "EIP-8246: preserved balance must carry into a later-tx CREATE2 on the assembler's shared IBS")
 }
 
-// getVersionedAccount must not treat a later Balance/Nonce/CodeHash write
-// as a revival. An in-block-created account that self-destructs (preserving
-// balance) and is then funded by a later tx must still be reconstructed — with
-// the later funding overlaid — so a concurrent reader sees it exist, matching
-// serial. Only a genuine re-creation (a later AddressPath) skips reconstruction.
+// getVersionedAccount must not mistake a later Balance/Nonce/CodeHash write for
+// a revival — only a later AddressPath write re-creates the account.
 func TestEIP8246_VersionedAccount_LaterBalanceWriteDoesNotSkipReconstruction(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x8246D"))
-	reader := newAccountStateReader() // in-block-created: no pre-block record
+	reader := newAccountStateReader()
 
 	vm := NewVersionMap(nil)
 	sdVer := Version{TxIndex: 0}
 	vm.WriteSelfDestruct(addr, sdVer, true, true)
 	vm.WriteBalance(addr, sdVer, *uint256.NewInt(1), true)
 	vm.WriteIncarnation(addr, sdVer, 1, true)
-	// A later tx funds the preserved account — a balance write only, no re-creation.
 	vm.WriteBalance(addr, Version{TxIndex: 1}, *uint256.NewInt(2), true)
 
 	ibs := New(reader)
@@ -121,12 +106,7 @@ func TestEIP8246_VersionedAccount_LaterBalanceWriteDoesNotSkipReconstruction(t *
 	require.Equal(t, *uint256.NewInt(2), bal, "reader must see the latest funded balance of the preserved account")
 }
 
-// The persisted balance-only record has incarnation 0, so a later CREATE2 over
-// a preserved account must compute incarnation 1 in every execution mode.
-// Selfdestruct publishes the pre-destruct IncarnationPath and extraction keeps
-// it even for self-destructed accounts; without a superseding write the
-// parallel worker's version map serves the stale value and the recreated
-// contract's domain record diverges from serial and from the next block.
+// The persisted preserved-balance record has incarnation 0, so a later CREATE2 must compute incarnation 1 consistently across execution modes.
 func TestEIP8246_CreateAfterPreservedSD_IncarnationAndBalanceAcrossModes(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x8246E1"))
@@ -188,11 +168,7 @@ func TestEIP8246_CreateAfterPreservedSD_IncarnationAndBalanceAcrossModes(t *test
 	})
 }
 
-// Account-level reconstruction of a preserved account must agree with the
-// field-level reads: a later tx's Nonce/CodeHash map entries overlay the
-// reconstructed account exactly like a later balance write does, so a caller
-// materializing the account through getStateObject sees the same fields a
-// per-path read returns.
+// Account-level reconstruction of a preserved account must agree with field-level reads: later Nonce/CodeHash writes overlay both the same way.
 func TestEIP8246_PreservedAccount_OverlaysLaterFieldWrites(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x8246F"))

--- a/execution/state/empty_characterization_test.go
+++ b/execution/state/empty_characterization_test.go
@@ -25,11 +25,8 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// Characterization of Empty() over the parallel (versionMap) path, pinning the
-// EIP-161 emptiness verdict across the cases that make Empty subtle — before
-// rationalizing the whole-account refresh it drives. Empty keys off AddressPath
-// existence and the {Balance,Nonce,CodeHash} fields; it never consults
-// Incarnation, and (EIP-6780) a same-tx self-destruct leaves the account alive.
+// Empty() keys off AddressPath existence and {Balance,Nonce,CodeHash}, never Incarnation; a same-tx
+// self-destruct (EIP-6780) leaves the account alive.
 func emptyCharIBS(reader *accountStateReader, vm *VersionMap, txIndex int) *IntraBlockState {
 	ibs := New(NewVersionedStateReader(txIndex, ReadSet{}, vm, reader))
 	ibs.SetTxContext(0, txIndex)
@@ -44,7 +41,7 @@ func TestEmpty_Characterization(t *testing.T) {
 	t.Run("warm non-empty (balance>0)", func(t *testing.T) {
 		t.Parallel()
 		addr := getAddress(1)
-		reader := newAccountStateReader(addr) // balance 100
+		reader := newAccountStateReader(addr)
 		empty, err := emptyCharIBS(reader, NewVersionMap(nil), 3).Empty(addr)
 		require.NoError(t, err)
 		require.False(t, empty)
@@ -54,7 +51,7 @@ func TestEmpty_Characterization(t *testing.T) {
 		t.Parallel()
 		addr := getAddress(2)
 		reader := &accountStateReader{accounts: map[accounts.Address]*accounts.Account{}}
-		zero := accounts.NewAccount() // balance 0, nonce 0, empty code hash
+		zero := accounts.NewAccount()
 		reader.accounts[addr] = &zero
 		empty, err := emptyCharIBS(reader, NewVersionMap(nil), 3).Empty(addr)
 		require.NoError(t, err)
@@ -77,7 +74,7 @@ func TestEmpty_Characterization(t *testing.T) {
 	t.Run("cross-tx self-destruct (no revival) is empty", func(t *testing.T) {
 		t.Parallel()
 		addr := getAddress(4)
-		reader := newAccountStateReader(addr) // balance 100 in DB
+		reader := newAccountStateReader(addr)
 		vm := NewVersionMap(nil)
 		writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 1}, true, true)
 		empty, err := emptyCharIBS(reader, vm, 3).Empty(addr)
@@ -88,10 +85,8 @@ func TestEmpty_Characterization(t *testing.T) {
 	t.Run("field write without AddressPath zeroes balance -> empty", func(t *testing.T) {
 		t.Parallel()
 		addr := getAddress(5)
-		reader := newAccountStateReader(addr) // balance 100 in DB
+		reader := newAccountStateReader(addr)
 		vm := NewVersionMap(nil)
-		// A prior tx wrote only BalancePath=0 (no AddressPath). Empty overlays
-		// the field on the base record: balance 0, nonce 0, empty code -> empty.
 		writeFor(vm, addr, BalancePath, accounts.NilKey, Version{TxIndex: 1}, uint256.Int{}, true)
 		empty, err := emptyCharIBS(reader, vm, 3).Empty(addr)
 		require.NoError(t, err)

--- a/execution/state/finalize_reader_blockcache_test.go
+++ b/execution/state/finalize_reader_blockcache_test.go
@@ -27,34 +27,8 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TestFinalizeReaderSeesBlockCacheWrite reproduces the root-cause pattern
-// of the trie-root race at block 24839300.
-//
-// In the parallel executor, applyVersionedWrites (rw_v3.go) writes per-tx
-// account updates into the per-block BlockStateCache only — nothing lands
-// in sd.mem until the whole block's BlockStateCache is Flushed at the end.
-//
-// At block-finalize time (engine.Finalize, withdrawals, EIP-7002/7251
-// system calls) an IBS is constructed. When the block is classified
-// historic (tip-adjacent, past the last frozen tx num boundary), the
-// reader used is HistoryReaderV3WithSharedDomains, which chains
-// sd.GetAsOf → ttx.GetAsOf. Neither tier consults the BlockStateCache.
-//
-// As a result, withdrawal processing reads the *pre-block* balance for
-// any address that received an intra-block SubBalance or AddBalance, and
-// then its own balance update overwrites the in-block write at a higher
-// TxIndex during the next flush. The effect observed in the wild:
-// block 24839223 tx 28 subtracts 0.583 ETH from 0x6be457e0...; the
-// block-finalize IBS reads the stale pre-block value, the withdrawal
-// write stomps tx 28's write, and the corruption propagates 77 blocks
-// forward to tx 29 of block 24839300 (+1506 gas diff).
-//
-// This test seeds domains with a pre-block account, mutates the account
-// via BlockStateCache (standing in for tx 28's applyVersionedWrites),
-// and checks both reader variants. CurrentCachedReaderV3 returns the
-// post-tx value (passes). HistoryReaderV3WithSharedDomains misses the
-// blockCache entirely and returns the stale pre-block value — this is
-// the bug the test pins down.
+// Pins that HistoryReaderV3WithBlockCache (unlike WithSharedDomains) sees a
+// pre-flush BlockStateCache write at block-finalize time.
 func TestFinalizeReaderSeesBlockCacheWrite(t *testing.T) {
 	t.Parallel()
 
@@ -64,7 +38,6 @@ func TestFinalizeReaderSeesBlockCacheWrite(t *testing.T) {
 	addr := accounts.InternAddress(common.HexToAddress("0x6be457e04092b28865e0cba84e3b2cfa0f871e67"))
 	addrValue := addr.Value()
 
-	// Pre-block committed balance: the value sd.mem / ttx would return.
 	preBlockBalance := uint256.NewInt(7290)
 	preAcc := &accounts.Account{
 		Nonce:       1,
@@ -77,16 +50,13 @@ func TestFinalizeReaderSeesBlockCacheWrite(t *testing.T) {
 	const preBlockTxNum uint64 = 10
 	const blockStartTxNum uint64 = 20
 	const tx28TxNum uint64 = 28
-	const finalTxNum uint64 = 30 // block-finalize / withdrawal txNum
+	const finalTxNum uint64 = 30
 
 	domains.SetTxNum(preBlockTxNum)
 	require.NoError(t,
 		domains.DomainPut(kv.AccountsDomain, tx, addrValue[:], preEnc, preBlockTxNum, nil),
 	)
 
-	// Simulate tx 28's SubBalance landing in the BlockStateCache (and only
-	// the BlockStateCache — applyVersionedWrites never touches sd.mem in the
-	// parallel path).
 	postTx28Balance := uint256.NewInt(6707)
 	postAcc := &accounts.Account{
 		Nonce:       1,
@@ -100,8 +70,6 @@ func TestFinalizeReaderSeesBlockCacheWrite(t *testing.T) {
 	blockCache.PutCommittedAccount(addr, preAcc)
 	blockCache.WriteAccount(addr, postEnc, 100)
 
-	// Sanity: CurrentCachedReaderV3 (the reader used for non-historic
-	// blocks) sees the post-tx28 value.
 	curReader := NewCurrentCachedReaderV3(domains.AsGetter(tx), blockCache)
 	curAcc, err := curReader.ReadAccountData(addr)
 	require.NoError(t, err)
@@ -109,12 +77,6 @@ func TestFinalizeReaderSeesBlockCacheWrite(t *testing.T) {
 	require.Equal(t, *postTx28Balance, curAcc.Balance,
 		"CurrentCachedReaderV3 must return the post-tx28 balance from blockCache")
 
-	// The actual bug: HistoryReaderV3WithSharedDomains (the reader used
-	// for tip-adjacent historic blocks at finalize time) ignores the
-	// BlockStateCache entirely and reads from sd.mem → ttx.
-	// The blockCache-aware variant must see the post-tx28 balance,
-	// otherwise withdrawal processing reads a stale value and overwrites
-	// tx 28's write.
 	_ = tx28TxNum
 	_ = blockStartTxNum
 	histReader := NewHistoryReaderV3WithBlockCache(tx, domains, blockCache, finalTxNum)
@@ -126,10 +88,6 @@ func TestFinalizeReaderSeesBlockCacheWrite(t *testing.T) {
 			"otherwise withdrawal processing reads the stale pre-block balance and stomps tx 28's write, "+
 			"which is the root cause of the trie-root race at block 24839300")
 
-	// Sanity: the sd-only variant still misses the blockCache write. This
-	// pins down why callers that construct a finalize IBS must use the
-	// blockCache-aware constructor above — swapping it back would
-	// reintroduce the 24839300 bug.
 	sdOnly := NewHistoryReaderV3WithSharedDomains(tx, domains, finalTxNum)
 	sdAcc, err := sdOnly.ReadAccountData(addr)
 	require.NoError(t, err)

--- a/execution/state/genesiswrite/genesis_test.go
+++ b/execution/state/genesiswrite/genesis_test.go
@@ -147,8 +147,7 @@ func TestAllocConstructor(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	// This deployment code initially sets contract's 0th storage to 0x2a
-	// and its 1st storage to 0x01c9.
+	// sets storage slot 0 to 0x2a and slot 1 to 0x01c9
 	deploymentCode := common.FromHex("602a5f556101c960015560048060135f395ff35f355f55")
 
 	funds := big.NewInt(1000000000)
@@ -168,7 +167,6 @@ func TestAllocConstructor(t *testing.T) {
 	require.NoError(err)
 	defer tx.Rollback()
 
-	//TODO: support historyV3
 	reader, err := rpchelper.CreateHistoryStateReader(ctx, tx, 1, 0, rawdbv3.TxNums)
 	require.NoError(err)
 	state := state.New(reader)
@@ -216,14 +214,11 @@ func TestGenesisStorageBearingEmptyAccountIsPresent(t *testing.T) {
 	require.NoError(err)
 	defer tx.Rollback()
 
-	// Ground truth for DomainDel's guard: the accounts domain must hold a
-	// non-empty entry for this address (not dangling storage under an absent account).
 	av := address.Value()
 	acc, _, err := tx.GetLatest(kv.AccountsDomain, av[:])
 	require.NoError(err)
 	require.NotEmpty(acc, "storage-bearing empty alloc must produce a present accounts-domain entry")
 
-	// High-level view agrees: account exists, storage is set, balance/nonce/code stay empty.
 	reader, err := rpchelper.CreateHistoryStateReader(ctx, tx, 1, 0, rawdbv3.TxNums)
 	require.NoError(err)
 	st := state.New(reader)
@@ -245,7 +240,6 @@ func TestGenesisStorageBearingEmptyAccountIsPresent(t *testing.T) {
 	assert.Equal(u256.U64(0x2a), got, "storage slot must be readable")
 }
 
-// See https://github.com/erigontech/erigon/pull/11264
 func TestDecodeBalance0(t *testing.T) {
 	genesisData, err := os.ReadFile("./genesis_test.json")
 	require.NoError(t, err)
@@ -314,10 +308,6 @@ func TestSetupGenesis(t *testing.T) {
 			wantConfig: customg.Config,
 		},
 		{
-			// Reproduces the hive EEST consume-rlp scenario:
-			// 1. `erigon init genesis.json` writes a custom genesis + config
-			// 2. `erigon --import` reopens the DB with genesis=nil, chainName="mainnet" (default)
-			// The custom config must be preserved, not overwritten with mainnet's.
 			name: "custom block in DB, genesis == nil, chainName mainnet",
 			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
 				genesiswrite.MustCommitGenesis(&customg, db, datadir.New(tmpdir), logger)
@@ -348,11 +338,6 @@ func TestSetupGenesis(t *testing.T) {
 		{
 			name: "incompatible config in DB",
 			fn: func(t *testing.T, db kv.RwDB, tmpdir string) (*chain.Config, *types.Block, error) {
-				//if ethconfig.EnableHistoryV4InTest {
-				//	t.Skip("fix me")
-				//}
-				// Commit the 'old' genesis block with Homestead transition at #2.
-				// Advance to block #4, past the homestead transition block of customg.
 				key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 				m := execmoduletester.New(t, execmoduletester.WithGenesisSpec(&oldcustomg), execmoduletester.WithKey(key))
 
@@ -363,7 +348,6 @@ func TestSetupGenesis(t *testing.T) {
 				if err := m.InsertChain(chainBlocks); err != nil {
 					return nil, nil, err
 				}
-				// This should return a compatibility error.
 				return genesiswrite.CommitGenesisBlock(m.DB, &customg, "", datadir.New(tmpdir), logger)
 			},
 			wantHash:   customghash,
@@ -384,7 +368,6 @@ func TestSetupGenesis(t *testing.T) {
 			db := temporaltest.NewTestDB(t, dirs)
 			blockReader := freezeblocks.NewBlockReader(db.(freezeblocks.HasBlockFiles).DebugBlockFiles(), nil)
 			config, genesis, err := test.fn(t, db, tmpdir)
-			// Check the return values.
 			if !reflect.DeepEqual(err, test.wantErr) {
 				spew := spew.ConfigState{DisablePointerAddresses: true, DisableCapacities: true}
 				t.Fatalf("%s: returned error %#v, want %#v", test.name, spew.NewFormatter(err), spew.NewFormatter(test.wantErr))
@@ -405,7 +388,6 @@ func TestSetupGenesis(t *testing.T) {
 				t.Errorf("%s: returned hash %s, want %s", test.name, genesis.Hash().Hex(), test.wantHash.Hex())
 			} else if err == nil {
 				if dbErr := db.View(context.Background(), func(tx kv.Tx) error {
-					// Check database content.
 					stored, _, _ := blockReader.BlockWithSenders(context.Background(), tx, test.wantHash, 0)
 					if stored.Hash() != test.wantHash {
 						t.Errorf("%s: block in DB has hash %s, want %s", test.name, stored.Hash(), test.wantHash)

--- a/execution/state/genesiswrite/genesis_write.go
+++ b/execution/state/genesiswrite/genesis_write.go
@@ -54,8 +54,6 @@ import (
 	polygonchain "github.com/erigontech/erigon/polygon/chain"
 )
 
-// GenesisMismatchError is raised when trying to overwrite an existing
-// genesis block with an incompatible one.
 type GenesisMismatchError struct {
 	Stored, New common.Hash
 }
@@ -75,19 +73,7 @@ func (e *GenesisMismatchError) Error() string {
 	return fmt.Sprintf("database contains genesis (have %x, new %x)", e.Stored, e.New) + advice
 }
 
-// CommitGenesisBlock writes or updates the genesis block in db.
-// The block that will be used is:
-//
-//	                     genesis == nil       genesis != nil
-//	                  +------------------------------------------
-//	db has no genesis |  main-net          |  genesis
-//	db has genesis    |  from DB           |  genesis (if compatible)
-//
-// The stored chain configuration will be updated if it is compatible (i.e. does not
-// specify a fork block below the local head block). In case of a conflict, the
-// error is a *params.ConfigCompatError and the new, unwritten config is returned.
-//
-// The returned chain configuration is never nil.
+// CommitGenesisBlock writes or updates the genesis block in db, keeping the stored block unless a compatible new genesis is given; a fork-order conflict returns *chain.ConfigCompatError with the new, unwritten config.
 func CommitGenesisBlock(db kv.RwDB, genesis *types.Genesis, chainName string, dirs datadir.Dirs, logger log.Logger) (*chain.Config, *types.Block, error) {
 	return CommitGenesisBlockWithOverride(db, genesis, chainName, nil, nil, false, dirs, logger)
 }
@@ -136,7 +122,6 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, chainName string, ove
 			return nil, nil, err
 		}
 	}
-	// Just commit the new block if there is no stored genesis block.
 	storedHash, storedErr := rawdb.ReadCanonicalHash(tx, 0)
 	if storedErr != nil {
 		return nil, nil, storedErr
@@ -169,7 +154,6 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, chainName string, ove
 		return genesis.Config, block, nil
 	}
 
-	// Check whether the genesis block is already written.
 	if genesis != nil {
 		block, ibs, err1 := GenesisToBlock(genesis, dirs, logger)
 		if err1 != nil {
@@ -189,7 +173,6 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, chainName string, ove
 			return genesis.Config, nil, err
 		}
 	}
-	// Get the existing chain configuration.
 	newCfg := configOrDefault(genesis, chainName, storedHash)
 	applyOverrides(newCfg)
 	if err := newCfg.CheckConfigForkOrder(); err != nil {
@@ -207,19 +190,13 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, chainName string, ove
 		}
 		return newCfg, storedBlock, nil
 	}
-	// Special case: don't change the existing config of a private chain if no new
-	// config is supplied. This is useful, for example, to preserve DB config created by erigon init.
-	// In that case, only apply the overrides.
 	if genesis == nil {
 		if !keepStoredChainConfig {
 			spec, err := chainspec.ChainSpecByName(chainName)
 			if err != nil {
-				// Unknown chain name — always keep stored config
-				keepStoredChainConfig = true
+				keepStoredChainConfig = true // unknown chain name
 			} else if spec.GenesisHash != (common.Hash{}) && spec.GenesisHash != storedHash {
-				// Known chain name but genesis hash doesn't match (e.g. custom
-				// genesis with chainId 1 in Hive tests) — keep stored config
-				keepStoredChainConfig = true
+				keepStoredChainConfig = true // genesis hash doesn't match the named chain
 			}
 		}
 		if keepStoredChainConfig {
@@ -227,8 +204,7 @@ func WriteGenesisBlock(tx kv.RwTx, genesis *types.Genesis, chainName string, ove
 			applyOverrides(newCfg)
 		}
 	}
-	// Check config compatibility and write the config. Compatibility errors
-	// are returned to the caller unless we're already at block zero.
+	// compatibility errors are ignored at block zero, since there is nothing to rewind yet
 	height := rawdb.ReadHeaderNumber(tx, rawdb.ReadHeadHeaderHash(tx))
 	if height != nil {
 		compatibilityErr := storedCfg.CheckCompatible(newCfg, *height)
@@ -279,8 +255,6 @@ func MustCommitGenesis(g *types.Genesis, db kv.RwDB, dirs datadir.Dirs, logger l
 	return block
 }
 
-// Write writes the block and state of a genesis specification to the database.
-// The block is committed as the canonical head block.
 func write(tx kv.RwTx, g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*types.Block, error) {
 	block, err := WriteGenesisState(g, dirs, logger)
 	if err != nil {
@@ -290,8 +264,6 @@ func write(tx kv.RwTx, g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (
 	return block, err
 }
 
-// Write writes the block a genesis specification to the database.
-// The block is committed as the canonical head block.
 func WriteGenesisBesideState(block *types.Block, tx kv.RwTx, g *types.Genesis) error {
 	config := g.Config
 	if config == nil {
@@ -326,28 +298,17 @@ func WriteGenesisBesideState(block *types.Block, tx kv.RwTx, g *types.Genesis) e
 	return rawdb.WriteChainConfig(tx, block.Hash(), config)
 }
 
-// GenesisToBlock creates the genesis block and writes state of a genesis specification
-// to the given database (or discards it if nil).
 func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*types.Block, *state.IntraBlockState, error) {
 	if dirs.SnapDomain == "" {
 		panic("empty `dirs` variable")
 	}
-	_ = g.Alloc //nil-check
+	_ = g.Alloc // clear panic here if g is nil, instead of a cryptic one deeper in the call chain
 
 	head, withdrawals := GenesisWithoutStateToBlock(g)
 
 	ctx := context.Background()
 
-	// some users creating > 1Gb custom genesis by `erigon init`.
-	// On Windows, MDBX file-mappings are backed by the paging file for their
-	// full map size, so a large reservation immediately exhausts the pagefile
-	// when parallel goroutines open multiple databases. On Linux/macOS the
-	// reservation is sparse, but each open env still eats from the process's
-	// finite virtual address space (~128 TB on x86-64) — enough to matter
-	// when many EngineApiTester instances are alive in one process. 16 GB
-	// keeps headroom for outsized custom genesis allocations while letting
-	// 100+ testers coexist. 1 GB on Windows because the pagefile minimum is
-	// 8 GB.
+	// Windows reserves the whole map size against the pagefile up front, so cap it small there; the reservation is sparse on Linux/macOS but still eats finite process address space when many DBs are open at once.
 	genesisMapSize := 16 * datasize.GB
 	if runtime.GOOS == "windows" {
 		genesisMapSize = 1 * datasize.GB
@@ -397,7 +358,7 @@ func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*ty
 
 func ComputeGenesisCommitment(ctx context.Context, g *types.Genesis, tx kv.TemporalTx, sd *execctx.SharedDomains, head *types.Header) ([]byte, *state.IntraBlockState, error) {
 	blockNum := uint64(0)
-	txNum := uint64(1) // 2 system txs in begin/end of block. Attribute state-writes to first, consensus state-changes to second
+	txNum := uint64(1) // first of 2 system txs; state writes attribute here, consensus changes to the second
 
 	r, w := state.NewReaderV3(sd.AsGetter(tx)), state.NewWriter(sd.AsPutDel(tx), nil, txNum)
 
@@ -474,7 +435,6 @@ func ComputeGenesisCommitment(ctx context.Context, g *types.Genesis, tx kv.Tempo
 	return rh, statedb, nil
 }
 
-// GenesisWithoutStateToBlock creates the genesis block, assuming an empty state.
 func GenesisWithoutStateToBlock(g *types.Genesis) (head *types.Header, withdrawals []*types.Withdrawal) {
 	head = &types.Header{
 		Number:        *uint256.NewInt(g.Number),
@@ -556,7 +516,6 @@ func GenesisWithoutStateToBlock(g *types.Genesis) (head *types.Header, withdrawa
 		}
 	}
 
-	// these fields need to be overridden for Bor running in a kurtosis devnet
 	if g.Config != nil && g.Config.Bor != nil && g.Config.ChainID.Uint64() == polygonchain.BorKurtosisDevnetChainId {
 		withdrawals = []*types.Withdrawal{}
 		head.BlobGasUsed = new(uint64)

--- a/execution/state/history_reader_v3.go
+++ b/execution/state/history_reader_v3.go
@@ -32,29 +32,10 @@ import (
 
 var PrunedError = errors.New("old data not available due to pruning")
 
-// HistoryReaderV3 Implements StateReader and StateWriter.
-//
-// The read chain, from most-recent to persisted, is:
-//
-//	blockCache (in-flight parallel-block writes, per-field) →
-//	sd.GetAsOf (in-batch memory state) →
-//	ttx.GetAsOf (DB history + snapshot files).
-//
-// blockCache is populated by applyVersionedWrites in the parallel executor
-// for every committed tx in the current block. Those writes do NOT land in
-// sd.mem until Flush at block boundary, so a finalize-time IBS constructed
-// in historic mode (withdrawals, EIP-7002/7251 system calls on a
-// tip-adjacent historic block) would otherwise read the pre-block balance
-// and stomp a prior tx's in-block update. Consulting blockCache first fixes
-// that gap.
-//
-// sd is the SharedDomains for the batch. When non-nil, the reader checks
-// sd.GetAsOf before ttx.GetAsOf so prior-batch writes that haven't been
-// flushed to the history index yet are still visible.
-//
-// RPC and other consumers that want to read strictly persisted history
-// pass sd=nil and blockCache=nil via the legacy NewHistoryReaderV3
-// constructor.
+// HistoryReaderV3 implements StateReader/StateWriter, reading blockCache
+// (in-flight per-block writes) before sd.GetAsOf (unflushed in-batch state)
+// before ttx.GetAsOf (persisted history): a finalize-time historic read would
+// otherwise see the pre-block value and stomp an earlier tx's write.
 type HistoryReaderV3 struct {
 	ttx         kv.TemporalTx
 	sd          *execctx.SharedDomains
@@ -70,42 +51,20 @@ func NewHistoryReaderV3(ttx kv.TemporalTx, txNum uint64) *HistoryReaderV3 {
 	return &HistoryReaderV3{ttx: ttx, txNum: txNum}
 }
 
-// NewHistoryReaderV3WithSharedDomains is the in-batch variant used by the
-// parallel executor. Reads chain sd.GetAsOf (in-memory batch state) then
-// fall back to ttx.GetAsOf so a tx can see prior-tx writes from the same
-// batch that have not yet been flushed to the history index.
 func NewHistoryReaderV3WithSharedDomains(ttx kv.TemporalTx, sd *execctx.SharedDomains, txNum uint64) *HistoryReaderV3 {
 	return &HistoryReaderV3{ttx: ttx, sd: sd, txNum: txNum}
 }
 
-// NewHistoryReaderV3WithBlockCache is the finalize-time variant used by
-// the parallel executor for historic blocks. In addition to the
-// sd.GetAsOf → ttx.GetAsOf chain, it consults the per-block BlockStateCache
-// first so the block-finalize IBS (withdrawals, EIP-7002/7251 system calls)
-// sees every prior-tx write recorded in the current block, not just the
-// pre-block committed state.
 func NewHistoryReaderV3WithBlockCache(ttx kv.TemporalTx, sd *execctx.SharedDomains, blockCache *BlockStateCache, txNum uint64) *HistoryReaderV3 {
 	return &HistoryReaderV3{ttx: ttx, sd: sd, blockCache: blockCache, txNum: txNum}
 }
 
-// SetBlockStateCache updates the in-flight block cache tier. Used when the
-// reader is reused across blocks in the parallel executor.
 func (hr *HistoryReaderV3) SetBlockStateCache(cache *BlockStateCache) {
 	hr.blockCache = cache
 }
 
-// getAsOf chains blockCache (in-flight parallel block writes, per-field)
-// before sd.GetAsOf (in-batch memory) and ttx.GetAsOf (DB history +
-// snapshot files). Callers requesting only persisted history construct the
-// reader with sd=nil and blockCache=nil. If sd.mem has inMemHistoryReads
-// disabled (e.g. the serial executor path), sd.GetAsOf returns an error —
-// we silently fall through to ttx so the same reader type is usable in
-// both modes.
-//
-// blockCache is consulted for the AccountsDomain and StorageDomain only;
-// CodeDomain is not currently cached per block, so for code reads we fall
-// straight through to sd/ttx. For storage we use the full 52-byte
-// composite key (addr||slot) like the rest of the state domain.
+// blockCache covers Accounts/Storage only, not Code. sd.GetAsOf errors (e.g.
+// history reads disabled) fall through to ttx rather than failing the read.
 func (hr *HistoryReaderV3) getAsOf(domain kv.Domain, key []byte) (enc []byte, ok bool, err error) {
 	if hr.blockCache != nil {
 		switch domain {
@@ -115,12 +74,8 @@ func (hr *HistoryReaderV3) getAsOf(domain kv.Domain, key []byte) (enc []byte, ok
 				copy(raw[:], key)
 				addr := accounts.InternAddress(raw)
 				if cached, hit := hr.blockCache.GetCurrentAccount(addr); hit {
-					// hit==true is authoritative for the in-flight block, including the
-					// deletion case (cached==nil). Return immediately rather than falling
-					// through to sd/ttx, which would surface the pre-deletion value from
-					// history. Downstream callers (ReadAccountData) treat enc=nil as
-					// "no account" regardless of ok, so emitting ok=true here just
-					// reflects the cache's authoritative status.
+					// hit==true is authoritative even when cached==nil (deleted): return
+					// now, don't fall through to sd/ttx and resurrect the pre-deletion value.
 					if cached == nil {
 						return nil, false, nil
 					}
@@ -136,8 +91,7 @@ func (hr *HistoryReaderV3) getAsOf(domain kv.Domain, key []byte) (enc []byte, ok
 				addr := accounts.InternAddress(rawAddr)
 				slot := accounts.InternKey(rawSlot)
 				if cached, hit := hr.blockCache.GetCurrentStorage(addr, slot); hit {
-					// Same as the account case above: hit==true is authoritative even
-					// when the slot was cleared (len(cached)==0), so do not fall through.
+					// Same as the account case: authoritative even when cleared (len==0).
 					if len(cached) == 0 {
 						return nil, false, nil
 					}
@@ -174,12 +128,6 @@ func (r *HistoryReaderV3) TracePrefix() string {
 	return r.tracePrefix
 }
 
-// Gets the txNum where Account, Storage and Code history begins.
-// If the node is an archive node all history will be available therefore
-// the result will be 0.
-//
-// For non-archive node old history files get deleted, so this number will vary
-// but the goal is to know where the historical data begins.
 func StateHistoryStartTxNum(ttx kv.TemporalTx) uint64 {
 	dbg := ttx.Debug()
 	return min(
@@ -210,8 +158,6 @@ func (hr *HistoryReaderV3) ReadAccountData(address accounts.Address) (*accounts.
 	return &a, nil
 }
 
-// ReadAccountDataForDebug - is like ReadAccountData, but without adding key to `readList`.
-// Used to get `prev` account balance
 func (hr *HistoryReaderV3) ReadAccountDataForDebug(address accounts.Address) (*accounts.Account, error) {
 	return hr.ReadAccountData(address)
 }
@@ -245,10 +191,7 @@ func (hr *HistoryReaderV3) HasStorage(address accounts.Address) (bool, error) {
 	}
 
 	defer it.Close()
-	// Note: if a storage for an address gets deleted, the historical RangeAsOf will return its slots as empty values.
-	// If the address doesn't have any storage slots, then we return "no storage" immediately
-	// If the address has storage slots, but they are all empty, then we return "no storage"
-	// If we see a non-empty slot for then address, then we return "has storage" immediately
+	// A deleted storage slot surfaces as an empty value in RangeAsOf's history, not as an absent key.
 	for it.HasNext() {
 		_, v, err := it.Next()
 		if err != nil {
@@ -264,8 +207,7 @@ func (hr *HistoryReaderV3) HasStorage(address accounts.Address) (bool, error) {
 }
 
 func (hr *HistoryReaderV3) ReadAccountCode(address accounts.Address) ([]byte, error) {
-	//  must pass key2=Nil here: because Erigon4 does concatinate key1+key2 under the hood
-	//code, _, err := hr.ttx.GetAsOf(kv.CodeDomain, address.Bytes(), codeHash.Bytes(), hr.txNum)
+	// CodeDomain keys are address-only; do not append codeHash.
 	hr.addr = address.Value()
 	code, _, err := hr.getAsOf(kv.CodeDomain, hr.addr[:])
 	if hr.trace {

--- a/execution/state/ibs_2cache_test.go
+++ b/execution/state/ibs_2cache_test.go
@@ -14,10 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Erigon. If not, see <http://www.gnu.org/licenses/>.
 
-// Package-level baseline tests for the 2-cache IBS refactor (issue #19623).
-// Phase 1: tests only, no production code changes.
-// These tests document current invariants and will catch regressions across
-// subsequent phases.
 package state
 
 import (
@@ -32,9 +28,8 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// writeIndex builds a lookup map from a WriteSet, keyed by (Path, Key) — the
-// address is not part of the key, so this assumes a single-address WriteSet
-// (use addrWriteIndex for multiple). Value is the typed Val field.
+// writeIndex indexes a WriteSet by (Path, Key), dropping Address — safe only
+// for a single-address WriteSet (see addrWriteIndex for multiple).
 func writeIndex(writes *WriteSet) map[AccountKey]any {
 	idx := make(map[AccountKey]any)
 	for h := range writes.AllHeaders() {
@@ -43,7 +38,6 @@ func writeIndex(writes *WriteSet) map[AccountKey]any {
 	return idx
 }
 
-// addrWriteIndex is like writeIndex but scoped to a single address.
 func addrWriteIndex(writes *WriteSet, addr accounts.Address) map[AccountKey]any {
 	idx := make(map[AccountKey]any)
 	for h := range writes.AllHeaders() {
@@ -54,12 +48,6 @@ func addrWriteIndex(writes *WriteSet, addr accounts.Address) map[AccountKey]any 
 	return idx
 }
 
-// TestVersionedWritesMatchStateObjects verifies that after a sequence of EVM
-// state operations every field in every stateObject is reflected in
-// VersionedWrites with the same value.
-//
-// This is the fundamental invariant that allows Phase 2 to derive StateUpdates
-// directly from VersionedWrites without reconstructing an IBS.
 func TestVersionedWritesMatchStateObjects(t *testing.T) {
 	t.Parallel()
 
@@ -76,7 +64,6 @@ func TestVersionedWritesMatchStateObjects(t *testing.T) {
 	key2 := accounts.InternKey(common.HexToHash("0x0002"))
 	code1 := []byte{0xde, 0xad, 0xbe, 0xef}
 
-	// addr1: balance + nonce + code + two storage slots
 	err := ibs.SetBalance(addr1, *uint256.NewInt(100), tracing.BalanceChangeUnspecified)
 	require.NoError(t, err)
 	err = ibs.SetNonce(addr1, 7, tracing.NonceChangeUnspecified)
@@ -88,15 +75,13 @@ func TestVersionedWritesMatchStateObjects(t *testing.T) {
 	err = ibs.SetState(addr1, key2, *uint256.NewInt(99))
 	require.NoError(t, err)
 
-	// addr2: CreateAccount + balance only
 	ibs.CreateAccount(addr2, true)
 	err = ibs.SetBalance(addr2, *uint256.NewInt(200), tracing.BalanceChangeUnspecified)
 	require.NoError(t, err)
 
-	// Capture VersionedWrites BEFORE FinalizeTx (journal.dirties still intact).
+	// Capture writes before FinalizeTx: it clears journal.dirties.
 	writes := ibs.VersionedWrites()
 
-	// — addr1 checks —
 	idx1 := addrWriteIndex(writes, addr1)
 
 	wbal1, ok := idx1[AccountKey{Path: BalancePath, Key: accounts.NilKey}]
@@ -129,7 +114,6 @@ func TestVersionedWritesMatchStateObjects(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, stor2, wstor2.(uint256.Int), "addr1: storage[key2] mismatch between stateObject and VersionedWrites")
 
-	// — addr2 checks —
 	idx2 := addrWriteIndex(writes, addr2)
 
 	wbal2, ok := idx2[AccountKey{Path: BalancePath, Key: accounts.NilKey}]
@@ -139,13 +123,8 @@ func TestVersionedWritesMatchStateObjects(t *testing.T) {
 	require.Equal(t, bal2, wbal2.(uint256.Int), "addr2: balance mismatch between stateObject and VersionedWrites")
 }
 
-// TestSnapshotRandomWithVersionMap extends the snapshot-revert correctness
-// check to the versionMap path. It verifies that after reverting to a
-// snapshot, both stateObject accessors and VersionedWrites agree on the
-// pre-snapshot values.
-//
-// In Phase 5 (remove stateObject), the stateObject side of this comparison
-// disappears; the VersionedWrites side must still pass.
+// TestSnapshotRandomWithVersionMap checks that stateObject accessors and
+// VersionedWrites agree after a snapshot revert.
 func TestSnapshotRandomWithVersionMap(t *testing.T) {
 	t.Parallel()
 
@@ -160,7 +139,6 @@ func TestSnapshotRandomWithVersionMap(t *testing.T) {
 	defer ibs.Close()
 	ibs.SetTxContext(1, 0)
 
-	// Pre-snapshot state
 	err := ibs.SetBalance(addr, *uint256.NewInt(50), tracing.BalanceChangeUnspecified)
 	require.NoError(t, err)
 	err = ibs.SetNonce(addr, 3, tracing.NonceChangeUnspecified)
@@ -170,7 +148,6 @@ func TestSnapshotRandomWithVersionMap(t *testing.T) {
 
 	snap := ibs.PushSnapshot()
 
-	// Post-snapshot modifications
 	err = ibs.SetBalance(addr, *uint256.NewInt(999), tracing.BalanceChangeUnspecified)
 	require.NoError(t, err)
 	err = ibs.SetNonce(addr, 42, tracing.NonceChangeUnspecified)
@@ -178,11 +155,9 @@ func TestSnapshotRandomWithVersionMap(t *testing.T) {
 	err = ibs.SetState(addr, key, *uint256.NewInt(77))
 	require.NoError(t, err)
 
-	// Revert to snapshot
 	ibs.RevertToSnapshot(snap, nil)
 	ibs.PopSnapshot(snap)
 
-	// stateObject accessors must reflect pre-snapshot values
 	bal, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
 	require.Equal(t, uint256.NewInt(50), &bal, "balance should be reverted to pre-snapshot value")
@@ -195,7 +170,6 @@ func TestSnapshotRandomWithVersionMap(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint256.NewInt(11), &stor, "storage should be reverted to pre-snapshot value")
 
-	// VersionedWrites must reflect the same reverted values.
 	writes := ibs.VersionedWrites()
 	idx := addrWriteIndex(writes, addr)
 
@@ -212,16 +186,8 @@ func TestSnapshotRandomWithVersionMap(t *testing.T) {
 	require.Equal(t, *uint256.NewInt(11), wstor.(uint256.Int), "VersionedWrites storage should reflect reverted value")
 }
 
-// TestCommittedStateWithVersionMap verifies that GetCommittedState returns the
-// pre-transaction value (the EIP-1283 "original value") when reading through
-// a versionMap.
-//
-// Concretely: tx0 writes val1 to (addr, key) and flushes to the versionMap;
-// tx1 then writes val2 to the same slot. A call to GetCommittedState from tx1
-// must return val1 (the value as seen at the start of tx1), not val2.
-//
-// This invariant is required for SSTORE gas calculation correctness and must
-// hold after all 2-cache refactor phases.
+// TestCommittedStateWithVersionMap checks GetCommittedState returns the
+// pre-tx value (EIP-1283 "original value") even after a later tx overwrites it.
 func TestCommittedStateWithVersionMap(t *testing.T) {
 	t.Parallel()
 
@@ -235,7 +201,6 @@ func TestCommittedStateWithVersionMap(t *testing.T) {
 	val1 := *uint256.NewInt(111)
 	val2 := *uint256.NewInt(222)
 
-	// — tx0 (txIndex 0) — writes val1, flushes to versionMap —
 	ibs0 := NewWithVersionMap(reader, mvhm)
 	defer ibs0.Close()
 	ibs0.SetTxContext(1, 0)
@@ -243,40 +208,31 @@ func TestCommittedStateWithVersionMap(t *testing.T) {
 	err := ibs0.SetState(addr, key, val1)
 	require.NoError(t, err)
 
-	// Capture and flush before FinalizeTx (journal.dirties still populated).
 	writes0 := ibs0.VersionedWrites()
 	mvhm.FlushVersionedWrites(writes0, true, "")
 
-	// — tx1 (txIndex 1) — reads committed state before modifying —
 	ibs1 := NewWithVersionMap(reader, mvhm)
 	defer ibs1.Close()
 	ibs1.SetTxContext(1, 1)
 
-	// Before tx1 writes anything, committed state must be val1.
 	committed, err := ibs1.GetCommittedState(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val1, committed, "GetCommittedState must return pre-tx value (val1) before any tx1 write")
 
-	// tx1 now writes val2 to the same slot.
 	err = ibs1.SetState(addr, key, val2)
 	require.NoError(t, err)
 
-	// Even after writing val2, committed state must still be val1.
 	committed2, err := ibs1.GetCommittedState(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val1, committed2, "GetCommittedState must continue to return val1 after tx1 writes val2")
 
-	// Current (non-committed) state must be val2.
 	current, err := ibs1.GetState(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val2, current, "GetState must return the current tx1 value (val2)")
 }
 
-// TestCrossBlockStateReadConsistency verifies that a new IBS created for
-// block N+1 correctly reads state written by block N through SharedDomains.
-//
-// This is the baseline cross-block read correctness test. It must pass
-// throughout all 2-cache refactor phases.
+// TestCrossBlockStateReadConsistency checks a new IBS for block N+1 reads
+// state block N committed to SharedDomains.
 func TestCrossBlockStateReadConsistency(t *testing.T) {
 	t.Parallel()
 
@@ -288,7 +244,6 @@ func TestCrossBlockStateReadConsistency(t *testing.T) {
 	wantNonce := uint64(13)
 	wantStorage := *uint256.NewInt(555)
 
-	// — Block N: write state then commit to domains via Writer —
 	{
 		ibsN := New(NewReaderV3(domains.AsGetter(tx)))
 		defer ibsN.Close()
@@ -306,7 +261,6 @@ func TestCrossBlockStateReadConsistency(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// — Block N+1: fresh IBS reads state that block N wrote to domains —
 	ibsN1 := New(NewReaderV3(domains.AsGetter(tx)))
 	defer ibsN1.Close()
 
@@ -323,12 +277,8 @@ func TestCrossBlockStateReadConsistency(t *testing.T) {
 	require.Equal(t, wantStorage, gotStorage, "block N+1 must read block N's committed storage")
 }
 
-// TestDomainApplyFromVersionedWrites verifies that applying VersionedWrites
-// through the existing round-trip path (ApplyVersionedWrites → IBS →
-// FinalizeTx → Writer) produces the correct domain state.
-//
-// This is the baseline that Phase 2's StateUpdatesFromVersionedWrites must
-// reproduce without the IBS round-trip.
+// TestDomainApplyFromVersionedWrites checks that replaying VersionedWrites
+// through ApplyVersionedWrites + FinalizeTx yields the same domain state.
 func TestDomainApplyFromVersionedWrites(t *testing.T) {
 	t.Parallel()
 
@@ -342,7 +292,6 @@ func TestDomainApplyFromVersionedWrites(t *testing.T) {
 	wantNonce := uint64(9)
 	wantStorage := *uint256.NewInt(456)
 
-	// — Step 1: produce VersionedWrites via a tx —
 	ibsTx := NewWithVersionMap(reader, mvhm)
 	defer ibsTx.Close()
 	ibsTx.SetTxContext(1, 0)
@@ -357,7 +306,6 @@ func TestDomainApplyFromVersionedWrites(t *testing.T) {
 	writes := ibsTx.VersionedWrites()
 	require.NotEmpty(t, writes, "VersionedWrites must not be empty")
 
-	// — Step 2: apply VersionedWrites through existing round-trip path —
 	ibsApply := New(reader)
 	defer ibsApply.Close()
 	err = ibsApply.ApplyVersionedWrites(writes)
@@ -367,7 +315,6 @@ func TestDomainApplyFromVersionedWrites(t *testing.T) {
 	err = ibsApply.FinalizeTx(&chain.Rules{}, w)
 	require.NoError(t, err)
 
-	// — Step 3: read back from domains, assert correct state —
 	ibsRead := New(NewReaderV3(domains.AsGetter(tx)))
 	defer ibsRead.Close()
 

--- a/execution/state/intra_block_state.go
+++ b/execution/state/intra_block_state.go
@@ -45,7 +45,7 @@ import (
 	"github.com/erigontech/erigon/execution/vm/evmtypes"
 )
 
-var _ evmtypes.IntraBlockState = new(IntraBlockState) // compile-time interface-check
+var _ evmtypes.IntraBlockState = new(IntraBlockState)
 
 type revision struct {
 	id           int
@@ -88,7 +88,6 @@ func (r *revisions) reset() {
 }
 
 func (r *revisions) revertToSnapshot(revid int) int {
-	// Find the snapshot in the stack of valid snapshots.
 	idx := sort.Search(len(r.valid), func(i int) bool {
 		return r.valid[i].id >= revid
 	})
@@ -107,19 +106,14 @@ func (r *revisions) revertToSnapshot(revid int) int {
 	return snapshot.journalIndex
 }
 
-// Snapshot depth tracks EVM call depth: the inline buf covers typical depth
-// alloc-free, deeper stacks spill to the heap, and legal depth (1024 calls
-// plus a few outer tx-level snapshots) grows to at most cap 1280. A slice
-// beyond 2048 means push/pop discipline is broken somewhere — fall back to
-// the inline buf on reset instead of retaining it for the IBS lifetime.
+// Legal call depth keeps this near 1280; growth past 2048 signals broken push/pop discipline, so Reset drops back to the inline buffer.
 const maxRetainedRevisionsCap = 2048
 
-// BalanceIncrease represents the increase of balance of an account that did not require
-// reading the account first
+// BalanceIncrease is a deferred balance increase applied without reading the account first.
 type BalanceIncrease struct {
 	increase    uint256.Int
-	transferred bool // Set to true when the corresponding stateObject is created and balance increase is transferred to the stateObject
-	count       int  // Number of increases - this needs tracking for proper reversion
+	transferred bool
+	count       int
 }
 
 type accessOptions struct {
@@ -138,55 +132,38 @@ func (aa AccessSet) Merge(other AccessSet) AccessSet {
 	return dst
 }
 
-// IntraBlockState is responsible for caching and managing state changes
-// that occur during block's execution.
-// NOT THREAD SAFE!
+// IntraBlockState caches and manages state changes during block execution; NOT THREAD SAFE.
 type IntraBlockState struct {
 	stateReader StateReader
 
-	// This map holds 'live' objects, which will get modified while processing a state transition.
 	stateObjects      map[accounts.Address]*stateObject // used only if `noMaterialize == false`
 	stateObjectsDirty map[accounts.Address]struct{}
 
-	nilAccounts map[accounts.Address]struct{} // Remember non-existent account to avoid reading them again
+	nilAccounts map[accounts.Address]struct{}
 
-	// The refund counter, also used by state transitioning.
 	refund uint64
 
 	txIndex  int
 	blockNum uint64
 	logs     logArena
 
-	// Per-transaction access list
 	accessList accessList
 
-	// Transient storage
 	transientStorage transientStorage
 
-	// Journal of state modifications. This is the backbone of
-	// Snapshot and RevertToSnapshot.
 	journal          *journal
 	stateObjectArena stateObjectArena // same lifetime with `journal`. used only if `noMaterialize == true`
 
 	trace        bool
 	tracingHooks *tracing.Hooks
-	balanceInc   map[accounts.Address]*BalanceIncrease // Map of balance increases (without first reading the account)
-	recordAccess bool                                  // gates MarkAddressAccess — enabled in Prepare
+	balanceInc   map[accounts.Address]*BalanceIncrease
+	recordAccess bool // gates MarkAddressAccess — enabled in Prepare
 
-	// Versioned storage used for parallel tx processing, versions
-	// are maintaned across transactions until they are reset
-	// at the block level.  Per-path typed maps give single-level lookups for
-	// non-storage paths; the AccountKey{Path,Key} struct allocation is gone
-	// from the probe hot path.
+	// Versioned storage for parallel tx processing, reset per block; per-path typed maps avoid an allocation on the read hot path.
 	versionMap      *VersionMap
 	versionedWrites WriteSet
 	versionedReads  ReadSet
-	// committedBase memoizes the per-tx committed (pre-block) account fallback
-	// used by versionedAccountBase when the versionMap has no cell for addr.
-	// The committed view is block-immutable and this branch is only reached on
-	// a versionMap miss (a written account returns via the write-set), so the
-	// cached pointer is safe to share across the tx's read-only callers. Reset
-	// per tx.
+	// committedBase memoizes the per-tx fallback account read when versionMap has no cell; safe to share since the committed view is block-immutable.
 	committedBase       map[accounts.Address]*accounts.Account
 	accountReadDuration time.Duration
 	accountReadCount    int64
@@ -197,30 +174,16 @@ type IntraBlockState struct {
 	version             int
 	dep                 int
 
-	// Per-attempt memo of the shared-versionMap SelfDestruct probe. The probe
-	// (read_paths.go) fires on every versionedReadCore call but reads only
-	// prior-tx SD writes — stable within one execution attempt — so a warm
-	// multi-field refresh repeats the same locked read. sdProbeEpoch is bumped
-	// on every Reset/SetTxContext, discarding the memo across txs and
-	// re-executions without a per-tx map clear.
+	// sdProbe memoizes the SelfDestruct probe per attempt; sdProbeEpoch invalidates it on Reset/SetTxContext.
 	sdProbe      map[accounts.Address]sdProbeEntry
 	sdProbeEpoch uint64
 
-	// noMaterialize suppresses the stateObject cache on the parallel execution
-	// path: create/write flows record only versioned cells and committed reads
-	// resolve from the state reader, gated by this tx's own CreateContract /
-	// SelfDestruct cells. Left false for genesis/RPC/serial, which still commit
-	// via FinalizeTx→so.data.
+	// noMaterialize suppresses the stateObject cache on the parallel path: writes go to versioned cells only. False for genesis/RPC/serial.
 	noMaterialize bool
 
-	// eip8246 pins whether SELFDESTRUCT preserves the account (EIP-8246 removes
-	// the balance burn). Set per-tx from the block rules in Prepare; under it a
-	// SelfDestructPath=true account must read as a live, balance-preserving,
-	// empty-code account rather than a destroyed one.
+	// eip8246: EIP-8246 drops the SELFDESTRUCT balance burn; set per-tx from block rules in Prepare.
 	eip8246 bool
-	// eip161 and isAura gate nil≡empty dead-equivalence on the read paths (AuRa
-	// retains its empty SystemAddress; pre-161 existing-empty is gas-observable).
-	// Set per-tx from the block rules in Prepare.
+	// eip161/isAura gate nil-vs-empty account equivalence on reads (AuRa keeps an empty SystemAddress; pre-161 empty is gas-observable).
 	eip161 bool
 	isAura bool
 
@@ -234,7 +197,6 @@ type sdProbeEntry struct {
 	ok         bool
 }
 
-// Create a new state from a given trie
 func New(stateReader StateReader) *IntraBlockState {
 	ibs := &IntraBlockState{
 		stateReader:       stateReader,
@@ -300,8 +262,6 @@ func (sdb *IntraBlockState) VersionMap() *VersionMap {
 	return sdb.versionMap
 }
 
-// SetNoMaterialize enables the cache-free parallel path: create/write flows
-// record only versioned cells and never populate the stateObject map.
 func (sdb *IntraBlockState) SetNoMaterialize(v bool) {
 	if dbg.AssertEnabled && v != sdb.noMaterialize && !sdb.stateObjectArena.empty() {
 		panic("noMaterialize changed with arena slots outstanding")
@@ -334,7 +294,7 @@ func (sdb *IntraBlockState) HasStorage(addr accounts.Address) (bool, error) {
 		return false, nil
 	}
 
-	// If the fake storage is set, only lookup the state here(in the debugging mode)
+	// fakeStorage overrides storage for debugging only.
 	if len(so.fakeStorage) > 0 {
 		for _, v := range so.fakeStorage {
 			if !v.IsZero() {
@@ -345,28 +305,21 @@ func (sdb *IntraBlockState) HasStorage(addr accounts.Address) (bool, error) {
 		return false, nil
 	}
 
-	// If we know of at least one non-empty cached storage slot, then the object has storage
 	for _, v := range so.originStorage {
 		if !v.IsZero() {
 			return true, nil
 		}
 	}
 
-	// If we know of at least one non-empty dirty storage slot, then the object has storage
 	for _, v := range so.dirtyStorage {
 		if !v.IsZero() {
 			return true, nil
 		}
 	}
 
-	// In parallel execution mode, check if a prior TX wrote IncarnationPath.
-	// IncarnationPath is written ONLY by CreateAccount and Selfdestruct —
-	// both operations that clear all storage.  If a prior TX wrote it, the
-	// account was created or destroyed in this block and HasStorage should
-	// return false. Mirrors the StoragePath check in versionedReadCore.
+	// A prior-tx IncarnationPath write (only from CreateAccount/Selfdestruct) means the account was created or destroyed this block, so it has no storage.
 	if sdb.versionMap != nil {
 		if inc, incRes, ok := sdb.versionMap.ReadIncarnation(addr, sdb.txIndex); ok && incRes.Status() == MVReadResultDone {
-			// Record IncarnationPath dependency for validation.
 			sdb.versionedReads.SetIncarnation(addr, VersionedRead[uint64]{
 				ReadHeader: ReadHeader{Source: MapRead, Version: Version{TxIndex: incRes.DepIdx(), Incarnation: incRes.Incarnation()}},
 				Val:        inc,
@@ -375,15 +328,11 @@ func (sdb *IntraBlockState) HasStorage(addr accounts.Address) (bool, error) {
 		}
 	}
 
-	// EIP-684 CREATE-collision fall-through: the in-memory checks missed, so ask
-	// the reader — on snapshot-backed storage this is a kv.HasPrefix(StorageDomain)
-	// walk through the .bt index, a validation hot-path cost.
+	// EIP-684 CREATE-collision fallback: ask the reader when in-memory checks miss (a HasPrefix walk on snapshot-backed storage).
 	result, err := sdb.stateReader.HasStorage(addr)
 	return result, err
 }
 
-// Reset clears out all ephemeral state objects from the state db, but keeps
-// the underlying state trie to avoid reloading data for the next operations.
 func (sdb *IntraBlockState) Reset() {
 	clear(sdb.nilAccounts)
 	for _, so := range sdb.stateObjects {
@@ -399,20 +348,11 @@ func (sdb *IntraBlockState) Reset() {
 	sdb.accessList.Reset()
 	clear(sdb.transientStorage)
 	sdb.versionMap = nil
-	// noMaterialize is meaningful only alongside a versionMap; clear it with the
-	// map so a reused IBS can't run unversioned with the stateObject cache still
-	// suppressed (which would silently drop writes). The versioned worker re-sets
-	// both right after Reset; the block assembler never calls Reset mid-block.
+	// noMaterialize only matters alongside a versionMap, so clear it here too, or a reused IBS could run unversioned with the cache still suppressed.
 	sdb.noMaterialize = false
 	clear(sdb.committedBase)
-	// Read side rebinds to a fresh empty set: VersionedReads() at end of
-	// tx hands the per-path maps to result.TxIn, so rebinding leaves the
-	// handed-over maps intact while the next tx lazily reallocs.
+	// Rebinds instead of clearing: a finished tx's result may still hold the previous per-path maps.
 	sdb.versionedReads = ReadSet{}
-	// Write side: VersionedWrites() returns Cloned snapshots, so the
-	// originals in sdb.versionedWrites are no longer referenced after the
-	// boundary call.  Walk the per-path maps and return every VW to its
-	// typed pool before resetting.
 	sdb.versionedWrites.ReleaseAndReset()
 	sdb.recordAccess = false
 	sdb.accountReadDuration = 0
@@ -427,10 +367,7 @@ func (sdb *IntraBlockState) Reset() {
 // Release Deprecated use Close
 func (sdb *IntraBlockState) Release(bool) { sdb.Close() }
 
-// Close returns pooled resources (like journal, stateObjects, versioned writes)
-// back to their pools. Call this when the IntraBlockState is no longer needed.
-// Call Reset() to re-use IntraBlockState object
-// Idempotent, thread-unsafe
+// Close is idempotent and not thread-safe; Reset re-uses the IntraBlockState instead of releasing it.
 func (sdb *IntraBlockState) Close() {
 	if sdb == nil || sdb.stateObjects == nil {
 		return
@@ -441,15 +378,13 @@ func (sdb *IntraBlockState) Close() {
 	sdb.stateObjectArena.release()
 	sdb.logs.release()
 	sdb.revisions.reset()
-	// Safe to pool: VersionedWrites/FinalizedWrites hand out deep clones, and the
-	// set is unexported, so nothing outside holds a raw VersionedWrite.
+	// Safe to pool: VersionedWrites/FinalizedWrites hand out deep clones, and the set is unexported.
 	sdb.versionedWrites.ReleaseAndReset()
 
 	releaseResources(stateObjects, journal)
 }
 
-// The noMaterialize path never releases what it takes, so a pool draw there
-// would be a one-way drain on the materializing paths.
+// The noMaterialize path never releases what it takes, so a pool draw here would drain the materializing paths.
 func (sdb *IntraBlockState) allocStateObject() *stateObject {
 	if sdb.noMaterialize {
 		if so := sdb.stateObjectArena.alloc(); so != nil {
@@ -469,16 +404,11 @@ func releaseResources(stateObjects map[accounts.Address]*stateObject, journal *j
 	}
 }
 
-// AllocLog reserves the next log slot of the current tx and returns it sized for
-// numTopics/dataSize. The caller must write every topic and every data byte, then
-// call NotifyLog; whatever it leaves unwritten belongs to whichever transaction
-// held the entry before. The entry is owned by the arena and handed to a later
-// transaction, so it must never be passed on without copying.
+// AllocLog reserves the next log slot; the arena reuses it later, so callers must never retain it without copying.
 func (sdb *IntraBlockState) AllocLog(addr common.Address, numTopics, dataSize int) *types.Log {
 	return sdb.logs.alloc(sdb.journal, addr, sdb.txIndex, numTopics, dataSize)
 }
 
-// NotifyLog runs the OnLog hook after a log's fields are populated.
 func (sdb *IntraBlockState) NotifyLog(lp *types.Log) {
 	if dbg.TraceLogs && (sdb.trace || dbg.TraceAccount(accounts.InternAddress(lp.Address).Handle())) {
 		var topics string
@@ -496,8 +426,6 @@ func (sdb *IntraBlockState) NotifyLog(lp *types.Log) {
 	}
 }
 
-// AddLog copies log into the next slot. TxIndex and Index are assigned by the
-// state; every other field comes from the caller.
 func (sdb *IntraBlockState) AddLog(log *types.Log) {
 	lp := sdb.AllocLog(log.Address, len(log.Topics), len(log.Data))
 	copy(lp.Topics, log.Topics)
@@ -508,8 +436,7 @@ func (sdb *IntraBlockState) AddLog(log *types.Log) {
 	sdb.NotifyLog(lp)
 }
 
-// GetLogs deep-copies the tx's logs, so the result is safe to hold after the
-// arena reuses the entry.
+// GetLogs deep-copies the tx's logs, so the result is safe to hold after the arena reuses the entry.
 func (sdb *IntraBlockState) GetLogs(txIndex int, txnHash common.Hash, blockNumber uint64, blockHash common.Hash) types.Logs {
 	logs := sdb.logs.forTx(txIndex).Copy()
 	for _, l := range logs {
@@ -520,8 +447,6 @@ func (sdb *IntraBlockState) GetLogs(txIndex int, txnHash common.Hash, blockNumbe
 	return logs
 }
 
-// GetRawLogs - is like GetLogs, but allow postpone calculation of `txn.Hash()`.
-// Example: if you need filter logs and only then set `txn.Hash()` for filtered logs - then no reason to calc for all transactions.
 func (sdb *IntraBlockState) GetRawLogs(txIndex int) types.Logs {
 	return sdb.logs.forTx(txIndex).Copy()
 }
@@ -533,19 +458,15 @@ func (sdb *IntraBlockState) Logs() types.Logs {
 	return sdb.logs.entries.Copy()
 }
 
-// LogsRlpHash is rlpHash of Logs, without building the flattened slice.
 func (sdb *IntraBlockState) LogsRlpHash() common.Hash {
 	return types.RlpHashLogs(sdb.logs.entries)
 }
 
-// AddRefund adds gas to the refund counter
 func (sdb *IntraBlockState) AddRefund(gas uint64) {
 	sdb.journal.refundChange(sdb.refund)
 	sdb.refund += gas
 }
 
-// SubRefund removes gas from the refund counter.
-// This method will panic if the refund counter goes below zero
 func (sdb *IntraBlockState) SubRefund(gas uint64) error {
 	sdb.journal.refundChange(sdb.refund)
 	if gas > sdb.refund {
@@ -555,8 +476,7 @@ func (sdb *IntraBlockState) SubRefund(gas uint64) error {
 	return nil
 }
 
-// Exist reports whether the given account address exists in the state.
-// Notably this also returns true for self destructed accounts.
+// Exist also returns true for self-destructed accounts.
 func (sdb *IntraBlockState) Exist(addr accounts.Address) (exists bool, err error) {
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 		defer func() {
@@ -571,10 +491,7 @@ func (sdb *IntraBlockState) Exist(addr accounts.Address) (exists bool, err error
 		return s != nil && !s.deleted, nil
 	}
 
-	// Existence needs only the base record + self-destruct gate, not the
-	// per-field overlay.
-	// Same-tx self-destruct: the account is still alive (EIP-6780).
-	// Cross-tx self-destruct: versionedAccountBase returns nil.
+	// Needs only the base record + self-destruct gate, not the per-field overlay.
 	readAccount, _, _, err := sdb.versionedAccountBase(addr, true)
 	if err != nil {
 		return false, err
@@ -582,8 +499,7 @@ func (sdb *IntraBlockState) Exist(addr accounts.Address) (exists bool, err error
 	return readAccount != nil, nil
 }
 
-// Empty returns whether the state object is either non-existent
-// or empty according to the EIP161 specification (balance = nonce = code = 0)
+// Empty reports non-existence or EIP-161 emptiness (balance = nonce = code = 0).
 func (sdb *IntraBlockState) Empty(addr accounts.Address) (empty bool, err error) {
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 		defer func() {
@@ -598,34 +514,18 @@ func (sdb *IntraBlockState) Empty(addr accounts.Address) (empty bool, err error)
 
 		return so == nil || so.deleted || so.data.Empty(), nil
 	}
-	// Existence + the self-destruct/revival gate, without reconstructing the
-	// whole account: the EIP-161 verdict needs only the current balance, nonce
-	// and code hash, read per-field below (short-circuiting), so the per-field
-	// overlay and a full-account allocation are avoided.
+	// Existence + self-destruct gate only; per-field emptiness is checked below.
 	account, _, _, err := sdb.versionedAccountBase(addr, true)
 	if err != nil {
 		return false, err
 	}
 	if account == nil {
 		sdb.touchAccount(addr)
-		// Do NOT call accountRead here: versionedAccountBase already recorded
-		// the AddressPath read (via versionedReadCore) with Val=nil.  Calling
-		// accountRead(&emptyAccount) would overwrite that nil with a non-nil
-		// pointer to an empty Account.  Downstream code (getBalance →
-		// versionedReadCore for BalancePath → recursive AddressPath lookup) treats
-		// non-nil as "account exists", creating a stateObject instead of going
-		// through createObject.  When createObject is skipped, AddressPath is
-		// never written to the version map, and other txs that read this
-		// address miss the conflict during validation.
+		// Do not call accountRead: it would overwrite the nil AddressPath read already recorded, hiding this address from conflict detection.
 		return true, nil
 	}
 
-	// EIP-6780: an account self-destructed in THIS tx stays alive until end-of-tx
-	// cleanup, so it must not read as empty (it had code — it executed SELFDESTRUCT).
-	// main encodes this via its resident stateObject; on the noMaterialize path the
-	// self-destruct has already cleared the versioned nonce/code-hash/balance cells,
-	// so recognize the own-tx SelfDestruct write directly. Cross-tx destructs are
-	// handled above by versionedAccountBase returning nil.
+	// EIP-6780: an account self-destructed in this tx stays alive until end of tx, so it must not read as empty.
 	if sdb.hasWrite(addr, SelfDestructPath, accounts.NilKey) {
 		return false, nil
 	}
@@ -633,11 +533,7 @@ func (sdb *IntraBlockState) Empty(addr accounts.Address) (empty bool, err error)
 	return sdb.emptyFromVersionedFields(addr, account)
 }
 
-// emptyFromVersionedFields computes the EIP-161 emptiness verdict for an
-// account that versionedAccountBase resolved as existing, reading the current
-// balance/nonce/codeHash per-field (short-circuiting on the first non-empty
-// field) instead of reconstructing the whole account. The per-field refresh
-// reads apply the same self-destruct gate as the whole-account path.
+// emptyFromVersionedFields checks EIP-161 emptiness per-field, short-circuiting instead of reconstructing the whole account.
 func (sdb *IntraBlockState) emptyFromVersionedFields(addr accounts.Address, account *accounts.Account) (bool, error) {
 	balance, _, _, err := refreshBalance(sdb, addr, account.Balance)
 	if err != nil {
@@ -660,8 +556,6 @@ func (sdb *IntraBlockState) emptyFromVersionedFields(addr accounts.Address, acco
 	return codeHash == accounts.EmptyCodeHash, nil
 }
 
-// GetBalance retrieves the balance from the given address or 0 if object not found
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetBalance(addr accounts.Address) (uint256.Int, error) {
 	balance, _, err := sdb.getBalance(addr)
 	return balance, err
@@ -691,7 +585,6 @@ func (sdb *IntraBlockState) getBalance(addr accounts.Address) (uint256.Int, bool
 	return balance, source == StorageRead || source == MapRead, err
 }
 
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetNonce(addr accounts.Address) (uint64, error) {
 	if sdb.versionMap == nil {
 		stateObject, err := sdb.getStateObject(addr, true)
@@ -713,12 +606,10 @@ func (sdb *IntraBlockState) GetNonce(addr accounts.Address) (uint64, error) {
 	return nonce, err
 }
 
-// TxIndex returns the current transaction index set by Prepare.
 func (sdb *IntraBlockState) TxnIndex() int {
 	return sdb.txIndex
 }
 
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCode(addr accounts.Address) ([]byte, error) {
 	return sdb.getCode(addr, false)
 }
@@ -748,12 +639,7 @@ func (sdb *IntraBlockState) getCode(addr accounts.Address, commited bool) ([]byt
 		}
 		return nil, nil
 	}
-	// When commited=true (used by ResolveCode for EIP-7702 delegation),
-	// versionedReadCore skips local versionedWrites and may return a stale
-	// ReadSet value. If the CURRENT tx has set this account's code (e.g.,
-	// via EIP-7702 authorization processing), return the dirty code directly.
-	// We must also check hasWrite to ensure the code was set in this tx,
-	// not in a previous tx sharing the same IBS (block generator reuses IBS).
+	// commited=true (EIP-7702 ResolveCode) may see a stale ReadSet value; hasWrite confirms this tx's own code write.
 	if commited {
 		if so, ok := sdb.stateObjects[addr]; ok && so.dirtyCode && sdb.hasWrite(addr, CodePath, accounts.NilKey) {
 			sdb.callCodeAccessHook(addr, so.code.Bytes)
@@ -776,7 +662,6 @@ func (sdb *IntraBlockState) getCode(addr accounts.Address, commited bool) ([]byt
 	return code, err
 }
 
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCodeSize(addr accounts.Address) (int, error) {
 	if sdb.versionMap == nil {
 		stateObject, err := sdb.getStateObject(addr, true)
@@ -793,11 +678,7 @@ func (sdb *IntraBlockState) GetCodeSize(addr accounts.Address) (int, error) {
 		if stateObject.data.CodeHash.IsEmpty() {
 			return 0, nil
 		}
-		// Size-only read: ReadAccountCodeSize, not ReadAccountCode. It routes
-		// through the size-only cache layer, and is correct on the Stateless
-		// reader — a size-only witness node has the size but no bytes, so
-		// ReadAccountCode there returns nil (EXTCODESIZE 0) and diverges from
-		// consensus.
+		// Must call ReadAccountCodeSize, not ReadAccountCode: a size-only witness node has no bytes and would desync EXTCODESIZE.
 		size, err := sdb.stateReader.ReadAccountCodeSize(addr)
 		if err != nil {
 			return 0, err
@@ -814,9 +695,7 @@ func (sdb *IntraBlockState) GetCodeSize(addr accounts.Address) (int, error) {
 	return size, err
 }
 
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
-// codeAccessTracker lets a stateReader observe code accesses (EIP-7928 BAL /
-// EIP-7702 delegation). No-op when the reader doesn't implement it.
+// codeAccessTracker lets a stateReader observe code accesses (EIP-7928 BAL / EIP-7702); no-op if unimplemented.
 type codeAccessTracker interface {
 	OnCodeAccess(accounts.Address, []byte)
 }
@@ -843,21 +722,14 @@ func (sdb *IntraBlockState) GetCodeHash(addr accounts.Address) (accounts.CodeHas
 	if err != nil {
 		return accounts.NilCodeHash, err
 	}
-	// EIP-6780: a contract self-destructed in THIS tx stays alive until end-of-tx
-	// cleanup, so EXTCODEHASH within the same tx must return its real code hash. The
-	// SELFDESTRUCT cleared the CodeHashPath cell (that clear is for later-tx reads,
-	// where extraction drops the path), but the code itself is still present —
-	// recompute the hash from it, matching the materialized path's resident object.
+	// EIP-6780: a same-tx self-destructed contract must still return its real code hash, recomputed since CodeHashPath is cleared.
 	if hash == accounts.EmptyCodeHash && sdb.hasWrite(addr, SelfDestructPath, accounts.NilKey) {
 		if cw, ok := sdb.versionedWrites.GetCode(addr); ok && len(cw.Val.Bytes) > 0 {
 			return accounts.InternCodeHash(crypto.Keccak256Hash(cw.Val.Bytes)), nil
 		}
 	}
 	if sdb.eip8246 && hash == accounts.NilCodeHash {
-		// A prior tx's EIP-8246 SELFDESTRUCT leaves an existing empty-code
-		// account, but its CodeHashPath is dropped from the version map, so
-		// recover the codehash from the reconstructed account (EmptyCodeHash),
-		// distinguishing it from a genuinely absent account (NilCodeHash).
+		// A prior tx's EIP-8246 SELFDESTRUCT leaves an empty-code account whose CodeHashPath is dropped; recover it from the account instead.
 		acc, _, _, err := sdb.getVersionedAccount(addr, false)
 		if err != nil {
 			return accounts.NilCodeHash, err
@@ -870,7 +742,6 @@ func (sdb *IntraBlockState) GetCodeHash(addr accounts.Address) (accounts.CodeHas
 }
 
 func (sdb *IntraBlockState) ResolveCodeHash(addr accounts.Address) (accounts.CodeHash, error) {
-	// eip-7702
 	dd, ok, err := sdb.GetDelegatedDesignation(addr)
 
 	if ok {
@@ -885,12 +756,8 @@ func (sdb *IntraBlockState) ResolveCodeHash(addr accounts.Address) (accounts.Cod
 }
 
 func (sdb *IntraBlockState) ResolveCode(addr accounts.Address) ([]byte, error) {
-	// committed=false so the tx's own writes (e.g. from EIP-7702 authorization
-	// list) are visible. With committed=true the parallel executor reads stale
-	// delegation code from the version map instead of the current tx's SetCode.
-	// CodePath exemptions in versionedReadCore already handle SelfDestruct cases.
+	// committed=false so this tx's own EIP-7702 authorization-list writes are visible, not stale delegation code.
 	code, err := sdb.getCode(addr, false)
-	// eip-7702
 	if delegation, ok := types.ParseDelegation(code); ok {
 		return sdb.getCode(delegation, false)
 	}
@@ -901,15 +768,9 @@ func (sdb *IntraBlockState) ResolveCode(addr accounts.Address) ([]byte, error) {
 }
 
 func (sdb *IntraBlockState) GetDelegatedDesignation(addr accounts.Address) (accounts.Address, bool, error) {
-	// eip-7702 - for account read recording we don't count this as
-	// it may not result in an actual gas recorded access - if it
-	// is it will be marked via a direct call
+	// EIP-7702: this probe isn't recorded as an account read, since it may not be a gas-charged access.
 	if sdb.versionMap != nil {
-		// Read through the version-aware CodePath so validation can reject a
-		// speculative execution that raced a prior transaction publishing its
-		// CodeHashPath and CodePath. Going through getCode would also report a
-		// BAL code access for non-delegated code, so use readCode directly and
-		// preserve the existing hook semantics below.
+		// Reads via versioned CodePath so validation can catch a race; uses readCode directly to avoid a spurious BAL code access.
 		code, _, _, err := readCode(sdb, addr, false)
 		if err != nil {
 			return accounts.ZeroAddress, false, err
@@ -938,8 +799,6 @@ func (sdb *IntraBlockState) GetDelegatedDesignation(addr accounts.Address) (acco
 	return accounts.ZeroAddress, false, nil
 }
 
-// GetState retrieves a value from the given account's storage trie.
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetState(addr accounts.Address, key accounts.StorageKey) (uint256.Int, error) {
 	versionedValue, source, _, err := readState(sdb, addr, key)
 
@@ -950,8 +809,6 @@ func (sdb *IntraBlockState) GetState(addr accounts.Address, key accounts.Storage
 	return versionedValue, err
 }
 
-// GetCommittedState retrieves a value from the given account's committed storage trie.
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) GetCommittedState(addr accounts.Address, key accounts.StorageKey) (uint256.Int, error) {
 	versionedValue, source, _, err := readCommittedState(sdb, addr, key)
 
@@ -971,13 +828,7 @@ func (sdb *IntraBlockState) ReadVersion(addr accounts.Address, path AccountPath,
 	return sdb.versionMap.ReadStatus(addr, path, key, txIdx)
 }
 
-// writeBalanceVersioned records a balance change on the versionMap write-set and
-// the journal without materializing the stateObject on the common existing-alive
-// path. An absent or destroyed-no-revival account is materialized via
-// GetOrNewStateObject so createObject records the AddressPath write OCC needs; the
-// create path never reads balance (matching the old stateObject path). The journal
-// prev is read only in the existing branch so a create does not widen the OCC
-// read-set with a spurious BalancePath read.
+// writeBalanceVersioned skips materializing on the existing-alive path; absent/destroyed accounts still go through GetOrNewStateObject.
 func (sdb *IntraBlockState) writeBalanceVersioned(addr accounts.Address, update uint256.Int, wasCommited bool, reason tracing.BalanceChangeReason) error {
 	base, _, _, err := sdb.versionedAccountBase(addr, true)
 	if err != nil {
@@ -988,11 +839,7 @@ func (sdb *IntraBlockState) writeBalanceVersioned(addr accounts.Address, update 
 		if err != nil {
 			return err
 		}
-		// A destroyed-then-revived account's transient is rebuilt from the base
-		// record and lags this tx's own balance write, so SetBalance's journal
-		// entry would capture a stale prev and a revert would restore the wrong
-		// balance. Seed the live balance first. The base==nil create path never
-		// read balance, so leave it untouched (avoids widening the OCC read-set).
+		// A destroyed-then-revived stateObject's transient balance lags this tx's own write; seed it first or SetBalance's journal captures a stale prev.
 		if base != nil {
 			cur, _, err := sdb.getBalance(addr)
 			if err != nil {
@@ -1016,11 +863,8 @@ func (sdb *IntraBlockState) writeBalanceVersioned(addr accounts.Address, update 
 	return nil
 }
 
-// AddBalance adds amount to the account associated with addr.
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) AddBalance(addr accounts.Address, amount uint256.Int, reason tracing.BalanceChangeReason) error {
 	if sdb.versionMap == nil {
-		// If this account has not been read, add to the balance increment map
 		if _, needAccount := sdb.stateObjects[addr]; !needAccount && addr == ripemd && amount.IsZero() {
 			sdb.journal.balanceIncrease(addr, amount)
 
@@ -1031,7 +875,6 @@ func (sdb *IntraBlockState) AddBalance(addr accounts.Address, amount uint256.Int
 			}
 
 			if sdb.tracingHooks != nil && sdb.tracingHooks.OnBalanceChange != nil {
-				// TODO: discuss if we should ignore error
 				prev := new(uint256.Int)
 				amount := amount
 				if dbg.TraceDomainIO || (dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle()))) {
@@ -1062,8 +905,7 @@ func (sdb *IntraBlockState) AddBalance(addr accounts.Address, amount uint256.Int
 		}
 	}
 
-	// EIP161: We must check emptiness for the objects such that the account
-	// clearing (0,0,0 objects) can take effect.
+	// EIP-161: check emptiness so a zero-value transfer can still clear a (0,0,0) account.
 	if amount.IsZero() {
 		return sdb.TouchAccount(addr)
 	}
@@ -1073,8 +915,8 @@ func (sdb *IntraBlockState) AddBalance(addr accounts.Address, amount uint256.Int
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 		defer func() {
 			bal, _ := sdb.GetBalance(addr)
-			prev := prev     // avoid capture allocation unless we're tracing
-			amount := amount // avoid capture allocation unless we're tracing
+			prev := prev // avoid capture allocation unless we're tracing
+			amount := amount
 			expected := (&uint256.Int{}).Add(&prev, &amount)
 			if bal.Cmp(expected) != 0 {
 				panic(fmt.Sprintf("add failed: expected: %d got: %s", expected, bal.String()))
@@ -1101,23 +943,19 @@ func (sdb *IntraBlockState) AddBalance(addr accounts.Address, amount uint256.Int
 func (sdb *IntraBlockState) touchAccount(addr accounts.Address) {
 	sdb.journal.touchAccount(addr, false, uint256.Int{})
 	if addr == ripemd {
-		// Explicitly put it in the dirty-cache, which is otherwise generated from
-		// flattened journals.
+		// Marks it dirty directly; normal entries get this from flattened journals.
 		sdb.journal.dirty(addr)
 	}
 }
 
-// TouchAccount materializes an empty account and records the zero-balance touch
-// needed for state clearing and trie consistency.
+// TouchAccount materializes an empty account, recording the zero-balance touch EIP-161 state clearing needs.
 func (sdb *IntraBlockState) TouchAccount(addr accounts.Address) error {
 	markTouched := func() {
 		if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 			fmt.Printf("%d (%d.%d) Touch %x\n", sdb.blockNum, sdb.txIndex, sdb.version, addr)
 		}
 		if sdb.versionMap != nil {
-			// Versioned path: pair the BalancePath=0 write with a journal entry
-			// that reverts it, so the write-set stays in step through reverts
-			// without any dirties re-processing (deprecated on this path).
+			// Pairs the BalancePath=0 write with a reverting journal entry so the write-set stays in step through reverts.
 			prevWrite, had := sdb.versionedWrites.GetBalance(addr)
 			var prev uint256.Int
 			if had {
@@ -1134,10 +972,7 @@ func (sdb *IntraBlockState) TouchAccount(addr accounts.Address) error {
 	}
 
 	if sdb.versionMap != nil {
-		// The touch only depends on emptiness. For an existing account compute
-		// it from field reads without materializing/reconstructing the
-		// stateObject; only an absent account needs GetOrNewStateObject so
-		// createObject records the AddressPath write (OCC create detection).
+		// Touch depends only on emptiness, computed from field reads without reconstructing the stateObject.
 		account, _, _, err := sdb.versionedAccountBase(addr, true)
 		if err != nil {
 			return err
@@ -1165,24 +1000,11 @@ func (sdb *IntraBlockState) TouchAccount(addr accounts.Address) error {
 	return nil
 }
 
-// synthesizeCreatedAccountBase reconstructs the record of an account that is
-// absent from both the versionMap AddressPath and the DB, from its sub-field
-// cells: an EIP-7928 BAL pre-populates balance/nonce/code but not the record
-// itself, and a worker flush strips the record for destroyed accounts. With a
-// BAL the cells are deterministic (written before execution starts), so
-// resolving existence from them removes the read-after-create race with the
-// creator's flush. Only a non-EIP-161-empty result synthesizes: an
-// existing-empty account is not gas-equivalent to a non-existent one. Non-Done
-// cells (racing worker estimates) and destroyed accounts return ok=false.
+// synthesizeCreatedAccountBase rebuilds an absent account from its EIP-7928 BAL sub-field cells; declines for an empty, estimated, or destroyed result.
 func (sdb *IntraBlockState) synthesizeCreatedAccountBase(addr accounts.Address) (*accounts.Account, bool) {
 	if sdb.versionMap == nil {
 		return nil, false
 	}
-	// A definitive nil record read means this tx already consumed the account's
-	// absence; synthesizing from cells flushed since would fork the tx's view of
-	// the address mid-execution and reconcile the fork out of validation's
-	// sight. Only a provisional (mid-load) probe may adopt fresh cells — the
-	// stale conclusion re-executes via commit-time validation instead.
 	if sdb.consumedAddressAbsence(addr) {
 		return nil, false
 	}
@@ -1239,18 +1061,13 @@ func (sdb *IntraBlockState) synthesizeCreatedAccountBase(addr accounts.Address) 
 	return acc, true
 }
 
-// consumedAddressAbsence reports whether this tx holds a definitive
-// (non-provisional) nil AddressPath read — it already concluded the account is
-// absent, so later loads must not adopt cells flushed since.
+// consumedAddressAbsence reports whether this tx already holds a definitive nil AddressPath read; later loads must not adopt cells flushed since.
 func (sdb *IntraBlockState) consumedAddressAbsence(addr accounts.Address) bool {
 	tr, ok := sdb.versionedReads.GetAddress(addr)
 	return ok && tr.Source != ProvisionalRead && (tr.Val == nil || tr.Val.Account() == nil)
 }
 
-// finalizeProvisionalAddressRead demotes a load's in-flight nil record probe
-// to a definitive storage read once the load concludes the account is absent:
-// the EVM is about to consume that answer, so a later flush must conflict with
-// it instead of being silently adopted.
+// finalizeProvisionalAddressRead demotes an in-flight nil probe to a definitive read, so a later flush must conflict with it.
 func (sdb *IntraBlockState) finalizeProvisionalAddressRead(addr accounts.Address) {
 	if tr, ok := sdb.versionedReads.GetAddress(addr); ok && tr.Source == ProvisionalRead {
 		tr.Source = StorageRead
@@ -1258,11 +1075,7 @@ func (sdb *IntraBlockState) finalizeProvisionalAddressRead(addr accounts.Address
 	}
 }
 
-// readSelfDestructMemo returns the shared-versionMap SelfDestruct probe for the
-// current execution attempt, caching it so a warm multi-field read does not
-// re-acquire the versionMap RWMutex per field. The probe reads only prior-tx SD
-// writes; the tx's own SelfDestruct lives in versionedWrites and is consulted
-// separately, so the memoized value is stable for the attempt.
+// readSelfDestructMemo caches the SelfDestruct probe per attempt, stable since it excludes this tx's own writes.
 func (sdb *IntraBlockState) readSelfDestructMemo(addr accounts.Address) (bool, ReadResult, bool) {
 	if e, hit := sdb.sdProbe[addr]; hit && e.epoch == sdb.sdProbeEpoch {
 		return e.destructed, e.res, e.ok
@@ -1275,12 +1088,7 @@ func (sdb *IntraBlockState) readSelfDestructMemo(addr accounts.Address) (bool, R
 	return destructed, res, ok
 }
 
-// eip8246PreservedAccount reconstructs the live account a prior tx left behind
-// when EIP-8246 removed the SELFDESTRUCT burn: the balance survives, code and
-// nonce are cleared at destruction, and any later per-field map writes overlay
-// the reconstruction so account-level reads agree with the field-level ones.
-// Returns nil when the balance was moved out, leaving an empty account that
-// EIP-161 removes.
+// eip8246PreservedAccount rebuilds the account a prior EIP-8246 SELFDESTRUCT left alive; returns nil once the balance is drained.
 func (sdb *IntraBlockState) eip8246PreservedAccount(addr accounts.Address) (*accounts.Account, error) {
 	bal, _, _, err := readBalance(sdb, addr)
 	if err != nil {
@@ -1306,19 +1114,11 @@ func (sdb *IntraBlockState) eip8246PreservedAccount(addr accounts.Address) (*acc
 	return &acc, nil
 }
 
-// getVersionedAccount returns the account reconstructed from the base record
-// plus the versionMap field overlays. Whole-account consumers (stateObject
-// construction) need the reconstructed record; field-oriented callers
-// (GetBalance/Empty/Exist) read what they need without it.
 func (sdb *IntraBlockState) getVersionedAccount(addr accounts.Address, readStorage bool) (*accounts.Account, ReadSource, Version, error) {
 	return sdb.versionedAccountBase(addr, readStorage)
 }
 
-// versionedAccountBase resolves account existence via the AddressPath read (and
-// storage fallback), applying the self-destruct/revival gate, but does NOT
-// overlay the per-field versionMap cells. It returns nil when the account is
-// absent or was destroyed with no revival. The AddressPath read it performs
-// records the nil-read that OCC uses to detect create/absent conflicts.
+// versionedAccountBase resolves existence via the AddressPath read, applying the self-destruct/revival gate but not per-field overlays.
 func (sdb *IntraBlockState) versionedAccountBase(addr accounts.Address, readStorage bool) (*accounts.Account, ReadSource, Version, error) {
 	if sdb.versionMap == nil {
 		return nil, UnknownSource, UnknownVersion, nil
@@ -1330,18 +1130,10 @@ func (sdb *IntraBlockState) versionedAccountBase(addr accounts.Address, readStor
 		return nil, UnknownSource, UnknownVersion, err
 	}
 
-	// EIP-8246: a prior tx's SELFDESTRUCT preserves the account (balance kept,
-	// code/nonce cleared) rather than destroying it. AddressPath reads zero
-	// under SD, so reconstruct the surviving account from the version map here,
-	// covering both committed and in-block-created accounts — unless a later tx
-	// re-created it, in which case fall through to the normal read.
+	// EIP-8246: SELFDESTRUCT preserves the account instead of destroying it; reconstruct it here unless a later tx re-created it.
 	if sdb.eip8246 && readAccount == nil {
 		if destructed, sdRes, ok := sdb.versionMap.ReadSelfDestruct(addr, sdb.txIndex); ok && sdRes.Status() == MVReadResultDone && destructed {
-			// A definitive nil AddressPath read means this tx already consumed the
-			// account's absence, so reconstructing from cells flushed since would
-			// fork its view out of validation's sight — abort and re-execute.
-			// Exempt only an absence concluded from this destruct itself,
-			// recorded as a MapRead at the destruct cell's exact version.
+			// Exempts only the read this same destruct itself produced; any other definitive nil read aborts here.
 			if tr, ok := sdb.versionedReads.GetAddress(addr); ok && tr.Source != ProvisionalRead && (tr.Val == nil || tr.Val.Account() == nil) &&
 				!(tr.Source == MapRead && tr.Version.TxIndex == sdRes.DepIdx() && tr.Version.Incarnation == sdRes.Incarnation()) {
 				if sdRes.DepIdx() > sdb.dep {
@@ -1350,12 +1142,7 @@ func (sdb *IntraBlockState) versionedAccountBase(addr accounts.Address, readStor
 				panic(ErrDependency)
 			}
 			destructTxIndex := sdRes.DepIdx()
-			// Only a genuine re-creation (a later CreateAccount, which writes
-			// AddressPath) skips reconstruction. Later Balance/Nonce/CodeHash
-			// writes are updates to the still-preserved account, not a revival:
-			// reconstruct it and let eip8246PreservedAccount overlay the latest
-			// balance, nonce and code hash, so e.g. an account funded after its
-			// SELFDESTRUCT still reads as existing — matching serial.
+			// Only a later CreateAccount counts as revival; later Balance/Nonce/CodeHash writes just update the still-preserved account.
 			revived := false
 			if hi, ok := sdb.versionMap.LatestTxIndex(addr, AddressPath, accounts.NilKey, sdb.txIndex-1); ok && hi > destructTxIndex {
 				revived = true
@@ -1369,9 +1156,6 @@ func (sdb *IntraBlockState) versionedAccountBase(addr accounts.Address, readStor
 					sdb.finalizeProvisionalAddressRead(addr)
 					return nil, StorageRead, UnknownVersion, nil
 				}
-				// The EVM consumes this conclusion: reconcile the provisional
-				// nil probe with the preserved account so a later flush
-				// conflicts with it instead of being silently adopted.
 				sdb.accountRead(addr, preserved, MapRead, Version{TxIndex: destructTxIndex})
 				return preserved, MapRead, Version{TxIndex: destructTxIndex}, nil
 			}
@@ -1408,9 +1192,6 @@ func (sdb *IntraBlockState) versionedAccountBase(addr accounts.Address, readStor
 
 		if readAccount == nil || err != nil {
 			if err == nil && readStorage {
-				// A created account absent from the DB resolves its existence
-				// from the BAL-prepopulated sub-field cells; the fields
-				// themselves flow through the per-field cell reads downstream.
 				if synth, ok := sdb.synthesizeCreatedAccountBase(addr); ok {
 					sdb.accountRead(addr, synth, MapRead, UnknownVersion)
 					return synth, StorageRead, UnknownVersion, nil
@@ -1422,37 +1203,22 @@ func (sdb *IntraBlockState) versionedAccountBase(addr accounts.Address, readStor
 			return nil, StorageRead, UnknownVersion, err
 		}
 
-		// CachedReaderV3 bypasses the versionMap, so a prior in-block SD'd
-		// address still returns its pre-SD record. Without this gate the
-		// stale nonce/codeHash flows through the per-field refresh (which
-		// only overwrites fields a versionMap cell exists for), so Empty()
-		// returns false and the EVM misses CallNewAccountGas.
+		// CachedReaderV3 bypasses versionMap and returns a pre-SD record; without this gate stale fields survive and Empty() misses CallNewAccountGas.
 		if destroyed, _, revived := sdb.versionMap.AccountLifecycle(addr, sdb.txIndex); destroyed && !revived {
 			sdb.finalizeProvisionalAddressRead(addr)
 			return nil, StorageRead, UnknownVersion, nil
 		}
-		// readAccount above recorded a nil map-read marker; the DB resolved
-		// the account, so reconcile the recorded read — a later record cell
-		// would otherwise spuriously invalidate the nil against a live
-		// account.
+		// readAccount recorded a nil map-read; reconcile it now the DB resolved the account, or a later cell would spuriously invalidate it.
 		sdb.accountRead(addr, readAccount, source, version)
 	}
 
 	return readAccount, source, version, nil
 }
 
-// SubBalance subtracts amount from the account associated with addr.
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SubBalance(addr accounts.Address, amount uint256.Int, reason tracing.BalanceChangeReason) error {
 	if amount.IsZero() {
 		if addr == params.SystemAddress {
-			// Gnosis/AuRa keeps an empty system account even after
-			// Spurious Dragon (see PR 5645 and Issue 18276).
-			//
-			// The primary syscall path in evm.call() handles this via
-			// TouchAccount directly; this branch is retained as
-			// defense-in-depth for other callers (AuRa engine,
-			// consensus callbacks).
+			// Gnosis/AuRa keeps an empty system account alive post-Spurious-Dragon, as defense-in-depth, not the primary path.
 			return sdb.TouchAccount(addr)
 		}
 		return nil
@@ -1463,8 +1229,8 @@ func (sdb *IntraBlockState) SubBalance(addr accounts.Address, amount uint256.Int
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 		defer func() {
 			bal, _ := sdb.GetBalance(addr)
-			prev := prev     // avoid capture allocation unless we're tracing
-			amount := amount // avoid capture allocation unless we're tracing
+			prev := prev
+			amount := amount
 			fmt.Printf("%d (%d.%d) SubBalance %x, %s-%s=%s\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, prev.String(), amount.String(), bal.String())
 		}()
 	}
@@ -1483,7 +1249,6 @@ func (sdb *IntraBlockState) SubBalance(addr accounts.Address, amount uint256.Int
 	return nil
 }
 
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SetBalance(addr accounts.Address, amount uint256.Int, reason tracing.BalanceChangeReason) error {
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 		amount := amount
@@ -1501,7 +1266,6 @@ func (sdb *IntraBlockState) SetBalance(addr accounts.Address, amount uint256.Int
 	return nil
 }
 
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SetNonce(addr accounts.Address, nonce uint64, reason tracing.NonceChangeReason) error {
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 		fmt.Printf("%d (%d.%d) SetNonce %x, %d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, nonce)
@@ -1522,12 +1286,7 @@ func (sdb *IntraBlockState) SetNonce(addr accounts.Address, nonce uint64, reason
 	return nil
 }
 
-// writeNonceVersioned records a nonce write on the parallel (versionMap) path
-// without materializing a stateObject for an existing, live account. A nonce SET
-// does not depend on the prior value, so prev is read WITHOUT recording an OCC
-// read (versionedWrites for this tx's own prior write, else the base record) —
-// matching the materialized path's AddressPath-only footprint. Absent/destroyed
-// accounts still materialize (account creation).
+// writeNonceVersioned skips materializing on the existing-alive path; prev is read without recording an OCC read.
 func (sdb *IntraBlockState) writeNonceVersioned(addr accounts.Address, nonce uint64, wasCommited bool, reason tracing.NonceChangeReason) error {
 	base, _, _, err := sdb.versionedAccountBase(addr, true)
 	if err != nil {
@@ -1543,16 +1302,12 @@ func (sdb *IntraBlockState) writeNonceVersioned(addr accounts.Address, nonce uin
 		return nil
 	}
 	prev := base.Nonce
-	// Keep an already-materialized stateObject's so.data in step so the
-	// so.data-based commit paths (genesis FinalizeTx, RPC) stay correct. We
-	// don't materialize one that isn't present — that's the whole point.
+	// Keeps an already-materialized stateObject's so.data in step so genesis/RPC's so.data-based commit paths stay correct.
 	if so, ok := sdb.stateObjects[addr]; ok {
 		prev = so.data.Nonce
 		so.setNonce(nonce)
 	}
-	// The tx's own nonce cell is authoritative for the journal prev: it records
-	// every prior same-tx write, whereas so.data can lag if the object was
-	// materialized after those writes. Prefer it over so.data and base.
+	// The tx's own nonce cell is authoritative for journal prev, since so.data can lag if materialized after those writes.
 	if vw, ok := sdb.versionedWrites.GetNonce(addr); ok {
 		prev = vw.Val
 	}
@@ -1582,8 +1337,6 @@ func printCode(c []byte) (int, string) {
 	return lenc, fmt.Sprintf("%x...", c)
 }
 
-// DESCRIBED: docs/programmers_guide/guide.md#code-hash
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SetCode(addr accounts.Address, code []byte, reason tracing.CodeChangeReason) error {
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 		lenc, cs := printCode(code)
@@ -1599,22 +1352,14 @@ func (sdb *IntraBlockState) SetCode(addr accounts.Address, code []byte, reason t
 	baseCodeHash := stateObject.data.CodeHash
 	origHash := stateObject.original.CodeHash
 	if sdb.versionMap != nil {
-		// so.data/so.original are the base record and miss a prior-tx
-		// CodeHashPath-only write (the per-field reads no longer rebuild a
-		// full account).
-		// baseCodeHash ("what this SetCode saw") = the current cell, including
-		// this tx's own earlier code writes. origHash (the cumulative net-zero
-		// baseline) = the versionMap floor at txIndex — the tx-start value,
-		// excluding this tx's unflushed writes.
+		// baseCodeHash is the current cell (incl. this tx's writes); origHash is the versionMap floor at tx-start.
 		if ch, chErr := sdb.GetCodeHash(addr); chErr == nil {
 			baseCodeHash = ch
 		}
 		if ch, res, ok := sdb.versionMap.ReadCodeHash(addr, sdb.txIndex); ok && res.Status() == MVReadResultDone {
 			origHash = ch
 		} else if sdb.noMaterialize {
-			// The rebuilt transient's original reflects this tx's own code cell
-			// (readAccount folds CodeHashPath), not the tx-start value. With no
-			// prior-tx floor entry the cumulative baseline is the committed hash.
+			// The rebuilt transient's original reflects this tx's own code cell; with no floor entry it falls back to the committed hash.
 			origHash, err = sdb.committedCodeHash(addr)
 			if err != nil {
 				return err
@@ -1633,12 +1378,7 @@ func (sdb *IntraBlockState) SetCode(addr accounts.Address, code []byte, reason t
 		return err
 	}
 	if written {
-		// Skip when the new code matches either (1) the value seen by THIS
-		// SetCode call (revert to in-tx base), or (2) the pre-tx original
-		// (cumulative net-zero — e.g. EIP-7702 authority that delegates and
-		// then resets within the same tx). Case (2) is disabled for newly
-		// created stateObjects: original holds the pre-creation snapshot,
-		// and deleting CodePath/CodeHashPath writes would corrupt the trie.
+		// Skips when code matches the base this call saw, or (unless newly created) the pre-tx original.
 		matchesOriginal := !stateObject.newlyCreated && codeHash == origHash
 		if codeHash == baseCodeHash || matchesOriginal {
 			if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
@@ -1691,7 +1431,6 @@ func (sdb *IntraBlockState) Incarnation() int {
 	return sdb.version
 }
 
-// DESCRIBED: docs/programmers_guide/guide.md#address---identifier-of-an-account
 func (sdb *IntraBlockState) SetState(addr accounts.Address, key accounts.StorageKey, value uint256.Int) error {
 	return sdb.setState(addr, key, value, false)
 }
@@ -1701,9 +1440,7 @@ func (sdb *IntraBlockState) setState(addr accounts.Address, key accounts.Storage
 		fmt.Printf("%d (%d.%d) SetState %x, %x=%s\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, key, value.Hex())
 	}
 
-	// The EVM SSTORE path (force==false) writes through cells without
-	// materializing a stateObject. force==true (ApplyVersionedWrites replay) and
-	// a fakeStorage override (eth_simulate) still need the object.
+	// The EVM SSTORE path (force==false) writes through cells without materializing; force==true or a fakeStorage override still need the object.
 	if sdb.versionMap != nil && !force {
 		if so, ok := sdb.stateObjects[addr]; !ok || so.fakeStorage == nil {
 			return sdb.setStateVersioned(addr, key, value)
@@ -1719,30 +1456,18 @@ func (sdb *IntraBlockState) setState(addr accounts.Address, key accounts.Storage
 		return err
 	}
 	if set {
-		// Always record the write even when the value equals the origin.
-		// Deleting the write entry when value == origin broke revert semantics:
-		// if a nested call writes a value and the outer call reverts, the journal
-		// must restore the previous write entry. With the deletion optimization,
-		// the entry was gone and the revert had nothing to restore.
+		// Always records the write, even value==origin: skipping it once broke revert semantics on a nested-call revert.
 		sdb.recordWriteStorage(addr, key, value)
 	}
 	return nil
 }
 
-// setStateVersioned records a storage write on the parallel (versionMap) path
-// without materializing a stateObject. It mirrors stateObject.SetState's set
-// decision and journalling; the prev value comes from the cell-based
-// readStateForSet. An already-materialized stateObject is kept in step so the
-// so.data-based commit paths (genesis FinalizeTx, RPC) stay correct.
 func (sdb *IntraBlockState) setStateVersioned(addr accounts.Address, key accounts.StorageKey, value uint256.Int) error {
 	prev, source, _, commited, err := readStateForSet(sdb, addr, key)
 	if err != nil {
 		return err
 	}
-	// See stateObject.SetState: a value resolved from a cached read or the
-	// version map has no versioned write for this key this tx, so this is the
-	// first write and commited must be true for storageChange.revert to delete
-	// (not update) the cell.
+	// Mirrors stateObject.SetState: no versioned write yet means this is the first write, so commited must be true for revert to delete the cell.
 	if source != WriteSetRead && source != UnknownSource && source != StorageRead {
 		commited = true
 	}
@@ -1760,8 +1485,7 @@ func (sdb *IntraBlockState) setStateVersioned(addr accounts.Address, key account
 	return nil
 }
 
-// SetStorage replaces the entire storage for the specified account with given
-// storage. This function should only be used for debugging.
+// SetStorage replaces all storage for the account; debugging use only.
 func (sdb *IntraBlockState) SetStorage(addr accounts.Address, storage Storage) error {
 	stateObject, err := sdb.GetOrNewStateObject(addr)
 	if err != nil {
@@ -1773,7 +1497,6 @@ func (sdb *IntraBlockState) SetStorage(addr accounts.Address, storage Storage) e
 	return nil
 }
 
-// SetIncarnation sets incarnation for account if account exists
 func (sdb *IntraBlockState) SetIncarnation(addr accounts.Address, incarnation uint64) error {
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 		fmt.Printf("%d (%d.%d) SetIncarnation %x, %d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, incarnation)
@@ -1811,13 +1534,7 @@ func (sdb *IntraBlockState) GetIncarnation(addr accounts.Address) (uint64, error
 	return incarnation, err
 }
 
-// Selfdestruct marks the given account as suicided. When preserveBalance is
-// false the account balance is burned (pre-EIP-6780/6780 behaviour); when true
-// the balance is left untouched (EIP-8246) and only cleared at finalization if
-// the account ends up empty.
-//
-// The account's state object is still available until the state is committed,
-// getStateObject will return a non-nil account after Suicide.
+// Selfdestruct marks the account suicided; preserveBalance leaves the balance untouched (EIP-8246) instead of burning it.
 func (sdb *IntraBlockState) Selfdestruct(addr accounts.Address, preserveBalance bool) (bool, error) {
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 		fmt.Printf("%d (%d.%d) SelfDestruct %x\n", sdb.blockNum, sdb.txIndex, sdb.version, addr)
@@ -1849,34 +1566,18 @@ func (sdb *IntraBlockState) Selfdestruct(addr accounts.Address, preserveBalance 
 		sdb.recordWriteBalance(addr, uint256.Int{})
 	}
 
-	// NOTE: we intentionally do NOT versionWritten(StoragePath, key, 0) for the
-	// dirty slots here. Pre-Cancun (and for CALL-based SELFDESTRUCT generally)
-	// the account stays alive until end-of-tx, so a re-entry's GetState must
-	// still see the dirty values — and versionedReadCore consults versionedWrites
-	// before the stateObject, so a spurious StoragePath=0 here would make those
-	// reads return 0 (wrong gas: SSTORE_SET vs dirty-update, and wrong value).
-	// The parallel commitment calculator gets the per-slot DELETE entries from
-	// Normalize's SD cascade (sdStorageSlots = vm.StorageKeys ∪
-	// domainStorageKeys), so they don't need to be emitted here.
+	// Deliberately skips StoragePath=0 writes for dirty slots: the account stays alive until end-of-tx, so GetState must still see them.
 
 	return true, nil
 }
 
-// selfdestructVersioned records a self-destruct on the parallel (versionMap)
-// path without materializing a stateObject. Existence and the prior
-// self-destruct flag / balance / incarnation are read from the base record plus
-// this tx's own versioned writes, never a cached object. An already-materialized
-// stateObject is kept in step for the so.data-based commit paths (genesis
-// FinalizeTx, RPC).
+// selfdestructVersioned records self-destruct on the versionMap path without materializing a stateObject.
 func (sdb *IntraBlockState) selfdestructVersioned(addr accounts.Address, preserveBalance bool) (bool, error) {
 	base, _, _, err := sdb.versionedAccountBase(addr, true)
 	if err != nil {
 		return false, err
 	}
-	// base is nil for an absent account and for one destroyed in a prior tx and
-	// not revived (versionedAccountBase applies that gate) — the serial path's
-	// stateObject.deleted check. A same-tx repeat SELFDESTRUCT still proceeds:
-	// the serial object stays deleted==false until finalize, so it re-runs.
+	// base is nil when absent or destroyed-without-revival; a same-tx repeat SELFDESTRUCT still proceeds since deleted stays false until finalize.
 	if base == nil {
 		return false, nil
 	}
@@ -1894,15 +1595,12 @@ func (sdb *IntraBlockState) selfdestructVersioned(addr accounts.Address, preserv
 		inc = vw.Val
 	}
 
-	// Capture the pre-destruct versioned incarnation write, which the self-destruct
-	// clears below, so a revert restores it rather than the cleared value.
+	// Captures the pre-destruct versioned incarnation write so a revert restores it rather than the cleared value.
 	hadIncarnation, prevIncarnation := false, uint64(0)
 	if vw, ok := sdb.versionedWrites.GetIncarnation(addr); ok {
 		hadIncarnation, prevIncarnation = true, vw.Val
 	}
-	// Same for the balance write: the self-destruct records BalancePath=0 below,
-	// so a revert must restore the pre-destruct write (which may predate the
-	// snapshot) rather than delete the cell.
+	// Same for the balance write: a revert must restore the pre-destruct write rather than delete the cell.
 	hadBalance := false
 	var prevBalanceVersioned uint256.Int
 	if vw, ok := sdb.versionedWrites.GetBalance(addr); ok {
@@ -1926,18 +1624,12 @@ func (sdb *IntraBlockState) selfdestructVersioned(addr accounts.Address, preserv
 
 	sdb.recordWriteSelfDestruct(addr, true)
 	if !preserveBalance {
-		// Pre-EIP-8246: SELFDESTRUCT burns the balance and the account is deleted;
-		// keep the pre-destruct incarnation for the storage-delete cascade.
+		// Pre-EIP-8246: SELFDESTRUCT burns the balance; keep the pre-destruct incarnation for the storage-delete cascade.
 		sdb.recordWriteIncarnation(addr, inc)
 		sdb.recordWriteBalance(addr, uint256.Int{})
 		return true, nil
 	}
-	// EIP-8246: the balance is preserved, leaving a balance-only account, and a
-	// re-creation bumps the incarnation from 0 (matching serial). Nonce and code
-	// hash are not written here: extraction already drops them for a
-	// self-destructed account, so the reconstruction reads empty code / zero
-	// nonce. Writing explicit zero cells instead made a same-tx re-creation at the
-	// address read them and abort with a phantom collision.
+	// EIP-8246: balance is preserved, so re-creation bumps incarnation from 0; explicit zero cells caused a phantom collision instead.
 	sdb.recordWriteIncarnation(addr, 0)
 
 	return true, nil
@@ -1945,7 +1637,6 @@ func (sdb *IntraBlockState) selfdestructVersioned(addr accounts.Address, preserv
 
 var zeroBalance uint256.Int
 
-// Used for EIP-6780
 func (sdb *IntraBlockState) IsNewContract(addr accounts.Address) (bool, error) {
 	stateObject, err := sdb.getStateObject(addr, true)
 	if err != nil {
@@ -1965,9 +1656,6 @@ func (sdb *IntraBlockState) IsNewContract(addr accounts.Address) (bool, error) {
 	return !delegated, nil
 }
 
-// SetTransientState sets transient storage for a given account. It
-// adds the change to the journal so that it can be rolled back
-// to its previous value if there is a revert.
 func (sdb *IntraBlockState) SetTransientState(addr accounts.Address, key accounts.StorageKey, value uint256.Int) {
 	prev := sdb.GetTransientState(addr, key)
 	if prev == value {
@@ -1979,13 +1667,10 @@ func (sdb *IntraBlockState) SetTransientState(addr accounts.Address, key account
 	sdb.setTransientState(addr, key, value)
 }
 
-// setTransientState is a lower level setter for transient storage. It
-// is called during a revert to prevent modifications to the journal.
 func (sdb *IntraBlockState) setTransientState(addr accounts.Address, key accounts.StorageKey, value uint256.Int) {
 	sdb.transientStorage.Set(addr, key, value)
 }
 
-// GetTransientState gets transient storage for a given account.
 func (sdb *IntraBlockState) GetTransientState(addr accounts.Address, key accounts.StorageKey) uint256.Int {
 	return sdb.transientStorage.Get(addr, key)
 }
@@ -2001,15 +1686,11 @@ func (sdb *IntraBlockState) stateObjectForAccount(addr accounts.Address, account
 }
 
 func (sdb *IntraBlockState) getStateObject(addr accounts.Address, recordRead bool) (*stateObject, error) {
-	// A cached object is returned without re-reading the versionMap. This is safe
-	// only because the materializing versioned flows keep so.data in step with the
-	// cells on every write (the setters mirror recordWrite*); the noMaterialize
-	// path never populates this cache, so it can't serve a stale object there.
+	// A cached object skips re-reading the versionMap: materializing flows keep so.data in step with every write.
 	if so, ok := sdb.stateObjects[addr]; ok {
 		return so, nil
 	}
 
-	// Load the object from the database.
 	if _, ok := sdb.nilAccounts[addr]; ok {
 		if bi, ok := sdb.balanceInc[addr]; ok && !bi.transferred && sdb.versionMap == nil {
 			return sdb.createObject(addr, nil), nil
@@ -2041,9 +1722,7 @@ func (sdb *IntraBlockState) getStateObject(addr accounts.Address, recordRead boo
 	sdb.stateReader.SetTrace(false, "")
 
 	accountSource := StorageRead
-	// A DB-loaded record is pre-block state — older than any in-block cell.
-	// Stamping it with the reader's own version would rank it above those
-	// cells; UnknownVersion keeps every cell overlay ahead of it.
+	// A DB-loaded record is pre-block state; UnknownVersion keeps every in-block cell overlay ahead of it.
 	accountVersion := UnknownVersion
 
 	if err != nil {
@@ -2068,9 +1747,7 @@ func (sdb *IntraBlockState) getStateObject(addr accounts.Address, recordRead boo
 					return nil, err
 				}
 			} else {
-				// The synthesized path skips this: synthesizeCreatedAccountBase
-				// already bails on a destructed floor, and refreshSelfDestruct
-				// would record a racing SD read the BAL cannot resolve.
+				// The synthesized path skips this: it already bails on a destructed floor.
 				destructed, _, _, err := refreshSelfDestruct(sdb, addr)
 				if destructed || err != nil {
 					sdb.finalizeProvisionalAddressRead(addr)
@@ -2100,18 +1777,9 @@ func (sdb *IntraBlockState) getStateObject(addr accounts.Address, recordRead boo
 	if sdb.versionMap != nil {
 		account = readAccount
 
-		// Check if a prior tx selfdestructed this account. The AddressPath
-		// versionedReadCore above returned nil (SelfDestructPath early-exit), but
-		// stateReader returned a committed value from SharedDomains. Read
-		// SelfDestructPath directly from the versionMap (not via versionedReadCore
-		// which itself short-circuits on the same flag). Use the same pattern
-		// as CreateAccount (line 1628).
+		// A prior tx's SelfDestructPath early-exits versionedReadCore above; read it directly here instead.
 		if sdVer, ok := sdb.versionMap.FindDoneSelfDestructInRange(addr, 0, sdb.txIndex, true); ok && !sdb.versionMap.selfDestructRevived(addr, sdVer.TxIndex, sdb.txIndex) {
-			// Revival must be evidenced by cells written after the destruct
-			// index (e.g. a BAL-funded balance): the DB record's own fields are
-			// pre-block state, so their non-emptiness says nothing about life
-			// after an in-block self-destruct.
-			// Only honour if the current tx hasn't already resurrected.
+			// Revival needs cells written after the destruct index; skip if this tx already resurrected it.
 			localResurrected := false
 			if sdVal, ok := sdb.versionedWriteSelfDestruct(addr); ok {
 				if !sdVal {
@@ -2139,16 +1807,13 @@ func (sdb *IntraBlockState) getStateObject(addr accounts.Address, recordRead boo
 		account = readAccount
 	}
 
-	// recordRead=false must still reconcile on the versioned path: the map-miss above
-	// already recorded a nil marker (refreshAccount/getVersionedAccount), and a
-	// wrong nil read would spuriously invalidate against a later record cell.
+	// recordRead=false still must reconcile on the versioned path, since the map-miss above already recorded a nil marker.
 	if recordRead || sdb.versionMap != nil {
 		sdb.accountRead(addr, account, accountSource, accountVersion)
 	}
 	obj := newObject(sdb, addr, account, account)
 	if code.Bytes != nil {
-		// The account record can lag a prior tx's code write, so the resolved
-		// hash wins: SetCode's revert-to-original check would drop the write.
+		// The account record can lag a prior tx's code write, so the resolved hash wins over SetCode's revert-to-original check.
 		codeHash := code.codeHash(codeSource, obj.data.CodeHash)
 		obj.code = accounts.Code{Hash: codeHash, Bytes: code.Bytes}
 		if codeHash != obj.data.CodeHash {
@@ -2177,20 +1842,18 @@ func (sdb *IntraBlockState) setStateObject(addr accounts.Address, object *stateO
 	sdb.stateObjects[addr] = object
 }
 
-// Retrieve a state object or create a new state object if nil.
 func (sdb *IntraBlockState) GetOrNewStateObject(addr accounts.Address) (*stateObject, error) {
 	stateObject, err := sdb.getStateObject(addr, true)
 	if err != nil {
 		return nil, err
 	}
 	if stateObject == nil || stateObject.deleted {
-		stateObject = sdb.createObject(addr, stateObject /* previous */)
+		stateObject = sdb.createObject(addr, stateObject)
 	}
 	return stateObject, nil
 }
 
-// createObject creates a new state object. If there is an existing account with
-// the given address, it is overwritten.
+// createObject creates a new state object, overwriting any existing one at addr.
 func (sdb *IntraBlockState) createObject(addr accounts.Address, previous *stateObject) (newobj *stateObject) {
 	account := &accounts.Account{}
 	var original *accounts.Account
@@ -2202,7 +1865,7 @@ func (sdb *IntraBlockState) createObject(addr accounts.Address, previous *stateO
 
 	account.Root.SetBytes(trie.EmptyRoot[:]) // old storage should be ignored
 	newobj = newObject(sdb, addr, account, original)
-	newobj.setNonce(0) // sets the object to dirty
+	newobj.setNonce(0)
 	if previous == nil {
 		sdb.journal.createObjectChange(addr)
 	} else {
@@ -2218,24 +1881,12 @@ func (sdb *IntraBlockState) createObject(addr accounts.Address, previous *stateO
 	}
 	data := newobj.data
 	sdb.recordWriteAddress(addr, &data)
-	// Write CodeHashPath so that any stale versionedReads cache entry
-	// (e.g. from the pre-creation GetCodeHash check in EVM create()) is
-	// invalidated.  newObject normalises the zero-value CodeHash to
-	// EmptyCodeHash, so this records keccak256("") for a fresh account.
+	// Writes CodeHashPath so a stale versionedReads cache entry is invalidated, recording keccak256("") for a fresh account.
 	sdb.recordWriteCodeHash(addr, newobj.data.CodeHash)
 	return newobj
 }
 
-// CreateAccount explicitly creates a state object. If a state object with the address
-// already exists the balance is carried over to the new account.
-//
-// CreateAccount is called during the EVM CREATE operation. The situation might arise that
-// a contract does the following:
-//
-//  1. sends funds to sha(account ++ (nonce + 1))
-//  2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
-//
-// Carrying over the balance ensures that Ether doesn't disappear.
+// CreateAccount creates a state object, carrying over any existing balance so a pre-funded address doesn't lose ether.
 func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreation bool) (err error) {
 	var prevInc uint64
 	var previous *stateObject
@@ -2273,11 +1924,7 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 		if readAccount != nil {
 			account := readAccount
 
-			// Derive destructed without recording a SelfDestructPath read: the
-			// flag is a worker signal the BAL cannot pre-populate, so a recorded
-			// probe races the destroyer's flush on a CREATE2 re-creation. The
-			// value-carrying synthetic incarnation/balance reads below pin every
-			// consequence of the flag, so a stale conclusion still invalidates.
+			// Derives destructed without recording a SelfDestructPath read, since that would race a CREATE2 re-creation.
 			destructed := false
 			if sd, ok := sdb.versionedWriteSelfDestruct(addr); ok {
 				destructed = sd
@@ -2285,25 +1932,14 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 				destructed = true
 			}
 
-			// Reuse the cached stateObject directly `previous` so that (a) selfdestructed=true is captured,
-			// (b) the accumulated incarnation is used for the new object's PrevIncarnation (important when the
-			// account was created and destroyed multiple times within the same block), and
-			// (c) after a REVERT CommitBlock can still emit DeleteAccount for it (accumulated-IBS
-			// path, e.g. GenerateChain, where the map carries no SelfDestructPath cell).
+			// Reuses the cached stateObject as previous so selfdestructed/incarnation history survives a later revert.
 			if !destructed {
 				if so, ok := sdb.stateObjects[addr]; ok && so.selfdestructed {
 					previous = so
 				}
 			}
 
-			// Honour same-block revival (#21319): a prior tx's self-destruct is
-			// overridden by a later tx that revived the account to a non-empty
-			// state (a value transfer leaving balance/nonce/code behind). A value-0
-			// no-op transfer that leaves it empty does NOT revive it (EIP-161
-			// removes it again). account is the version-map-refreshed record, so
-			// its emptiness is the authoritative revival test. Without this,
-			// CreateAccount keeps previous.selfdestructed set and skips the balance
-			// carry below — losing the revived funds.
+			// A later tx's non-empty transfer revives a prior self-destruct (EIP-161 emptiness is the authoritative test).
 			if destructed && sdb.versionMap != nil && !account.Empty() {
 				destructed = false
 			}
@@ -2313,23 +1949,11 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 				previous.selfdestructed = destructed
 			}
 		} else if so, ok := sdb.stateObjects[addr]; ok && so.deleted {
-			// The account was selfdestructed in an earlier transaction within the
-			// same block (accumulated IBS, e.g. GenerateChain) AND the underlying
-			// storage has no record of it (e.g. it was created within this block).
-			// getVersionedAccount returned nil; preserve the deleted stateObject as
-			// `previous` so that after a REVERT CommitBlock can still emit
-			// DeleteAccount for it.
 			previous = so
 		} else if so, ok := sdb.stateObjects[addr]; ok {
-			// The serial block builder runs with a version map but does not flush
-			// per-tx writes to it, so a same-block credit on this IBS lives only in
-			// the cache; reuse it as `previous` to keep the balance carry-over below.
 			previous = so
 		} else if sd, ok := sdb.versionedWriteSelfDestruct(addr); ok && sd {
-			// Cache-free parallel path: a within-tx create→self-destruct leaves no
-			// committed base record and no cached stateObject. Rebuild `previous`
-			// from this tx's own cells so the recreated account's incarnation still
-			// accumulates and the resurrect write is emitted.
+			// Cache-free path: rebuilds previous from this tx's own cells since a create-then-destroy leaves no base record or cached object.
 			prev := newObject(sdb, addr, &accounts.Account{}, &accounts.Account{})
 			prev.selfdestructed = true
 			if vw, ok := sdb.versionedWrites.GetIncarnation(addr); ok {
@@ -2350,9 +1974,7 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 	if previous != nil && prevInc < previous.data.PrevIncarnation {
 		prevInc = previous.data.PrevIncarnation
 	}
-	// Capture each path's own (source, version) for the synthetic reads stamped
-	// at the bottom of the function — inheriting the account-record version
-	// would trip the validator on the recursive AddressPath check.
+	// Captures each path's own (source, version) for the synthetic reads below, since inheriting the account-record version would trip the validator.
 	incSource, incVersion := StorageRead, UnknownVersion
 	if sdb.versionMap != nil {
 		if inc, res, ok := sdb.versionMap.ReadIncarnation(addr, sdb.txIndex); ok && res.Status() == MVReadResultDone {
@@ -2370,8 +1992,6 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 			balVersion = Version{TxIndex: res.DepIdx(), Incarnation: res.Incarnation()}
 		}
 	}
-	// Writer.DeleteAccount stores the selfdestructed incarnation in rs.selfdestructedByTx.
-	// Recover it here so that CreateAccount in the next tx computes newInc = prevInc+1 correctly.
 	if sdb.versionMap == nil && previous == nil {
 		type deletedIncReader interface {
 			ReadDeletedIncarnation(accounts.Address) (uint64, bool)
@@ -2383,12 +2003,6 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 		}
 	}
 
-	// Capture the address's current balance BEFORE createObject writes the fresh
-	// zero-balance record. versionedAccountBase returns the base record without
-	// overlaying this tx's own field writes, so previous.data.Balance can lag
-	// either an in-block credit (genesis Constructor: AddBalance then SysCreate)
-	// or a committed prefund (CREATE at a pre-funded address). Reading after
-	// createObject would see the just-written zero and drop the balance.
 	var carryBalance uint256.Int
 	carryBalanceValid := previous != nil && !previous.selfdestructed
 	if carryBalanceValid {
@@ -2400,11 +2014,7 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 	}
 	newObj := sdb.createObject(addr, previous)
 	if previous != nil && previous.selfdestructed {
-		// The reset-object journal entry already marks addr dirty, but that
-		// mark is dropped if the entry is reverted; this un-journalled
-		// increment keeps a resurrected address in journal.dirties across an
-		// intra-tx revert. Confined to CreateAccount — the GetOrNewStateObject
-		// AddBalance path must NOT mark dirty here.
+		// The reset-object journal entry's dirty mark drops on revert; this un-journalled increment keeps it dirty, confined to CreateAccount.
 		sdb.journal.dirty(addr)
 	}
 	if carryBalanceValid {
@@ -2415,9 +2025,7 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 	if contractCreation {
 		newObj.createdContract = true
 		newObj.data.Incarnation = prevInc + 1
-		// Record contract creation in the versioned writes so that
-		// Normalize knows this address was created (prevents
-		// empty account deletion for newly deployed contracts).
+		// Records contract creation so Normalize knows this address was created, preventing empty-account deletion.
 		sdb.recordWriteCreateContract(addr, true)
 		if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(addr.Handle())) {
 			fmt.Printf("%d (%d.%d) New Incarnation %x: %d\n", sdb.blockNum, sdb.txIndex, sdb.version, addr, newObj.data.Incarnation)
@@ -2426,15 +2034,7 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 		newObj.selfdestructed = false
 	}
 
-	// for newly created accounts these synthetic read/writes are used so that account
-	// creation clashes between transactions get detected. Only record the BalancePath
-	// read on the first creation of this account in the tx: a re-creation (e.g. CREATE2
-	// to an address funded and created earlier in the same tx) carries the live
-	// post-transfer balance, and overwriting the first read's pre-tx value with it would
-	// seed a wrong block-access-list baseline and drop the real balance change. But if
-	// that first read was internal (conflict-detection only, so excluded from the block
-	// access list), promote it: without a real read the unchanged balance write has no
-	// baseline and would emit a spurious net-zero balance change.
+	// Only the first creation's BalancePath read is kept as the BAL baseline; a same-tx re-creation must not overwrite it.
 	sdb.MarkAddressAccess(addr, true)
 	if sdb.versionMap != nil {
 		if vr, seen := sdb.versionedReads.GetBalance(addr); !seen {
@@ -2454,7 +2054,6 @@ func (sdb *IntraBlockState) CreateAccount(addr accounts.Address, contractCreatio
 	return nil
 }
 
-// Snapshot returns an identifier for the current revision of the state.
 func (sdb *IntraBlockState) PushSnapshot() int {
 	return sdb.revisions.snapshot(sdb.journal)
 }
@@ -2463,7 +2062,6 @@ func (sdb *IntraBlockState) PopSnapshot(snapshot int) {
 	sdb.revisions.returnSnapshot(snapshot)
 }
 
-// RevertToSnapshot reverts all state changes made since the given revision.
 func (sdb *IntraBlockState) RevertToSnapshot(revid int, err error) {
 	var traced bool
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TracingAccounts()) {
@@ -2480,7 +2078,6 @@ func (sdb *IntraBlockState) RevertToSnapshot(revid int, err error) {
 	}
 
 	snapshot := sdb.revisions.revertToSnapshot(revid)
-	// Replay the journal to undo changes and remove invalidated snapshots
 	sdb.journal.revert(sdb, snapshot)
 
 	if traced {
@@ -2488,22 +2085,18 @@ func (sdb *IntraBlockState) RevertToSnapshot(revid int, err error) {
 	}
 }
 
-// GetRefund returns the current value of the refund counter.
 func (sdb *IntraBlockState) GetRefund() uint64 {
 	return sdb.refund
 }
 
-// EIP161EmptyRemoval reports whether an empty account at addr is removed under
-// EIP-161 (SpuriousDragon). AuRa retains its SystemAddress even when empty, to
-// match the reference implementation.
+// EIP161EmptyRemoval reports EIP-161 removal, except AuRa keeps its SystemAddress even when empty.
 func EIP161EmptyRemoval(eip161Enabled, isAura bool, addr accounts.Address) bool {
 	return eip161Enabled && (!isAura || addr != params.SystemAddress)
 }
 
 func updateAccount(eip161Enabled bool, isAura bool, stateWriter StateWriter, addr accounts.Address, stateObject *stateObject, isDirty bool, trace bool, tracingHooks *tracing.Hooks, useBlockOrigin bool, eip8246 bool) error {
 	emptyRemoval := EIP161EmptyRemoval(eip161Enabled, isAura, addr) && stateObject.data.Empty()
-	// EIP-8246: a self-destructed account that still holds a balance is reset to
-	// a balance-only account (nonce 0, empty code, empty storage) not deleted.
+	// EIP-8246: a self-destructed account still holding a balance resets to a balance-only account, not deleted.
 	sdPreserveBalance := eip8246 && stateObject.selfdestructed && !stateObject.data.Balance.IsZero()
 	if (stateObject.selfdestructed && !sdPreserveBalance) || (isDirty && emptyRemoval) {
 		balance := stateObject.Balance()
@@ -2526,10 +2119,7 @@ func updateAccount(eip161Enabled bool, isAura bool, stateWriter StateWriter, add
 		stateObject.data.Incarnation = 0
 		stateObject.code = accounts.Code{}
 		stateObject.deleted = false
-		// Supersede Selfdestruct's pre-destruct IncarnationPath: extraction keeps
-		// incarnation for self-destructed accounts (unlike nonce/code/codeHash,
-		// which the extraction filter drops), and a later CREATE2 must see the
-		// persisted balance-only record's 0 in every execution mode.
+		// Supersedes the pre-destruct IncarnationPath so a later CREATE2 sees this record's 0 explicitly.
 		stateObject.db.recordWriteIncarnation(addr, 0)
 		if err := stateWriter.CreateContract(addr); err != nil {
 			return err
@@ -2539,9 +2129,7 @@ func updateAccount(eip161Enabled bool, isAura bool, stateWriter StateWriter, add
 		}
 	} else if isDirty && (stateObject.createdContract || !stateObject.selfdestructed) && !emptyRemoval {
 		stateObject.deleted = false
-		// Write any contract code associated with the state object; dirtyCode is
-		// set only when code actually changed, so a clear-to-empty must still
-		// write through (empty CodeDomain, consistent with the empty codeHash).
+		// dirtyCode is set only when code actually changed; a clear-to-empty must still write through for a consistent CodeDomain.
 		if stateObject.dirtyCode {
 			if err := stateWriter.UpdateAccountCode(addr, stateObject.data.Incarnation, stateObject.data.CodeHash, stateObject.code.Bytes); err != nil {
 				return err
@@ -2564,11 +2152,7 @@ func updateAccount(eip161Enabled bool, isAura bool, stateWriter StateWriter, add
 		if err := stateWriter.UpdateAccountData(addr, &stateObject.original, &stateObject.data); err != nil {
 			return err
 		}
-		// Note: in parallel mode, individual setters (AddBalance, SetNonce)
-		// call versionWritten for their specific field. Fields not modified
-		// by the TX (e.g., CodeHash when only balance changed) are NOT in
-		// the versionMap's WriteSet. The Normalize function handles
-		// this by reading missing account fields from the stateReader.
+		// In parallel mode, untouched fields aren't in the versionMap's WriteSet; Normalize fills those in from the stateReader.
 	}
 	return nil
 }
@@ -2579,7 +2163,6 @@ func printAccount(eip161Enabled bool, isAura bool, addr accounts.Address, stateO
 		fmt.Printf("delete: %x\n", addr)
 	}
 	if isDirty && (stateObject.createdContract || !stateObject.selfdestructed) && !emptyRemoval {
-		// Write any contract code associated with the state object
 		if stateObject.code.Bytes != nil && stateObject.dirtyCode {
 			fmt.Printf("UpdateCode: %x,%x\n", addr, stateObject.data.CodeHash)
 		}
@@ -2601,12 +2184,7 @@ func (sdb *IntraBlockState) FinalizeTx(chainRules *chain.Rules, stateWriter Stat
 	for addr := range sdb.journal.dirties {
 		so, exist := sdb.stateObjects[addr]
 		if !exist {
-			// ripeMD is 'touched' at block 1714175, in txn 0x1237f737031e40bcde4a8b7e717b2d15e3ecadfe49bb1bbc71ee9deb09c6fcf2
-			// That txn goes out of gas, and although the notion of 'touched' does not exist there, the
-			// touch-event will still be recorded in the journal. Since ripeMD is a special snowflake,
-			// it will persist in the journal even though the journal is reverted. In this special circumstance,
-			// it may exist in `sdb.journal.dirties` but not in `sdb.stateObjects`.
-			// Thus, we can safely ignore it here
+			// ripeMD is a special case: an out-of-gas touch still journals it and survives a revert, so it can lack a stateObject — safe to skip.
 			continue
 		}
 
@@ -2614,26 +2192,14 @@ func (sdb *IntraBlockState) FinalizeTx(chainRules *chain.Rules, stateWriter Stat
 			return err
 		}
 
-		// Per EIP-6780 + EIP-7928: SELFDESTRUCT of a SAME-TX created contract
-		// wipes storage at end-of-tx, so the BAL must record dirty slots as
-		// reads, not changes. Zero storage versionedWrites so AsBlockAccessList
-		// folds them away via net-zero. Must run BEFORE so.newlyCreated = false.
-		// The block assembler's BAL is built per-tx from ibs.TxIO() and never
-		// fires the MakeWriteSet hook, so this per-tx hook is required for
-		// assembler/validator BAL convergence.
+		// EIP-6780+EIP-7928: a same-tx contract's SELFDESTRUCT wipes storage; zero the writes so the BAL folds them away via net-zero.
 		if sdb.versionMap != nil && so.selfdestructed && so.newlyCreated {
 			for key := range so.dirtyStorage {
 				sdb.recordWriteStorage(addr, key, uint256.Int{})
 			}
 		}
 
-		// EIP-8246: a balance-preserving SELFDESTRUCT leaves the account alive
-		// (balance kept, code/nonce/storage cleared). The block assembler reuses
-		// one IBS across txs without Reset, so replace the destroyed object with
-		// a clean balance-only one — done after the storage/BAL cleanup above,
-		// which still needs the selfdestructed marker. Otherwise a later tx's
-		// CREATE2 at this address sees a stale selfdestructed flag and drops the
-		// preserved balance, building an invalid block.
+		// EIP-8246 leaves a balance-preserving SELFDESTRUCT alive; replace it with a clean balance-only object since the assembler reuses one IBS across txs.
 		if so.selfdestructed && !so.deleted {
 			preserved := accounts.NewAccount()
 			preserved.Balance = so.data.Balance
@@ -2650,23 +2216,15 @@ func (sdb *IntraBlockState) FinalizeTx(chainRules *chain.Rules, stateWriter Stat
 
 func (sdb *IntraBlockState) SoftFinalise() {
 	for addr := range sdb.journal.dirties {
-		// versionMap (parallel) path: a write can be recorded to versionedWrites
-		// without materializing a stateObject, so dirtiness must come from the
-		// journal (populated alongside every recordWrite), not stateObject
-		// existence — else MakeWriteSet's revert reconciliation drops the write.
-		// Serial path keeps the stateObject gate: a touched-but-reverted address
-		// (ripeMD, out-of-gas) lingers in journal.dirties without a stateObject.
+		// Parallel path: dirtiness must come from the journal, not stateObject existence, or MakeWriteSet drops writes.
 		if _, exist := sdb.stateObjects[addr]; !exist && sdb.versionMap == nil {
 			continue
 		}
 		sdb.stateObjectsDirty[addr] = struct{}{}
 	}
-	// Invalidate journal because reverting across transactions is not allowed.
 	sdb.clearJournalAndRefund()
 }
 
-// CommitBlock finalizes the state by removing the self destructed objects
-// and clears the journal as well as the refunds.
 func (sdb *IntraBlockState) CommitBlock(chainRules *chain.Rules, stateWriter StateWriter) error {
 	for addr, bi := range sdb.balanceInc {
 		if !bi.transferred {
@@ -2676,20 +2234,14 @@ func (sdb *IntraBlockState) CommitBlock(chainRules *chain.Rules, stateWriter Sta
 	return sdb.MakeWriteSet(chainRules, stateWriter)
 }
 
-// ExtractAndClearDirty snapshots the current stateObjectsDirty set and clears it.
-// Used by eth_simulateV1 to separate accounts dirtied by stateOverrides from those
-// dirtied by actual transaction execution, so CommitBlock does not apply EIP-161 to
-// override-only accounts.
+// ExtractAndClearDirty snapshots and clears stateObjectsDirty, so eth_simulateV1 can skip EIP-161 on override-only accounts.
 func (sdb *IntraBlockState) ExtractAndClearDirty() map[accounts.Address]struct{} {
 	dirty := maps.Clone(sdb.stateObjectsDirty)
 	clear(sdb.stateObjectsDirty)
 	return dirty
 }
 
-// CommitOverrideDirtyAccounts writes state-override accounts that were not subsequently
-// touched by any transaction (and therefore not handled by CommitBlock).  EIP-161 is
-// intentionally disabled: override accounts are simulation-only mutations and must not
-// be removed simply because they are "empty" by consensus rules.
+// CommitOverrideDirtyAccounts writes override accounts CommitBlock didn't reach; EIP-161 is disabled so they aren't dropped for looking empty.
 func (sdb *IntraBlockState) CommitOverrideDirtyAccounts(chainRules *chain.Rules, stateWriter StateWriter, overrideDirty map[accounts.Address]struct{}) error {
 	for addr := range overrideDirty {
 		if _, alsoTxDirty := sdb.stateObjectsDirty[addr]; alsoTxDirty {
@@ -2744,10 +2296,7 @@ func (sdb *IntraBlockState) MakeWriteSet(chainRules *chain.Rules, stateWriter St
 		if err := updateAccount(chainRules.IsEIP161Enabled(), chainRules.IsAura, stateWriter, addr, stateObject, isDirty, sdb.trace, sdb.tracingHooks, true, chainRules.IsAmsterdam); err != nil {
 			return err
 		}
-		// Per EIP-6780 + EIP-7928: a SELFDESTRUCT against a SAME-TX created
-		// contract clears storage at end-of-tx, so the BAL must record the
-		// dirty slots as reads, not changes. Zero the storage versionedWrite
-		// values so AsBlockAccessList's net-zero check folds them away.
+		// EIP-6780/7928: a same-tx contract's SELFDESTRUCT wipes storage; zero the writes here too so AsBlockAccessList nets them away.
 		if sdb.versionMap != nil && stateObject.selfdestructed && stateObject.newlyCreated {
 			for key := range stateObject.dirtyStorage {
 				sdb.recordWriteStorage(addr, key, uint256.Int{})
@@ -2768,24 +2317,18 @@ func (sdb *IntraBlockState) MakeWriteSet(chainRules *chain.Rules, stateWriter St
 		sdb.versionedWrites.deleteAddr(addr)
 	}
 
-	// Invalidate journal because reverting across transactions is not allowed.
 	sdb.clearJournalAndRefund()
 	return nil
 }
 
-// FinalizedWrites applies EIP-6780 normalization and EIP-161 filtering, then
-// returns a detached committable snapshot.
+// FinalizedWrites applies EIP-6780 normalization and EIP-161 filtering, returning a detached committable snapshot.
 func (sdb *IntraBlockState) FinalizedWrites(chainRules *chain.Rules) *WriteSet {
 	writes := sdb.versionedWrites.Finalize()
 	sdb.withholdCreatedEmptyAccounts(chainRules, writes)
 	return writes
 }
 
-// withholdCreatedEmptyAccounts drops writes for accounts the tx observed as
-// absent and left empty (EIP-161): such an account is absent both before and
-// after the tx, so omitting its writes is exact and no deletion marker is
-// needed. An account that existed before is kept even when it ends empty —
-// clearing it needs an explicit delete, which commit-time normalization emits.
+// withholdCreatedEmptyAccounts drops writes for an account absent both before and after the tx (EIP-161).
 func (sdb *IntraBlockState) withholdCreatedEmptyAccounts(chainRules *chain.Rules, writes *WriteSet) {
 	if sdb.blockNum == 0 || chainRules == nil {
 		return
@@ -2802,13 +2345,11 @@ func (sdb *IntraBlockState) withholdCreatedEmptyAccounts(chainRules *chain.Rules
 	}
 }
 
-// MergeTxIOInto folds the current transaction's reads and supplied writes into io.
 func (sdb *IntraBlockState) MergeTxIOInto(io *VersionedIO, writes *WriteSet) {
 	version := Version{BlockNum: sdb.blockNum, TxIndex: sdb.txIndex, Incarnation: sdb.version}
 	io.mergeTx(version, sdb.versionedReads, writes)
 }
 
-// FlushWritesToVersionMap publishes the supplied writes to this state's version map.
 func (sdb *IntraBlockState) FlushWritesToVersionMap(writes *WriteSet) {
 	if sdb.versionMap == nil {
 		return
@@ -2825,52 +2366,25 @@ func (sdb *IntraBlockState) Print(chainRules chain.Rules, all bool) {
 	}
 }
 
-// SetTxContext sets the current transaction index which
-// used when the EVM emits new state logs. It should be invoked before
-// transaction execution.
+// SetTxContext sets the tx index used for new state logs; call before transaction execution.
 func (sdb *IntraBlockState) SetTxContext(bn uint64, ti int) {
-	/* Not sure what this test is for it seems to break some tests
-	if len(sdb.logs.entries) > 0 && ti == 0 {
-		err := fmt.Errorf("seems you forgot `ibs.Reset` or `ibs.TxIndex()`. len(sdb.logs.entries)=%d, ti=%d", len(sdb.logs.entries), ti)
-		panic(err)
-	}
-	if sdb.txIndex >= 0 && sdb.txIndex > ti {
-		err := fmt.Errorf("seems you forgot `ibs.Reset` or `ibs.TxIndex()`. sdb.txIndex=%d, ti=%d", sdb.txIndex, ti)
-		panic(err)
-	}
-	*/
 	sdb.txIndex = ti
 	sdb.blockNum = bn
 	sdb.sdProbeEpoch++
 }
 
-// no not lock
 func (sdb *IntraBlockState) clearJournalAndRefund() {
 	sdb.journal.Reset()
 	sdb.revisions.reset()
 	sdb.refund = uint64(0)
 	if dbg.AssertEnabled && !sdb.noMaterialize && !sdb.stateObjectArena.empty() {
-		// Slots are rewound per transaction, so only the path that caches nothing
-		// may draw them.
+		// Slots are rewound per transaction, so only the path that caches nothing may draw them.
 		panic("stateObjectArena not empty with noMaterialize=false")
 	}
-	sdb.stateObjectArena.reset() // same lifetime with `journal`
+	sdb.stateObjectArena.reset()
 }
 
-// Prepare handles the preparatory steps for executing a state transition.
-// This method must be invoked before state transition.
-//
-// Berlin fork:
-// - Add sender to access list (EIP-2929)
-// - Add destination to access list (EIP-2929)
-// - Add precompiles to access list (EIP-2929)
-// - Add the contents of the optional txn access list (EIP-2930)
-//
-// Shanghai fork:
-// - Add coinbase to access list (EIP-3651)
-//
-// Cancun fork:
-// - Reset transient storage (EIP-1153)
+// Prepare runs the preparatory access-list/transient-storage steps (EIP-2929/2930/3651/1153); must be invoked before a state transition.
 func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase accounts.Address, dst accounts.Address,
 	precompiles []accounts.Address, list types.AccessList) {
 	if dbg.TraceTransactionIO && (sdb.trace || dbg.TraceAccount(sender.Handle()) || !dst.IsNil() && dbg.TraceAccount(dst.Handle())) {
@@ -2880,14 +2394,12 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 	sdb.eip161 = rules.IsEIP161Enabled()
 	sdb.isAura = rules.IsAura
 	if rules.IsBerlin {
-		// Clear out any leftover from previous executions
 		sdb.accessList.Reset()
 		al := &sdb.accessList
 
 		al.AddAddress(sender)
 		if !dst.IsNil() {
 			al.AddAddress(dst)
-			// If it's a create-tx, the destination will be added inside evm.create
 		}
 		for _, addr := range precompiles {
 			al.AddAddress(addr)
@@ -2899,11 +2411,10 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 				al.AddSlot(address, accounts.InternKey(key))
 			}
 		}
-		if rules.IsShanghai { // EIP-3651: warm coinbase
+		if rules.IsShanghai {
 			al.AddAddress(coinbase)
 		}
 	}
-	// Reset transient storage at the beginning of transaction execution
 	clear(sdb.transientStorage)
 	sdb.versionedReads.access = nil
 	sdb.recordAccess = true
@@ -2914,7 +2425,6 @@ func (sdb *IntraBlockState) Prepare(rules *chain.Rules, sender, coinbase account
 	}
 }
 
-// AddAddressToAccessList adds the given address to the access list
 func (sdb *IntraBlockState) AddAddressToAccessList(addr accounts.Address) (addrMod bool) {
 	addrMod = sdb.accessList.AddAddress(addr)
 	if addrMod {
@@ -2923,14 +2433,10 @@ func (sdb *IntraBlockState) AddAddressToAccessList(addr accounts.Address) (addrM
 	return addrMod
 }
 
-// AddSlotToAccessList adds the given (address, slot)-tuple to the access list
 func (sdb *IntraBlockState) AddSlotToAccessList(addr accounts.Address, slot accounts.StorageKey) (addrMod, slotMod bool) {
 	addrMod, slotMod = sdb.accessList.AddSlot(addr, slot)
 	if addrMod {
-		// In practice, this should not happen, since there is no way to enter the
-		// scope of 'address' without having the 'address' become already added
-		// to the access list (via call-variant, create, etc).
-		// Better safe than sorry, though
+		// Defensive: entering 'address' scope should already imply it's access-listed.
 		sdb.journal.accessListAddAccountChange(addr)
 	}
 	if slotMod {
@@ -2939,7 +2445,6 @@ func (sdb *IntraBlockState) AddSlotToAccessList(addr accounts.Address, slot acco
 	return addrMod, slotMod
 }
 
-// AddressInAccessList returns true if the given address is in the access list.
 func (sdb *IntraBlockState) AddressInAccessList(addr accounts.Address) bool {
 	return sdb.accessList.ContainsAddress(addr)
 }
@@ -2948,9 +2453,7 @@ func (sdb *IntraBlockState) SlotInAccessList(addr accounts.Address, slot account
 	return sdb.accessList.Contains(addr, slot)
 }
 
-// SlotKnownWarm is a conservative fast check: true means the (addr, slot) pair
-// is warm; false means unknown — callers must fall back to AddSlotToAccessList.
-// It stays cheap enough to inline at every SLOAD/SSTORE gas-charge site.
+// SlotKnownWarm is conservative: true means warm, false means unknown, so the caller must fall back to AddSlotToAccessList.
 func (sdb *IntraBlockState) SlotKnownWarm(addr accounts.Address, slot accounts.StorageKey) bool {
 	return sdb.accessList.lastSlots != nil && sdb.accessList.lastAddr == addr && slot == sdb.accessList.lastWarmSlot
 }
@@ -2972,20 +2475,12 @@ func (sdb *IntraBlockState) MarkAddressAccess(addr accounts.Address, revertable 
 	}
 }
 
-// StartAccessRecording enables versioned access tracking until ResetVersionedIO.
-// Block finalization re-enables it (Prepare only runs for user txs) so that an
-// address touched but left absent — e.g. a zero-amount withdrawal recipient —
-// still reaches the BAL as an access-only entry: its reads are validation-only
-// and FinalizedWrites withholds its created-empty writes.
+// StartAccessRecording enables versioned access tracking until ResetVersionedIO, so a touched-but-absent address still reaches the BAL.
 func (sdb *IntraBlockState) StartAccessRecording() {
 	sdb.recordAccess = true
 }
 
-// MarkReadsInternal marks all versioned reads for addr as internal.
-// Internal reads are kept for parallel-execution conflict detection
-// but excluded from the block access list (BAL).  This is used when
-// a state read was performed for gas calculation but the operation
-// was rejected (e.g. CALL with value inside STATICCALL).
+// MarkReadsInternal marks addr's reads as internal: kept for conflict detection but excluded from the BAL.
 func (sdb *IntraBlockState) MarkReadsInternal(addr accounts.Address) {
 	sdb.versionedReads.ScanAddr(addr, func(_ AccountPath, _ accounts.StorageKey, hdr *ReadHeader) {
 		hdr.internal = true
@@ -3001,21 +2496,15 @@ func (sdb *IntraBlockState) accountRead(addr accounts.Address, account *accounts
 	if sdb.versionMap != nil {
 		sdb.MarkAddressAccess(addr, true)
 		if source == WriteSetRead {
-			// A read satisfied by this tx's own earlier write carries no
-			// cross-tx dependency; recording it would make the validator
-			// (floored below the tx's own writes) return None and wrongly
-			// invalidate the tx.
+			// A read from this tx's own earlier write has no cross-tx dependency; recording it would wrongly invalidate the tx.
 			return
 		}
 		if source == ReadSetRead {
-			// Served from the read set: the entry being reconciled is already
-			// recorded with its real source; re-recording would launder the
-			// synthetic tx-reads source into validation, which rejects it.
+			// Served from the read set: already recorded with its real source; re-recording would launder it past validation.
 			return
 		}
 		data := *account
-		// Demote a sub-field MapRead promotion when AddressPath itself has no cell,
-		// or the validator non-converges on its recursive AddressPath check.
+		// Demotes a sub-field MapRead promotion when AddressPath itself has no cell, or the validator non-converges.
 		if source == MapRead {
 			if _, res, ok := sdb.versionMap.ReadAddress(addr, sdb.txIndex); !ok || res.Status() != MVReadResultDone {
 				source = StorageRead
@@ -3029,15 +2518,7 @@ func (sdb *IntraBlockState) accountRead(addr accounts.Address, account *accounts
 	}
 }
 
-// recordWriteX helpers record a versioned write at the specified path
-// directly into the typed per-path map.  No generic dispatcher / runtime
-// type switch — each helper is monomorphic by path.
-
-// recordWrite* — typed write recorders for each AccountPath.  Pool fast
-// path: a repeat write to the same (addr[,key]) reuses the existing
-// *VersionedWrite[T] in place (no alloc, no map churn).  Only the first
-// write per (addr[,key]) per tx hits getVW* + SetX.  WriteSet.ReleaseAndReset
-// returns every VW to its pool.
+// recordWrite* helpers are monomorphic per AccountPath: a repeat write reuses the existing *VersionedWrite[T] with no alloc.
 
 func (sdb *IntraBlockState) recordWriteBalance(addr accounts.Address, val uint256.Int) {
 	sdb.MarkAddressAccess(addr, true)
@@ -3232,16 +2713,7 @@ func traceWrite[T any](sdb *IntraBlockState, vw *VersionedWrite[T]) {
 		hdr.Address, AccountKey{Path: hdr.Path, Key: hdr.Key}, vw.Val, hdr.Version.TxIndex, hdr.Version.Incarnation)
 }
 
-// versionedWriteSelfDestruct returns the SelfDestructPath write for addr
-// in the dirty per-tx write set, if any.
-// accountLifecycle returns the complete self-destruct verdict for the current
-// tx, layering the tx's own field-level SelfDestruct write over the versionMap
-// floor — the account-level analogue of what versionedReadCore does per field.
-// It consults the read/write collections and the versionMap only, never the
-// stateObject (whose deleted flag is a redundant cache of the own SelfDestruct
-// write). An own-tx SelfDestruct write is authoritative (newest): true after a
-// same-tx SD, false after a same-tx recreate. With no own write, the floor's
-// destroyed-and-not-revived verdict applies.
+// accountLifecycle layers this tx's own SelfDestruct write over the versionMap floor to give the self-destruct verdict.
 func (sdb *IntraBlockState) accountLifecycle(addr accounts.Address) (destroyed bool) {
 	if own, ok := sdb.versionedWriteSelfDestruct(addr); ok {
 		return own
@@ -3264,9 +2736,7 @@ func (sdb *IntraBlockState) versionedWriteSelfDestruct(addr accounts.Address) (b
 	return vw.Val, true
 }
 
-// versionedWriteCreateContract reports whether this tx's own writes created a
-// contract at addr (the CreateContract cell). Guarded by journal.dirties so a
-// stale entry from a reverted create is ignored.
+// versionedWriteCreateContract reports whether this tx's own writes created a contract at addr, guarded by journal.dirties.
 func (sdb *IntraBlockState) versionedWriteCreateContract(addr accounts.Address) (bool, bool) {
 	if sdb.versionMap == nil {
 		return false, false
@@ -3281,11 +2751,7 @@ func (sdb *IntraBlockState) versionedWriteCreateContract(addr accounts.Address) 
 	return vw.Val, true
 }
 
-// reconstructCellFlags stamps the transient (uncached) stateObject's
-// create/self-destruct flags from this tx's own versioned-write cells. Under
-// noMaterialize the stateObject is rebuilt on every getStateObject call, so the
-// createdContract / newlyCreated / selfdestructed state that a materialized
-// object would have carried must be recovered from the cells instead.
+// reconstructCellFlags stamps a transient stateObject's create/self-destruct flags from this tx's own write cells.
 func (sdb *IntraBlockState) reconstructCellFlags(obj *stateObject, addr accounts.Address) {
 	if obj == nil {
 		return
@@ -3297,16 +2763,7 @@ func (sdb *IntraBlockState) reconstructCellFlags(obj *stateObject, addr accounts
 	if sd, ok := sdb.versionedWriteSelfDestruct(addr); ok && sd {
 		obj.selfdestructed = true
 	}
-	// The transient is rebuilt from the AddressPath account, whose CodeHash can
-	// lag the CodePath/CodeHashPath cells (e.g. a delegation set by a prior tx
-	// whose AddressPath record was published with an empty code hash). Seed the
-	// code from this tx's own Code write, else the versionMap floor cell, so
-	// object code reads (GetDelegatedDesignation, stateObject.Code()) agree with
-	// the cells — matching the refresh-and-sync the fall-through getStateObject
-	// path performs for accounts it materializes from scratch. An own write is
-	// authoritative even when it clears code to empty (EIP-7702 delegation
-	// clearing writes nil bytes / EmptyCodeHash); falling through to the floor
-	// there would resurrect the prior-tx delegation.
+	// The transient's CodeHash can lag CodePath/CodeHashPath cells; seed code from this tx's own write or the floor cell.
 	if _, isDirty := sdb.journal.dirties[addr]; isDirty {
 		if vw, ok := sdb.versionedWrites.GetCode(addr); ok {
 			obj.code = vw.Val
@@ -3327,11 +2784,7 @@ func (sdb *IntraBlockState) reconstructCellFlags(obj *stateObject, addr accounts
 	obj.original.CodeHash = codeHash
 }
 
-// versionedWriteHit probes the dirty per-tx write set for a write at
-// (addr, path, key) and, when present, populates the corresponding
-// per-typed pointer field on r.  Returns true when a write was found.
-// The non-storage paths share a single non-nil typed field; the storage
-// path uses r.vwStorage.
+// versionedWriteHit probes the dirty write set for (addr, path, key) and populates the matching typed pointer field on r.
 func (sdb *IntraBlockState) versionedWriteHit(addr accounts.Address, path AccountPath, key accounts.StorageKey, r *readPathResult) bool {
 	if sdb.versionMap == nil {
 		return false
@@ -3414,10 +2867,7 @@ func (sdb *IntraBlockState) Version() Version {
 	}
 }
 
-// VersionedReads returns the in-flight per-path read set.  The returned
-// value shares the underlying maps with the IBS; it is handed over at
-// end of tx (RecordReads / TxIn), after which ResetVersionedIO rebinds
-// the IBS field to a fresh set.
+// VersionedReads returns the in-flight read set, sharing its maps with the IBS until ResetVersionedIO rebinds it.
 func (sdb *IntraBlockState) VersionedReads() ReadSet {
 	return sdb.versionedReads
 }
@@ -3429,27 +2879,20 @@ func (sdb *IntraBlockState) ResetVersionedIO() {
 	sdb.recordAccess = false
 }
 
-// ResetVersionedReads clears tracked versioned reads without affecting writes.
 func (sdb *IntraBlockState) ResetVersionedReads() {
 	sdb.versionedReads = ReadSet{}
 }
 
-// VersionedWrites returns a frozen typed snapshot of this tx's recorded writes.
-// The snapshot logic lives on the write-set itself (WriteSet.Snapshot); this is
-// the IntraBlockState accessor for it.
 func (sdb *IntraBlockState) VersionedWrites() *WriteSet {
 	return sdb.versionedWrites.Snapshot()
 }
 
-// Apply entries in a given write set to StateDB. Note that this function does not change MVHashMap nor write set
-// of the current StateDB.
+// ApplyVersionedWrites applies entries to StateDB without changing MVHashMap or this tx's write set.
 func (sdb *IntraBlockState) ApplyVersionedWrites(writes *WriteSet) error {
 	if writes == nil {
 		return nil
 	}
-	// Deterministic (Address, Path, Key) order: Code/SelfDestruct load the state
-	// object and may record an extra read depending on whether a prior
-	// same-address write already loaded it, which changes the EIP-7928 BAL hash.
+	// Deterministic (Address, Path, Key) order matters: load order changes whether Code/SelfDestruct records an extra read, altering the EIP-7928 BAL hash.
 	headers := make([]WriteHeader, 0, writes.Count())
 	for h := range writes.AllHeaders() {
 		headers = append(headers, h)
@@ -3505,11 +2948,7 @@ func (sdb *IntraBlockState) ApplyVersionedWrites(writes *WriteSet) error {
 			if err != nil {
 				return err
 			}
-			// Force-set code bypassing stateObject.SetCode's equality check.
-			// The finalize IBS uses a VersionedStateReader whose ReadSet may
-			// contain the post-write code value (when the worker read the code
-			// after a SetCodeTx modified it), causing SetCode's equality
-			// comparison to incorrectly skip the update and leave dirtyCode unset.
+			// Force-sets code, bypassing SetCode's equality check, since the finalize IBS's ReadSet may already hold the post-write value.
 			sdb.journal.codeChange(addr, stateObject.code.Bytes, stateObject.data.CodeHash, !sdb.hasWrite(addr, CodePath, accounts.NilKey))
 			stateObject.setCode(code)
 			sdb.recordWriteCode(addr, code)
@@ -3523,10 +2962,7 @@ func (sdb *IntraBlockState) ApplyVersionedWrites(writes *WriteSet) error {
 				continue
 			}
 			if vw.Val {
-				// Ensure the state object exists before calling Selfdestruct.
-				// For newly-created accounts (with no pre-block DB entry)
-				// getStateObject returns nil and Selfdestruct silently no-ops, so
-				// materialize the object first to keep the selfdestructed marking.
+				// Materializes the object first: for a newly-created account, Selfdestruct would otherwise silently no-op.
 				if _, err := sdb.GetOrNewStateObject(addr); err != nil {
 					return err
 				}
@@ -3534,10 +2970,7 @@ func (sdb *IntraBlockState) ApplyVersionedWrites(writes *WriteSet) error {
 					return err
 				}
 			} else {
-				// SelfDestructPath=false indicates account resurrection in this block.
-				// The worker IBS set createdContract=true (ensuring CreateContract is called
-				// during commit to clear old storage), but that flag is not a versioned write
-				// path and is lost in the finalize IBS.
+				// SelfDestructPath=false means resurrection; the worker's createdContract=true isn't a versioned write path, so it's restored below.
 				so, err := sdb.GetOrNewStateObject(addr)
 				if err != nil {
 					return err
@@ -3546,18 +2979,14 @@ func (sdb *IntraBlockState) ApplyVersionedWrites(writes *WriteSet) error {
 					so.selfdestructed = false
 					so.createdContract = true
 				}
-				// Re-emit SelfDestructPath=false so the global versionMap reflects the
-				// resurrection; subsequent workers reading SelfDestructPath will see the
-				// updated value and not mistake the account for still being selfdestructed.
+				// Re-emits SelfDestructPath=false so later readers won't mistake the account for still-destructed.
 				sdb.recordWriteSelfDestruct(addr, false)
 			}
 		case CreateContractPath:
-			// A same-tx self-destruct dominates the creation marker: skip applying
-			// CreateContract so the account is not resurrected as a live contract.
+			// A same-tx self-destruct dominates the creation marker: skip CreateContract so the account isn't resurrected as live.
 			if sw, ok := writes.GetSelfDestruct(addr); ok && sw.Val {
 				continue
 			}
-			// Contract creation: set createdContract flag on the stateObject.
 			so, err := sdb.GetOrNewStateObject(addr)
 			if err != nil {
 				return err

--- a/execution/state/intra_block_state_test.go
+++ b/execution/state/intra_block_state_test.go
@@ -63,22 +63,13 @@ func TestSnapshotRandom(t *testing.T) {
 	}
 }
 
-// A snapshotTest checks that reverting IntraBlockState snapshots properly undoes all changes
-// captured by the snapshot. Instances of this test with pseudorandom content are created
-// by Generate.
-//
-// The test works as follows:
-//
-// A new state is created and all actions are applied to it. Several snapshots are taken
-// in between actions. The test then reverts each snapshot. For each snapshot the actions
-// leading up to it are replayed on a fresh, empty state. The behaviour of all public
-// accessor methods on the reverted state must match the return value of the equivalent
-// methods on the replayed state.
+// snapshotTest checks that reverting a snapshot exactly undoes the actions
+// recorded since it was taken; Generate produces randomized instances.
 type snapshotTest struct {
-	addrs     []accounts.Address // all account addresses
-	actions   []testAction       // modifications to the state
-	snapshots []int              // actions indexes at which snapshot is taken
-	err       error              // failure details are reported through this field
+	addrs     []accounts.Address
+	actions   []testAction
+	snapshots []int
+	err       error
 }
 
 type testAction struct {
@@ -88,7 +79,6 @@ type testAction struct {
 	noAddr bool
 }
 
-// newTestAction creates a random action that changes state.
 func newTestAction(addr accounts.Address, r *rand.Rand) testAction {
 	actions := []testAction{
 		{
@@ -199,10 +189,7 @@ func newTestAction(addr accounts.Address, r *rand.Rand) testAction {
 	return action
 }
 
-// Generate returns a new snapshot test of the given size. All randomness is
-// derived from r.
 func (*snapshotTest) Generate(r *rand.Rand, size int) reflect.Value {
-	// Generate random actions.
 	addrs := make([]accounts.Address, 50)
 	for i := range addrs {
 		addrs[i] = accounts.InternAddress(common.Address{byte(i)})
@@ -212,7 +199,6 @@ func (*snapshotTest) Generate(r *rand.Rand, size int) reflect.Value {
 		addr := addrs[r.Intn(len(addrs))]
 		actions[i] = newTestAction(addr, r)
 	}
-	// Generate snapshot indexes.
 	nsnapshots := int(math.Sqrt(float64(size)))
 	if size > 0 && nsnapshots == 0 {
 		nsnapshots = 1
@@ -220,7 +206,6 @@ func (*snapshotTest) Generate(r *rand.Rand, size int) reflect.Value {
 	snapshots := make([]int, nsnapshots)
 	snaplen := len(actions) / nsnapshots
 	for i := range snapshots {
-		// Try to place the snapshots some number of actions apart from each other.
 		snapshots[i] = (i * snaplen) + r.Intn(snaplen)
 	}
 	return reflect.ValueOf(&snapshotTest{addrs, actions, snapshots, nil})
@@ -260,8 +245,6 @@ func (test *snapshotTest) run(t *testing.T) bool {
 		}
 		action.fn(action, state)
 	}
-	// Revert all snapshots in reverse order. Each revert must yield a state
-	// that is equivalent to fresh state with all actions up the snapshot applied.
 	for sindex--; sindex >= 0; sindex-- {
 		checkstate := New(NewReaderV3(tx))
 		for _, action := range test.actions[:test.snapshots[sindex]] {
@@ -279,7 +262,6 @@ func (test *snapshotTest) run(t *testing.T) bool {
 	return true
 }
 
-// checkEqual checks that methods of state and checkstate return the same values.
 func (test *snapshotTest) checkEqual(state, checkstate *IntraBlockState) error {
 	for _, addr := range test.addrs {
 		var err error
@@ -297,7 +279,6 @@ func (test *snapshotTest) checkEqual(state, checkstate *IntraBlockState) error {
 			}
 			return true
 		}
-		// Check basic accessor methods.
 		se, err := state.Exist(addr)
 		if err != nil {
 			return err
@@ -363,7 +344,6 @@ func (test *snapshotTest) checkEqual(state, checkstate *IntraBlockState) error {
 			return err
 		}
 		checkeq("GetCodeSize", scs, ccs)
-		// Check storage.
 		obj, err := state.getStateObject(addr, true)
 		if err != nil {
 			return err
@@ -414,13 +394,10 @@ func TestTransientStorage(t *testing.T) {
 	if exp, got := 1, state.journal.length(); exp != got {
 		t.Fatalf("journal length mismatch: have %d, want %d", got, exp)
 	}
-	// the retrieved value should equal what was set
 	if got := state.GetTransientState(addr, key); got != *value {
 		t.Fatalf("transient storage mismatch: have %x, want %x", got, value)
 	}
 
-	// revert the transient state being set and then check that the
-	// value is now the empty hash
 	state.journal.revert(state, 0)
 	if got, exp := state.GetTransientState(addr, key), (uint256.Int{}); exp != got {
 		t.Fatalf("transient storage mismatch: have %x, want %x", got, exp)
@@ -479,7 +456,6 @@ func TestVersionMapReadWriteDelete(t *testing.T) {
 
 	states := []*IntraBlockState{s}
 
-	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
 		defer sCopy.Close() //nolint:gocritic
@@ -492,18 +468,15 @@ func TestVersionMapReadWriteDelete(t *testing.T) {
 	val := u256.U64(1)
 	balance := u256.U64(100)
 
-	// Tx0 read
 	v, err := states[0].GetState(addr, key)
 	assert.NoError(t, err)
 	assert.Equal(t, uint256.Int{}, v)
 
-	// Tx1 write
 	states[1].GetOrNewStateObject(addr)
 	states[1].SetState(addr, key, val)
 	states[1].SetBalance(addr, balance, tracing.BalanceChangeUnspecified)
 	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(), true, "")
 
-	// Tx1 read
 	v, err = states[1].GetState(addr, key)
 	assert.NoError(t, err)
 	b, err := states[1].GetBalance(addr)
@@ -511,7 +484,6 @@ func TestVersionMapReadWriteDelete(t *testing.T) {
 	assert.Equal(t, val, v)
 	assert.Equal(t, balance, b)
 
-	// Tx2 read
 	v, err = states[2].GetState(addr, key)
 	assert.NoError(t, err)
 	b, err = states[2].GetBalance(addr)
@@ -519,27 +491,21 @@ func TestVersionMapReadWriteDelete(t *testing.T) {
 	assert.Equal(t, val, v)
 	assert.Equal(t, balance, b)
 
-	// Tx3 delete. FinalizeTx below is the materialized-object commit path
-	// (serial/genesis/RPC); the parallel executor never runs it (see the
-	// IsVersioned guards in txtask.go) and instead commits via the write-set.
-	// Materialize explicitly here — as Tx1 does — so FinalizeTx's updateAccount
-	// marks the object deleted and the post-finalize read observes the wipe.
+	// Materialize explicitly: only the serial/genesis/RPC path calls
+	// FinalizeTx here; the parallel executor commits via the write-set instead.
 	states[3].GetOrNewStateObject(addr)
 	states[3].Selfdestruct(addr, false)
 
-	// Within Tx 3, the state should not change before finalize
 	v, err = states[3].GetState(addr, key)
 	assert.NoError(t, err)
 	assert.Equal(t, val, v)
 
-	// After finalizing Tx 3, the state will change
 	states[3].FinalizeTx(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 0))
 	v, err = states[3].GetState(addr, key)
 	assert.NoError(t, err)
 	assert.Equal(t, uint256.Int{}, v)
 	states[3].versionMap.FlushVersionedWrites(states[3].VersionedWrites(), true, "")
 
-	// Tx4 read
 	v, err = states[4].GetState(addr, key)
 	assert.NoError(t, err)
 	b, err = states[4].GetBalance(addr)
@@ -560,7 +526,6 @@ func TestVersionMapRevert(t *testing.T) {
 
 	states := []*IntraBlockState{s}
 
-	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
 		defer sCopy.Close() //nolint:gocritic
@@ -573,13 +538,11 @@ func TestVersionMapRevert(t *testing.T) {
 	val := u256.U64(1)
 	balance := u256.U64(100)
 
-	// Tx0 write
 	states[0].GetOrNewStateObject(addr)
 	states[0].SetState(addr, key, val)
 	states[0].SetBalance(addr, balance, tracing.BalanceChangeUnspecified)
 	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(), true, "")
 
-	// Tx1 perform some ops and then revert
 	snapshot := states[1].PushSnapshot()
 	states[1].AddBalance(addr, u256.U64(100), tracing.BalanceChangeUnspecified)
 	states[1].SetState(addr, key, u256.U64(1))
@@ -604,7 +567,6 @@ func TestVersionMapRevert(t *testing.T) {
 	states[1].FinalizeTx(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 0))
 	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(), true, "")
 
-	// Tx2 check the state and balance
 	v, err = states[2].GetState(addr, key)
 	assert.NoError(t, err)
 	b, err = states[2].GetBalance(addr)
@@ -623,7 +585,6 @@ func TestVersionMapMarkEstimate(t *testing.T) {
 	defer s.Close()
 	states := []*IntraBlockState{s}
 
-	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
 		defer sCopy.Close() //nolint:gocritic
@@ -636,25 +597,21 @@ func TestVersionMapMarkEstimate(t *testing.T) {
 	val := u256.U64(1)
 	balance := u256.U64(100)
 
-	// Tx0 read
 	v, err := states[0].GetState(addr, key)
 	assert.NoError(t, err)
 	assert.Equal(t, uint256.Int{}, v)
 
-	// Tx0 write
 	states[0].SetState(addr, key, val)
 	v, err = states[0].GetState(addr, key)
 	assert.NoError(t, err)
 	assert.Equal(t, val, v)
 	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(), true, "")
 
-	// Tx1 write
 	states[1].GetOrNewStateObject(addr)
 	states[1].SetState(addr, key, val)
 	states[1].SetBalance(addr, balance, tracing.BalanceChangeUnspecified)
 	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(), true, "")
 
-	// Tx2 read
 	v, err = states[2].GetState(addr, key)
 	assert.NoError(t, err)
 	b, err := states[2].GetBalance(addr)
@@ -662,16 +619,12 @@ func TestVersionMapMarkEstimate(t *testing.T) {
 	assert.Equal(t, val, v)
 	assert.Equal(t, balance, b)
 
-	// Tx1 mark estimate
 	for h := range states[1].VersionedWrites().AllHeaders() {
 		mvhm.MarkEstimate(h.Address, h.Path, h.Key, 1)
 	}
 
-	// Read-once (Block-STM): states[2] already recorded its state/balance reads
-	// above, so the repeat reads are served from the read-set and no longer abort
-	// eagerly when Tx1's writes are marked ESTIMATE. The estimate dependency is
-	// caught at commit — ValidateVersion re-reads Tx1's now-Estimate balance cell
-	// (MVReadResultDependency) and returns VersionInvalid, which drives re-execution.
+	// Block-STM read-once: reads already recorded above are served from the
+	// read-set and don't abort on ESTIMATE; commit-time validation catches it.
 	v, err = states[2].GetState(addr, key)
 	assert.NoError(t, err)
 	assert.Equal(t, u256.U64(1), v)
@@ -688,7 +641,6 @@ func TestVersionMapMarkEstimate(t *testing.T) {
 	}, true, false, false, "")
 	assert.Equal(t, VersionInvalid, valid, "commit-time validation catches the ESTIMATE dependency")
 
-	// Tx1 read again should get Tx0 vals
 	v, err = states[1].GetState(addr, key)
 	assert.NoError(t, err)
 	assert.Equal(t, val, v)
@@ -705,7 +657,6 @@ func TestVersionMapOverwrite(t *testing.T) {
 
 	states := []*IntraBlockState{s}
 
-	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
 		defer sCopy.Close() //nolint:gocritic
@@ -720,13 +671,11 @@ func TestVersionMapOverwrite(t *testing.T) {
 	val2 := u256.U64(2)
 	balance2 := u256.U64(200)
 
-	// Tx0 write
 	states[0].GetOrNewStateObject(addr)
 	states[0].SetState(addr, key, val1)
 	states[0].SetBalance(addr, balance1, tracing.BalanceChangeUnspecified)
 	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(), true, "")
 
-	// Tx1 write
 	states[1].SetState(addr, key, val2)
 	states[1].SetBalance(addr, balance2, tracing.BalanceChangeUnspecified)
 	v, err := states[1].GetState(addr, key)
@@ -738,7 +687,6 @@ func TestVersionMapOverwrite(t *testing.T) {
 	assert.Equal(t, val2, v)
 	assert.Equal(t, balance2, b)
 
-	// Tx2 read should get Tx1's value
 	v, err = states[2].GetState(addr, key)
 	assert.NoError(t, err)
 	b, err = states[2].GetBalance(addr)
@@ -746,13 +694,11 @@ func TestVersionMapOverwrite(t *testing.T) {
 	assert.Equal(t, val2, v)
 	assert.Equal(t, balance2, b)
 
-	// Tx1 delete
 	for h := range states[1].versionedWrites.AllHeaders() {
 		mvhm.Delete(h.Address, h.Path, h.Key, 1, true)
 	}
 	states[1].versionedWrites = WriteSet{}
 
-	// Tx2 read should get Tx0's value
 	states[2].versionedReads = ReadSet{}
 	v, err = states[2].GetState(addr, key)
 	assert.NoError(t, err)
@@ -761,7 +707,6 @@ func TestVersionMapOverwrite(t *testing.T) {
 	assert.Equal(t, val1, v)
 	assert.Equal(t, balance1, b)
 
-	// Tx1 read should get Tx0's value
 	v, err = states[1].GetState(addr, key)
 	assert.NoError(t, err)
 	b, err = states[1].GetBalance(addr)
@@ -769,13 +714,11 @@ func TestVersionMapOverwrite(t *testing.T) {
 	assert.Equal(t, val1, v)
 	assert.Equal(t, balance1, b)
 
-	// Tx0 delete
 	for h := range states[0].versionedWrites.AllHeaders() {
 		mvhm.Delete(h.Address, h.Path, h.Key, 0, true)
 	}
 	states[0].versionedWrites = WriteSet{}
 
-	// Tx2 read again should get default vals
 	states[2].versionedReads = ReadSet{}
 	v, err = states[2].GetState(addr, key)
 	assert.NoError(t, err)
@@ -796,7 +739,6 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 
 	states := []*IntraBlockState{s}
 
-	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
 		defer sCopy.Close() //nolint:gocritic
@@ -811,43 +753,34 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	balance1 := u256.U64(100)
 	val2 := u256.U64(2)
 
-	// Tx0 write
 	states[0].GetOrNewStateObject(addr)
 	states[0].versionMap.FlushVersionedWrites(states[0].VersionedWrites(), true, "")
 
-	// Tx2 write
 	states[2].SetState(addr, key2, val2)
 	states[2].versionMap.FlushVersionedWrites(states[2].VersionedWrites(), true, "")
 
-	// Tx1 write
 	tx1Snapshot := states[1].PushSnapshot()
 	states[1].SetState(addr, key1, val1)
 	states[1].SetBalance(addr, balance1, tracing.BalanceChangeUnspecified)
 	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(), true, "")
 
-	// Tx1 read
 	v, err := states[1].GetState(addr, key1)
 	assert.NoError(t, err)
 	assert.Equal(t, val1, v)
 	b, err := states[1].GetBalance(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, balance1, b)
-	// Tx1 should see empty value in key2
 	v, err = states[1].GetState(addr, key2)
 	assert.NoError(t, err)
 	assert.Equal(t, uint256.Int{}, v)
 
-	// Tx2 read
-	// Clear cached reads and state objects from Tx2's SetState call above —
-	// those reads were recorded when Tx1 hadn't flushed yet (Tx0's version).
-	// Now that Tx1 has flushed, re-reading without stale cache simulates a
-	// re-execution that the scheduler would trigger on dependency.
+	// Clear cached reads/objects recorded before Tx1 flushed; re-reading here
+	// simulates the scheduler's re-execution on a dependency conflict.
 	states[2].stateObjects = map[accounts.Address]*stateObject{}
 	states[2].versionedReads = ReadSet{}
 	v, err = states[2].GetState(addr, key2)
 	assert.NoError(t, err)
 	assert.Equal(t, val2, v)
-	// Tx2 should see values written by Tx1
 	v, err = states[2].GetState(addr, key1)
 	assert.NoError(t, err)
 	assert.Equal(t, val1, v)
@@ -855,7 +788,6 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, balance1, b)
 
-	// Tx3 read
 	v, err = states[3].GetState(addr, key1)
 	assert.NoError(t, err)
 	assert.Equal(t, val1, v)
@@ -866,13 +798,11 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, balance1, b)
 
-	// Tx2 delete
 	for h := range states[2].versionedWrites.AllHeaders() {
 		mvhm.Delete(h.Address, h.Path, h.Key, 2, true)
 	}
 	states[2].versionedWrites = WriteSet{}
 
-	// Tx3 read
 	states[3].versionedReads = ReadSet{}
 	v, err = states[3].GetState(addr, key1)
 	assert.NoError(t, err)
@@ -880,23 +810,19 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	b, err = states[3].GetBalance(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, balance1, b)
-	// Tx3 should see empty value in key2
 	v, err = states[3].GetState(addr, key2)
 	assert.NoError(t, err)
 	assert.Equal(t, uint256.Int{}, v)
 
-	// Tx1 revert
 	states[1].RevertToSnapshot(tx1Snapshot, nil)
 	states[1].PopSnapshot(tx1Snapshot)
 	states[1].versionMap.FlushVersionedWrites(states[1].VersionedWrites(), true, "")
-	// map deletes necessary here as they happen in scheduler not ibs
+	// The scheduler issues these deletes normally; done manually here for the test.
 	states[1].versionMap.Delete(addr, StoragePath, key1, 1, true)
 	states[1].versionMap.Delete(addr, StoragePath, key2, 1, true)
 	states[1].versionMap.Delete(addr, BalancePath, accounts.NilKey, 1, true)
 
-	// Tx3 read
-	// we need to flush the local state objects as we're not
-	// resetting the state - which is artificial for the test
+	// Flush cached state objects manually since the test doesn't reset state.
 	states[3].stateObjects = map[accounts.Address]*stateObject{}
 	states[3].versionedReads = ReadSet{}
 	v, err = states[3].GetState(addr, key1)
@@ -909,13 +835,11 @@ func TestVersionMapWriteNoConflict(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint256.Int{}, b)
 
-	// Tx1 delete
 	for h := range states[1].versionedWrites.AllHeaders() {
 		mvhm.Delete(h.Address, h.Path, h.Key, 1, true)
 	}
 	states[1].versionedWrites = WriteSet{}
 
-	// Tx3 read
 	states[3].versionedReads = ReadSet{}
 	v, err = states[3].GetState(addr, key1)
 	assert.NoError(t, err)
@@ -943,7 +867,6 @@ func TestApplyVersionedWrites(t *testing.T) {
 
 	states := []*IntraBlockState{s}
 
-	// Create copies of the original state for each transition
 	for i := 1; i <= 4; i++ {
 		sCopy := NewWithVersionMap(reader, mvhm)
 		defer sCopy.Close() //nolint:gocritic
@@ -962,7 +885,6 @@ func TestApplyVersionedWrites(t *testing.T) {
 	balance2 := uint256.NewInt(200)
 	code := []byte{1, 2, 3}
 
-	// Tx0 write
 	states[0].GetOrNewStateObject(addr1)
 	states[0].SetState(addr1, key1, val1)
 	states[0].SetBalance(addr1, *balance1, tracing.BalanceChangeUnspecified)
@@ -979,7 +901,6 @@ func TestApplyVersionedWrites(t *testing.T) {
 
 	sClean.ApplyVersionedWrites(states[0].VersionedWrites())
 
-	// Tx1 write
 	states[1].SetState(addr1, key2, val2)
 	states[1].SetBalance(addr1, *balance2, tracing.BalanceChangeUnspecified)
 	states[1].SetNonce(addr1, 1, tracing.NonceChangeUnspecified)
@@ -992,7 +913,6 @@ func TestApplyVersionedWrites(t *testing.T) {
 
 	sClean.ApplyVersionedWrites(states[1].VersionedWrites())
 
-	// Tx2 write
 	states[2].SetState(addr1, key1, val2)
 	states[2].SetBalance(addr1, *balance2, tracing.BalanceChangeUnspecified)
 	states[2].SetNonce(addr1, 2, tracing.NonceChangeUnspecified)
@@ -1005,7 +925,6 @@ func TestApplyVersionedWrites(t *testing.T) {
 
 	sClean.ApplyVersionedWrites(states[2].VersionedWrites())
 
-	// Tx3 write
 	states[3].Selfdestruct(addr2, false)
 	states[3].SetCode(addr1, code, tracing.CodeChangeUnspecified)
 	states[3].FinalizeTx(&chain.Rules{}, NewWriter(domains.AsPutDel(tx), nil, 0))
@@ -1017,12 +936,8 @@ func TestApplyVersionedWrites(t *testing.T) {
 	sClean.ApplyVersionedWrites(states[3].VersionedWrites())
 }
 
-// TestMakeWriteSetClearsCodeDomainOnEmptyOverride pins that clearing an
-// account's code (e.g. an eth_simulateV1 stateOverride of "code":"0x") writes
-// through to the CodeDomain, keeping it consistent with the now-empty account
-// codeHash. Regression: gating the code write on a non-nil code slice skipped
-// the clear, leaving the CodeDomain holding stale code and tripping the
-// commitment codeHash-mismatch assert.
+// Regression: gating the code write on a non-nil slice skipped clearing
+// CodeDomain, leaving it inconsistent with the now-empty codeHash.
 func TestMakeWriteSetClearsCodeDomainOnEmptyOverride(t *testing.T) {
 	t.Parallel()
 

--- a/execution/state/journal.go
+++ b/execution/state/journal.go
@@ -37,7 +37,6 @@ var journalPool = sync.Pool{
 	},
 }
 
-// entryKind discriminates the compact journal entry union below.
 type entryKind uint8
 
 const (
@@ -67,8 +66,6 @@ const (
 	flagSelfdestructHadBalance     uint8 = 1 << 3 // kindSelfdestruct: a versioned balance write predated the destruct
 )
 
-// journalExtra holds the fields needed only by the infrequent entry kinds,
-// kept out of line so the common entry stays small (see TestJournalEntrySize).
 type journalExtra struct {
 	prevObj              *stateObject         // kindResetObject
 	prevWrites           *createWriteSnapshot // kindResetObject
@@ -78,10 +75,6 @@ type journalExtra struct {
 	prevBalanceVersioned uint256.Int          // kindSelfdestruct, when flagSelfdestructHadBalance is set
 }
 
-// journalEntry is a compact tagged union stored inline in journal.entries.
-// Fields are reused across kinds: value holds the reverted uint256, aux the
-// reverted scalar (nonce/refund/log index/incarnation), flags the booleans,
-// extra only what the infrequent kinds need.
 type journalEntry struct {
 	account accounts.Address
 	key     accounts.StorageKey
@@ -92,20 +85,15 @@ type journalEntry struct {
 	flags   uint8
 }
 
-// journal contains the list of state modifications applied since the last state
-// commit. These are tracked to be able to be reverted in case of an execution
-// exception or revertal request.
 type journal struct {
-	dirties map[accounts.Address]int // Dirty accounts and the number of changes
-	entries []journalEntry           // Current changes tracked by the journal
+	dirties map[accounts.Address]int
+	entries []journalEntry
 }
 
-// newJournal gets a journal from the pool.
 func newJournal() *journal {
 	return journalPool.Get().(*journal)
 }
 
-// release returns the journal to the pool after resetting it.
 func (j *journal) release() {
 	j.Reset()
 	clear(j.entries[:cap(j.entries)]) // [:cap] because Reset already resliced to zero
@@ -116,18 +104,13 @@ func (j *journal) Reset() {
 	clear(j.dirties)
 }
 
-// revert undoes a batch of journalled modifications along with any reverted
-// dirty handling too.
 func (j *journal) revert(statedb *IntraBlockState, snapshot int) {
 	for i := len(j.entries) - 1; i >= snapshot; i-- {
-		// Undo the changes made by the operation. A revert error means a
-		// journalled account can no longer be loaded — the state would be left
-		// half-reverted, so fail loudly rather than continue corrupt.
+		// A revert error would leave state half-reverted, so panic instead of continuing with corrupt state.
 		if err := j.entries[i].revert(statedb); err != nil {
 			panic(fmt.Sprintf("journal: revert of kind %d failed: %v", j.entries[i].kind, err))
 		}
 
-		// Drop any dirty tracking induced by the change
 		if addr, isdirty := j.entries[i].dirtied(); isdirty {
 			if j.dirties[addr]--; j.dirties[addr] == 0 {
 				delete(j.dirties, addr)
@@ -137,15 +120,11 @@ func (j *journal) revert(statedb *IntraBlockState, snapshot int) {
 	j.entries = j.entries[:snapshot]
 }
 
-// dirty explicitly sets an address to dirty, even if the change entries would
-// otherwise suggest it as clean. This method is an ugly hack to handle the RIPEMD
-// precompile consensus exception; CreateAccount also uses it to keep a
-// resurrected address dirty across an intra-tx revert.
+// dirty force-marks an address dirty for the RIPEMD consensus exception and for a resurrected address across revert.
 func (j *journal) dirty(addr accounts.Address) {
 	j.dirties[addr]++
 }
 
-// length returns the current number of entries in the journal.
 func (j *journal) length() int {
 	return len(j.entries)
 }
@@ -158,13 +137,6 @@ func commitFlag(wasCommitted bool) uint8 {
 }
 
 func (je *journalEntry) committed() bool { return je.flags&flagCommitted != 0 }
-
-// --- entry constructors: one per modification kind ---
-//
-// Each updates dirties itself rather than deriving it from the entry: the kind
-// is fixed at the call site, and a shared helper that rediscovers it via
-// dirtied() measured materially slower. revert undoes the accounting through
-// dirtied(), so the two must agree on every kind.
 
 func (j *journal) createObjectChange(account accounts.Address) {
 	j.entries = append(j.entries, journalEntry{kind: kindCreateObject, account: account})
@@ -185,9 +157,6 @@ func (j *journal) selfdestructChange(account accounts.Address, prev bool, prevba
 	j.dirties[account]++
 }
 
-// selfdestructChangeVersioned records a self-destruct on the parallel path,
-// capturing the versioned balance/incarnation writes it overwrites so a revert
-// can restore them (see selfdestructChange.revert).
 func (j *journal) selfdestructChangeVersioned(account accounts.Address, prev bool, prevbalance uint256.Int, wasCommitted, hadIncarnation bool, prevIncarnation uint64, hadBalance bool, prevBalanceVersioned uint256.Int) {
 	flags := commitFlag(wasCommitted)
 	if prev {
@@ -264,10 +233,7 @@ func (j *journal) transientStorageChange(account accounts.Address, key accounts.
 	j.entries = append(j.entries, journalEntry{kind: kindTransientStorage, account: account, key: key, value: prevalue})
 }
 
-// dirtied returns the address modified by this entry, or (NilAddress, false) for
-// entries that don't imply a dirty account. kindCreateObject and kindResetObject
-// must both stay dirty: they place a stateObject at the same address, and
-// dropping either loses a recreated account from dirties, diverging the state root.
+// kindCreateObject and kindResetObject must both stay dirty: dropping either loses a recreated account and diverges the state root.
 func (je *journalEntry) dirtied() (accounts.Address, bool) {
 	switch je.kind {
 	case kindBalanceIncreaseTransfer, kindTransientStorage, kindRefund, kindAddLog, kindAccessListAddAccount, kindAccessListAddSlot:
@@ -280,7 +246,6 @@ func (je *journalEntry) dirtied() (accounts.Address, bool) {
 
 var ripemd = accounts.InternAddress(common.HexToAddress("0000000000000000000000000000000000000003"))
 
-// revert undoes the change recorded by this entry.
 func (je *journalEntry) revert(s *IntraBlockState) error {
 	switch je.kind {
 	case kindCreateObject:
@@ -289,11 +254,7 @@ func (je *journalEntry) revert(s *IntraBlockState) error {
 		}
 		delete(s.stateObjects, je.account)
 		delete(s.stateObjectsDirty, je.account)
-		// The account did not exist before this create, so all of its versioned
-		// writes originate from the creation being reverted. Field-level entries
-		// (balance/nonce/…) prune themselves on revert; the account-record writes
-		// createObject emits (address/codeHash/…) have no field-level journal entry,
-		// so drop them here to keep versionedWrites in step with the journal.
+		// The account didn't exist before this create, so drop its account-record writes here — they have no field-level journal entry.
 		if s.versionMap != nil {
 			s.versionedWrites.deleteAddr(je.account)
 		}
@@ -309,9 +270,7 @@ func (je *journalEntry) revert(s *IntraBlockState) error {
 		} else {
 			s.setStateObject(je.account, prev)
 		}
-		// Restore the account-record writes the recreation overwrote back to the
-		// snapshot taken before it ran, so versionedWrites reflects prev's state
-		// again (the field-level entries handle the fields creation doesn't write).
+		// Restores the account-record writes the recreation overwrote, so versionedWrites reflects prev again.
 		if s.versionMap != nil {
 			s.versionedWrites.restoreCreateFields(je.account, je.extra.prevWrites)
 		}
@@ -338,18 +297,13 @@ func (je *journalEntry) revert(s *IntraBlockState) error {
 			} else if _, ok := s.versionedWrites.GetSelfDestruct(je.account); ok {
 				s.versionedWrites.updateSelfDestruct(je.account, prev)
 			}
-			// The self-destruct records BalancePath=0; restore the pre-destruct
-			// versioned balance write, or drop the cell if the self-destruct created
-			// it. Gating this on committed (which describes SelfDestructPath, not
-			// BalancePath) deleted balance writes that predated the snapshot.
+			// Restores the pre-destruct balance write, or drops it if self-destruct created it; committed here means SelfDestructPath, not BalancePath.
 			if je.flags&flagSelfdestructHadBalance != 0 {
 				s.versionedWrites.updateBalance(je.account, je.extra.prevBalanceVersioned)
 			} else {
 				s.versionedWrites.DelBalance(je.account)
 			}
-			// selfdestructVersioned clears the incarnation cell on both paths. Restore
-			// it to its pre-destruct versioned value, or drop the write if the
-			// self-destruct created it.
+			// Same restore-or-drop pattern for the incarnation cell.
 			if je.flags&flagSelfdestructHadIncarnation != 0 {
 				s.versionedWrites.updateIncarnation(je.account, je.aux)
 			} else {
@@ -359,10 +313,7 @@ func (je *journalEntry) revert(s *IntraBlockState) error {
 		return nil
 
 	case kindBalance:
-		// Keep a materialized so.data in step (serial always has one; the parallel
-		// path only when the account was materialized for some other reason). Never
-		// materialize one just to revert on the parallel path — the cells below are
-		// authoritative there.
+		// Never materialize a stateObject just to revert on the parallel path — the versioned cells below are authoritative there.
 		if so, ok := s.stateObjects[je.account]; ok {
 			so.setBalance(je.value)
 		} else if s.versionMap == nil {
@@ -493,22 +444,8 @@ func (je *journalEntry) revert(s *IntraBlockState) error {
 		return nil
 
 	case kindTouch:
-		// Do NOT delete versionedReads here.  Even though the touch is being
-		// reverted (e.g. a CREATE that ran out of gas), the read that triggered
-		// the touch already happened — the tx observed the account's state and
-		// branched on it (e.g. Empty() returning true vs false).  Removing the
-		// read-set entry causes ValidateVersion to miss the dependency, allowing
-		// stale reads to pass validation and produce incorrect results.
-		//
-		// The touch's BalancePath=0 write must be undone, though: leaving it orphaned
-		// lets Normalize's EIP-161 pass delete an account whose touch was rolled back.
-		// Mirror kindBalance — drop the write if the touch created it, else restore
-		// the prior value.
-		//
-		// RIPEMD-160 is the exception: touchAccount bumps its dirty count so the
-		// touch outlives the revert and EIP-161 still sweeps it. Undoing the write
-		// here would drop that sweep on the versioned path only, leaving the
-		// account in the trie and diverging from serial's root.
+		// Keep versionedReads: the read already happened and influenced execution.
+		// Undo BalancePath except for RIPEMD-160, which EIP-161 must still sweep.
 		if s.versionMap != nil && je.account != ripemd {
 			if je.committed() {
 				s.versionedWrites.DelBalance(je.account)
@@ -519,15 +456,7 @@ func (je *journalEntry) revert(s *IntraBlockState) error {
 		return nil
 
 	case kindAccessListAddAccount:
-		/*
-			One important invariant here, is that whenever a (addr, slot) is added, if the
-			addr is not already present, the add causes two journal entries:
-			- one for the address,
-			- one for the (address,slot)
-			Therefore, when unrolling the change, we can always blindly delete the
-			(addr) at this point, since no storage adds can remain when come upon
-			a single (addr) change.
-		*/
+		// Adding a (addr, slot) whose addr is not yet present emits address then slot, so unrolling can blindly delete the address here.
 		s.accessList.DeleteAddress(je.account)
 		return nil
 

--- a/execution/state/journal_test.go
+++ b/execution/state/journal_test.go
@@ -10,18 +10,14 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TestJournalEntrySize guards the compact union against accidental bloat,
-// e.g. inlining rare *stateObject/[]byte fields that belong in journalExtra.
+// Guards the compact union against accidental bloat from inlining rare fields that belong in journalExtra.
 func TestJournalEntrySize(t *testing.T) {
 	if got := unsafe.Sizeof(journalEntry{}); got > 72 {
 		t.Fatalf("journalEntry grew to %d B (want <= 72)", got)
 	}
 }
 
-// TestJournalDirtySymmetry pins every constructor's dirties accounting against
-// dirtied(), which revert uses to undo it. A kind the two disagree about leaves
-// the dirties refcount unbalanced — under-dirtying drops a modified account and
-// diverges the state root, over-dirtying leaks entries across the revert.
+// Pins each constructor's dirties accounting against dirtied(): a mismatch either drops a modified account or leaks entries.
 func TestJournalDirtySymmetry(t *testing.T) {
 	addr := accounts.InternAddress(common.HexToAddress("0x00000000000000000000000000000000000000aa"))
 	key := accounts.InternKey(common.HexToHash("0x01"))
@@ -68,8 +64,6 @@ func TestJournalDirtySymmetry(t *testing.T) {
 			if j.entries[0].kind != tc.kind {
 				t.Fatalf("appended kind %d, want %d", j.entries[0].kind, tc.kind)
 			}
-			// revert decrements exactly once, for exactly the address dirtied()
-			// names, so the constructor must have incremented exactly that.
 			wantAddr, wantDirty := j.entries[0].dirtied()
 			if !wantDirty {
 				if len(j.dirties) != 0 {
@@ -94,8 +88,7 @@ func TestJournalDirtySymmetry(t *testing.T) {
 	}
 }
 
-// BenchmarkJournalStorageChange measures the hot append path; it must stay at
-// zero allocs per op once the entries slice has warmed up.
+// Must stay at zero allocs/op once the entries slice has warmed up.
 func BenchmarkJournalStorageChange(b *testing.B) {
 	j := newJournal()
 	defer j.release()

--- a/execution/state/log_arena.go
+++ b/execution/state/log_arena.go
@@ -26,53 +26,39 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-// reset is the ownership boundary: everything handed out since the last one is
-// live, and reset takes it back. What the arena holds is therefore one caller's
-// unit of work — a transaction for the executor and the trace workers, a block
-// for the assembler and the tooling, which reset once it is built.
+// reset is the ownership boundary: what it hands out stays live until reclaimed — a transaction's worth or a block's, by caller.
 const (
 	// What one transaction's gas can buy, under the EIP-7825 cap.
-	maxLogsPerTxn     = int(params.MaxTxnGasLimit / params.LogGas)     // 44739
-	maxLogBytesPerTxn = int(params.MaxTxnGasLimit / params.LogDataGas) // 2MB
+	maxLogsPerTxn     = int(params.MaxTxnGasLimit / params.LogGas)
+	maxLogBytesPerTxn = int(params.MaxTxnGasLimit / params.LogDataGas)
 
-	// Fractions of those, because the pool never shrinks: the whole ceiling would
-	// park 13MB of entries per arena, while a tenth still holds the ~1700 logs of
-	// a p99 block that a caller resetting per block pools in one go.
+	// The pool never shrinks: the full ceiling would park 13MB per arena, a tenth covers a p99 block's ~1700 logs.
 	maxPooledLogEntries = maxLogsPerTxn / 10
 	maxPooledLogBytes   = maxLogBytesPerTxn / 2
 
-	// One large log must not take the whole budget and starve the small entries
-	// real traffic is made of, and a cap much lower would throw away the reuse
-	// that makes a block of large logs cheap.
+	// One large log must not take the whole budget from small entries, and a much lower cap would lose large-log reuse.
 	maxPooledLogDataCap = maxPooledLogBytes / 8
 
-	// Slots the arena keeps between resets. The run is a block for a caller that
-	// resets per block, so this is bounded by the memory it costs rather than by
-	// a transaction's budget: 32KB of pointers, holding a p99 block's ~1700.
+	// Bounded by memory (32KB of pointers), not by a transaction's budget: the run's size follows a block.
 	maxRetainedLogSlots = 32 * 1024 / 8
 )
 
-// logArena owns a block's log entries and recycles them through a pool, so what
-// it holds follows the largest transaction rather than the widest block.
+// logArena recycles a block's log entries through a pool, so memory use follows the largest transaction, not the widest block.
 type logArena struct {
-	entries      types.Logs   // the block so far, in order — one transaction, for a caller that resets per transaction
+	entries      types.Logs   // current run's entries, in allocation order
 	pool         []*types.Log // entries taken back at reset, for any transaction to reuse
 	poolBytes    int          // Data the pool holds
 	indexInBlock uint
 }
 
-// alloc journals the allocation for revertLast, then returns txIndex's next
-// entry sized for numTopics/dataSize. The caller must write every topic and data
-// byte; what it leaves unwritten is the previous transaction's. The arena owns
-// the entry, so it must never be handed out without copying.
+// alloc's entry keeps unwritten fields from the previous tx and must be copied before being retained past this call.
 func (a *logArena) alloc(j *journal, addr common.Address, txIndex, numTopics, dataSize int) *types.Log {
 	j.addLogChange(txIndex)
 	logIdx := len(a.entries)
 	entries := slices.Grow(a.entries, 1)[:logIdx+1]
 	a.entries = entries
 
-	// Always take: reset and revertLast empty a slot before shrinking past it, so
-	// a slot that still held an entry would be one two transactions share.
+	// Always take: prior reset/revertLast already emptied this slot, so no live entry is ever double-issued.
 	lp := a.take()
 	entries[logIdx] = lp
 	lp.Address = addr
@@ -82,8 +68,7 @@ func (a *logArena) alloc(j *journal, addr common.Address, txIndex, numTopics, da
 	lp.TxHash, lp.BlockHash = common.Hash{}, common.Hash{}
 	lp.TxIndex = hexutil.Uint(txIndex)
 	lp.BlockNumber = 0 // non-consensus field, assigned by the caller
-	// Block-wide, not per-tx: receipts.DeriveFields reads Logs[0].Index to
-	// recover FirstLogIndexWithinBlock.
+	// Block-wide: receipts.DeriveFields reads Logs[0].Index for FirstLogIndexWithinBlock.
 	lp.Index = hexutil.Uint(a.indexInBlock)
 	a.indexInBlock++
 	return lp
@@ -101,8 +86,7 @@ func (a *logArena) take() *types.Log {
 	return lp
 }
 
-// put keeps an entry for the next transaction, dropping the Data it may not
-// hold. The entry itself is small enough to keep either way.
+// put pools the entry for reuse, dropping Data over budget; past the entry cap it drops the entry too.
 func (a *logArena) put(lp *types.Log) {
 	if len(a.pool) >= maxPooledLogEntries {
 		return
@@ -114,8 +98,7 @@ func (a *logArena) put(lp *types.Log) {
 	a.pool = append(a.pool, lp)
 }
 
-// reset takes back what was written: the entries return to the pool and the
-// block goes empty. It walks only what the caller wrote, not the block's width.
+// reset returns written entries to the pool, walking only what was written, not the block's full width.
 func (a *logArena) reset() {
 	a.indexInBlock = 0
 	entries := a.entries
@@ -133,7 +116,6 @@ func (a *logArena) reset() {
 	}
 }
 
-// revertLast drops the entry allocated last, returning it to the pool.
 func (a *logArena) revertLast(txIndex int) {
 	entries := a.entries
 	last := len(entries) - 1
@@ -148,16 +130,11 @@ func (a *logArena) revertLast(txIndex int) {
 	a.indexInBlock--
 }
 
-// forTx returns the entries txIndex emitted, owned by the arena. They are held
-// in one run rather than grouped, and a transaction's own are the tail of it, so
-// a transaction newer than the tail reads as empty and an older one panics.
+// forTx returns txIndex's entries, the run's tail: newer reads as empty (nothing emitted yet); older panics rather than returning a stale tail.
 func (a *logArena) forTx(txIndex int) types.Logs {
 	entries := a.entries
 	i := len(entries)
 	if i > 0 && txIndex < int(entries[i-1].TxIndex) {
-		// Newer than the tail is a transaction that emitted nothing, which is
-		// how most of them end. Older is a caller reading what it has left:
-		// answering empty would read as "emitted no logs", so say so instead.
 		panic(fmt.Sprintf("logs of tx %d asked for, the run has reached tx %d",
 			txIndex, int(entries[i-1].TxIndex)))
 	}

--- a/execution/state/log_arena_test.go
+++ b/execution/state/log_arena_test.go
@@ -58,9 +58,8 @@ func TestLogsRlpHash(t *testing.T) {
 	})
 }
 
-// A reused entry must not carry any field of the block that used it before.
-// Address is the sharpest one: it is a consensus field with no length the
-// caller has to honour, so AllocLog takes it rather than trusting the caller.
+// A reused entry must not carry the previous block's fields. AllocLog takes
+// Address itself rather than trust the caller to clear it.
 func TestAllocLogClearsReusedEntry(t *testing.T) {
 	t.Parallel()
 
@@ -84,8 +83,6 @@ func TestAllocLogClearsReusedEntry(t *testing.T) {
 	require.False(t, reused.Removed)
 }
 
-// Growing the run past its capacity must keep what earlier transactions wrote:
-// Logs and LogsRlpHash read the whole block.
 func TestAllocLogKeepsEarlierTxsAcrossGrowth(t *testing.T) {
 	t.Parallel()
 
@@ -131,8 +128,6 @@ func TestAddLogKeepsCallerTxAndBlockHash(t *testing.T) {
 	require.Equal(t, common.HexToHash("0xad"), logs[0].BlockHash)
 }
 
-// A reverted entry goes back to the pool, and Data past the per-entry cap does
-// not go with it.
 func TestRevertDropsOversizedLogData(t *testing.T) {
 	t.Parallel()
 
@@ -152,9 +147,6 @@ func TestRevertDropsOversizedLogData(t *testing.T) {
 	require.LessOrEqual(t, cap(lp.Data), maxPooledLogDataCap)
 }
 
-// Entries survive Reset for reuse, so retention belongs to the IntraBlockState
-// and not to one block: a burst of logs at a fresh tx index every block would
-// otherwise add a high-water mark per block. The pool is the whole of it.
 func TestResetBoundsRetainedLogMemory(t *testing.T) {
 	t.Parallel()
 
@@ -177,8 +169,8 @@ func TestResetBoundsRetainedLogMemory(t *testing.T) {
 	require.Zero(t, dataBytes)
 }
 
-// A transaction that fits the pool costs no entry the next time round. The pool
-// hands them back in its own order, so what is pinned is the set, not the place.
+// The pool hands entries back in its own order, so Reset pins the set of
+// reused entries, not their positions.
 func TestResetKeepsLogsWithinBudget(t *testing.T) {
 	t.Parallel()
 
@@ -200,8 +192,7 @@ func TestResetKeepsLogsWithinBudget(t *testing.T) {
 	}
 }
 
-// poolBytes is what the pool admits itself against, so it has to match the Data
-// the pooled entries actually hold, through emit, revert and reset.
+// poolBytes must equal the summed cap of the pooled entries' Data.
 func TestLogPoolBytesMatchPooledData(t *testing.T) {
 	t.Parallel()
 
@@ -232,8 +223,6 @@ func TestLogPoolBytesMatchPooledData(t *testing.T) {
 	}
 }
 
-// A block of large logs is what the pool is for: the transactions run one after
-// another, so one buffer serves them all instead of one per transaction.
 func TestLogPoolReusesLargeDataAcrossTxs(t *testing.T) {
 	t.Parallel()
 
@@ -254,8 +243,6 @@ func TestLogPoolReusesLargeDataAcrossTxs(t *testing.T) {
 	require.Len(t, ibs.logs.pool, 1)
 }
 
-// Data past the per-entry cap is not pooled: one buffer that size would take the
-// whole budget and leave nothing for the small entries.
 func TestLogPoolRejectsOversizedData(t *testing.T) {
 	t.Parallel()
 
@@ -269,7 +256,6 @@ func TestLogPoolRejectsOversizedData(t *testing.T) {
 	require.Nil(t, ibs.logs.pool[0].Data)
 }
 
-// An outlier must not leave the array that held it behind.
 func TestResetDropsOutsizedLogSlots(t *testing.T) {
 	t.Parallel()
 
@@ -315,9 +301,6 @@ func TestRevertKeepsNormalLogBufferForReuse(t *testing.T) {
 	require.Same(t, first, lp)
 }
 
-// The OnLog hook is exported, so a tracer outside this repo may retain the
-// pointer it is handed. The value must stay valid after the emit buffer is
-// reused by a later block.
 func TestOnLogValueSurvivesBufferReuse(t *testing.T) {
 	t.Parallel()
 
@@ -348,8 +331,6 @@ func TestOnLogValueSurvivesBufferReuse(t *testing.T) {
 	require.Equal(t, hexutil.Bytes{1, 2, 3}, retained.Data)
 }
 
-// Splits the cost of the stable OnLog value: the untraced path keeps reusing
-// the buffer entry, only a configured hook pays for the copy.
 func BenchmarkAddLog(b *testing.B) {
 	log := &types.Log{
 		Address: common.HexToAddress("0x1"),
@@ -374,8 +355,6 @@ func BenchmarkAddLog(b *testing.B) {
 
 var sinkLog *types.Log
 
-// One transaction spending MaxTxnGasLimit entirely on logs: the most an arena
-// can be asked to hold before it resets. Reports what survives the reset.
 func BenchmarkLogEmitWorstCaseTx(b *testing.B) {
 	addr := common.HexToAddress("0x1")
 	ibs := New(nil)
@@ -391,9 +370,6 @@ func BenchmarkLogEmitWorstCaseTx(b *testing.B) {
 	b.ReportMetric(float64(ibs.logs.poolBytes)/1024, "poolKB")
 }
 
-// Blocks whose transactions each emit a 64KB log — the shape an attack sends.
-// The size is fixed rather than tied to a budget, so runs stay comparable when
-// the budgets move.
 func BenchmarkLogEmitLargeDataPerTx(b *testing.B) {
 	log := &types.Log{
 		Address: common.HexToAddress("0x1"),
@@ -415,11 +391,6 @@ func BenchmarkLogEmitLargeDataPerTx(b *testing.B) {
 	}
 }
 
-// The parallel executor resets before every transaction, so a block costs one
-// Reset per transaction while the buffers hold the whole block's logs.
-// The assembler and the tooling reset once a block is built, so a whole block's
-// entries reach the pool in one go — the shape that decides how small the pool
-// may be. p99 mainnet is ~1700 logs.
 func BenchmarkLogEmitBlockLevelReset(b *testing.B) {
 	log := &types.Log{
 		Address: common.HexToAddress("0x1"),
@@ -440,10 +411,6 @@ func BenchmarkLogEmitBlockLevelReset(b *testing.B) {
 	b.ReportMetric(float64(len(ibs.logs.pool)), "pooled")
 }
 
-// Blocks do not repeat their shape: the same logs land at different tx indexes
-// from one block to the next. An arena keyed by tx index keeps a slot for every
-// shape it has seen, while what a reset-per-tx caller needs live is one
-// transaction. Reports what is retained, which ns/op cannot show.
 func BenchmarkLogEmitShiftingShape(b *testing.B) {
 	shapes := []struct{ txs, logsPerTx int }{{200, 3}, {60, 10}, {400, 1}, {120, 5}}
 	log := &types.Log{
@@ -521,9 +488,6 @@ func BenchmarkLogsRlpHash(b *testing.B) {
 	})
 }
 
-// TestAddLogOnLogHookCopyContract pins the OnLog contract on the AddLog path:
-// the hook sees the emitted contents during the callback, and a copy taken then
-// stays intact after the buffer entry is reused by later blocks.
 func TestAddLogOnLogHookCopyContract(t *testing.T) {
 	t.Parallel()
 
@@ -549,9 +513,6 @@ func TestAddLogOnLogHookCopyContract(t *testing.T) {
 	require.Equal(t, []byte{0x01}, []byte(copied[0].Data))
 }
 
-// TestNotifyLogHookGetsStableCopy pins the OnLog contract on the AllocLog path
-// the EVM's makeLog uses: the hook owns what it receives, so retaining it is
-// safe even though the buffer entry behind it is reused by a later block.
 func TestNotifyLogHookGetsStableCopy(t *testing.T) {
 	t.Parallel()
 
@@ -583,9 +544,6 @@ func TestNotifyLogHookGetsStableCopy(t *testing.T) {
 	require.Equal(t, []byte{0xde, 0xad}, []byte(handed[1].Data))
 }
 
-// TestAddLogKeepsCallerBlockNumber pins that BlockNumber stays a caller-assigned
-// field: execution/state does not know the block number, so a reused entry must
-// not carry the previous caller's value either.
 func TestAddLogKeepsCallerBlockNumber(t *testing.T) {
 	t.Parallel()
 
@@ -600,10 +558,6 @@ func TestAddLogKeepsCallerBlockNumber(t *testing.T) {
 	require.Zero(t, logs[1].BlockNumber, "an unset BlockNumber must not inherit the previous log's")
 }
 
-// TestAllocLogPreservesCapacityAcrossRevert pins that fully reverting a tx's
-// logs (which truncates the outer buffer) and then logging again reuses the
-// inner buffer's capacity instead of dropping it — the same capacity Reset
-// preserves.
 func TestAllocLogPreservesCapacityAcrossRevert(t *testing.T) {
 	t.Parallel()
 
@@ -624,10 +578,6 @@ func TestAllocLogPreservesCapacityAcrossRevert(t *testing.T) {
 	require.Equal(t, capBefore, cap(ibs.logs.entries), "the array survives revert+relog")
 }
 
-// TestLogIndexIsBlockWide pins that AddLog stamps a block-wide log index:
-// receipts.DeriveFields derives FirstLogIndexWithinBlock from Logs[0].Index, so
-// the counter must run across transactions, roll back with a reverted log, and
-// restart at zero on Reset.
 func TestLogIndexIsBlockWide(t *testing.T) {
 	t.Parallel()
 
@@ -655,9 +605,6 @@ func TestLogIndexIsBlockWide(t *testing.T) {
 	require.Equal(t, hexutil.Uint(0), ibs.GetRawLogs(0)[0].Index, "next block restarts at zero")
 }
 
-// Reading a transaction the run has moved past would answer empty, which a
-// receipt records as "emitted no logs" - so it panics instead. A transaction that
-// simply emitted nothing is newer than the tail, not older, so it stays legal.
 func TestGetLogsOfPastTxPanics(t *testing.T) {
 	t.Parallel()
 
@@ -672,9 +619,7 @@ func TestGetLogsOfPastTxPanics(t *testing.T) {
 	require.Panics(t, func() { ibs.GetRawLogs(0) }, "the run has moved past tx 0")
 }
 
-// The past-transaction check guards production, not just assert builds: a caller
-// that reads what the run has left must not be handed the tail's logs as if they
-// were its own. Not parallel - it writes the global assert flag.
+// Not parallel: it mutates the global assert-enabled flag.
 func TestGetLogsOfPastTxPanicsWithoutAsserts(t *testing.T) {
 	defer func(prev bool) { dbg.AssertEnabled = prev }(dbg.AssertEnabled)
 	dbg.AssertEnabled = false
@@ -686,10 +631,6 @@ func TestGetLogsOfPastTxPanicsWithoutAsserts(t *testing.T) {
 	require.Panics(t, func() { ibs.GetRawLogs(2) }, "tx 2 is older than the tail")
 }
 
-// Whatever the traffic looks like, one arena holds a bounded amount: the pool,
-// and the one array the run left behind. This is the invariant a shape-specific
-// leak breaks — logs parked per tx index, an array kept because one block was
-// wide, Data kept because one log was large.
 func TestArenaRetentionStaysBounded(t *testing.T) {
 	t.Parallel()
 

--- a/execution/state/old_incarnation_recreate_test.go
+++ b/execution/state/old_incarnation_recreate_test.go
@@ -10,8 +10,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// tx0 writes slot k=4; tx1 self-destructs (pre-Cancun full destruct);
-// tx2 recreates the address without touching k; tx3 reads k and must see 0.
+// tx0 writes k=4; tx1 selfdestructs (pre-Cancun); tx2 recreates without touching k; tx3 must read k=0.
 func TestOldIncarnationStorageMaskedAfterRecreate(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xDE, 0xAD})
 	key := accounts.InternKey([32]byte{0x01})

--- a/execution/state/parallel_fixes_test.go
+++ b/execution/state/parallel_fixes_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// emptyReader is a stub StateReader that returns empty/nil for all reads.
 type emptyReader struct{}
 
 func (r *emptyReader) ReadAccountData(accounts.Address) (*accounts.Account, error) { return nil, nil }
@@ -31,41 +30,32 @@ func (r *emptyReader) SetTrace(bool, string)                                   {
 func (r *emptyReader) Trace() bool                                             { return false }
 func (r *emptyReader) TracePrefix() string                                     { return "" }
 
-// TestValueTiebreaker_BalancePath verifies that validation does not
-// invalidate a StorageRead when the versionMap Done value matches the
-// read value. This prevents unnecessary re-executions that cause
-// cascading state errors.
+// Validation tiebreaks on value: a StorageRead matching the versionMap Done value is valid even though its Version differs.
 func TestValueTiebreaker_BalancePath(t *testing.T) {
 	vm := NewVersionMap(nil)
 
 	addr := accounts.InternAddress([20]byte{0x01})
 	balance := uint256.NewInt(1000)
 
-	// Write a balance to the versionMap at txIndex=5
 	vm.WriteBalance(addr, Version{TxIndex: 5, Incarnation: 0}, *balance, true)
 
-	// Validate a read from txIndex=10 that read the SAME value from storage
-	readVal := *balance // Same value
+	readVal := *balance
 
 	valid := validateRead(vm, 10, addr, BalancePath, accounts.NilKey, StorageRead, Version{TxIndex: UnknownDep},
-		readVal, liveBalance, eqUint256, absentUint256, recordBalance, // value tiebreaker
+		readVal, liveBalance, eqUint256, absentUint256, recordBalance,
 		func(rv, wv Version) VersionValidity { return VersionValid },
 		false, "")
 
 	assert.Equal(t, VersionValid, valid, "Should be valid when StorageRead value matches versionMap Done value")
 }
 
-// TestValueTiebreaker_DifferentBalance verifies that validation DOES
-// invalidate when the StorageRead value differs from the versionMap value.
 func TestValueTiebreaker_DifferentBalance(t *testing.T) {
 	vm := NewVersionMap(nil)
 
 	addr := accounts.InternAddress([20]byte{0x01})
 
-	// Write balance=1000 to versionMap
 	vm.WriteBalance(addr, Version{TxIndex: 5, Incarnation: 0}, *uint256.NewInt(1000), true)
 
-	// Validate a read that got balance=500 from storage (stale)
 	readVal := *uint256.NewInt(500)
 
 	valid := validateRead(vm, 10, addr, BalancePath, accounts.NilKey, StorageRead, Version{TxIndex: UnknownDep},
@@ -76,23 +66,19 @@ func TestValueTiebreaker_DifferentBalance(t *testing.T) {
 	assert.Equal(t, VersionInvalid, valid, "Should be invalid when StorageRead value differs from versionMap Done value")
 }
 
-// TestValueTiebreaker_NoncePath verifies nonce comparison works.
 func TestValueTiebreaker_NoncePath(t *testing.T) {
 	vm := NewVersionMap(nil)
 
 	addr := accounts.InternAddress([20]byte{0x02})
 
-	// Write nonce=42 to versionMap
 	vm.WriteNonce(addr, Version{TxIndex: 5, Incarnation: 0}, uint64(42), true)
 
-	// Same nonce from storage → valid
 	valid := validateRead(vm, 10, addr, NoncePath, accounts.NilKey, StorageRead, Version{TxIndex: UnknownDep},
 		uint64(42), liveNonce, eqUint64, absentUint64, recordNonce,
 		func(rv, wv Version) VersionValidity { return VersionValid },
 		false, "")
 	assert.Equal(t, VersionValid, valid, "Same nonce should be valid")
 
-	// Different nonce → invalid
 	valid = validateRead(vm, 10, addr, NoncePath, accounts.NilKey, StorageRead, Version{TxIndex: UnknownDep},
 		uint64(41), liveNonce, eqUint64, absentUint64, recordNonce,
 		func(rv, wv Version) VersionValidity { return VersionValid },
@@ -100,79 +86,57 @@ func TestValueTiebreaker_NoncePath(t *testing.T) {
 	assert.Equal(t, VersionInvalid, valid, "Different nonce should be invalid")
 }
 
-// TestVersionedWriteVersion verifies that VersionedWrite entries at
-// txIndex=0 are still reachable. The bug was that finalizeTx appended
-// writes without Version (zero value = txIndex=0), making them only
-// visible via floor(0) but invisible to floor(N-1) for N > 1.
+// A zero-value Version (TxIndex 0) must not shadow a real higher-tx entry when read from a later floor.
 func TestVersionedWriteVersion(t *testing.T) {
 	vm := NewVersionMap(nil)
 
 	addr := accounts.InternAddress([20]byte{0x03})
 
-	// Write at txIndex=10 with correct Version
 	vm.WriteBalance(addr, Version{TxIndex: 10, Incarnation: 1}, *uint256.NewInt(500), true)
 
-	// Read at txIndex=11 should find txIndex=10
 	_, rr, _ := vm.ReadBalance(addr, 11)
 	assert.Equal(t, MVReadResultDone, rr.Status(), "Should find entry at floor(10)")
 	assert.Equal(t, 10, rr.DepIdx(), "Should be from txIndex 10")
 
-	// Now also write at txIndex=0 (simulates the zero-Version bug)
 	vm.WriteBalance(addr, Version{TxIndex: 0, Incarnation: 0}, *uint256.NewInt(999), true)
 
-	// Read at txIndex=11 should STILL find txIndex=10 (not 0)
 	_, rr, _ = vm.ReadBalance(addr, 11)
 	assert.Equal(t, MVReadResultDone, rr.Status())
 	assert.Equal(t, 10, rr.DepIdx(), "Should find txIndex=10, not txIndex=0")
 
-	// But read at txIndex=1 should find txIndex=0
 	_, rr, _ = vm.ReadBalance(addr, 1)
 	assert.Equal(t, MVReadResultDone, rr.Status())
 	assert.Equal(t, 0, rr.DepIdx(), "Should find txIndex=0 for floor(0)")
 }
 
-// TestAccessListResetInIBSReset verifies that IBS.Reset() clears the
-// access list, preventing stale warm addresses from leaking between
-// TX executions on the same worker.
+// Reset must clear the access list so a reused worker doesn't leak warm addresses into the next tx.
 func TestAccessListResetInIBSReset(t *testing.T) {
 	ibs := New(nil)
 	defer ibs.Close()
 
-	// Add an address to the access list
 	testAddr := accounts.InternAddress([20]byte{0x42})
 	ibs.AddAddressToAccessList(testAddr)
 	assert.True(t, ibs.AddressInAccessList(testAddr), "Address should be warm")
 
-	// Reset
 	ibs.Reset()
 
-	// Address should be cold after reset
 	assert.False(t, ibs.AddressInAccessList(testAddr), "Address should be cold after Reset")
 }
 
-// TestAddressAccessResetInIBSReset verifies that IBS.Reset() clears BAL
-// address-access recording. An aborted incarnation never harvests
-// AccessedAddresses, and only regular txs call Prepare (which re-inits
-// recording) — a worker next assigned a system block-start/block-end
-// transaction never calls Prepare, so it would harvest the leftovers into
-// its own block's access list as phantom entries.
+// System block-start/end txs never call Prepare, so a leftover AccessedAddresses from an
+// aborted incarnation would leak into the next block as phantom entries unless Reset clears it.
 func TestAddressAccessResetInIBSReset(t *testing.T) {
 	ibs := New(nil)
 	defer ibs.Close()
 	sender := accounts.InternAddress([20]byte{0x01})
 	coinbase := accounts.InternAddress([20]byte{0x02})
 	leaked := accounts.InternAddress([20]byte{0x42})
-	// Prepare enables access recording at tx start.
 	ibs.Prepare(&chain.Rules{}, sender, coinbase, accounts.NilAddress, nil, nil)
 	ibs.MarkAddressAccess(leaked, false)
-	// Tx aborts: AccessedAddresses is never harvested. The worker resets
-	// the shared IBS before the next task.
 	ibs.Reset()
 	assert.Empty(t, ibs.versionedReads.access, "no recorded accesses should survive Reset")
 }
 
-// TestTransientStorageResetInIBSReset verifies that IBS.Reset() clears
-// transient storage (EIP-1153).
 func TestTransientStorageResetInIBSReset(t *testing.T) {
 	ibs := New(nil)
 	defer ibs.Close()
@@ -180,35 +144,27 @@ func TestTransientStorageResetInIBSReset(t *testing.T) {
 	testAddr := accounts.InternAddress([20]byte{0x42})
 	testKey := accounts.InternKey([32]byte{0x01})
 
-	// Set transient storage
 	ibs.SetTransientState(testAddr, testKey, *uint256.NewInt(42))
 	val := ibs.GetTransientState(testAddr, testKey)
 	assert.False(t, val.IsZero(), "Transient storage should be set")
 
-	// Reset
 	ibs.Reset()
 
-	// Transient storage should be cleared
 	val = ibs.GetTransientState(testAddr, testKey)
 	assert.True(t, val.IsZero(), "Transient storage should be zero after Reset")
 }
 
-// TestCodeReadFromVersionMap verifies that the versionMap CodePath
-// entries are accessible. This ensures EIP-7702 synthetic code
-// (delegation prefix) written by a prior TX is visible to subsequent
-// TXs via the versionMap.
+// EIP-7702 delegation code written by a prior tx must be visible to later txs via the versionMap CodePath.
 func TestCodeReadFromVersionMap(t *testing.T) {
 	vm := NewVersionMap(nil)
 
 	addr := accounts.InternAddress([20]byte{0x55})
 
-	// Write EIP-7702 delegation code to versionMap at txIndex=5
 	delegationCode := []byte{0xef, 0x01, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
 		0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
 		0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14}
 	vm.WriteCode(addr, Version{TxIndex: 5, Incarnation: 0}, accounts.NewCode(delegationCode), true)
 
-	// Read at txIndex=10 should find the code
 	code, rr, ok := vm.ReadCode(addr, 10)
 	require.Equal(t, MVReadResultDone, rr.Status(), "Should find CodePath entry")
 
@@ -218,14 +174,10 @@ func TestCodeReadFromVersionMap(t *testing.T) {
 	assert.Equal(t, accounts.NewCode(delegationCode).Hash, code.Hash,
 		"hash must survive the versionMap round-trip, not be stripped")
 
-	// Read at txIndex=3 should NOT find it (before the write)
 	_, rr, _ = vm.ReadCode(addr, 3)
 	assert.NotEqual(t, MVReadResultDone, rr.Status(), "Should not find code before write txIndex")
 }
 
-// TestTouchUpdates_Account verifies that TouchUpdates feeds account field
-// writes directly to commitment.Updates via TouchPlainKeyDirect, producing
-// merged Updates with correct key count.
 func TestTouchUpdates_Account(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x42})
 
@@ -239,12 +191,10 @@ func TestTouchUpdates_Account(t *testing.T) {
 	updates := commitment.NewUpdates(commitment.ModeUpdate, t.TempDir(), func(k []byte) []byte { return k })
 	writes.TouchUpdates(updates)
 
-	// All 4 fields merge into 1 key (same address)
 	assert.Equal(t, uint64(1), updates.Size(), "Should have 1 merged key for same address")
 }
 
-// TestTouchUpdates_AccountModeParallel: ModeParallel must merge per-field
-// touches of one address additively, like ModeUpdate.
+// ModeParallel must merge per-field touches of one address the same as ModeUpdate.
 func TestTouchUpdates_AccountModeParallel(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x42})
 
@@ -261,7 +211,6 @@ func TestTouchUpdates_AccountModeParallel(t *testing.T) {
 	assert.Equal(t, uint64(1), updates.Size(), "Should have 1 merged key for same address")
 }
 
-// TestToTouchKeys_Storage verifies storage entries use correct composite keys.
 func TestToTouchKeys_Storage(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x55})
 	slot1 := accounts.InternKey([32]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04})
@@ -277,11 +226,9 @@ func TestToTouchKeys_Storage(t *testing.T) {
 	updates := commitment.NewUpdates(commitment.ModeUpdate, t.TempDir(), func(k []byte) []byte { return k })
 	writes.TouchUpdates(updates)
 
-	// Should have 2 unique keys (different slots)
 	assert.Equal(t, uint64(2), updates.Size(), "Should have 2 storage keys")
 }
 
-// TestTouchUpdates_Code verifies code writes feed through TouchUpdates.
 func TestTouchUpdates_Code(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xd2})
 	code := []byte{0xef, 0x01, 0x00, 0x01, 0x02, 0x03}
@@ -296,45 +243,34 @@ func TestTouchUpdates_Code(t *testing.T) {
 	assert.Equal(t, uint64(1), updates.Size(), "Should have 1 code key")
 }
 
-// TestTouchUpdates_MixedBatch verifies that a mixed batch of writes
-// (accounts + storage + code) feeds correctly through TouchUpdates.
 func TestTouchUpdates_MixedBatch(t *testing.T) {
 	addr1 := accounts.InternAddress([20]byte{0x01})
 	addr2 := accounts.InternAddress([20]byte{0x02})
 	slot := accounts.InternKey([32]byte{0x04})
 
 	writes := newWriteSet(
-		// Account 1: balance + nonce + code
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr1, Path: BalancePath}, Val: *uint256.NewInt(100)},
 		&VersionedWrite[uint64]{WriteHeader: WriteHeader{Address: addr1, Path: NoncePath}, Val: uint64(1)},
 		&VersionedWrite[uint64]{WriteHeader: WriteHeader{Address: addr1, Path: IncarnationPath}, Val: uint64(0)},
 		&VersionedWrite[accounts.CodeHash]{WriteHeader: WriteHeader{Address: addr1, Path: CodeHashPath}, Val: accounts.InternCodeHash([32]byte{})},
 		&VersionedWrite[accounts.Code]{WriteHeader: WriteHeader{Address: addr1, Path: CodePath}, Val: accounts.Code{Hash: accounts.InternCodeHash(crypto.Keccak256Hash([]byte{0x60, 0x00})), Bytes: []byte{0x60, 0x00}}},
-		// Account 2: storage write
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr2, Path: StoragePath, Key: slot}, Val: *uint256.NewInt(999)},
 	)
 
 	updates := commitment.NewUpdates(commitment.ModeUpdate, t.TempDir(), func(k []byte) []byte { return k })
 	writes.TouchUpdates(updates)
 
-	// addr1: account fields + code all merge into 1 key
-	// addr2+slot: 1 storage key
-	// Total: 2 unique keys
 	assert.Equal(t, uint64(2), updates.Size(), "2 unique keys (addr1 merged, addr2 storage)")
 }
 
-// TestBlockStateCacheWriteAccount_NilCommitted verifies that WriteAccount
-// doesn't panic when the committed cache has a nil account entry.
-// This can happen when PutCommittedAccount stores nil (account doesn't exist).
+// A nil committed entry is legitimate: PutCommittedAccount stores nil when the account doesn't exist pre-block.
 func TestBlockStateCacheWriteAccount_NilCommitted(t *testing.T) {
 	cache := NewBlockStateCache()
 
 	addr := accounts.InternAddress([20]byte{0x42})
 
-	// Put a nil committed account (account doesn't exist in pre-block state)
 	cache.PutCommittedAccount(addr, nil)
 
-	// Write a new account — should not panic
 	acc := accounts.NewAccount()
 	acc.Balance = *uint256.NewInt(1000)
 	acc.Nonce = 1
@@ -344,22 +280,17 @@ func TestBlockStateCacheWriteAccount_NilCommitted(t *testing.T) {
 		cache.WriteAccount(addr, enc, 1)
 	}, "WriteAccount should not panic with nil committed account")
 
-	// Verify the write is recorded.
 	current, ok := cache.GetCurrentAccount(addr)
 	assert.True(t, ok, "Should have current account")
 	assert.Equal(t, enc, current, "Current account should match written value")
 }
 
-// TestBlockStateCacheWriteAccountUpdatesCurrent verifies that successive
-// writes update the current view to the latest value (last write wins
-// for read access via GetCurrentAccount). The full per-tx history is
-// preserved in writeLog for Flush.
+// GetCurrentAccount is last-write-wins; the full per-tx history still lives in writeLog for Flush.
 func TestBlockStateCacheWriteAccountUpdatesCurrent(t *testing.T) {
 	cache := NewBlockStateCache()
 
 	addr := accounts.InternAddress([20]byte{0x55})
 
-	// Set up committed account
 	acc := accounts.NewAccount()
 	acc.Balance = *uint256.NewInt(500)
 	acc.Nonce = 3
@@ -379,11 +310,8 @@ func TestBlockStateCacheWriteAccountUpdatesCurrent(t *testing.T) {
 	assert.Equal(t, enc2, current, "GetCurrentAccount should return the latest write")
 }
 
-// Pins that a second DeleteAccount in the same block is a writeLog no-op —
-// Flush must emit exactly one DomainDel per address (matching serial's IBS
-// short-circuit). Without this dedup the redundant nil-history entry feeds
-// into commitment-cache step keys and produces a non-deterministic state
-// root between parallel-exec nodes validating each other's blocks.
+// A second DeleteAccount in the same block must be a writeLog no-op; without dedup the
+// redundant entry can produce a non-deterministic state root across parallel-exec nodes.
 func TestBlockStateCacheDeleteAccount_IdempotentInBlock(t *testing.T) {
 	cache := NewBlockStateCache()
 	addr := accounts.InternAddress([20]byte{0x77})
@@ -404,9 +332,7 @@ func TestBlockStateCacheDeleteAccount_IdempotentInBlock(t *testing.T) {
 	assert.Nil(t, enc, "current view value must remain nil")
 }
 
-// Pins the recreate-then-redelete pattern: an intervening WriteAccount
-// resets the dedup so the next DeleteAccount IS recorded — only the
-// "no write in between" duplicate is collapsed.
+// An intervening WriteAccount resets the dedup, so a later DeleteAccount is recorded again.
 func TestBlockStateCacheDeleteAccount_RecreateThenDeleteRecords(t *testing.T) {
 	cache := NewBlockStateCache()
 	addr := accounts.InternAddress([20]byte{0x88})
@@ -428,19 +354,8 @@ func TestBlockStateCacheDeleteAccount_RecreateThenDeleteRecords(t *testing.T) {
 	assert.Equal(t, 2, deletes, "delete after recreate must be recorded; only no-op duplicates are collapsed")
 }
 
-// TestSelfDestructKeepsDirtyStorageReadableSameTx verifies that after an
-// account self-destructs (versionMap active), a subsequent same-tx GetState
-// still returns the dirty value written before the SELFDESTRUCT. Pre-Cancun
-// (and for CALL-based SELFDESTRUCT generally) the account stays alive until
-// end-of-tx, so re-entered code must see the real storage — not zero.
-//
-// Regression: IBS.Selfdestruct used to versionWritten(StoragePath, key, 0)
-// for every dirty slot to feed the parallel commitment calculator. Because
-// versionedRead consults versionedWrites before the stateObject, those
-// spurious zero writes made same-tx re-reads return 0 — wrong gas
-// (SSTORE_SET vs dirty-update, +19900) and a wrong written value
-// (EEST cancun/eip6780_selfdestruct/* under EXEC3_PARALLEL). The calc now
-// gets per-slot DELETEs from Normalize's SD cascade instead.
+// Pre-Cancun (and for CALL-based SELFDESTRUCT), the account stays alive until end-of-tx, so
+// a same-tx re-read after SELFDESTRUCT must still see the dirty storage, not zero.
 func TestSelfDestructKeepsDirtyStorageReadableSameTx(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xAA})
 	slot0 := accounts.InternKey([32]byte{0x00})
@@ -461,7 +376,6 @@ func TestSelfDestructKeepsDirtyStorageReadableSameTx(t *testing.T) {
 	_, err := ibs.Selfdestruct(addr, false)
 	require.NoError(t, err)
 
-	// After SELFDESTRUCT, same-tx reads must still see the dirty values.
 	got0, err := ibs.GetState(addr, slot0)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(42), got0.Uint64(), "slot0 must read back as 42, not 0, after SELFDESTRUCT")
@@ -469,12 +383,10 @@ func TestSelfDestructKeepsDirtyStorageReadableSameTx(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(99), got1.Uint64(), "slot1 must read back as 99, not 0, after SELFDESTRUCT")
 
-	// SelfDestructPath is still recorded.
 	destructed, err := ibs.HasSelfdestructed(addr)
 	require.NoError(t, err)
 	assert.True(t, destructed)
 
-	// And it must NOT have emitted spurious StoragePath=0 writes.
 	for waddr, slots := range ibs.VersionedWrites().Storages() {
 		if waddr != addr {
 			continue

--- a/execution/state/read_paths.go
+++ b/execution/state/read_paths.go
@@ -19,9 +19,6 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// codeSizeFromStateObject is the per-stateObject code-size fetch used by
-// readCodeSize: cached so.code first, else a single code read that populates
-// the cache.
 func codeSizeFromStateObject(sdb *IntraBlockState, so *stateObject, addr accounts.Address) (int, error) {
 	if so == nil || so.deleted {
 		return 0, nil
@@ -40,9 +37,7 @@ func codeSizeFromStateObject(sdb *IntraBlockState, so *stateObject, addr account
 	if dbg.KVReadLevelledMetrics {
 		readStart = time.Now()
 	}
-	// Size-only read for Stateless-witness correctness (see GetCodeSize): a
-	// witness node has the size but not the bytes, so ReadAccountCode returns
-	// nil there and reports EXTCODESIZE 0.
+	// A witness node holds the size but not the code bytes, so read size directly.
 	size, err := sdb.stateReader.ReadAccountCodeSize(addr)
 	if dbg.KVReadLevelledMetrics {
 		sdb.codeReadDuration += time.Since(readStart)
@@ -52,12 +47,8 @@ func codeSizeFromStateObject(sdb *IntraBlockState, so *stateObject, addr account
 	return size, err
 }
 
-// committedStorageDirect reads a storage slot's committed value straight from
-// the state reader, with no stateObject. Used on the parallel path for a cold
-// slot: no versionMap cell and no stateObject materialized this tx. When this
-// tx created the contract (own CreateContract cell) its storage is fresh, so a
-// cold slot reads zero rather than a prior incarnation's committed value —
-// under noMaterialize there is no fresh stateObject to short-circuit that.
+// committedStorageDirect reads a cold slot straight from the state reader; a
+// contract this tx created reads zero here, never a prior incarnation's value.
 func (sdb *IntraBlockState) committedStorageDirect(addr accounts.Address, key accounts.StorageKey) (uint256.Int, error) {
 	if cc, ok := sdb.versionedWriteCreateContract(addr); ok && cc {
 		return uint256.Int{}, nil
@@ -84,11 +75,6 @@ func (sdb *IntraBlockState) committedStorageDirect(addr accounts.Address, key ac
 	return res, nil
 }
 
-// committedCodeDirect reads an account's committed code bytes straight from the
-// state reader, with no stateObject. Reached only for a cold CodePath read (the
-// versionMap CodePath cell already missed upstream). A contract this tx created
-// (own CreateContract cell) has no code until SetCode runs, so it reads empty
-// rather than a prior incarnation's bytes.
 func (sdb *IntraBlockState) committedCodeDirect(addr accounts.Address) ([]byte, error) {
 	if cc, ok := sdb.versionedWriteCreateContract(addr); ok && cc {
 		return nil, nil
@@ -116,12 +102,8 @@ func (sdb *IntraBlockState) committedCodeDirect(addr accounts.Address) ([]byte, 
 	return code, err
 }
 
-// codeSeed returns the code this tx currently sees at addr — its own Code write
-// cell if it wrote one, else the committed value — without recording an OCC
-// read. On the noMaterialize path the transient stateObject is rebuilt from the
-// tx-start account, so its code reflects the committed value; seeding it with
-// this lets stateObject.SetCode compare against the current code (matching the
-// cached path) instead of the stale tx-start value.
+// codeSeed returns the code this tx currently sees (own write, else committed)
+// without recording an OCC read, so SetCode compares against current code.
 func (sdb *IntraBlockState) codeSeed(addr accounts.Address, currentHash accounts.CodeHash) (accounts.Code, error) {
 	if _, isDirty := sdb.journal.dirties[addr]; isDirty {
 		if vw, ok := sdb.versionedWrites.GetCode(addr); ok {
@@ -138,10 +120,7 @@ func (sdb *IntraBlockState) codeSeed(addr accounts.Address, currentHash accounts
 	return accounts.Code{Hash: currentHash, Bytes: bytes}, nil
 }
 
-// committedCodeHash returns the tx-start code hash from the committed reader
-// (normalised to EmptyCodeHash for an absent or code-less account), without
-// recording an OCC read. Used on the noMaterialize path where the rebuilt
-// transient's original reflects this tx's own code cell rather than tx start.
+// committedCodeHash normalizes an absent or code-less account to EmptyCodeHash.
 func (sdb *IntraBlockState) committedCodeHash(addr accounts.Address) (accounts.CodeHash, error) {
 	acc, err := sdb.stateReader.ReadAccountData(addr)
 	if err != nil {
@@ -153,10 +132,6 @@ func (sdb *IntraBlockState) committedCodeHash(addr accounts.Address) (accounts.C
 	return acc.CodeHash, nil
 }
 
-// committedCodeSizeDirect reads an account's committed code size straight from
-// the state reader, with no stateObject. Size-only for stateless-witness
-// correctness (a witness node carries the size but not the bytes). A contract
-// this tx created has zero code size until SetCode runs.
 func (sdb *IntraBlockState) committedCodeSizeDirect(addr accounts.Address) (int, error) {
 	if cc, ok := sdb.versionedWriteCreateContract(addr); ok && cc {
 		return 0, nil
@@ -184,33 +159,22 @@ func (sdb *IntraBlockState) committedCodeSizeDirect(addr accounts.Address) (int,
 	return size, err
 }
 
-// versionedReadCore runs the type-independent part of a versionMap-aware read —
-// the writeSet/versionMap/readSet tier probes plus destruct/revival logic — and
-// returns a readPathResult telling the typed wrapper which source to read the
-// path-typed value from. Panics ErrDependency on an intra-tx version conflict.
 type readPathOutcome uint8
 
 const (
-	outcomeLegacyStorage readPathOutcome = iota // versionMap == nil: typed wrapper does direct storage read on r.so
-	outcomeWriteSetHit                          // r.vw is set; typed wrapper returns its Val*
-	outcomeMapDone                              // versionMap hit; the path's typed map*Val field carries the value
-	outcomeReadSetHit                           // a prior read matched; typed wrapper re-fetches it via GetX
-	outcomeStorageRead                          // r.so resolved; wrapper does typed storage read + records r.hdr
-	outcomeReturnZero                           // typed wrapper returns the path-typed zero value
-	outcomeReturnDefault                        // typed wrapper returns its caller-supplied defaultV
+	outcomeLegacyStorage readPathOutcome = iota
+	outcomeWriteSetHit
+	outcomeMapDone
+	outcomeReadSetHit
+	outcomeStorageRead
+	outcomeReturnZero    // erased by self-destruct, or genuinely absent: the path-typed zero
+	outcomeReturnDefault // no information either way: the caller's current in-memory value
 )
 
-// readPathResult communicates the outcome of versionedReadCore to a
-// typed wrapper.  Exactly one source field is populated for the
-// tier-hit outcomes; the wrapper performs the typed extraction and
-// records the read via the typed ReadSet.SetX path when r.recordVR is true.
+// readPathResult is versionedReadCore's result: outcome selects which field below holds the value.
 type readPathResult struct {
 	outcome readPathOutcome
 
-	// Source records for typed extraction.  For outcomeWriteSetHit the
-	// path-typed pointer corresponding to the read path is set; the
-	// others are nil.  Per-typed fields avoid the any-boxing that a
-	// single AnyVersionedWrite field would force on the hot path.
 	vwAddress        *VersionedWrite[*accounts.Account]
 	vwBalance        *VersionedWrite[uint256.Int]
 	vwNonce          *VersionedWrite[uint64]
@@ -222,12 +186,9 @@ type readPathResult struct {
 	vwCodeSize       *VersionedWrite[int]
 	vwStorage        *VersionedWrite[uint256.Int]
 
-	so *stateObject // outcomeStorageRead / outcomeLegacyStorage
+	so *stateObject
 
-	// Typed map-read values: the wrapper reads its path's field directly,
-	// avoiding the any-box (a heap alloc per non-storage read) the generic
-	// ReadResult.value would impose. Value, not *WriteCell, so reads are
-	// race-free against a concurrent FlushVersionedWrites mutating cell.Value.
+	// Values, not *WriteCell: copying out keeps reads race-free against a concurrent FlushVersionedWrites mutating cell.Value.
 	mapAddressVal        *accounts.Account
 	mapBalanceVal        uint256.Int
 	mapNonceVal          uint64
@@ -239,12 +200,8 @@ type readPathResult struct {
 	mapCodeSizeVal       int
 	mapStorageVal        uint256.Int
 
-	// Hash the CodePath source stored with mapCodeVal; assign the two together.
-	// NilCodeHash means the caller must resolve it.
 	hashOfMapCodeVal accounts.CodeHash
 
-	// hdr is the skeleton header for the wrapper to record (with its typed
-	// value) via the typed recordX path when recordVR is true.
 	hdr      ReadHeader
 	recordVR bool
 
@@ -254,26 +211,8 @@ type readPathResult struct {
 	err error
 }
 
-// versionedReadCore is the non-generic body that drives the read.
-// Typed wrappers (readBalance, readNonce, readState, …) consume the
-// result.  See readPathOutcome for the outcome enumeration.
-//
-// skipStorage=true: do not attempt a storage-read fallback when the
-// in-memory tiers miss — the caller resolves the value itself (refresh*
-// wrappers return their defaultV; AddressPath reads avoid recursing back
-// through getStateObject).
-//
-// versionedReadCore writes its discriminated result into *r (caller
-// allocates on the stack).  This avoids a ~256-byte return-value copy
-// per call — the readPathResult struct is large because it bundles
-// every outcome's source field; pointer-passing keeps the struct in
-// the caller's stack frame and the core mutates it in place.
-// readValueUnchanged reports whether the prior recorded read's value for
-// (addr, path, key) equals the value just read into r — a spurious version-only
-// churn, not a real data dependency. AddressPath is existence-only: its
-// sub-fields are each recorded and validated as their own reads. Deliberately
-// narrower than validation's tiebreakers (no CodePath/CodeSizePath arms): the
-// default is "changed", which re-reads — fail-safe, never stale.
+// readValueUnchanged reports whether a version churn actually changed the value,
+// so a spurious churn need not abort the tx. Unhandled paths default to "changed".
 func (s *IntraBlockState) readValueUnchanged(addr accounts.Address, path AccountPath, key accounts.StorageKey, r *readPathResult) bool {
 	switch path {
 	case AddressPath:
@@ -309,10 +248,9 @@ func (s *IntraBlockState) readValueUnchanged(addr accounts.Address, path Account
 	}
 }
 
+// versionedReadCore drives the read into the caller-allocated *r. skipStorage=true
+// skips the storage-read fallback: the caller resolves the value itself.
 func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPath, key accounts.StorageKey, commited bool, skipStorage bool, r *readPathResult) {
-	// Callers pass a fresh, zero-valued *r (a stack `var r readPathResult`), so no
-	// re-zero here — that would be a redundant 256-byte memclr on every read.
-
 	if s.versionMap == nil {
 		so, err := s.getStateObject(addr, true)
 		if err != nil {
@@ -329,9 +267,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 	}
 
 	if so, ok := s.stateObjects[addr]; ok && so.deleted {
-		// When the in-memory deletion reflects a prior tx's selfdestruct, surface
-		// the SD version rather than UnknownVersion, so synthetic CreateAccount read
-		// records match later SD-zero-path reads and don't force a version conflict.
+		// Surface the prior tx's self-destruct version so this synthetic read matches later SD-zero reads.
 		destructed, sdRes, sdOK := s.readSelfDestructMemo(addr)
 		switch {
 		case sdOK && sdRes.Status() == MVReadResultDone && destructed:
@@ -347,10 +283,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 			r.version = sdVer
 			return
 		case sdOK && sdRes.Status() == MVReadResultDone && !destructed:
-			// A later tx revived the account: the cached deleted object is stale
-			// against the map, so fall through — map floors serve the revival's
-			// cells, and paths without cells resolve through the deleted object's
-			// committed fall-through, which correctly reads as wiped.
+			// A later tx revived the account: fall through so map cells serve the revival.
 		default:
 			r.outcome = outcomeReturnDefault
 			r.source = StorageRead
@@ -359,14 +292,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 		}
 	}
 
-	// Read-side cache (warm read, Block-STM read-once): a Done value already
-	// resolved for (addr, path, key) earlier in this execution attempt is a
-	// consistent snapshot — commit-time ValidateVersion re-checks the whole
-	// read-set, so returning it without re-probing the version map is safe. The
-	// first read of any path still takes the full path (estimates panic there, so
-	// the dependency-wait is untouched); only a repeat read of a Done value skips
-	// the probe. Own writes take precedence via the dirty gate (the same gate
-	// versionedWriteHit uses), so a written path never takes this branch.
+	// Read-once fast path: a Done value resolved this attempt is safe to reuse without re-probing.
 	if !commited {
 		if _, dirty := s.journal.dirties[addr]; !dirty {
 			if prHeader, ok := s.versionedReads.getHeader(addr, path, key); ok &&
@@ -383,8 +309,6 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 	if destructed, sdRes, ok := s.readSelfDestructMemo(addr); ok && sdRes.Status() == MVReadResultDone && destructed {
 		destructTxIndex := sdRes.DepIdx()
 		sdVer := Version{TxIndex: sdRes.DepIdx(), Incarnation: sdRes.Incarnation()}
-		// A tx's own same-tx write to this path is returned directly: it always
-		// observes its own write, even after a prior tx's self-destruct.
 		if !commited {
 			if hasWrite := s.versionedWriteHit(addr, path, key, r); hasWrite {
 				r.outcome = outcomeWriteSetHit
@@ -393,9 +317,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 				return
 			}
 		}
-		// This field is revived only if the version map holds a write to THIS path
-		// at a strictly higher TxIndex; per-path (not account-wide) so a field with
-		// no post-self-destruct write correctly reads as the fresh account's zero.
+		// Revival is per-path, not account-wide: an unwritten field stays the fresh account's zero.
 		revived := false
 		if pathRevival := s.versionMap.ReadStatus(addr, path, key, s.txIndex); pathRevival.DepIdx() > destructTxIndex &&
 			(pathRevival.Status() == MVReadResultDone || pathRevival.Status() == MVReadResultDependency) {
@@ -404,10 +326,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 		if !revived && path != CodePath {
 			sdVersion := Version{TxIndex: destructTxIndex, Incarnation: sdVer.Incarnation}
 			if s.eip8246 && (path == BalancePath || path == CodeHashPath || path == IncarnationPath) {
-				// EIP-8246 removes the SELFDESTRUCT burn: a destroyed account keeps
-				// its balance and stays alive, so a concurrent reader must see the
-				// live account, not a zeroed one. Record the SelfDestructPath
-				// dependency for validation, then fall through to the actual value.
+				// EIP-8246: no burn, so record the dependency and fall through to the live value.
 				s.versionedReads.SetSelfDestruct(addr, VersionedRead[bool]{
 					ReadHeader: ReadHeader{Source: MapRead, Version: sdVersion},
 					Val:        true,
@@ -419,14 +338,8 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 					r.version = sdVersion
 					return
 				}
-				// Match main's `versionedWrite(addr, SelfDestructPath, key)`: the
-				// own-write lookup is keyed by `key`, so for a StoragePath read
-				// (key=slot) it never matches the per-address SelfDestructPath write
-				// (stored under NilKey) and the slot reads as the post-SD zero — a
-				// fresh contract's slots are empty. Only an account-field read
-				// (key=NilKey) consults the SelfDestructPath own-write; a same-tx
-				// SelfDestructPath=false there means the account was revived, so we
-				// fall through.
+				// Keyed by `key`: a StoragePath read (key=slot) never matches the per-address
+				// SelfDestructPath write (key=NilKey), so slots read as post-SD zero.
 				sd, sdOK := false, false
 				if key == accounts.NilKey {
 					sd, sdOK = s.versionedWriteSelfDestruct(addr)
@@ -436,10 +349,8 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 						ReadHeader: ReadHeader{Source: MapRead, Version: sdVersion},
 						Val:        true,
 					})
-					// Per-path revival misses account-level life: a balance-only
-					// credit (fee, transfer) revives the account without writing a
-					// CodeHash entry, and a live account's wiped code hash is
-					// keccak(''), not the nil hash of a nonexistent one.
+					// A balance-only revival writes no CodeHash entry, yet a live account's
+					// wiped code hash is keccak(''), not the nil hash of a nonexistent one.
 					if path == CodeHashPath && !s.versionMap.destroyedAndUnrevived(addr, s.txIndex) {
 						r.outcome = outcomeMapDone
 						r.mapCodeHashVal = accounts.EmptyCodeHash
@@ -454,18 +365,12 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 					r.version = sdVersion
 					return
 				}
-				// SelfDestructPath write exists with Val==false: fall through with
-				// destructedVersion recorded so the stale-readSet dependency check
-				// can use it.
+				// Revived (SelfDestruct=false): keep destructedVersion for the stale-read check below.
 				destructedVersion = Version{TxIndex: destructTxIndex}
 			}
 		}
 	}
 
-	// Dispatch to the path's typed ReadX: returns T directly plus a ReadResult
-	// (Status/DepIdx/Incarnation), never an any-boxed value — the box the
-	// generic Read does is a heap alloc per non-storage read. On a miss ReadX
-	// returns a pre-seeded (UnknownDep, -1) result, so res is always valid.
 	var res ReadResult
 	switch path {
 	case AddressPath:
@@ -545,9 +450,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 	switch res.Status() {
 	case MVReadResultDone:
 		hdr.Source = MapRead
-		// A provisional prior read is this same load's nil probe: a cell flushed
-		// in between was never consumed, so adopt it below and let the load's
-		// reconciliation re-record the read.
+		// A provisional prior read is this load's own nil probe; skip it and adopt the fresh header below.
 		if prHeader, ok := s.versionedReads.getHeader(addr, path, key); ok && prHeader.Source != ProvisionalRead {
 			if prHeader.Version == hdr.Version {
 				if dbg.TraceTransactionIO && (s.trace || dbg.TraceAccount(addr.Handle())) {
@@ -561,9 +464,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 				return
 			}
 			if s.readValueUnchanged(addr, path, key, r) {
-				// Value-aware relaxation: the version churned but the value is
-				// unchanged (existence-only for the AddressPath record) — a spurious
-				// version-only dependency. Keep the recorded read, do not abort.
+				// Version churned but the value didn't: a spurious dependency, not a real one.
 				r.outcome = outcomeReadSetHit
 				r.source = MapRead
 				r.version = prHeader.Version
@@ -600,25 +501,12 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 			s.versionedReads.SetHeader(addr, path, key, hdr)
 			panic(ErrDependency)
 		}
-		// The value we found may predate a SELFDESTRUCT that erased it. If a
-		// later transaction destroyed this account, the erased fields and
-		// slots must read as zero/empty even though the old value is still in
-		// the map — and asking only for the LATEST SelfDestruct entry is not
-		// enough, because re-creating the account writes SelfDestruct=false
-		// on top of the destruction. So scan the whole range between the
-		// value and this reader for a destruction. Per-path bound, matching
-		// validation: for storage/code/nonce a value written by the same tx
-		// that destroyed the account is erased too (scan includes that
-		// index); for balance and code hash the destroyer's own entries are
-		// what remains AFTER destruction (EIP-8246 keeps the balance, the
-		// code hash is reset) and must be served, so the scan starts above
-		// them. Incarnation alone cannot detect this: a plain CREATE bumps
-		// it without erasing storage. Record what we conclude, twice: the
-		// zero/empty value, stamped with the old entry's version so
-		// validation accepts it as long as nothing new is written there; and
-		// a SelfDestruct=true read of the destruction itself, so the
-		// conclusion is re-checked if that destruction is ever re-executed
-		// away.
+		// A cached value may predate a later SELFDESTRUCT that erased it; checking
+		// only the latest SelfDestruct entry misses this, since a revival writes
+		// SelfDestruct=false on top. Scan the range for a destruction (bounds differ
+		// per path: EIP-8246 keeps balance/code-hash entries written by the
+		// destroyer, so their scan starts above it) and record both the wipe and a
+		// SelfDestruct=true dependency, so a re-executed destruction is re-checked.
 		if path == StoragePath || path == CodePath || path == CodeSizePath || path == NoncePath ||
 			path == CodeHashPath || path == BalancePath {
 			lo := hdr.Version.TxIndex
@@ -633,12 +521,6 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 						Val:        true,
 					})
 				}
-				// The code hash is account-level: a revival re-creates the
-				// account with a live empty-code hash even though nothing
-				// writes a CodeHash entry, so serve keccak('') for a revived
-				// account and the nil hash only while it stays dead. The other
-				// paths stay erased unless explicitly rewritten, which would
-				// be the entry above this scan.
 				if path == CodeHashPath && !s.versionMap.destroyedAndUnrevived(addr, s.txIndex) {
 					r.outcome = outcomeMapDone
 					r.mapCodeHashVal = accounts.EmptyCodeHash
@@ -718,23 +600,12 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 							hdr.Version.TxIndex, hdr.Version.Incarnation,
 							addr, AccountKey{path, key})
 					}
-					// Fall through to storage read.
 				}
 			}
 		}
 
-		// A self-destructed account's per-account field with no versionMap cell
-		// reads as the post-SD zero, recorded as a dependency on the SelfDestructPath
-		// entry; a bare StorageRead/UnknownVersion would be rejected by the validator
-		// (path==AddressPath cross-check) and loop on validator-invalid retries.
-		// Range-scan: a revival's SelfDestruct=false cell must not shadow the
-		// destruct — a balance-only revival rewrites nothing here, so the wipe
-		// still stands. Record the wiped value at the destruct's version: with
-		// no cell for the path, validation accepts exactly that pairing, a
-		// later re-establishing cell version-mismatches it, and removing the
-		// destruct fails the recorded SelfDestruct witness. The wiped code
-		// hash of an account still alive (e.g. after that balance-only
-		// revival) is keccak(''), not the nil hash of a nonexistent account.
+		// A bare StorageRead/UnknownVersion here would fail the validator's cross-check
+		// and livelock; record the wipe pinned to the destruct's version instead.
 		if path == BalancePath || path == NoncePath || path == IncarnationPath ||
 			path == CodeHashPath || path == CodePath || path == CodeSizePath {
 			if sdVer, ok := s.versionMap.FindDoneSelfDestructInRange(addr, 0, s.txIndex, true); ok {
@@ -761,10 +632,8 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 			}
 		}
 
-		// A prior tx that bumped Incarnation cleared the old incarnation's storage
-		// and code; read them as empty when no newer cell exists. A revival writes
-		// its own CodePath/StoragePath cell, which the version-map read above returns
-		// before reaching here, so reaching here means the field is genuinely cleared.
+		// A prior tx's incarnation bump cleared the old storage/code; a revival's own
+		// cell would have matched the version-map read above, so this is genuinely empty.
 		if path == StoragePath || path == CodePath || path == CodeSizePath {
 			if inc, incRes, incOK := s.versionMap.ReadIncarnation(addr, s.txIndex); incOK && incRes.Status() == MVReadResultDone {
 				hdr.Source = StorageRead
@@ -786,9 +655,6 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 			}
 		}
 
-		// skipStorage: callers that don't want a storage fallback (the
-		// refresh* wrappers + AddressPath internal callers).  Signal the
-		// wrapper to record a header-only read for ValidateVersion.
 		if skipStorage {
 			r.outcome = outcomeReturnDefault
 			r.source = UnknownSource
@@ -801,8 +667,6 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 			return
 		}
 
-		// Resolve stateObject (via AddressPath account for the four
-		// account-field paths, else direct getStateObject fallback).
 		var so *stateObject
 		if path == BalancePath || path == NoncePath || path == IncarnationPath || path == CodeHashPath {
 			readAccount, accSource, accVersion, err := readAccountInternal(s, addr)
@@ -814,11 +678,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 				return
 			}
 			if readAccount != nil {
-				// A read-set-served account probe carries the synthetic
-				// ReadSetRead source; the field read recorded below must carry
-				// the entry's UNDERLYING source — validation rejects tx-reads at
-				// MVReadResultNone, and re-executions repeat the flow
-				// identically, livelocking the tx.
+				// Carry the entry's underlying source: validation rejects ReadSetRead at MVReadResultNone.
 				if accSource == ReadSetRead {
 					if pr, ok := s.versionedReads.GetAddress(addr); ok {
 						accSource = pr.Source
@@ -833,18 +693,12 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 				so = newObject(s, addr, readAccount, readAccount)
 			}
 		}
-		// Cold committed storage read: resolve directly from the state reader
-		// without materializing a stateObject. A stateObject exists here only
-		// when a write this tx materialized one (created contract / fakeStorage /
-		// dirty slots live on that object), so reuse it when present.
 		if path == StoragePath && so == nil {
 			hdr.Source = StorageRead
 			if cached, ok := s.stateObjects[addr]; ok {
 				so = cached
 			} else {
-				// A cold slot depends only on its own StoragePath cell — record
-				// no AddressPath dependency (that would be a false dep). The value
-				// is the committed slot straight from the state reader.
+				// A cold slot depends only on its own cell; an AddressPath dependency here would be false.
 				val, err := s.committedStorageDirect(addr, key)
 				if err != nil {
 					r.err = err
@@ -862,11 +716,6 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 				return
 			}
 		}
-		// Cold code / code-size read: resolve directly from the state reader
-		// without materializing a stateObject. A cached object (write this tx)
-		// carries dirtyCode / the loaded bytes, so reuse it when present. Code
-		// paths record only their own dependency (no false AddressPath dep) and
-		// their recorded value is not compared in validation (noValueRead).
 		if (path == CodePath || path == CodeSizePath) && so == nil {
 			hdr.Source = StorageRead
 			if cached, ok := s.stateObjects[addr]; ok {
@@ -916,10 +765,7 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 		r.outcome = outcomeStorageRead
 		r.so = so
 		r.hdr = hdr
-		// A field read whose account resolved from this tx's own AddressPath
-		// write (WriteSetRead) carries no cross-tx dependency; recording it
-		// would make the validator (floored below the tx's own writes) return
-		// None and wrongly invalidate the tx. Same rule as accountRead.
+		// An account resolved from this tx's own write carries no cross-tx dependency to record.
 		r.recordVR = hdr.Source != WriteSetRead
 		r.source = hdr.Source
 		r.version = hdr.Version
@@ -931,9 +777,6 @@ func versionedReadCore(s *IntraBlockState, addr accounts.Address, path AccountPa
 	r.version = UnknownVersion
 }
 
-// readAccountInternal performs an AddressPath versionedReadCore + typed
-// extraction of *accounts.Account.  Used internally by versionedReadCore
-// to resolve sibling-account reads without taking a typed callback.
 func readAccountInternal(s *IntraBlockState, addr accounts.Address) (*accounts.Account, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetAddress(addr); ok && warmSource(tr.Source) {
@@ -964,8 +807,6 @@ func readAccountInternal(s *IntraBlockState, addr accounts.Address) (*accounts.A
 		}
 		return acc, r.source, r.version, nil
 	case outcomeReturnZero, outcomeReturnDefault:
-		// outcomeReturnDefault from the skipStorage branch may carry
-		// recordVR=true.  The AddressPath defaultV is nil.
 		if r.recordVR {
 			hdr := r.hdr
 			hdr.Source = ProvisionalRead
@@ -977,8 +818,6 @@ func readAccountInternal(s *IntraBlockState, addr accounts.Address) (*accounts.A
 	}
 }
 
-// traceDepReadContext dumps the account-level version-map context behind an
-// AddressPath dependency, for the TraceReexec DEP-RD print.
 func (s *IntraBlockState) traceDepReadContext(addr accounts.Address, r *readPathResult) {
 	balV, balRes, balOK := s.versionMap.ReadBalance(addr, s.txIndex)
 	nonV, nonRes, nonOK := s.versionMap.ReadNonce(addr, s.txIndex)
@@ -1010,9 +849,6 @@ func (s *IntraBlockState) traceDepReadContext(addr accounts.Address, r *readPath
 	)
 }
 
-// recordWipedRead records a read that resolved to "erased by a SELFDESTRUCT":
-// the zero/empty value the reader returns, stamped with the version of the
-// stale entry it replaces.
 func (s *IntraBlockState) recordWipedRead(addr accounts.Address, path AccountPath, key accounts.StorageKey, ver Version) {
 	hdr := ReadHeader{Source: MapRead, Version: ver}
 	switch path {
@@ -1035,20 +871,13 @@ func (s *IntraBlockState) recordWipedRead(addr accounts.Address, path AccountPat
 	}
 }
 
-// warmSource reports whether a recorded read source is a plain committed/map
-// read that the wrapper-level read-once fast path can return directly.
 func warmSource(src ReadSource) bool { return src == MapRead || src == StorageRead }
 
-// warmReadable reports whether addr has no own write this tx, so a recorded read
-// of it is a stable snapshot the read-once fast path can serve (own writes take
-// precedence and must go through the full path). Same gate as versionedWriteHit.
 func (s *IntraBlockState) warmReadable(addr accounts.Address) bool {
 	_, dirty := s.journal.dirties[addr]
 	return !dirty
 }
 
-// readBalance returns the address's balance using the version-aware
-// read pipeline.  Inlines the storage-read fallback.
 func readBalance(s *IntraBlockState, addr accounts.Address) (uint256.Int, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetBalance(addr); ok && warmSource(tr.Source) {
@@ -1093,9 +922,6 @@ func readBalance(s *IntraBlockState, addr accounts.Address) (uint256.Int, ReadSo
 	}
 }
 
-// refreshBalance is the in-memory-only variant: returns currentBalance on
-// miss and does not perform a storage fallback.  When the core signals
-// recordVR, records the read with currentBalance as the typed default.
 func refreshBalance(s *IntraBlockState, addr accounts.Address, currentBalance uint256.Int) (uint256.Int, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetBalance(addr); ok && warmSource(tr.Source) {
@@ -1114,17 +940,13 @@ func refreshBalance(s *IntraBlockState, addr accounts.Address, currentBalance ui
 		tr, _ := s.versionedReads.GetBalance(addr)
 		return tr.Val, r.source, r.version, nil
 	case outcomeMapDone:
-		// Record the cell read so a repeat (e.g. the next Empty()) hits the
-		// read-once fast path instead of re-probing the version map; commit-time
-		// validation covers the recorded read.
+		// recordVR: cache the read so a same-tx repeat hits the read-once fast
+		// path instead of re-probing the version map.
 		if r.recordVR {
 			s.versionedReads.SetBalance(addr, VersionedRead[uint256.Int]{r.hdr, r.mapBalanceVal})
 		}
 		return r.mapBalanceVal, r.source, r.version, nil
 	case outcomeReturnZero:
-		// Account was self-destructed (or not present): return the zero value,
-		// NOT the caller's stale pre-destruct balance. outcomeReturnDefault
-		// keeps the current value; only this branch must zero it.
 		return uint256.Int{}, r.source, r.version, nil
 	case outcomeReturnDefault:
 		if r.recordVR {
@@ -1136,7 +958,6 @@ func refreshBalance(s *IntraBlockState, addr accounts.Address, currentBalance ui
 	}
 }
 
-// readNonce returns the nonce using the version-aware read pipeline.
 func readNonce(s *IntraBlockState, addr accounts.Address) (uint64, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetNonce(addr); ok && warmSource(tr.Source) {
@@ -1215,7 +1036,6 @@ func refreshNonce(s *IntraBlockState, addr accounts.Address, currentNonce uint64
 	}
 }
 
-// readIncarnation returns the incarnation counter.
 func readIncarnation(s *IntraBlockState, addr accounts.Address) (uint64, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetIncarnation(addr); ok && warmSource(tr.Source) {
@@ -1277,19 +1097,13 @@ func refreshIncarnation(s *IntraBlockState, addr accounts.Address, currentIncarn
 	case outcomeReturnZero:
 		return 0, r.source, r.version, nil
 	case outcomeReturnDefault:
-		// Not recorded: with no cell the current incarnation is pre-block state
-		// (or a synthesis guess), and every consequence of a prior tx re-creating
-		// the account is pinned by the value-validated field reads; the final
-		// incarnation is resolved from the map at write normalization. Recording
-		// it here would spuriously invalidate against the creator's flush.
+		// Not recorded: the final incarnation is resolved from the map at write normalization.
 		return currentIncarnation, r.source, r.version, nil
 	default:
 		panic(fmt.Sprintf("refreshIncarnation: unexpected outcome %d for %x", r.outcome, addr))
 	}
 }
 
-// readCode returns the contract code. The commited flag selects whether
-// the version-aware lookup honours the committed-only contract.
 func readCode(s *IntraBlockState, addr accounts.Address, commited bool) ([]byte, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetCode(addr); ok && warmSource(tr.Source) {
@@ -1350,9 +1164,7 @@ type refreshedCode struct {
 	KnownHash accounts.CodeHash
 }
 
-// refreshCode is the in-memory-only variant for CodePath.
-// CodePath is never recorded via the skipStorage branch in legacy
-// (the `path != CodePath` guard), so no recording on the default case.
+// refreshCode never records on a miss: CodePath is excluded from the skipStorage default-recording branch.
 func refreshCode(s *IntraBlockState, addr accounts.Address) (refreshedCode, ReadSource, Version, error) {
 	var r readPathResult
 	versionedReadCore(s, addr, CodePath, accounts.NilKey, false, true, &r)
@@ -1364,8 +1176,6 @@ func refreshCode(s *IntraBlockState, addr accounts.Address) (refreshedCode, Read
 		return refreshedCode{r.vwCode.Val.Bytes, r.vwCode.Val.Hash}, r.source, r.version, nil
 	case outcomeReadSetHit:
 		tr, _ := s.versionedReads.GetCode(addr)
-		// The recorded read and the probed cell share a version, so they are the
-		// same cell and its hash pairs with tr.Val. Nil when no probe ran.
 		return refreshedCode{tr.Val, r.hashOfMapCodeVal}, r.source, r.version, nil
 	case outcomeMapDone:
 		return refreshedCode{r.mapCodeVal, r.hashOfMapCodeVal}, r.source, r.version, nil
@@ -1388,7 +1198,6 @@ func (c refreshedCode) codeHash(source ReadSource, accountHash accounts.CodeHash
 	return accounts.InternCodeHash(crypto.Keccak256Hash(c.Bytes))
 }
 
-// readCodeSize returns the contract code size.
 func readCodeSize(s *IntraBlockState, addr accounts.Address) (int, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetCodeSize(addr); ok && warmSource(tr.Source) {
@@ -1415,9 +1224,6 @@ func readCodeSize(s *IntraBlockState, addr accounts.Address) (int, ReadSource, V
 	case outcomeStorageRead:
 		var v int
 		if r.so != nil {
-			// CodeSizePath delegates to the per-stateObject code-size pattern:
-			// prefer cached so.code length, else load full code once (geth-style)
-			// and populate so.code.
 			sz, err := codeSizeFromStateObject(s, r.so, addr)
 			if err != nil {
 				return 0, r.source, r.version, err
@@ -1443,7 +1249,6 @@ func readCodeSize(s *IntraBlockState, addr accounts.Address) (int, ReadSource, V
 	}
 }
 
-// readCodeHash returns the contract code hash.
 func readCodeHash(s *IntraBlockState, addr accounts.Address) (accounts.CodeHash, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetCodeHash(addr); ok && warmSource(tr.Source) {
@@ -1490,7 +1295,6 @@ func readCodeHash(s *IntraBlockState, addr accounts.Address) (accounts.CodeHash,
 	}
 }
 
-// refreshCodeHash is the in-memory-only variant for CodeHashPath.
 func refreshCodeHash(s *IntraBlockState, addr accounts.Address, currentHash accounts.CodeHash) (accounts.CodeHash, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetCodeHash(addr); ok && warmSource(tr.Source) {
@@ -1525,17 +1329,13 @@ func refreshCodeHash(s *IntraBlockState, addr accounts.Address, currentHash acco
 	}
 }
 
-// readState reads a storage slot; it is readStateForSet without the
-// SetState-only "clean" bool.
 func readState(s *IntraBlockState, addr accounts.Address, key accounts.StorageKey) (uint256.Int, ReadSource, Version, error) {
 	v, source, version, _, err := readStateForSet(s, addr, key)
 	return v, source, version, err
 }
 
-// readStateForSet is the SetState-specific variant.  Returns the
-// additional "clean" bool (the second return of stateObject.GetState),
-// which SetState uses to decide between deleting vs. updating the
-// versioned write on revert.
+// readStateForSet also returns stateObject.GetState's "clean" bool, which
+// SetState uses to choose delete vs. update on revert.
 func readStateForSet(s *IntraBlockState, addr accounts.Address, key accounts.StorageKey) (uint256.Int, ReadSource, Version, bool, error) {
 	var r readPathResult
 	versionedReadCore(s, addr, StoragePath, key, false, false, &r)
@@ -1562,8 +1362,7 @@ func readStateForSet(s *IntraBlockState, addr accounts.Address, key accounts.Sto
 				v, clean = r.so.GetState(key)
 			}
 		} else {
-			// Cold committed read resolved by committedStorageDirect: no dirty
-			// value exists on the parallel path, so it is always clean.
+			// Cold committed read: no dirty value exists on the parallel path, so it's always clean.
 			v, clean = r.mapStorageVal, true
 		}
 		if r.recordVR {
@@ -1583,7 +1382,6 @@ func readStateForSet(s *IntraBlockState, addr accounts.Address, key accounts.Sto
 	}
 }
 
-// readCommittedState reads a storage slot with committed-view semantics.
 func readCommittedState(s *IntraBlockState, addr accounts.Address, key accounts.StorageKey) (uint256.Int, ReadSource, Version, error) {
 	var r readPathResult
 	versionedReadCore(s, addr, StoragePath, key, true, false, &r)
@@ -1632,7 +1430,6 @@ func readCommittedState(s *IntraBlockState, addr accounts.Address, key accounts.
 	}
 }
 
-// readSelfDestruct returns whether the account is selfdestructed.
 func readSelfDestruct(s *IntraBlockState, addr accounts.Address) (bool, ReadSource, Version, error) {
 	if s.warmReadable(addr) {
 		if tr, ok := s.versionedReads.GetSelfDestruct(addr); ok && warmSource(tr.Source) {
@@ -1687,7 +1484,6 @@ func readSelfDestruct(s *IntraBlockState, addr accounts.Address) (bool, ReadSour
 	}
 }
 
-// refreshSelfDestruct is the in-memory-only variant.
 func refreshSelfDestruct(s *IntraBlockState, addr accounts.Address) (bool, ReadSource, Version, error) {
 	var r readPathResult
 	versionedReadCore(s, addr, SelfDestructPath, accounts.NilKey, false, true, &r)
@@ -1704,7 +1500,6 @@ func refreshSelfDestruct(s *IntraBlockState, addr accounts.Address) (bool, ReadS
 		return r.mapSelfDestructVal, r.source, r.version, nil
 	case outcomeReturnZero, outcomeReturnDefault:
 		if r.recordVR {
-			// SelfDestructPath defaultV is false — the zero value.
 			s.versionedReads.SetSelfDestruct(addr, VersionedRead[bool]{ReadHeader: r.hdr})
 		}
 		return false, r.source, r.version, nil
@@ -1713,12 +1508,10 @@ func refreshSelfDestruct(s *IntraBlockState, addr accounts.Address) (bool, ReadS
 	}
 }
 
-// readAccount returns the *accounts.Account for an address.
 func readAccount(s *IntraBlockState, addr accounts.Address) (*accounts.Account, ReadSource, Version, error) {
 	return readAccountInternal(s, addr)
 }
 
-// refreshAccount is the in-memory-only variant for AddressPath.
 func refreshAccount(s *IntraBlockState, addr accounts.Address) (*accounts.Account, ReadSource, Version, error) {
 	var r readPathResult
 	versionedReadCore(s, addr, AddressPath, accounts.NilKey, false, true, &r)
@@ -1738,7 +1531,6 @@ func refreshAccount(s *IntraBlockState, addr accounts.Address) (*accounts.Accoun
 		return r.mapAddressVal, r.source, r.version, nil
 	case outcomeReturnZero, outcomeReturnDefault:
 		if r.recordVR {
-			// AddressPath defaultV is nil.
 			hdr := r.hdr
 			hdr.Source = ProvisionalRead
 			s.versionedReads.SetAddress(addr, VersionedRead[AccountView]{ReadHeader: hdr})

--- a/execution/state/reset_bench_test.go
+++ b/execution/state/reset_bench_test.go
@@ -26,10 +26,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// BenchmarkIntraBlockStateReset measures the touch-then-Reset cycle the executor
-// runs per tx, at a few realistic touched-account counts. The touch phase stays
-// inside the timer on purpose: reusing a map's buckets saves the regrow cost on
-// the next fill, which timing Reset alone would hide.
+// The touch phase stays inside the timer on purpose: reusing a map's buckets saves regrow cost that a Reset-only timing would hide.
 func BenchmarkIntraBlockStateReset(b *testing.B) {
 	for _, n := range []int{8, 64, 512} {
 		b.Run(fmt.Sprintf("accounts=%d", n), func(b *testing.B) {

--- a/execution/state/reverted_touch_versioned_test.go
+++ b/execution/state/reverted_touch_versioned_test.go
@@ -8,15 +8,12 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// A touch of an existing empty account records a BalancePath=0 versioned write
-// paired only with a touchAccount journal entry whose revert is a no-op. If the
-// frame is reverted, the address leaves journal.dirties but the write must not
-// survive into the published write set — otherwise Normalize's EIP-161 pass would
-// delete an account whose touch was rolled back (the ripeMD wrong-root shape).
+// A reverted touch on an empty account must not publish its BalancePath=0 write, even though the address stays in
+// journal.dirties — else EIP-161 Normalize would delete an account whose touch was rolled back (the RIPEMD wrong-root case).
 func TestNoMaterialize_RevertedTouchNotPublished(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress([20]byte{0x11, 0x22, 0x33})
-	empty := accounts.NewAccount() // existing but EIP-161-empty: nonce 0, balance 0, no code
+	empty := accounts.NewAccount()
 	reader := &fieldReader{addr: addr, account: &empty}
 
 	vm := NewVersionMap(nil)

--- a/execution/state/revival_consistency_test.go
+++ b/execution/state/revival_consistency_test.go
@@ -26,18 +26,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// Revival is decided at three sites with two different definitions:
-//
-//   - the two readers — getVersionedAccount and versionedStateReader.ReadAccountData —
-//     agree exactly: revived = AddressPath >= destructTx OR {Balance,Nonce,CodeHash} > destructTx
-//   - the validator — validateReadImpl — omits the AddressPath >= arm:
-//     revived = {Balance,Nonce,CodeHash} > destructTx
-//
-// These tests pin whether that omission is observably divergent. The invariant
-// they lock: production revival (createObject) always co-writes CodeHash at the
-// revival tx, so the two definitions never disagree on a production-shaped
-// history — but the validator's verdict *does* diverge from the readers in the
-// synthetic AddressPath-only revival, which is why the co-write is load-bearing.
+// The reader treats AddressPath >= destructTx as revival too; the validator doesn't. Production's CodeHash co-write at the revival tx is what keeps the two definitions from diverging.
 
 func recreatedAccount(inc uint64) *accounts.Account {
 	return &accounts.Account{
@@ -47,25 +36,20 @@ func recreatedAccount(inc uint64) *accounts.Account {
 	}
 }
 
-// Production-shaped same-tx metamorphic SD+CREATE2: the reader surfaces the
-// re-created account, and the validator invalidates a pre-destruct field read —
-// consistent, because the re-create re-writes the read's own path at the same
-// tx, so checkVersion catches the staleness before the revival arm is reached.
+// Same-tx SD+CREATE2: the re-create rewrites the read's own path at the same
+// tx, so checkVersion catches staleness before the revival arm is reached.
 func TestRevivalConsistency_SameTxMetamorphic_ReaderAndValidatorAgree(t *testing.T) {
 	t.Parallel()
 	addr := getAddress(78)
 
 	vm := NewVersionMap(nil)
-	// Pre-destruct account established at tx0.
 	writeFor(vm, addr, BalancePath, accounts.NilKey, Version{TxIndex: 0}, *uint256.NewInt(1_000), true)
-	// Tx3: SD + CREATE2, all writes at (3,0) — what createObject/newObject emit.
 	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 3}, true, true)
 	writeFor(vm, addr, BalancePath, accounts.NilKey, Version{TxIndex: 3}, uint256.Int{}, true)
 	writeFor(vm, addr, IncarnationPath, accounts.NilKey, Version{TxIndex: 3}, uint64(2), true)
 	writeFor(vm, addr, CodeHashPath, accounts.NilKey, Version{TxIndex: 3}, recreatedAccount(2).CodeHash, true)
 	vm.WriteAddress(addr, Version{TxIndex: 3}, recreatedAccount(2), true)
 
-	// Reader: tx4 sees the re-created account (AddressPath >= destructTx arm).
 	reader := newAccountStateReader(addr)
 	ibs := New(NewVersionedStateReader(4, ReadSet{}, vm, reader))
 	ibs.SetTxContext(0, 4)
@@ -76,9 +60,6 @@ func TestRevivalConsistency_SameTxMetamorphic_ReaderAndValidatorAgree(t *testing
 	require.NotNil(t, account, "reader must surface the re-created account")
 	require.Equal(t, uint64(2), account.Incarnation)
 
-	// Validator: tx4 recorded the pre-destruct balance (1000 @ {0,0}). The
-	// re-create re-wrote balance at tx3, so this read is genuinely stale and
-	// must invalidate — caught by version mismatch, not the revival arm.
 	io := NewVersionedIO(5)
 	rs := ReadSet{}
 	rs.SetBalance(addr, VersionedRead[uint256.Int]{
@@ -90,11 +71,8 @@ func TestRevivalConsistency_SameTxMetamorphic_ReaderAndValidatorAgree(t *testing
 		"pre-destruct field read is stale after same-tx re-create — reader and validator agree the old value is gone")
 }
 
-// Synthetic AddressPath-only revival: no field is re-written at the revival tx.
-// Here the reader reports revived (AddressPath >= arm) while the validator does
-// not (it lacks that arm) — the divergence. Production never produces this
-// history because createObject always co-writes CodeHash; this test documents
-// that the co-write is what keeps the two revival definitions consistent.
+// AddressPath-only revival — no field rewritten at the same tx — makes the
+// reader report revived while the validator doesn't; createObject never produces this shape.
 func TestRevivalConsistency_AddressPathOnly_ReaderAndValidatorDiverge(t *testing.T) {
 	t.Parallel()
 	addr := getAddress(79)
@@ -102,8 +80,6 @@ func TestRevivalConsistency_AddressPathOnly_ReaderAndValidatorDiverge(t *testing
 	vm := NewVersionMap(nil)
 	writeFor(vm, addr, BalancePath, accounts.NilKey, Version{TxIndex: 0}, *uint256.NewInt(1_000), true)
 	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 2}, true, true)
-	// Revival writes ONLY AddressPath at the same tx as the destruct — no
-	// Balance/Nonce/CodeHash re-write. createObject never does this.
 	vm.WriteAddress(addr, Version{TxIndex: 2}, recreatedAccount(2), true)
 
 	reader := newAccountStateReader(addr)
@@ -115,10 +91,6 @@ func TestRevivalConsistency_AddressPathOnly_ReaderAndValidatorDiverge(t *testing
 	require.NoError(t, err)
 	require.NotNil(t, account, "reader's AddressPath >= arm reports the account revived")
 
-	// The pre-destruct balance read still matches the latest balance write
-	// ({0,0}=1000, since revival wrote no balance), so checkVersion passes and
-	// the SD-staleness revival arm is actually reached — and the validator,
-	// lacking the AddressPath arm, invalidates where the reader revived.
 	io := NewVersionedIO(6)
 	rs := ReadSet{}
 	rs.SetBalance(addr, VersionedRead[uint256.Int]{

--- a/execution/state/rw_v3.go
+++ b/execution/state/rw_v3.go
@@ -47,8 +47,7 @@ type StateV3 struct {
 	txNum                  uint64
 	trace                  atomic.Bool
 
-	// Scratch for the per-transaction index writes; the apply goroutine alone
-	// touches them.
+	// Scratch for the per-transaction index writes; the apply goroutine alone touches them.
 	receiptsWriter rawtemporaldb.ReceiptWriter
 	traceAddr      common.Address
 }
@@ -58,7 +57,6 @@ func NewStateV3(domains *execctx.SharedDomains, persistReceiptsCacheV2 bool, log
 		domains:                domains,
 		logger:                 logger,
 		persistReceiptsCacheV2: persistReceiptsCacheV2,
-		//trace: true,
 	}
 }
 
@@ -74,24 +72,12 @@ func (rs *StateV3) SetTxNum(txNum uint64) {
 	rs.txNum = txNum
 }
 
-// Apply writes this (already-Normalized) write-set directly to the shared
-// domains, no intermediate BTree — the single write-set commit path shared by
-// the parallel executor and block production. trace gates the dbg.TraceApply
-// logging StateV3 used to read from its own flag.
-//
-// A write set may carry only the account fields that changed, so Apply overlays
-// it on the current account, read from the block cache or AccountsDomain. A
-// self-destructed address is the exception: its base stays empty so cleared
-// fields cannot be resurrected, and it carries at most the balance EIP-8246
-// preserves plus its storage-delete cascade — Normalize drops the nonce,
-// incarnation and code hash, and assertSelfDestructNormalized pins that.
 func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx, blockNum, txNum uint64, balanceIncreases map[accounts.Address]uint256.Int, rules *chain.Rules, blockCache *BlockStateCache, trace bool) error {
 	if writes != nil && !writes.IsEmpty() {
 		if dbg.AssertEnabled {
 			writes.assertSelfDestructNormalized()
 		}
-		// Field presence is tracked with has-flags rather than pointers: the
-		// pointer form heap-escapes one allocation per field per address.
+		// Has-flags avoid pointer fields, which would heap-escape once per field per address.
 		type addrState struct {
 			balance        uint256.Int
 			nonce          uint64
@@ -117,8 +103,6 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 			}
 			return d
 		}
-		// Range the typed collections directly rather than AllHeaders()+GetX —
-		// the header walk plus a second per-value map probe is strictly more work.
 		for a, vw := range writes.Balances() {
 			d := ensure(a)
 			d.balance = vw.Val
@@ -134,8 +118,7 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 			d.incarnation = vw.Val
 			d.hasIncarnation = true
 		}
-		// CodeHashes before Codes: an explicit CodeHashPath write wins; a code
-		// write only supplies the hash when no explicit one was recorded.
+		// CodeHashes must be applied before Codes: an explicit hash write wins over one derived from a Codes write.
 		for a, vw := range writes.CodeHashes() {
 			d := ensure(a)
 			d.codeHash = vw.Val
@@ -159,9 +142,7 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 			}
 		}
 
-		// Sort addresses before iterating so that trace output is deterministic.
-		// Domain writes are buffered into a sorted BTree by key, so order of
-		// iteration does not affect correctness — only debug reproducibility.
+		// Sorted only for deterministic trace output; BTree buffering makes iteration order irrelevant to correctness.
 		addrs := make([]accounts.Address, 0, len(perAddr))
 		for addr := range perAddr {
 			addrs = append(addrs, addr)
@@ -179,18 +160,12 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 				if dbg.TraceApply && (trace || dbg.TraceAccount(addr.Handle())) {
 					fmt.Printf("%d apply:del code+storage: %x\n", blockNum, addr)
 				}
-				// An EIP-8246 self-destruct keeps its balance write; the record
-				// survives only when a non-zero balance is left to preserve.
+				// EIP-8246: a non-zero balance survives self-destruct, so this isn't a pure delete.
 				sdPreservedBalance := d.hasBalance && !d.balance.IsZero()
 				pureDelete := !sdPreservedBalance && !d.hasNonce && !d.hasIncarnation && !d.hasCodeHash
 				if blockCache != nil {
-					// Route the account+code delete and storage-prefix wipe through
-					// the cache so they're recorded in writeLog order. A later
-					// SELFDESTRUCT must supersede an earlier put for the same address
-					// in the same block; a direct domain delete (applied immediately,
-					// before the block-end Flush replays the earlier put) would be
-					// overwritten by that replay — TestDeleteRecreateSlotsAcrossManyBlocks
-					// block 31 (destruct → resurrect → destruct in one block).
+					// Routed through the cache so a later SELFDESTRUCT in the same block supersedes
+					// an earlier put; a direct domain delete would be overwritten by Flush's replay.
 					blockCache.DeleteAccount(addr, txNum)
 					if !domains.InlineTouchKeyDisabled() {
 						domains.GetCommitmentContext().TouchKey(kv.AccountsDomain, string(address[:]), nil)
@@ -218,12 +193,8 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 						continue
 					}
 				}
-				// Otherwise an EIP-8246 balance survives: code and storage are
-				// gone, and the account is written back from an empty base below.
 			}
 
-			// Contract creation: clear stale storage before writing new account.
-			// Matches Writer.CreateContract which calls DomainDelPrefix.
 			if d.createContract {
 				if err := domains.DomainDelPrefix(kv.StorageDomain, roTx, address[:], txNum); err != nil {
 					return err
@@ -231,9 +202,7 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 			}
 
 			if d.hasBalance || d.hasNonce || d.hasIncarnation || d.hasCodeHash || d.codeWritten {
-				// A WriteSet may contain only the changed account fields, so
-				// overlay it on the current state. Self-destruct is the exception:
-				// its base stays empty so cleared fields cannot be resurrected.
+				// Self-destruct is the exception: its base stays empty so cleared fields aren't resurrected.
 				acc := accounts.NewAccount()
 				if !d.selfDestruct {
 					if blockCache != nil {
@@ -340,13 +309,11 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 	var acc accounts.Account
 	for addr, increase := range balanceIncreases {
 		addrValue := addr.Value()
-		// Read current account — from blockCache if available, otherwise domain.
 		var enc0 []byte
 		if blockCache != nil {
 			if enc, ok := blockCache.GetCurrentAccount(addr); ok {
 				enc0 = enc
 			} else {
-				// Not in cache yet — read from domain (pre-block state).
 				var err error
 				enc0, _, err = domains.GetLatest(kv.AccountsDomain, roTx, addrValue[:])
 				if err != nil {
@@ -395,11 +362,8 @@ func (writes *WriteSet) Apply(domains *execctx.SharedDomains, roTx kv.TemporalTx
 	return nil
 }
 
-// ApplyStateWrites applies account/storage/code mutations. When blockCache is
-// non-nil (parallel executor), writes go to the block-level cache and only
-// TouchKey is called for per-TX commitment tracking. The cache is flushed to
-// SharedDomains at block boundary. When blockCache is nil (serial executor),
-// writes go directly to SharedDomains via DomainPut.
+// With blockCache set, writes land in the cache and flush to SharedDomains at
+// the block boundary instead of going there directly.
 func (rs *StateV3) ApplyStateWrites(_ context.Context,
 	roTx kv.TemporalTx,
 	blockNum uint64,
@@ -415,16 +379,10 @@ func (rs *StateV3) ApplyStateWrites(_ context.Context,
 	if err := writes.Apply(rs.domains, roTx, blockNum, txNum, balanceIncreases, rules, blockCache, rs.trace.Load()); err != nil {
 		return fmt.Errorf("StateV3.ApplyStateWrites: %w", err)
 	}
-	// Step-boundary commitment is computed by the explicit CommitStepBoundary
-	// call (serial) or the commitment calculator (parallel), not here.
 	return nil
 }
 
-// ApplyTxIndexes writes trace indices, log indices, and receipts.
-// When skipReceiptCache is true, the receipt-cache domain write is skipped.
-// This is needed for the parallel executor's block-finalize txResult which
-// shares the system-tx-end txNum; a second DomainPut at the same txNum would
-// overwrite the history entry that preserves the last regular tx's receipt.
+// skipReceiptCache avoids a second write at the shared system-tx-end txNum overwriting the last regular tx's receipt history.
 func (rs *StateV3) ApplyTxIndexes(
 	roTx kv.TemporalTx,
 	txNum uint64,
@@ -442,10 +400,6 @@ func (rs *StateV3) ApplyTxIndexes(
 	return nil
 }
 
-// CommitStepBoundary computes and persists a trie commitment when txNum falls
-// on an aggregation step boundary. This ensures commitment domain snapshots
-// contain a commitment state at each step end, even when the boundary falls
-// mid-block.
 func (rs *StateV3) CommitStepBoundary(ctx context.Context, roTx kv.TemporalTx, blockNum, txNum uint64) error {
 	if rs.domains.IsUnfrozenStepEdge(roTx, txNum) && !rs.domains.InlineTouchKeyDisabled() {
 		_, err := rs.domains.ComputeCommitment(ctx, roTx, true, blockNum, txNum,
@@ -511,7 +465,6 @@ func (rs *StateV3) applyLogsAndTraces4(tx kv.TemporalTx, txNum uint64, receipt *
 	return nil
 }
 
-// SizeEstimateBeforeCommitment - including esitmation of future ComputeCommitment on current state changes
 func (rs *StateV3) SizeEstimateBeforeCommitment() uint64 {
 	if rs.domains == nil {
 		return 0
@@ -521,7 +474,6 @@ func (rs *StateV3) SizeEstimateBeforeCommitment() uint64 {
 	return sz
 }
 
-// SizeEstimateAfterCommitment - not including any additional estimations. Use it after ComputeCommitment calc - to see
 func (rs *StateV3) SizeEstimateAfterCommitment() uint64 {
 	if rs.domains == nil {
 		return 0
@@ -558,13 +510,8 @@ func NewStateV3Buffered(state *StateV3) *StateV3Buffered {
 	return bufferedState
 }
 
-// ClearAccountsCache drops all entries from the cross-block account cache.
-// Must be called after a block's state writes are fully applied to SharedDomains
-// (sd.mem) and before the next block's workers start reading. Without this,
-// stale entries from the previous block's versionedWriteCollector (populated
-// during engine.Finalize → MakeWriteSet) leak into subsequent blocks, causing
-// workers to read outdated nonces/balances from the BufferedReader cache
-// instead of the correct values in sd.mem.
+// ClearAccountsCache must run after a block's writes are applied to SharedDomains
+// and before the next block starts reading, or workers see stale cached values.
 func (s *StateV3Buffered) ClearAccountsCache() {
 	s.accountsMutex.Lock()
 	clear(s.accounts)
@@ -579,49 +526,30 @@ func (s *StateV3Buffered) WithDomains(domains *execctx.SharedDomains) *StateV3Bu
 	}
 }
 
-// versionedWriteCollector implements StateWriter and collects writes as a
-// flat VersionedWrites slice for direct domain apply via applyVersionedWrites.
-//
-// When FinalizeTx calls UpdateAccountData, complete account state (all fields)
-// is emitted so that applyVersionedWrites can reconstruct the full serialised
-// account without domain reads. Code and storage writes are collected similarly.
-//
-// It also maintains rs.accounts synchronously for the cross-block timing hole
-// bridge: block N+1 workers may read block N state before the async applyResults
-// goroutine has flushed it to SharedDomains.
+// versionedWriteCollector buffers StateWriter calls into a WriteSet and mirrors
+// them into rs.accounts, so block N+1 workers can see block N before the async flush.
 type versionedWriteCollector struct {
 	rs     *StateV3Buffered
 	writes *WriteSet
 }
 
-// NewVersionedWriteCollector creates a versionedWriteCollector that collects
-// StateWriter calls into a VersionedWrites slice and maintains rs.accounts.
 func NewVersionedWriteCollector(rs *StateV3Buffered) *versionedWriteCollector {
 	return &versionedWriteCollector{rs: rs, writes: &WriteSet{}}
 }
 
-// Writes returns the collected write set for domain apply.
 func (c *versionedWriteCollector) Writes() *WriteSet { return c.writes }
 
 func (c *versionedWriteCollector) UpdateAccountData(address accounts.Address, original, account *accounts.Account) error {
-	// Copy to prevent aliasing with pooled stateObjects. After tx finalization
-	// the stateObject is returned to the pool and its Account may be overwritten.
+	// Copy to avoid aliasing a pooled stateObject, which may be overwritten after tx finalization.
 	var accountCopy accounts.Account
 	accountCopy.Copy(account)
 	accountCopy.PrevIncarnation = account.PrevIncarnation
 
-	// When the original incarnation was higher than the new incarnation
-	// (pre-existing contract destroyed then recreated at a lower incarnation),
-	// emit a SelfDestructPath write first to signal code+storage cleanup before
-	// the new account state is written. applyVersionedWrites detects the presence
-	// of account fields after SelfDestructPath to distinguish cleanup+recreate
-	// from a pure account deletion.
+	// A higher original incarnation than the new one means destroy-then-recreate:
+	// emit SelfDestructPath first so applyVersionedWrites treats it as cleanup, not deletion.
 	needsCleanup := original.Incarnation > accountCopy.Incarnation
-	// Cross-block reincarnation: in the parallel executor, versionedReadCore
-	// returns a nil account (Incarnation=0) for addresses self-destructed
-	// in a prior block, so the check above misses the cleanup. Blocks are
-	// processed sequentially, so rs.accounts already has the deleted marker
-	// from the prior block's DeleteAccount by the time this runs.
+	// Cross-block case: a prior-block self-destruct reads back as Incarnation=0, which
+	// the check above misses; rs.accounts still carries that block's deleted marker.
 	if !needsCleanup && accountCopy.Incarnation > 0 {
 		c.rs.accountsMutex.RLock()
 		if obj, ok := c.rs.accounts[address]; ok && obj.wasDeleted {
@@ -633,14 +561,11 @@ func (c *versionedWriteCollector) UpdateAccountData(address accounts.Address, or
 		c.writes.SetSelfDestruct(address, &VersionedWrite[bool]{WriteHeader: WriteHeader{Address: address, Path: SelfDestructPath}, Val: true})
 	}
 
-	// Emit complete account state so applyVersionedWrites can reconstruct the
-	// full serialised account.
 	c.writes.SetBalance(address, &VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: address, Path: BalancePath}, Val: accountCopy.Balance})
 	c.writes.SetNonce(address, &VersionedWrite[uint64]{WriteHeader: WriteHeader{Address: address, Path: NoncePath}, Val: accountCopy.Nonce})
 	c.writes.SetIncarnation(address, &VersionedWrite[uint64]{WriteHeader: WriteHeader{Address: address, Path: IncarnationPath}, Val: accountCopy.Incarnation})
 	c.writes.SetCodeHash(address, &VersionedWrite[accounts.CodeHash]{WriteHeader: WriteHeader{Address: address, Path: CodeHashPath}, Val: accountCopy.CodeHash})
 
-	// Maintain rs.accounts for the cross-block timing hole bridge.
 	c.rs.accountsMutex.Lock()
 	obj, ok := c.rs.accounts[address]
 	if !ok || obj.data == &deleted {
@@ -671,7 +596,6 @@ func (c *versionedWriteCollector) UpdateAccountCode(address accounts.Address, in
 }
 
 func (c *versionedWriteCollector) DeleteAccount(address accounts.Address, original *accounts.Account) error {
-	// IBS records any accompanying incarnation change separately.
 	c.writes.SetSelfDestruct(address, &VersionedWrite[bool]{WriteHeader: WriteHeader{Address: address, Path: SelfDestructPath}, Val: true})
 
 	c.rs.accountsMutex.Lock()
@@ -711,10 +635,7 @@ func (c *versionedWriteCollector) WriteAccountStorage(address accounts.Address, 
 
 func (c *versionedWriteCollector) CreateContract(_ accounts.Address) error { return nil }
 
-// NotifyAccumulator drives txpool state-diff notifications from VersionedWrites.
-// It reconstructs account state from the per-field writes and calls
-// ChangeAccount/ChangeCode/ChangeStorage on the accumulator. StartChange must
-// have been called on the accumulator before this function is invoked.
+// Caller must call StartChange on accumulator before invoking this.
 func NotifyAccumulator(accumulator *shards.Accumulator, writes *WriteSet) {
 	if accumulator == nil || writes.IsEmpty() {
 		return
@@ -771,10 +692,10 @@ func NotifyAccumulator(accumulator *shards.Accumulator, writes *WriteSet) {
 		}
 	}
 
-	// Flush pending account field groups.
 	for addr, p := range pending {
+		// UpdateAccountData always sets balance and nonce together, so this pair alone detects "no account write".
 		if p.balance == nil && p.nonce == nil {
-			continue // no account fields collected (e.g. only storage/code)
+			continue
 		}
 		var acc accounts.Account
 		if p.balance != nil {
@@ -794,7 +715,7 @@ func NotifyAccumulator(accumulator *shards.Accumulator, writes *WriteSet) {
 	}
 }
 
-// Writer - used by parallel workers to accumulate updates and then send them to conflict-resolution.
+// Writer accumulates per-worker updates for later conflict-resolution.
 type Writer struct {
 	tx          kv.TemporalPutDel
 	trace       bool
@@ -807,7 +728,6 @@ func NewWriter(tx kv.TemporalPutDel, accumulator *shards.Accumulator, txNum uint
 		tx:          tx,
 		accumulator: accumulator,
 		txNum:       txNum,
-		//trace: true,
 	}
 }
 
@@ -824,7 +744,6 @@ func (w *Writer) UpdateAccountData(address accounts.Address, original, account *
 	}
 	addressValue := address.Value()
 	if original.Incarnation > account.Incarnation {
-		//del, before create: to clanup code/storage
 		if err := w.tx.DomainDel(kv.CodeDomain, addressValue[:], w.txNum, nil); err != nil {
 			return err
 		}
@@ -865,20 +784,10 @@ func (w *Writer) DeleteAccount(address accounts.Address, original *accounts.Acco
 	if w.trace {
 		fmt.Printf("del acc: %x\n", address)
 	}
-	//TODO: move logic from SD
-	//if err := w.tx.DomainDelPrefix(kv.StorageDomain, address[:]); err != nil {
-	//	return err
-	//}
-	//if err := w.tx.DomainDel(kv.CodeDomain, address[:], nil); err != nil {
-	//	return err
-	//}
 	addressValue := address.Value()
 	if err := w.tx.DomainDel(kv.AccountsDomain, addressValue[:], w.txNum, nil); err != nil {
 		return err
 	}
-	// if w.accumulator != nil { TODO: investigate later. basically this will always panic. keeping this out should be fine anyway.
-	// 	w.accumulator.DeleteAccount(address)
-	// }
 	return nil
 }
 
@@ -934,16 +843,12 @@ type ReaderV3 struct {
 	tracePrefix string
 	getter      kv.TemporalGetter
 
-	// addr and composite are reused key buffers: as non-pointer fields of the
-	// heap-allocated reader, the key slices they back reach the interface getter
-	// with no per-call heap allocation.
-	addr      common.Address                  // reused account/code lookup key
-	composite [length.Addr + length.Hash]byte // reused storage lookup key (addr||slot)
+	addr      common.Address
+	composite [length.Addr + length.Hash]byte // addr||slot, reused across calls to avoid per-call allocation
 }
 
 func NewReaderV3(getter kv.TemporalGetter) *ReaderV3 {
 	return &ReaderV3{
-		//trace:  true,
 		getter: getter,
 	}
 }
@@ -968,66 +873,30 @@ func (r *ReaderV3) TracePrefix() string {
 	return r.tracePrefix
 }
 
-// BlockStateCache provides a block-level state buffer for the parallel
-// executor. It serves two roles:
-//
-//  1. Read cache: pre-block committed state is lazily populated on first
-//     access, providing a stable view for GetCommittedState that isn't
-//     affected by intra-block DomainPut calls.
-//
-//  2. Write buffer: per-TX ApplyStateWrites accumulate here instead of
-//     going directly to sd.mem. At block boundary, Flush writes the final
-//     state to SharedDomains. This ensures sd.mem only changes at block
-//     boundaries, eliminating cross-thread races.
-//
-// This is the embryonic BlockState from the IBS refactor plan
-// (github.com/erigontech/erigon/issues/19623).
-//
-// Thread-safe: multiple worker goroutines share one cache per block.
+// BlockStateCache buffers per-block state for the parallel executor: a
+// lazily-populated pre-block read cache, plus a write buffer Flush drains to SharedDomains at the block boundary.
+// Thread-safe: the block's worker goroutines all share one cache.
 type BlockStateCache struct {
 	mu sync.RWMutex
 
-	// committed holds pre-block state, lazily populated on first read.
-	// These values are returned by CachedReaderV3 for GetCommittedState.
-	// Both are write-once-per-key (an immutable pre-block view), so they are
-	// sync.Maps for lock-free reads off the shared mu hot path.
 	committedAccounts sync.Map // accounts.Address -> *accounts.Account (nil ptr = absent)
 	committedStorage  sync.Map // committedStorageKey -> []byte (nil slice = cached empty slot)
 
-	// current holds the latest state including intra-block writes.
-	// Updated by WriteAccount/WriteStorage. Read by block finalize.
-	// At block boundary, dirty entries are flushed to SharedDomains.
-	currentAccounts map[accounts.Address][]byte // serialized account blobs
+	currentAccounts map[accounts.Address][]byte
 	currentStorage  map[accounts.Address]map[accounts.StorageKey][]byte
 
-	// currentCode is the latest code per address (for fast read access via
-	// GetCurrentCode-style fallback if added; today only currentAccounts /
-	// currentStorage are exposed for read).
 	currentCode map[accounts.Address][]byte
 
-	// writeLog records every Write* / DeleteAccount call in order, each
-	// stamped with the txNum at which the write was made. Flush replays
-	// the log against SharedDomains at per-entry txNum so the AccountsDomain
-	// / StorageDomain / CodeDomain history is built per-tx — matching
-	// what the serial executor (and main's parallel executor) produce by
-	// calling DomainPut directly at per-tx txNum.
-	//
-	// Without per-entry txNum, Flush would stamp every write with one
-	// txNum (the block's finalize txNum), collapsing per-tx history
-	// entries into a single one and breaking history readers
-	// (sd.GetAsOf, eth_getBalance at historic blocks, intra-block
-	// commitment-domain reads) that ask for state at an intra-block
-	// txNum.
+	// writeLog stamps each write with its per-tx txNum; Flush replays at that txNum
+	// so per-tx domain history matches the serial executor instead of collapsing into one write.
 	writeLog []bcWriteOp
 }
 
-// committedStorageKey is the sync.Map key for BlockStateCache.committedStorage.
 type committedStorageKey struct {
 	addr accounts.Address
 	key  accounts.StorageKey
 }
 
-// bcOpKind enumerates the operations recorded in BlockStateCache.writeLog.
 type bcOpKind uint8
 
 const (
@@ -1037,12 +906,6 @@ const (
 	bcOpDeleteAccount          // self-destruct / empty-removal: del code + del storage prefix
 )
 
-// bcWriteOp is one entry in BlockStateCache.writeLog. txNum is the
-// per-tx txNum at the time of the write — Flush passes it to DomainPut /
-// DomainDel so the domain history matches the serial / main parallel
-// executor's per-tx DomainPut sequence. val is the serialized payload
-// (account blob, code, storage value); for delete-account ops val is
-// nil. key is set only for storage ops.
 type bcWriteOp struct {
 	kind  bcOpKind
 	addr  accounts.Address
@@ -1059,9 +922,6 @@ func NewBlockStateCache() *BlockStateCache {
 	}
 }
 
-// --- Committed (read cache) methods ---
-
-// GetCommittedAccount returns the pre-block account, or (nil, false) if not cached.
 func (c *BlockStateCache) GetCommittedAccount(addr accounts.Address) (*accounts.Account, bool) {
 	v, ok := c.committedAccounts.Load(addr)
 	if !ok {
@@ -1075,7 +935,6 @@ func (c *BlockStateCache) PutCommittedAccount(addr accounts.Address, acc *accoun
 	c.committedAccounts.Store(addr, acc)
 }
 
-// GetCommittedStorage returns the pre-block storage value, or (nil, false) if not cached.
 func (c *BlockStateCache) GetCommittedStorage(addr accounts.Address, key accounts.StorageKey) ([]byte, bool) {
 	v, ok := c.committedStorage.Load(committedStorageKey{addr: addr, key: key})
 	if !ok {
@@ -1089,18 +948,6 @@ func (c *BlockStateCache) PutCommittedStorage(addr accounts.Address, key account
 	c.committedStorage.Store(committedStorageKey{addr: addr, key: key}, val)
 }
 
-// --- Current (write buffer) methods ---
-
-// WriteAccount records an account write at txNum. The serialized blob
-// is appended to writeLog and currentAccounts is updated for fast read
-// access by finalize-IBS readers (NewCurrentCachedReaderV3 /
-// HistoryReaderV3WithBlockCache). Flush will emit DomainPut at the
-// recorded txNum, matching the serial / main parallel executor's
-// per-tx DomainPut sequence.
-//
-// Multiple writes to the same address in one block produce multiple
-// log entries — Flush emits a DomainPut for each, building per-tx
-// AccountsDomain history.
 func (c *BlockStateCache) WriteAccount(addr accounts.Address, enc []byte, txNum uint64) {
 	c.mu.Lock()
 	c.currentAccounts[addr] = enc
@@ -1108,7 +955,6 @@ func (c *BlockStateCache) WriteAccount(addr accounts.Address, enc []byte, txNum 
 	c.mu.Unlock()
 }
 
-// WriteStorage records a storage write at txNum. val=nil means delete.
 func (c *BlockStateCache) WriteStorage(addr accounts.Address, key accounts.StorageKey, val []byte, txNum uint64) {
 	c.mu.Lock()
 	slots, ok := c.currentStorage[addr]
@@ -1121,7 +967,6 @@ func (c *BlockStateCache) WriteStorage(addr accounts.Address, key accounts.Stora
 	c.mu.Unlock()
 }
 
-// WriteCode records a code write at txNum.
 func (c *BlockStateCache) WriteCode(addr accounts.Address, code []byte, txNum uint64) {
 	c.mu.Lock()
 	c.currentCode[addr] = code
@@ -1129,17 +974,12 @@ func (c *BlockStateCache) WriteCode(addr accounts.Address, code []byte, txNum ui
 	c.mu.Unlock()
 }
 
-// DeleteAccount records an account self-destruct / empty-removal at
-// txNum. Flush emits DomainDel(Code) + DomainDelPrefix(Storage) at the
-// recorded txNum.
 func (c *BlockStateCache) DeleteAccount(addr accounts.Address, txNum uint64) {
 	c.mu.Lock()
-	// Mark deleted in the current view so subsequent in-block reads / puts
-	// see the destruction immediately. nil (not absent) so GetCurrentAccount
-	// reports "present but empty" rather than falling back to committed state.
+	// nil (not absent) marks deletion, so GetCurrentAccount reports "present but
+	// empty" instead of falling back to committed state.
 	if v, present := c.currentAccounts[addr]; present && v == nil {
-		// Already deleted by an earlier tx in this block — match serial's
-		// IBS short-circuit so Flush emits a single DomainDel per address.
+		// Already deleted earlier in this block; skip so Flush emits one DomainDel.
 		c.mu.Unlock()
 		return
 	}
@@ -1150,8 +990,6 @@ func (c *BlockStateCache) DeleteAccount(addr accounts.Address, txNum uint64) {
 	c.mu.Unlock()
 }
 
-// GetCurrentAccountDecoded returns the latest account (including intra-block
-// writes), avoiding GetCurrentAccount's re-encode of the committed entry.
 func (c *BlockStateCache) GetCurrentAccountDecoded(addr accounts.Address) (*accounts.Account, bool, error) {
 	c.mu.RLock()
 	enc, written := c.currentAccounts[addr]
@@ -1176,8 +1014,6 @@ func (c *BlockStateCache) GetCurrentAccountDecoded(addr accounts.Address) (*acco
 	return nil, false, nil
 }
 
-// GetCurrentAccount returns the latest account blob (including intra-block writes).
-// Falls back to committed state if no write exists. Returns (nil, false) if not cached.
 func (c *BlockStateCache) GetCurrentAccount(addr accounts.Address) ([]byte, bool) {
 	c.mu.RLock()
 	if enc, ok := c.currentAccounts[addr]; ok {
@@ -1185,12 +1021,8 @@ func (c *BlockStateCache) GetCurrentAccount(addr accounts.Address) ([]byte, bool
 		return enc, true
 	}
 	c.mu.RUnlock()
-	// The committed fallback runs after releasing mu, so the two reads are not one
-	// point-in-time snapshot. That is safe because committedAccounts is a
-	// write-once immutable pre-block view (a sync.Map for lock-free reads): a
-	// concurrent WriteAccount can only add a currentAccounts entry we'd miss —
-	// which the RLock-then-fallback ordering can't prevent regardless — never tear
-	// a committed value.
+	// Reading committed after releasing mu is safe: committedAccounts is a write-once
+	// immutable view, so a concurrent write can only add an entry we'd miss, never tear a value.
 	if v, ok := c.committedAccounts.Load(addr); ok {
 		acc := v.(*accounts.Account)
 		if acc == nil {
@@ -1201,8 +1033,6 @@ func (c *BlockStateCache) GetCurrentAccount(addr accounts.Address) ([]byte, bool
 	return nil, false
 }
 
-// GetCurrentStorage returns the latest storage value (including intra-block writes).
-// Falls back to committed state if no write exists. Returns (nil, false) if not cached.
 func (c *BlockStateCache) GetCurrentStorage(addr accounts.Address, key accounts.StorageKey) ([]byte, bool) {
 	c.mu.RLock()
 	if slots, ok := c.currentStorage[addr]; ok {
@@ -1228,16 +1058,8 @@ func (c *BlockStateCache) GetCurrentCode(addr accounts.Address) ([]byte, bool) {
 	return nil, false
 }
 
-// Flush replays writeLog against SharedDomains in write order. Each
-// entry is stamped with the txNum at which the write was originally
-// made, so the AccountsDomain / StorageDomain / CodeDomain history is
-// built per-tx — matching what serial executor (and main's parallel
-// executor) produce by calling DomainPut at per-tx txNum directly.
-// Called at block boundary after all TXs are applied.
-//
-// DomainPut/DomainDel internally no-op when the write matches the
-// current sd.mem value, so logging every Write* call (including ones
-// that don't change sd.mem) is safe.
+// Flush replays writeLog into SharedDomains at each entry's txNum. DomainPut/DomainDel
+// no-op on a value that already matches sd.mem, so logging every Write* call is safe.
 func (c *BlockStateCache) Flush(domains *execctx.SharedDomains, roTx kv.TemporalTx) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -1247,9 +1069,6 @@ func (c *BlockStateCache) Flush(domains *execctx.SharedDomains, roTx kv.Temporal
 		addrVal := op.addr.Value()
 		switch op.kind {
 		case bcOpDeleteAccount:
-			// self-destruct / empty-removal: delete account + code, wipe storage
-			// prefix. Replayed in writeLog order so it correctly supersedes any
-			// earlier put for the same address in this block.
 			if err := domains.DomainDel(kv.AccountsDomain, roTx, addrVal[:], op.txNum, nil); err != nil {
 				return err
 			}
@@ -1291,8 +1110,6 @@ func (c *BlockStateCache) Flush(domains *execctx.SharedDomains, roTx kv.Temporal
 	return nil
 }
 
-// CachedReaderV3 wraps ReaderV3 and caches ReadAccountData results in a
-// BlockStateCache so parallel workers see a stable pre-block committed view.
 type CachedReaderV3 struct {
 	*ReaderV3
 	blockCache  *BlockStateCache
@@ -1306,9 +1123,7 @@ func NewCachedReaderV3(getter kv.TemporalGetter, blockCache *BlockStateCache) *C
 	}
 }
 
-// NewCurrentCachedReaderV3 creates a reader that reads from the write buffer
-// (currentAccounts) first, seeing all per-TX writes accumulated in the block.
-// Used by the block finalize IBS which needs the post-TX coinbase balance.
+// NewCurrentCachedReaderV3 reads the in-block write buffer first, for callers needing post-TX state.
 func NewCurrentCachedReaderV3(getter kv.TemporalGetter, blockCache *BlockStateCache) *CachedReaderV3 {
 	return &CachedReaderV3{
 		ReaderV3:    NewReaderV3(getter),
@@ -1317,7 +1132,6 @@ func NewCurrentCachedReaderV3(getter kv.TemporalGetter, blockCache *BlockStateCa
 	}
 }
 
-// SetBlockStateCache updates the cache for a new block.
 func (r *CachedReaderV3) SetBlockStateCache(cache *BlockStateCache) {
 	r.blockCache = cache
 }
@@ -1325,7 +1139,6 @@ func (r *CachedReaderV3) SetBlockStateCache(cache *BlockStateCache) {
 func (r *CachedReaderV3) ReadAccountData(address accounts.Address) (*accounts.Account, error) {
 	if r.blockCache != nil {
 		if r.readCurrent {
-			// Sees accumulated per-TX writes.
 			acc, ok, err := r.blockCache.GetCurrentAccountDecoded(address)
 			if err != nil {
 				return nil, err
@@ -1334,7 +1147,6 @@ func (r *CachedReaderV3) ReadAccountData(address accounts.Address) (*accounts.Ac
 				return acc, nil
 			}
 		} else {
-			// Read from committed cache — stable pre-block view.
 			if acc, ok := r.blockCache.GetCommittedAccount(address); ok {
 				if acc == nil {
 					return nil, nil
@@ -1411,8 +1223,7 @@ func (r *CachedReaderV3) ReadAccountStorage(address accounts.Address, key accoun
 
 func (r *ReaderV3) HasStorage(address accounts.Address) (bool, error) {
 	r.addr = address.Value()
-	// this is an optimization, but also checks the account is checked in the domain
-	// for being deleted on unwind before we try to access the storage
+	// Checking AccountsDomain first also catches an unwind-deleted account before trusting stale storage.
 	if enc, _, err := r.getter.GetLatest(kv.AccountsDomain, r.addr[:]); len(enc) == 0 {
 		return false, err
 	}
@@ -1489,10 +1300,6 @@ func (r *ReaderV3) traceReadAccountStorage(address accounts.Address, key account
 
 func (r *ReaderV3) ReadAccountCode(address accounts.Address) ([]byte, error) {
 	r.addr = address.Value()
-	// Pure read: prefer the content-addressed fast path (addr → codeHash →
-	// cached bytes, no per-address CodeDomain read) when the getter offers it.
-	// This is a getter, never a setter — it must not feed a DomainPut prevVal,
-	// so it does not use the addr-keyed GetLatest the write path relies on.
 	var enc []byte
 	var err error
 	if cg, ok := r.getter.(codeGetter); ok {
@@ -1510,17 +1317,12 @@ func (r *ReaderV3) ReadAccountCode(address accounts.Address) ([]byte, error) {
 	return enc, nil
 }
 
-// codeGetter is the type-asserted fast-path interface for full-code reads
-// (EXTCODECOPY / CALL / ReadAccountCode). Implemented by execctx.temporalGetter;
-// callers fall back to GetLatest otherwise. Read-only: never used to resolve a
-// DomainPut prevVal (setters resolve prevVal via the addr-keyed GetLatest).
+// codeGetter is the fast-path interface for full-code reads. Read-only: never used
+// to resolve a DomainPut prevVal, unlike the setter path's GetLatest.
 type codeGetter interface {
 	GetCode(addr []byte, txNum uint64) ([]byte, bool, error)
 }
 
-// codeSizeGetter is the type-asserted fast-path interface for callers
-// that only need the length of the code (EXTCODESIZE / EXTCODEHASH).
-// Implemented by execctx.temporalGetter; fallback to GetLatest otherwise.
 type codeSizeGetter interface {
 	GetCodeSize(addr []byte, txNum uint64) (int, bool, error)
 }
@@ -1692,8 +1494,6 @@ func (r *bufferedReader) HasStorage(address accounts.Address) (bool, error) {
 		}
 
 		if so.storage != nil && so.storage.Len() > 0 {
-			// TODO - we really need to return the first key
-			// for this we need to order the list of hashes
 			r.bufferedState.accountsMutex.RUnlock()
 			return true, nil
 		}
@@ -1786,10 +1586,5 @@ func returnReadList(v ReadLists) {
 	if v == nil {
 		return
 	}
-	//for _, tbl := range v {
-	//	clear(tbl.Keys)
-	//	clear(tbl.Vals)
-	//	tbl.Keys, tbl.Vals = tbl.Keys[:0], tbl.Vals[:0]
-	//}
 	readListPool.Put(v)
 }

--- a/execution/state/rw_v3_allocs_test.go
+++ b/execution/state/rw_v3_allocs_test.go
@@ -50,7 +50,7 @@ func (m histMockTx) GetAsOf(domain kv.Domain, key []byte, ts uint64) ([]byte, bo
 func TestStateReader_ReadMethods_Allocs(t *testing.T) {
 	var acc accounts.Account
 	acc.Nonce = 1
-	accEnc := accounts.SerialiseV3(&acc) // valid encoding so ReadAccountData hits the deserialize path
+	accEnc := accounts.SerialiseV3(&acc)
 
 	r := NewReaderV3(fixedGetter{val: accEnc})
 	addr := accounts.InternAddress(common.Address{0x11})
@@ -68,21 +68,21 @@ func TestStateReader_ReadMethods_Allocs(t *testing.T) {
 		fn   func()
 	}{
 		{"ReaderV3.ReadAccountStorage", 0, func() { _, _, _ = r.ReadAccountStorage(addr, key) }},
-		{"ReaderV3.ReadAccountData", 1, func() { _, _ = r.ReadAccountData(addr) }}, // 1: returns *accounts.Account
+		{"ReaderV3.ReadAccountData", 1, func() { _, _ = r.ReadAccountData(addr) }},
 		{"ReaderV3.HasStorage", 0, func() { _, _ = r.HasStorage(addr) }},
 		{"ReaderV3.ReadAccountCode", 0, func() { _, _ = r.ReadAccountCode(addr) }},
 		{"ReaderV3.ReadAccountCodeSize", 0, func() { _, _ = r.ReadAccountCodeSize(addr) }},
-		{"ReaderV3.ReadAccountDataForDebug", 1, func() { _, _ = r.ReadAccountDataForDebug(addr) }}, // 1: returns *accounts.Account
+		{"ReaderV3.ReadAccountDataForDebug", 1, func() { _, _ = r.ReadAccountDataForDebug(addr) }},
 		{"ReaderV3.ReadAccountIncarnation", 0, func() { _, _ = r.ReadAccountIncarnation(addr) }},
 
 		{"HistoryReaderV3.ReadAccountStorage", 0, func() { _, _, _ = hr.ReadAccountStorage(addr, key) }},
 		{"HistoryReaderV3.ReadAccountCode", 0, func() { _, _ = hr.ReadAccountCode(addr) }},
 		{"HistoryReaderV3.ReadAccountCodeSize", 0, func() { _, _ = hr.ReadAccountCodeSize(addr) }},
-		{"HistoryReaderV3.ReadAccountData", 1, func() { _, _ = hr.ReadAccountData(addr) }},                 // 1: returns *accounts.Account
-		{"HistoryReaderV3.ReadAccountDataForDebug", 1, func() { _, _ = hr.ReadAccountDataForDebug(addr) }}, // 1: returns *accounts.Account
+		{"HistoryReaderV3.ReadAccountData", 1, func() { _, _ = hr.ReadAccountData(addr) }},
+		{"HistoryReaderV3.ReadAccountDataForDebug", 1, func() { _, _ = hr.ReadAccountDataForDebug(addr) }},
 
 		{"CachedReaderV3.ReadAccountStorage (cache hit)", 0, func() { _, _, _ = cr.ReadAccountStorage(addr, key) }},
-		{"CachedReaderV3.ReadAccountData (cache hit)", 1, func() { _, _ = cr.ReadAccountData(addr) }}, // 1: returns *accounts.Account
+		{"CachedReaderV3.ReadAccountData (cache hit)", 1, func() { _, _ = cr.ReadAccountData(addr) }},
 		{"CachedReaderV3.ReadAccountCode", 0, func() { _, _ = cr.ReadAccountCode(addr) }},
 		{"CachedReaderV3.ReadAccountCodeSize", 0, func() { _, _ = cr.ReadAccountCodeSize(addr) }},
 		{"CachedReaderV3.HasStorage", 0, func() { _, _ = cr.HasStorage(addr) }},
@@ -121,8 +121,7 @@ func TestCachedReaderV3_CurrentReadsCommittedWhenUnwritten(t *testing.T) {
 	require.NotSame(t, want, got, "the caller must not be able to mutate the cached account")
 }
 
-// A write this block shadows the committed view, and a nil write means the
-// account was destroyed — neither may fall through to the committed entry.
+// A block write shadows the committed view; a nil write means destroyed — neither may fall through to committed.
 func TestCachedReaderV3_CurrentPrefersBlockWrite(t *testing.T) {
 	t.Parallel()
 
@@ -155,8 +154,6 @@ func TestCachedReaderV3_CurrentReturnsNilForCommittedAbsence(t *testing.T) {
 	require.Nil(t, got)
 }
 
-// BenchmarkCachedReaderAccountRead prices one apply-loop account read that hits
-// the block state cache, on each of its two paths.
 func BenchmarkCachedReaderAccountRead(b *testing.B) {
 	addr := accounts.InternAddress(common.HexToAddress("0xc0ffee"))
 	acc := cacheReadTestAccount()

--- a/execution/state/selfdestruct_codehash_sametx_test.go
+++ b/execution/state/selfdestruct_codehash_sametx_test.go
@@ -10,12 +10,8 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// EIP-6780: a contract self-destructed in the CURRENT tx is alive until end-of-tx
-// cleanup, so EXTCODEHASH within the same tx must return its real code hash. On the
-// versioned path the self-destruct clears the CodeHashPath cell (for later-tx reads),
-// but the code is still present — GetCodeHash must recompute the real hash, else the
-// eip1052/eip6780 EXTCODEHASH-of-self-destructed-contract zkevm fixtures store the
-// empty hash and diverge (wrong BAL / state root).
+// EIP-6780: a same-tx self-destructed contract is alive until finalize, so EXTCODEHASH must still return the real
+// code hash — GetCodeHash must recompute it, since the versioned path clears the CodeHashPath cell for later-tx reads.
 func TestEIP6780_SelfdestructVersioned_CodeHashSameTx(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x82474"))
@@ -31,7 +27,7 @@ func TestEIP6780_SelfdestructVersioned_CodeHashSameTx(t *testing.T) {
 	want, err := ibs.GetCodeHash(addr)
 	require.NoError(t, err)
 
-	_, err = ibs.Selfdestruct(addr, true /* preserveBalance */)
+	_, err = ibs.Selfdestruct(addr, true)
 	require.NoError(t, err)
 
 	got, err := ibs.GetCodeHash(addr)

--- a/execution/state/selfdestruct_empty_sametx_test.go
+++ b/execution/state/selfdestruct_empty_sametx_test.go
@@ -10,12 +10,8 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// EIP-6780: a contract self-destructed in the CURRENT tx stays alive until
-// end-of-tx cleanup, so Empty() must report it as NON-empty within the same tx
-// (it had code — it executed SELFDESTRUCT). On the versioned path the SD clears
-// the nonce/code-hash/balance cells, so emptyFromVersionedFields wrongly returns
-// empty=true -> a same-tx CALL to it charges params.StateGasNewAccount (183600),
-// over-charging gas (the eip8246/eip6780 post_send_opcode_CALL zkevm failures).
+// EIP-6780: a same-tx self-destructed contract stays alive until finalize, so Empty() must still report it non-empty
+// even though the versioned path clears its balance/nonce/codehash cells.
 func TestEIP6780_SelfdestructVersioned_NotEmptySameTx(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x82472"))
@@ -28,7 +24,7 @@ func TestEIP6780_SelfdestructVersioned_NotEmptySameTx(t *testing.T) {
 
 	require.NoError(t, ibs.CreateAccount(addr, true))
 	require.NoError(t, ibs.SetCode(addr, []byte("contract-runtime-code"), tracing.CodeChangeUnspecified))
-	_, err := ibs.Selfdestruct(addr, true /* preserveBalance */)
+	_, err := ibs.Selfdestruct(addr, true)
 	require.NoError(t, err)
 
 	empty, err := ibs.Empty(addr)

--- a/execution/state/selfdestruct_parallel_test.go
+++ b/execution/state/selfdestruct_parallel_test.go
@@ -26,9 +26,6 @@ func (r *sdAccountReader) ReadAccountData(addr accounts.Address) (*accounts.Acco
 	return nil, nil
 }
 
-// TestSelfdestructParallel_NoMaterialize verifies that on the parallel
-// (versionMap) path Selfdestruct records the self-destruct through
-// versioned-write cells without materializing/caching a stateObject.
 func TestSelfdestructParallel_NoMaterialize(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xDE, 0xAD})
 	acc := accounts.NewAccount()
@@ -58,10 +55,7 @@ func TestSelfdestructParallel_NoMaterialize(t *testing.T) {
 	assert.Empty(t, ibs.stateObjects, "parallel Selfdestruct must not materialize a stateObject")
 }
 
-// TestSelfdestructParallel_RepeatedSameTx verifies that a second SELFDESTRUCT of
-// the same account within a tx still proceeds (returns true and re-clears a
-// balance credited in between) — matching the serial object, whose deleted flag
-// stays false until finalize.
+// A second SELFDESTRUCT in the same tx must still proceed and re-clear balance — the serial object's deleted flag stays false until finalize.
 func TestSelfdestructParallel_RepeatedSameTx(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xDE, 0xAD})
 	acc := accounts.NewAccount()
@@ -89,8 +83,6 @@ func TestSelfdestructParallel_RepeatedSameTx(t *testing.T) {
 	assert.True(t, bal.Val.IsZero(), "balance credited between the two SELFDESTRUCTs must be re-cleared")
 }
 
-// TestSelfdestructParallel_AbsentAccount verifies that self-destructing an
-// account that does not exist returns false and records nothing.
 func TestSelfdestructParallel_AbsentAccount(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xBE, 0xEF})
 

--- a/execution/state/selfdestruct_revert_versioned_test.go
+++ b/execution/state/selfdestruct_revert_versioned_test.go
@@ -11,12 +11,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TestSelfdestructVersioned_RevertPreservesPriorBalanceWrite pins that reverting
-// a SELFDESTRUCT does not delete a balance write that predates the snapshot. The
-// self-destruct records BalancePath=0; the revert must restore the pre-destruct
-// versioned balance write rather than delete the cell outright (which would also
-// wipe a legitimate prior balance write and diverge the trie root / BAL). This
-// mirrors the pre-destruct incarnation-cell restore.
+// Revert must restore a pre-destruct balance write, not delete the cell outright, or a legitimate prior write is lost.
 func TestSelfdestructVersioned_RevertPreservesPriorBalanceWrite(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x5DBA1"))
@@ -27,15 +22,13 @@ func TestSelfdestructVersioned_RevertPreservesPriorBalanceWrite(t *testing.T) {
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
 
-	// Balance written BEFORE the snapshot; no prior SelfDestructPath write, so the
-	// revert takes the wasCommited branch that previously deleted the balance cell.
 	require.NoError(t, ibs.AddBalance(addr, *uint256.NewInt(1000), tracing.BalanceChangeUnspecified))
 	pre, ok := ibs.versionedWrites.GetBalance(addr)
 	require.True(t, ok, "precondition: a versioned balance write exists")
 	require.Equal(t, uint64(1000), pre.Val.Uint64())
 
 	snap := ibs.PushSnapshot()
-	_, err := ibs.Selfdestruct(addr, false /* burn balance */)
+	_, err := ibs.Selfdestruct(addr, false)
 	require.NoError(t, err)
 
 	ibs.RevertToSnapshot(snap, nil)
@@ -45,13 +38,7 @@ func TestSelfdestructVersioned_RevertPreservesPriorBalanceWrite(t *testing.T) {
 	require.Equal(t, uint64(1000), got.Val.Uint64(), "the pre-snapshot balance value must be restored")
 }
 
-// A same-tx-created contract bumps its nonce (e.g. it CREATEs a child) and then
-// SELFDESTRUCTs (EIP-8246 preserve-balance). The versioned self-destruct must
-// NOT clear the nonce/code cells: the account is alive until finalize, and a
-// same-tx re-creation at the address reads those cells for its collision check —
-// zeroing them there is invisible to the collision but zeroing the versioned
-// WRITE made the re-creation abort with a phantom collision. It must also survive
-// a revert with the bumped nonce intact.
+// EIP-8246: versioned self-destruct must not clear the nonce/code cells — a same-tx re-create reads them for its collision check.
 func TestEIP8246_SelfdestructVersioned_PreservesBumpedNonce(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x8246F"))
@@ -68,7 +55,7 @@ func TestEIP8246_SelfdestructVersioned_PreservesBumpedNonce(t *testing.T) {
 	require.NoError(t, ibs.SetNonce(addr, 2, tracing.NonceChangeUnspecified))
 
 	snap := ibs.PushSnapshot()
-	_, err := ibs.Selfdestruct(addr, true /* preserveBalance */)
+	_, err := ibs.Selfdestruct(addr, true)
 	require.NoError(t, err)
 	n, err := ibs.GetNonce(addr)
 	require.NoError(t, err)

--- a/execution/state/setcode_parallel_test.go
+++ b/execution/state/setcode_parallel_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// codeReader is a stub StateReader that returns a pre-configured account with
-// code for one address.  All other addresses return nil.
 type codeReader struct {
 	emptyReader
 	addr    accounts.Address
@@ -45,19 +43,8 @@ func (r *codeReader) ReadAccountCodeSize(addr accounts.Address) (int, error) {
 	return 0, nil
 }
 
-// TestSetCodeParallel_RevertToOriginalBug verifies that the "revert-to-original"
-// optimisation in SetCode does not incorrectly delete CodePath writes when a
-// prior transaction within the same block cleared the code.
-//
-// Scenario (EIP-7702 delegation flip):
-//   - Domain has account with delegation code (hash A).
-//   - TX 88 clears the code → writes EmptyCodeHash to versionMap.
-//   - TX 90 re-sets the same delegation code.
-//
-// Before the fix, SetCode compared codeHash against stateObject.original.CodeHash
-// which holds the *domain* value (hash A), not the versionMap value (empty).
-// Because codeHash == original.CodeHash, the optimisation deleted the CodePath
-// write, causing subsequent GetCode reads to return empty code via the versionMap.
+// TestSetCodeParallel_RevertToOriginalBug pins that revert-to-original must
+// diff codeHash against the versionMap's value, not the domain's, or it drops a CodePath write after an earlier same-block tx clears the code.
 func TestSetCodeParallel_RevertToOriginalBug(t *testing.T) {
 	delegationCode := []byte{0xef, 0x01, 0x00,
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
@@ -67,7 +54,6 @@ func TestSetCodeParallel_RevertToOriginalBug(t *testing.T) {
 
 	addr := accounts.InternAddress([20]byte{0xDE, 0xAD})
 
-	// Domain state: account exists with delegation code hash A.
 	domainAccount := accounts.NewAccount()
 	domainAccount.CodeHash = codeHashA
 	domainAccount.Nonce = 1
@@ -80,30 +66,22 @@ func TestSetCodeParallel_RevertToOriginalBug(t *testing.T) {
 
 	vm := NewVersionMap(nil)
 
-	// -----------------------------------------------------------
-	// TX 88: clear the code (write EmptyCodeHash + nil code)
-	// -----------------------------------------------------------
 	ibs88 := NewWithVersionMap(reader, vm)
 	defer ibs88.Close()
 	ibs88.SetTxContext(100, 88)
 	ibs88.SetVersion(0)
 
-	err := ibs88.SetCode(addr, nil, tracing.CodeChangeUnspecified) // clear code
+	err := ibs88.SetCode(addr, nil, tracing.CodeChangeUnspecified)
 	require.NoError(t, err)
 
-	// Flush TX 88 writes to versionMap
 	writes88 := ibs88.VersionedWrites()
 	vm.FlushVersionedWrites(writes88, true, "")
 
-	// Verify TX 88 wrote empty code hash to versionMap
 	ch, rr, ok := vm.ReadCodeHash(addr, 89)
 	require.Equal(t, MVReadResultDone, rr.Status(), "TX 88 should have written CodeHashPath")
 	require.True(t, ok)
 	assert.Equal(t, accounts.EmptyCodeHash, ch, "TX 88 should have written EmptyCodeHash")
 
-	// -----------------------------------------------------------
-	// TX 90: re-set the same delegation code (hash A)
-	// -----------------------------------------------------------
 	ibs90 := NewWithVersionMap(reader, vm)
 	defer ibs90.Close()
 	ibs90.SetTxContext(100, 90)
@@ -112,32 +90,19 @@ func TestSetCodeParallel_RevertToOriginalBug(t *testing.T) {
 	err = ibs90.SetCode(addr, delegationCode, tracing.CodeChangeUnspecified)
 	require.NoError(t, err)
 
-	// -----------------------------------------------------------
-	// Verify: GetCode on the TX 90 IBS should return the delegation code,
-	// NOT empty/nil.
-	// -----------------------------------------------------------
 	code, err := ibs90.GetCode(addr)
 	require.NoError(t, err)
 	assert.Equal(t, delegationCode, code,
 		"GetCode after SetCode(delegationCode) should return the delegation code, not empty")
 
-	// Also verify that the versionedWrites contain the CodePath entry.
 	writes90 := ibs90.VersionedWrites()
 	_, hasCodeWrite := writes90.GetCode(addr)
 	assert.True(t, hasCodeWrite,
 		"TX 90 should have a CodePath write in versionedWrites (the revert-to-original optimisation should NOT have fired)")
 }
 
-// TestSetCodeParallel_NoMaterialize_DelegateThenRevoke pins the within-tx
-// delegate-then-revoke net-zero elision on the cache-free (noMaterialize) path
-// — the EIP-7702 case that regressed the BAL hive suite.
-//
-// A single tx sets a delegation on an EOA then revokes it (sets code back to
-// empty). The net effect is no code change, so both code writes must fold away.
-// Without the current-code seed, the transient stateObject rebuilt for the
-// second SetCode saw the tx-start (empty) code as its prev, computed
-// written=false for the revoke, and left the first SetCode's cell in place —
-// producing wrong code and a receiptHash mismatch.
+// TestSetCodeParallel_NoMaterialize_DelegateThenRevoke pins that a delegate-then-revoke within one tx folds to no code write on the noMaterialize path:
+// each SetCode must seed from the tx's own prior write, not the tx-start value.
 func TestSetCodeParallel_NoMaterialize_DelegateThenRevoke(t *testing.T) {
 	delegationCode := []byte{0xef, 0x01, 0x00,
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
@@ -145,7 +110,6 @@ func TestSetCodeParallel_NoMaterialize_DelegateThenRevoke(t *testing.T) {
 	}
 	addr := accounts.InternAddress([20]byte{0xDE, 0xAD})
 
-	// EOA with no code at tx start.
 	acc := accounts.NewAccount()
 	acc.Nonce = 1
 	reader := &codeReader{addr: addr, account: &acc}
@@ -156,7 +120,7 @@ func TestSetCodeParallel_NoMaterialize_DelegateThenRevoke(t *testing.T) {
 	ibs.SetVersion(0)
 
 	require.NoError(t, ibs.SetCode(addr, delegationCode, tracing.CodeChangeUnspecified))
-	require.NoError(t, ibs.SetCode(addr, nil, tracing.CodeChangeUnspecified)) // revoke
+	require.NoError(t, ibs.SetCode(addr, nil, tracing.CodeChangeUnspecified))
 
 	code, err := ibs.GetCode(addr)
 	require.NoError(t, err)
@@ -168,12 +132,8 @@ func TestSetCodeParallel_NoMaterialize_DelegateThenRevoke(t *testing.T) {
 	assert.Empty(t, ibs.stateObjects, "noMaterialize SetCode must not cache a stateObject")
 }
 
-// TestGetDelegatedDesignationParallel_NoMaterialize_OwnWrite pins the multi-hop
-// EIP-7702 case: a delegation set earlier in the same tx must be visible to
-// GetDelegatedDesignation (used for the auth state-gas refund). On the
-// noMaterialize path stateObject.Code() resolves via the versionMap floor
-// (prior-tx only) and would miss this tx's own SetCode without the code seed in
-// reconstructCellFlags.
+// TestGetDelegatedDesignationParallel_NoMaterialize_OwnWrite pins that a delegation set earlier in the same tx is visible to GetDelegatedDesignation
+// on the noMaterialize path, where Code() otherwise resolves only prior-tx state.
 func TestGetDelegatedDesignationParallel_NoMaterialize_OwnWrite(t *testing.T) {
 	target := accounts.InternAddress([20]byte{0xBB, 0xBB})
 	delegationCode := types.AddressToDelegation(target)
@@ -197,11 +157,8 @@ func TestGetDelegatedDesignationParallel_NoMaterialize_OwnWrite(t *testing.T) {
 	assert.Empty(t, ibs.stateObjects, "GetDelegatedDesignation must not materialize a stateObject")
 }
 
-// TestGetDelegatedDesignation_TracksSplitCodePublish reproduces a narrow
-// optimistic concurrency control (OCC) window where a prior transaction's
-// CodeHashPath is visible before its CodePath. The speculative read must record
-// the missing CodePath so validation rejects it once the delegation bytecode is
-// published.
+// TestGetDelegatedDesignation_TracksSplitCodePublish pins an OCC window where a prior tx's CodeHashPath is visible before its CodePath:
+// the speculative read must record the missing CodePath so validation rejects it once bytecode publishes.
 func TestGetDelegatedDesignation_TracksSplitCodePublish(t *testing.T) {
 	t.Parallel()
 	authority := accounts.InternAddress([20]byte{0xaa})

--- a/execution/state/setstate_parallel_test.go
+++ b/execution/state/setstate_parallel_test.go
@@ -10,9 +10,6 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TestSetStateParallel_NoMaterialize verifies that an SSTORE on the parallel
-// (versionMap) path records the storage write through versioned-write cells
-// without materializing/caching a stateObject.
 func TestSetStateParallel_NoMaterialize(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xC0, 0xDE})
 	key := accounts.InternKey([32]byte{0x01})
@@ -37,16 +34,12 @@ func TestSetStateParallel_NoMaterialize(t *testing.T) {
 	assert.Equal(t, uint256.NewInt(42), &vw.Val)
 	assert.Empty(t, ibs.stateObjects, "parallel SSTORE must not materialize a stateObject")
 
-	// Reading the slot back within the tx returns the written value.
 	got, err := ibs.GetState(addr, key)
 	require.NoError(t, err)
 	assert.Equal(t, uint256.NewInt(42), &got)
 	assert.Empty(t, ibs.stateObjects)
 }
 
-// TestSetStateParallel_NoOpToCommitted verifies that writing the current
-// committed value records no versioned write (matches stateObject.SetState's
-// set decision).
 func TestSetStateParallel_NoOpToCommitted(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xC0, 0xDE})
 	key := accounts.InternKey([32]byte{0x02})

--- a/execution/state/state_object.go
+++ b/execution/state/state_object.go
@@ -49,8 +49,7 @@ func newHeapObject() *stateObject {
 
 type Storage map[accounts.StorageKey]uint256.Int
 
-// set allocates the map on first write, so an object that never writes keeps a
-// nil Storage.
+// set allocates the map on first write, so an object that never writes keeps a nil Storage.
 func (s *Storage) set(key accounts.StorageKey, value uint256.Int) {
 	if *s == nil {
 		*s = make(Storage)
@@ -71,43 +70,29 @@ func (s Storage) Copy() Storage {
 	return maps.Clone(s)
 }
 
-// stateObject represents an Ethereum account which is being modified.
-//
-// The usage pattern is as follows:
-// First you need to obtain a state object.
-// Account values can be accessed and modified through the object.
 type stateObject struct {
 	address  accounts.Address
 	data     accounts.Account
 	original accounts.Account
 	db       *IntraBlockState
 
-	// Write caches.
-	//trie Trie // storage trie, which becomes non-nil on first access
-	code accounts.Code // contract bytecode, hash + canonical bytes
+	code accounts.Code
 
-	originStorage Storage // Storage cache of original entries to dedup rewrites
-	// blockOriginStorage keeps the values of storage items at the beginning of the block
-	// Used to make decision on whether to make a write to the
-	// database (value != origin) or not (value == origin)
+	originStorage      Storage
 	blockOriginStorage Storage
-	dirtyStorage       Storage // Storage entries that need to be flushed to disk
-	fakeStorage        Storage // Fake storage which constructed by caller for debugging purpose.
+	dirtyStorage       Storage
+	fakeStorage        Storage // overrides all storage reads/writes, for debugging and call simulation
 
-	// Cache flags.
-	// When an object is marked selfdestructed it will be delete from the trie
-	// during the "update" phase of the state transition.
-	dirtyCode       bool // true if the code was updated
+	dirtyCode       bool
 	selfdestructed  bool
-	deleted         bool // true if account was deleted during the lifetime of this object
-	newlyCreated    bool // true if this object was created in the current transaction
-	createdContract bool // true if this object represents a newly created contract
+	deleted         bool
+	newlyCreated    bool
+	createdContract bool
 
 	// Set by stateObjectArena.alloc; keeps release from pooling a slot the arena owns.
 	arena bool
 }
 
-// newObject creates a state object from the arena or the pool.
 func newObject(db *IntraBlockState, address accounts.Address, data, original *accounts.Account) *stateObject {
 	so := db.allocStateObject()
 	so.db = db
@@ -151,7 +136,6 @@ func (so *stateObject) release() {
 	stateObjectPool.Put(so)
 }
 
-// EncodeRLP implements rlp.Encoder.
 func (so *stateObject) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, &so.data)
 }
@@ -160,9 +144,7 @@ func (so *stateObject) markSelfdestructed() {
 	so.selfdestructed = true
 }
 
-// GetState returns a value from account storage.
 func (so *stateObject) GetState(key accounts.StorageKey) (uint256.Int, bool) {
-	// If the fake storage is set, only lookup the state here (in the debugging mode)
 	if so.fakeStorage != nil {
 		return so.fakeStorage[key], false
 	}
@@ -170,24 +152,19 @@ func (so *stateObject) GetState(key accounts.StorageKey) (uint256.Int, bool) {
 	if dirty {
 		return value, false
 	}
-	// Otherwise return the entry's original value
 	value, _ = so.GetCommittedState(key)
 	return value, true
 }
 
-// GetCommittedState retrieves a value from the committed account storage trie.
 func (so *stateObject) GetOriginState(key accounts.StorageKey) (uint256.Int, bool) {
 	value, cached := so.originStorage[key]
 	return value, cached
 }
 
-// GetCommittedState retrieves a value from the committed account storage trie.
 func (so *stateObject) GetCommittedState(key accounts.StorageKey) (uint256.Int, error) {
-	// If the fake storage is set, only lookup the state here (in the debugging mode)
 	if so.fakeStorage != nil {
 		return so.fakeStorage[key], nil
 	}
-	// If we have the original value cached, return that
 	{
 		value, cached := so.originStorage[key]
 		if cached {
@@ -201,7 +178,6 @@ func (so *stateObject) GetCommittedState(key accounts.StorageKey) (uint256.Int, 
 		}
 		return uint256.Int{}, nil
 	}
-	// Load from DB in case it is missing.
 	if dbg.TraceDomainIO || (dbg.TraceTransactionIO && (so.db.trace || dbg.TraceAccount(so.address.Handle()))) {
 		so.db.stateReader.SetTrace(true, fmt.Sprintf("%d (%d.%d)", so.db.blockNum, so.db.txIndex, so.db.version))
 	}
@@ -230,32 +206,25 @@ func (so *stateObject) GetCommittedState(key accounts.StorageKey) (uint256.Int, 
 	return res, err
 }
 
-// SetState updates a value in account storage.
 func (so *stateObject) SetState(key accounts.StorageKey, value uint256.Int, force bool) (_ bool, err error) {
-	// If the fake storage is set, put the temporary state update here.
 	if so.fakeStorage != nil {
 		so.db.journal.fakeStorageChange(so.address, key, so.fakeStorage[key])
 		so.fakeStorage[key] = value
 		return true, nil
 	}
-	// If the new value is the same as old, don't set
 	var prev uint256.Int
 	var commited bool
 	var source ReadSource
 
-	// we need to use versioned read here otherwise we will miss versionmap entries
+	// Must use a versioned read here, or version-map entries get missed.
 	prev, source, _, commited, err = readStateForSet(so.db, so.address, key)
 	if err != nil {
 		return false, err
 	}
 
-	// When versionedReadCore resolves the previous value from a cached read
-	// (ReadSetRead) or from the version map (MapRead), the readStorage
-	// callback is never called and commited stays at its zero-value (false).
-	// In both cases there is no versioned write for this key in the current
-	// transaction, so this IS the first write — commited must be true so
-	// that the storage-change revert deletes the versioned write instead of
-	// updating it to the prevalue.
+	// commited stays false when the previous value came from a cached read or the
+	// version map rather than the readStorage callback; force it true so a revert
+	// deletes the versioned write instead of restoring it to prevalue.
 	if source != WriteSetRead && source != UnknownSource && source != StorageRead {
 		commited = true
 	}
@@ -264,7 +233,6 @@ func (so *stateObject) SetState(key accounts.StorageKey, value uint256.Int, forc
 		return false, nil
 	}
 
-	// New value is different, update and journal the change
 	so.db.journal.storageChange(so.address, key, prev, commited)
 
 	if so.db.tracingHooks != nil && so.db.tracingHooks.OnStorageChange != nil {
@@ -275,18 +243,10 @@ func (so *stateObject) SetState(key accounts.StorageKey, value uint256.Int, forc
 	return true, nil
 }
 
-// SetStorage replaces the entire state storage with the given one.
-//
-// After this function is called, all the original state will be ignored and state
-// lookup only happens in the fake state storage.
-//
-// Note this function should only be used for call/block simulation and debugging purpose.
 func (so *stateObject) SetStorage(storage Storage) {
-	// Allocate fake storage if it's nil.
 	if so.fakeStorage == nil {
 		so.fakeStorage = make(Storage)
 	}
-	// Set the fake storage through SetState to ensure journalling is done correctly.
 	for key, value := range storage {
 		so.SetState(key, value, false)
 	}
@@ -296,28 +256,18 @@ func (so *stateObject) setState(key accounts.StorageKey, value uint256.Int) {
 	so.dirtyStorage.set(key, value)
 }
 
-// updateStorage writes cached storage modifications into the object's storage trie.
-// useBlockOrigin selects which baseline to compare against when deciding whether to skip
-// a write: false → use originStorage (last value written to MDBX within this block,
-// correct for per-tx FinalizeTx writes); true → use blockOriginStorage (value at block
-// start, correct for CommitBlock's system-txNum write which must not be skipped even
-// when a slot returned to its block-start value mid-block).
 func (so *stateObject) updateStorage(stateWriter StateWriter, useBlockOrigin bool) error {
-	// When using full state override, only the fake storage matters (see also SetStorage)
 	if so.fakeStorage != nil {
-		// First, delete the account to wipe out the original storage
 		err := stateWriter.DeleteAccount(so.address, &so.original)
 		if err != nil {
 			return err
 		}
-		// Then, we need to apply the fake storage changes to compute the state root correctly
 		err = so.applyStorageChanges(stateWriter, so.fakeStorage, useBlockOrigin)
 		if err != nil {
 			return err
 		}
 		return nil
 	}
-	// Normal behaviour, apply the dirty storage changes
 	err := so.applyStorageChanges(stateWriter, so.dirtyStorage, useBlockOrigin)
 	if err != nil {
 		return err
@@ -327,17 +277,8 @@ func (so *stateObject) updateStorage(stateWriter StateWriter, useBlockOrigin boo
 
 func (so *stateObject) applyStorageChanges(stateWriter StateWriter, updatedStorage Storage, useBlockOrigin bool) error {
 	for key, value := range updatedStorage {
-		// Choose the baseline for the skip-if-unchanged check:
-		//
-		//   useBlockOrigin=false (FinalizeTx): use originStorage[key], the last value
-		//   written to MDBX within this block. This avoids a stale-MDBX bug when a
-		//   slot returns to its block-start value mid-block (A→B→A): blockOriginStorage
-		//   would falsely report "no change" while MDBX still holds B from an earlier tx.
-		//
-		//   useBlockOrigin=true (CommitBlock): use blockOriginStorage[key]. After all
-		//   FinalizeTx calls, originStorage[key] already equals the final dirty value, so
-		//   using it would always skip the write. The CommitBlock write at system_txNum is
-		//   required by ComputeCommitment and must not be skipped.
+		// CommitBlock must compare against blockOriginStorage, not originStorage: its
+		// system-txNum write is required by ComputeCommitment and must never be skipped.
 		var originValue uint256.Int
 		if useBlockOrigin {
 			originValue = so.blockOriginStorage[key]
@@ -376,23 +317,16 @@ func (so *stateObject) setBalance(amount uint256.Int) {
 	so.data.Balance = amount
 }
 
-// Return the gas back to the origin. Used by the Virtual machine or Closures
 func (so *stateObject) ReturnGas(gas *big.Int) {}
 
 func (so *stateObject) setIncarnation(incarnation uint64) {
 	so.data.SetIncarnation(incarnation)
 }
 
-//
-// Attribute accessors
-//
-
-// Returns the address of the contract/account
 func (so *stateObject) Address() accounts.Address {
 	return so.address
 }
 
-// Code returns the contract code associated with this object, if any.
 func (so *stateObject) Code() ([]byte, error) {
 	c, err := so.CodeTyped()
 	if err != nil {
@@ -401,9 +335,6 @@ func (so *stateObject) Code() ([]byte, error) {
 	return c.Bytes, nil
 }
 
-// CodeTyped returns the contract code as an accounts.Code carrying the
-// interned CodeHash alongside the bytes. Prefer this over Code() when the
-// caller needs the hash too — saves a Keccak.
 func (so *stateObject) CodeTyped() (accounts.Code, error) {
 	if so.code.Bytes != nil {
 		return so.code, nil
@@ -412,9 +343,7 @@ func (so *stateObject) CodeTyped() (accounts.Code, error) {
 		return accounts.Code{Hash: so.data.CodeHash}, nil
 	}
 
-	// When a versionMap is present (parallel execution), check for CodePath
-	// entries from prior TXs (e.g. EIP-7702 SetCode). The versionMap has the
-	// synthetic code but the domain/stateReader does not.
+	// versionMap can hold synthetic code from a prior tx's EIP-7702 SetCode that the domain/stateReader doesn't have yet.
 	if so.db.versionMap != nil {
 		if c, rr, ok := so.db.versionMap.ReadCode(so.address, so.db.txIndex); ok && rr.Status() == MVReadResultDone {
 			so.code = c
@@ -438,10 +367,7 @@ func (so *stateObject) CodeTyped() (accounts.Code, error) {
 	if err != nil {
 		return accounts.Code{}, fmt.Errorf("can't read code for %x: %w", so.Address(), err)
 	}
-	// Trust the committed (CodeHash, bytes) pair rather than re-hashing on every
-	// load; the only case they disagree is codeHash-without-code state (empty
-	// bytes, non-empty hash), reported honestly as empty so SetCode's compare
-	// still heals it.
+	// Trusts the committed (CodeHash, bytes) pair over re-hashing; a codeHash-without-code mismatch reports as empty so SetCode's compare still heals it.
 	var c accounts.Code
 	if len(code) == 0 {
 		c = accounts.EmptyCode
@@ -458,8 +384,7 @@ func (so *stateObject) SetCode(code accounts.Code, wasCommited bool, reason trac
 		return false, err
 	}
 
-	// bytes.Equal confirm guards the codeHash-without-code case: a matching hash
-	// against empty prev bytes must still heal the CodeDomain, not skip.
+	// Guards the codeHash-without-code case: a hash match against empty prev bytes must still heal the CodeDomain, not skip.
 	if prev.Hash == code.Hash && bytes.Equal(prev.Bytes, code.Bytes) {
 		return false, nil
 	}
@@ -506,9 +431,7 @@ func (so *stateObject) IsDirty() bool {
 	return so.dirtyCode || len(so.dirtyStorage) > 0 || so.data != so.original
 }
 
-// Never called, but must be present to allow stateObject to be used
-// as a vm.Account interface that also satisfies the vm.ContractRef
-// interface. Interfaces are awesome.
+// Never called; required so stateObject satisfies both vm.Account and vm.ContractRef.
 func (so *stateObject) Value() *big.Int {
 	panic("Value on stateObject should never be called")
 }

--- a/execution/state/state_object_arena.go
+++ b/execution/state/state_object_arena.go
@@ -16,19 +16,16 @@
 
 package state
 
-// The cap bounds the working set, not coverage: slots are handed out in
-// sequence, so an arena that outgrows L2 costs more in cache misses than the
-// allocations it saves. 2048 slots is 574 KB. Past the cap the caller
-// allocates, which is what every object did before the arena.
+// The cap bounds the working set to fit L2 (2048 slots = 574 KB); past it the
+// caller falls back to a normal allocation, as before the arena existed.
 const (
 	arenaSlabSize   = 64
 	arenaMaxSlabs   = 32
 	arenaMaxObjects = arenaSlabSize * arenaMaxSlabs
 )
 
-// stateObjectArena is a slab allocator for stateObjects that are never cached
-// and so die with the transaction that created them. Slabs are append-only, so
-// a pointer stays valid until reset.
+// stateObjectArena is a slab allocator for stateObjects that die with the tx.
+// Slabs are append-only, so a pointer stays valid until reset.
 type stateObjectArena struct {
 	slabs []*[arenaSlabSize]stateObject
 	slab  int
@@ -40,9 +37,7 @@ func (a *stateObjectArena) alloc() *stateObject {
 		return nil
 	}
 	so := &a.slabs[a.slab][a.idx]
-	// One store establishes every field, so what a caller gets never depends on
-	// the rewind having cleared the slot first. The arena tag rides along: it is
-	// slot identity, and release() must not hand a live slot to the shared pool.
+	// The full-struct store means a slot never depends on the prior rewind; the arena tag rides along so release() won't pool a live slot.
 	*so = stateObject{arena: true}
 	a.idx++
 	if a.idx == arenaSlabSize {
@@ -52,7 +47,6 @@ func (a *stateObjectArena) alloc() *stateObject {
 	return so
 }
 
-// empty reports whether no slot has been drawn since the last rewind.
 func (a *stateObjectArena) empty() bool { return a.slab == 0 && a.idx == 0 }
 
 func (a *stateObjectArena) grow() bool {
@@ -63,10 +57,7 @@ func (a *stateObjectArena) grow() bool {
 	return true
 }
 
-// reset makes every slot handed out since the last reset available again. Slots
-// are zeroed as well as rewound so a slot that is not reused stops retaining the
-// account and code it last held; alloc re-establishes the slot, so correctness
-// does not depend on this pass.
+// Zeroes every handed-out slot so it stops pinning old account/code data; alloc's full overwrite means correctness never depends on this cleanup.
 func (a *stateObjectArena) reset() {
 	for s := 0; s <= a.slab && s < len(a.slabs); s++ {
 		used := a.slabs[s][:]

--- a/execution/state/state_object_arena_test.go
+++ b/execution/state/state_object_arena_test.go
@@ -28,8 +28,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// staticAccountReader returns a fixed account without allocating, so an
-// AllocsPerRun loop measures only the IntraBlockState path.
+// staticAccountReader returns a fixed account without allocating, keeping an AllocsPerRun loop limited to measuring the IntraBlockState path.
 type staticAccountReader struct {
 	emptyReader
 	addr accounts.Address
@@ -43,8 +42,7 @@ func (r *staticAccountReader) ReadAccountData(addr accounts.Address) (*accounts.
 	return nil, nil
 }
 
-// anyAccountReader answers every address with the same account, so a benchmark
-// can touch an arbitrary number of distinct accounts.
+// anyAccountReader answers every address with the same account, so a benchmark can touch an arbitrary number of distinct accounts.
 type anyAccountReader struct {
 	emptyReader
 	acc *accounts.Account
@@ -67,11 +65,7 @@ func startNoMaterializeTx(ibs *IntraBlockState, vm *VersionMap, txIndex int) {
 	ibs.SetTxContext(1, txIndex)
 }
 
-// TestTxBoundaryRewindsArenaWithoutReset pins that the rewind rides on the
-// journal clear rather than on Reset. The BAL block assembler sets noMaterialize
-// and never calls Reset — its per-tx boundary reaches clearJournalAndRefund
-// through FinalizeTx — so an arena rewound only by Reset would grow to its cap
-// there and hold every slot's account and code for the whole block.
+// TestTxBoundaryRewindsArenaWithoutReset pins that the arena rewinds on every per-tx boundary, not only on Reset — a caller that never calls Reset would otherwise grow the arena to its cap and hold every slot for the whole block.
 func TestTxBoundaryRewindsArenaWithoutReset(t *testing.T) {
 	ibs, _ := newNoMaterializeIBS(&emptyReader{})
 	defer ibs.Close()
@@ -80,14 +74,11 @@ func TestTxBoundaryRewindsArenaWithoutReset(t *testing.T) {
 	first := ibs.allocStateObject()
 	require.True(t, first.arena)
 
-	ibs.SoftFinalise() // a transaction boundary, without Reset
+	ibs.SoftFinalise()
 
 	require.Same(t, first, ibs.allocStateObject(), "the transaction boundary must free the slot")
 }
 
-// TestNoMaterializeReadReusesArena pins that account reads on the parallel path
-// are served from the arena and that consecutive transactions reuse the same
-// slab instead of growing it.
 func TestNoMaterializeReadReusesArena(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xAB})
 	acc := accounts.NewAccount()
@@ -114,8 +105,6 @@ func TestNoMaterializeReadReusesArena(t *testing.T) {
 		"the arena must stop growing after the first transaction")
 }
 
-// TestNoMaterializeAllocStateObjectUsesArena pins the routing: the parallel path
-// takes arena slots, the materializing path takes pooled objects.
 func TestNoMaterializeAllocStateObjectUsesArena(t *testing.T) {
 	ibs, _ := newNoMaterializeIBS(&emptyReader{})
 	defer ibs.Close()
@@ -128,9 +117,7 @@ func TestNoMaterializeAllocStateObjectUsesArena(t *testing.T) {
 	assert.True(t, ibs.allocStateObject().arena, "parallel path must use the arena")
 }
 
-// TestNoMaterializeOverflowSkipsPool pins that once the arena is full the
-// parallel path allocates rather than draining the shared pool, since objects it
-// hands out are never released back.
+// TestNoMaterializeOverflowSkipsPool pins that once the arena is full, overflow allocates rather than draining the shared pool, since objects it hands out are never released back.
 func TestNoMaterializeOverflowSkipsPool(t *testing.T) {
 	ibs, _ := newNoMaterializeIBS(&emptyReader{})
 	defer ibs.Close()
@@ -140,16 +127,13 @@ func TestNoMaterializeOverflowSkipsPool(t *testing.T) {
 		require.True(t, ibs.allocStateObject().arena)
 	}
 
-	// Only a pool draw can hand a sentinel back. The reverse does not hold: a GC
-	// or a P migration between Put and Get empties the pool, so a drain can slip
-	// through - but a correct alloc can never fail this.
+	// A GC or P migration between Put and Get can empty the pool on its own, so this only proves alloc avoided the sentinels below, not that a drain can never happen.
 	sentinels := make([]*stateObject, 4)
 	for i := range sentinels {
 		sentinels[i] = newHeapObject()
 		stateObjectPool.Put(sentinels[i])
 	}
-	// stateObjectPool is package-global: drain what this test pushed so sibling
-	// tests do not run against a pool it primed.
+	// stateObjectPool is package-global: drain what this test pushed so other tests don't run against a primed pool.
 	t.Cleanup(func() {
 		for range sentinels {
 			stateObjectPool.Get()
@@ -165,9 +149,7 @@ func TestNoMaterializeOverflowSkipsPool(t *testing.T) {
 	require.Len(t, overflow.dirtyStorage, 1, "overflow object must be usable")
 }
 
-// TestNoMaterializeAccountReadAllocs guards against the stateObject allocation
-// coming back. The residual allocations belong to the per-transaction ReadSet,
-// not to the stateObject.
+// TestNoMaterializeAccountReadAllocs guards against the stateObject allocation coming back; residual allocs belong to the per-tx ReadSet, not the stateObject.
 func TestNoMaterializeAccountReadAllocs(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xAB})
 	acc := accounts.NewAccount()
@@ -184,19 +166,14 @@ func TestNoMaterializeAccountReadAllocs(t *testing.T) {
 		}
 	})
 
-	// Assert the arena served the read directly: the alloc bound alone would still
-	// pass if allocStateObject regressed to a pool draw, since a warm pool also
-	// costs nothing.
+	// the alloc bound alone can't tell a real arena hit from a regression to a warm pool draw, which also costs nothing — check the arena index directly
 	require.NotZero(t, ibs.stateObjectArena.idx, "the read must be served from the arena")
 
-	//goland:noinspection GoBoolExpressions
 	if !race.Enabled {
 		require.LessOrEqual(t, allocs, 5.0, "stateObject must not be heap-allocated per transaction")
 	}
 }
 
-// TestStateObjectArenaRecyclesSlots pins that reset hands the same backing
-// slots out again, carrying no state from their previous use.
 func TestStateObjectArenaRecyclesSlots(t *testing.T) {
 	var a stateObjectArena
 
@@ -226,9 +203,7 @@ func TestStateObjectArenaRecyclesSlots(t *testing.T) {
 	assert.True(t, reused.arena, "hand-out re-tags the slot")
 }
 
-// TestNoMaterializeIsStableWhileSlotsOutstanding pins the mutual exclusion: arena
-// slots are rewound per transaction, so the mode that decides whether an object is
-// cached for the block must not change while any are live.
+// TestNoMaterializeIsStableWhileSlotsOutstanding pins that noMaterialize can't flip while arena slots are live, since they're rewound per transaction under the mode active when drawn.
 func TestNoMaterializeIsStableWhileSlotsOutstanding(t *testing.T) {
 	defer func(prev bool) { dbg.AssertEnabled = prev }(dbg.AssertEnabled)
 	dbg.AssertEnabled = true
@@ -245,8 +220,7 @@ func TestNoMaterializeIsStableWhileSlotsOutstanding(t *testing.T) {
 	require.Panics(t, func() { ibs.SetNoMaterialize(false) }, "flipping with slots outstanding")
 }
 
-// TestStateObjectArenaFallsBackToHeap pins that the arena stops growing at its
-// cap and signals the caller to allocate instead.
+// TestStateObjectArenaFallsBackToHeap pins that the arena stops growing at its cap and signals the caller (a nil return) to allocate instead.
 func TestStateObjectArenaFallsBackToHeap(t *testing.T) {
 	var a stateObjectArena
 
@@ -259,8 +233,6 @@ func TestStateObjectArenaFallsBackToHeap(t *testing.T) {
 	require.NotNil(t, a.alloc(), "reset must make the arena usable again")
 }
 
-// TestStateObjectArenaPointersSurviveGrowth pins that a pointer handed out
-// before the arena grows still refers to the same object afterwards.
 func TestStateObjectArenaPointersSurviveGrowth(t *testing.T) {
 	var a stateObjectArena
 
@@ -274,8 +246,6 @@ func TestStateObjectArenaPointersSurviveGrowth(t *testing.T) {
 	assert.EqualValues(t, 42, first.data.Nonce, "growth must not relocate live slots")
 }
 
-// TestStateObjectArenaReleaseKeepsSlotOutOfPool pins that an arena slot reaching
-// release() is reset but not handed to the shared pool.
 func TestStateObjectArenaReleaseKeepsSlotOutOfPool(t *testing.T) {
 	var a stateObjectArena
 
@@ -288,8 +258,6 @@ func TestStateObjectArenaReleaseKeepsSlotOutOfPool(t *testing.T) {
 	require.Same(t, so, &a.slabs[0][0], "the slot stays owned by the arena")
 }
 
-// BenchmarkNoMaterializeTx models a parallel-exec transaction: reset, then read
-// the account fields of a set of distinct accounts.
 func BenchmarkNoMaterializeTx(b *testing.B) {
 	acc := accounts.NewAccount()
 	acc.Nonce = 3
@@ -314,9 +282,7 @@ func BenchmarkNoMaterializeTx(b *testing.B) {
 	}
 }
 
-// TestStateObjectArenaResetCoversVaryingHighWater pins that a slot is clean on
-// hand-out even when transactions consume different numbers of slots: a slot is
-// reset by every generation that handed it out.
+// TestStateObjectArenaResetCoversVaryingHighWater pins that a slot is clean on hand-out even when successive transactions consume different numbers of slots.
 func TestStateObjectArenaResetCoversVaryingHighWater(t *testing.T) {
 	var a stateObjectArena
 

--- a/execution/state/state_test.go
+++ b/execution/state/state_test.go
@@ -45,7 +45,6 @@ func toAddr(a []byte) accounts.Address {
 	return accounts.InternAddress(common.BytesToAddress(a))
 }
 
-// recordingWriter wraps NoopWriter and captures WriteAccountStorage calls.
 type recordingWriter struct {
 	NoopWriter
 	storageWrites []struct{ orig, val uint256.Int }
@@ -56,14 +55,8 @@ func (rw *recordingWriter) WriteAccountStorage(_ accounts.Address, _ uint64, _ a
 	return nil
 }
 
-// TestFinalizeTxDoesNotSkipStorageRevertToBlockOrigin is a regression test for a bug
-// where FinalizeTx used blockOriginStorage (block-start value) instead of originStorage
-// (last-written value) to decide whether a storage write could be skipped.
-//
-// Scenario: slot starts at A. Tx1 writes A→B (FinalizeTx stores B in MDBX, sets
-// originStorage=B). Tx2 writes B→A (reverts to block-start). Old code compared
-// value(A) == blockOriginStorage(A) and skipped the write, leaving MDBX with B.
-// Fixed code compares value(A) != originStorage(B) and correctly writes A.
+// Regression: FinalizeTx must compare against originStorage (last write),
+// not blockOriginStorage (block-start value), or reverting A→B→A drops the write.
 func TestFinalizeTxDoesNotSkipStorageRevertToBlockOrigin(t *testing.T) {
 	t.Parallel()
 
@@ -71,10 +64,9 @@ func TestFinalizeTxDoesNotSkipStorageRevertToBlockOrigin(t *testing.T) {
 
 	addr := toAddr([]byte("acct"))
 	key := accounts.ZeroKey
-	valA := *uint256.NewInt(1) // block-start value
+	valA := *uint256.NewInt(1)
 	valB := *uint256.NewInt(2)
 
-	// Write block-start state: account exists with slot=A.
 	txNum := uint64(1)
 	err := rawdbv3.TxNums.Append(tx, 1, 1)
 	require.NoError(t, err)
@@ -89,11 +81,9 @@ func TestFinalizeTxDoesNotSkipStorageRevertToBlockOrigin(t *testing.T) {
 	err = setup.CommitBlock(&chain.Rules{}, w)
 	require.NoError(t, err)
 
-	// IBS for the next block — reads block-start state (slot=A) from domains.
 	ibs := New(NewReaderV3(domains.AsGetter(tx)))
 	defer ibs.Close()
 
-	// Tx1: A → B.
 	ibs.SetState(addr, key, valB)
 	rw1 := &recordingWriter{}
 	err = ibs.FinalizeTx(&chain.Rules{}, rw1)
@@ -101,14 +91,11 @@ func TestFinalizeTxDoesNotSkipStorageRevertToBlockOrigin(t *testing.T) {
 	require.Len(t, rw1.storageWrites, 1, "tx1 must emit a storage write")
 	require.Equal(t, valB, rw1.storageWrites[0].val, "tx1 must write B")
 
-	// Tx2: B → A (reverts to the block-start value).
 	ibs.SetState(addr, key, valA)
 	rw2 := &recordingWriter{}
 	err = ibs.FinalizeTx(&chain.Rules{}, rw2)
 	require.NoError(t, err)
 
-	// Regression: old code used blockOriginStorage[key]==A as origin, saw
-	// value==A, and silently skipped the write, leaving MDBX with B.
 	require.Len(t, rw2.storageWrites, 1, "tx2 must emit a storage write (A→B→A must not be skipped)")
 	require.Equal(t, valA, rw2.storageWrites[0].val, "tx2 must write A")
 	require.Equal(t, valB, rw2.storageWrites[0].orig, "tx2 origin must be B (last written value)")
@@ -129,7 +116,6 @@ func TestNull(t *testing.T) {
 
 	address := accounts.InternAddress(common.HexToAddress("0x823140710bf13990e4500136726d8b55"))
 	state.CreateAccount(address, true)
-	//value := common.FromHex("0x823140710bf13990e4500136726d8b55")
 	var value uint256.Int
 
 	state.SetState(address, accounts.ZeroKey, value)
@@ -200,14 +186,11 @@ func TestSnapshot(t *testing.T) {
 	data1 := uint256.NewInt(42)
 	data2 := uint256.NewInt(43)
 
-	// snapshot the genesis state
 	genesis := state.PushSnapshot()
 
-	// set initial state object value
 	state.SetState(stateobjaddr, storageaddr, *data1)
 	snapshot := state.PushSnapshot()
 
-	// set a new state object value, revert it and ensure correct content
 	state.SetState(stateobjaddr, storageaddr, *data2)
 	state.RevertToSnapshot(snapshot, nil)
 	state.PopSnapshot(snapshot)
@@ -218,7 +201,6 @@ func TestSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint256.Int{}, value)
 
-	// revert up to the genesis state and ensure correct content
 	state.RevertToSnapshot(genesis, nil)
 	state.PopSnapshot(genesis)
 	value, err = state.GetState(stateobjaddr, storageaddr)
@@ -245,8 +227,6 @@ func TestSnapshotEmpty(t *testing.T) {
 	state.PopSnapshot(snapshot)
 }
 
-// use testing instead of checker because checker does not support
-// printing/logging in tests (-check.vv does not work)
 func TestSnapshot2(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -270,7 +250,6 @@ func TestSnapshot2(t *testing.T) {
 	state.SetState(stateobjaddr0, storageaddr, *data0)
 	state.SetState(stateobjaddr1, storageaddr, *data1)
 
-	// db, trie are already non-empty values
 	so0, err := state.getStateObject(stateobjaddr0, true)
 	require.NoError(t, err)
 	so0.SetBalance(*uint256.NewInt(42), true, tracing.BalanceChangeUnspecified)
@@ -286,7 +265,6 @@ func TestSnapshot2(t *testing.T) {
 	err = state.CommitBlock(&chain.Rules{}, w)
 	require.NoError(t, err)
 
-	// and one with deleted == true
 	so1, err := state.getStateObject(stateobjaddr1, true)
 	require.NoError(t, err)
 	so1.SetBalance(*uint256.NewInt(52), true, tracing.BalanceChangeUnspecified)
@@ -308,13 +286,11 @@ func TestSnapshot2(t *testing.T) {
 
 	so0Restored, err := state.getStateObject(stateobjaddr0, true)
 	require.NoError(t, err)
-	// Update lazily-loaded values before comparing.
+	// Trigger lazy-loaded fields before comparing, or compareStateObjects sees stale values.
 	so0Restored.GetState(storageaddr)
 	so0Restored.Code()
-	// non-deleted is equal (restored)
 	compareStateObjects(so0Restored, so0, t)
 
-	// deleted should be nil, both before and after restore of state copy
 	so1Restored, err := state.getStateObject(stateobjaddr1, true)
 	require.NoError(t, err)
 	if so1Restored != nil && !so1Restored.deleted {
@@ -438,7 +414,6 @@ func TestDump(t *testing.T) {
 	st := New(NewReaderV3(domains.AsGetter(tx)))
 	defer st.Close()
 
-	// generate a few entries
 	obj1, err := st.GetOrNewStateObject(toAddr([]byte{0x01}))
 	require.NoError(t, err)
 	st.AddBalance(toAddr([]byte{0x01}), *uint256.NewInt(22), tracing.BalanceChangeUnspecified)
@@ -451,7 +426,6 @@ func TestDump(t *testing.T) {
 	obj3.SetBalance(*uint256.NewInt(44), true, tracing.BalanceChangeUnspecified)
 
 	w := NewWriter(domains.AsPutDel(tx), nil, txNum)
-	// write some of them to the trie
 	err = w.UpdateAccountData(obj1.address, &obj1.data, new(accounts.Account))
 	require.NoError(t, err)
 	err = w.UpdateAccountData(obj2.address, &obj2.data, new(accounts.Account))
@@ -465,7 +439,6 @@ func TestDump(t *testing.T) {
 	err = domains.Flush(context.Background(), tx)
 	require.NoError(t, err)
 
-	// check that dump contains the state objects that are in trie
 	got := string(NewDumper(tx, rawdbv3.TxNums, 1).DefaultDump())
 	want := `{
     "root": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/execution/state/state_types.go
+++ b/execution/state/state_types.go
@@ -25,46 +25,32 @@ import (
 )
 
 type (
-	// CanTransferFunc is the signature of a transfer guard function
 	CanTransferFunc func(*IntraBlockState, common.Address, *uint256.Int) bool
 
-	// TransferFunc is the signature of a transfer function
 	TransferFunc func(*IntraBlockState, common.Address, common.Address, *uint256.Int, bool)
 
-	// GetHashFunc returns the nth block hash in the blockchain
-	// and is used by the BLOCKHASH EVM op code.
 	GetHashFunc func(uint64) common.Hash
 )
 
-// BlockContext provides the EVM with auxiliary information. Once provided
-// it shouldn't be modified.
 type BlockContext struct {
-	// CanTransfer returns whether the account contains
-	// sufficient ether to transfer the value
 	CanTransfer CanTransferFunc
-	// Transfer transfers ether from one account to the other
-	Transfer TransferFunc
-	// GetHash returns the hash corresponding to n
-	GetHash GetHashFunc
+	Transfer    TransferFunc
+	GetHash     GetHashFunc
 
-	// Block information
-	Coinbase      common.Address // Provides information for COINBASE
-	GasLimit      uint64         // Provides information for GASLIMIT
-	MaxGasLimit   bool           // Use GasLimit override for 2^256-1 (to be compatible with OpenEthereum's trace_call)
-	BlockNumber   uint64         // Provides information for NUMBER
-	Time          uint64         // Provides information for TIME
-	Difficulty    *big.Int       // Provides information for DIFFICULTY
-	BaseFee       *uint256.Int   // Provides information for BASEFEE
-	PrevRanDao    *common.Hash   // Provides information for PREVRANDAO
-	ExcessBlobGas *uint64        // Provides information for handling data blobs
+	Coinbase      common.Address
+	GasLimit      uint64
+	MaxGasLimit   bool // overrides GasLimit to 2^256-1, for compatibility with OpenEthereum's trace_call
+	BlockNumber   uint64
+	Time          uint64
+	Difficulty    *big.Int
+	BaseFee       *uint256.Int
+	PrevRanDao    *common.Hash
+	ExcessBlobGas *uint64
 }
 
-// TxContext provides the EVM with information about a transaction.
-// All fields can change between transactions.
 type TxContext struct {
-	// Message information
 	TxHash     common.Hash
-	Origin     common.Address // Provides information for ORIGIN
-	GasPrice   *uint256.Int   // Provides information for GASPRICE
-	BlobHashes []common.Hash  // Provides versioned blob hashes for BLOBHASH
+	Origin     common.Address
+	GasPrice   *uint256.Int
+	BlobHashes []common.Hash
 }

--- a/execution/state/storage_read_parallel_test.go
+++ b/execution/state/storage_read_parallel_test.go
@@ -35,9 +35,6 @@ func (r *storageReader) ReadAccountStorage(addr accounts.Address, key accounts.S
 	return uint256.Int{}, false, nil
 }
 
-// TestStorageReadParallel_NoMaterialize verifies that a cold storage read on the
-// parallel (versionMap) path returns the committed value without
-// materializing/caching a stateObject.
 func TestStorageReadParallel_NoMaterialize(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xDE, 0xAD})
 	key := accounts.InternKey([32]byte{0x01})
@@ -59,15 +56,12 @@ func TestStorageReadParallel_NoMaterialize(t *testing.T) {
 	assert.Equal(t, uint256.NewInt(42), &v, "cold SLOAD must return the committed value")
 	assert.Empty(t, ibs.stateObjects, "cold parallel SLOAD must not materialize a stateObject")
 
-	// A repeat read hits the recorded ReadSet and must return the same value.
 	v2, err := ibs.GetState(addr, key)
 	require.NoError(t, err)
 	assert.Equal(t, v, v2)
 	assert.Empty(t, ibs.stateObjects, "repeat SLOAD must still not materialize a stateObject")
 }
 
-// TestStorageReadParallel_CommittedRead verifies GetCommittedState on the
-// parallel path also avoids materialization.
 func TestStorageReadParallel_CommittedRead(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xDE, 0xAD})
 	key := accounts.InternKey([32]byte{0x02})

--- a/execution/state/system_call_storage_test.go
+++ b/execution/state/system_call_storage_test.go
@@ -10,39 +10,22 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// TestSystemCallStoragePropagation simulates the serial block loop where
-// a system call (engine.Finalize) reads and writes a system contract's
-// storage each block. The next block's system call should see the previous
-// block's writes via sd.mem.
-//
-// This test verifies that:
-//  1. Serial path: DomainPut writes are visible to the next block's GetLatest
-//  2. Parallel path: BlockStateCache Flush writes are visible to the next
-//     block's CachedReaderV3 fallthrough to GetLatest
-//
-// The test uses a withdrawal request contract pattern: each block reads
-// a queue pointer (slot 4), dequeues a request, and writes a new pointer.
+// TestSystemCallStoragePropagation_DirectDomainPut pins that a system-call
+// write in one block is visible to the next block's read via sd.mem (serial path).
 func TestSystemCallStoragePropagation_DirectDomainPut(t *testing.T) {
-	// This test simulates the serial path: direct DomainPut per block.
-	// Each block's system call reads slot 4, modifies it, writes via DomainPut.
-	// The next block reads the updated value.
-
 	addr := accounts.InternAddress([20]byte{0x00, 0x00, 0x09, 0x61})
 	slot := accounts.InternKey([32]byte{0x04})
 
-	// Simulate 5 blocks with alternating values (like a queue with 2 entries)
 	values := [][]byte{
-		{0x3f, 0x2f, 0x74, 0x24}, // block 0 writes this
-		{0x7c, 0x1f, 0xed, 0x52}, // block 1 writes this
-		{0x3f, 0x2f, 0x74, 0x24}, // block 2 writes this (same as block 0)
-		{0x7c, 0x1f, 0xed, 0x52}, // block 3 writes this
-		{0x3f, 0x2f, 0x74, 0x24}, // block 4 writes this
+		{0x3f, 0x2f, 0x74, 0x24},
+		{0x7c, 0x1f, 0xed, 0x52},
+		{0x3f, 0x2f, 0x74, 0x24},
+		{0x7c, 0x1f, 0xed, 0x52},
+		{0x3f, 0x2f, 0x74, 0x24},
 	}
 
-	// Use a simple map to simulate sd.mem
 	sdMem := map[string][]byte{}
 
-	// Write initial value (from snapshot)
 	composite := make([]byte, 20+32)
 	addrVal := addr.Value()
 	copy(composite, addrVal[:])
@@ -51,30 +34,24 @@ func TestSystemCallStoragePropagation_DirectDomainPut(t *testing.T) {
 	sdMem[string(composite)] = values[0]
 
 	for blockIdx := range 5 {
-		// Read current value (simulates system call reading slot 4)
 		currentVal := sdMem[string(composite)]
 		t.Logf("Block %d: read slot4=%x", blockIdx, currentVal)
 
-		// Verify we read the expected value
 		if blockIdx > 0 {
 			expectedVal := values[blockIdx-1]
-			// After block N writes values[N], block N+1 should read values[N]
 			assert.True(t, bytes.Equal(currentVal, expectedVal),
 				"Block %d should read value written by block %d: got %x, want %x",
 				blockIdx, blockIdx-1, currentVal, expectedVal)
 		}
 
-		// Write new value (simulates system call updating queue pointer)
 		newVal := values[blockIdx]
 		sdMem[string(composite)] = newVal
 		t.Logf("Block %d: wrote slot4=%x", blockIdx, newVal)
 	}
 }
 
-// TestSystemCallStoragePropagation_BlockStateCache simulates the parallel
-// path where system call writes go through BlockStateCache → Flush → sd.mem.
-// Each block gets a fresh BlockStateCache. The Flush writes to sd.mem.
-// The next block reads from sd.mem via the CachedReaderV3 fallthrough.
+// TestSystemCallStoragePropagation_BlockStateCache pins the parallel path:
+// BlockStateCache Flush writes reach sd.mem for the next block to read.
 func TestSystemCallStoragePropagation_BlockStateCache(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x00, 0x00, 0x09, 0x61})
 	slot := accounts.InternKey([32]byte{0x04})
@@ -87,7 +64,6 @@ func TestSystemCallStoragePropagation_BlockStateCache(t *testing.T) {
 		{0x3f, 0x2f, 0x74, 0x24},
 	}
 
-	// Simulate sd.mem with a map
 	sdMem := map[string][]byte{}
 
 	composite := make([]byte, 20+32)
@@ -96,24 +72,19 @@ func TestSystemCallStoragePropagation_BlockStateCache(t *testing.T) {
 	slotVal := slot.Value()
 	copy(composite[20:], slotVal[:])
 
-	// Write initial value
 	sdMem[string(composite)] = values[0]
 
 	for blockIdx := range 5 {
-		// Create a fresh BlockStateCache per block (like the parallel executor)
 		cache := NewBlockStateCache()
 
-		// Read from cache (empty) → fallthrough to sd.mem
 		val, ok := cache.GetCurrentStorage(addr, slot)
 		if !ok {
 			val, ok = cache.GetCommittedStorage(addr, slot)
 		}
 		if !ok {
-			// Fallthrough to sd.mem (simulates ReaderV3.ReadAccountStorage)
 			val = sdMem[string(composite)]
 			ok = len(val) > 0
 			if ok {
-				// Populate committed cache (like CachedReaderV3 does)
 				cache.PutCommittedStorage(addr, slot, val)
 			}
 		}
@@ -125,7 +96,6 @@ func TestSystemCallStoragePropagation_BlockStateCache(t *testing.T) {
 			return "empty"
 		}())
 
-		// Verify we read the expected value
 		if blockIdx > 0 {
 			expectedVal := values[blockIdx-1]
 			assert.True(t, bytes.Equal(val, expectedVal),
@@ -133,13 +103,9 @@ func TestSystemCallStoragePropagation_BlockStateCache(t *testing.T) {
 				blockIdx, blockIdx-1, val, expectedVal)
 		}
 
-		// System call writes new value to cache.
 		newVal := values[blockIdx]
 		cache.WriteStorage(addr, slot, newVal, uint64(blockIdx*100+1))
 
-		// Flush replays writeLog to sd.mem (simulated here as a map). For
-		// each storage write, push the latest value into the simulated
-		// sd.mem at the recorded txNum.
 		for i := range cache.writeLog {
 			op := &cache.writeLog[i]
 			if op.kind != bcOpPutStorage {
@@ -155,17 +121,13 @@ func TestSystemCallStoragePropagation_BlockStateCache(t *testing.T) {
 		}
 	}
 
-	// Final verification: sd.mem should have the last written value
 	finalVal := sdMem[string(composite)]
 	assert.True(t, bytes.Equal(finalVal, values[4]),
 		"Final sd.mem should have last written value: got %x, want %x", finalVal, values[4])
 }
 
-// TestBlockStateCacheStorageWriteLog verifies that WriteStorage appends
-// to writeLog, including the case where a same-value rewrite is logged
-// (system-call storage relies on every write reaching the domain so the
-// commitment trie picks up the touch — DomainPut itself no-ops on
-// identical value).
+// TestBlockStateCacheStorageWriteLog pins that a same-value rewrite still
+// appends to writeLog: the commitment trie needs the touch even though DomainPut no-ops.
 func TestBlockStateCacheStorageWriteLog(t *testing.T) {
 	cache := NewBlockStateCache()
 
@@ -174,30 +136,23 @@ func TestBlockStateCacheStorageWriteLog(t *testing.T) {
 
 	cache.PutCommittedStorage(addr, slot, []byte{0x01})
 
-	// Write same value — must still produce a writeLog entry so Flush
-	// emits a DomainPut and the commitment touch is recorded.
 	cache.WriteStorage(addr, slot, []byte{0x01}, 7)
 	require.Len(t, cache.writeLog, 1)
 	assert.Equal(t, bcOpPutStorage, cache.writeLog[0].kind)
 	assert.Equal(t, uint64(7), cache.writeLog[0].txNum)
 
-	// Different value — second writeLog entry preserved.
 	cache.WriteStorage(addr, slot, []byte{0x02}, 11)
 	require.Len(t, cache.writeLog, 2)
 	assert.Equal(t, uint64(11), cache.writeLog[1].txNum)
 	assert.Equal(t, []byte{0x02}, cache.writeLog[1].val)
 
-	// Current view returns the latest write.
 	val, ok := cache.GetCurrentStorage(addr, slot)
 	require.True(t, ok)
 	assert.Equal(t, []byte{0x02}, val, "Should have the latest value")
 }
 
-// TestBlockStateCacheWriteLogPerTxNum verifies the system-call storage
-// flow: the Flush replays per-tx writes against sd.mem with each entry's
-// recorded txNum, so the StorageDomain history retains per-tx
-// granularity that intra-block GetAsOf readers (commitment domain,
-// debug RPCs) depend on.
+// TestBlockStateCacheWriteLogPerTxNum pins that Flush replays each write at
+// its own recorded txNum, preserving per-tx granularity for GetAsOf readers.
 func TestBlockStateCacheWriteLogPerTxNum(t *testing.T) {
 	cache := NewBlockStateCache()
 

--- a/execution/state/transient_stale_read_test.go
+++ b/execution/state/transient_stale_read_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// fieldReader returns a fixed committed account (+ optional code) for one addr.
 type fieldReader struct {
 	emptyReader
 	addr    accounts.Address
@@ -44,22 +43,17 @@ func (r *fieldReader) ReadAccountCodeSize(addr accounts.Address) (int, error) {
 	return 0, nil
 }
 
-// TestTransientStale_FieldGettersPreferCells pins that, on the noMaterialize
-// (parallel) path, every account-field getter reads the per-field versionMap
-// cell — not the AddressPath account record, which a prior tx can publish stale
-// (its Nonce/CodeHash lagging the field cells). A later tx must see the cells.
+// Field getters on the noMaterialize path must read the versionMap's per-field cell, not a stale AddressPath record.
 func TestTransientStale_FieldGettersPreferCells(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x35, 0x85, 0x97, 0xa2})
 	delegationCode := types.AddressToDelegation(accounts.InternAddress([20]byte{0x55, 0xe5, 0xb3, 0x85}))
 	delegHash := accounts.InternCodeHash(crypto.Keccak256Hash(delegationCode))
 
-	committed := accounts.NewAccount() // committed EOA: nonce 0, no code
+	committed := accounts.NewAccount()
 	reader := &fieldReader{addr: addr, account: &committed}
 
 	vm := NewVersionMap(nil)
 
-	// tx1 (TxIndex=1) publishes a STALE AddressPath account record (nonce 0,
-	// empty codehash, zero balance) alongside NEWER per-field cells.
 	stale := accounts.NewAccount()
 	v1 := Version{TxIndex: 1, Incarnation: 0}
 	vm.WriteAddress(addr, v1, &stale, true)
@@ -100,28 +94,21 @@ func TestTransientStale_FieldGettersPreferCells(t *testing.T) {
 	assert.Equal(t, uint64(3), inc, "incarnation must come from the IncarnationPath cell")
 }
 
-// TestTransientStale_GetDelegatedDesignation is the warm-callcode consensus
-// regression. A prior tx published an AddressPath account record with an EMPTY
-// code hash (stale) alongside CodePath/CodeHashPath cells carrying a delegation.
-// GetDelegatedDesignation goes through getStateObject, which on the noMaterialize
-// path rebuilds a transient from the AddressPath record. It must reconcile the
-// transient's code with the CodePath cell — otherwise it sees empty code,
-// reports "not delegated", the EIP-7702 authorization is skipped, the delegation
-// persists, and a later CALL runs the delegated code and runs out of gas
-// (execution over-counts gas, producing a wrong receipt/trie root).
+// GetDelegatedDesignation must reconcile a transient rebuilt from a stale
+// AddressPath record with the CodePath cell, or it misses an active EIP-7702 delegation.
 func TestTransientStale_GetDelegatedDesignation(t *testing.T) {
 	authority := accounts.InternAddress([20]byte{0x35, 0x85, 0x97, 0xa2})
 	target := accounts.InternAddress([20]byte{0x55, 0xe5, 0xb3, 0x85})
 	delegationCode := types.AddressToDelegation(target)
 	delegHash := accounts.InternCodeHash(crypto.Keccak256Hash(delegationCode))
 
-	reader := &fieldReader{addr: authority, account: nil} // committed: absent
+	reader := &fieldReader{addr: authority, account: nil}
 
 	vm := NewVersionMap(nil)
 
 	stale := accounts.NewAccount()
 	stale.Nonce = 1
-	stale.CodeHash = accounts.EmptyCodeHash // stale — lags the CodeHashPath cell
+	stale.CodeHash = accounts.EmptyCodeHash
 	v1 := Version{TxIndex: 1, Incarnation: 0}
 	vm.WriteAddress(authority, v1, &stale, true)
 	vm.WriteNonce(authority, v1, uint64(1), true)
@@ -141,21 +128,15 @@ func TestTransientStale_GetDelegatedDesignation(t *testing.T) {
 	assert.Empty(t, ibs.stateObjects, "GetDelegatedDesignation must not materialize a stateObject")
 }
 
-// TestCrossTxSelfDestruct_CodeReadsEmpty pins that an account self-destructed by
-// a PRIOR tx reads empty CODE, consistent with its empty code hash. The
-// version-map self-destruct gate must cover CodePath as well as CodeHashPath;
-// excluding CodePath let a later tx read the stale committed code alongside the
-// (correctly) empty code hash — a CALL then executed the destroyed contract and
-// over-counted gas, producing a wrong trie root.
+// An account self-destructed by a prior tx must read empty code: the self-destruct gate must cover CodePath, not only CodeHashPath.
 func TestCrossTxSelfDestruct_CodeReadsEmpty(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x4d, 0x95, 0xfb, 0xaf})
-	code := []byte{0x60, 0x60, 0x60, 0x40, 0x52, 0x00} // non-empty committed code
+	code := []byte{0x60, 0x60, 0x60, 0x40, 0x52, 0x00}
 	committed := accounts.NewAccount()
 	committed.CodeHash = accounts.InternCodeHash(crypto.Keccak256Hash(code))
 	reader := &fieldReader{addr: addr, account: &committed, code: code}
 
 	vm := NewVersionMap(nil)
-	// tx1 self-destructs the account; no later revival.
 	vm.WriteSelfDestruct(addr, Version{TxIndex: 1, Incarnation: 0}, true, true)
 
 	ibs := NewWithVersionMap(reader, vm)
@@ -177,22 +158,16 @@ func TestCrossTxSelfDestruct_CodeReadsEmpty(t *testing.T) {
 	assert.Zero(t, sz, "code size must be 0")
 }
 
-// TestCrossTxIncarnationBump_CodeReadsEmpty pins that when a prior tx bumps an
-// account's Incarnation and clears its code hash but writes no CodePath cell, a
-// later tx reads empty code — not the stale committed code — consistent with the
-// empty code hash. The incarnation-zeroing gate must cover CodePath, not only
-// StoragePath; otherwise a CALL executes a destroyed contract and over-counts gas.
+// An incarnation bump that clears CodeHash but writes no CodePath cell must still read empty code, not the stale committed bytes.
 func TestCrossTxIncarnationBump_CodeReadsEmpty(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x4d, 0x95, 0xfb, 0xaf})
-	code := []byte{0x60, 0x60, 0x60, 0x40, 0x52, 0x00} // committed code from a prior block
+	code := []byte{0x60, 0x60, 0x60, 0x40, 0x52, 0x00}
 	committed := accounts.NewAccount()
 	committed.Incarnation = 1
 	committed.CodeHash = accounts.InternCodeHash(crypto.Keccak256Hash(code))
 	reader := &fieldReader{addr: addr, account: &committed, code: code}
 
 	vm := NewVersionMap(nil)
-	// tx1 bumps the incarnation and clears the code hash, but writes no CodePath
-	// cell (no revival).
 	v1 := Version{TxIndex: 1, Incarnation: 0}
 	vm.WriteIncarnation(addr, v1, uint64(2), true)
 	vm.WriteCodeHash(addr, v1, accounts.EmptyCodeHash, true)

--- a/execution/state/transient_storage.go
+++ b/execution/state/transient_storage.go
@@ -24,15 +24,13 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// transientStorage is a representation of EIP-1153 "Transient Storage".
+// transientStorage implements EIP-1153 transient storage.
 type transientStorage map[accounts.Address]Storage
 
-// newTransientStorage creates a new instance of a transientStorage.
 func newTransientStorage() transientStorage {
 	return make(transientStorage)
 }
 
-// Set sets the transient-storage `value` for `key` at the given `addr`.
 func (t transientStorage) Set(addr accounts.Address, key accounts.StorageKey, value uint256.Int) {
 	slots, ok := t[addr]
 	if value.IsZero() {
@@ -50,7 +48,6 @@ func (t transientStorage) Set(addr accounts.Address, key accounts.StorageKey, va
 	slots[key] = value
 }
 
-// Get gets the transient storage for `key` at the given `addr`.
 func (t transientStorage) Get(addr accounts.Address, key accounts.StorageKey) uint256.Int {
 	val, ok := t[addr]
 	if !ok {

--- a/execution/state/triedb_state.go
+++ b/execution/state/triedb_state.go
@@ -18,39 +18,23 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// Buffer is a structure holding updates, deletes, and reads registered within one change period
-// A change period can be transaction within a block, or a block within group of blocks
+// Buffer holds updates/deletes/reads for one change period — a tx within a block, or a block within a group.
 type Buffer struct {
 	codeReads     map[common.Hash]witnesstypes.CodeWithHash
 	codeSizeReads map[common.Hash]common.Hash
 	codeUpdates   map[common.Hash][]byte
-	// storageUpdates structure collects the effects of the block (or transaction) execution. It does not necessarily
-	// include all the intermediate reads and write that happened. For example, if the storage of some contract has
-	// been modified, and then the contract has subsequently self-destructed, this structure will not contain any
-	// keys related to the storage of this contract, because they are irrelevant for the final state
+	// storageUpdates holds only the final effect; a self-destructed contract's prior writes are dropped as irrelevant.
 	storageUpdates     map[common.Hash]map[common.Hash][]byte
 	storageIncarnation map[common.Hash]uint64
-	// storageReads structure collects all the keys of items that have been modified (or also just read, if the
-	// tds.resolveReads flag is turned on, which happens during the generation of block witnesses).
-	// Even if the final results of the execution do not include some items, they will still be present in this structure.
-	// For example, if the storage of some contract has been modified, and then the contract has subsequently self-destructed,
-	// this structure will contain all the keys that have been modified or deleted prior to the self-destruction.
-	// It is important to keep them because they will be used to apply changes to the trie one after another.
-	// There is a potential for optimisation - we may actually skip all the intermediate modification of the trie if
-	// we know that in the end, the entire storage will be dropped. However, this optimisation has not yet been
-	// implemented.
-	storageReads map[common.StorageKey][]byte
-	// accountUpdates structure collects the effects of the block (or transaxction) execution.
-	accountUpdates map[common.Hash]witnesstypes.AccountWithAddress
-	// accountReads structure collects all the address hashes of the accounts that have been modified (or also just read,
-	// if tds.resolveReads flag is turned on, which happens during the generation of block witnesses).
+	// storageReads keeps every touched key, including ones storageUpdates drops after a self-destruct, to replay trie changes in order.
+	storageReads            map[common.StorageKey][]byte
+	accountUpdates          map[common.Hash]witnesstypes.AccountWithAddress
 	accountReads            map[common.Hash]accounts.Address
 	accountReadsIncarnation map[common.Hash]uint64
 	deleted                 map[common.Hash]accounts.Address
 	created                 map[common.Hash]accounts.Address
 }
 
-// Prepares buffer for work or clears previous data
 func (b *Buffer) initialise() {
 	b.codeReads = make(map[common.Hash]witnesstypes.CodeWithHash)
 	b.codeSizeReads = make(map[common.Hash]common.Hash)
@@ -65,7 +49,6 @@ func (b *Buffer) initialise() {
 	b.created = make(map[common.Hash]accounts.Address)
 }
 
-// Replaces account pointer with pointers to the copies
 func (b *Buffer) detachAccounts() {
 	for addrHash, accountWithAddress := range b.accountUpdates {
 		address := accountWithAddress.Address
@@ -76,7 +59,6 @@ func (b *Buffer) detachAccounts() {
 	}
 }
 
-// Merges the content of another buffer into this one
 func (b *Buffer) merge(other *Buffer) {
 	maps.Copy(b.codeReads, other.codeReads)
 
@@ -122,11 +104,11 @@ type TrieDbState struct {
 	rl                *trie.RetainList
 	blockNr           uint64
 	buffers           []*Buffer
-	aggregateBuffer   *Buffer // Merge of all buffers
+	aggregateBuffer   *Buffer
 	currentBuffer     *Buffer
 	resolveReads      bool
 	retainListBuilder *trie.RetainListBuilder
-	incarnationMap    map[accounts.Address]uint64 // Temporary map of incarnation for the cases when contracts are deleted and recreated within 1 block
+	incarnationMap    map[accounts.Address]uint64 // tracks incarnation across a delete+recreate of the same contract within one block
 }
 
 func NewTrieDbState(root common.Hash, blockNr uint64, stateReader StateReader) *TrieDbState {
@@ -247,8 +229,7 @@ func (tds *TrieDbState) LastRoot() common.Hash {
 	return tds.t.Hash()
 }
 
-// UpdateStateTrie assumes that the state trie is already fully resolved, i.e. any operations
-// will find necessary data inside the trie.
+// UpdateStateTrie assumes the trie is already fully resolved.
 func (tds *TrieDbState) UpdateStateTrie() ([]common.Hash, error) {
 	tds.tMu.Lock()
 	defer tds.tMu.Unlock()
@@ -269,7 +250,6 @@ func (tds *TrieDbState) buildPlainStorageReads() ([][]byte, [][]byte) {
 	storageHashedKeys := make([][]byte, 0, len(tds.aggregateBuffer.storageReads))
 
 	for storageHashedKey, storagePlainKey := range tds.aggregateBuffer.storageReads {
-		// to prevent variable capture in Go 1.21
 		storagePlainKeyCopy := make([]byte, len(storagePlainKey))
 		copy(storagePlainKeyCopy, storagePlainKey)
 		storageHashedKeyCopy := make([]byte, len(storageHashedKey))
@@ -278,18 +258,15 @@ func (tds *TrieDbState) buildPlainStorageReads() ([][]byte, [][]byte) {
 		storageHashedKeys = append(storageHashedKeys, storageHashedKeyCopy)
 	}
 
-	// Create a slice of indices to track original positions
 	indices := make([]int, len(storagePlainKeys))
 	for i := range indices {
 		indices[i] = i
 	}
 
-	// Sort indices based on accountAddresses
 	slices.SortStableFunc(indices, func(a, b int) int {
 		return bytes.Compare(storagePlainKeys[a], storagePlainKeys[b])
 	})
 
-	// Apply the sorted order to accountAddresses and accountAddressHashes
 	sortedStoragePlainKeys := make([][]byte, len(storagePlainKeys))
 	sortedStorageHashedKeys := make([][]byte, len(storageHashedKeys))
 	for i, idx := range indices {
@@ -299,13 +276,7 @@ func (tds *TrieDbState) buildPlainStorageReads() ([][]byte, [][]byte) {
 	return sortedStorageHashedKeys, sortedStoragePlainKeys
 }
 
-// BuildStorageReads builds a sorted list of all storage key hashes that were modified
-// (or also just read, if tds.resolveReads flag is turned on) within the
-// period for which we are aggregating updates. It includes the keys of items that
-// were nullified by subsequent updates - best example is the
-// self-destruction of a contract, which nullifies all previous
-// modifications of the contract's storage. In such case, all previously modified storage
-// item updates would be inclided.
+// BuildStorageReads returns all touched storage key hashes, sorted.
 func (tds *TrieDbState) BuildStorageReads() common.StorageKeys {
 	storageTouches := make(common.StorageKeys, 0, len(tds.aggregateBuffer.storageReads))
 	for storageKey := range tds.aggregateBuffer.storageReads {
@@ -315,7 +286,6 @@ func (tds *TrieDbState) BuildStorageReads() common.StorageKeys {
 	return storageTouches
 }
 
-// Populate pending block proof so that it will be sufficient for accessing all storage slots in storageTouches
 func (tds *TrieDbState) PopulateStorageBlockProof(storageTouches common.StorageKeys) error { //nolint
 	for _, storageKey := range storageTouches {
 		addr, _, hash := dbutils.ParseCompositeStorageKey(storageKey[:])
@@ -329,9 +299,6 @@ func (tds *TrieDbState) BuildCodeTouches() map[common.Hash]witnesstypes.CodeWith
 	return tds.aggregateBuffer.codeReads
 }
 
-// BuildAccountReads builds a sorted list of all address hashes that were modified
-// (or also just read, if tds.resolveReads flags is turned one) within the
-// period for which we are aggregating update
 func (tds *TrieDbState) BuildAccountReads() common.Hashes {
 	accountTouches := make(common.Hashes, 0, len(tds.aggregateBuffer.accountReads))
 	for addrHash := range tds.aggregateBuffer.accountReads {
@@ -354,18 +321,15 @@ func (tds *TrieDbState) buildAccountAddressReads() ([][]byte, [][]byte) {
 		accountAddressHashes = append(accountAddressHashes, addrHash[:])
 	}
 
-	// Create a slice of indices to track original positions
 	indices := make([]int, len(accountAddresses))
 	for i := range indices {
 		indices[i] = i
 	}
 
-	// Sort indices based on accountAddresses
 	slices.SortStableFunc(indices, func(a, b int) int {
 		return bytes.Compare(accountAddresses[a], accountAddresses[b])
 	})
 
-	// Apply the sorted order to accountAddresses and accountAddressHashes
 	sortedAccountAddresses := make([][]byte, len(accountAddresses))
 	sortedAccountAddressHashes := make([][]byte, len(accountAddressHashes))
 	for i, idx := range indices {
@@ -373,7 +337,6 @@ func (tds *TrieDbState) buildAccountAddressReads() ([][]byte, [][]byte) {
 		sortedAccountAddressHashes[i] = accountAddressHashes[idx]
 	}
 
-	// Check if sorting is correct
 	for i := range sortedAccountAddresses {
 		addrHash := sortedAccountAddressHashes[i]
 		accountAddress := sortedAccountAddresses[i]
@@ -393,9 +356,7 @@ func (tds *TrieDbState) PopulateAccountBlockProof(accountTouches common.Hashes) 
 	}
 }
 
-// ExtractTouches returns two lists of keys - for accounts and storage items correspondingly
-// Each list is the collection of keys that have been "touched" (inserted, updated, or simply accessed)
-// since the last invocation of `ExtractTouches`.
+// ExtractTouches returns account and storage keys touched since the last call.
 func (tds *TrieDbState) ExtractTouches() (accountTouches [][]byte, storageTouches [][]byte) {
 	return tds.retainListBuilder.ExtractTouches()
 }
@@ -404,10 +365,8 @@ func (tds *TrieDbState) GetRetainList() *trie.RetainList {
 	return tds.retainListBuilder.Build(false)
 }
 
-// Get list of account and storage touches
-// First come the account touches then the storage touches
+// GetTouchedPlainKeys returns account touches before storage touches in both slices.
 func (tds *TrieDbState) GetTouchedPlainKeys() (plainKeys [][]byte, hashedKeys [][]byte) {
-	// Aggregating the current buffer, if any
 	if tds.currentBuffer != nil {
 		if tds.aggregateBuffer == nil {
 			tds.aggregateBuffer = &Buffer{}
@@ -438,30 +397,20 @@ func (tds *TrieDbState) ResolveBuffer() {
 	}
 }
 
-// forward is `true` if the function is used to progress the state forward (by adding blocks)
-// forward is `false` if the function is used to rewind the state (for reorgs, for example)
+// forward is false when rewinding the state during a reorg; per-buffer roots populate receipt.PostState on pre-Byzantium chains.
 func (tds *TrieDbState) updateTrieRoots(forward bool) ([]common.Hash, error) {
-	// Perform actual updates on the tries, and compute one trie root per buffer
-	// These roots can be used to populate receipt.PostState on pre-Byzantium
 	roots := make([]common.Hash, len(tds.buffers))
 	for i, b := range tds.buffers {
-		// For the contracts that got deleted, we clear the storage
 		for addrHash := range b.deleted {
-			// The only difference between Delete and DeleteSubtree is that Delete would delete accountNode too,
-			// wherewas DeleteSubtree will keep the accountNode, but will make the storage sub-trie empty
+			// DeleteSubtree clears the storage sub-trie but keeps the accountNode, unlike Delete.
 			tds.t.DeleteSubtree(addrHash[:])
 		}
-		// New contracts are being created at these addresses. Therefore, we need to clear the storage items
-		// that might be remaining in the trie and figure out the next incarnations
 		for addrHash := range b.created {
-			// The only difference between Delete and DeleteSubtree is that Delete would delete accountNode too,
-			// wherewas DeleteSubtree will keep the accountNode, but will make the storage sub-trie empty
 			tds.t.DeleteSubtree(addrHash[:])
 		}
 
 		for addrHash, accountWithAddress := range b.accountUpdates {
 			if accountWithAddress.Account != nil {
-				//fmt.Println("updateTrieRoots b.accountUpdates", addrHash.String(), account.Incarnation)
 				tds.t.UpdateAccount(addrHash[:], accountWithAddress.Account)
 			} else {
 				tds.t.Delete(addrHash[:])
@@ -477,15 +426,10 @@ func (tds *TrieDbState) updateTrieRoots(forward bool) ([]common.Hash, error) {
 			for keyHash, v := range m {
 				cKey := dbutils.GenerateCompositeTrieKey(addrHash, keyHash)
 				if len(v) > 0 {
-					//fmt.Printf("Update storage trie addrHash %x, keyHash %x: %x\n", addrHash, keyHash, v)
 					if forward {
 						tds.t.Update(cKey, v)
 					} else {
-						// If rewinding, it might not be possible to execute storage item update.
-						// If we rewind from the state where a contract does not exist anymore (it was self-destructed)
-						// to the point where it existed (with storage), then rewinding to the point of existence
-						// will not bring back the full storage trie. Instead there will be one hashNode.
-						// So we probe for this situation first
+						// Rewinding past a self-destruct can leave only a hashNode, so probe with Get before Update/Delete.
 						if _, ok := tds.t.Get(cKey); ok {
 							tds.t.Update(cKey, v)
 						}
@@ -494,11 +438,6 @@ func (tds *TrieDbState) updateTrieRoots(forward bool) ([]common.Hash, error) {
 					if forward {
 						tds.t.Delete(cKey)
 					} else {
-						// If rewinding, it might not be possible to execute storage item update.
-						// If we rewind from the state where a contract does not exist anymore (it was self-destructed)
-						// to the point where it existed (with storage), then rewinding to the point of existence
-						// will not bring back the full storage trie. Instead there will be one hashNode.
-						// So we probe for this situation first
 						if _, ok := tds.t.Get(cKey); ok {
 							tds.t.Delete(cKey)
 						}
@@ -510,9 +449,7 @@ func (tds *TrieDbState) updateTrieRoots(forward bool) ([]common.Hash, error) {
 				ok, root := tds.t.DeepHash(addrHash[:])
 				if ok {
 					accountWithAddress.Account.Root = root
-					//fmt.Printf("(b)Set %x root for addrHash %x\n", root, addrHash)
 				} else {
-					//fmt.Printf("(b)Set empty root for addrHash %x\n", addrHash)
 					accountWithAddress.Account.Root = trie.EmptyRoot
 				}
 			}
@@ -614,13 +551,11 @@ func (tds *TrieDbState) ReadAccountStorage(address accounts.Address, key account
 func (tds *TrieDbState) HasStorage(address accounts.Address) (bool, error) {
 	addressValue := address.Value()
 	addrHash := crypto.Keccak256Hash(addressValue[:])
-	// check if we know about any storage updates with non-empty values
 	for _, v := range tds.currentBuffer.storageUpdates[addrHash] {
 		if len(v) > 0 {
 			return true, nil
 		}
 	}
-	// fallback to underlying state reader if we don't know of non-empty storage slots yet
 	return tds.StateReader.HasStorage(address)
 }
 
@@ -647,9 +582,7 @@ func (tds *TrieDbState) ReadAccountCode(address accounts.Address) (code []byte, 
 	}
 	if tds.resolveReads {
 		tds.currentBuffer.accountReads[addrHash] = address
-		// we have to be careful, because the code might change
-		// during the block executuion, so we are always
-		// storing the latest code hash
+		// Recomputes the hash each time since code can change mid-block.
 		codeHash := accounts.InternCodeHash(crypto.Keccak256Hash(code))
 		tds.currentBuffer.codeReads[addrHash] = witnesstypes.CodeWithHash{Code: code, CodeHash: codeHash}
 		tds.retainListBuilder.ReadCode(codeHash, code)
@@ -669,7 +602,7 @@ func (tds *TrieDbState) ReadAccountCodeSize(address accounts.Address) (codeSize 
 		}
 	}
 	if tds.resolveReads {
-		// We will need to read the code explicitly to make sure code is in the witness
+		// Reads the code explicitly (discarding it) so the code itself ends up in the witness too.
 		code, err := tds.ReadAccountCode(address)
 		if err != nil {
 			return 0, err
@@ -678,11 +611,7 @@ func (tds *TrieDbState) ReadAccountCodeSize(address accounts.Address) (codeSize 
 		codeHash := crypto.Keccak256Hash(code)
 
 		tds.currentBuffer.accountReads[addrHash] = address
-		// we have to be careful, because the code might change
-		// during the block executuion, so we are always
-		// storing the latest code hash
 		tds.currentBuffer.codeSizeReads[addrHash] = codeHash
-		// FIXME: support codeSize in witnesses if makes sense
 		tds.retainListBuilder.ReadCode(accounts.InternCodeHash(codeHash), code)
 	}
 	return codeSize, nil
@@ -722,7 +651,7 @@ func (tsw *TrieStateWriter) UpdateAccountData(address accounts.Address, original
 func (tsw *TrieStateWriter) DeleteAccount(address accounts.Address, original *accounts.Account) error {
 	addressValue := address.Value()
 	addrHash := crypto.Keccak256Hash(addressValue[:])
-	tsw.tds.currentBuffer.accountUpdates[addrHash] = witnesstypes.AccountWithAddress{Address: addressValue, Account: original} // TODO: might be needed to use *AccountWithAddress to point to nil
+	tsw.tds.currentBuffer.accountUpdates[addrHash] = witnesstypes.AccountWithAddress{Address: addressValue, Account: original}
 	tsw.tds.currentBuffer.accountReads[addrHash] = address
 	if original != nil {
 		tsw.tds.currentBuffer.accountReadsIncarnation[addrHash] = original.Incarnation
@@ -766,18 +695,15 @@ func (tsw *TrieStateWriter) WriteAccountStorage(address accounts.Address, incarn
 	storagePlainKey := dbutils.GenerateStoragePlainKey(addressValue, keyValue)
 	tsw.tds.currentBuffer.storageReads[storageKey] = storagePlainKey
 	m[seckey] = v
-	//fmt.Printf("WriteAccountStorage %x %x: %x, buffer %d\n", addrHash, seckey, value, len(tsw.tds.buffers))
 	return nil
 }
 
-// ExtractWitness produces block witness for the block just been processed, in a serialised form
 func (tds *TrieDbState) ExtractWitness(trace bool, isBinary bool) (*trie.Witness, error) {
 	rs := tds.retainListBuilder.Build(isBinary)
 
 	return tds.makeBlockWitness(trace, rs, isBinary)
 }
 
-// ExtractWitness produces block witness for the block just been processed, in a serialised form
 func (tds *TrieDbState) ExtractWitnessForPrefix(prefix []byte, trace bool, isBinary bool) (*trie.Witness, error) {
 	rs := tds.retainListBuilder.Build(isBinary)
 
@@ -789,9 +715,6 @@ func (tds *TrieDbState) makeBlockWitnessForPrefix(prefix []byte, trace bool, rl 
 	defer tds.tMu.Unlock()
 
 	t := tds.t
-	// if isBinary {
-	// 	t = trie.HexToBin(tds.t).Trie()
-	// }
 
 	return t.ExtractWitnessForPrefix(prefix, trace, rl)
 }
@@ -801,9 +724,6 @@ func (tds *TrieDbState) makeBlockWitness(trace bool, rl trie.RetainDecider, isBi
 	defer tds.tMu.Unlock()
 
 	t := tds.t
-	// if isBinary {
-	// 	t = trie.HexToBin(tds.t).Trie()
-	// }
 
 	return t.ExtractWitness(trace, rl)
 }

--- a/execution/state/versioned_read_bench_test.go
+++ b/execution/state/versioned_read_bench_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// BenchmarkVersionedReadGetters measures per-call allocs for GetNonce/GetBalance/GetState
-// when the IBS is backed by a VersionMap (parallel execution path).
 func BenchmarkVersionedReadGetters(b *testing.B) {
 	_, tx, domains := NewTestRwTx(b)
 	_ = tx
@@ -20,13 +18,11 @@ func BenchmarkVersionedReadGetters(b *testing.B) {
 	addr := accounts.InternAddress([20]byte{0x01})
 	key := accounts.InternKey([32]byte{0x01})
 
-	// Seed version map: tx 0 wrote nonce, balance, storage
 	v0 := Version{TxIndex: 0, Incarnation: 1}
 	mvhm.WriteNonce(addr, v0, uint64(42), true)
 	mvhm.WriteBalance(addr, v0, *uint256.NewInt(100), true)
 	mvhm.WriteStorage(addr, key, v0, *uint256.NewInt(123), true)
 
-	// tx 1 reads → hits MapRead path inside versionedRead
 	s := NewWithVersionMap(reader, mvhm)
 	defer s.Close()
 	s.txIndex = 1
@@ -53,10 +49,7 @@ func BenchmarkVersionedReadGetters(b *testing.B) {
 	})
 }
 
-// BenchmarkWarmExtCodeHash measures the warm EXTCODEHASH opcode sequence
-// (Empty + GetCodeHash) on the noMaterialize/versionMap path — the hot path of
-// the warm-extcodehash perf cell. After the first iteration the reads hit the
-// read-once fast-path, so this isolates the steady-state warm-read cost + allocs.
+// Isolates steady-state warm-read cost: after the first Empty+GetCodeHash the reads hit the read-once fast path.
 func BenchmarkWarmExtCodeHashSeq(b *testing.B) {
 	_, tx, domains := NewTestRwTx(b)
 	mvhm := NewVersionMap(nil)
@@ -74,7 +67,6 @@ func BenchmarkWarmExtCodeHashSeq(b *testing.B) {
 	s := NewWithVersionMap(reader, mvhm)
 	s.SetNoMaterialize(true)
 	s.txIndex = 1
-	// warm the read-set (first EXTCODEHASH)
 	_, _ = s.Empty(addr)
 	_, _ = s.GetCodeHash(addr)
 

--- a/execution/state/versioned_read_paths_test.go
+++ b/execution/state/versioned_read_paths_test.go
@@ -12,31 +12,17 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// These tests pin the observable behavior of the versioned read across its
-// distinct branches (non-generic core + per-path read* wrappers) so a
-// restructure can be validated against an identical surface.
-
-// ------------------------------------------------------------------
-// Section A: versionMap == nil (legacy / serial path)
-// ------------------------------------------------------------------
-
-// legacy path with a backing stateObject returns the storage value.
 func TestVersionedRead_A1_LegacyWithStorage(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress([20]byte{0xa1})
 
-	// IBS without versionMap → legacy/serial path
 	ibs := New(&emptyReader{})
 	defer ibs.Close()
 	bal, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
-	// emptyReader returns nil account → zero balance, no error
 	assert.True(t, bal.IsZero(), "legacy path with empty reader returns zero")
 }
 
-// legacy path, GetCode triggers the readStorage==nil branch.
-// (When versionMap is nil, getStateObject is consulted directly; readStorage
-// closure on CodePath is non-nil so this exercises the storage branch too.)
 func TestVersionedRead_A2_LegacyGetCodeReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress([20]byte{0xa2})
@@ -48,13 +34,7 @@ func TestVersionedRead_A2_LegacyGetCodeReturnsEmpty(t *testing.T) {
 	assert.Empty(t, code, "empty reader => empty code")
 }
 
-// ------------------------------------------------------------------
-// Section B: deleted stateObject short-circuit
-// ------------------------------------------------------------------
-
-// B: a deleted stateObject in the local map short-circuits to defaultV.
-// We trigger this by Selfdestruct-ing the address inside the same IBS,
-// then reading another field (which sees so.deleted in the local map).
+// Selfdestructing then reading another field triggers the local-map deleted short-circuit.
 func TestVersionedRead_B_DeletedStateObjectReturnsDefault(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -65,25 +45,16 @@ func TestVersionedRead_B_DeletedStateObjectReturnsDefault(t *testing.T) {
 	ibs.SetTxContext(1, 0)
 
 	addr := accounts.InternAddress(common.HexToAddress("0xdead"))
-	// Create + selfdestruct → state object marked deleted at FinalizeTx
 	ibs.CreateAccount(addr, true)
 	err := ibs.SetBalance(addr, *uint256.NewInt(50), 0)
 	require.NoError(t, err)
 	_, err = ibs.Selfdestruct(addr, false)
 	require.NoError(t, err)
-	// After Selfdestruct, GetBalance on the same address returns zero per
-	// EIP semantics (deleted in this tx).
 	bal, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
 	assert.True(t, bal.IsZero(), "balance after selfdestruct is zero")
 }
 
-// ------------------------------------------------------------------
-// Section C: SelfDestruct active in versionMap
-// ------------------------------------------------------------------
-
-// a prior tx marked the address selfdestructed (in versionMap), then
-// GetCommittedState (committed=true) must return zero immediately.
 func TestVersionedRead_C5_DestructedCommittedReturnsZero(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -95,20 +66,14 @@ func TestVersionedRead_C5_DestructedCommittedReturnsZero(t *testing.T) {
 
 	addr := accounts.InternAddress([20]byte{0xc5})
 	key := accounts.InternKey([32]byte{0x01})
-	// tx 1 wrote a slot value
 	mvhm.WriteStorage(addr, key, Version{TxIndex: 1, Incarnation: 0}, *uint256.NewInt(99), true)
-	// tx 2 selfdestructed the account
 	mvhm.WriteSelfDestruct(addr, Version{TxIndex: 2, Incarnation: 0}, true, true)
 
-	// Read at tx 5 with committed=true: must return zero, ignoring slot value.
 	v, err := ibs.GetCommittedState(addr, key)
 	require.NoError(t, err)
 	assert.True(t, v.IsZero(), "committed read past selfdestruct returns zero")
 }
 
-// a prior tx marked the address selfdestructed; non-committed read
-// at a path != CodePath records the SelfDestructPath dependency in the
-// readSet and returns zero.
 func TestVersionedRead_C6_DestructedRecordsDepAndReturnsZero(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -125,14 +90,11 @@ func TestVersionedRead_C6_DestructedRecordsDepAndReturnsZero(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, bal.IsZero(), "non-committed balance read past selfdestruct returns zero")
 
-	// SelfDestructPath dep must be recorded in readSet.
 	_, ok := ibs.versionedReads.getHeader(addr, SelfDestructPath, accounts.NilKey)
 	assert.True(t, ok, "SelfDestructPath dependency must be recorded")
 }
 
-// CodePath is exempt from the SelfDestruct short-circuit. Even if SD
-// is active, a CodePath read must fall through to the actual code-read
-// branches rather than returning zero.
+// CodePath is exempt from the SelfDestruct short-circuit and must fall through to the real code-read branch.
 func TestVersionedRead_C4_CodePathBypassesSelfDestruct(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -145,8 +107,7 @@ func TestVersionedRead_C4_CodePathBypassesSelfDestruct(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xc4})
 	code := []byte{0x60, 0x42, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3}
 	mvhm.WriteCode(addr, Version{TxIndex: 2, Incarnation: 0}, accounts.NewCode(code), true)
-	// Selfdestruct at an EARLIER tx than the code write so the SD doesn't
-	// trump the code (the CodePath+SD trump check uses sdres.DepIdx).
+	// SD is earlier than the code write here, so it doesn't trump the code (trump check uses sdres.DepIdx).
 	mvhm.WriteSelfDestruct(addr, Version{TxIndex: 1, Incarnation: 0}, true, true)
 
 	got, err := ibs.GetCode(addr)
@@ -154,9 +115,7 @@ func TestVersionedRead_C4_CodePathBypassesSelfDestruct(t *testing.T) {
 	assert.Equal(t, code, got, "CodePath should bypass SelfDestruct short-circuit")
 }
 
-// revival. After SelfDestruct, a later write to Balance / Nonce /
-// CodeHash at a higher txIndex revives the account. Subsequent reads must
-// see the revived value, not zero.
+// A write to Balance/Nonce/CodeHash after a SelfDestruct, at a higher txIndex, revives the account.
 func TestVersionedRead_C1_RevivalViaBalance(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -176,14 +135,8 @@ func TestVersionedRead_C1_RevivalViaBalance(t *testing.T) {
 	assert.Equal(t, *revivedBalance, bal, "balance after revival must be the revived value, not zero")
 }
 
-// Regression for the refresh* wrappers' missing outcomeReturnZero case: after a
-// self-destruct, the per-field refresh (refreshBalance/refreshNonce/
-// refreshIncarnation/refreshCodeHash, the per-field account refresh that rebuilds
-// an account) must return the typed ZERO, not the caller's stale pre-destruct
-// value. Returning the stale value gives the rebuilt account a phantom pre-SD
-// codeHash/balance, so the codeHash-change check compares the stale value
-// against itself and validation never catches the divergence — a silent wrong
-// state root.
+// After a self-destruct, refresh* must return the typed zero, not the stale pre-destruct
+// value — otherwise validation can't detect the divergence and the state root is silently wrong.
 func TestVersionedRead_C7_RefreshReturnsZeroPastSelfDestruct(t *testing.T) {
 	t.Parallel()
 
@@ -220,11 +173,6 @@ func TestVersionedRead_C7_RefreshReturnsZeroPastSelfDestruct(t *testing.T) {
 	assert.Equal(t, accounts.NilCodeHash, ch, "refreshCodeHash past SD must return the zero codeHash, not the phantom 0xab")
 }
 
-// ------------------------------------------------------------------
-// Section D: writeSet hit (intra-tx writes)
-// ------------------------------------------------------------------
-
-// a write in the current tx is read back via versionedWrites.
 func TestVersionedRead_D2_WriteSetHit(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -244,12 +192,6 @@ func TestVersionedRead_D2_WriteSetHit(t *testing.T) {
 	assert.Equal(t, *target, bal, "writeSet hit returns the intra-tx written value")
 }
 
-// ------------------------------------------------------------------
-// Section E: MVReadResultDone (versionMap has a definite value)
-// ------------------------------------------------------------------
-
-// versionMap MapRead hit on first call; second read at same tx hits
-// the readSet (via the pr.Version == vr.Version branch).
 func TestVersionedRead_E1_MapHitThenReadSetSameVersion(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -263,19 +205,16 @@ func TestVersionedRead_E1_MapHitThenReadSetSameVersion(t *testing.T) {
 	target := uint256.NewInt(42)
 	mvhm.WriteBalance(addr, Version{TxIndex: 1, Incarnation: 0}, *target, true)
 
-	// First read populates the readSet via MapRead.
 	bal1, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
 	assert.Equal(t, *target, bal1)
 
-	// Second read: same tx, same version → readSet hit.
 	bal2, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
 	assert.Equal(t, *target, bal2)
 }
 
-// a Done MVReadResult for CodePath is trumped if a SelfDestruct at
-// a >= DepIdx is also Done — return defaultV (nil code).
+// A SelfDestruct at DepIdx >= the code write's DepIdx trumps CodePath, returning nil code.
 func TestVersionedRead_E3a_CodePathTrumpedBySelfDestruct(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -287,7 +226,6 @@ func TestVersionedRead_E3a_CodePathTrumpedBySelfDestruct(t *testing.T) {
 
 	addr := accounts.InternAddress([20]byte{0xe3})
 	code := []byte{0xfe, 0xfe}
-	// Code at tx 2; SelfDestruct at tx 3 (strictly later → trumps code).
 	mvhm.WriteCode(addr, Version{TxIndex: 2, Incarnation: 0}, accounts.NewCode(code), true)
 	mvhm.WriteSelfDestruct(addr, Version{TxIndex: 3, Incarnation: 0}, true, true)
 
@@ -296,12 +234,6 @@ func TestVersionedRead_E3a_CodePathTrumpedBySelfDestruct(t *testing.T) {
 	assert.Empty(t, got, "CodePath trumped by SelfDestruct returns nil/empty code")
 }
 
-// ------------------------------------------------------------------
-// Section G: MVReadResultNone (no entry in versionMap for this key)
-// ------------------------------------------------------------------
-
-// readSet hit at MVReadResultNone (ReadSetRead source). Second read
-// of an unwritten slot hits readSet from the first read's record.
 func TestVersionedRead_G1_ReadSetReadOnSecondCall(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -314,25 +246,19 @@ func TestVersionedRead_G1_ReadSetReadOnSecondCall(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x91})
 	key := accounts.InternKey([32]byte{0x99})
 
-	// First read of an unwritten slot: versionMap None → storage fallback →
-	// records defaultV in readSet.
 	v1, err := ibs.GetState(addr, key)
 	require.NoError(t, err)
 	assert.True(t, v1.IsZero())
 
-	// Second read: same tx, same key → readSet hit.
 	v2, err := ibs.GetState(addr, key)
 	require.NoError(t, err)
 	assert.True(t, v2.IsZero())
 
-	// readSet must hold the StoragePath entry.
 	_, ok := ibs.versionedReads.getHeader(addr, StoragePath, key)
 	assert.True(t, ok, "StoragePath read must be recorded")
 }
 
-// StoragePath read on an unwritten slot with IncarnationPath written
-// by a prior tx → returns zero (account was created/destroyed this block,
-// all unwritten slots must be zero) and records the IncarnationPath dep.
+// An IncarnationPath rewrite means the account was created/destroyed this block, so unwritten slots must read zero.
 func TestVersionedRead_G6_StorageZeroOnIncarnationWritten(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -344,20 +270,16 @@ func TestVersionedRead_G6_StorageZeroOnIncarnationWritten(t *testing.T) {
 
 	addr := accounts.InternAddress([20]byte{0x96})
 	key := accounts.InternKey([32]byte{0xab})
-	// Prior tx wrote IncarnationPath (CreateAccount / Selfdestruct event)
 	mvhm.WriteIncarnation(addr, Version{TxIndex: 2, Incarnation: 0}, 1, true)
 
 	got, err := ibs.GetState(addr, key)
 	require.NoError(t, err)
 	assert.True(t, got.IsZero(), "unwritten slot reads zero after Incarnation rewrite")
 
-	// IncarnationPath dep must be recorded.
 	_, ok := ibs.versionedReads.getHeader(addr, IncarnationPath, accounts.NilKey)
 	assert.True(t, ok, "IncarnationPath dependency must be recorded")
 }
 
-// BalancePath read with no map/writeSet/readSet entry but a prior tx
-// wrote an AddressPath account → use that account's balance.
 func TestVersionedRead_G7_BalanceViaResolvedAddressPath(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -376,9 +298,6 @@ func TestVersionedRead_G7_BalanceViaResolvedAddressPath(t *testing.T) {
 	assert.Equal(t, *uint256.NewInt(555), bal, "balance resolved via AddressPath account")
 }
 
-// storage fallback. Empty reader + no prior writes/reads → falls through
-// to the readStorage callback (returns zero from emptyReader) and records
-// defaultV in readSet.
 func TestVersionedRead_G8_StorageFallbackEmptyReader(t *testing.T) {
 	t.Parallel()
 	mvhm := NewVersionMap(nil)
@@ -392,28 +311,11 @@ func TestVersionedRead_G8_StorageFallbackEmptyReader(t *testing.T) {
 	assert.True(t, bal.IsZero(), "empty reader storage fallback returns zero")
 }
 
-// refresh path: the legacy readStorage==nil branch for
-// BalancePath/NoncePath/CodeHashPath/IncarnationPath records the
-// caller-supplied defaultV (the "current" account field) into the
-// versionedReads ReadSet, with vr.Source = StorageRead.  ValidateVersion
-// and tiebreaker logic depend on the RECORDED value matching what
-// downstream tx readers will see — recording the typed zero instead of
-// the caller's currentBalance is a behavioral divergence that breaks
-// integration tests (wrong trie root in execution/engineapi).
-//
-// This test calls per-field-account-refresh-style scenarios by going
-// through getVersionedAccount which triggers refreshBalance/refreshNonce/
-// refreshCodeHash/refreshIncarnation with the storage-read account's
-// fields as defaultV.  Asserts that subsequent reads through the
-// versionedReads ReadSet see the same typed defaultV that the legacy
-// code recorded.
+// The legacy readStorage==nil refresh records the caller's defaultV in the ReadSet, not
+// the typed zero — ValidateVersion's tiebreaker depends on the recorded value matching what downstream reads see.
 func TestVersionedRead_G4_RefreshRecordsTypedDefaultInReadSet(t *testing.T) {
 	t.Parallel()
 
-	// emptyReader returns nil account — the per-field refresh won't
-	// run for nil-account paths.  We need a reader that returns a
-	// non-nil account so the per-field refresh*
-	// calls run with non-zero defaultV.
 	r := &refreshReader{
 		account: &accounts.Account{
 			Balance:     *uint256.NewInt(1234),
@@ -429,10 +331,7 @@ func TestVersionedRead_G4_RefreshRecordsTypedDefaultInReadSet(t *testing.T) {
 
 	addr := accounts.InternAddress([20]byte{0xa4})
 
-	// Lean read footprint: GetBalance reads only the balance field from the
-	// cell pipeline — it no longer drags in a whole-account refresh, so nonce /
-	// incarnation / codeHash are NOT recorded. Balance is recorded because
-	// GetBalance genuinely read it.
+	// GetBalance has a lean read footprint: it records only BalancePath, not a whole-account refresh.
 	bal, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
 	assert.Equal(t, *uint256.NewInt(1234), bal,
@@ -451,9 +350,6 @@ func TestVersionedRead_G4_RefreshRecordsTypedDefaultInReadSet(t *testing.T) {
 	require.False(t, ok, "CodeHashPath must NOT be recorded by a balance-only read")
 }
 
-// refreshReader returns a fixed account for ReadAccountData and zero/empty
-// for everything else.  Used by TestVersionedRead_G4 to exercise the
-// refresh path with non-zero typed defaultVs.
 type refreshReader struct {
 	account *accounts.Account
 }
@@ -475,7 +371,6 @@ func (r *refreshReader) SetTrace(bool, string)                                  
 func (r *refreshReader) Trace() bool                                             { return false }
 func (r *refreshReader) TracePrefix() string                                     { return "" }
 
-// revival via NoncePath rewrite at a higher TxIdx than the SD.
 func TestVersionedRead_C2_RevivalViaNonce(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -494,7 +389,6 @@ func TestVersionedRead_C2_RevivalViaNonce(t *testing.T) {
 	assert.Equal(t, uint64(7), n, "nonce after revival via NoncePath rewrite")
 }
 
-// revival via CodeHashPath rewrite at a higher TxIdx than the SD.
 func TestVersionedRead_C3_RevivalViaCodeHash(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -514,9 +408,6 @@ func TestVersionedRead_C3_RevivalViaCodeHash(t *testing.T) {
 	assert.Equal(t, revivedHash, got, "codehash after revival via CodeHashPath rewrite")
 }
 
-// when the readSet already records a different Version than the current
-// versionMap value at MapRead, versionedRead panics with ErrDependency so
-// the executor knows to re-execute. Captured via recover().
 func TestVersionedRead_E2_StaleMapReadCaughtAtCommit(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -527,20 +418,15 @@ func TestVersionedRead_E2_StaleMapReadCaughtAtCommit(t *testing.T) {
 	ibs.SetTxContext(1, 10)
 
 	addr := accounts.InternAddress([20]byte{0xe2})
-	// Two writes at different versions; the later version wins in versionMap.
 	mvhm.WriteBalance(addr, Version{TxIndex: 2, Incarnation: 0}, *uint256.NewInt(10), true)
 
-	// Manually seed readSet with a stale version (TxIndex 1).
 	ibs.versionedReads.SetBalance(addr, VersionedRead[uint256.Int]{
 		ReadHeader: ReadHeader{Source: MapRead, Version: Version{TxIndex: 1, Incarnation: 0}},
 		Val:        *uint256.NewInt(99),
 	})
 
-	// Read-once (Block-STM): a path already recorded this execution attempt is
-	// served from the read-set without re-probing the version map, so a repeat
-	// read no longer aborts eagerly. The stale read is caught at commit —
-	// ValidateVersion re-checks it against the newer version-map write (TxIndex 2)
-	// and returns VersionInvalid, which is what drives re-execution.
+	// Read-once (Block-STM): a path already recorded this attempt is served from the read-set
+	// without re-probing the version map; the stale read is instead caught at commit-time validation.
 	got, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
 	assert.Equal(t, *uint256.NewInt(99), got, "read-once returns the recorded value")
@@ -556,10 +442,7 @@ func TestVersionedRead_E2_StaleMapReadCaughtAtCommit(t *testing.T) {
 	assert.Equal(t, VersionInvalid, valid, "commit-time validation catches the stale read")
 }
 
-// F: MVReadResultDependency status (versionMap saw an in-progress dep at a
-// higher TxIdx than the current tx) → panic ErrDependency. Triggered by
-// writing at our own txIndex's Done-but-Estimate state. Simplest reliable
-// trigger: an Estimate-status entry (complete=false) at a TxIdx <= ours.
+// An Estimate entry (complete=false) at a TxIdx <= ours reports MVReadResultDependency and panics with ErrDependency.
 func TestVersionedRead_F_MVReadResultDependencyPanics(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -570,7 +453,6 @@ func TestVersionedRead_F_MVReadResultDependencyPanics(t *testing.T) {
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xf0})
-	// Estimate entry (complete=false) at txIndex 2 < 5 → Dependency.
 	mvhm.WriteBalance(addr, Version{TxIndex: 2, Incarnation: 0}, *uint256.NewInt(50), false)
 
 	defer func() {
@@ -583,10 +465,7 @@ func TestVersionedRead_F_MVReadResultDependencyPanics(t *testing.T) {
 	_, _ = ibs.GetBalance(addr)
 }
 
-// writeSet hit at MVReadResultDone, but readSet has a stale version
-// → panic ErrDependency (a write was based on a stale read). The current
-// tx wrote, but the readSet for the same path holds a version older than
-// the versionMap's Done entry.
+// A writeSet hit whose readSet entry is older than the versionMap's Done write panics with ErrDependency.
 func TestVersionedRead_D1_WriteSetHitWithStaleReadSetPanics(t *testing.T) {
 	t.Parallel()
 	_, tx, domains := NewTestRwTx(t)
@@ -597,17 +476,12 @@ func TestVersionedRead_D1_WriteSetHitWithStaleReadSetPanics(t *testing.T) {
 	ibs.SetTxContext(1, 5)
 
 	addr := accounts.InternAddress([20]byte{0xd1})
-	// versionMap Done at tx 3 — higher than the readSet's stale tx-1 entry.
 	mvhm.WriteBalance(addr, Version{TxIndex: 3, Incarnation: 0}, *uint256.NewInt(30), true)
 
-	// Seed a current-tx writeSet entry (intra-tx write) so the writeSet
-	// branch fires.
 	err := ibs.SetBalance(addr, *uint256.NewInt(77), 0)
 	require.NoError(t, err)
 
-	// Seed a stale readSet entry at a lower version AFTER the write:
-	// seeding it first would already panic inside SetBalance's account
-	// refresh, before the writeSet-hit branch under test is reached.
+	// Seeded after the write: seeding first would panic inside SetBalance's own account refresh before this branch runs.
 	ibs.versionedReads.SetBalance(addr, VersionedRead[uint256.Int]{
 		ReadHeader: ReadHeader{Source: MapRead, Version: Version{TxIndex: 1, Incarnation: 0}},
 		Val:        *uint256.NewInt(99),
@@ -622,9 +496,7 @@ func TestVersionedRead_D1_WriteSetHitWithStaleReadSetPanics(t *testing.T) {
 	_, _ = ibs.GetBalance(addr)
 }
 
-// The nil≡empty arm of readValueUnchanged carries the same gates as
-// validation's dead-equivalence: no equivalence pre-EIP-161, and none for
-// AuRa's retained SystemAddress.
+// nil≡empty in readValueUnchanged is gated like validation's dead-equivalence: none pre-EIP-161, none for AuRa's SystemAddress.
 func TestReadValueUnchanged_NilEmptyArmGated(t *testing.T) {
 	newIBS := func(addr accounts.Address, eip161 bool, isAura bool) *IntraBlockState {
 		ibs := NewWithVersionMap(&emptyReader{}, NewVersionMap(nil))

--- a/execution/state/versionedio.go
+++ b/execution/state/versionedio.go
@@ -65,64 +65,41 @@ const (
 	StorageRead
 	WriteSetRead
 	ReadSetRead
-	// ProvisionalRead marks a nil record probe made mid-account-load, before
-	// the load has exposed any value to the EVM: a re-probe in the same load
-	// that finds a freshly flushed cell adopts it instead of aborting.
+	// ProvisionalRead: a nil probe mid-account-load that a later re-probe may adopt instead of aborting.
 	ProvisionalRead
 )
 
-// ReadHeader is the type-agnostic part of a versioned read: the tx-version
-// that produced the value and the tier it came from.  Shared by every
-// per-path read via embedding in VersionedRead.
 type ReadHeader struct {
 	Source   ReadSource
 	Version  Version
 	internal bool // conflict-detection only; excluded from the block access list
 }
 
-// VersionedRead is a single versioned read.  The per-path map it lives in fixes
-// the address (map key) and path — and, for storage, the slot key — so the
-// struct carries only the header and the path-typed value.
 type VersionedRead[T any] struct {
 	ReadHeader
 	Val T
 }
 
-// AccountView abstracts the AddressPath read's account payload so the read
-// can be backed by an already-materialised account today and, later, by a
-// versionMap cell without changing consumers.  Scoped to the read path —
-// deliberately not the package-wide accounts.Account.
 type AccountView interface {
 	Account() *accounts.Account
 	IsNil() bool
 }
 
-// concreteAccountView is the AccountView backed by an already-materialised
-// account.  It is pointer-shaped, so it costs no extra allocation when held
-// in an AccountView interface value.
 type concreteAccountView struct{ acc *accounts.Account }
 
 func (c concreteAccountView) Account() *accounts.Account { return c.acc }
 func (c concreteAccountView) IsNil() bool                { return c.acc == nil }
 
-// NewAccountView wraps a materialised account as an AccountView.
 func NewAccountView(acc *accounts.Account) AccountView { return concreteAccountView{acc} }
 
-// ReadSet holds per-task versioned reads in per-path maps keyed by address
-// (and by storage slot for the storage path).  Each read is held by value;
-// the per-path split keeps the record path off the heap and collapses
-// non-storage probes to a single map lookup.  All maps are lazily allocated
-// on first write.
 type ReadSet struct {
 	address      map[accounts.Address]VersionedRead[AccountView]
 	balance      map[accounts.Address]VersionedRead[uint256.Int]
 	nonce        map[accounts.Address]VersionedRead[uint64]
 	incarnation  map[accounts.Address]VersionedRead[uint64]
 	selfDestruct map[accounts.Address]VersionedRead[bool]
-	// selfDestructWitnesses holds the OTHER distinct destruct versions a tx
-	// consumed when it recorded more than one (a wipe from each of several
-	// destroy/recreate cycles of one address): validation must re-check every
-	// destruct a conclusion depended on, not only the last-recorded one.
+	// selfDestructWitnesses holds other destruct versions a tx also depended on;
+	// validation must re-check every one, not just the last-recorded destruct.
 	selfDestructWitnesses map[accounts.Address][]VersionedRead[bool]
 	createContract        map[accounts.Address]VersionedRead[bool]
 	code                  map[accounts.Address]VersionedRead[[]byte]
@@ -130,9 +107,7 @@ type ReadSet struct {
 	codeSize              map[accounts.Address]VersionedRead[int]
 	storage               map[accounts.Address]map[accounts.StorageKey]VersionedRead[uint256.Int]
 
-	// access carries EIP-7928 "address was accessed" marks (with the
-	// non-revertable "real EVM access" bit) on the read side, so the access set
-	// travels with the read-set rather than as a separate IntraBlockState cache.
+	// access carries EIP-7928 access marks, so the access set travels with the read-set.
 	access AccessSet
 }
 
@@ -239,10 +214,6 @@ func (s *ReadSet) GetStorage(addr accounts.Address, key accounts.StorageKey) (Ve
 	return tr, ok
 }
 
-// getHeader probes the read set for path and returns the type-agnostic
-// header only.  This is the single read-set probe versionedReadCore uses —
-// uniform return type, so the runtime path switch works without the value
-// type leaking into the probe.
 func (s *ReadSet) getHeader(addr accounts.Address, path AccountPath, key accounts.StorageKey) (ReadHeader, bool) {
 	switch path {
 	case AddressPath:
@@ -283,10 +254,6 @@ func (s *ReadSet) getHeader(addr accounts.Address, path AccountPath, key account
 	return ReadHeader{}, false
 }
 
-// setHeader records a header-only read (zero value) at (addr, path, key).
-// Used on the dependency-conflict paths where versionedReadCore records the
-// read purely for ValidateVersion's version check — the value is never
-// consulted there (it was zero in the legacy VersionedRead path too).
 func (s *ReadSet) SetHeader(addr accounts.Address, path AccountPath, key accounts.StorageKey, hdr ReadHeader) {
 	switch path {
 	case AddressPath:
@@ -312,8 +279,6 @@ func (s *ReadSet) SetHeader(addr accounts.Address, path AccountPath, key account
 	}
 }
 
-// scanAddrPath visits the addr entry of one non-storage path map, writing
-// any header mutation back.  Helper for ScanAddr.
 func scanAddrPath[T any](m map[accounts.Address]VersionedRead[T], addr accounts.Address, path AccountPath, fn func(AccountPath, accounts.StorageKey, *ReadHeader)) int {
 	if tr, ok := m[addr]; ok {
 		fn(path, accounts.NilKey, &tr.ReadHeader)
@@ -323,9 +288,6 @@ func scanAddrPath[T any](m map[accounts.Address]VersionedRead[T], addr accounts.
 	return 0
 }
 
-// ScanAddr visits every entry under addr (all paths), passing the path, key
-// and a pointer to the mutable header.  Any header mutation is written back
-// into the map.  Returns the number of entries visited.
 func (s *ReadSet) ScanAddr(addr accounts.Address, fn func(path AccountPath, key accounts.StorageKey, hdr *ReadHeader)) int {
 	n := scanAddrPath(s.address, addr, AddressPath, fn) +
 		scanAddrPath(s.balance, addr, BalancePath, fn) +
@@ -346,7 +308,6 @@ func (s *ReadSet) ScanAddr(addr accounts.Address, fn func(path AccountPath, key 
 	return n
 }
 
-// hasAddr reports whether any path has an entry for addr.
 func (s *ReadSet) hasAddr(addr accounts.Address) bool {
 	if _, ok := s.address[addr]; ok {
 		return true
@@ -379,7 +340,6 @@ func (s *ReadSet) hasAddr(addr accounts.Address) bool {
 	return ok
 }
 
-// Delete removes every path entry for addr.
 func (s *ReadSet) Delete(addr accounts.Address) {
 	delete(s.address, addr)
 	delete(s.balance, addr)
@@ -393,8 +353,6 @@ func (s *ReadSet) Delete(addr accounts.Address) {
 	delete(s.storage, addr)
 }
 
-// Len returns the total entry count across all paths.  Value receiver so it
-// can be called on a function-returned read set directly.
 func (s ReadSet) Len() int {
 	n := len(s.address) + len(s.balance) + len(s.nonce) + len(s.incarnation) +
 		len(s.selfDestruct) + len(s.createContract) +
@@ -405,7 +363,6 @@ func (s ReadSet) Len() int {
 	return n
 }
 
-// mergeFrom copies every entry of src into s, overwriting on collision.
 func (s *ReadSet) mergeFrom(src ReadSet) {
 	for a, tr := range src.address {
 		readSetPut(&s.address, a, tr)
@@ -452,8 +409,6 @@ func (s *ReadSet) mergeFrom(src ReadSet) {
 	}
 }
 
-// Merge returns a new read set containing every entry of s then o.  On a
-// collision o's entry wins.
 func (s ReadSet) Merge(o ReadSet) ReadSet {
 	var out ReadSet
 	out.mergeFrom(s)
@@ -461,13 +416,10 @@ func (s ReadSet) Merge(o ReadSet) ReadSet {
 	return out
 }
 
-// MergeFrom merges o into s in place, without allocating a new ReadSet.
 func (s *ReadSet) MergeFrom(o ReadSet) {
 	s.mergeFrom(o)
 }
 
-// TraceReads prints every read in path-major order, prefixed.  Debug only —
-// keeps the per-path iteration inside this package.
 func (s ReadSet) TraceReads(prefix string) {
 	for addr, tr := range s.address {
 		fmt.Println(prefix, "RD", traceReadStr(addr, AddressPath, accounts.NilKey, tr.ReadHeader, accountViewString(tr.Val)))
@@ -523,8 +475,6 @@ func eachHeaderOf[T any](m map[accounts.Address]VersionedRead[T], yield func(Rea
 	return true
 }
 
-// eachHeader visits the type-agnostic header of every read; the callback
-// returns false to stop early.
 func (s ReadSet) eachHeader(yield func(ReadHeader) bool) {
 	if !eachHeaderOf(s.address, yield) ||
 		!eachHeaderOf(s.balance, yield) ||
@@ -546,9 +496,6 @@ func (s ReadSet) eachHeader(yield func(ReadHeader) bool) {
 	}
 }
 
-// WriteHeader is the type-agnostic part of a versioned write: address,
-// path, optional storage key, tx-version and balance-change reason.
-// Shared across every per-path write via embedding in VersionedWrite[T].
 type WriteHeader struct {
 	Address     accounts.Address
 	Key         accounts.StorageKey
@@ -562,9 +509,6 @@ func (h WriteHeader) String() string {
 	return fmt.Sprintf("%x %s (%d.%d)", h.Address, AccountKey{Path: h.Path, Key: h.Key}, h.Version.TxIndex, h.Version.Incarnation)
 }
 
-// VersionedWrite is a single versioned write.  The per-path map it lives
-// in fixes the address (map key), path — and, for storage, the slot key.
-// The struct carries the header and the path-typed value.
 type VersionedWrite[T any] struct {
 	WriteHeader
 	Val T
@@ -579,14 +523,6 @@ func (w *VersionedWrite[T]) String() string {
 	return fmt.Sprintf("%s: %v", w.WriteHeader, w.Val)
 }
 
-// Per-path *VersionedWrite[T] pools.  Each pool sources fresh cleared
-// instances; callers fill the WriteHeader + Val before inserting into the
-// typed map on WriteSet.  Lifetime is per-tx — WriteSet.ReleaseAndReset
-// walks the maps at tx-finalize and returns every VW to its pool.
-//
-// Slice-valued payloads (CodePath) have their Val cleared on release to
-// avoid pinning external memory; same pattern as versionmap.go's WriteCell
-// pool (releaseCellCode).
 var (
 	vwPoolAddress        = sync.Pool{New: func() any { return &VersionedWrite[*accounts.Account]{} }}
 	vwPoolBalance        = sync.Pool{New: func() any { return &VersionedWrite[uint256.Int]{} }}
@@ -644,8 +580,6 @@ func releaseVWCodeHash(vw *VersionedWrite[accounts.CodeHash]) { vwPoolCodeHash.P
 func releaseVWCodeSize(vw *VersionedWrite[int])               { vwPoolCodeSize.Put(vw) }
 func releaseVWStorage(vw *VersionedWrite[uint256.Int])        { vwPoolStorage.Put(vw) }
 
-// WriteSet is the cell-pipeline target shape for versionedWrites.
-// Symmetric with ReadSet — see that type for rationale.
 type WriteSet struct {
 	address        map[accounts.Address]*VersionedWrite[*accounts.Account]
 	balance        map[accounts.Address]*VersionedWrite[uint256.Int]
@@ -659,13 +593,7 @@ type WriteSet struct {
 	storage        map[accounts.Address]map[accounts.StorageKey]*VersionedWrite[uint256.Int]
 }
 
-// vwMapPool[T] pools the per-path map[Address]*VersionedWrite[T] containers
-// themselves, not just the *VersionedWrite[T] values (those are in vwPool*).
-// put() walks no entries — by contract, callers release every VW to its
-// vwPool before put() — but it does call clear() so the map header survives
-// with cleared buckets ready for the next checkout.  Pooling the container
-// preserves bucket capacity across txs; clear() is precisely the behaviour
-// pool-resident containers want.
+// vwMapPool pools the map container; put() assumes every VW was already released to its own pool.
 type vwMapPool[T any] struct{ p sync.Pool }
 
 func newVWMapPool[T any]() *vwMapPool[T] {
@@ -728,9 +656,6 @@ func wsPutStorageOuter(m map[accounts.Address]map[accounts.StorageKey]*Versioned
 	wsMapPoolStorageOuter.Put(m)
 }
 
-// writeSetPut lazily checks out a pooled map and inserts vw at addr.
-// First write per tx pays vwMapPool.Get (cheap); subsequent writes are
-// direct map insert.  ReleaseAndReset puts the map back on tx-finalize.
 func writeSetPut[T any](m *map[accounts.Address]*VersionedWrite[T], addr accounts.Address, vw *VersionedWrite[T], pool *vwMapPool[T]) {
 	if *m == nil {
 		*m = pool.get()
@@ -786,13 +711,11 @@ func (s *WriteSet) IsEmpty() bool {
 		len(s.code) == 0 && len(s.codeHash) == 0 && len(s.codeSize) == 0 && len(s.storage) == 0
 }
 
-// Has reports whether a write exists at h's (Address, Path, Key).
 func (s *WriteSet) Has(h WriteHeader) bool {
 	return s.hasHeader(h)
 }
 
-// Filter returns a new WriteSet holding only the writes whose header satisfies
-// keep. The kept writes are shared (not cloned) with the receiver.
+// Filter returns a new WriteSet holding the writes matching keep; entries are shared, not cloned, with the receiver.
 func (s *WriteSet) Filter(keep func(WriteHeader) bool) *WriteSet {
 	if s == nil {
 		return nil
@@ -853,21 +776,12 @@ func (s *WriteSet) Filter(keep func(WriteHeader) bool) *WriteSet {
 	return out
 }
 
-// Finalize produces the committable write-set for a tx from the raw recorded
-// writes: it applies the EIP-6780 net-zero storage wipe, then returns the
-// filtered Snapshot. It operates on the write-set alone — no IntraBlockState —
-// so the parallel finalize can be driven straight from the recorded IO.
 func (s *WriteSet) Finalize() *WriteSet {
 	s.zeroSameTxCreateDestructStorage()
 	return s.Snapshot()
 }
 
-// zeroSameTxCreateDestructStorage implements EIP-6780 + EIP-7928: when a
-// contract is created and self-destructed in the same tx, its storage is wiped
-// at end-of-tx, so the BAL must record the dirty slots as reads (net-zero), not
-// changes. Zero the storage write values so AsBlockAccessList folds them away.
-// The create+destruct pair is detectable from the write-set itself
-// (createContract survives SELFDESTRUCT), so no stateObject is needed.
+// EIP-6780 + EIP-7928: same-tx create+destruct storage is zeroed here (not deleted) so the BAL folds it in as reads, not changes.
 func (s *WriteSet) zeroSameTxCreateDestructStorage() {
 	for addr, cc := range s.createContract {
 		if !cc.Val {
@@ -884,13 +798,8 @@ func (s *WriteSet) zeroSameTxCreateDestructStorage() {
 	}
 }
 
-// Snapshot returns a frozen typed copy of the recorded writes. The journal keeps
-// the write-set in step with reverts, so every address present is a surviving
-// write — no dirty reconciliation is needed. Under self-destruct only
-// SelfDestruct/Balance/Incarnation/Storage/CreateContract are kept (the BAL needs
-// residual balance, resurrection needs the prior incarnation, the calculator
-// needs per-slot deletes, and fee finalization needs the creation marker);
-// Nonce/Code/CodeHash/CodeSize/Address drop.
+// Snapshot freezes the recorded writes (no reconciliation needed — the journal
+// already tracks reverts). Self-destruct keeps only SelfDestruct/Balance/Incarnation/Storage/CreateContract; the rest drop.
 func (s *WriteSet) Snapshot() *WriteSet {
 	out := &WriteSet{}
 
@@ -916,10 +825,8 @@ func (s *WriteSet) Snapshot() *WriteSet {
 				out.SetStorage(addr, k, cloneVW(vw))
 			}
 		}
-		// CreateContract survives self-destruct: fee finalization and the BAL need
-		// the creation marker, and zeroSameTxCreateDestructStorage detects the
-		// create+destruct pair from it. ApplyVersionedWrites skips applying it under
-		// self-destruct, so keeping it here does not resurrect the account.
+		// CreateContract is kept under self-destruct for the BAL; apply skips it when the
+		// same tx self-destructs, so it can't resurrect the account.
 		if vw, ok := s.createContract[addr]; ok {
 			out.SetCreateContract(addr, cloneVW(vw))
 		}
@@ -957,11 +864,6 @@ func (s *WriteSet) deleteAddr(addr accounts.Address) {
 	delete(s.storage, addr)
 }
 
-// createWriteSnapshot holds a deep copy of the account-record writes that
-// createObject/createAccount overwrite when (re)creating an account. It lets a
-// reverted recreation restore the prior writes rather than leave them
-// overwritten — the record-level create journal entry maintaining its own
-// field-level writes.
 type createWriteSnapshot struct {
 	address        *VersionedWrite[*accounts.Account]
 	balance        *VersionedWrite[uint256.Int]
@@ -971,10 +873,6 @@ type createWriteSnapshot struct {
 	codeHash       *VersionedWrite[accounts.CodeHash]
 }
 
-// snapshotCreateFields clones the account-record writes that a subsequent
-// createObject/createAccount will overwrite, so a reverted recreation can
-// restore them. Fields creation never writes (nonce/code/codeSize/storage) are
-// not captured — they survive the recreation untouched.
 func (s *WriteSet) snapshotCreateFields(addr accounts.Address) *createWriteSnapshot {
 	snap := &createWriteSnapshot{}
 	if vw, ok := s.address[addr]; ok {
@@ -998,9 +896,7 @@ func (s *WriteSet) snapshotCreateFields(addr accounts.Address) *createWriteSnaps
 	return snap
 }
 
-// restoreCreateFields reverts the account-record writes overwritten by a
-// recreation back to snap (nil entries in snap become deletions). Only the
-// fields creation writes are touched.
+// restoreCreateFields reverts to snap; a nil field in snap deletes that write.
 func (s *WriteSet) restoreCreateFields(addr accounts.Address, snap *createWriteSnapshot) {
 	delete(s.address, addr)
 	delete(s.balance, addr)
@@ -1031,12 +927,8 @@ func (s *WriteSet) restoreCreateFields(addr accounts.Address, snap *createWriteS
 	}
 }
 
-// assertSelfDestructNormalized panics if a self-destructed address still carries
-// the account fields Normalize is required to drop. Any of them makes Apply
-// compute pureDelete=false and take the cleanup-before-recreate branch, which
-// writes the account back with a live incarnation instead of deleting it — a
-// phantom account that breaks a later CREATE2 at the same address. Balance
-// (retained under EIP-8246) and the storage-delete cascade are legal.
+// assertSelfDestructNormalized panics if a self-destructed address still has
+// fields Normalize should drop — Apply would then leave a phantom account with a live incarnation, breaking a later CREATE2 there.
 func (s *WriteSet) assertSelfDestructNormalized() {
 	for addr, sdw := range s.selfDestruct {
 		if !sdw.Val {
@@ -1057,8 +949,6 @@ func (s *WriteSet) assertSelfDestructNormalized() {
 	}
 }
 
-// DeleteAccountFields removes the Balance/Nonce/Incarnation/CodeHash writes for
-// addr, leaving storage/code/self-destruct intact.
 func (s *WriteSet) DeleteAccountFields(addr accounts.Address) {
 	delete(s.balance, addr)
 	delete(s.nonce, addr)
@@ -1066,7 +956,6 @@ func (s *WriteSet) DeleteAccountFields(addr accounts.Address) {
 	delete(s.codeHash, addr)
 }
 
-// Count is the total number of writes across all paths.
 func (s *WriteSet) Count() int {
 	if s == nil {
 		return 0
@@ -1154,9 +1043,7 @@ func (s *WriteSet) GetStorage(addr accounts.Address, key accounts.StorageKey) (*
 	return vw, ok
 }
 
-// forEachAddr calls f for every address with at least one entry, allocating
-// nothing. An address present in several paths is visited once per path, so
-// callers must tolerate repeats (use addrs() when a deduped set is required).
+// forEachAddr calls f once per path an address appears in; callers must tolerate repeats.
 func (s *WriteSet) forEachAddr(f func(accounts.Address)) {
 	if s == nil {
 		return
@@ -1167,8 +1054,6 @@ func (s *WriteSet) forEachAddr(f func(accounts.Address)) {
 	s.forEachFieldAddr(f)
 }
 
-// forEachFieldAddr is forEachAddr restricted to field-level writes: it skips the
-// record-level AddressPath map, whose entries carry no field of their own.
 func (s *WriteSet) forEachFieldAddr(f func(accounts.Address)) {
 	if s == nil {
 		return
@@ -1202,9 +1087,6 @@ func (s *WriteSet) forEachFieldAddr(f func(accounts.Address)) {
 	}
 }
 
-// addrs returns the union of all addresses that have at least one entry.
-// Iteration order across the union is non-deterministic — caller sorts
-// before use if determinism matters.
 func (s *WriteSet) addrs() map[accounts.Address]struct{} {
 	out := map[accounts.Address]struct{}{}
 	for a := range s.address {
@@ -1240,10 +1122,8 @@ func (s *WriteSet) addrs() map[accounts.Address]struct{} {
 	return out
 }
 
-// Per-path typed iterators over the write collections. Consumers that depend on
-// the self-destruct-vs-field priority iterate these in explicit order (e.g.
-// SelfDestructs before the reviving field writes) rather than relying on a flat
-// stream's element order.
+// Per-path typed iterators over the write collections. Callers that care about
+// self-destruct-vs-field priority must iterate SelfDestructs before the field writes explicitly.
 func (s *WriteSet) Balances() iter.Seq2[accounts.Address, *VersionedWrite[uint256.Int]] {
 	if s == nil {
 		return maps.All(map[accounts.Address]*VersionedWrite[uint256.Int](nil))
@@ -1296,8 +1176,6 @@ func eachWriteHeaderOf[T any](m map[accounts.Address]*VersionedWrite[T], yield f
 	return true
 }
 
-// AllHeaders visits the type-agnostic header of every write; the value is read
-// typed-by-path from the per-path maps, so nothing is erased to an interface.
 func (s *WriteSet) AllHeaders() iter.Seq[WriteHeader] {
 	return func(yield func(WriteHeader) bool) {
 		if s == nil {
@@ -1324,11 +1202,8 @@ func (s *WriteSet) AllHeaders() iter.Seq[WriteHeader] {
 	}
 }
 
-// ReleaseAndReset returns every *VersionedWrite[T] held by the set to its
-// typed sync.Pool, then returns the per-path maps to their map-pools.
-// Called at tx-finalize so both the VW values and the map buckets cycle
-// through pools rather than getting GC'd. The values must go back before
-// ReleaseMaps clears the maps that hold them.
+// ReleaseAndReset releases every write to its pool before returning the maps to
+// theirs — order matters, or ReleaseMaps clears them first.
 func (s *WriteSet) ReleaseAndReset() {
 	for _, vw := range s.address {
 		releaseVWAddress(vw)
@@ -1365,10 +1240,8 @@ func (s *WriteSet) ReleaseAndReset() {
 	s.ReleaseMaps()
 }
 
-// ReleaseMaps returns the map containers to their pools without releasing the
-// VersionedWrite values, which stay owned by GC — they may be shared with other
-// sets after MergeInto. Use ReleaseAndReset only for sets whose VWs came from
-// the vwPools and are exclusively owned.
+// ReleaseMaps returns only the map containers; VersionedWrite values are left for
+// GC since a merge may share them with other sets.
 func (s *WriteSet) ReleaseMaps() {
 	if s == nil {
 		return
@@ -1388,11 +1261,6 @@ func (s *WriteSet) ReleaseMaps() {
 	wsPutStorageOuter(s.storage)
 	*s = WriteSet{}
 }
-
-// Per-path typed delete methods.  Direct map access, no internal switch
-// (mirrors the Set/Get/update* shape).  Each Del* releases the displaced
-// *VersionedWrite[T] back to its pool — keeps the pool cycle closed so
-// allocs land on Get and end at Del/ReleaseAndReset.
 
 func (s *WriteSet) DelBalance(addr accounts.Address) {
 	if vw, ok := s.balance[addr]; ok {
@@ -1448,8 +1316,7 @@ func (s *WriteSet) DelStorage(addr accounts.Address, key accounts.StorageKey) {
 	}
 }
 
-// updateBalance, updateNonce etc. are typed in-place mutations on the
-// existing per-path entry.  No-op when no entry exists for addr.
+// updateBalance, updateNonce etc. mutate the existing per-path entry in place; a no-op if addr has none.
 func (s *WriteSet) updateBalance(addr accounts.Address, val uint256.Int) {
 	if vw, ok := s.balance[addr]; ok {
 		vw.Val = val
@@ -1563,16 +1430,9 @@ func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*acco
 		return &updated, nil
 	}
 
-	// Check version map for AddressPath — handles accounts created by
-	// prior transactions in the same block that aren't in the read set.
 	if vr.versionMap != nil {
-		// A prior tx may have self-destructed this account. Honor the
-		// destruct ONLY if no subsequent write at a strictly higher
-		// TxIndex re-creates the account. EIP-161 emits a SelfDestruct
-		// for the coinbase when a TX touches it without tipping (Balance
-		// stays 0 → empty-account prune); a later TX that tips the same
-		// coinbase re-creates it, and we must surface the re-created
-		// account so finalize accumulates the prior cumulative value.
+		// Honor a prior self-destruct only if no later tx recreates the account.
+		// EIP-161: an untipped-touch coinbase self-destructs; a later tip revives it and must surface here.
 		if destroyed, _, revived := vr.versionMap.AccountLifecycle(address, vr.txIndex); destroyed && !revived {
 			return nil, nil
 		}
@@ -1582,8 +1442,7 @@ func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*acco
 		}
 	}
 
-	// A recorded AddressPath read with no account is the tx's own conclusion that
-	// the address holds nothing; the domain cannot say otherwise.
+	// A recorded AddressPath read with no account is the tx's final word that the address holds nothing.
 	if vr.stateReader != nil && !recorded {
 		account, err := vr.stateReader.ReadAccountData(address)
 
@@ -1597,21 +1456,12 @@ func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*acco
 		}
 	}
 
-	// Account doesn't exist in state reader and no AddressPath entry in
-	// versionMap. The BAL pre-population writes only BalancePath/NoncePath/
-	// CodePath/StoragePath entries (NOT AddressPath, by design — see
-	// validateRead invariant). For an account that is created mid-block
-	// purely by tip credits (e.g. fee_recipient with no pre-state and no
-	// transfers to it), the BAL has the post-tx balance at each TxIndex,
-	// but ReadAccountData would return nil because it only checks
-	// AddressPath / stateReader. Synthesize an empty account and let
-	// applyVersionedUpdates apply the BAL-preloaded fields.
+	// BAL pre-population writes Balance/Nonce/Code/Storage but never AddressPath, so
+	// a tip-only account (e.g. a fresh fee_recipient) reads nil here; synthesize an
+	// empty account so applyVersionedUpdates can still apply the BAL-preloaded fields.
 	if vr.versionMap != nil {
 		var synth accounts.Account
 		updated := vr.applyVersionedUpdates(address, synth)
-		// Only return the synthesized account if applyVersionedUpdates
-		// actually applied at least one field — otherwise we'd return a
-		// zero account for addresses that have no versionMap entries.
 		if updated != synth {
 			return &updated, nil
 		}
@@ -1620,13 +1470,8 @@ func (vr *versionedStateReader) ReadAccountData(address accounts.Address) (*acco
 	return nil, nil
 }
 
-// Per-path versionedUpdate helpers replace the legacy generic
-// versionedUpdate[T] — they consume the typed VersionMap Read primitives
-// directly so neither the call site nor the read path crosses an any
-// boundary. Each returns the cell value if a Done OR Dependency (Estimate)
-// write exists at txIndex (a Dependency cell holds the same latest in-block
-// write a Done cell does; finalize reconstruction must consume it, not fall
-// back to the pre-block DB value), otherwise zero value and ok=false.
+// A Dependency (Estimate) cell holds the same latest in-block write a Done
+// cell does, so these treat it as found too rather than falling back to the pre-block DB value.
 
 func versionedUpdateAddress(vm *VersionMap, addr accounts.Address, txIndex int) (*accounts.Account, bool) {
 	val, res, ok := vm.ReadAddress(addr, txIndex)
@@ -1652,10 +1497,8 @@ func versionedUpdateStorage(vm *VersionMap, addr accounts.Address, key accounts.
 	return uint256.Int{}, false
 }
 
-// applyVersionedUpdates overlays the version map's per-field writes onto account.
-// The reader/writer API treats an account's sub-fields as one group, so a prior
-// tx that wrote only a subset would otherwise be lost here — and those fields are
-// not recorded as reads, so validation would not catch the miss either.
+// applyVersionedUpdates overlays per-field writes onto account: without it, a
+// prior tx's partial write would be silently lost here and go uncaught by validation.
 func (vr versionedStateReader) applyVersionedUpdates(address accounts.Address, account accounts.Account) accounts.Account {
 	vr.versionMap.applySubFieldWrites(address, vr.txIndex, &account)
 	return account
@@ -1687,7 +1530,6 @@ func (vr versionedStateReader) ReadAccountStorage(address accounts.Address, key 
 		return r.Val, true, nil
 	}
 
-	// Check version map for storage written by prior transactions.
 	if vr.versionMap != nil {
 		if destructed, res, ok := vr.versionMap.ReadSelfDestruct(address, vr.txIndex); ok && res.Status() == MVReadResultDone {
 			if destructed {
@@ -1723,8 +1565,7 @@ func (vr versionedStateReader) ReadAccountCode(address accounts.Address) ([]byte
 		return r.Val, nil
 	}
 
-	// Check version map for CodePath entries written by prior transactions
-	// (e.g. EIP-7702 delegation set by an earlier tx in the same block).
+	// EIP-7702 delegation can set CodePath from an earlier tx in the same block.
 	if vr.versionMap != nil {
 		if destructed, res, ok := vr.versionMap.ReadSelfDestruct(address, vr.txIndex); ok && res.Status() == MVReadResultDone {
 			if destructed {
@@ -1778,8 +1619,6 @@ func (vr versionedStateReader) ReadAccountIncarnation(address accounts.Address) 
 	return 0, nil
 }
 
-// SetAccountFieldFromMap resolves an account field from the version map and
-// sets it into out, returning whether a Done value was found.
 func SetAccountFieldFromMap(out *WriteSet, vm *VersionMap, addr accounts.Address, path AccountPath, ver Version, txIdx int) bool {
 	switch path {
 	case BalancePath:
@@ -1810,10 +1649,6 @@ func SetAccountFieldFromMap(out *WriteSet, vm *VersionMap, addr accounts.Address
 	return false
 }
 
-// NewAccountFieldZeroWrite returns a typed *VersionedWrite[T] for path
-// holding the zero value (used by the SD-earlier fallback that emits
-// post-destruction defaults).  Path must be Balance/Nonce/Incarnation/CodeHash.
-// SetAccountFieldZero sets the post-destruction zero value for path into out.
 func SetAccountFieldZero(out *WriteSet, addr accounts.Address, path AccountPath, ver Version) {
 	switch path {
 	case BalancePath:
@@ -1827,10 +1662,6 @@ func SetAccountFieldZero(out *WriteSet, addr accounts.Address, path AccountPath,
 	}
 }
 
-// NewAccountFieldWriteFromAccount returns a typed *VersionedWrite[T]
-// populated from acc (may be nil — falls back to zero values except for
-// CodeHash which becomes EmptyCodeHash).
-// SetAccountFieldFromAccount sets path's value from acc into out.
 func SetAccountFieldFromAccount(out *WriteSet, addr accounts.Address, path AccountPath, ver Version, acc *accounts.Account) {
 	switch path {
 	case BalancePath:
@@ -1860,9 +1691,6 @@ func SetAccountFieldFromAccount(out *WriteSet, addr accounts.Address, path Accou
 	}
 }
 
-// TouchUpdates feeds the write set directly to a commitment.Updates buffer
-// via TouchPlainKeyDirect, one partial Update per write. The buffer merges
-// per key (ModeUpdate and ModeParallel both accumulate flags additively).
 func (s *WriteSet) TouchUpdates(updates *commitment.Updates) {
 	if s == nil {
 		return
@@ -1924,9 +1752,6 @@ func (s *WriteSet) TouchUpdates(updates *commitment.Updates) {
 	}
 }
 
-// sortWriteHeaders sorts headers by (Address, Path, Key) for deterministic
-// processing order; WriteSet map iteration is non-deterministic in Go.
-// The sort relies on the AccountPath enum ordering defined in versionmap.go.
 func sortWriteHeaders(headers []WriteHeader) {
 	slices.SortFunc(headers, func(a, b WriteHeader) int {
 		if c := a.Address.Cmp(b.Address); c != 0 {
@@ -1942,7 +1767,6 @@ func sortWriteHeaders(headers []WriteHeader) {
 	})
 }
 
-// hasHeader reports whether a write exists at h's (Address, Path, Key).
 func (s *WriteSet) hasHeader(h WriteHeader) bool {
 	if s == nil {
 		return false
@@ -1984,9 +1808,8 @@ func (s *WriteSet) hasHeader(h WriteHeader) bool {
 	return false
 }
 
-// copyFrom merges src into s, value-copying each VersionedWrite so the result
-// shares no *VersionedWrite with src — the in-place recordWrite mutators would
-// otherwise make either side observe the other's later edits.
+// copyFrom clones each VersionedWrite so s shares none with src — otherwise
+// in-place mutators on one side would leak edits to the other.
 func (s *WriteSet) copyFrom(src *WriteSet) {
 	if src == nil {
 		return
@@ -2025,9 +1848,7 @@ func (s *WriteSet) copyFrom(src *WriteSet) {
 	}
 }
 
-// copyMissingFrom adds the entries s does not already hold, sharing src's
-// *VersionedWrite pointers rather than cloning them — see MergeInto for what
-// the sharing costs the caller.
+// copyMissingFrom, unlike copyFrom, shares src's *VersionedWrite pointers instead of cloning them.
 func (s *WriteSet) copyMissingFrom(src *WriteSet) {
 	if src == nil {
 		return
@@ -2087,7 +1908,6 @@ func (s *WriteSet) copyMissingFrom(src *WriteSet) {
 	}
 }
 
-// Merge returns the union of prev and next, with next winning on (addr,path,key).
 func (prev *WriteSet) Merge(next *WriteSet) *WriteSet {
 	if prev.IsEmpty() {
 		return next
@@ -2101,14 +1921,9 @@ func (prev *WriteSet) Merge(next *WriteSet) *WriteSet {
 	return out
 }
 
-// MergeInto folds prev's entries into next in place and returns the surviving
-// set, next winning on (addr, path, key). That is next, except that an empty
-// side short-circuits to the other one — so the result can be prev, and a
-// caller that releases or mutates it must compare identity first. Unlike Merge
-// it shares *VersionedWrite pointers instead of cloning, so next must be
-// exclusively owned by the caller and neither side may mutate a shared
-// VersionedWrite in place afterwards; prev's maps are never touched, so
-// map-level deletes on prev stay safe.
+// MergeInto shares *VersionedWrite pointers instead of cloning (next must be
+// exclusively owned; neither side mutates a shared value afterward). An empty
+// side short-circuits to the other, so the result can be prev — compare identity before releasing or mutating it.
 func (prev *WriteSet) MergeInto(next *WriteSet) *WriteSet {
 	if prev.IsEmpty() {
 		return next
@@ -2120,7 +1935,6 @@ func (prev *WriteSet) MergeInto(next *WriteSet) *WriteSet {
 	return next
 }
 
-// hasNewWrite: returns true if the current set has a new write compared to the input
 func (writes *WriteSet) HasNewWrite(cmpSet *WriteSet) bool {
 	if writes.IsEmpty() {
 		return false
@@ -2136,18 +1950,8 @@ func (writes *WriteSet) HasNewWrite(cmpSet *WriteSet) bool {
 	return false
 }
 
-// StripBalanceWrite removes the BalancePath write for addr from the write set
-// and computes the TX's net balance delta by comparing the stale write with
-// the stale read from readSet. This is used in finalize to prevent stale
-// speculative coinbase/burnt-contract balance writes from being applied via
-// ApplyVersionedWrites. The delta is returned so it can be applied separately
-// on top of the correct base balance from the VersionedStateReader.
-//
-// Returns:
-//   - stripped: the write set with the balance write removed
-//   - delta: the absolute difference between stale write and stale read
-//   - increase: true if the TX increased the balance, false if decreased
-//   - found: true if both a stale read and write were found and a non-zero delta computed
+// StripBalanceWrite strips a stale speculative coinbase/burnt-contract balance
+// write so finalize can re-apply the delta on top of the correct base balance.
 func (writes *WriteSet) StripBalanceWrite(addr accounts.Address, readSet ReadSet) (stripped *WriteSet, delta uint256.Int, increase bool, found bool) {
 	stripped = writes
 	if writes == nil || addr.IsNil() {
@@ -2155,8 +1959,6 @@ func (writes *WriteSet) StripBalanceWrite(addr accounts.Address, readSet ReadSet
 	}
 	bw, hasWrite := writes.balance[addr]
 	if !readSet.hasAddr(addr) {
-		// TX didn't read this address — no delta to compute. Still strip the
-		// write to prevent stale cache pollution.
 		if hasWrite {
 			delete(writes.balance, addr)
 		}
@@ -2185,9 +1987,6 @@ type VersionedIO struct {
 	inputs  []versionedReadSet
 	outputs []*WriteSet // write sets that should be checked during validation
 
-	// outputsReleased marks ReleaseOutputMaps having run. A read after that
-	// point sees emptied sets rather than failing, so under assertions the
-	// accessors panic instead. Only written when dbg.AssertEnabled.
 	outputsReleased bool
 }
 
@@ -2253,9 +2052,6 @@ func (io *VersionedIO) assertOutputsLive(op string) {
 	}
 }
 
-// ReleaseOutputMaps returns every recorded write set's map containers to their
-// pools and empties the slots. Only for a VersionedIO whose last reader is
-// done; the shared VersionedWrite values are left to GC.
 func (io *VersionedIO) ReleaseOutputMaps() {
 	for _, output := range io.outputs {
 		output.ReleaseMaps()
@@ -2323,10 +2119,6 @@ func (io *VersionedIO) Merge(other *VersionedIO) *VersionedIO {
 	return merged
 }
 
-// mergeTx folds a single transaction's reads, writes and accesses (recorded at
-// version.TxIndex) into io at that index, accumulating into the slot rather
-// than overwriting it the way RecordReads does. The three per-tx slices grow in
-// lockstep so they stay equal length.
 func (io *VersionedIO) mergeTx(version Version, reads ReadSet, writes *WriteSet) {
 	idx := version.TxIndex + 1
 	n := max(idx+1, len(io.inputs), len(io.outputs))
@@ -2336,14 +2128,10 @@ func (io *VersionedIO) mergeTx(version Version, reads ReadSet, writes *WriteSet)
 	if n > len(io.outputs) {
 		io.outputs = append(io.outputs, make([]*WriteSet, n-len(io.outputs))...)
 	}
-	// Fold the read set when it carries typed reads OR access-only marks: an
-	// access-only phase has Len()==0 but must still reach io.inputs for the
-	// EIP-7928 BAL. Len() itself stays access-free so the parallel executor's
-	// HasReads/ReadSetIncarnation/ReadCount keep their read-presence semantics.
+	// Fold on typed reads OR access-only marks (the latter still needed for the
+	// EIP-7928 BAL); Len() itself stays access-free so read-presence checks elsewhere stay correct.
 	if reads.Len() > 0 || len(reads.access) > 0 {
 		if io.inputs[idx].readSet.Len() == 0 && len(io.inputs[idx].readSet.access) == 0 {
-			// Production call sites merge each tx once into an empty slot; hand the
-			// read set over directly (like RecordReads) instead of deep-copying.
 			io.inputs[idx] = versionedReadSet{version.Incarnation, reads}
 		} else {
 			io.inputs[idx] = io.inputs[idx].Merge(versionedReadSet{version.Incarnation, reads})
@@ -2355,8 +2143,7 @@ func (io *VersionedIO) mergeTx(version Version, reads ReadSet, writes *WriteSet)
 }
 
 // AsBlockAccessList assembles the EIP-7928 block access list. EIP-7928 and
-// EIP-8246 both activate with Amsterdam, so balance writes always use the
-// no-burn SELFDESTRUCT semantics.
+// EIP-8246 activate together at Amsterdam, so balance writes always use no-burn SELFDESTRUCT semantics.
 func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 	if io == nil {
 		return nil
@@ -2366,7 +2153,6 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 	maxTxIndex := io.Len() - 1
 
 	for txIndex := -1; txIndex <= maxTxIndex; txIndex++ {
-		// EIP-7928 requires every accessed address to appear in the BAL, so each per-path read map must register its address.
 		rs := io.ReadSet(txIndex)
 		for addr, tr := range rs.balance {
 			if addr.IsNil() || tr.internal {
@@ -2389,10 +2175,6 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 			if addr.IsNil() || tr.internal {
 				continue
 			}
-			// Skip validation-only reads for non-existent accounts.
-			// These are recorded when the version map has no entry
-			// (MVReadResultNone) so that conflict detection works across
-			// transactions, but they should not appear in the block access list.
 			if tr.Val == nil || tr.Val.IsNil() {
 				continue
 			}
@@ -2433,10 +2215,8 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 				continue
 			}
 			account := ensureAccountState(ac, addr)
-			// A pre-block-empty code hash marks the baseline empty so applyToCode drops a
-			// net-zero same-tx set-then-clear. Only an empty read seen before any code
-			// change is the pre-block value — a later read of an already-cleared delegation
-			// also reads empty and must not poison the baseline into dropping that clear.
+			// Only an empty code-hash read seen before any code change counts as the
+			// pre-block baseline; a later empty read of an already-cleared value must not re-trigger it.
 			if tr.Val.IsEmpty() && len(account.code.changes.entries) == 0 {
 				account.initialCodeEmpty = true
 			}
@@ -2449,9 +2229,6 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 		}
 
 		if writes := io.WriteSet(txIndex); writes != nil {
-			// Self-destruct is applied before the balance writes so the EIP-7928
-			// burn (zeroing a non-zero balance written by the destroying tx) fires
-			// — the priority is explicit in loop order.
 			for addr, w := range writes.SelfDestructs() {
 				if addr.IsNil() || !w.Val {
 					continue
@@ -2485,18 +2262,11 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 					account.applyWriteStorage(key, w.Val, w.Version.blockAccessIndex())
 				}
 			}
-			// EIP-7928 requires every touched address to appear. The value-carrying
-			// paths above register via ensureAccountState; a single sweep over the
-			// full address union covers the rest (incarnation/codeHash/create/
-			// codeSize/address) and can't silently miss a future path — the repeat
-			// ensureAccountState is a harmless get-or-create.
 			for addr := range writes.addrs() {
 				if addr.IsNil() {
 					continue
 				}
 				account := ensureAccountState(ac, addr)
-				// A contract created this block did not exist pre-block, so its pre-block
-				// code is empty; applyToCode uses this to drop a net-zero empty code change.
 				if vw, ok := writes.GetCreateContract(addr); ok && vw.Val {
 					account.initialCodeEmpty = true
 				}
@@ -2510,12 +2280,6 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 			}
 
 			account := ensureAccountState(ac, addr)
-			// A non-revertable access means the address was the target of
-			// an actual EVM operation (evm.Call, evm.Create, SELFDESTRUCT
-			// with non-zero balance, BALANCE, EXTCODESIZE, etc.) — not just
-			// a gas-calculation read. This is used to distinguish real state
-			// access from incidental reads (e.g. Empty() in gas calc) for
-			// the system address filter.
 			if isUserTx && !opts.revertable {
 				account.nonRevertableUserAccess = true
 			}
@@ -2526,14 +2290,8 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 	for _, account := range ac {
 		account.finalize()
 		account.changes.Normalize()
-		// The system address (0xff...fe) is touched during every block's system
-		// call (EIP-4788 beacon root) because it is msg.sender. Per EIP-7928,
-		// "SYSTEM_ADDRESS MUST NOT be included unless it experiences state access
-		// itself." We use the non-revertable access flag from MarkAddressAccess
-		// to distinguish real state access (evm.Call target, SELFDESTRUCT
-		// beneficiary, BALANCE opcode, etc.) from incidental gas-calculation
-		// reads (Empty() in statefulGasCall). Keep it when it has actual state
-		// changes or when a user tx performed a non-revertable access to it.
+		// EIP-7928: SYSTEM_ADDRESS is excluded unless it has real account changes or a
+		// non-revertable user access — the EIP-4788 system call touches it every block.
 		if account.changes.Address == params.SystemAddress && !hasAccountChanges(account.changes) && !account.nonRevertableUserAccess {
 			continue
 		}
@@ -2547,8 +2305,6 @@ func (io *VersionedIO) AsBlockAccessList() types.BlockAccessList {
 	return bal
 }
 
-// hasAccountChanges returns true if the account has any state changes
-// (storage, balance, nonce, or code) that belong in the BAL.
 func hasAccountChanges(ac *types.AccountChanges) bool {
 	return len(ac.StorageChanges) > 0 || len(ac.StorageReads) > 0 ||
 		len(ac.BalanceChanges) > 0 || len(ac.NonceChanges) > 0 ||
@@ -2560,14 +2316,13 @@ type accountState struct {
 	balance                 *fieldTracker[uint256.Int]
 	nonce                   *fieldTracker[uint64]
 	code                    *fieldTracker[accounts.Code]
-	balanceValue            *uint256.Int                        // tracks latest seen balance
-	initialBalanceValue     *uint256.Int                        // tracks pre-block balance for net-zero detection
-	storageReadValues       map[accounts.StorageKey]uint256.Int // original read values for net-zero detection
-	nonRevertableUserAccess bool                                // true if a user tx (txIndex >= 0) has non-revertable access
-	initialCodeEmpty        bool                                // pre-block code was empty (created contract or empty-codehash read)
+	balanceValue            *uint256.Int
+	initialBalanceValue     *uint256.Int
+	storageReadValues       map[accounts.StorageKey]uint256.Int
+	nonRevertableUserAccess bool
+	initialCodeEmpty        bool
 }
 
-// check pre- and post-values, add to BAL if different
 func (a *accountState) finalize() {
 	applyToBalance(a.balance, a.changes, a.initialBalanceValue)
 	applyToNonce(a.nonce, a.changes)
@@ -2587,11 +2342,8 @@ func newBalanceTracker() *fieldTracker[uint256.Int] {
 }
 
 func applyToBalance(bt *fieldTracker[uint256.Int], ac *types.AccountChanges, initialBalance *uint256.Int) {
-	// Get the sorted indices to identify the first (lowest-index) entry.
-	// If the first entry equals the pre-block balance, it's a net-zero
-	// change from a reverted tx (e.g. CALL with value then revert) and
-	// must be excluded. Geth's scope-based BAL builder handles this via
-	// ExitScope which converts reverted writes to reads.
+	// If the first (lowest-index) entry equals the pre-block balance, it's a
+	// net-zero change from a reverted tx (e.g. CALL-with-value then revert) — exclude it.
 	firstFiltered := false
 	bt.changes.apply(func(idx uint32, value uint256.Int) {
 		if !firstFiltered {
@@ -2625,9 +2377,8 @@ func newCodeTracker() *fieldTracker[accounts.Code] {
 }
 
 func applyToCode(ct *fieldTracker[accounts.Code], ac *types.AccountChanges, initialCodeEmpty bool) {
-	// A first code change back to empty when pre-block code was already empty
-	// (e.g. an EIP-7702 delegation set then cleared in the same tx) is a net-zero
-	// change and is omitted, matching EELS's post-vs-pre code-hash diff.
+	// A first code change back to empty, when pre-block code was already empty (e.g.
+	// an EIP-7702 delegation set then cleared in the same tx), is net-zero — omit it.
 	firstFiltered := false
 	ct.changes.apply(func(idx uint32, value accounts.Code) {
 		if !firstFiltered {
@@ -2643,9 +2394,8 @@ func applyToCode(ct *fieldTracker[accounts.Code], ac *types.AccountChanges, init
 	})
 }
 
-// changeTracker stores the latest written value per access index. For CodePath
-// the entry borrows the canonical bytecode owned by cache.StateCache; applyToCode
-// clones it into the BAL CodeChange so the consensus-visible output owns its bytes.
+// changeTracker's CodePath entries borrow bytecode owned by cache.StateCache;
+// applyToCode clones it into the BAL CodeChange so the consensus-visible output owns its bytes.
 type changeTracker[T any] struct {
 	entries map[uint32]T
 }
@@ -2695,9 +2445,7 @@ func ensureAccountState(accounts map[accounts.Address]*accountState, addr accoun
 }
 
 func (account *accountState) applyWriteStorage(key accounts.StorageKey, val uint256.Int, accessIndex uint32) {
-	// Skip intra-tx net-zero storage writes: if this is the first write
-	// to the slot (no prior tx wrote to it) and the written value equals
-	// the original read value, it's a no-op that should remain as a read.
+	// Skip a first storage write that restores the original read value — net-zero, so it stays a read, not a write.
 	if !hasStorageWrite(account.changes, key) {
 		if origVal, wasRead := account.storageReadValues[key]; wasRead && val.Eq(&origVal) {
 			return
@@ -2716,16 +2464,9 @@ func (account *accountState) applyWriteCode(val accounts.Code, accessIndex uint3
 
 func (account *accountState) applyWriteBalance(val uint256.Int, accessIndex uint32) {
 	{
-		// If we haven't seen a balance and the first write is zero, treat it
-		// as a touch only when the pre-block balance is (or is implicitly) zero:
-		//   - No prior read: the account wasn't accessed before, so its
-		//     pre-block balance is implicitly zero (e.g. a newly CREATE'd
-		//     contract or a receiver observed only via the post-write finalize
-		//     path). Writing zero is a no-op.
-		//   - Prior read showed zero: write matches initial state, no-op.
-		// If a prior read showed a non-zero pre-block balance, the zero write
-		// is a genuine depletion (e.g. a sender whose funds were consumed by
-		// gas) and must be recorded as a real balance change.
+		// A first zero-balance write is a no-op touch only if the pre-block balance
+		// was also (implicitly) zero; if a prior read showed non-zero, a zero write
+		// is a real depletion and must be recorded.
 		if account.balanceValue == nil && val.IsZero() &&
 			(account.initialBalanceValue == nil || account.initialBalanceValue.IsZero()) {
 			if account.initialBalanceValue == nil {
@@ -2735,16 +2476,13 @@ func (account *accountState) applyWriteBalance(val uint256.Int, accessIndex uint
 			account.setBalanceValue(val)
 			return
 		}
-		// Skip no-op writes.
 		if account.balanceValue != nil && val.Eq(account.balanceValue) {
 			account.setBalanceValue(val)
 			return
 		}
-		// Skip balance writes that match the pre-block (initial) balance,
-		// but ONLY when no intermediate balance changes have been recorded.
-		// If intermediate changes exist (e.g. tx58 sets balance=0xa141,
-		// tx78 restores initial 0x16ffd), the restoring write MUST be
-		// recorded so parallel executors see the correct value at tx78.
+		// A write matching the pre-block balance is a no-op ONLY if no intermediate
+		// write was recorded — a later restore to the initial value must still be
+		// recorded so parallel readers see it at that index.
 		if account.initialBalanceValue != nil && val.Eq(account.initialBalanceValue) && len(account.balance.changes.entries) == 0 {
 			account.setBalanceValue(val)
 			return
@@ -2755,8 +2493,6 @@ func (account *accountState) applyWriteBalance(val uint256.Int, accessIndex uint
 }
 
 func (account *accountState) updateReadStorage(key accounts.StorageKey, val uint256.Int) {
-	// Record the original read value for net-zero detection.
-	// Only the first read for each slot is recorded (the original value).
 	if account.storageReadValues == nil {
 		account.storageReadValues = make(map[accounts.StorageKey]uint256.Int)
 	}
@@ -2770,28 +2506,18 @@ func (account *accountState) updateReadStorage(key accounts.StorageKey, val uint
 }
 
 func (account *accountState) updateReadBalance(val uint256.Int) {
-	// Record the initial (pre-block) balance for net-zero detection.
-	// Only set from the first read AND only before any writes have
-	// been recorded. A read that arrives after a write (e.g. the
-	// block-end finalize in the parallel executor reading from a
-	// fresh IBS, or a BAL-prepopulated read of a tx's predicted
-	// write) reflects post-write state, not the pre-block balance,
-	// and must not be used for net-zero filtering.
+	// A read after a write may reflect post-write state, so it must not become the pre-block baseline.
 	if account.initialBalanceValue == nil && account.balanceValue == nil {
 		v := val
 		account.initialBalanceValue = &v
 	}
-	// Only update balanceValue from reads when no writes have been
-	// recorded yet. After a write, balanceValue tracks the written
-	// state; a stale read from the DB must not override it, or the
-	// no-op check in updateWrite will incorrectly skip a real write.
+	// Once a write exists, a later read must not override the tracked value.
 	if len(account.balance.changes.entries) == 0 {
 		account.setBalanceValue(val)
 	}
 }
 
 func addStorageUpdate(ac *types.AccountChanges, slot accounts.StorageKey, val uint256.Int, txIndex uint32) {
-	// If we already recorded a read for this slot, drop it because a write takes precedence.
 	removeStorageRead(ac, slot)
 
 	if ac.StorageChanges == nil {
@@ -2804,7 +2530,6 @@ func addStorageUpdate(ac *types.AccountChanges, slot accounts.StorageKey, val ui
 
 	for _, slotChange := range ac.StorageChanges {
 		if slotChange.Slot == slot {
-			// EIP-7928 no-op filter: skip if value equals the slot's last recorded write.
 			if n := len(slotChange.Changes); n > 0 && val.Eq(&slotChange.Changes[n-1].Value) {
 				return
 			}
@@ -2849,7 +2574,6 @@ type versionedReadSet struct {
 	readSet     ReadSet
 }
 
-// AllHeaders iterates the type-agnostic header of every read in the set.
 func (s versionedReadSet) AllHeaders() iter.Seq[ReadHeader] {
 	return func(yield func(ReadHeader) bool) {
 		s.readSet.eachHeader(yield)

--- a/execution/state/versionedio_test.go
+++ b/execution/state/versionedio_test.go
@@ -34,9 +34,6 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// newWriteSet builds a typed *WriteSet from heterogeneous *VersionedWrite[T]
-// values, routing each into the correct per-path map by its WriteHeader. It is
-// the test-side replacement for the deleted flat VersionedWrites slice literal.
 func newWriteSet(writes ...any) *WriteSet {
 	ws := &WriteSet{}
 	for _, w := range writes {
@@ -78,9 +75,6 @@ func addWriteToSet(ws *WriteSet, w any) {
 	}
 }
 
-// writeSetVal reads the typed value for a header from the WriteSet's per-path
-// maps and returns it as an any, the test-side replacement for the deleted
-// Val[T] extractor.
 func writeSetVal(s *WriteSet, h WriteHeader) any {
 	switch h.Path {
 	case AddressPath:
@@ -118,8 +112,7 @@ func writeSetVal(s *WriteSet, h WriteHeader) any {
 	return nil
 }
 
-// minimalStateReader is a no-op StateReader for tests that create fresh accounts.
-// All methods return zero/nil — the IBS will create new empty state objects.
+// minimalStateReader is a no-op reader: zero/nil lets the IBS create fresh state objects.
 type minimalStateReader struct{}
 
 func (r *minimalStateReader) ReadAccountData(addr accounts.Address) (*accounts.Account, error) {
@@ -143,23 +136,16 @@ func (r *minimalStateReader) SetTrace(trace bool, tracePrefix string) {}
 func (r *minimalStateReader) Trace() bool                             { return false }
 func (r *minimalStateReader) TracePrefix() string                     { return "" }
 
-// TestAsBlockAccessList_SystemAddressExcludedWithoutChanges verifies that the
-// system address (0xff...fe) is excluded from the BAL when it has no actual
-// state changes and only revertable accesses (e.g. incidental gas-calculation
-// reads during system calls).
 func TestAsBlockAccessList_SystemAddressExcludedWithoutChanges(t *testing.T) {
 	t.Parallel()
 
 	sysAddr := params.SystemAddress
 	userAddr := accounts.InternAddress(common.HexToAddress("0x1111"))
 
-	io := NewVersionedIO(1) // 2 tx slots: system call at -1, user tx at 0
+	io := NewVersionedIO(1)
 
-	// System call (txIndex = -1): record system address as a revertable access.
-	// This simulates EIP-4788 beacon root call where system address is msg.sender.
 	recordTouch(io, -1, sysAddr, true)
 
-	// User tx (txIndex = 0): record a normal address with a balance write.
 	readSets := ReadSet{}
 	readSets.SetBalance(userAddr, VersionedRead[uint256.Int]{Val: *uint256.NewInt(100)})
 	io.RecordReads(Version{TxIndex: 0}, readSets)
@@ -169,12 +155,10 @@ func TestAsBlockAccessList_SystemAddressExcludedWithoutChanges(t *testing.T) {
 
 	bal := io.AsBlockAccessList()
 
-	// System address should be excluded (no state changes, only revertable access).
 	for _, ac := range bal {
 		require.NotEqual(t, sysAddr, ac.Address,
 			"system address should be excluded from BAL when it has no state changes and only revertable accesses")
 	}
-	// User address should be present.
 	found := false
 	for _, ac := range bal {
 		if ac.Address == userAddr {
@@ -185,21 +169,15 @@ func TestAsBlockAccessList_SystemAddressExcludedWithoutChanges(t *testing.T) {
 	require.True(t, found, "user address should be present in BAL")
 }
 
-// TestAsBlockAccessList_SystemAddressIncludedWithNonRevertableAccess verifies
-// that the system address is included in the BAL when a user tx performs a
-// non-revertable access to it (e.g. BALANCE opcode, direct call, SELFDESTRUCT
-// beneficiary), even without actual state changes.
 func TestAsBlockAccessList_SystemAddressIncludedWithNonRevertableAccess(t *testing.T) {
 	t.Parallel()
 
 	sysAddr := params.SystemAddress
 
-	io := NewVersionedIO(1) // system call at -1, user tx at 0
+	io := NewVersionedIO(1)
 
-	// System call (txIndex = -1): revertable access (as usual).
 	recordTouch(io, -1, sysAddr, true)
 
-	// User tx (txIndex = 0): non-revertable access (e.g. BALANCE opcode on system address).
 	recordTouch(io, 0, sysAddr, false)
 
 	bal := io.AsBlockAccessList()
@@ -231,9 +209,6 @@ func TestPrepareRecordsSystemCoinbaseInBlockAccessList(t *testing.T) {
 	require.Equal(t, params.SystemAddress, bal[0].Address)
 }
 
-// TestAsBlockAccessList_SystemAddressIncludedWithStateChanges verifies that the
-// system address is kept in the BAL when it has actual state changes (e.g. a
-// value transfer to the system address), regardless of access type.
 func TestAsBlockAccessList_SystemAddressIncludedWithStateChanges(t *testing.T) {
 	t.Parallel()
 
@@ -241,11 +216,8 @@ func TestAsBlockAccessList_SystemAddressIncludedWithStateChanges(t *testing.T) {
 
 	io := NewVersionedIO(1)
 
-	// System call (txIndex = -1): revertable access only.
 	recordTouch(io, -1, sysAddr, true)
 
-	// User tx (txIndex = 0): revertable access BUT with a balance change
-	// (e.g. ETH transferred to system address).
 	recordTouch(io, 0, sysAddr, true)
 	io.RecordWrites(Version{TxIndex: 0}, newWriteSet(
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: sysAddr, Path: BalancePath, Version: Version{TxIndex: 0}}, Val: *uint256.NewInt(42)},
@@ -264,9 +236,7 @@ func TestAsBlockAccessList_SystemAddressIncludedWithStateChanges(t *testing.T) {
 		"system address should be included in BAL when it has actual state changes")
 }
 
-// TestAsBlockAccessList_SystemAddressRevertableFromSystemCallOnly verifies that
-// a revertable access from a system call (txIndex = -1) does NOT set the
-// nonRevertableUserAccess flag, so the system address is still excluded.
+// A revertable access from a system call (TxIndex < 0) must not set nonRevertableUserAccess.
 func TestAsBlockAccessList_SystemAddressRevertableFromSystemCallOnly(t *testing.T) {
 	t.Parallel()
 
@@ -275,13 +245,8 @@ func TestAsBlockAccessList_SystemAddressRevertableFromSystemCallOnly(t *testing.
 
 	io := NewVersionedIO(1)
 
-	// System call (txIndex = -1): non-revertable access. Even though it's
-	// non-revertable, it's from a system call (txIndex < 0) so it should
-	// NOT mark the system address for inclusion.
 	recordTouch(io, -1, sysAddr, false)
 
-	// User tx (txIndex = 0): touches a different address to ensure there's
-	// at least one user tx in the block.
 	readSets := ReadSet{}
 	readSets.SetBalance(otherAddr, VersionedRead[uint256.Int]{Val: *uint256.NewInt(50)})
 	io.RecordReads(Version{TxIndex: 0}, readSets)
@@ -297,24 +262,17 @@ func TestAsBlockAccessList_SystemAddressRevertableFromSystemCallOnly(t *testing.
 	}
 }
 
-// TestAsBlockAccessList_NonRevertableOverridesRevertable verifies that if the
-// system address first gets a revertable access from a user tx, then a
-// non-revertable access from another user tx, the non-revertable wins and the
-// address is included.
 func TestAsBlockAccessList_NonRevertableOverridesRevertable(t *testing.T) {
 	t.Parallel()
 
 	sysAddr := params.SystemAddress
 
-	io := NewVersionedIO(2) // 3 slots: system call at -1, user tx 0, user tx 1
+	io := NewVersionedIO(2)
 
-	// System call: revertable.
 	recordTouch(io, -1, sysAddr, true)
 
-	// User tx 0: revertable access (e.g. gas calc).
 	recordTouch(io, 0, sysAddr, true)
 
-	// User tx 1: non-revertable access (e.g. BALANCE opcode).
 	recordTouch(io, 1, sysAddr, false)
 
 	bal := io.AsBlockAccessList()
@@ -331,9 +289,6 @@ func TestAsBlockAccessList_NonRevertableOverridesRevertable(t *testing.T) {
 
 }
 
-// TestVersionedIO_BalanceNetZeroWriteOmittedFromBAL verifies that a balance
-// write that restores the exact pre-block value (with no intermediate writes)
-// is treated as a net-zero change and omitted from the BAL.
 func TestVersionedIO_BalanceNetZeroWriteOmittedFromBAL(t *testing.T) {
 	t.Parallel()
 
@@ -342,12 +297,10 @@ func TestVersionedIO_BalanceNetZeroWriteOmittedFromBAL(t *testing.T) {
 
 	io := NewVersionedIO(1)
 
-	// System tx reads the pre-block balance (establishes initialBalanceValue).
 	reads := ReadSet{}
 	reads.SetBalance(addr, VersionedRead[uint256.Int]{Val: initial})
 	io.RecordReads(Version{TxIndex: -1}, reads)
 
-	// User tx writes the exact same balance back — net-zero, should be omitted.
 	io.RecordWrites(Version{TxIndex: 0}, newWriteSet(
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Version: Version{TxIndex: 0}}, Val: initial},
 	))
@@ -361,10 +314,6 @@ func TestVersionedIO_BalanceNetZeroWriteOmittedFromBAL(t *testing.T) {
 	}
 }
 
-// TestVersionedIO_BalanceRestoreAfterIntermediateIsRecorded verifies that
-// restoring a balance to the pre-block (initial) value IS recorded in the BAL
-// when intermediate balance changes exist. The restore write is needed so that
-// parallel executors observing the tx see the correct value.
 func TestVersionedIO_BalanceRestoreAfterIntermediateIsRecorded(t *testing.T) {
 	t.Parallel()
 
@@ -374,17 +323,14 @@ func TestVersionedIO_BalanceRestoreAfterIntermediateIsRecorded(t *testing.T) {
 
 	io := NewVersionedIO(2)
 
-	// System tx establishes pre-block balance.
 	reads := ReadSet{}
 	reads.SetBalance(addr, VersionedRead[uint256.Int]{Val: initial})
 	io.RecordReads(Version{TxIndex: -1}, reads)
 
-	// tx0: intermediate write (changes balance away from initial).
 	io.RecordWrites(Version{TxIndex: 0}, newWriteSet(
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Version: Version{TxIndex: 0}}, Val: intermediate},
 	))
 
-	// tx1: restores initial balance — must be recorded because an intermediate exists.
 	io.RecordWrites(Version{TxIndex: 1}, newWriteSet(
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Version: Version{TxIndex: 1}}, Val: initial},
 	))
@@ -402,27 +348,20 @@ func TestVersionedIO_BalanceRestoreAfterIntermediateIsRecorded(t *testing.T) {
 	require.True(t, found, "address must appear in BAL")
 }
 
-// TestVersionedIO_StaleBalanceReadAfterWriteDoesNotCorruptNoOpCheck verifies
-// that a stale BalancePath read arriving after a write (e.g. from a cached DB
-// value that pre-dates the write) does not override balanceValue and cause a
-// subsequent identical write to be incorrectly recorded as a new change.
 func TestVersionedIO_StaleBalanceReadAfterWriteDoesNotCorruptNoOpCheck(t *testing.T) {
 	t.Parallel()
 
 	addr := accounts.InternAddress(common.HexToAddress("0xcccc"))
 	io := NewVersionedIO(2)
 
-	// tx0: writes balance=200.
 	io.RecordWrites(Version{TxIndex: 0}, newWriteSet(
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Version: Version{TxIndex: 0}}, Val: *uint256.NewInt(200)},
 	))
 
-	// tx1: stale DB read of balance=100 (DB value predates tx0's write).
 	reads := ReadSet{}
 	reads.SetBalance(addr, VersionedRead[uint256.Int]{Val: *uint256.NewInt(100)})
 	io.RecordReads(Version{TxIndex: 1}, reads)
 
-	// tx1: writes balance=200 again — same as tx0, a true no-op.
 	io.RecordWrites(Version{TxIndex: 1}, newWriteSet(
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Version: Version{TxIndex: 1}}, Val: *uint256.NewInt(200)},
 	))
@@ -435,7 +374,7 @@ func TestVersionedIO_StaleBalanceReadAfterWriteDoesNotCorruptNoOpCheck(t *testin
 			found = true
 			require.Len(t, ac.BalanceChanges, 1,
 				"tx1's write of 200 is a no-op (same as tx0's 200); stale read must not cause a spurious second entry")
-			// blockAccessIndex = TxIndex+1, so tx0 (TxIndex=0) → Index=1.
+			// blockAccessIndex is TxIndex+1.
 			require.Equal(t, uint32(1), ac.BalanceChanges[0].Index,
 				"the single balance change must be from tx0 (blockAccessIndex=1)")
 		}
@@ -443,38 +382,20 @@ func TestVersionedIO_StaleBalanceReadAfterWriteDoesNotCorruptNoOpCheck(t *testin
 	require.True(t, found, "address must appear in BAL (tx0's write is a real change)")
 }
 
-// TestVersionedIO_PostWriteBalanceReadDoesNotPoisonInitialBalance is the
-// regression test for the bal-devnet-3 block-91648 BAL hash mismatch.
-//
-// Pattern reproduced from the production failure: a single user-tx balance
-// write to an address (the EIP-1559 burnt contract on this devnet — the zero
-// address) followed by a *later* BalancePath read of the same address with
-// the same value. The later read is the one the parallel executor's block-end
-// finalize emits when it spins up a fresh IntraBlockState — the cached state
-// objects from the per-tx execution aren't shared, so the finalize hits the
-// underlying state and observes the post-write value (or, in the validator
-// path, the value that was pre-populated into the version map from the BAL
-// sidecar).
-//
-// Before the fix, updateRead would seed initialBalanceValue from this
-// post-write read; applyToBalance's net-zero filter would then see the very
-// first recorded write equal to "initialBalanceValue" and drop it, producing
-// a BAL hash that disagreed with the header.
+// A BalancePath write followed by a later read of the same value must not seed
+// initialBalanceValue, or the net-zero filter wrongly drops the write.
 func TestVersionedIO_PostWriteBalanceReadDoesNotPoisonInitialBalance(t *testing.T) {
 	t.Parallel()
 
 	addr := accounts.InternAddress(common.HexToAddress("0x0000000000000000000000000000000000000000"))
-	burned := *uint256.NewInt(0x16eaeb76) // value pulled from bal-devnet-3 block 91648
+	burned := *uint256.NewInt(0x16eaeb76)
 
 	io := NewVersionedIO(2)
 
-	// Tx 1 burns the base fee to addr (value goes from pre-block balance to `burned`).
 	io.RecordWrites(Version{TxIndex: 1}, newWriteSet(
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Version: Version{TxIndex: 1}}, Val: burned},
 	))
 
-	// A later BalancePath read of the same value — emitted by the fresh-IBS
-	// finalize / BAL pre-pop. Before the fix, this poisoned initialBalanceValue.
 	reads := ReadSet{}
 	reads.SetBalance(addr, VersionedRead[uint256.Int]{Val: burned})
 	io.RecordReads(Version{TxIndex: 2}, reads)
@@ -487,7 +408,6 @@ func TestVersionedIO_PostWriteBalanceReadDoesNotPoisonInitialBalance(t *testing.
 			found = true
 			require.Len(t, ac.BalanceChanges, 1,
 				"tx 1's burn write must remain in BAL — a post-write read with the same value must not seed initialBalanceValue and trigger the net-zero filter")
-			// blockAccessIndex = TxIndex+1, so tx 1 → Index=2.
 			require.Equal(t, uint32(2), ac.BalanceChanges[0].Index)
 			require.True(t, ac.BalanceChanges[0].Value.Eq(&burned),
 				"the surviving balance change must hold the actual burn value")
@@ -496,10 +416,7 @@ func TestVersionedIO_PostWriteBalanceReadDoesNotPoisonInitialBalance(t *testing.
 	require.True(t, found, "burn target address must appear in BAL")
 }
 
-// TestVersionedIO_StorageNoOpWriteAfterChangeOmittedFromBAL verifies the
-// EIP-7928 rule that, for a slot written multiple times in a block, a write
-// storing the value an earlier write already set is a no-op and must be
-// excluded from storage_changes — only value-changing writes are recorded.
+// EIP-7928: a repeated write of an already-set value is a no-op, excluded from storage_changes.
 func TestVersionedIO_StorageNoOpWriteAfterChangeOmittedFromBAL(t *testing.T) {
 	t.Parallel()
 
@@ -514,10 +431,10 @@ func TestVersionedIO_StorageNoOpWriteAfterChangeOmittedFromBAL(t *testing.T) {
 			&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr, Path: StoragePath, Key: slot, Version: Version{TxIndex: txIndex}}, Val: v},
 		))
 	}
-	write(0, valA) // slot: 0 -> A  (real change)
-	write(1, valB) // slot: A -> B  (real change)
-	write(2, valB) // slot: B -> B  (no-op)
-	write(3, valB) // slot: B -> B  (no-op)
+	write(0, valA)
+	write(1, valB)
+	write(2, valB)
+	write(3, valB)
 
 	bal := io.AsBlockAccessList()
 
@@ -539,9 +456,6 @@ func TestVersionedIO_StorageNoOpWriteAfterChangeOmittedFromBAL(t *testing.T) {
 	require.True(t, found, "contract must appear in BAL")
 }
 
-// fallthroughStateReader returns a fixed account and a fixed storage value, so
-// a test can observe whether a versionedRead fell through to the underlying
-// state (vs. returning a version-map value or aborting).
 type fallthroughStateReader struct {
 	minimalStateReader
 	acct       *accounts.Account
@@ -560,10 +474,8 @@ func (r *fallthroughStateReader) ReadAccountStorage(addr accounts.Address, key a
 	return uint256.Int{}, false, nil
 }
 
-// TestVersionedIO_RemovedDependencyFallsThroughToStorage pins the
-// MVReadResultNone fallthrough in versionedRead: a stale MapRead whose
-// version-map cell has been removed must read the underlying storage value
-// rather than abort with ErrDependency.
+// Pins the MVReadResultNone fallthrough: a stale MapRead whose version-map cell
+// was removed must read the underlying storage value, not abort with ErrDependency.
 func TestVersionedIO_RemovedDependencyFallsThroughToStorage(t *testing.T) {
 	t.Parallel()
 
@@ -582,20 +494,10 @@ func TestVersionedIO_RemovedDependencyFallsThroughToStorage(t *testing.T) {
 		Val:        *uint256.NewInt(0xBB),
 	})
 
-	// Read-once (Block-STM): the repeat read is served from the read-set without
-	// re-probing, so it returns the recorded MapRead value rather than eagerly
-	// falling through to storage. The removed dependency (a MapRead whose
-	// version-map cell is now gone) is caught at commit — validateReadImpl
-	// invalidates a MapRead that resolves to MVReadResultNone (verified in
-	// validateReadImpl; exercised end-to-end by the parallel exec tests + hive) —
-	// which re-executes the tx and then falls through to the underlying storage.
 	got, err := ibs.GetState(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, *uint256.NewInt(0xBB), got, "read-once returns the recorded value")
 
-	// The recorded MapRead points at Tx1's now-removed cell, so at commit it
-	// resolves to MVReadResultNone and must be invalidated (which re-executes the
-	// tx so it falls through to storage). Without this the stale read commits.
 	valid := validateRead(ibs.versionMap, 2, addr, StoragePath, key, MapRead,
 		Version{TxIndex: 1, Incarnation: 0}, *uint256.NewInt(0xBB), liveStorage, eqUint256, absentUint256, nil,
 		func(rv, wv Version) VersionValidity { return VersionValid }, false, "")
@@ -603,10 +505,6 @@ func TestVersionedIO_RemovedDependencyFallsThroughToStorage(t *testing.T) {
 		"a MapRead whose version-map cell was removed must invalidate at commit")
 }
 
-// TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths verifies
-// that IntraBlockState.VersionedWrites retains SelfDestructPath, BalancePath
-// (including non-zero residual balances — EIP-7708 case 2), and IncarnationPath
-// after selfdestruct, and drops NoncePath/CodePath which selfdestruct resets.
 func TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths(t *testing.T) {
 	t.Parallel()
 
@@ -614,22 +512,15 @@ func TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths(t *testing
 	ibs := NewWithVersionMap(&minimalStateReader{}, NewVersionMap(nil))
 	ibs.SetTxContext(1, 0)
 
-	// Create the contract in the same tx — CreateContractPath must survive the
-	// selfdestruct write-set filter (kept under SD).
 	require.NoError(t, ibs.CreateAccount(addr, true))
-	// Establish nonce and code before selfdestruct — these should be dropped.
 	require.NoError(t, ibs.SetNonce(addr, 5, tracing.NonceChangeUnspecified))
 	require.NoError(t, ibs.SetCode(addr, []byte{0x60, 0x00}, tracing.CodeChangeUnspecified))
 	require.NoError(t, ibs.SetBalance(addr, *uint256.NewInt(0), tracing.BalanceChangeUnspecified))
 
-	// Selfdestruct: records SelfDestructPath=true, IncarnationPath, BalancePath=0.
 	destructed, err := ibs.Selfdestruct(addr, false)
 	require.NoError(t, err)
 	require.True(t, destructed)
 
-	// Simulate a non-zero post-selfdestruct balance write (EIP-7708 case 2:
-	// value sent to a selfdestructed address in the same block). This overwrites
-	// the zero-balance from Selfdestruct with a non-zero value that must be kept.
 	require.NoError(t, ibs.SetBalance(addr, *uint256.NewInt(500), tracing.BalanceChangeUnspecified))
 
 	writes := ibs.VersionedWrites()
@@ -641,21 +532,15 @@ func TestIBSVersionedWrites_SelfdestructRetainsBalanceDropsOtherPaths(t *testing
 		}
 	}
 
-	// Retained paths.
 	require.True(t, pathSet[SelfDestructPath], "SelfDestructPath must be retained")
 	require.True(t, pathSet[IncarnationPath], "IncarnationPath must be retained")
 	require.True(t, pathSet[BalancePath], "BalancePath (non-zero residual) must be retained")
 	require.True(t, pathSet[CreateContractPath], "CreateContractPath must be retained")
 
-	// Dropped paths — selfdestruct resets nonce and code, so they must not appear.
 	require.False(t, pathSet[NoncePath], "NoncePath must be dropped after selfdestruct")
 	require.False(t, pathSet[CodePath], "CodePath must be dropped after selfdestruct")
 }
 
-// --- StripBalanceWrite tests ---
-
-// TestStripBalanceWrite_NoRead verifies that when the TX didn't read the
-// address, the write is stripped but no delta is computed.
 func TestStripBalanceWrite_NoRead(t *testing.T) {
 	t.Parallel()
 
@@ -677,8 +562,6 @@ func TestStripBalanceWrite_NoRead(t *testing.T) {
 	require.False(t, increase)
 }
 
-// TestStripBalanceWrite_WithIncreaseDelta verifies delta computation when the
-// TX wrote a higher balance than it read (increase).
 func TestStripBalanceWrite_WithIncreaseDelta(t *testing.T) {
 	t.Parallel()
 
@@ -698,8 +581,6 @@ func TestStripBalanceWrite_WithIncreaseDelta(t *testing.T) {
 	require.Equal(t, uint256.NewInt(50), &delta, "delta should be 50 (150-100)")
 }
 
-// TestStripBalanceWrite_WithDecreaseDelta verifies delta computation when the
-// TX wrote a lower balance than it read (decrease).
 func TestStripBalanceWrite_WithDecreaseDelta(t *testing.T) {
 	t.Parallel()
 
@@ -719,7 +600,6 @@ func TestStripBalanceWrite_WithDecreaseDelta(t *testing.T) {
 	require.Equal(t, uint256.NewInt(30), &delta, "delta should be 30 (100-70)")
 }
 
-// TestStripBalanceWrite_NilAddress verifies that nil address is a no-op.
 func TestStripBalanceWrite_NilAddress(t *testing.T) {
 	t.Parallel()
 
@@ -735,18 +615,9 @@ func TestStripBalanceWrite_NilAddress(t *testing.T) {
 	require.False(t, increase)
 }
 
-// --- ApplyVersionedWrites reads generation tests ---
-// These verify what reads the IBS produces when applying different write types.
-// The direct finalize path must produce equivalent reads for BAL correctness.
-//
-// Key insight: the per-field account refresh (the source of BalancePath reads) only
-// runs for accounts that ALREADY EXIST in the stateReader or version map.
-// For newly-created accounts, GetOrNewStateObject calls createObject which
-// skips the per-field account refresh. This is the normal case for accounts born
-// in the current block (e.g. contract CREATE).
+// The per-field account refresh (BalancePath reads) only runs for accounts already
+// in the stateReader/version map; new accounts go through createObject, which skips it.
 
-// accountStateReader returns pre-configured accounts for specific addresses.
-// Used to simulate accounts that exist in the DB before execution.
 type accountStateReader struct {
 	minimalStateReader
 	accounts map[accounts.Address]*accounts.Account
@@ -769,9 +640,6 @@ func newAccountStateReader(addrs ...accounts.Address) *accountStateReader {
 	return r
 }
 
-// TestApplyVersionedWrites_BalanceWriteGeneratesBalanceRead verifies that a
-// BalancePath write through ApplyVersionedWrites generates a BalancePath read
-// (via the per-field account refresh in GetOrNewStateObject) for an existing account.
 func TestApplyVersionedWrites_BalanceWriteGeneratesBalanceRead(t *testing.T) {
 	t.Parallel()
 
@@ -792,9 +660,6 @@ func TestApplyVersionedWrites_BalanceWriteGeneratesBalanceRead(t *testing.T) {
 	require.True(t, hasRead(reads, addr, BalancePath), "BalancePath write must generate a BalancePath read for existing accounts")
 }
 
-// TestApplyVersionedWrites_StorageWriteNoBalanceRead verifies the lean
-// footprint: a StoragePath write through ApplyVersionedWrites no longer drags in
-// a whole-account refresh, so it records no BalancePath read.
 func TestApplyVersionedWrites_StorageWriteNoBalanceRead(t *testing.T) {
 	t.Parallel()
 
@@ -812,17 +677,11 @@ func TestApplyVersionedWrites_StorageWriteNoBalanceRead(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	// Lean footprint: a storage write no longer drags in a whole-account
-	// refresh, so it records no BalancePath read. Balance is not a BAL read
-	// field (only StorageReads exist), so this is BAL-neutral.
 	reads := ibs.VersionedReads()
 	require.False(t, hasRead(reads, addr, BalancePath),
 		"StoragePath write must not generate a spurious BalancePath read")
 }
 
-// TestApplyVersionedWrites_NonceWriteNoBalanceRead verifies the lean footprint:
-// a NoncePath write no longer drags in a whole-account refresh, so it records no
-// BalancePath read.
 func TestApplyVersionedWrites_NonceWriteNoBalanceRead(t *testing.T) {
 	t.Parallel()
 
@@ -839,16 +698,11 @@ func TestApplyVersionedWrites_NonceWriteNoBalanceRead(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	// Lean footprint: a nonce write no longer drags in a whole-account refresh.
 	reads := ibs.VersionedReads()
 	require.False(t, hasRead(reads, addr, BalancePath),
 		"NoncePath write must not generate a spurious BalancePath read")
 }
 
-// TestApplyVersionedWrites_MultipleAccountsOnlyBalanceWriteReadsBalance verifies
-// the lean footprint: when multiple existing accounts have writes of different
-// types, only the balance write reads its prior balance (the net-zero baseline);
-// nonce/storage writes record no BalancePath read.
 func TestApplyVersionedWrites_MultipleAccountsOnlyBalanceWriteReadsBalance(t *testing.T) {
 	t.Parallel()
 
@@ -870,25 +724,17 @@ func TestApplyVersionedWrites_MultipleAccountsOnlyBalanceWriteReadsBalance(t *te
 	))
 	require.NoError(t, err)
 
-	// Lean footprint: only a balance write reads prior balance (the net-zero
-	// baseline). Nonce/storage writes no longer drag in a whole-account refresh,
-	// so they record no spurious BalancePath read.
 	reads := ibs.VersionedReads()
 	require.True(t, hasRead(reads, addrA, BalancePath), "addrA (BalancePath write) reads its prior balance (net-zero baseline)")
 	require.False(t, hasRead(reads, addrB, BalancePath), "addrB (NoncePath write) must not have a spurious BalancePath read")
 	require.False(t, hasRead(reads, addrC, BalancePath), "addrC (StoragePath write) must not have a spurious BalancePath read")
 }
 
-// TestApplyVersionedWrites_NewAccountNoBalanceRead verifies that for accounts
-// that DON'T exist in the DB (newly created in this block), ApplyVersionedWrites
-// does NOT generate a BalancePath read. The per-field account refresh is skipped
-// because createObject is called instead.
 func TestApplyVersionedWrites_NewAccountNoBalanceRead(t *testing.T) {
 	t.Parallel()
 
 	addr := accounts.InternAddress(common.HexToAddress("0xF500"))
 	vm := NewVersionMap(nil)
-	// Use minimalStateReader — returns nil for all accounts.
 	ibs := New(NewVersionedStateReader(0, ReadSet{}, vm, &minimalStateReader{}))
 	ibs.SetTxContext(1, 0)
 	ibs.SetVersion(0)
@@ -904,8 +750,6 @@ func TestApplyVersionedWrites_NewAccountNoBalanceRead(t *testing.T) {
 		"newly-created account (not in DB) should NOT generate a BalancePath read")
 }
 
-// recordTouch records an address-level ephemeral access for txIndex on the
-// read-set (accesses feed the BAL through the read-set now).
 func recordTouch(io *VersionedIO, txIndex int, addr accounts.Address, revertable bool) {
 	rs := io.ReadSet(txIndex)
 	if rs.access == nil {
@@ -915,17 +759,13 @@ func recordTouch(io *VersionedIO, txIndex int, addr accounts.Address, revertable
 	io.RecordReads(Version{TxIndex: txIndex}, rs)
 }
 
-// hasRead reports whether the ReadSet has a read for the given address and path.
 func hasRead(reads ReadSet, addr accounts.Address, path AccountPath) bool {
 	_, ok := reads.getHeader(addr, path, accounts.NilKey)
 	return ok
 }
 
-// When a prior tx wrote a sub-field (e.g. BalancePath via AddBalance) without
-// writing AddressPath, the per-field account refresh promotes the sub-field version
-// onto accountRead's AddressPath stamp. The validator's vm.Read(AddressPath)
-// must not invalidate that stamp — otherwise OCC re-execution races
-// identically until the retry budget exhausts.
+// A per-field write with no AddressPath write promotes its version onto accountRead's
+// AddressPath stamp; invalidating that stamp on validation livelocks OCC re-execution.
 func TestAccountRead_BalancePathPromotion_DoesNotInvalidate(t *testing.T) {
 	t.Parallel()
 
@@ -944,16 +784,11 @@ func TestAccountRead_BalancePathPromotion_DoesNotInvalidate(t *testing.T) {
 	ibs.SetVersion(0)
 	ibs.SetVersionMap(vm)
 
-	// Simulate the per-field account refresh's promoted return value:
-	// BalancePath at (0,0) bumped (source, version) above the
-	// account-record's own.
 	acc := accounts.NewAccount()
 	acc.Balance = postWithdrawalBalance
 	acc.CodeHash = accounts.EmptyCodeHash
 	ibs.accountRead(addr, &acc, MapRead, Version{TxIndex: 0, Incarnation: 0})
 
-	// Same call the parallel-exec scheduler makes between worker
-	// completion and apply.
 	io := NewVersionedIO(1)
 	io.RecordReads(Version{TxIndex: 1, Incarnation: 0}, ibs.VersionedReads())
 
@@ -972,16 +807,8 @@ func TestAccountRead_BalancePathPromotion_DoesNotInvalidate(t *testing.T) {
 			"makes validation fail and produces the cross-chain OCC livelock")
 }
 
-// When CreateAccount runs on an address whose only versionMap entry is a
-// sub-field (e.g. BalancePath from a prior credit), the synthetic
-// IncarnationPath read must default to (StorageRead, UnknownVersion), not
-// the outer (MapRead, V_bal) promotion — same livelock class as the
-// accountRead path.
-// CreateAccount must not record a SelfDestructPath read: the flag is a worker
-// signal the BAL cannot pre-populate, so a recorded probe races the destroyer's
-// flush when a CREATE2 re-creates an address destroyed earlier in the block.
-// The value-carrying synthetic incarnation/balance reads pin every consequence
-// of the flag, so validation coverage is unchanged.
+// CreateAccount must not record a SelfDestructPath read: it's a worker-only signal, and a
+// recorded probe would race a destroyer's flush when CREATE2 revives the same address.
 func TestCreateAccount_RecordsNoSelfDestructRead(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0xC4EA7E01"))
@@ -1035,23 +862,18 @@ func TestCreateAccount_SyntheticIncarnationStamp_DoesNotInvalidate(t *testing.T)
 			"BalancePath version")
 }
 
-// getVersionedAccount must honour a prior tx's SelfDestructPath cell even
-// when stateReader (which doesn't consult the versionMap) returns the pre-SD
-// record. Without this gate Empty() returns false and a CALL-with-value to
-// the SD'd address misses CallNewAccountGas.
+// getVersionedAccount must honor a prior tx's SelfDestructPath cell even when stateReader
+// (version-map-unaware) returns the pre-SD record, or Empty() wrongly returns false.
 func TestGetVersionedAccount_PriorTxSelfDestruct_ReturnsNil(t *testing.T) {
 	t.Parallel()
 
 	addr := accounts.InternAddress(common.HexToAddress("0xF1F5555B"))
 	reader := newAccountStateReader(addr)
-	// Pre-SD record: a deployed contract with nonce=1 and a real codeHash.
 	reader.accounts[addr].Nonce = 1
 	codeHash := accounts.InternCodeHash(common.HexToHash("0x31537ad3f3619e1f93aac0ddfdb0d8a0013bd170b427d81dd5abbee4f3f5248e"))
 	reader.accounts[addr].CodeHash = codeHash
 
 	vm := NewVersionMap(nil)
-	// Tx 3 self-destructs: SelfDestructPath=true only — SD doesn't write
-	// Nonce/CodeHash into the versionMap.
 	vm.WriteSelfDestruct(addr,
 		Version{TxIndex: 3, Incarnation: 0}, true, true)
 	vm.WriteBalance(addr,
@@ -1059,10 +881,6 @@ func TestGetVersionedAccount_PriorTxSelfDestruct_ReturnsNil(t *testing.T) {
 	vm.WriteIncarnation(addr,
 		Version{TxIndex: 3, Incarnation: 0}, uint64(1), true)
 
-	// Tx 4's worker IBS. The reader (analogous to CachedReaderV3) returns
-	// the pre-SD account directly — no versionMap-aware wrapper short-circuits
-	// the SD case. Only getVersionedAccount's versionMap check should convert
-	// that to nil.
 	ibs := New(reader)
 	ibs.SetTxContext(0, 4)
 	ibs.SetVersion(0)
@@ -1076,10 +894,8 @@ func TestGetVersionedAccount_PriorTxSelfDestruct_ReturnsNil(t *testing.T) {
 			"stateReader still surfaces the pre-SD record")
 }
 
-// Metamorphic SD+CREATE2 in one tx: SelfDestructPath=true and a fresh
-// AddressPath land at the SAME TxIdx. A strict hi > destructTxIndex
-// revival check would miss this; getVersionedAccount must recognise
-// AddressPath at TxIdx >= destructTxIndex as revival.
+// Same-tx SD+CREATE2 lands SelfDestructPath and a fresh AddressPath at the same TxIdx, so
+// getVersionedAccount must treat AddressPath >= destructTxIndex as revival, not just >.
 func TestGetVersionedAccount_SameTxMetamorphicRecreate_ReturnsAccount(t *testing.T) {
 	t.Parallel()
 
@@ -1088,7 +904,6 @@ func TestGetVersionedAccount_SameTxMetamorphicRecreate_ReturnsAccount(t *testing
 	reader.accounts[addr].Nonce = 1
 	reader.accounts[addr].CodeHash = accounts.InternCodeHash(common.HexToHash("0xc8c04ce6368db80967fe4c88faa37d1a3d3becb3b9e442a62a5dc8c1df6e14ee"))
 
-	// Tx 3: SD + CREATE2 re-deploy. All writes land at (TxIdx=3, Inc=0).
 	vm := NewVersionMap(nil)
 	vm.WriteSelfDestruct(addr,
 		Version{TxIndex: 3, Incarnation: 0}, true, true)
@@ -1096,7 +911,6 @@ func TestGetVersionedAccount_SameTxMetamorphicRecreate_ReturnsAccount(t *testing
 		Version{TxIndex: 3, Incarnation: 0}, uint256.Int{}, true)
 	vm.WriteIncarnation(addr,
 		Version{TxIndex: 3, Incarnation: 0}, uint64(2), true)
-	// Fresh AddressPath at the same TxIdx as the SD.
 	recreatedAcc := &accounts.Account{
 		Nonce:       1,
 		Incarnation: 2,
@@ -1105,9 +919,6 @@ func TestGetVersionedAccount_SameTxMetamorphicRecreate_ReturnsAccount(t *testing
 	vm.WriteAddress(addr,
 		Version{TxIndex: 3, Incarnation: 0}, recreatedAcc, true)
 
-	// Tx 4 reads addr. Strict-greater on subfields wouldn't see the
-	// same-TxIdx Balance/Nonce/CodeHash; the AddressPath >= destructTxIndex
-	// branch is what surfaces the re-created account.
 	ibs := New(NewVersionedStateReader(4, ReadSet{}, vm, reader))
 	ibs.SetTxContext(0, 4)
 	ibs.SetVersion(0)
@@ -1122,21 +933,14 @@ func TestGetVersionedAccount_SameTxMetamorphicRecreate_ReturnsAccount(t *testing
 		"the re-created account's Incarnation should reflect the CREATE2 (not the pre-SD value)")
 }
 
-// TestVersionedRead_EIP8246_PriorTxSelfDestructReadsAsPreserved verifies that
-// under EIP-8246 a concurrent tx reading an account self-destructed by a prior
-// tx sees it preserved (balance kept, empty code, exists) rather than zeroed —
-// the parallel-exec equivalent of serial's balance-preserving finalize. Without
-// this, a later tx's BALANCE/EXTCODEHASH of the SD'd account diverge from serial
-// (0 vs preserved), flipping SSTORE new-slot classification and block state gas.
+// EIP-8246: a self-destructed account must read as preserved (balance kept, empty code,
+// exists) for a concurrent tx, not zeroed — else SSTORE slot classification diverges from serial.
 func TestVersionedRead_EIP8246_PriorTxSelfDestructReadsAsPreserved(t *testing.T) {
 	t.Parallel()
 
 	addr := accounts.InternAddress(common.HexToAddress("0x8246A"))
 	preserved := *uint256.NewInt(1)
 
-	// Post-EIP-6780 a self-destructed account was created in the same tx, so it
-	// has no pre-block record, and extraction drops its nonce/code/codeHash
-	// writes — the map carries only what a real destroying tx publishes.
 	newIBS := func(eip8246 bool) *IntraBlockState {
 		reader := newAccountStateReader()
 		vm := NewVersionMap(nil)
@@ -1184,10 +988,7 @@ func TestVersionedRead_EIP8246_PriorTxSelfDestructReadsAsPreserved(t *testing.T)
 	require.False(t, preExists, "pre-EIP-8246: SD'd account does not exist")
 }
 
-// EIP-7928 net-zero guard: a slot that is read and then written back to the
-// same value must stay a read in the BAL, not become a write. The filter
-// lives in accountState.applyWriteStorage (the helper addStorageUpdate only
-// appends). This locks the behaviour down across the typed-vio refactor.
+// EIP-7928: a slot read then written back to the same value stays a read in the BAL, not a write.
 func TestUpdateWrite_StorageReadThenWriteBackSameValue_StaysRead(t *testing.T) {
 	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
 	slot := accounts.InternKey(common.HexToHash("0x07"))
@@ -1206,8 +1007,6 @@ func TestUpdateWrite_StorageReadThenWriteBackSameValue_StaysRead(t *testing.T) {
 		"the net-zero write-back must remain a read")
 }
 
-// The complement: a read followed by a write to a DIFFERENT value is a real
-// state change — it becomes a write and supersedes the recorded read.
 func TestUpdateWrite_StorageReadThenWriteDifferentValue_BecomesWrite(t *testing.T) {
 	addr := accounts.InternAddress(common.HexToAddress("0xbeef"))
 	slot := accounts.InternKey(common.HexToHash("0x07"))
@@ -1227,9 +1026,7 @@ func TestUpdateWrite_StorageReadThenWriteDifferentValue_BecomesWrite(t *testing.
 		"a real write supersedes the recorded read")
 }
 
-// EIP-7928 and EIP-8246 activate together, so a same-tx SELFDESTRUCT no longer
-// burns: the account's balance write records as-is, and a destroyed account
-// touched without net changes still gets its (empty) BAL entry.
+// EIP-7928 + EIP-8246: a same-tx SELFDESTRUCT no longer burns the balance write.
 func TestAsBlockAccessList_SelfdestructNoBurn(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x9e1989c1ba17e9b8fdae0b5d43a2b0c676a2070f"))
@@ -1286,12 +1083,8 @@ func TestEIP161EmptyRemoval(t *testing.T) {
 	}
 }
 
-// TestVersionedUpdates_EstimateCellConsumed pins that finalize reconstruction
-// consumes an in-block subfield write sitting in an Estimate (Dependency) cell
-// rather than falling back to the stale pre-block value. The per-path
-// versionedUpdate helpers must gate on != MVReadResultNone (Done OR Dependency);
-// gating on == MVReadResultDone drops the Estimate cell and reads stale state,
-// diverging balance/nonce/codeHash/storage and the trie root.
+// Finalize reconstruction must consume an in-block write sitting in an Estimate (Dependency)
+// cell — gating on MVReadResultDone only would drop it and read stale pre-block state.
 func TestVersionedUpdates_EstimateCellConsumed(t *testing.T) {
 	t.Parallel()
 
@@ -1306,7 +1099,6 @@ func TestVersionedUpdates_EstimateCellConsumed(t *testing.T) {
 	newCodeHash := accounts.InternCodeHash(crypto.Keccak256Hash([]byte{0x60, 0x00}))
 	newStorage := *uint256.NewInt(0x5707)
 
-	// complete=false → Estimate cells (Dependency status when read from tx 5).
 	vm.WriteBalance(addr, ver, newBalance, false)
 	vm.WriteNonce(addr, ver, newNonce, false)
 	vm.WriteIncarnation(addr, ver, newIncarnation, false)
@@ -1333,7 +1125,6 @@ func TestVersionedUpdates_EstimateCellConsumed(t *testing.T) {
 	require.Equal(t, newStorage, storageGot, "Estimate-cell storage must be consumed, not stale")
 }
 
-// countingStateReader records how many account reads reached the domain.
 type countingStateReader struct {
 	minimalStateReader
 	acc            *accounts.Account
@@ -1349,8 +1140,7 @@ func (r *countingStateReader) ReadAccountData(addr accounts.Address) (*accounts.
 	return r.acc, nil
 }
 
-// A tx that read an address and found no account records the AddressPath entry
-// header-only; that entry is the answer, not a gap to fill from the domain.
+// A recorded header-only absent read is the answer, not a gap to fill from the domain.
 func TestVersionedStateReader_RecordedAbsentSkipsDomain(t *testing.T) {
 	t.Parallel()
 
@@ -1385,8 +1175,6 @@ func TestVersionedStateReader_UnrecordedAddressReadsDomain(t *testing.T) {
 	require.Equal(t, 1, reader.accountReads)
 }
 
-// writeSetFixture builds a WriteSet covering every path, multiple addresses and
-// storage keys — the input for the iteration closed-loop tests.
 func writeSetFixture() (*WriteSet, []string) {
 	a1 := accounts.InternAddress(common.HexToAddress("0xaa01"))
 	a2 := accounts.InternAddress(common.HexToAddress("0xbb02"))
@@ -1432,8 +1220,6 @@ func writeKeyStr(h WriteHeader, val string) string {
 	return fmt.Sprintf("%x|%d|%x|%s", h.Address, h.Path, h.Key, val)
 }
 
-// headerValStr reads the typed value for h from the per-path maps (the new
-// iteration: AllHeaders + typed getters, no cast) and formats it.
 func headerValStr(s *WriteSet, h WriteHeader) string {
 	switch h.Path {
 	case BalancePath:
@@ -1467,9 +1253,6 @@ func headerValStr(s *WriteSet, h WriteHeader) string {
 	return ""
 }
 
-// TestWriteSet_AllHeaders_RoundTrip pins that AllHeaders + typed getters visits
-// every inserted write exactly once with the correct typed value — the durable
-// guard that the post-refactor iteration loses nothing.
 func TestWriteSet_AllHeaders_RoundTrip(t *testing.T) {
 	t.Parallel()
 	s, want := writeSetFixture()
@@ -1481,10 +1264,6 @@ func TestWriteSet_AllHeaders_RoundTrip(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
-// TestVersionedIO_mergeTxEquivalentToMerge asserts that folding per-tx IO into
-// an accumulator via mergeTx matches repeated Merge channel by channel (reads,
-// writes, accesses) and as a whole BAL — including the begin-system tx at index
-// -1 and two txs touching the same index.
 func TestVersionedIO_mergeTxEquivalentToMerge(t *testing.T) {
 	t.Parallel()
 
@@ -1504,16 +1283,12 @@ func TestVersionedIO_mergeTxEquivalentToMerge(t *testing.T) {
 		slot  accounts.StorageKey
 		val   uint64
 	}
-	// A StoragePath read on a slot the tx does not write surfaces in the BAL as
-	// a StorageRead, so a dropped read also changes the hash; a balance read
-	// would contribute no BAL field.
 	reads := func(x txIO) ReadSet {
 		rs := ReadSet{}
 		rs.SetStorage(x.addr, x.slot, VersionedRead[uint256.Int]{
 			ReadHeader: ReadHeader{Source: StorageRead, Version: Version{TxIndex: x.txIdx, Incarnation: x.inc}},
 			Val:        *uint256.NewInt(x.val),
 		})
-		// Access marks travel on the read-set now.
 		rs.access = AccessSet{x.addr: accessOptions{}}
 		return rs
 	}
@@ -1524,14 +1299,13 @@ func TestVersionedIO_mergeTxEquivalentToMerge(t *testing.T) {
 	}
 
 	txs := []txIO{
-		{-1, 0, addrs[0], slots[0], 5}, // begin-system tx (TxIndex -1)
+		{-1, 0, addrs[0], slots[0], 5},
 		{0, 0, addrs[0], slots[0], 10},
 		{1, 0, addrs[1], slots[0], 20},
 		{2, 1, addrs[2], slots[0], 30},
-		{2, 2, addrs[0], slots[1], 40}, // same index, higher incarnation: merge-into-existing
+		{2, 2, addrs[0], slots[1], 40},
 	}
 
-	// Oracle: build a single-tx VersionedIO per tx and fold via repeated Merge.
 	merged := &VersionedIO{}
 	for _, x := range txs {
 		v := Version{TxIndex: x.txIdx, Incarnation: x.inc}
@@ -1550,10 +1324,8 @@ func TestVersionedIO_mergeTxEquivalentToMerge(t *testing.T) {
 	require.Equal(t, merged.AsBlockAccessList().Hash(), fused.AsBlockAccessList().Hash(),
 		"mergeTx must produce a BAL identical to repeated Merge")
 
-	// The BAL hash does not surface a dropped access (a non-system access adds
-	// no BAL field), so compare every channel at every index directly: a mergeTx
-	// that overwrote instead of merged a slot passes the hash check but fails here.
-	// Access marks travel on the read-set now, so the ReadSet compare covers them.
+	// The BAL hash alone won't catch an overwrite-instead-of-merge bug (no BAL field for a
+	// non-system access), so also compare every channel — reads, writes, incarnation — per index.
 	for i := -1; i < merged.Len()-1; i++ {
 		require.Equal(t, merged.ReadSet(i), fused.ReadSet(i), "reads differ at tx %d", i)
 		require.Equal(t, merged.ReadSetIncarnation(i), fused.ReadSetIncarnation(i), "incarnation differs at tx %d", i)
@@ -1598,9 +1370,9 @@ func TestCreateAccount_FundedThenCreated_SyntheticReadKeepsPreTxBalance(t *testi
 	ibs.SetVersion(0)
 
 	addr := accounts.InternAddress(common.HexToAddress("0xf11577"))
-	require.NoError(t, ibs.CreateAccount(addr, false))                                          // value transfer creates the recipient
-	require.NoError(t, ibs.AddBalance(addr, *uint256.NewInt(1), tracing.BalanceChangeTransfer)) // funds it 0 -> 1
-	require.NoError(t, ibs.CreateAccount(addr, true))                                           // CREATE2 deploys the contract
+	require.NoError(t, ibs.CreateAccount(addr, false))
+	require.NoError(t, ibs.AddBalance(addr, *uint256.NewInt(1), tracing.BalanceChangeTransfer))
+	require.NoError(t, ibs.CreateAccount(addr, true))
 
 	rs := ibs.VersionedReads()
 	vr, ok := rs.GetBalance(addr)
@@ -1620,13 +1392,10 @@ func TestCreateAccount_InternalBalanceReadPromotedOnCreate_NoSpuriousBalanceChan
 	ibs.SetTxContext(0, 0)
 	ibs.SetVersion(0)
 
-	// The rejected value-CALL reads the target's balance during gas calc;
-	// MarkReadsInternal then flags that read as conflict-detection only.
 	_, err := ibs.GetBalance(addr)
 	require.NoError(t, err)
 	ibs.MarkReadsInternal(addr)
 
-	// The parent frame CREATE2-deploys to that same pre-funded address.
 	require.NoError(t, ibs.CreateAccount(addr, true))
 
 	io := NewVersionedIO(1)
@@ -1648,7 +1417,6 @@ func TestVersionedIO_CreatedAccountEmptyCodeChangeOmitted(t *testing.T) {
 
 	io := NewVersionedIO(1)
 
-	// The authority did not exist pre-block: its CodeHash reads as empty.
 	reads := ReadSet{}
 	reads.SetCodeHash(addr, VersionedRead[accounts.CodeHash]{Val: accounts.EmptyCodeHash})
 	io.RecordReads(Version{TxIndex: 0}, reads)
@@ -1680,8 +1448,6 @@ func TestVersionedIO_MidBlockEmptyCodeHashReadMustNotDropRealClear(t *testing.T)
 
 	io := NewVersionedIO(2)
 
-	// tx0: auth processing reads the authority's pre-tx (non-empty) code hash,
-	// then clears the delegation and bumps the nonce.
 	reads0 := ReadSet{}
 	reads0.SetCodeHash(addr, VersionedRead[accounts.CodeHash]{Val: delegation.Hash})
 	io.RecordReads(Version{TxIndex: 0}, reads0)
@@ -1690,7 +1456,6 @@ func TestVersionedIO_MidBlockEmptyCodeHashReadMustNotDropRealClear(t *testing.T)
 		&VersionedWrite[accounts.Code]{WriteHeader: WriteHeader{Address: addr, Path: CodePath, Version: Version{TxIndex: 0}}, Val: accounts.Code{}},
 	))
 
-	// tx1: reads the (now cleared) code hash mid-block.
 	reads1 := ReadSet{}
 	reads1.SetCodeHash(addr, VersionedRead[accounts.CodeHash]{Val: accounts.EmptyCodeHash})
 	io.RecordReads(Version{TxIndex: 1}, reads1)

--- a/execution/state/versionmap.go
+++ b/execution/state/versionmap.go
@@ -49,12 +49,7 @@ func (p AccountPath) String() string {
 	}
 }
 
-// AccountPath enum values. The numeric order matters: AsBlockAccessList
-// sorts writes by Path to ensure deterministic processing. SelfDestructPath
-// MUST precede BalancePath because updateWrite zeroes non-zero balance writes
-// in the same tx as a selfdestruct — the selfDestructed flag must be set
-// before balance writes are evaluated. Do not reorder without reviewing
-// updateWrite in versionedio.go.
+// Order matters: SelfDestructPath must precede BalancePath, so a same-tx destruct is seen before its balance write is zeroed.
 const (
 	AddressPath AccountPath = iota
 	SelfDestructPath
@@ -68,10 +63,6 @@ const (
 	CreateContractPath
 )
 
-// AccountKey is a (Path, Key) pair used as a selector for the field within
-// an AddressEntry and as a debug-printable identifier. It is no longer used
-// as an internal map key — VersionMap dispatches on Path via a switch on
-// the AddressEntry struct so the inner map's composite-key hash is gone.
 type AccountKey struct {
 	Path AccountPath
 	Key  accounts.StorageKey
@@ -85,17 +76,7 @@ func (k AccountKey) String() string {
 	return k.Path.String()
 }
 
-// AddressEntry holds the multi-version cells for one address, organised
-// per AccountPath. Each field is typed by the AccountPath's value-type
-// contract so adding the wrong type to a cell is a compile-time error
-// rather than a runtime panic — and the storage layer carries the typed
-// value end-to-end (no interface box on writes).
-//
-// Invariant — per-field independence: no consumer treats AddressEntry as
-// a transactional whole. Reads, writes, mark-estimate/complete, delete
-// and validation all operate at (Path, Key) granularity. Helpers that
-// look like address-level operations (DeleteAll, StorageKeys) are pure
-// iterations of per-field operations.
+// AddressEntry holds per-field multi-version cells for one address; no consumer treats it as a transactional whole across paths.
 type AddressEntry struct {
 	Address        *btree.Map[int, *WriteCell[*accounts.Account]]
 	SelfDestruct   *btree.Map[int, *WriteCell[bool]]
@@ -107,18 +88,11 @@ type AddressEntry struct {
 	CodeSize       *btree.Map[int, *WriteCell[int]]
 	CreateContract *btree.Map[int, *WriteCell[bool]]
 	Storage        map[accounts.StorageKey]*btree.Map[int, *WriteCell[uint256.Int]]
-	// mu guards this account's cell maps. Held RLock for reads (readFloor and
-	// the per-path scans) and Lock for writes (putCell / Delete / markFlag).
+	// mu guards this account's cell maps: RLock for reads, Lock for writes.
 	mu sync.RWMutex
 }
 
 // putCell sets or updates a typed cell at txIdx. Caller must hold e.mu.Lock().
-// Returns the (possibly newly-created) cell map for the caller to assign back
-// to its AddressEntry field. `getCell` is the per-T pool fetcher (e.g.
-// getCellBalance for the BalancePath); it is a static function-value, so
-// passing it costs no allocation. The write path uses pool-supplied cells
-// instead of `&WriteCell[T]{...}` literals — Delete/DeleteAll return them
-// to the same pool for reuse across blocks.
 func putCell[T any](cells *btree.Map[int, *WriteCell[T]], addr accounts.Address, path AccountPath, txIdx, incarnation int, flag statusFlag, value T, getCell func() *WriteCell[T]) *btree.Map[int, *WriteCell[T]] {
 	if cells == nil {
 		cells = &btree.Map[int, *WriteCell[T]]{}
@@ -140,9 +114,6 @@ func putCell[T any](cells *btree.Map[int, *WriteCell[T]], addr accounts.Address,
 	return cells
 }
 
-// markCellFlag sets the flag on an existing typed cell. Panics with msg if
-// no cell is present at txIdx — used by MarkEstimate/MarkComplete which
-// require a prior write.
 func markCellFlag[T any](cells *btree.Map[int, *WriteCell[T]], txIdx int, flag statusFlag, msg string) {
 	if cells == nil {
 		panic(msg)
@@ -155,13 +126,8 @@ func markCellFlag[T any](cells *btree.Map[int, *WriteCell[T]], txIdx int, flag s
 }
 
 type VersionMap struct {
-	// s maps address → *AddressEntry as a sync.Map so account lookup is
-	// lock-free on the read hot path (no shared reader-counter to contend on).
-	// Each AddressEntry carries its own RWMutex guarding that account's cells,
-	// so reads/writes of different accounts never contend — the global RWMutex
-	// this replaced serialised every access. Per-read conflict detection is
-	// unchanged; only the lock granularity moved from global to per-account.
-	s     sync.Map // accounts.Address -> *AddressEntry
+	// s maps address to *AddressEntry via sync.Map: lookups are lock-free and different accounts never contend on the same mutex.
+	s     sync.Map
 	trace bool
 }
 
@@ -171,7 +137,6 @@ func NewVersionMap(changes []*types.AccountChanges) *VersionMap {
 	return vm
 }
 
-// load returns the AddressEntry for addr, or nil when absent. Lock-free.
 func (vm *VersionMap) load(addr accounts.Address) *AddressEntry {
 	if e, ok := vm.s.Load(addr); ok {
 		return e.(*AddressEntry)
@@ -183,10 +148,6 @@ func (vm *VersionMap) SetTrace(trace bool) {
 	vm.trace = trace
 }
 
-// StorageKeys returns every storage slot key recorded for addr. Used by
-// Normalize to emit synthetic delete entries for every slot of a
-// selfdestructed contract, matching DomainDelPrefix behaviour from the
-// sequential path.
 func (vm *VersionMap) StorageKeys(addr accounts.Address) []accounts.StorageKey {
 	e := vm.load(addr)
 	if e == nil {
@@ -204,11 +165,7 @@ func (vm *VersionMap) StorageKeys(addr accounts.Address) []accounts.StorageKey {
 	return keys
 }
 
-// WriteChanges pre-populates the version map from a BAL (EIP-7928). Each
-// per-path change is routed through the typed Write primitive so the value
-// type is enforced at compile time — a future BAL field-type change that
-// breaks the contract surfaces as a build error here rather than a runtime
-// panic on the first read of the cell.
+// WriteChanges pre-populates the version map from a BAL (EIP-7928).
 func (vm *VersionMap) WriteChanges(changes []*types.AccountChanges) {
 	for _, accountChanges := range changes {
 		if dbg.TraceBALFeed {
@@ -271,9 +228,7 @@ func (vm *VersionMap) WriteChanges(changes []*types.AccountChanges) {
 					len(codeChange.Bytecode),
 				)
 			}
-			// Seed the whole code trio so pre-population matches what tx execution
-			// flushes together; a CodePath cell without its CodeHashPath/CodeSizePath
-			// siblings lets a concurrent reader see code but no code hash.
+			// Seed the whole code trio together: a Code cell without its CodeHash/CodeSize siblings lets a reader see code but no hash.
 			code := accounts.NewCode(codeChange.Bytecode)
 			v := Version{TxIndex: int(codeChange.Index) - 1}
 			vm.WriteCode(accountChanges.Address, v, code, true)
@@ -283,9 +238,7 @@ func (vm *VersionMap) WriteChanges(changes []*types.AccountChanges) {
 	}
 }
 
-// Typed Write primitives. Each takes the AccountPath-contracted value type
-// directly so wrong-type writes are caught at compile time — there is no
-// runtime data.(T) assertion path through these.
+// Typed Write primitives: each takes its AccountPath-contracted value type directly, so a wrong-type write fails to compile.
 
 func (vm *VersionMap) WriteAddress(addr accounts.Address, v Version, value *accounts.Account, complete bool) {
 	e := vm.entryOrCreate(addr)
@@ -360,9 +313,7 @@ func (vm *VersionMap) WriteStorage(addr accounts.Address, key accounts.StorageKe
 	e.Storage[key] = putCell(e.Storage[key], addr, StoragePath, v.TxIndex, v.Incarnation, flagFor(complete), value, getCellStorage)
 }
 
-// entryOrCreate returns the AddressEntry for addr, creating it if absent. The
-// returned pointer is stable for the map's lifetime; the caller locks e.mu for
-// the cell mutation. Self-synchronised via sync.Map — no caller lock required.
+// entryOrCreate returns addr's AddressEntry, creating it if absent. Self-synchronised via sync.Map: no caller lock required.
 func (vm *VersionMap) entryOrCreate(addr accounts.Address) *AddressEntry {
 	if e, ok := vm.s.Load(addr); ok {
 		return e.(*AddressEntry)
@@ -378,15 +329,8 @@ func flagFor(complete bool) statusFlag {
 	return FlagEstimate
 }
 
-// Typed Read primitives. Each returns the typed value, a ReadResult holding
-// the conflict-detection metadata (depIdx, incarnation), and ok=true when a
-// cell exists.
+// Typed Read primitives: each returns the typed value, a ReadResult with conflict-detection metadata, and ok=true if a cell exists.
 
-// readFloor performs the floor read shared by every typed ReadX primitive:
-// it descends sel(e)'s btree for the highest write strictly below txIdx and
-// returns its value plus the conflict-detection metadata (depIdx and, when the
-// floor cell is Done, its incarnation). sel extracts the per-path cell map from
-// the address entry, returning nil when the path is unset.
 func readFloor[T any](vm *VersionMap, addr accounts.Address, txIdx int, sel func(*AddressEntry) *btree.Map[int, *WriteCell[T]]) (val T, res ReadResult, ok bool) {
 	res.depIdx = UnknownDep
 	res.incarnation = -1
@@ -414,8 +358,7 @@ func readFloor[T any](vm *VersionMap, addr accounts.Address, txIdx int, sel func
 	return fv.Value, res, true
 }
 
-// floorCell returns the highest write strictly below txIdx, or (UnknownDep, nil)
-// when the path holds none. Caller must hold the address entry's read lock.
+// floorCell returns the highest write strictly below txIdx, or (UnknownDep, nil). Caller must hold the entry's read lock.
 func floorCell[T any](cells *btree.Map[int, *WriteCell[T]], txIdx int) (int, *WriteCell[T]) {
 	if cells == nil {
 		return UnknownDep, nil
@@ -432,11 +375,7 @@ func floorCell[T any](cells *btree.Map[int, *WriteCell[T]], txIdx int) (int, *Wr
 	return fk, fv
 }
 
-// applySubFieldWrites layers the Balance/Nonce/Incarnation/CodeHash writes for
-// addr onto account, taking one entry lookup and one read lock where the
-// per-path ReadX primitives would take one of each. An Estimate cell counts the
-// same as a Done one — it holds the same latest in-block write, which finalize
-// reconstruction must consume rather than fall back to the pre-block DB value.
+// applySubFieldWrites layers Balance/Nonce/Incarnation/CodeHash onto account in one lookup. An Estimate cell counts the same as Done: it's still the latest in-block write.
 func (vm *VersionMap) applySubFieldWrites(addr accounts.Address, txIdx int, account *accounts.Account) {
 	if vm == nil {
 		return
@@ -506,9 +445,7 @@ func (vm *VersionMap) ReadStorage(addr accounts.Address, key accounts.StorageKey
 	})
 }
 
-// ReadStatus returns a path's read outcome (Status/Version/DepIdx/Incarnation)
-// for callers that need only version/status (the validator's common path,
-// revival checks). It dispatches to the typed ReadX and discards the value.
+// ReadStatus dispatches to the typed ReadX and discards the value, for callers that need only version/status.
 func (vm *VersionMap) ReadStatus(addr accounts.Address, path AccountPath, key accounts.StorageKey, txIdx int) ReadResult {
 	var res ReadResult
 	switch path {
@@ -538,11 +475,6 @@ func (vm *VersionMap) ReadStatus(addr accounts.Address, path AccountPath, key ac
 	return res
 }
 
-// LatestTxIndex returns the largest TxIndex (≤ txIdxLimit) at which a write
-// exists for the given (addr, path, key). Returns ok=false when no entry
-// exists at or below the limit. Used to detect account revival after a
-// SelfDestruct: any newer non-SelfDestruct write at a strictly higher
-// TxIndex re-creates the account.
 func (vm *VersionMap) LatestTxIndex(addr accounts.Address, path AccountPath, key accounts.StorageKey, txIdxLimit int) (int, bool) {
 	if vm == nil {
 		return 0, false
@@ -605,15 +537,7 @@ func (vm *VersionMap) LatestTxIndex(addr accounts.Address, path AccountPath, key
 	return fk, true
 }
 
-// AccountLifecycle resolves an account's self-destruct/revival verdict at txIdx
-// from the synthetic lifecycle paths, using a single revival definition that all
-// consumers share (readers, validation, and the create decision) so they cannot
-// diverge. destroyed reports a Done SelfDestruct write at TxIdx ≤ txIdx with
-// value true; destroyedAt is that write's TxIndex. revived reports a re-creation
-// strictly after the destruct and before txIdx: AddressPath ≥ destroyedAt
-// (catches same-tx metamorphic SD+CREATE2, where both land at the same TxIdx) or
-// any of {Balance,Nonce,CodeHash} > destroyedAt. A destroyed-and-not-revived
-// account reads as gone.
+// AccountLifecycle is the one revival definition shared by readers, validation, and create decisions: AddressPath alone uses >= destroyedAt, since same-tx SD+CREATE2 lands both writes at one TxIdx.
 func (vm *VersionMap) AccountLifecycle(addr accounts.Address, txIdx int) (destroyed bool, destroyedAt int, revived bool) {
 	if vm == nil {
 		return false, 0, false
@@ -635,10 +559,7 @@ func (vm *VersionMap) AccountLifecycle(addr accounts.Address, txIdx int) (destro
 	return true, destroyedAt, false
 }
 
-// AnyDoneSelfDestructEquals reports whether any Done SelfDestruct write at
-// TxIdx ≤ txIdxLimit has value == target. Detects a prior in-block
-// SelfDestructPath=true write that a later revival flipped back to false
-// — a case Read alone (latest-only) misses.
+// AnyDoneSelfDestructEquals catches an in-block destruct that a later revival flipped back, which latest-only Read would miss.
 func (vm *VersionMap) AnyDoneSelfDestructEquals(addr accounts.Address, txIdxLimit int, target bool) bool {
 	if vm == nil {
 		return false
@@ -666,14 +587,7 @@ func (vm *VersionMap) AnyDoneSelfDestructEquals(addr accounts.Address, txIdxLimi
 	return found
 }
 
-// selfDestructRevived reports whether any cell written after the destruct
-// index (and below txIndex) shows the account alive again. Same-tx
-// re-creation (metamorphic SD+CREATE2) writes both SelfDestructPath and
-// AddressPath at the SAME TxIdx, so AddressPath uses >= (not strict >).
-// LatestTxIndex counts Estimate cells: an in-flight post-destruct write is
-// a possible revival, and treating it as one keeps the dead-account
-// relaxations off until it resolves (fail-safe: the reader re-executes),
-// mirroring accountLiveSince's estimate handling.
+// selfDestructRevived reports life after a destruct; AddressPath uses >= destructTxIndex since same-tx SD+CREATE2 writes both paths at one TxIdx.
 func (vm *VersionMap) selfDestructRevived(addr accounts.Address, destructTxIndex int, txIndex int) bool {
 	revivalLimit := txIndex - 1
 	if hi, ok := vm.LatestTxIndex(addr, AddressPath, accounts.NilKey, revivalLimit); ok && hi >= destructTxIndex {
@@ -687,12 +601,7 @@ func (vm *VersionMap) selfDestructRevived(addr accounts.Address, destructTxIndex
 	return false
 }
 
-// destroyedAndUnrevived reports whether the latest destruct (highest Done
-// SelfDestruct=true below txIndex, immune to a shadowing revival cell above
-// it) has no later cell showing life again. Destroyed does not imply dead:
-// beyond the strictly-later revival cells, a self-destruct that preserves a
-// non-zero balance (EIP-8246) writes it AT the destruct index, so deadness
-// additionally requires no live sub-field floor from that index on.
+// destroyedAndUnrevived: destroyed does not imply dead, since EIP-8246 lets a self-destruct preserve a non-zero balance written at the destruct index itself.
 func (vm *VersionMap) destroyedAndUnrevived(addr accounts.Address, txIndex int) bool {
 	sdVer, ok := vm.FindDoneSelfDestructInRange(addr, 0, txIndex, true)
 	if !ok {
@@ -704,12 +613,7 @@ func (vm *VersionMap) destroyedAndUnrevived(addr accounts.Address, txIndex int) 
 	return !vm.accountLiveSince(addr, sdVer.TxIndex, txIndex)
 }
 
-// accountLiveSince reports whether any sub-field cell written at or after
-// fromIdx (and below txIdx) shows the account EIP-161-non-empty — e.g. a
-// self-destruct that preserves a non-zero balance writes it at the destruct
-// index itself. Cells older than fromIdx are pre-destruct state and say
-// nothing about life afterwards. Estimate cells cannot prove death and count
-// as live (fail-safe: the reader re-executes).
+// accountLiveSince reports EIP-161-non-empty from any sub-field cell at or after fromIdx; Estimate cells count as live (fail-safe: re-execute).
 func (vm *VersionMap) accountLiveSince(addr accounts.Address, fromIdx int, txIdx int) bool {
 	if bal, rr, ok := vm.ReadBalance(addr, txIdx); ok && (rr.Status() != MVReadResultDone || (rr.DepIdx() >= fromIdx && !bal.IsZero())) {
 		return true
@@ -726,11 +630,7 @@ func (vm *VersionMap) accountLiveSince(addr accounts.Address, fromIdx int, txIdx
 	return false
 }
 
-// FindDoneSelfDestructInRange returns the version of the highest Done
-// SelfDestruct write with lo <= TxIdx < hi whose value == target, if any.
-// Read-side mirror of AnyDoneSelfDestructEquals: it finds an in-block
-// SELFDESTRUCT even when a later revival (SelfDestruct=false) hides it from
-// latest-only ReadSelfDestruct.
+// FindDoneSelfDestructInRange finds a destruct hidden from latest-only ReadSelfDestruct by a later revival.
 func (vm *VersionMap) FindDoneSelfDestructInRange(addr accounts.Address, lo, hi int, target bool) (Version, bool) {
 	if vm == nil || hi <= lo {
 		return Version{}, false
@@ -760,25 +660,12 @@ func (vm *VersionMap) FindDoneSelfDestructInRange(addr accounts.Address, lo, hi 
 	return ver, found
 }
 
-// FlushVersionedWrites atomically flushes all writes to the version map
-// under a single lock acquisition. This prevents concurrent readers from
-// observing a partially-flushed state (e.g. seeing an AddressPath write
-// but not the corresponding CodePath write from the same transaction),
-// which could cause non-deterministic BAL (EIP-7928) hashes during
-// parallel execution.
-// FlushVersionedWrites routes a tx's typed write collections into the version
-// map. Each cell is positioned by the write's (txIndex, incarnation), so the
-// per-path loop order does not affect the result.
 func (vm *VersionMap) FlushVersionedWrites(writes *WriteSet, complete bool, tracePrefix string) {
 	if writes == nil {
 		return
 	}
 	flag := flagFor(complete)
-	// Flush per account under that account's lock so all of a tx's writes to one
-	// account (e.g. AddressPath + CodePath) become visible atomically — the
-	// property the former global lock guaranteed, now scoped to the account. A
-	// reader of a different account never contends. Cross-account partial
-	// visibility is resolved by commit-time ValidateVersion.
+	// Per-account lock makes all of a tx's writes to one account visible atomically; cross-account partial visibility is resolved by commit-time ValidateVersion.
 	seen := make(map[accounts.Address]struct{})
 	writes.forEachAddr(func(addr accounts.Address) {
 		if _, dup := seen[addr]; dup {
@@ -836,9 +723,7 @@ func (vm *VersionMap) MarkEstimate(addr accounts.Address, path AccountPath, key 
 	markFlag(e, addr, path, key, txIdx, FlagEstimate)
 }
 
-// markFlag updates the flag on an existing (addr, path, key, txIdx) cell.
-// Caller must hold e.mu.Lock(). Panics if no cell is present at txIdx —
-// MarkEstimate requires a prior write.
+// markFlag requires the caller to hold e.mu.Lock(), and panics if no cell exists at txIdx.
 func markFlag(e *AddressEntry, addr accounts.Address, path AccountPath, key accounts.StorageKey, txIdx int, flag statusFlag) {
 	msg := fmt.Sprintf("markFlag: missing cell. addr=%x path=%s key=%x txIdx=%d", addr, path, key, txIdx)
 	switch path {
@@ -1037,11 +922,7 @@ const (
 	VersionTooEarly
 )
 
-// validateRead validates one typed read. The recorded value stays typed T and is
-// never boxed into `any`: readLive fetches the live version-map value for the
-// same path and eq compares them for the rare value tiebreaker. The recursive
-// cross-path core (validateReadImpl) is value-less — it probes other paths of
-// other types, so it cannot itself be generic over T.
+// validateRead keeps the recorded value typed T (never boxed) for the tiebreaker; validateReadImpl is value-less since it must probe other paths' types too.
 func validateRead[T any](vm *VersionMap, txIndex int, addr accounts.Address, path AccountPath, key accounts.StorageKey, source ReadSource, version Version,
 	readVal T,
 	readLive func(*VersionMap, accounts.Address, accounts.StorageKey, int) (T, ReadResult, bool),
@@ -1050,19 +931,9 @@ func validateRead[T any](vm *VersionMap, txIndex int, addr accounts.Address, pat
 	recordField func(*accounts.Account) T,
 	checkVersion func(readVersion, writeVersion Version) VersionValidity,
 	traceInvalid bool, tracePrefix string) VersionValidity {
-	// One typed read supplies BOTH the status (for the version check) and the
-	// live value (for the rare tiebreaker) — no second lookup, no boxing. The
-	// tiebreaker branch in validateReadImpl only fires when rr is Done, so eq
-	// compares against the value that came with rr.
 	live, rr, ok := readLive(vm, addr, key, txIndex)
 	matchesLive := func() bool { return ok && eq(readVal, live) }
-	// A recorded zero/absent value means the read concluded absence; the
-	// destroyed-account relaxations are only sound for those. Typed check —
-	// the eq helpers carry dead-equivalence semantics, not zero-ness.
 	absent := isAbsent(readVal)
-	// A read folded onto the account record tiebreaks against the live record's
-	// field: record churn that keeps the field unchanged is not a conflict. A
-	// non-Done or absent record cannot prove equality (fail-safe: re-execute).
 	var matchesRecord func() bool
 	if recordField != nil {
 		matchesRecord = func() bool {
@@ -1094,8 +965,6 @@ func validateRead[T any](vm *VersionMap, txIndex int, addr accounts.Address, pat
 	return valid
 }
 
-// Typed live-value readers (uniform signature so validateRead can thread them
-// generically) and equality helpers for the value tiebreaker.
 func liveBalance(vm *VersionMap, a accounts.Address, _ accounts.StorageKey, tx int) (uint256.Int, ReadResult, bool) {
 	return vm.ReadBalance(a, tx)
 }
@@ -1124,8 +993,6 @@ func liveCodeSize(vm *VersionMap, a accounts.Address, _ accounts.StorageKey, tx 
 
 func eqUint256(a, b uint256.Int) bool { return a.Eq(&b) }
 
-// Typed absence predicates (threaded like eq, so validateRead never boxes the
-// recorded value): a zero/absent value means the read concluded absence.
 func absentAccount(a *accounts.Account) bool   { return a == nil }
 func absentBytes(b []byte) bool                { return len(b) == 0 }
 func absentUint256(v uint256.Int) bool         { return v.IsZero() }
@@ -1139,24 +1006,12 @@ func eqCodeHash(a, b accounts.CodeHash) bool {
 	return a == b
 }
 
-// Record-field extractors for the fold tiebreaker: a sub-field read with no
-// dedicated cell validates against the account record, by field value.
 func recordBalance(a *accounts.Account) uint256.Int        { return a.Balance }
 func recordNonce(a *accounts.Account) uint64               { return a.Nonce }
 func recordIncarnation(a *accounts.Account) uint64         { return a.Incarnation }
 func recordCodeHash(a *accounts.Account) accounts.CodeHash { return a.CodeHash }
 
-// The AddressPath record tiebreakers are existence-only: the record's version
-// churns as workers re-stamp it, but each sub-field (balance/nonce/codeHash)
-// is recorded and validated as its own read. Under EIP-161 a nil read is
-// additionally equivalent to a dead account — EVM-indistinguishable from a
-// non-existent one. Before EIP-161 that does not hold (existing-empty accounts
-// persist and CALL charges new-account gas on non-existence only), so the
-// strict form applies there.
-//
-// The record cell is a creation-time snapshot: an account created empty and
-// funded afterwards keeps an empty-shaped record next to a non-zero sub-field
-// cell, so deadness must be assembled from the sub-field floors too.
+// AddressPath tiebreakers are existence-only. Under EIP-161 a nil read is also equivalent to a dead account; before the fork, existing-empty accounts persist, so the strict form applies.
 func (vm *VersionMap) eqAccountDead(txIdx int, addr accounts.Address, isAura bool, a *accounts.Account, b *accounts.Account) bool {
 	if EIP161EmptyRemoval(true, isAura, addr) && a.Empty() && b.Empty() && !vm.accountLiveAt(addr, txIdx) {
 		return true
@@ -1164,9 +1019,7 @@ func (vm *VersionMap) eqAccountDead(txIdx int, addr accounts.Address, isAura boo
 	return a != nil && b != nil
 }
 
-// accountLiveAt reports whether any sub-field cell below txIdx makes the
-// account EIP-161-non-empty. Estimate cells cannot prove death and count as
-// live (fail-safe: the reader re-executes).
+// accountLiveAt reports EIP-161-non-empty from any sub-field cell below txIdx; Estimate cells count as live (fail-safe: re-execute).
 func (vm *VersionMap) accountLiveAt(addr accounts.Address, txIdx int) bool {
 	if bal, rr, ok := vm.ReadBalance(addr, txIdx); ok && (rr.Status() != MVReadResultDone || !bal.IsZero()) {
 		return true
@@ -1187,10 +1040,7 @@ func eqAccountStrict(a, b *accounts.Account) bool {
 	return a != nil && b != nil
 }
 
-// validateReadImpl is validateRead with a recursive flag: the cross-validate
-// probes (AddressPath / SelfDestructPath / IncarnationPath) pass recursive=true
-// so they can be distinguished from a top-level read — a synthetic probe carries
-// no recorded value of its own and must not invalidate on a bare Done entry.
+// validateReadImpl adds a recursive flag: a synthetic cross-validate probe carries no recorded value and must not invalidate on a bare Done entry.
 func (vm *VersionMap) validateReadImpl(txIndex int, addr accounts.Address, path AccountPath, key accounts.StorageKey, source ReadSource, version Version,
 	rr ReadResult,
 	matchesLive func() bool,
@@ -1206,15 +1056,9 @@ func (vm *VersionMap) validateReadImpl(txIndex int, addr accounts.Address, path 
 		if source != MapRead {
 			switch {
 			case recursive && matchesLive == nil:
-				// Synthetic cross-validate probe (no recorded value of its
-				// own) — the outer entry's validation covers it. Without this
-				// guard a recursive AddressPath/SelfDestructPath probe that
-				// lands on a Done cell would over-invalidate.
+				// Synthetic probe carries no recorded value, so there's nothing to invalidate here.
 			case matchesLive != nil && matchesLive():
-				// Value tiebreaker: a Done entry now exists where the read
-				// saw storage, but it holds the same value (e.g. a no-op write
-				// of a BAL-pre-populated path) — read stays valid. Evaluated
-				// typed by the caller; no boxing.
+				// Tiebreaker: a new Done entry holds the same value the read saw, so it stays valid.
 			default:
 				valid = VersionInvalid
 				invReason = "done-notmap"
@@ -1222,19 +1066,14 @@ func (vm *VersionMap) validateReadImpl(txIndex int, addr accounts.Address, path 
 		} else {
 			valid = checkVersion(version, rr.Version())
 			if valid == VersionInvalid && matchesLive != nil && matchesLive() {
-				// Value tiebreaker: the writer version churned (a lower tx
-				// re-executed) but the read's value is unchanged — not a real
-				// conflict, so the read stays valid and does not re-execute.
+				// Writer version churned but the value is unchanged: not a real conflict.
 				valid = VersionValid
 			}
 			if valid == VersionInvalid {
 				invReason = "done-vercheck"
 			}
 		}
-		// A later destruct makes a read predating it stale; checkVersion alone
-		// misses it because the SD doesn't write the read's own path. AddressPath
-		// is existence-only, so it stays valid unless the account is dead
-		// (destroyed, unrevived, no live floor).
+		// A later destruct can make a read stale without checkVersion noticing, since the SD doesn't write the read's own path.
 		if valid == VersionValid && path == AddressPath {
 			if _, ok := vm.FindDoneSelfDestructInRange(addr, rr.Version().TxIndex+1, txIndex, true); ok &&
 				vm.destroyedAndUnrevived(addr, txIndex) {
@@ -1244,17 +1083,7 @@ func (vm *VersionMap) validateReadImpl(txIndex int, addr accounts.Address, path 
 		}
 		if valid == VersionValid && !absent && path != SelfDestructPath && path != AddressPath &&
 			path != IncarnationPath && path != CreateContractPath {
-			// Range-scan mirroring the read path's per-path destruct resolution
-			// (a re-creation flushes SelfDestruct=false above the wiping true
-			// cell, so latest-only probing misses it). Only non-absent reads
-			// consult the net: a destruct makes absence the truth, and a later
-			// re-establishment writes a cell that becomes the floor, so a stale
-			// absent read version-mismatches on its own. No revival relaxation,
-			// for the same reason. Deploy-derived paths scan inclusive of the
-			// floor index (a same-tx write+destruct wipes the cell itself);
-			// Balance/CodeHash stay strictly-above — the destroyer's own cells
-			// there (EIP-8246 preserved balance, reset code hash) are
-			// post-destruct truth.
+			// Storage/Code/CodeSize/Nonce scan the floor index inclusive (a same-tx write+destruct wipes the cell); Balance/CodeHash stay strictly-above since EIP-8246 preserves those post-destruct.
 			lo := rr.Version().TxIndex + 1
 			if path == StoragePath || path == CodePath || path == CodeSizePath || path == NoncePath {
 				lo = rr.Version().TxIndex
@@ -1268,11 +1097,7 @@ func (vm *VersionMap) validateReadImpl(txIndex int, addr accounts.Address, path 
 		valid = VersionInvalid
 		invReason = "dependency"
 	case MVReadResultNone:
-		// A wiped-by-destruct record: an absent value stamped with the version
-		// of a Done SelfDestruct=true cell, with still no cell for the path
-		// itself. Valid as recorded — a later re-establishment writes a cell
-		// (version mismatch against this record), and the destruct going away
-		// fails the recorded SelfDestruct witness.
+		// Wiped-by-destruct record: valid as recorded, since a re-establishment or the destruct vanishing both version-mismatch.
 		if source == MapRead && absent && version.TxIndex >= 0 {
 			if _, ok := vm.FindDoneSelfDestructInRange(addr, version.TxIndex, version.TxIndex+1, true); ok {
 				break
@@ -1281,9 +1106,7 @@ func (vm *VersionMap) validateReadImpl(txIndex int, addr accounts.Address, path 
 		switch {
 		case source == MapRead && !recursive &&
 			(path == BalancePath || path == NoncePath || path == IncarnationPath || path == CodeHashPath):
-			// A sub-field read with no dedicated cell is recorded folded onto
-			// AddressPath (its source/version), so validate it against AddressPath
-			// at that version — with the record-field value as the tiebreaker.
+			// Folded onto AddressPath: validate against AddressPath's version, with the record field as tiebreaker.
 			valid = vm.validateReadImpl(txIndex, addr, AddressPath, accounts.StorageKey{}, source,
 				version, vm.ReadStatus(addr, AddressPath, accounts.StorageKey{}, txIndex), matchesRecord, nil, absent, checkVersion, traceInvalid, tracePrefix, true)
 			if valid == VersionInvalid {
@@ -1294,10 +1117,7 @@ func (vm *VersionMap) validateReadImpl(txIndex int, addr accounts.Address, path 
 			invReason = "none-notstorage"
 		default:
 			if valid = checkVersion(version, version); valid == VersionValid {
-				// Cross-validate any account property read against AddressPath
-				// and SelfDestructPath.  A prior tx may have created or
-				// self-destructed the account, invalidating storage reads of
-				// any property (code, storage slots, balance, nonce, etc.).
+				// A prior create or self-destruct can invalidate any property read, so cross-validate against AddressPath and SelfDestructPath too.
 				if path != AddressPath && path != SelfDestructPath {
 					if valid = vm.validateReadImpl(txIndex, addr, AddressPath, accounts.StorageKey{}, source,
 						version, vm.ReadStatus(addr, AddressPath, accounts.StorageKey{}, txIndex), nil, nil, absent, checkVersion, traceInvalid, tracePrefix, true); valid == VersionValid {
@@ -1318,20 +1138,7 @@ func (vm *VersionMap) validateReadImpl(txIndex int, addr accounts.Address, path 
 						invReason = "addr-xval-sd"
 					}
 
-					// A prior tx creating, destroying or re-creating this account
-					// can make an AddressPath storage read stale; IncarnationPath
-					// is the specific signal (written only by CreateAccount and
-					// SelfDestruct), unlike BalancePath which overfires for every
-					// gas payer. Non-recursive means the record IS the AddressPath
-					// read and absent is recorded non-existence: it must match
-					// cell-evidenced deadness — a nil read is valid only for a
-					// destroyed-and-unrevived account, an alive read only for a
-					// live one (e.g. EIP-8246 preserved balance). Recursive means
-					// a sub-field storage read cross-validating its account and
-					// absent is field emptiness: an empty read stays correct (an
-					// in-block non-empty write would have left a cell the floor
-					// probe finds), while a non-empty committed value is stale
-					// under any lifecycle churn, which clears fields.
+					// IncarnationPath is the create/destroy signal (BalancePath overfires for any gas payer); non-recursive absent means recorded non-existence, recursive absent means field emptiness.
 					if valid == VersionValid {
 						if _, incRR, ok := vm.ReadIncarnation(addr, txIndex); ok && incRR.Status() == MVReadResultDone {
 							stale := !absent
@@ -1394,23 +1201,17 @@ func (vm *VersionMap) validateReadImpl(txIndex int, addr accounts.Address, path 
 	return valid
 }
 
-// ValidateVersion check if transaction's readSet is still valid based on the current multi-versioned memory
 func (vm *VersionMap) ValidateVersion(txIdx int, lastIO *VersionedIO, checkVersion func(readVersion, writeVersion Version) VersionValidity, eip161 bool, isAura bool, traceInvalid bool, tracePrefix string) (valid VersionValidity) {
 	rs := lastIO.ReadSet(txIdx)
 	valid = VersionValid
 	// ok checks one validity result, latching valid; ok==false stops the scan.
 	ok := func(v VersionValidity) bool { valid = v; return v == VersionValid }
-	// noValueRead validates a path whose recorded value carries no tiebreaker
-	// (self-destruct / create-contract / code / code-size): the version/status
-	// check is authoritative. One ReadStatus, no value comparison.
+	// noValueRead validates a path with no value tiebreaker: the version/status check alone is authoritative.
 	noValueRead := func(addr accounts.Address, path AccountPath, key accounts.StorageKey, hdr ReadHeader) VersionValidity {
 		return vm.validateReadImpl(txIdx, addr, path, key, hdr.Source, hdr.Version,
 			vm.ReadStatus(addr, path, key, txIdx), nil, nil, false, checkVersion, traceInvalid, tracePrefix, false)
 	}
 
-	// Value paths go through the generic validateRead so the recorded value stays
-	// typed (never boxed) and the single typed read supplies both status and the
-	// tiebreaker value.
 	for a, tr := range rs.address {
 		var rv *accounts.Account
 		if tr.Val != nil {
@@ -1452,12 +1253,7 @@ func (vm *VersionMap) ValidateVersion(txIdx int, lastIO *VersionedIO, checkVersi
 		}
 	}
 	validateSelfDestruct := func(a accounts.Address, tr VersionedRead[bool]) bool {
-		// A MapRead record names the concrete SelfDestruct cell it consumed —
-		// e.g. the historical destruct behind a wiped read — and a later
-		// revival cell must not shadow it: valid iff the cell at the recorded
-		// version is still Done with the recorded value (an Estimate or a
-		// changed value re-executes, fail-safe). Storage-versioned records
-		// keep the floor check: any destruct appearing invalidates them.
+		// A MapRead record names the concrete cell it consumed: valid iff that version is still Done with the recorded value (fail-safe re-execute otherwise).
 		if tr.Source == MapRead && tr.Version.TxIndex >= 0 {
 			if _, found := vm.FindDoneSelfDestructInRange(a, tr.Version.TxIndex, tr.Version.TxIndex+1, tr.Val); !found {
 				if traceInvalid && dbg.TraceReexec {
@@ -1471,9 +1267,7 @@ func (vm *VersionMap) ValidateVersion(txIdx int, lastIO *VersionedIO, checkVersi
 		}
 		return ok(noValueRead(a, SelfDestructPath, accounts.NilKey, tr.ReadHeader))
 	}
-	// Every distinct destruct a tx consumed is re-checked: a conclusion can
-	// rest on several destroy/recreate cycles of one address, and losing any
-	// one of them to re-execution invalidates the tx.
+	// Every distinct destruct a tx consumed is re-checked: losing any one to re-execution invalidates the tx.
 	for a, tr := range rs.selfDestruct {
 		if !validateSelfDestruct(a, tr) {
 			return
@@ -1502,31 +1296,14 @@ func (vm *VersionMap) ValidateVersion(txIdx int, lastIO *VersionedIO, checkVersi
 	return
 }
 
-// WriteCell holds one version of a typed value on a (path, key) cell. The
-// type parameter T matches the AccountPath's value-type contract: writing
-// the wrong T to a cell is a compile-time error, not a runtime panic.
-//
-// Typed Read primitives (ReadBalance / ReadStorage / etc.) consume Value
-// directly without crossing the any boundary.
+// WriteCell holds one version of a typed value on a (path, key) cell.
 type WriteCell[T any] struct {
 	flag        statusFlag
 	incarnation int
 	Value       T
 }
 
-// Per-T pools for *WriteCell[T]. Each VersionMap write goes through
-// putCellFromPool which retrieves a zeroed cell from the path-corresponding
-// pool; Delete/DeleteAll return cells to the same pool. The pools span
-// VersionMap lifetimes — a freed cell from block N is recycled into
-// block N+1's first write.
-//
-// Invariants:
-//   - Get returns a zeroed cell (we overwrite all fields immediately, so the
-//     prior contents are irrelevant; pool's New func returns a zero struct).
-//   - Put on slice-valued types (ValBytes / []byte for CodePath) must clear
-//     the slice header to avoid pinning bytecode in the pool entry —
-//     handled in releaseCellCode below. Other types are value-shaped and
-//     don't pin external memory.
+// Per-T pools for *WriteCell[T] span VersionMap lifetimes: a freed cell recycles into the next block's first write. Slice-valued releases must clear the slice header to avoid pinning memory.
 var (
 	cellPoolAccount        = sync.Pool{New: func() any { return &WriteCell[*accounts.Account]{} }}
 	cellPoolSelfDestruct   = sync.Pool{New: func() any { return &WriteCell[bool]{} }}
@@ -1540,9 +1317,6 @@ var (
 	cellPoolStorage        = sync.Pool{New: func() any { return &WriteCell[uint256.Int]{} }}
 )
 
-// getCellAccount and the family of getCell* helpers each fetch a typed
-// *WriteCell[T] from the per-path pool. Caller fills the fields before
-// inserting into a btree.
 func getCellAccount() *WriteCell[*accounts.Account] {
 	return cellPoolAccount.Get().(*WriteCell[*accounts.Account])
 }
@@ -1566,8 +1340,6 @@ func getCellStorage() *WriteCell[uint256.Int] {
 	return cellPoolStorage.Get().(*WriteCell[uint256.Int])
 }
 
-// releaseCell* return a typed cell to its pool. For slice-valued types the
-// payload slice header is cleared to avoid pinning external memory.
 func releaseCellAccount(c *WriteCell[*accounts.Account]) {
 	c.Value = nil
 	cellPoolAccount.Put(c)

--- a/execution/state/versionmap_concurrent_test.go
+++ b/execution/state/versionmap_concurrent_test.go
@@ -10,10 +10,7 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// The parallel executor writes each committed tx's cells into a shared VersionMap
-// while other workers read and validate against it concurrently. This exercises
-// that surface with real goroutines so the race detector can catch unsynchronised
-// access to the per-address entries (run under -race in CI's race shards).
+// Uses real goroutines so `go test -race` can catch unsynchronized access to the shared VersionMap's per-address entries.
 func TestVersionMap_ConcurrentWriteReadValidate(t *testing.T) {
 	t.Parallel()
 	vm := NewVersionMap(nil)
@@ -24,8 +21,6 @@ func TestVersionMap_ConcurrentWriteReadValidate(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	// Writers: each publishes a balance cell for its own tx index, then a few
-	// shared addresses so writers and readers contend on the same entries.
 	for w := range workers {
 		wg.Add(1)
 		go func(txIdx int) {
@@ -36,7 +31,6 @@ func TestVersionMap_ConcurrentWriteReadValidate(t *testing.T) {
 			vm.WriteNonce(addrs[txIdx], v, uint64(txIdx), true)
 		}(w)
 	}
-	// Readers: concurrently read balances across all addresses at varying floors.
 	for r := range workers {
 		wg.Add(1)
 		go func(txIdx int) {
@@ -49,8 +43,7 @@ func TestVersionMap_ConcurrentWriteReadValidate(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Each writer's own-address balance must be its published value (last writer
-	// wins per address; own addresses have a single writer).
+	// Only addrs[1:] have a single writer each, so their balance is deterministic; addrs[0] is shared and skipped.
 	for i := 1; i < workers; i++ {
 		got, res, ok := vm.ReadBalance(addrs[i], workers)
 		require.True(t, ok && res.Status() == MVReadResultDone)

--- a/execution/state/versionmap_test.go
+++ b/execution/state/versionmap_test.go
@@ -19,11 +19,6 @@ import (
 
 var randomness = rand.Intn(10) + 10
 
-// valueFor returns a typed test value matching the AccountPath's value-type
-// contract enforced by the typed AddressEntry. Tests pass the path so the
-// VersionMap stores type-correct values without runtime conversion errors.
-// Most tests pass AddressPath since the original byte-based helper was used
-// almost exclusively for AddressPath; per-path-specific tests pass their path.
 func valueFor(path AccountPath, txIdx, inc int) any {
 	seed := uint64(txIdx*100 + inc)
 	switch path {
@@ -55,9 +50,6 @@ func getAddress(i int) accounts.Address {
 	return accounts.InternAddress(addr)
 }
 
-// writeFor dispatches a typed Write by path so the path-parameterized tests
-// keep driving the VersionMap through one call shape after the generic
-// Write(data any) primitive was removed.
 func writeFor(vm *VersionMap, addr accounts.Address, path AccountPath, key accounts.StorageKey, v Version, value any, complete bool) {
 	switch path {
 	case AddressPath:
@@ -85,8 +77,6 @@ func writeFor(vm *VersionMap, addr accounts.Address, path AccountPath, key accou
 	}
 }
 
-// readFor dispatches a typed Read by path, returning the typed value as any
-// alongside the ReadResult metadata.
 func readFor(vm *VersionMap, addr accounts.Address, path AccountPath, key accounts.StorageKey, txIdx int) (any, ReadResult, bool) {
 	switch path {
 	case AddressPath:
@@ -156,9 +146,7 @@ func TestFlushMVWrite(t *testing.T) {
 	var res ReadResult
 	var resVal any
 
-	// A WriteSet holds at most one AddressPath cell per address, so each
-	// versioned write is flushed in its own WriteSet to reproduce the
-	// accumulation TestMVWriteRead drives through sequential Write calls.
+	// A WriteSet holds at most one AddressPath cell per address, so each write needs its own WriteSet.
 	flushAddress := func(addr accounts.Address, ver Version) {
 		ws := &WriteSet{}
 		ws.SetAddress(addr, &VersionedWrite[*accounts.Account]{
@@ -192,8 +180,6 @@ func TestFlushMVWrite(t *testing.T) {
 	require.Equal(t, 0, res.Status())
 }
 
-// TODO - handle panic
-
 func TestLowerIncarnation(t *testing.T) {
 	t.Parallel()
 
@@ -223,7 +209,6 @@ func TestMarkEstimate(t *testing.T) {
 func TestMVHashMapBasics(t *testing.T) {
 	t.Parallel()
 
-	// memory locations
 	ap1 := getAddress(1)
 	ap2 := getAddress(2)
 	ap3 := getAddress(3)
@@ -240,17 +225,14 @@ func TestMVHashMapBasics(t *testing.T) {
 	_, res, _ = readFor(mvh, ap1, AddressPath, accounts.NilKey, 10)
 	require.Equal(t, UnknownDep, res.depIdx, "Read returns entries from smaller txns, not txn 10")
 
-	// Reads for a higher txn return the entry written by txn 10.
 	resVal, res, _ := readFor(mvh, ap1, AddressPath, accounts.NilKey, 15)
 	require.Equal(t, 10, res.depIdx, "reads for a higher txn return the entry written by txn 10.")
 	require.Equal(t, 1, res.incarnation)
 	require.Equal(t, valueFor(AddressPath, 10, 1), resVal)
 
-	// More writes.
 	writeFor(mvh, ap1, AddressPath, accounts.NilKey, Version{0, 0, 12, 0}, valueFor(AddressPath, 12, 0), true)
 	writeFor(mvh, ap1, AddressPath, accounts.NilKey, Version{0, 0, 8, 3}, valueFor(AddressPath, 8, 3), true)
 
-	// Verify reads.
 	resVal, res, _ = readFor(mvh, ap1, AddressPath, accounts.NilKey, 15)
 	require.Equal(t, 12, res.depIdx)
 	require.Equal(t, 0, res.incarnation)
@@ -266,24 +248,20 @@ func TestMVHashMapBasics(t *testing.T) {
 	require.Equal(t, 3, res.incarnation)
 	require.Equal(t, valueFor(AddressPath, 8, 3), resVal)
 
-	// Mark the entry written by 10 as an estimate.
 	mvh.MarkEstimate(ap1, AddressPath, accounts.NilKey, 10)
 
 	_, res, _ = readFor(mvh, ap1, AddressPath, accounts.NilKey, 11)
 	require.Equal(t, 10, res.depIdx)
 	require.Equal(t, -1, res.incarnation, "dep at tx 10 is now an estimate")
 
-	// Delete the entry written by 10, write to a different ap.
 	mvh.Delete(ap1, AddressPath, accounts.NilKey, 10, true)
 	writeFor(mvh, ap2, AddressPath, accounts.NilKey, Version{0, 0, 10, 2}, valueFor(AddressPath, 10, 2), true)
 
-	// Read by txn 11 no longer observes entry from txn 10.
 	resVal, res, _ = readFor(mvh, ap1, AddressPath, accounts.NilKey, 11)
 	require.Equal(t, 8, res.depIdx)
 	require.Equal(t, 3, res.incarnation)
 	require.Equal(t, valueFor(AddressPath, 8, 3), resVal)
 
-	// Reads, writes for ap2 and ap3.
 	writeFor(mvh, ap2, AddressPath, accounts.NilKey, Version{0, 0, 5, 0}, valueFor(AddressPath, 5, 0), true)
 	writeFor(mvh, ap3, AddressPath, accounts.NilKey, Version{0, 0, 20, 4}, valueFor(AddressPath, 20, 4), true)
 
@@ -297,32 +275,24 @@ func TestMVHashMapBasics(t *testing.T) {
 	require.Equal(t, 4, res.incarnation)
 	require.Equal(t, valueFor(AddressPath, 20, 4), resVal)
 
-	// Clear ap1 and ap3.
 	mvh.Delete(ap1, AddressPath, accounts.NilKey, 12, true)
 	mvh.Delete(ap1, AddressPath, accounts.NilKey, 8, true)
 	mvh.Delete(ap3, AddressPath, accounts.NilKey, 20, true)
 
-	// Reads from ap1 and ap3 go to db.
 	_, res, _ = readFor(mvh, ap1, AddressPath, accounts.NilKey, 30)
 	require.Equal(t, UnknownDep, res.depIdx)
 
 	_, res, _ = readFor(mvh, ap3, AddressPath, accounts.NilKey, 30)
 	require.Equal(t, UnknownDep, res.depIdx)
 
-	// No-op delete at ap2 - doesn't panic because ap2 does exist
 	mvh.Delete(ap2, AddressPath, accounts.NilKey, 11, true)
 
-	// Read entry by txn 10 at ap2.
 	resVal, res, _ = readFor(mvh, ap2, AddressPath, accounts.NilKey, 15)
 	require.Equal(t, 10, res.depIdx)
 	require.Equal(t, 2, res.incarnation)
 	require.Equal(t, valueFor(AddressPath, 10, 2), resVal)
 }
 
-// TestValidateRead_NewAddressEntryInvalidatesStorageRead: a new
-// MVReadResultDone entry on AddressPath means a real state change (e.g.
-// account creation) from a concurrent worker, and a nil storage-sourced read
-// must be invalidated.
 func TestValidateRead_NewAddressEntryInvalidatesStorageRead(t *testing.T) {
 	t.Parallel()
 
@@ -336,10 +306,8 @@ func TestValidateRead_NewAddressEntryInvalidatesStorageRead(t *testing.T) {
 
 	vm := NewVersionMap(nil)
 
-	// A concurrent worker wrote to AddressPath at txIndex 0.
 	writeFor(vm, addr, AddressPath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 1}, valueFor(AddressPath, 0, 1), true)
 
-	// Tx 2 originally read from storage (no map entry at execution time).
 	io := NewVersionedIO(2)
 	rs := ReadSet{}
 	rs.SetAddress(addr, VersionedRead[AccountView]{
@@ -351,9 +319,6 @@ func TestValidateRead_NewAddressEntryInvalidatesStorageRead(t *testing.T) {
 	require.Equal(t, VersionInvalid, valid)
 }
 
-// TestValidateRead_ChangedValueInvalidatesStorageRead: a StorageRead that now
-// finds a MVReadResultDone entry with a different value must be invalidated,
-// regardless of path.
 func TestValidateRead_ChangedValueInvalidatesStorageRead(t *testing.T) {
 	t.Parallel()
 
@@ -369,10 +334,8 @@ func TestValidateRead_ChangedValueInvalidatesStorageRead(t *testing.T) {
 		t.Run(path.String(), func(t *testing.T) {
 			vm := NewVersionMap(nil)
 
-			// A concurrent worker wrote at txIndex 0.
 			writeFor(vm, addr, path, accounts.NilKey, Version{TxIndex: 0, Incarnation: 1}, valueFor(path, 0, 1), true)
 
-			// Tx 2 originally read from storage (no map entry).
 			io := NewVersionedIO(2)
 			rs := ReadSet{}
 			rs.SetHeader(addr, path, accounts.NilKey, ReadHeader{Source: StorageRead, Version: Version{TxIndex: 2, Incarnation: 1}})
@@ -424,7 +387,6 @@ func TestTimeComplexity(t *testing.T) {
 	}
 	t.Parallel()
 
-	// for 1000000 read and write with no dependency at different memory location
 	mvh1 := NewVersionMap(nil)
 
 	for i := range 1000000 {
@@ -433,7 +395,6 @@ func TestTimeComplexity(t *testing.T) {
 		readFor(mvh1, ap1, AddressPath, accounts.NilKey, i)
 	}
 
-	// for 1000000 read and write with dependency at same memory location
 	mvh2 := NewVersionMap(nil)
 	ap2 := getAddress(2)
 
@@ -495,9 +456,6 @@ func TestReadTimeSameLocation(t *testing.T) {
 	}
 }
 
-// TestValidateRead_StoragePath_ValueTiebreaker verifies that when a StoragePath
-// read was from storage (source=StorageRead) but the versionMap now has a Done
-// entry with the SAME value, validation considers it valid (value tiebreaker).
 func TestValidateRead_StoragePath_ValueTiebreaker(t *testing.T) {
 	t.Parallel()
 
@@ -514,11 +472,8 @@ func TestValidateRead_StoragePath_ValueTiebreaker(t *testing.T) {
 
 	vm := NewVersionMap(nil)
 
-	// TX 5 wrote storage value 100 to the versionMap.
 	writeFor(vm, addr, StoragePath, storageKey, Version{TxIndex: 5, Incarnation: 1}, storageVal, true)
 
-	// TX 10 originally read from storage (no versionMap entry at execution
-	// time) and got value 100 — the same value TX 5 later wrote.
 	io := NewVersionedIO(10)
 	rs := ReadSet{}
 	rs.SetStorage(addr, storageKey, VersionedRead[uint256.Int]{
@@ -531,7 +486,6 @@ func TestValidateRead_StoragePath_ValueTiebreaker(t *testing.T) {
 	require.Equal(t, VersionValid, valid,
 		"StoragePath read with matching value should be valid via tiebreaker")
 
-	// Now test with a DIFFERENT value — should be invalid.
 	vm2 := NewVersionMap(nil)
 	writeFor(vm2, addr, StoragePath, storageKey, Version{TxIndex: 5, Incarnation: 1}, *uint256.NewInt(999), true)
 
@@ -540,37 +494,29 @@ func TestValidateRead_StoragePath_ValueTiebreaker(t *testing.T) {
 		"StoragePath read with different value should be invalid")
 }
 
-// TestFlushEstimate_ValidTxNotMarkedEstimate verifies that when
-// FlushVersionedWrites is called with complete=true for a valid TX,
-// the entries are FlagDone (not FlagEstimate). This is critical:
-// marking valid TX writes as Estimate causes downstream TXs to
-// abort with ErrDependency, leading to livelocks.
+// Marking a valid tx's writes as Estimate would make downstream txs abort with ErrDependency and livelock.
 func TestFlushEstimate_ValidTxNotMarkedEstimate(t *testing.T) {
 	t.Parallel()
 
 	addr := getAddress(42)
 	vm := NewVersionMap(nil)
 
-	// Simulate: TX 5 is valid, flushed as Done (complete=true).
 	writes := newWriteSet(
 		&VersionedWrite[uint256.Int]{WriteHeader: WriteHeader{Address: addr, Path: BalancePath, Key: accounts.NilKey, Version: Version{TxIndex: 5, Incarnation: 1}}, Val: *uint256.NewInt(100)},
 	)
 	vm.FlushVersionedWrites(writes, true, "")
 
-	// TX 10 reads should see FlagDone → MVReadResultDone.
 	_, res, _ := readFor(vm, addr, BalancePath, accounts.NilKey, 10)
 	require.Equal(t, MVReadResultDone, res.Status(),
 		"valid TX flush should produce Done entries, not Estimate")
 	require.Equal(t, 5, res.DepIdx())
 	require.Equal(t, 1, res.Incarnation())
 
-	// Simulate: TX 7 is invalid, flushed as Estimate (complete=false).
 	writes2 := newWriteSet(
 		&VersionedWrite[uint64]{WriteHeader: WriteHeader{Address: addr, Path: NoncePath, Key: accounts.NilKey, Version: Version{TxIndex: 7, Incarnation: 2}}, Val: uint64(5)},
 	)
 	vm.FlushVersionedWrites(writes2, false, "")
 
-	// TX 10 reads NoncePath should see FlagEstimate → MVReadResultDependency.
 	_, res2, _ := readFor(vm, addr, NoncePath, accounts.NilKey, 10)
 	require.Equal(t, MVReadResultDependency, res2.Status(),
 		"invalid TX flush should produce Estimate entries")
@@ -584,24 +530,16 @@ func validateEqualVersion(readVersion, writeVersion Version) VersionValidity {
 	return VersionInvalid
 }
 
-// TestValidateRead_PriorAccountCreation_DetectedViaIncarnationPath covers the
-// validateReadImpl AddressPath→IncarnationPath cross-check (versionmap.go): a
-// prior tx created the account (writing IncarnationPath, which the BAL does not
-// pre-populate), so a speculative storage-fallback AddressPath read is stale and
-// must invalidate. Restored after the typed-vio rework removed the original.
+// The BAL does not pre-populate IncarnationPath, so a prior account creation is only visible through a direct write to it.
 func TestValidateRead_PriorAccountCreation_DetectedViaIncarnationPath(t *testing.T) {
 	t.Parallel()
 	addr := getAddress(99)
 
 	vm := NewVersionMap(nil)
-	// Post-flush state after tx 0 creates the account: BAL pre-populated
-	// Balance/Nonce/CodeHash; the worker additionally flushed Incarnation
-	// (CreateAccount writes it, BAL does not). AddressPath was BAL-filtered out.
 	writeFor(vm, addr, BalancePath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, *uint256.NewInt(1_000), true)
 	writeFor(vm, addr, NoncePath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, uint64(0), true)
 	writeFor(vm, addr, IncarnationPath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, uint64(1), true)
 
-	// Tx 1 speculatively read AddressPath from storage (no map entry at exec).
 	io := NewVersionedIO(2)
 	rs := ReadSet{}
 	rs.SetAddress(addr, VersionedRead[AccountView]{
@@ -612,10 +550,6 @@ func TestValidateRead_PriorAccountCreation_DetectedViaIncarnationPath(t *testing
 	require.Equal(t, VersionInvalid, vm.ValidateVersion(1, io, validateEqualVersion, true, false, false, ""))
 }
 
-// TestValidateRead_SDStaleness_InvalidatesPreDestructRead covers the
-// validateReadImpl SD-staleness branch: a later tx self-destructed the account
-// with no revival, so a version-consistent pre-destruct BalancePath read is
-// stale and must invalidate. Restored after the typed-vio rework.
 func TestValidateRead_SDStaleness_InvalidatesPreDestructRead(t *testing.T) {
 	t.Parallel()
 	addr := getAddress(77)
@@ -624,8 +558,6 @@ func TestValidateRead_SDStaleness_InvalidatesPreDestructRead(t *testing.T) {
 	writeFor(vm, addr, BalancePath, accounts.NilKey, Version{TxIndex: 0, Incarnation: 0}, *uint256.NewInt(1_000), true)
 	writeFor(vm, addr, SelfDestructPath, accounts.NilKey, Version{TxIndex: 2, Incarnation: 0}, true, true)
 
-	// Tx 5 read BalancePath as a MapRead at (0,0) — consistent on Balance alone,
-	// but stale because tx 2's destruct came after.
 	io := NewVersionedIO(5)
 	rs := ReadSet{}
 	rs.SetBalance(addr, VersionedRead[uint256.Int]{
@@ -637,10 +569,7 @@ func TestValidateRead_SDStaleness_InvalidatesPreDestructRead(t *testing.T) {
 	require.Equal(t, VersionInvalid, vm.ValidateVersion(5, io, validateEqualVersion, true, false, false, ""))
 }
 
-// A revival after the destruct re-creates the account fresh; it does not
-// resurrect pre-destruct field values. A revival that re-establishes a field
-// writes a cell above the destruct — which then is the read's floor — so a
-// read still floored below the destruct is stale regardless of revival.
+// A revival writes new cells above the destruct floor, so a read still floored below the destruct stays stale regardless of revival.
 func TestValidateRead_SDStaleness_RevivalDoesNotResurrectPreDestructRead(t *testing.T) {
 	t.Parallel()
 	addr := getAddress(78)
@@ -661,14 +590,8 @@ func TestValidateRead_SDStaleness_RevivalDoesNotResurrectPreDestructRead(t *test
 	require.Equal(t, VersionInvalid, vm.ValidateVersion(5, io, validateEqualVersion, true, false, false, ""))
 }
 
-// TestVersionedWritePoolReuse_NoStaleFields guards the *VersionedWrite[T] pool
-// invariant: getVW* returns a recycled cell that may still hold a prior write's
-// contents, so the record path MUST wholesale-overwrite it. It drives the
-// production recorder (recordWriteBalance → getVWBalance) after seeding the pool
-// with a fully-poisoned cell, asserting nothing from the prior write survives —
-// including Key/Reason, which a balance write omits and which a field-by-field
-// assignment would leak. Not parallel: it seeds the process-global vwPoolBalance,
-// so it must run without a concurrent pool user.
+// A recycled *VersionedWrite pool cell may still hold a prior write's fields, so the record path must
+// wholesale-overwrite it, not assign field-by-field. Not parallel: it shares the process-global pool.
 func TestVersionedWritePoolReuse_NoStaleFields(t *testing.T) {
 	_, tx, domains := NewTestRwTx(t)
 	vm := NewVersionMap(nil)
@@ -676,7 +599,6 @@ func TestVersionedWritePoolReuse_NoStaleFields(t *testing.T) {
 	defer ibs.Close()
 	ibs.SetTxContext(0, 3)
 
-	// Seed the pool so the recorder's getVWBalance hands back a poisoned cell.
 	vwPoolBalance.Put(&VersionedWrite[uint256.Int]{
 		WriteHeader: WriteHeader{
 			Address: getAddress(1),
@@ -701,10 +623,6 @@ func TestVersionedWritePoolReuse_NoStaleFields(t *testing.T) {
 	require.True(t, vw.Val.Eq(&want), "Val must not retain the recycled value")
 }
 
-// TestBALPrePop_SameSenderTxs_NoConflicts ports the same-sender BAL
-// conflict-detection coverage to the typed VersionMap API: when the BAL
-// pre-populates balance/nonce for a run of same-sender txs, each tx's recorded
-// reads must validate without spurious conflicts.
 func TestBALPrePop_SameSenderTxs_NoConflicts(t *testing.T) {
 	t.Parallel()
 
@@ -758,10 +676,6 @@ func TestBALPrePop_SameSenderTxs_NoConflicts(t *testing.T) {
 	}
 }
 
-// TestNoBAL_SameSenderTxs_DetectsConflicts is the safety counterpart: without a
-// BAL, a run of same-sender txs whose recorded StorageReads predate tx 0's
-// flushed balance/nonce must each invalidate (else parallel exec would commit
-// stale balances/nonces).
 func TestNoBAL_SameSenderTxs_DetectsConflicts(t *testing.T) {
 	t.Parallel()
 
@@ -804,7 +718,6 @@ func TestNoBAL_SameSenderTxs_DetectsConflicts(t *testing.T) {
 	}
 }
 
-// fixedAccountReader returns a fixed account from the DB/state reader.
 type fixedAccountReader struct {
 	minimalStateReader
 	acc *accounts.Account
@@ -864,8 +777,6 @@ func TestValidateRead_MapReadValueTiebreaker(t *testing.T) {
 	assert.Equal(t, VersionInvalid, valid2)
 }
 
-// readValueUnchanged is true when the recorded read's value equals the value
-// just read (a version-only churn), false on a real value change.
 func TestReadValueUnchanged(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0xcd, 0x02})
@@ -879,10 +790,7 @@ func TestReadValueUnchanged(t *testing.T) {
 	assert.False(t, ibs.readValueUnchanged(addr, BalancePath, accounts.NilKey, r))
 }
 
-// An account absent from both the versionMap AddressPath and the DB, but with
-// a BAL-prepopulated balance cell proving an earlier tx created it, is
-// synthesized at read time instead of read as non-existent — a read that would
-// otherwise race the creator's flush and re-execute.
+// A BAL-prepopulated cell proving an earlier tx created this account makes it synthesize as existing, instead of racing the creator's flush.
 func TestGetVersionedAccount_SynthesizesCreatedFromBAL(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0xba, 0x01})
@@ -900,10 +808,6 @@ func TestGetVersionedAccount_SynthesizesCreatedFromBAL(t *testing.T) {
 	require.NotNil(t, rd.Val.Account())
 }
 
-// A reader racing the creator's first flush must be shielded by the BAL feed:
-// the pre-populated cells resolve the account before the creator's own writes
-// land, so the recorded read is non-nil and survives both validation and the
-// mid-execution dependency re-check once the creator flushes.
 func TestBALFedReaderDoesNotRaceCreatorFlush(t *testing.T) {
 	balFedChanges := func(addr accounts.Address) []*types.AccountChanges {
 		return []*types.AccountChanges{{
@@ -1007,9 +911,7 @@ func TestBALFedReaderDoesNotRaceCreatorFlush(t *testing.T) {
 	}
 }
 
-// The provisional nil probe must not survive the destroyed-unrevived and
-// EIP-8246 preserved-account conclusions: once the EVM consumes either, a
-// later same-tx load must conflict with a fresh flush instead of adopting it.
+// Once the EVM consumes a provisional nil read, a later same-tx load must conflict with a fresh flush instead of silently adopting it.
 func TestVersionedAccountBase_DestroyedExitDemotesProvisional(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xd3, 0x01})
 	reader := &codeReader{addr: addr, account: &accounts.Account{Nonce: 1, Balance: *uint256.NewInt(9), CodeHash: accounts.EmptyCodeHash}}
@@ -1028,8 +930,6 @@ func TestVersionedAccountBase_DestroyedExitDemotesProvisional(t *testing.T) {
 	}
 }
 
-// EIP-8246 reconstruction with nothing preserved (zero balance floor) must
-// resolve to absent, not dereference a nil preserved account.
 func TestVersionedAccountBase_NilPreservedAccountResolvesAbsent(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xd3, 0x02})
 	reader := &codeReader{addr: addr, account: &accounts.Account{Nonce: 1, Balance: *uint256.NewInt(9), CodeHash: accounts.EmptyCodeHash}}
@@ -1050,9 +950,7 @@ func TestVersionedAccountBase_NilPreservedAccountResolvesAbsent(t *testing.T) {
 	}
 }
 
-// A stale ALIVE read of an in-block-destroyed, unrevived account must
-// invalidate: the destroyed-and-unrevived relaxation is only sound for reads
-// that concluded ABSENCE.
+// The destroyed-and-unrevived relaxation only covers reads that concluded absence; a stale ALIVE read must still invalidate.
 func TestValidateRead_StaleAliveReadOfDestroyedAccountMustInvalidate(t *testing.T) {
 	addr := getAddress(150)
 	alive := &accounts.Account{Nonce: 1, CodeHash: accounts.InternCodeHash([32]byte{0xaa})}
@@ -1069,8 +967,6 @@ func TestValidateRead_StaleAliveReadOfDestroyedAccountMustInvalidate(t *testing.
 	require.Equal(t, VersionInvalid, vm.ValidateVersion(3, io, validateEqualVersion, true, false, false, ""))
 }
 
-// CodePath twin of the stale-alive case: a recorded non-empty code read of a
-// destroyed, unrevived account must invalidate through the cross-validate arm.
 func TestValidateRead_StaleCodeReadOfDestroyedAccountMustInvalidate(t *testing.T) {
 	addr := getAddress(151)
 	io := NewVersionedIO(4)
@@ -1086,9 +982,6 @@ func TestValidateRead_StaleCodeReadOfDestroyedAccountMustInvalidate(t *testing.T
 	require.Equal(t, VersionInvalid, vm.ValidateVersion(3, io, validateEqualVersion, true, false, false, ""))
 }
 
-// The MapRead value tiebreaker must not bypass a LATER self-destruct: a read
-// whose value matches a churned cell is only valid if the account was not
-// destroyed (unrevived) after that cell.
 func TestValidateRead_TiebreakerMustNotBypassLaterSD(t *testing.T) {
 	addr := getAddress(160)
 	alive := &accounts.Account{Nonce: 1, CodeHash: accounts.EmptyCodeHash}
@@ -1106,8 +999,6 @@ func TestValidateRead_TiebreakerMustNotBypassLaterSD(t *testing.T) {
 	require.Equal(t, VersionInvalid, vm.ValidateVersion(5, io, validateEqualVersion, true, false, false, ""))
 }
 
-// CodePath twin of the tiebreaker bypass, plus the version-MATCH variant
-// (read at the cell's own version, SD after): both must see the lifecycle.
 func TestValidateRead_CodeReadMustSeeLaterSD(t *testing.T) {
 	addr := getAddress(161)
 	code := []byte{0x60, 0x00}
@@ -1130,11 +1021,8 @@ func TestValidateRead_CodeReadMustSeeLaterSD(t *testing.T) {
 	})
 }
 
-// Destroyed-and-unrevived is not non-existent under EIP-8246: a self-destruct
-// that preserves a non-zero balance leaves the account alive, so a nil record
-// read racing the destroyer's flush must invalidate and re-execute. Only a
-// cell-evidenced dead account (no live sub-field floors) relaxes the
-// created-account incarnation check.
+// EIP-8246: a self-destruct preserving a non-zero balance leaves the account alive, so a racing nil
+// read must invalidate. Only a cell-evidenced dead account relaxes the created-account check.
 func TestValidateRead_NilReadOfPreservedBalanceDestructInvalid(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x82, 0x46})
 	checkVersionEqual := func(readVersion, writeVersion Version) VersionValidity {
@@ -1168,11 +1056,6 @@ func TestValidateRead_NilReadOfPreservedBalanceDestructInvalid(t *testing.T) {
 	})
 }
 
-// A self-destruct shadowed by a later revival cell must still invalidate
-// pre-destruct reads: re-creation flushes SelfDestruct=false above the true
-// cell, so latest-only probing misses the wipe. The read path already
-// range-scans its floors; validation must mirror it or a stale slot value
-// validates while a fresh read returns zero.
 func TestValidateRead_StorageReadMustSeeShadowedSD(t *testing.T) {
 	addr := getAddress(170)
 	key := accounts.InternKey(common.BigToHash(big.NewInt(9)))
@@ -1213,11 +1096,7 @@ func TestValidateRead_StorageReadMustSeeShadowedSD(t *testing.T) {
 	})
 }
 
-// The metamorphic destroy-and-recreate scenario end to end: the AddressPath
-// record is existence-only, so a pre-destruction record read of an account
-// re-created with equal facets stays valid — every facet is recorded and
-// validated as its own read — while the stale pre-recreation slot read is
-// what carries the wipe and must invalidate.
+// AddressPath records existence only; each field validates as its own read, so a recreate can leave the record read valid while a stale slot read still invalidates.
 func TestValidateRead_MetamorphicRecreateInvalidatesSlotNotRecord(t *testing.T) {
 	addr := getAddress(171)
 	key := accounts.InternKey(common.BigToHash(big.NewInt(9)))
@@ -1262,11 +1141,6 @@ func TestValidateRead_MetamorphicRecreateInvalidatesSlotNotRecord(t *testing.T) 
 	})
 }
 
-// Sub-field storage reads cross-validate their account recursively, where
-// absent means field emptiness, not account non-existence. A balance-only
-// preserved account (EIP-8246) legitimately has empty nonce/code — empty
-// committed reads must stay valid — while a non-empty committed field value
-// is stale under the destroyer's lifecycle churn.
 func TestValidateRead_FieldReadsOfPreservedAccountCrossValidate(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x82, 0x47})
 	checkVersionEqual := func(readVersion, writeVersion Version) VersionValidity {
@@ -1306,10 +1180,7 @@ func TestValidateRead_FieldReadsOfPreservedAccountCrossValidate(t *testing.T) {
 	})
 }
 
-// A sub-field read with no dedicated cell folds onto the account record for
-// validation. A later record write that keeps the field's value unchanged
-// (fee-merge churn re-stamps the coinbase record every tx) must not invalidate
-// the folded read — the fold compares values, not record versions.
+// A sub-field read with no dedicated cell folds onto the account record, and the fold compares values, not record versions.
 func TestValidateRead_FoldedNonceSurvivesRecordChurn(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xee, 0x2d})
 	checkVersionEqual := func(readVersion, writeVersion Version) VersionValidity {
@@ -1348,11 +1219,7 @@ func TestValidateRead_FoldedNonceSurvivesRecordChurn(t *testing.T) {
 	})
 }
 
-// A synthesized account's incarnation is a guess (the BAL carries no
-// incarnation and an empty-code contract creation carries no code change
-// either), so the load must not record it as an incarnation read: the
-// creator's later Incarnation flush would spuriously invalidate the guess.
-// A DB-loaded account's incarnation is an observation and stays recorded.
+// A synthesized account's incarnation is a guess, not an observation, so it must not be recorded as an incarnation read, or the creator's later flush would spuriously invalidate it.
 func TestSynthesizedAccountRecordsNoIncarnationGuess(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xd9, 0x6c})
 	checkVersionEqual := func(readVersion, writeVersion Version) VersionValidity {
@@ -1382,12 +1249,6 @@ func TestSynthesizedAccountRecordsNoIncarnationGuess(t *testing.T) {
 	require.Equal(t, VersionValid, vm.ValidateVersion(227, io, checkVersionEqual, true, false, false, ""))
 }
 
-// The DB-loaded twin (fund-then-deploy): a balance-only account CREATE2'd onto
-// by the preceding tx. The reader's EVM-visible view is already deterministic
-// (nonce/code from BAL cells, balance from the DB), so the pre-block
-// incarnation must not be recorded either — the creator's Incarnation flush
-// would spuriously invalidate it while normalization resolves the final
-// incarnation from the map.
 func TestDBLoadedAccountRecordsNoIncarnationDefault(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xd9, 0x6d})
 	checkVersionEqual := func(readVersion, writeVersion Version) VersionValidity {
@@ -1420,10 +1281,7 @@ func TestDBLoadedAccountRecordsNoIncarnationDefault(t *testing.T) {
 	require.Equal(t, VersionValid, vm.ValidateVersion(227, io, checkVersionEqual, true, false, false, ""))
 }
 
-// A BAL code change determines the code's size and hash, so the pre-population
-// must write those derived cells too: an EXTCODESIZE/EXTCODEHASH reader of a
-// just-created contract otherwise misses the map, falls through to the DB, and
-// races the creator's flush.
+// A BAL code change must pre-populate the derived size/hash cells too, or an EXTCODESIZE/EXTCODEHASH reader falls through to the DB and races the creator's flush.
 func TestBALPrePopulatesDerivedCodeCells(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xcd, 0x01})
 	bytecode := []byte{0x60, 0x00, 0x60, 0x00, 0xf3}
@@ -1459,10 +1317,6 @@ func TestBALPrePopulatesDerivedCodeCells_ClearedCode(t *testing.T) {
 	require.Equal(t, accounts.EmptyCodeHash, hash)
 }
 
-// The provisional marker must not outlive its load: once a load concludes
-// "absent" (no cells, no DB record — the no-BAL shape) the EVM has consumed
-// that answer, so a later load in the same tx that finds the creator's flush
-// must abort as a dependency, not silently adopt the new cell.
 func TestAbsentConclusionThenCreatorFlushAborts(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xfc, 0x02})
 	vm := NewVersionMap(nil)
@@ -1482,10 +1336,6 @@ func TestAbsentConclusionThenCreatorFlushAborts(t *testing.T) {
 		Val:         1,
 	})
 	vm.FlushVersionedWrites(ws, true, "")
-	// The read-once fast path serves the repeat probe from the recorded read —
-	// consistent with the absence the EVM already consumed, never a silent
-	// adoption of the fresh cell — and commit-time validation catches the
-	// conflict and re-executes.
 	exists, err = ibs.Exist(addr)
 	require.NoError(t, err)
 	require.False(t, exists)
@@ -1494,9 +1344,6 @@ func TestAbsentConclusionThenCreatorFlushAborts(t *testing.T) {
 	require.Equal(t, VersionInvalid, vm.ValidateVersion(9, io, validateEqualVersion, true, false, false, ""))
 }
 
-// A creator flush landing between a load's provisional nil record-probe and
-// its re-probe must not abort the loader: the nil was never exposed to the
-// EVM, so the load re-reads the fresh cells and reconciles the record.
 func TestBALFedReaderSurvivesCreatorFlushMidLoad(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xfd, 0x01})
 	vm := NewVersionMap([]*types.AccountChanges{{
@@ -1549,13 +1396,8 @@ func TestBALFedReaderSurvivesCreatorFlushMidLoad(t *testing.T) {
 	require.Equal(t, VersionValid, vm.ValidateVersion(9, io, validateEqualVersion, true, false, false, ""))
 }
 
-// A cold account-field read resolves the account through readAccountInternal;
-// when that probe is served from the read set (the reconciled Address entry of
-// an earlier load), the field read must be recorded with the entry's
-// UNDERLYING source, not the synthetic ReadSetRead — validation rejects
-// tx-reads-sourced entries at MVReadResultNone, and since every re-execution
-// repeats the same flow, the tx livelocks into "too many validator-invalid
-// retries".
+// When a cold field read is served from an earlier load's reconciled read-set entry, it must record
+// that entry's underlying source, not a synthetic one — validation rejects synthetic sources and livelocks.
 func TestColdFieldReadAfterReconciledLoadValidates(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0x15, 0x24})
 	checkVersionEqual := func(readVersion, writeVersion Version) VersionValidity {
@@ -1585,10 +1427,6 @@ func TestColdFieldReadAfterReconciledLoadValidates(t *testing.T) {
 	require.Equal(t, VersionValid, vm.ValidateVersion(60, io, checkVersionEqual, true, false, false, ""))
 }
 
-// A DB-present account resolved after an AddressPath map-miss must reconcile
-// the recorded nil map-read marker with the loaded record: leaving the nil in
-// place spuriously invalidates the reader once a later record cell (e.g. the
-// calcFees coinbase record) is flushed at validation time.
 func TestGetVersionedAccount_ReconcilesDBLoadedRecordRead(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0xdb, 0x01})
@@ -1609,10 +1447,7 @@ func TestGetVersionedAccount_ReconcilesDBLoadedRecordRead(t *testing.T) {
 	require.NotNil(t, rd.Val.Account())
 }
 
-// A recordRead=false record read (delegation resolution, journal reverts)
-// still leaves refreshAccount's nil map-read marker in the read set; once the
-// DB resolves the account the marker must be reconciled all the same —
-// recordRead only means "don't add a read", not "leave a wrong one".
+// recordRead=false means don't add a new read, not leave a stale one — a nil marker still gets reconciled once the DB resolves the account.
 func TestGetStateObject_NoRecordReadStillReconciles(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0xdb, 0x02})
@@ -1630,8 +1465,6 @@ func TestGetStateObject_NoRecordReadStillReconciles(t *testing.T) {
 	require.NotNil(t, rd.Val.Account())
 }
 
-// Cells proving only an EIP-161-empty state must not synthesize: an
-// existing-empty account is not gas-equivalent to a non-existent one.
 func TestGetVersionedAccount_NoSynthesisForEmpty(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0xba, 0x03})
@@ -1644,7 +1477,6 @@ func TestGetVersionedAccount_NoSynthesisForEmpty(t *testing.T) {
 	assert.Nil(t, acc)
 }
 
-// An estimate (non-Done) cell is a racing speculative write — no synthesis.
 func TestGetVersionedAccount_NoSynthesisFromEstimate(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0xba, 0x04})
@@ -1657,7 +1489,6 @@ func TestGetVersionedAccount_NoSynthesisFromEstimate(t *testing.T) {
 	assert.Nil(t, acc)
 }
 
-// A destroyed account (SelfDestruct floor true) must not be synthesized.
 func TestGetVersionedAccount_NoSynthesisAfterSelfDestruct(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0xba, 0x05})
@@ -1671,8 +1502,6 @@ func TestGetVersionedAccount_NoSynthesisAfterSelfDestruct(t *testing.T) {
 	assert.Nil(t, acc)
 }
 
-// A created contract synthesized from its BAL code cell carries the code's
-// hash and a fresh incarnation, and getStateObject loads the code bytes.
 func TestGetStateObject_SynthesizedContractFromBAL(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0xba, 0x06})
@@ -1693,8 +1522,6 @@ func TestGetStateObject_SynthesizedContractFromBAL(t *testing.T) {
 	assert.Equal(t, code, loaded)
 }
 
-// A BAL-funded account with a stale SelfDestructPath flag must not be dropped;
-// only a genuinely empty destroyed account is deleted.
 func TestGetStateObject_SelfDestructedButBALFunded_StaysAlive(t *testing.T) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0x5d, 0x03})
@@ -1712,10 +1539,8 @@ func TestGetStateObject_SelfDestructedButBALFunded_StaysAlive(t *testing.T) {
 	assert.Equal(t, *uint256.NewInt(1000), bal)
 }
 
-// Under EIP-161 a nil record read is equivalent to a dead one — a dead
-// account is EVM-indistinguishable from a non-existent account; a live record
-// still fails against either. Pre-EIP-161 existing-empty is observable (CALL
-// new-account gas), so the strict form treats nil vs empty as a conflict.
+// EIP-161: a dead account is EVM-indistinguishable from a non-existent one, so nil and empty compare
+// dead-equal. Pre-EIP-161, existing-empty is gas-observable, so the strict form treats them as a conflict.
 func TestEqAccount_DeadEquivalence(t *testing.T) {
 	empty := &accounts.Account{CodeHash: accounts.EmptyCodeHash}
 	funded := &accounts.Account{Balance: *uint256.NewInt(5), CodeHash: accounts.EmptyCodeHash}
@@ -1734,9 +1559,6 @@ func TestEqAccount_DeadEquivalence(t *testing.T) {
 	assert.True(t, eqAccountStrict(empty, empty)) //nolint:gocritic
 }
 
-// Pre-EIP-161 a nil storage read validated against a created-empty record cell
-// must invalidate (existing-empty is gas-observable); under EIP-161 the same
-// read is valid (dead ≡ non-existent).
 func TestValidateRead_NilVsEmptyRecordForkAware(t *testing.T) {
 	t.Parallel()
 	addr := getAddress(88)
@@ -1755,9 +1577,7 @@ func TestValidateRead_NilVsEmptyRecordForkAware(t *testing.T) {
 	require.Equal(t, VersionInvalid, vm.ValidateVersion(2, newIO(), validateEqualVersion, false, false, false, ""))
 }
 
-// AuRa retains its empty SystemAddress even under EIP-161, and EIP-1052 makes
-// exists-empty vs non-existent observable — dead-equivalence must not apply
-// there. Non-system addresses keep it, as does the SystemAddress off AuRa.
+// AuRa keeps its empty SystemAddress observable even under EIP-161 (EIP-1052), so dead-equivalence must not apply to it.
 func TestValidateRead_AuraSystemAddressNotDeadEquivalent(t *testing.T) {
 	t.Parallel()
 	newIO := func(addr accounts.Address) *VersionedIO {
@@ -1787,11 +1607,6 @@ func TestValidateRead_AuraSystemAddressNotDeadEquivalent(t *testing.T) {
 	})
 }
 
-// The AddressPath record cell holds a creation-time snapshot: an account
-// created empty and funded later in the same tx has an EIP-161-empty-shaped
-// record next to a non-zero BalancePath cell. Dead-equivalence must assemble
-// the sub-field cells before declaring the record dead — a nil read of a
-// funded account is stale and must re-execute.
 func TestValidateRead_NilReadOfCreatedThenFundedAccountInvalid(t *testing.T) {
 	t.Parallel()
 	newIO := func(addr accounts.Address) *VersionedIO {
@@ -1847,9 +1662,6 @@ func TestValidateRead_NilReadOfCreatedThenFundedAccountInvalid(t *testing.T) {
 	})
 }
 
-// A nil AddressPath storage read of a created-then-destroyed account stays
-// valid: the Incarnation cell belongs to a dead account. A later revival makes
-// the same nil read stale again.
 func TestValidateRead_NilReadOfDestroyedAccountStaysValid(t *testing.T) {
 	t.Parallel()
 	addr := getAddress(77)
@@ -1872,10 +1684,7 @@ func TestValidateRead_NilReadOfDestroyedAccountStaysValid(t *testing.T) {
 	require.Equal(t, VersionInvalid, valid)
 }
 
-// A same-tx SSTORE + SELFDESTRUCT flushes the slot cell and SD=true at the
-// SAME index; the read path treats such a slot as wiped, so validation must
-// too. The wiped-read twin guards the livelock: a re-executed reader's zero
-// is recorded at the cell's own version and must stay valid.
+// A same-tx SSTORE then SELFDESTRUCT flushes the slot and SD=true at the same index; the read path treats the slot as wiped, so validation must too, or the reader livelocks.
 func TestValidateRead_SameIndexSDStorage(t *testing.T) {
 	addr := getAddress(210)
 	key := accounts.InternKey(common.BigToHash(big.NewInt(1)))
@@ -1905,10 +1714,6 @@ func TestValidateRead_SameIndexSDStorage(t *testing.T) {
 	})
 }
 
-// Account revival is not code revival: deploy, destruct, then transfer-revival
-// leaves the dead bytes as the only CodePath cell — reads of them are stale.
-// The wiped-read twin guards the livelock: the trump's empty read recorded at
-// the code cell's version must stay valid.
 func TestValidateRead_CodeReadRevivedWithoutCode(t *testing.T) {
 	addr := getAddress(211)
 	code := []byte{0x60, 0x00}
@@ -1940,11 +1745,6 @@ func TestValidateRead_CodeReadRevivedWithoutCode(t *testing.T) {
 	})
 }
 
-// The pre-EIP-6780 metamorphic shape end to end (cells @1, SD=true @2,
-// transfer-revival @3, reader @5): every conclusion the EVM consumes needs a
-// recorded witness that validation accepts as long as the conclusion holds —
-// wiped reads serve zero/empty, validate cleanly (no livelock), and a
-// post-read redeploy flush must invalidate the code conclusion.
 func TestMetamorphicShadowedDestruct_ReaderValidatorRoundTrip(t *testing.T) {
 	code := []byte{0x60, 0x00}
 	newVM := func(addr accounts.Address, withBalanceRevival bool) *VersionMap {
@@ -2027,11 +1827,6 @@ func TestMetamorphicShadowedDestruct_ReaderValidatorRoundTrip(t *testing.T) {
 	})
 }
 
-// A balance-only revival (withdrawal/reward-style AddBalance, no account
-// record write) leaves no code/codeHash cells, so the committed fall-through
-// must still resolve the destruct: the account is alive with wiped code —
-// hash keccak(”), size 0 — and the recorded reads must validate, or the
-// reader retries the same conclusion forever.
 func TestCommittedReadsAfterDestructWithBalanceOnlyRevival(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xc0, 0xde})
 	reader := &codeReader{addr: addr, account: &accounts.Account{Nonce: 1, CodeHash: accounts.InternCodeHash([32]byte{0xaa})}, code: []byte{0x60, 0x00}}
@@ -2058,9 +1853,6 @@ func TestCommittedReadsAfterDestructWithBalanceOnlyRevival(t *testing.T) {
 	require.Equal(t, VersionValid, vm.ValidateVersion(3, io, validateEqualVersion, true, false, false, ""))
 }
 
-// A Done CodeHash cell below a shadowed destruct must not be served to a
-// later reader: the wiped hash of an account still alive (revived balance-
-// only) is keccak(”), nil only while it stays dead.
 func TestCodeHashCellBelowShadowedDestruct(t *testing.T) {
 	addr := accounts.InternAddress([20]byte{0xc0, 0xdf})
 	vm := NewVersionMap(nil)
@@ -2081,11 +1873,8 @@ func TestCodeHashCellBelowShadowedDestruct(t *testing.T) {
 	require.Equal(t, VersionValid, vm.ValidateVersion(4, io, validateEqualVersion, true, false, false, ""))
 }
 
-// A transaction can consume wipes from TWO distinct destructs of the same
-// address (different slots, destroy/recreate cycles). Each wiped read records
-// its destruct witness; both must be retained and validated — if the later
-// witness silently replaces the earlier one (or vice versa), re-executing the
-// lost destruct away leaves a stale wiped read undetected.
+// A tx can consume wipes from two distinct destructs of the same address; each wiped read records its
+// own destruct witness, and both must be retained — one replacing the other hides a stale wipe.
 func TestValidateRead_DistinctDestructWitnessesBothValidated(t *testing.T) {
 	addr := getAddress(230)
 	keyA := accounts.InternKey(common.BigToHash(big.NewInt(1)))
@@ -2108,16 +1897,13 @@ func TestValidateRead_DistinctDestructWitnessesBothValidated(t *testing.T) {
 	newIO := func() *VersionedIO {
 		io := NewVersionedIO(31)
 		rs := ReadSet{}
-		// Slot A read as the post-tx20 wipe: zero, floored at the pre-wipe cell.
 		rs.SetStorage(addr, keyA, VersionedRead[uint256.Int]{
 			ReadHeader: ReadHeader{Source: MapRead, Version: Version{TxIndex: 15}},
 		})
-		// Witness of the tx20 destruct, recorded first...
 		rs.SetSelfDestruct(addr, VersionedRead[bool]{
 			ReadHeader: ReadHeader{Source: MapRead, Version: Version{TxIndex: 20}},
 			Val:        true,
 		})
-		// ...then a wiped read of another slot records the tx10 destruct.
 		rs.SetSelfDestruct(addr, VersionedRead[bool]{
 			ReadHeader: ReadHeader{Source: MapRead, Version: Version{TxIndex: 10}},
 			Val:        true,

--- a/execution/state/vio_exec_alloc_bench_test.go
+++ b/execution/state/vio_exec_alloc_bench_test.go
@@ -33,8 +33,7 @@ var (
 	sinkBool bool
 )
 
-// BenchmarkVersionMapRead_Typed measures the typed ReadXxx primitives, which
-// return T directly with no interface box.
+// BenchmarkVersionMapRead_Typed measures the typed ReadXxx primitives, which avoid interface-boxing allocations.
 func BenchmarkVersionMapRead_Typed(b *testing.B) {
 	mvhm := NewVersionMap(nil)
 	addr := accounts.InternAddress([20]byte{0x01})
@@ -75,12 +74,7 @@ func BenchmarkVersionMapRead_Typed(b *testing.B) {
 	})
 }
 
-// BenchmarkVersionedExecReads drives the real IBS typed read path
-// (GetBalance/GetNonce/GetCodeHash/GetState) over a versionMap pre-populated by
-// prior "transactions", resetting per iteration to model the per-tx read
-// boundary the parallel executor enforces. allocs/op here is the per-tx
-// read-side garbage the typed-vio model aims to drive to zero; the non-storage
-// paths currently box via ReadResult.Value() any.
+// Drives the real IBS typed read path per tx-boundary reset; allocs/op is the read-side garbage the typed-vio model targets toward zero.
 func BenchmarkVersionedExecReads(b *testing.B) {
 	_, tx, domains := NewTestRwTx(b)
 	mvhm := NewVersionMap(nil)
@@ -119,14 +113,8 @@ func BenchmarkVersionedExecReads(b *testing.B) {
 	}
 }
 
-// BenchmarkWarmExtCodeHash drives the Empty()+GetCodeHash opcode pattern. NOTE:
-// it does NOT reproduce the warm-extcodehash benchmarkoor cell's refresh path —
-// with only field cells and an empty reader, readAccount returns nil and Empty()
-// short-circuits on the absent path (getVersionedAccount returns before
-// the per-field account refresh). Making it hit refresh needs a populated reader, not
-// just versionMap cells; the real warm-refresh + SelfDestruct-probe cost of the
-// 20x outlier must be measured on the benchmarkoor cell (per the perf skill),
-// not here. Retained as an absent/existence-read + SD-probe alloc baseline.
+// Empty()+GetCodeHash here hits the absent-account path, not the warm-refresh
+// path its name suggests — treat this as an absent-read + SD-probe baseline only.
 func BenchmarkWarmExtCodeHash(b *testing.B) {
 	_, tx, domains := NewTestRwTx(b)
 	mvhm := NewVersionMap(nil)

--- a/execution/state/vw_alloc_bench_test.go
+++ b/execution/state/vw_alloc_bench_test.go
@@ -10,9 +10,6 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// BenchmarkSetBalance exercises the typed write-set Set path that the
-// IBS hot recordWriteBalance helper uses on every BalancePath emit.
-// Target: zero allocs/op (struct allocation aside).
 func BenchmarkSetBalance(b *testing.B) {
 	addr := accounts.InternAddress([20]byte{0x01})
 	v := *uint256.NewInt(0xdeadbeef)
@@ -83,9 +80,7 @@ func BenchmarkSetAddress(b *testing.B) {
 	}
 }
 
-// BenchmarkPoolCycle_* exercise the step-2 pool fast path: get from pool,
-// fill, insert, then release all on tx-finalize.  Target: 0 allocs/op
-// after warmup once the per-type sync.Pool has a steady supply.
+// BenchmarkPoolCycle_* expect 0 allocs/op after warmup, once the per-type sync.Pool has a steady supply.
 
 func BenchmarkPoolCycle_Balance(b *testing.B) {
 	addr := accounts.InternAddress([20]byte{0x01})
@@ -118,11 +113,8 @@ func BenchmarkPoolCycle_Storage(b *testing.B) {
 	}
 }
 
-// BenchmarkPoolCycle_TxBatch simulates a realistic per-tx mix: 1 sender
-// (balance + nonce) + 1 contract (many storage slots), single Reset.  This
-// matches sstore-bloated-no-slots's actual write pattern — writes
-// concentrate on ~1 contract address, so the per-addr inner-storage-map
-// cost amortizes across the full slot batch.
+// Mix mirrors real load: 1 sender write (balance+nonce) plus many storage writes concentrated on 1 contract,
+// so the per-address inner-storage-map cost amortizes across the batch.
 func BenchmarkPoolCycle_TxBatch(b *testing.B) {
 	const slotsPerTx = 50
 	sender := accounts.InternAddress([20]byte{0xaa})
@@ -141,7 +133,6 @@ func BenchmarkPoolCycle_TxBatch(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		// One balance + one nonce write per tx (typical sender)
 		vwb := getVWBalance()
 		vwb.WriteHeader = WriteHeader{Address: sender, Path: BalancePath}
 		vwb.Val = bal
@@ -152,7 +143,6 @@ func BenchmarkPoolCycle_TxBatch(b *testing.B) {
 		vwn.Val = uint64(n)
 		s.SetNonce(sender, vwn)
 
-		// Many storage writes to a single contract
 		for i := range slotsPerTx {
 			vws := getVWStorage()
 			vws.WriteHeader = WriteHeader{Address: contract, Path: StoragePath, Key: keys[i]}
@@ -164,9 +154,7 @@ func BenchmarkPoolCycle_TxBatch(b *testing.B) {
 	}
 }
 
-// BenchmarkPoolCycle_Reuse exercises the "second write to same addr" path:
-// recordWrite* should reuse the existing entry in place (no alloc, no pool
-// op).
+// A second write to the same address must reuse the existing entry in place: no alloc, no pool op.
 func BenchmarkPoolCycle_Reuse(b *testing.B) {
 	addr := accounts.InternAddress([20]byte{0x03})
 	v1 := *uint256.NewInt(1)

--- a/execution/state/writeset_merge_test.go
+++ b/execution/state/writeset_merge_test.go
@@ -107,16 +107,7 @@ func codeSizeWrite(addr accounts.Address, val int) *VersionedWrite[int] {
 	}
 }
 
-// Every path conflicts on address a — both sides write it with a different
-// value — so "next wins on a matched key" is exercised per-path instead of
-// passing vacuously. b is prev-only, c is next-only, and storage carries all
-// three shapes: k1 conflicts, k2 is prev-only, k3 is next-only.
-//
-// b's writes are the ones a merged set shares with prev, so they are what a
-// release test must assert. Its address and code writes make an accidental
-// release of a shared value fail deterministically: releaseVWAddress nils Val
-// and releaseVWCode clears the bytecode, while the other release funcs are
-// bare pool-Puts that leave the value readable until reuse.
+// a conflicts on every path, b is prev-only, c is next-only, same shape across storage keys k1/k2/k3.
 func mergeIntoFixture() (prev, next *WriteSet) {
 	a, b, c := mergeAddr(0xa1), mergeAddr(0xb2), mergeAddr(0xc3)
 	k1, k2, k3 := mergeKey(0x01), mergeKey(0x02), mergeKey(0x03)
@@ -156,8 +147,7 @@ func mergeIntoFixture() (prev, next *WriteSet) {
 	return prev, next
 }
 
-// writeKey is the identity a merge dedups on: (addr, path, key). Version is
-// excluded, so two writes to the same slot collide here.
+// writeKey excludes Version so two writes to the same (addr, path, key) collide, matching what a merge dedups on.
 type writeKey struct {
 	addr accounts.Address
 	key  accounts.StorageKey
@@ -181,8 +171,6 @@ func assertSameWrites(t *testing.T, want, got *WriteSet) {
 	}
 }
 
-// MergeInto must produce the same union as the cloning Merge: next wins on
-// (addr, path, key), prev fills the gaps.
 func TestWriteSetMergeInto_MatchesMergeOracle(t *testing.T) {
 	prevOracle, nextOracle := mergeIntoFixture()
 	oracle := prevOracle.Merge(nextOracle)
@@ -194,9 +182,7 @@ func TestWriteSetMergeInto_MatchesMergeOracle(t *testing.T) {
 	assertSameWrites(t, oracle, merged)
 }
 
-// A key held by both sides keeps next's write and drops prev's — that is the
-// merge policy, not a lost write: the merged set still holds every (addr,
-// path, key) either side wrote.
+// A matched key keeps next's write, not prev's, but the merged set still holds every key either side wrote.
 func TestWriteSetMergeInto_MatchedKeyKeepsNext(t *testing.T) {
 	prev, next := mergeIntoFixture()
 	prevKeys, nextKeys := writeKeysOf(prev), writeKeysOf(next)
@@ -230,9 +216,7 @@ func matchedKeys(a, b map[writeKey]bool) int {
 	return n
 }
 
-// prev is aliased by execResult.TxOut, which finalize later reads and mutates
-// (StripBalanceWrite deletes map entries). MergeInto must never touch prev's
-// maps, and deleting from prev afterwards must not affect the merged set.
+// prev may be aliased and mutated by the caller after merging, so MergeInto must never touch prev's own maps.
 func TestWriteSetMergeInto_PrevStaysIndependent(t *testing.T) {
 	a := mergeAddr(0xa1)
 	b := mergeAddr(0xb2)
@@ -246,7 +230,6 @@ func TestWriteSetMergeInto_PrevStaysIndependent(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, *uint256.NewInt(1), bw.Val, "prev's own value must survive")
 
-	// Simulate StripBalanceWrite on TxOut after the merge.
 	delete(prev.balance, b)
 	gotVW, ok := merged.balance[b]
 	require.True(t, ok, "merged set must keep entries deleted from prev")
@@ -263,8 +246,7 @@ func TestWriteSetMergeInto_EmptyEdges(t *testing.T) {
 	assert.Same(t, next, (*WriteSet)(nil).MergeInto(next), "nil prev returns next")
 }
 
-// Fee-merge shape from the parallel apply loop: prev is a full tx write set,
-// next is the small calcFees output.
+// Mirrors the parallel apply loop's fee merge: prev a full tx write set, next the small fee output.
 func buildMergeBenchSets(addrs, slots int) (*WriteSet, *WriteSet) {
 	prev := &WriteSet{}
 	for i := range addrs {
@@ -281,10 +263,7 @@ func buildMergeBenchSets(addrs, slots int) (*WriteSet, *WriteSet) {
 	return prev, next
 }
 
-// Both variants build their inputs inside the timed loop, since MergeInto
-// consumes next and cannot reuse one pair across iterations. That dilutes the
-// delta with the build cost, but it is the same cost on both sides - timing one
-// variant with a warm pair and the other with a fresh one measures the harness.
+// Inputs build inside the timed loop (MergeInto consumes next, so a pair can't be reused) — build cost is equal on both sides.
 func benchWriteSetMerge(b *testing.B, addrs, slots int, merge func(prev, next *WriteSet) *WriteSet) {
 	b.ReportAllocs()
 	for b.Loop() {
@@ -309,8 +288,7 @@ func BenchmarkWriteSetMergeInto(b *testing.B) {
 	}
 }
 
-// ReleaseMaps returns the map containers to their pools without touching the
-// VersionedWrite values, which may be shared with other sets after MergeInto.
+// ReleaseMaps returns containers to their pools but leaves VersionedWrite values untouched — they may still be shared after MergeInto.
 func TestWriteSetReleaseMaps(t *testing.T) {
 	a, b := mergeAddr(0xa1), mergeAddr(0xb2)
 	k2 := mergeKey(0x02)
@@ -321,8 +299,6 @@ func TestWriteSetReleaseMaps(t *testing.T) {
 	prev.ReleaseMaps()
 	assert.True(t, prev.IsEmpty(), "released set must be empty")
 
-	// The entries merged shares with prev are prev's non-conflicting ones —
-	// prev's writes on a lost the merge and never entered merged.
 	aw, ok := merged.address[b]
 	require.True(t, ok)
 	require.NotNil(t, aw.Val, "shared address write must not be released")
@@ -343,13 +319,11 @@ func TestWriteSetReleaseMaps(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, *uint256.NewInt(20), sw.Val)
 
-	// A released set must be reusable.
 	prev.SetBalance(a, balanceWrite(a, 7, 2))
 	bw, ok = prev.balance[a]
 	require.True(t, ok)
 	assert.Equal(t, *uint256.NewInt(7), bw.Val)
 
-	// Double release and nil-map release must not panic.
 	prev.ReleaseMaps()
 	prev.ReleaseMaps()
 }
@@ -362,22 +336,15 @@ func TestVersionedIOReleaseOutputMaps(t *testing.T) {
 	require.NotZero(t, io.WriteCount())
 	io.ReleaseOutputMaps()
 
-	// Read the slots directly: the accessors panic under assertions once the
-	// outputs are released, which is the point of the guard.
+	// Direct field access: the normal accessors panic once outputs are released.
 	for _, output := range io.outputs {
 		assert.True(t, output.IsEmpty(), "slots must be empty after release")
 	}
 
-	// Empty and already-released IO must not panic.
 	io.ReleaseOutputMaps()
 	NewVersionedIO(1).ReleaseOutputMaps()
 }
 
-// The apply-loop fee-merge pipeline around the merge itself: record the tx
-// write set into VersionedIO, merge the calcFees output, re-record, flush the
-// merged set into the VersionMap. Build cost of the inputs is identical in
-// both variants and included in the measured loop, since MergeInto consumes
-// next.
 func benchVersionedFeeMerge(b *testing.B, addrs, slots int, merge func(prev, next *WriteSet) *WriteSet) {
 	io := NewVersionedIO(1)
 	vm := NewVersionMap(nil)

--- a/execution/state/writeset_normalize.go
+++ b/execution/state/writeset_normalize.go
@@ -25,47 +25,18 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// codePathRecoveryHashMismatch counts BAL codePath recoveries skipped because
-// the recovered bytes didn't hash to the emitted codeHash; surfaced so the skip
-// isn't silent.
 var codePathRecoveryHashMismatch = metrics.GetOrCreateCounter("exec3_codepath_recovery_hash_mismatch")
 
-// Normalize produces a clean write set from the versionMap's WriteSet
-// for a given TX. It matches the serial IBS MakeWriteSet behaviour:
-//
-//  1. Storage no-op filter: removes writes where the value equals the origin
-//     (what this TX read at execution start). Matches applyStorageChanges
-//     which skips keys where dirty == originStorage.
-//
-//  2. Incarnation filter: only includes writes from the validated incarnation.
-//     Stale entries from prior incarnations are excluded.
-//
-//  3. Self-destruct: emits DELETE entries for all storage keys of self-destructed
-//     accounts (matching DomainDelPrefix behaviour).
-//
-//  4. Account field resolution: resolves account field values from the versionMap
-//     to get the correct accumulated values (not speculative worker values).
-//
-// The input is blockIO.WriteSet(txIndex) — the raw versionWritten output.
-// The output is ready for applyVersionedWrites and TouchUpdates.
-//
-// domainStorageKeys, when non-nil, must return every storage slot currently
-// committed for an address (from sd.mem + domain files) — used to emit the
-// full StoragePath=0 cascade when the address self-destructs. vm.StorageKeys
-// alone only covers slots written in the current batch; genesis-allocated or
-// prior-block storage isn't there, so the calc would never delete those slots
-// from the trie (wrong root in TestDeleteRecreateAccount / TestSelfDestructReceive
-// / TestEIP161AccountRemoval, all of which SD a contract whose storage predates
-// the block). Pass nil in unit tests that don't exercise pre-block storage.
+// Normalize produces a clean write set matching serial IBS MakeWriteSet:
+// no-op filtering, self-destruct cascade, account-field resolution.
+// domainStorageKeys must also cover storage committed before this batch.
 func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, stateReader StateReader, domainStorageKeys func(addr accounts.Address) []accounts.StorageKey, emptyRemoval bool, isAura bool, eip8246 bool) (*WriteSet, error) {
 	filtered := &WriteSet{}
 	if writes == nil {
 		return filtered, nil
 	}
 
-	// sdStorageSlots returns the union of vm.StorageKeys (this batch) and
-	// domainStorageKeys (committed before this batch), deduped — the complete
-	// set of storage slots that must be DELETE'd when addr self-destructs.
+	// Deduped union of batch-written and pre-committed storage slots — the full set to DELETE when addr self-destructs.
 	sdStorageSlots := func(addr accounts.Address) []accounts.StorageKey {
 		seen := make(map[accounts.StorageKey]struct{})
 		var out []accounts.StorageKey
@@ -86,32 +57,8 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		return out
 	}
 
-	// Pre-scan for SD'd addresses. IBS.Selfdestruct emits 3 writes for the
-	// SD'd account (IncarnationPath=preInc, SelfDestructPath=true, BalancePath=0).
-	// If we forward all 3 to applyVersionedWrites, it sees d.balance != nil ||
-	// d.incarnation != nil and routes into the "cleanup-before-recreate"
-	// branch — which writes the account back with {Bal=0, Inc=preInc} encoding
-	// instead of taking the pure-delete branch (DomainDel(Accounts)). The
-	// account stays in sd.mem with non-zero incarnation, and a subsequent
-	// block's CREATE2 at the same address sees a phantom existing account,
-	// producing wrong execution / wrong trie root in TestRecreateAndRewind.
-	// Drop the BalancePath/NoncePath/IncarnationPath/CodeHashPath writes for
-	// SD'd addresses so applyVersionedWrites reaches the pure-delete branch.
-	//
-	// Two filters applied here:
-	//   1. Validated-incarnation: mirror the `w.Version.Incarnation != incarnation`
-	//      skip the SelfDestructPath case uses below — a stale SelfDestructPath=true
-	//      from a non-validated incarnation must not mark the address as SD'd.
-	//   2. Final-state: pre-Cancun a single tx can SELFDESTRUCT an address and then
-	//      CREATE2-recreate at the same address; IBS emits SelfDestructPath=true
-	//      (from Selfdestruct) followed later by SelfDestructPath=false (from
-	//      CreateAccount, since the recreated object's selfdestructed flag is
-	//      cleared). The address ends ALIVE, so its recreate-time account-field
-	//      writes must survive — only mark sdSet when the LAST SelfDestructPath
-	//      entry for the address (in emission order) is true. applyVersionedWrites
-	//      already uses last-write-wins for d.selfDestruct, so this keeps the two
-	//      in agreement. (EIP-6780 narrows this pattern post-Cancun but doesn't
-	//      eliminate it; mainnet-rare, but cheap to get right.)
+	// SD'd addresses drop their other account-field writes below, else
+	// applyVersionedWrites takes cleanup-before-recreate over a pure delete.
 	var sdSet map[accounts.Address]bool
 	for addr, vw := range writes.selfDestruct {
 		if vw.Version.Incarnation == incarnation && vw.Val {
@@ -123,18 +70,12 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 	}
 
 	for h := range writes.AllHeaders() {
-		// Drop account-field writes for SD'd addresses so applyVersionedWrites
-		// takes the pure-delete branch instead of cleanup-before-recreate; drop
-		// raw StoragePath writes too (the SelfDestructPath case re-emits an
-		// explicit StoragePath=0 delete for every slot via sdStorageSlots).
 		if sdSet[h.Address] {
 			switch h.Path {
 			case NoncePath, IncarnationPath, CodeHashPath, CodePath, StoragePath:
 				continue
 			case BalancePath:
-				// EIP-8246 keeps the post-SD balance so the calculator can
-				// preserve a balance-only account (or delete it when zero);
-				// pre-8246 drops it so the account is purely deleted.
+				// EIP-8246 keeps the post-SD balance; pre-8246 drops it.
 				if !eip8246 {
 					continue
 				}
@@ -142,7 +83,6 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		}
 		switch h.Path {
 		case StoragePath:
-			// Only include writes from the current (validated) incarnation.
 			if h.Version.Incarnation != incarnation {
 				continue
 			}
@@ -151,43 +91,28 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 				continue
 			}
 			writeVal := sw.Val
-			// If addr was self-destructed by an earlier TX in this block, its
-			// storage was wiped — the effective baseline for any slot not
-			// re-written since is 0, regardless of what the versionMap (prior
-			// TX) or the domain (pre-block) still holds. The SD's per-slot
-			// zeroing is only re-emitted into the calc's writeset below, never
-			// flushed back to the versionMap, so without this a resurrect TX
-			// that re-writes a slot to its pre-SD value is wrongly dropped as a
-			// no-op (TestDeleteRecreateSlotsAcrossManyBlocks).
-			// Range-scan: a re-creation flushes SelfDestruct=false above the
-			// wiping true cell, and a same-value write-back over the wiped slot
-			// is not a no-op just because the pre-destruct cell held that value.
+			// An earlier SD in this block zeroes addr's storage baseline, unseen
+			// by the versionMap/domain — catch it here so a resurrect's
+			// write-back isn't wrongly treated as a no-op.
 			sdTxIdx, sdOk := -1, false
 			if sdVer, ok := vm.FindDoneSelfDestructInRange(h.Address, 0, txIndex, true); ok {
 				sdTxIdx, sdOk = sdVer.TxIndex, true
 			}
-			// No-op filter: compare against origin (what this TX would have read).
-			// First check versionMap floor (prior TX's write in this block).
-			// Then fall back to stateReader (pre-block value from domain).
 			originVal, origin, originOK := vm.ReadStorage(h.Address, h.Key, txIndex)
 			originValid := originOK && origin.Status() == MVReadResultDone &&
 				!(sdOk && sdTxIdx > origin.Version().TxIndex)
 			switch {
 			case originValid:
 				if writeVal.Eq(&originVal) {
-					continue // write-back same as prior TX's value — no-op
+					continue
 				}
 			case sdOk:
-				// SD'd earlier with no re-write since — baseline is 0.
 				if writeVal.IsZero() {
 					continue
 				}
 			case stateReader != nil:
-				// No destruct in this block at all (the range-scan above owns
-				// every SD-then-revival shape): compare against the pre-block
-				// value. Narrower than an IncarnationPath probe: pure CREATE
-				// (no prior SD=true) doesn't wipe pre-existing storage, so its
-				// same-value SSTOREs still no-op against pre-block.
+				// No SD found in range above: compare against pre-block value;
+				// a pure CREATE (never SD'd) still no-ops same-value SSTOREs.
 				if vm.AnyDoneSelfDestructEquals(h.Address, txIndex-1, true) {
 					if writeVal.IsZero() {
 						continue
@@ -207,8 +132,7 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			}
 			filtered.SetStorage(h.Address, h.Key, sw)
 		case BalancePath, NoncePath, IncarnationPath, CodeHashPath:
-			// Account fields: prefer the versionMap's accumulated value; fall
-			// back to the raw write when the map has none.
+			// Prefer the versionMap's accumulated value over the raw write.
 			if !SetAccountFieldFromMap(filtered, vm, h.Address, h.Path, h.Version, txIndex+1) {
 				switch h.Path {
 				case BalancePath:
@@ -247,8 +171,6 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			if h.Version.Incarnation != incarnation {
 				continue
 			}
-			// Only emit storage DELETE entries when the account was actually
-			// self-destructed (val=true).
 			sdw, ok := writes.GetSelfDestruct(h.Address)
 			if !ok || !sdw.Val {
 				continue
@@ -267,72 +189,38 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		case AddressPath:
 			// AddressPath is record-level — skip for field-level consumers.
 		case CodeSizePath:
-			// Code size is derived from the code bytes and isn't a domain field,
-			// so it's intentionally not carried into the calc/apply write set (as
-			// on serial). Cross-tx ReadCodeSize is served from the versionMap,
-			// which the worker populates directly — independent of this pass.
+			// Derived from code bytes; not a domain field, so not carried into the write set.
 		}
 	}
 
-	// For addresses that appear in the raw WriteSet but don't have account-level
-	// writes in the output, emit account field entries. Serial's MakeWriteSet
-	// always calls UpdateAccountData for every dirty object — the commitment
-	// needs the full account state. This covers:
-	// - Addresses with only storage writes (no balance/nonce changes)
-	// - Addresses whose storage writes were all filtered as no-ops
-	//   (the object was still dirty in the IBS)
+	// Every dirty address needs account fields filled in, covering storage-only or all-no-op addresses.
 	allAddresses := make(map[accounts.Address]bool)
 	writes.forEachFieldAddr(func(addr accounts.Address) { allAddresses[addr] = true })
 
 	for addr := range allAddresses {
 		if sdSet[addr] {
-			// Don't fill account fields for SD'd addresses — same rationale as
-			// the sdSet drop in the filter loop above. Without this, the
-			// stateReader fallback below would round-trip pre-SD account state
-			// (Nonce, CodeHash, Incarnation) back into the writeset and undo
-			// the SD when applyVersionedWrites picks the cleanup-then-recreate
-			// branch.
-			continue
+			continue // same drop as above — don't resurrect pre-SD fields
 		}
 		ver := Version{TxIndex: txIndex, Incarnation: incarnation}
 
-		// If addr was self-destructed by an earlier TX in this block and this
-		// TX re-creates it (it isn't in sdSet — this TX didn't re-destruct it),
-		// missing account fields are the post-destruction defaults, NOT the
-		// pre-SD values still sitting in the versionMap. IBS.Selfdestruct only
-		// records SelfDestructPath/BalancePath/IncarnationPath, so a re-creation
-		// via a plain value transfer (no CREATE) leaves the stale pre-SD nonce
-		// and codeHash in the map — reading them back here resurrects a phantom
-		// contract (wrong trie root: TestSelfDestructReceive, TestCVE2020_26265).
-		// If a later TX between the SD and this one re-created addr via CREATE2,
-		// vm.Read returns that recreate's SelfDestructPath=false, so we correctly
-		// fall through to the normal versionMap lookup.
 		sdEarlier := false
 		if v, sd, _ := vm.ReadSelfDestruct(addr, txIndex); sd.Status() == MVReadResultDone && v {
 			sdEarlier = true
 		}
 
-		// Only emit post-SD defaults when this TX created a new contract
-		// (CREATE/CREATE2). A value-transfer resurrect (no CreateContractPath)
-		// inherits the pre-SD account fields via the versionMap last-write-wins
-		// chain — that matches GenerateChain's accumulate-across-txs behaviour
-		// (no per-tx FinalizeTx). Forcing defaults here resets nonce/codeHash
-		// against that canonical state (TestSelfDestructReceive).
+		// Post-SD defaults apply only on a CREATE/CREATE2 revival; a plain value-transfer revival inherits pre-SD fields instead.
 		hasCreateContract := false
 		if vw, ok := writes.GetCreateContract(addr); ok && vw.Val {
 			hasCreateContract = true
 		}
 
-		// The stateReader fallback for every missing field reads the same
-		// account, so read (and decode) it at most once per address rather than
-		// per missing field (a storage-only dirty address misses all four).
+		// Decode the account once per address — every missing field's stateReader fallback reads the same one.
 		var fallbackAcc *accounts.Account
 		fallbackLoaded := false
 
-		// For each missing field, try versionMap then stateReader.
 		for _, path := range []AccountPath{BalancePath, NoncePath, IncarnationPath, CodeHashPath} {
 			if filtered.Has(WriteHeader{Address: addr, Path: path}) {
-				continue // already in output
+				continue
 			}
 			if sdEarlier && hasCreateContract {
 				SetAccountFieldZero(filtered, addr, path, ver)
@@ -341,7 +229,6 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			if SetAccountFieldFromMap(filtered, vm, addr, path, ver, txIndex+1) {
 				continue
 			}
-			// Fall back to stateReader for pre-block account
 			if stateReader != nil {
 				if !fallbackLoaded {
 					acc, err := stateReader.ReadAccountData(addr)
@@ -351,21 +238,13 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 					fallbackAcc = acc
 					fallbackLoaded = true
 				}
-				// New account (fallbackAcc == nil) — doesn't exist in domain yet.
-				// SetAccountFieldFromAccount emits default values so the
-				// commitment sees a full account (not a delete).
+				// fallbackAcc == nil (new account): emits defaults, not a delete.
 				SetAccountFieldFromAccount(filtered, addr, path, ver, fallbackAcc)
 			}
 		}
 	}
 
-	// CodePath must travel with CodeHashPath: the case above and the fill loop
-	// recover an account's codeHash but not its code, so a validated writeset
-	// lacking a fresh CodePath (e.g. a re-executing 7702 tx whose SetCode
-	// short-circuited) would persist a codeHash with no code. Recover the code
-	// (versionMap, else stateReader post-state) and re-emit CodePath, bounded to
-	// 7702 designators so unchanged contract code isn't re-emitted. Forward-only:
-	// it can't repair codeHash-no-code already collated into snapshots.
+	// A validated writeset can end up with a fresh codeHash but no CodePath (a re-executing 7702 short-circuit): recover the code and re-emit it.
 	for addr, hvw := range filtered.codeHash {
 		h := hvw.Val
 		if h.IsEmpty() || sdSet[addr] {
@@ -374,13 +253,7 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		if _, ok := filtered.code[addr]; ok {
 			continue
 		}
-		// Recover the code whose hash this tx emitted. Prefer the versionMap
-		// (this batch's writes); on the SetCode short-circuit path — a
-		// re-executing 7702 delegation whose code equals the already-committed
-		// designator, so the validated incarnation writes no CodePath and the
-		// prior incarnation's versionMap entry was invalidated on re-exec — the
-		// versionMap holds nothing for this tx, so fall back to the post-state
-		// via stateReader.
+		// Prefer the versionMap; a 7702 short-circuit re-exec leaves nothing there, so fall back to stateReader's post-state.
 		var code []byte
 		if c, _, ok := vm.ReadCode(addr, txIndex+1); ok {
 			code = c.Bytes
@@ -392,20 +265,14 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 			}
 			code = c
 		}
-		// Gate recovery to 7702 designators: that SetCode short-circuit is the only
-		// one that leaves uncommitted code without a CodePath. A regular deploy
-		// writes CodePath with CodeHashPath; a CREATE2/unchanged redeploy already
-		// has its code in CodeDomain. (Gating also never misattributes callee code.)
+		// The 7702 short-circuit is the only path leaving uncommitted code without a
+		// CodePath; a CREATE2/unchanged redeploy already has its code in CodeDomain.
 		if _, ok := types.ParseDelegation(code); !ok {
 			continue
 		}
-		// The recovered bytes (ceiling versionMap read or stateReader post-state)
-		// can race and disagree with the codeHash this tx emitted; only re-emit
-		// when they hash to it, else we'd persist code that mismatches its hash.
+		// Recovered bytes can race and disagree with the emitted codeHash; only re-emit when they actually hash to it.
 		recovered := accounts.NewCode(code)
 		if recovered.Hash.Value() != h.Value() {
-			// Cannot repair: re-emitting would persist code mismatching its hash.
-			// Skipping leaves codeHash-without-code, so signal rather than hide it.
 			codePathRecoveryHashMismatch.Inc()
 			log.Warn("[exec3] BAL codePath recovery skipped: recovered bytes do not hash to emitted codeHash",
 				"addr", addr, "txIndex", txIndex, "emittedHash", h.Value(), "recoveredHash", recovered.Hash.Value())
@@ -421,17 +288,7 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		})
 	}
 
-	// EIP-161 empty account removal: if an account has Balance=0, Nonce=0,
-	// and empty CodeHash, it should be deleted — not written as a regular
-	// account with zero values. Serial's updateAccount checks Empty() and
-	// calls DeleteAccount. We must match that behavior.
-	//
-	// The Nonce==0 check correctly excludes successful CREATE/CREATE2
-	// (which sets Nonce to 1 per EIP-161) — including the
-	// "constructor returned empty bytecode but wrote storage" case the
-	// calc-side 3-way Deleted branch protects via incarnation tracking.
-	// OOG-during-CREATE2 leaves Nonce==0 in the writeset, so it
-	// correctly falls through to deletion here.
+	// EIP-161: Balance=0/Nonce=0/empty CodeHash means delete, not a zero-valued account.
 	type acctState struct {
 		balance  uint256.Int
 		nonce    uint64
@@ -460,11 +317,7 @@ func (writes *WriteSet) Normalize(vm *VersionMap, txIndex int, incarnation int, 
 		acctStates[addr] = s
 	}
 
-	// Check for empty accounts and replace with Delete. Only when EIP-161
-	// (SpuriousDragon) is active — before that fork an empty account that's
-	// merely touched (e.g. a 0-value transfer) is created and persists, so
-	// converting it to a delete here would diverge from serial's trie root
-	// (TestEIP161AccountRemoval block 1, pre-SpuriousDragon).
+	// Only convert to Delete when EIP-161 is active — pre-fork, a merely touched empty account is created and persists instead.
 	var emptyAddrs []accounts.Address
 	for addr, s := range acctStates {
 		if EIP161EmptyRemoval(emptyRemoval, isAura, addr) &&

--- a/execution/state/writeset_normalize_bench_test.go
+++ b/execution/state/writeset_normalize_bench_test.go
@@ -40,15 +40,8 @@ func countStorage(ws *WriteSet) (n int) {
 	return n
 }
 
-// benchStorageVal is the value a slot holds after the prior tx; a write-back of
-// the same value is what the no-op filter must drop.
 func benchStorageVal(slot int) uint256.Int { return *uint256.NewInt(uint64(slot + 1)) }
 
-// buildNormalizeInput builds one tx's write set at txIndex: addrs accounts with
-// balance+nonce writes and slots storage writes each, half of them written back
-// unchanged so the no-op filter has something to drop, plus contract code on
-// every third account and two storage-only addresses that miss all four account
-// fields and so exercise the fill loop.
 func buildNormalizeInput(addrs, slots, txIndex int) *WriteSet {
 	ws := &WriteSet{}
 	ver := Version{TxIndex: txIndex, Incarnation: 0}
@@ -77,7 +70,7 @@ func buildNormalizeInput(addrs, slots, txIndex int) *WriteSet {
 			k := benchKey(s)
 			val := benchStorageVal(s)
 			if s%2 == 1 {
-				val = *uint256.NewInt(uint64(s + 1000)) // changed: survives the filter
+				val = *uint256.NewInt(uint64(s + 1000))
 			}
 			ws.SetStorage(a, k, &VersionedWrite[uint256.Int]{
 				WriteHeader: WriteHeader{Address: a, Path: StoragePath, Key: k, Version: ver},
@@ -96,9 +89,7 @@ func buildNormalizeInput(addrs, slots, txIndex int) *WriteSet {
 	return ws
 }
 
-// seedPriorTx flushes a preceding tx's storage values into the version map, so
-// that the benchmarked tx's write-backs of those same values reach the no-op
-// filter's drop arm rather than falling through to the state reader.
+// Flushes a prior tx's storage into the versionMap so write-backs hit the no-op filter instead of falling through to the state reader.
 func seedPriorTx(vm *VersionMap, addrs, slots int) {
 	prior := &WriteSet{}
 	ver := Version{TxIndex: 0, Incarnation: 0}
@@ -124,8 +115,7 @@ func BenchmarkWriteSetNormalize(b *testing.B) {
 			seedPriorTx(vm, size.addrs, size.slots)
 			vm.FlushVersionedWrites(ws, true, "")
 			reader := &minimalStateReader{}
-			// Guard the shape the numbers describe: the no-op filter must
-			// actually drop writes, else a regression in it stays invisible.
+			// Guards the shape being measured: if the no-op filter stops dropping writes, these numbers would silently mean something else.
 			probe, err := ws.Normalize(vm, txIndex, 0, reader, nil, true, false, false)
 			if err != nil {
 				b.Fatal(err)

--- a/execution/state/writeset_normalize_test.go
+++ b/execution/state/writeset_normalize_test.go
@@ -11,44 +11,32 @@ import (
 	"github.com/erigontech/erigon/execution/types/accounts"
 )
 
-// errAccountReader fails ReadAccountData, to verify Normalize surfaces a
-// state-read failure rather than swallowing it into a partial write set.
+// errAccountReader fails ReadAccountData so Normalize's error propagation can be tested.
 type errAccountReader struct{ minimalStateReader }
 
 func (r *errAccountReader) ReadAccountData(addr accounts.Address) (*accounts.Account, error) {
 	return nil, errors.New("boom: state read failed")
 }
 
-// TestNormalize_PropagatesStateReadError pins that a ReadAccountData failure
-// during account-field completion is returned, not discarded. A swallowed error
-// yields a seemingly-valid partial write set (e.g. missing fields prevent the
-// EIP-161 empty-account delete), which would corrupt the trie root.
+// A swallowed ReadAccountData error would silently yield a partial write set
+// (e.g. skipping the EIP-161 delete).
 func TestNormalize_PropagatesStateReadError(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x57"))
 	kVM := accounts.InternKey(common.HexToHash("0x01"))
 	vm := NewVersionMap(nil)
 	vm.WriteStorage(addr, kVM, Version{TxIndex: 0}, *uint256.NewInt(7), true)
-	// Storage-only dirty account: its account fields are all missing, forcing
-	// the stateReader fallback that must propagate the read error.
 	ws := &WriteSet{}
 	ws.SetStorage(addr, kVM, &VersionedWrite[uint256.Int]{
 		WriteHeader: WriteHeader{Address: addr, Path: StoragePath, Key: kVM, Version: Version{TxIndex: 0}},
 		Val:         *uint256.NewInt(7),
 	})
-	_, err := ws.Normalize(vm, 0, 0, &errAccountReader{}, nil, false /*emptyRemoval*/, false /*isAura*/, false /*eip8246*/)
+	_, err := ws.Normalize(vm, 0, 0, &errAccountReader{}, nil, false, false, false)
 	require.Error(t, err, "a stateReader ReadAccountData failure must be returned, not swallowed")
 }
 
-// Direct unit coverage for WriteSet.Normalize — the single commit oracle shared
-// by the parallel executor and the block generator. These pin the edge cases
-// that a generate-then-import differential check cannot (both sides run this
-// same method), per review discussion.
-
-// The incarnation arg is the validated-incarnation filter: writes whose
-// Version.Incarnation != incarnation are dropped. This is exactly the arg that
-// differs between block generation (sequential, incarnation 0) and parallel
-// import (the OCC result incarnation) — so it must be pinned.
+// incarnation differs between sequential generation (0) and parallel import
+// (the OCC result), so the validated-incarnation filter must be pinned here.
 func TestNormalize_IncarnationFilter(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0xC0DE"))
@@ -61,25 +49,19 @@ func TestNormalize_IncarnationFilter(t *testing.T) {
 		})
 		return ws
 	}
-	// Normalized at incarnation 0: the incarnation-1 write is filtered out.
 	out0, _ := build().Normalize(vm, 0, 0, &minimalStateReader{}, nil, false, false, false)
 	_, ok0 := out0.GetCreateContract(addr)
 	require.False(t, ok0, "write from a non-matching incarnation must be dropped")
-	// Normalized at incarnation 1: kept.
 	out1, _ := build().Normalize(vm, 0, 1, &minimalStateReader{}, nil, false, false, false)
 	_, ok1 := out1.GetCreateContract(addr)
 	require.True(t, ok1, "write from the matching incarnation must be kept")
 }
 
-// On self-destruct, Normalize must re-emit a StoragePath delete for every slot
-// the account holds — the union of slots written this batch (versionMap) and
-// slots committed before the batch (domainStorageKeys) — and drop the account's
-// own field writes so applyVersionedWrites reaches the pure-delete branch.
 func TestNormalize_SelfDestructDeletesVmAndDomainStorageSlots(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x5D"))
-	kVM := accounts.InternKey(common.HexToHash("0x01"))     // written this batch
-	kDomain := accounts.InternKey(common.HexToHash("0x02")) // pre-block, in domain only
+	kVM := accounts.InternKey(common.HexToHash("0x01"))
+	kDomain := accounts.InternKey(common.HexToHash("0x02"))
 	vm := NewVersionMap(nil)
 	vm.WriteStorage(addr, kVM, Version{TxIndex: 0}, *uint256.NewInt(9), true)
 	domainKeys := func(a accounts.Address) []accounts.StorageKey {
@@ -99,7 +81,7 @@ func TestNormalize_SelfDestructDeletesVmAndDomainStorageSlots(t *testing.T) {
 		Val:         *uint256.NewInt(0),
 	})
 
-	out, _ := ws.Normalize(vm, 1, 0, &minimalStateReader{}, domainKeys, false /*emptyRemoval*/, false /*isAura*/, false /*eip8246*/)
+	out, _ := ws.Normalize(vm, 1, 0, &minimalStateReader{}, domainKeys, false, false, false)
 
 	_, sdOK := out.GetSelfDestruct(addr)
 	require.True(t, sdOK, "self-destruct must be retained")
@@ -111,9 +93,7 @@ func TestNormalize_SelfDestructDeletesVmAndDomainStorageSlots(t *testing.T) {
 	require.False(t, balOK, "pre-8246 self-destruct drops the account's balance write")
 }
 
-// EIP-8246 (no-burn SELFDESTRUCT) keeps the post-SD balance so the account can
-// be preserved as balance-only rather than fully deleted; the pre-8246 path
-// drops it. Same SD, only the eip8246 flag differs.
+// EIP-8246 (no-burn SELFDESTRUCT) keeps the post-SD balance instead of dropping it.
 func TestNormalize_SelfDestructBalanceRetention_EIP8246(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x82"))
@@ -130,20 +110,15 @@ func TestNormalize_SelfDestructBalanceRetention_EIP8246(t *testing.T) {
 		})
 		return ws
 	}
-	pre, _ := build().Normalize(vm, 1, 0, &minimalStateReader{}, nil, false, false, false /*eip8246*/)
+	pre, _ := build().Normalize(vm, 1, 0, &minimalStateReader{}, nil, false, false, false)
 	_, preBal := pre.GetBalance(addr)
 	require.False(t, preBal, "pre-8246 SD drops the balance write")
 
-	post, _ := build().Normalize(vm, 1, 0, &minimalStateReader{}, nil, false, false, true /*eip8246*/)
+	post, _ := build().Normalize(vm, 1, 0, &minimalStateReader{}, nil, false, false, true)
 	_, postBal := post.GetBalance(addr)
 	require.True(t, postBal, "EIP-8246 SD retains the balance write")
 }
 
-// A self-destructed address must keep none of its account-field or raw storage
-// writes: any survivor makes Apply see a non-empty account and take the
-// cleanup-before-recreate branch instead of the pure delete, leaving a phantom
-// account whose incarnation breaks a later CREATE2 at the same address. Only
-// SelfDestructPath (and, under EIP-8246, the balance) may remain.
 func TestNormalize_SelfDestructDropsAccountFieldAndStorageWrites(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0x5DEAD"))
@@ -172,14 +147,13 @@ func TestNormalize_SelfDestructDropsAccountFieldAndStorageWrites(t *testing.T) {
 		WriteHeader: WriteHeader{Address: addr, Path: CodePath, Version: ver},
 		Val:         code,
 	})
-	// Not present in the versionMap or the domain, so the SD storage cascade
-	// cannot re-emit it — if it shows up, the raw write survived the SD filter.
+	// kRaw is absent from vm/domain, isolating the SD filter from the delete cascade.
 	ws.SetStorage(addr, kRaw, &VersionedWrite[uint256.Int]{
 		WriteHeader: WriteHeader{Address: addr, Path: StoragePath, Key: kRaw, Version: ver},
 		Val:         *uint256.NewInt(42),
 	})
 
-	out, err := ws.Normalize(NewVersionMap(nil), 1, 0, &minimalStateReader{}, nil, false /*emptyRemoval*/, false /*isAura*/, false /*eip8246*/)
+	out, err := ws.Normalize(NewVersionMap(nil), 1, 0, &minimalStateReader{}, nil, false, false, false)
 	require.NoError(t, err)
 
 	_, sdOK := out.GetSelfDestruct(addr)
@@ -196,11 +170,6 @@ func TestNormalize_SelfDestructDropsAccountFieldAndStorageWrites(t *testing.T) {
 	require.False(t, storageOK, "raw storage write of a self-destructed address must be dropped")
 }
 
-// The account-field writes of a self-destructed address are what make Apply
-// compute pureDelete=false and take the cleanup-before-recreate branch, leaving
-// a phantom account. Normalize drops them; this asserts the guarantee at the
-// consumer so a filter regression surfaces on the block that triggers it rather
-// than as a wrong trie root later.
 func TestAssertSelfDestructNormalized(t *testing.T) {
 	t.Parallel()
 	addr := accounts.InternAddress(common.HexToAddress("0xA55E27"))
@@ -240,8 +209,6 @@ func TestAssertSelfDestructNormalized(t *testing.T) {
 		ws.assertSelfDestructNormalized()
 	}, "an incarnation write on a self-destructed address must trip the assert")
 
-	// Balance (kept under EIP-8246) and the storage-delete cascade are the two
-	// things a normalized self-destruct legitimately carries.
 	require.NotPanics(t, func() {
 		ws := sd(&WriteSet{})
 		ws.SetBalance(addr, &VersionedWrite[uint256.Int]{


### PR DESCRIPTION
`execution/state` carried 4,489 lines of comment across 72 non-generated files — algorithm walkthroughs, doc comments restating their own signature, incident narration, and the same rationale repeated at every call site. This cuts it to 763, keeping the invariants, the lock discipline, and the spec references.

## Changes

- Surviving comments compressed to one or two lines; test-body narration dropped.
- Rationale repeated at several sites is stated once where it belongs.
- Generated `contracts/gen_*.go` untouched.

## Notes

- Comment-only: the Go token stream with comments skipped is identical to `main` across all 86 files.
- One fix rides along: `CommitGenesisBlock`'s doc named `*params.ConfigCompatError`; the type is `*chain.ConfigCompatError`.
