### PR TITLE
txnprovider/txpool: release the pool lock when a caller stops waiting for a block

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -729,6 +729,8 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf uint64,
 	for last := p.lastSeenBlock.Load(); last < onTopOf; last = p.lastSeenBlock.Load() {
 		select {
 		case <-ctx.Done():
+			// Leaving with the lock held would stop every later pool operation, not just this one.
+			p.lock.Unlock()
 			return false, 0, ctx.Err()
 		default:
 			// continue

--- a/txnprovider/txpool/pool_best_lock_test.go
+++ b/txnprovider/txpool/pool_best_lock_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package txpool
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/require"
+
+	mdgas "github.com/erigontech/erigon/execution/protocol/mdgas"
+)
+
+func TestBestReleasesTheLockWhenTheCallerGivesUpWaitingForABlock(t *testing.T) {
+	lock := &sync.Mutex{}
+	p := &TxPool{lock: lock, lastSeenCond: sync.NewCond(lock)}
+
+	// The requested block has not been seen, so the wait loop is entered, and the caller is already
+	// gone by the time it checks.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := p.best(ctx, 1, &TxnsRlp{}, 1, mdgas.FullMdGas{}, mapset.NewSet[[32]byte](), 0)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// Returning with the lock still held blocks every later pool operation, including the block
+	// updates that would have let this caller through, so nothing recovers on its own.
+	require.True(t, p.lock.TryLock(), "best returned holding the pool lock")
+	p.lock.Unlock()
+}


### PR DESCRIPTION
`TxPool.best` takes the pool lock and then waits for the block it was asked to build on top of:

```go
p.lock.Lock()
for last := p.lastSeenBlock.Load(); last < onTopOf; last = p.lastSeenBlock.Load() {
    select {
    case <-ctx.Done():
        return false, 0, ctx.Err()   // <- still holding p.lock
    default:
    }
    p.lastSeenCond.Wait()
}
...
p.lock.Unlock()
```

A caller that goes away while waiting returns from inside the loop without releasing the lock. The only unlock is past the loop, so the lock stays held for the life of the process and every later pool operation blocks behind it — `OnNewBlock`, `ProvideTxns`, `AddLocalTxns`, and shutdown.

It does not recover on its own: the thing that would let the wait finish is a block update, and that needs the same lock.

### Why now

Today this is reachable only at shutdown, because the only caller that cancels this context is the one shutting the node down, which is why it has not been noticed.

It stops being shutdown-only as soon as anything cancels a live build. #23272 gives each payload builder a cancellable context so that discarding an evicted one actually releases its resources, and a builder waiting here is then cancelled during normal operation — a routine eviction would deadlock the pool. @yperbasis found it while reviewing that PR and suggested taking it separately, which is what this is.

### Scope

Only the missing unlock. Two things I deliberately did not change:

- cancelling the context does not wake a goroutine parked in `lastSeenCond.Wait()`, so an evicted builder still returns at the next block rather than immediately. Making the wait cancellable is a larger change and a separate question from the lock being leaked.
- the ordering comment below the loop, about `p.lock` and the `poolDB` read-transaction limiter, is untouched.

`TestBestReleasesTheLockWhenTheCallerGivesUpWaitingForABlock` covers it, and fails on the current code with "best returned holding the pool lock".

Note: `make lint` reports `db/seg/decompress.go:199: field residencyOnce is unused`, which is pre-existing on `main` — I confirmed it with this change stashed. `golangci-lint` is clean for `txnprovider/txpool/...`.
