### PR TITLE
ci: fuzz — don't fail on the engine's end-of-fuzztime race, and persist the corpus

### DIFF
--- a/.github/actions/cleanup-erigon/action.yml
+++ b/.github/actions/cleanup-erigon/action.yml
@@ -1,6 +1,12 @@
 name: Cleanup Erigon
 description: Save build and module caches, and report uncached test packages
 
+inputs:
+  clean-fuzzcache:
+    description: "Set to 'false' to keep $GOCACHE/fuzz (for jobs that cache the fuzz corpus themselves)"
+    required: false
+    default: 'true'
+
 runs:
   using: composite
   steps:
@@ -28,6 +34,7 @@ runs:
       with:
         gocache: ${{ env.ERIGON_CI_GOCACHE_PATH }}
         key: ${{ env.ERIGON_CI_GOCACHE_KEY }}
+        clean-fuzzcache: ${{ inputs.clean-fuzzcache }}
 
     - name: Check for existing module cache entry
       id: modcache-probe

--- a/.github/actions/save-build-cache/action.yml
+++ b/.github/actions/save-build-cache/action.yml
@@ -8,6 +8,10 @@ inputs:
   key:
     description: "Cache key to save under (from restore-build-cache outputs.primary-key)"
     required: true
+  clean-fuzzcache:
+    description: "Set to 'false' to keep $GOCACHE/fuzz instead of dropping it before the save"
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -22,9 +26,11 @@ runs:
       shell: bash
       run: df -h
 
-    # TODO(TBD): we may not want to clean the fuzz cache here if we want fuzzing results to persist across runs.
+    # Fuzz corpora are dead weight in the build cache entry of a job that doesn't
+    # fuzz, so drop them by default. The fuzz workflow opts out: it persists
+    # $GOCACHE/fuzz in its own cache entry, which is saved after this step runs.
     - name: Clean fuzz cache
-      if: ${{ always() }}
+      if: ${{ always() && inputs.clean-fuzzcache != 'false' }}
       shell: bash
       run: go clean -fuzzcache
 

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -105,18 +105,41 @@ jobs:
         env:
           FUZZTIME: ${{ inputs.fuzztime || '120s' }}
           ERIGON_BUILD: ${{ steps.erigon.outputs.build }}
+          PKG: ${{ matrix.pkg }}
+          FN: ${{ matrix.fn }}
+          FUZZ_DIR: ${{ matrix.pkg }}/testdata/fuzz/${{ matrix.fn }}
         run: |
           mkdir -p "$ERIGON_BUILD/fuzz"
-          echo "::group::go test -fuzz ${{ matrix.fn }} (./${{ matrix.pkg }}, ${FUZZTIME})"
-          go test "./${{ matrix.pkg }}/" -run '^$' -fuzz "^${{ matrix.fn }}$" -fuzztime "${FUZZTIME}"
+          out="${RUNNER_TEMP}/fuzz.out"
+          echo "::group::go test -fuzz ${FN} (./${PKG}, ${FUZZTIME})"
+          set +e
+          go test "./${PKG}/" -run '^$' -fuzz "^${FN}\$" -fuzztime "${FUZZTIME}" 2>&1 | tee "$out"
+          status="${PIPESTATUS[0]}"
+          set -e
           echo "::endgroup::"
+          if [ "$status" -eq 0 ]; then exit 0; fi
+          # internal/fuzz can misreport the end of the fuzztime window as a failure:
+          # it compares the timeout context's error against the child context it
+          # cancels workers with, and cancellation reaches the parent's Done channel
+          # before the child's Err is set (golang/go#75804, fixed in Go 1.27 — drop
+          # this branch once CI runs 1.27+). That path writes no reproducer and its
+          # only detail is a bare "context deadline exceeded" — unlike a real crash,
+          # which always writes a reproducer, or a failing seed corpus entry, which
+          # names the entry. Suppress only that exact combination.
+          if grep -qE '^[[:space:]]*context deadline exceeded[[:space:]]*$' "$out" \
+            && ! grep -q 'failure while testing seed corpus entry' "$out" \
+            && [ -z "$(git ls-files --others --exclude-standard -- "$FUZZ_DIR" 2>/dev/null)" ]; then
+            echo "::warning::Fuzz ${FN} (${PKG}): engine reported 'context deadline exceeded' at the end of the fuzztime window — upstream race, no defect found"
+            exit 0
+          fi
+          exit "$status"
 
-      # Tell a genuine crash from an engine timeout. On a crash `go test` writes a
-      # minimized reproducer under <pkg>/testdata/fuzz/<Fn>/ as an untracked file
-      # (committed seeds are tracked, so they don't count). A `context deadline
-      # exceeded` at the end of the fuzztime window leaves no such file; that is
-      # noise to verify, not a bug. Record a per-leg marker either way so `notify`
-      # can list exactly what failed.
+      # Reaching here means a real failure. A crash leaves a minimized reproducer
+      # under <pkg>/testdata/fuzz/<Fn>/ as an untracked file (committed seeds are
+      # tracked, so they don't count); anything else — a failing seed corpus entry,
+      # a build error, the runner running out of memory — leaves none and still
+      # needs a human. Record a per-leg marker either way so `notify` can list
+      # exactly what failed.
       - name: Classify failure
         id: classify
         if: failure()
@@ -140,7 +163,7 @@ jobs:
           if [ "$kind" = crash ]; then
             echo "::error::Fuzz crash in $FN ($PKG) — reproducer written under $FUZZ_DIR"
           else
-            echo "::warning::Fuzz $FN ($PKG) failed with no reproducer (likely engine 'context deadline exceeded' at end of fuzztime)"
+            echo "::error::Fuzz $FN ($PKG) failed without writing a reproducer — check the step log"
           fi
 
       - name: Upload crash reproducer
@@ -159,8 +182,11 @@ jobs:
           path: fuzz-failure/${{ matrix.name }}.tsv
           if-no-files-found: ignore
 
+      # Keep $GOCACHE/fuzz: the corpus cache entry above is saved after this step.
       - uses: ./.github/actions/cleanup-erigon
         if: always()
+        with:
+          clean-fuzzcache: 'false'
 
   notify:
     needs: [fuzz]
@@ -194,7 +220,7 @@ jobs:
                 list="${list}- \`${name}\` — ${fn} (${pkg}): **crash, reproducer attached** (artifact \`fuzz-crash-${name}\`)"$'\n'
                 crashes=$((crashes + 1))
               else
-                list="${list}- \`${name}\` — ${fn} (${pkg}): failed with no reproducer (likely engine timeout — verify against the next run)"$'\n'
+                list="${list}- \`${name}\` — ${fn} (${pkg}): **failed without a reproducer** — read the step log"$'\n'
                 norepro=$((norepro + 1))
               fi
             done < "$f"
@@ -228,9 +254,8 @@ jobs:
           ${FAILED_LIST}
           Legs marked **crash** have a minimized reproducer uploaded as a
           \`fuzz-crash-<target>\` artifact on the run. Legs with **no reproducer**
-          most likely hit an engine \`context deadline exceeded\` at the end of the
-          fuzztime window rather than a real defect — confirm they clear on the
-          next scheduled run before spending time on them.
+          failed some other way — a failing seed corpus entry, a build error, the
+          runner running out of memory — and the step log says which.
 
           Per repo policy a fuzz crash must be **investigated and fixed**, not
           skipped. To reproduce locally, drop the reproducer file into the

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -62,6 +62,12 @@ go test ./db/seg/ -run '^$' -fuzz '^FuzzCompress$' -fuzztime 30s
 - Newly discovered "interesting" inputs are cached under
   `$(go env GOCACHE)/fuzz`; a crashing input is written to the package's
   `testdata/fuzz/<FuzzName>/` so it can be committed and replayed.
+- A `FAIL` whose only detail is `context deadline exceeded`, with no file written
+  under `testdata/fuzz/`, is the fuzzing engine misreporting the end of the
+  `fuzztime` window, not a finding — rerun it
+  ([golang/go#75804](https://github.com/golang/go/issues/75804), fixed in Go
+  1.27). The nightly workflow recognises and ignores that exact signature;
+  anything else is a real failure.
 
 Replay just the seed + discovered corpus (no mutation), e.g. to reproduce a
 crash file someone committed:


### PR DESCRIPTION
Fixes the false positive in #23315, plus a second defect found while confirming it.

## 1. `context deadline exceeded` is not a crash

`internal/fuzz` ends every `-fuzztime` window through `stop(ctx.Err())`, but `stop` compares that error against `fuzzCtx.Err()` — the *child* context it cancels workers with. `cancelCtx.cancel` closes the parent's `Done` channel before propagating to children, so the coordinator can observe `fuzzCtx.Err() == nil`, fail the comparison, and return `context.DeadlineExceeded` as the fuzz result. `testdeps.CoordinateFuzzing` then compares it against a third context, so nothing downstream catches it either.

Reproduced two ways: 2 of 120 real `go test -fuzz` runs on a loaded machine, signature identical to the run in #23315; and 4 of 200000 for the bare stdlib comparison in isolation.

This is [golang/go#75804](https://github.com/golang/go/issues/75804), fixed upstream by [CL 774140](https://go-review.googlesource.com/c/go/+/774140) in exactly the way the analysis above predicts. It ships in **Go 1.27** and was not backported to 1.25.x or 1.26.x, so with CI on go1.25.13 we keep hitting it. The suppression is therefore needed until CI moves to 1.27+, and the comment says to delete the branch then.

The step now suppresses exactly that signature — a bare `context deadline exceeded`, no reproducer written, no `failure while testing seed corpus entry` — and nothing else. Verified against four outcomes: engine race → pass; the same output with a reproducer present → fail; a real panic → fail; a failing seed corpus entry → fail.

That last case is why "no reproducer" alone was not a safe test: a seed corpus failure is a real defect and also writes no reproducer, so #22976's classifier would have labelled it likely-noise. The `no-reproducer` marker now means "real failure, read the log" and is reported as an error.

## 2. The nightly corpus has never persisted

`save-build-cache` runs `go clean -fuzzcache` as a main step, which wipes `$GOCACHE/fuzz` before `actions/cache`'s post step can save it. Every leg of the run in #23315, the green ones included, logged `Cache not found for input keys: fuzz-corpus-<target>-` and `warning: starting with empty corpus`, and no `fuzz-corpus-*` entry was ever saved. So each night re-explored from scratch and threw its findings away — that run found 28 new interesting inputs for `FuzzEncoder` and kept none. The `TODO(TBD)` on that step called this exact risk.

It is now an input defaulting to the current behaviour; only the fuzz workflow opts out, so no other workflow's build cache starts carrying corpora.

## Checks

`actionlint` clean with the same flags CI uses, all three files parse, and the step script was executed verbatim under `bash -eo pipefail` for both the pass and the suppression path.
