### PR TITLE
txnprovider/txpool: wake a caller that goes away while waiting for a block

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -725,6 +725,23 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf uint64,
 	availableGas mdgas.FullMdGas,
 	yielded mapset.Set[[32]byte], availableRlpSpace int) (bool, int, error) {
 
+	// sync.Cond has no notion of a context, so a caller that goes away while parked below would
+	// sleep until the next block broadcast the condition, or forever while the chain is stalled.
+	// Broadcasting on cancellation wakes it; every waiter rechecks its own condition anyway. The
+	// broadcast takes the lock so it cannot land between the check below and the wait, which is the
+	// window where a wakeup would be lost.
+	waitDone := make(chan struct{})
+	defer close(waitDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			p.lock.Lock()
+			p.lastSeenCond.Broadcast()
+			p.lock.Unlock()
+		case <-waitDone:
+		}
+	}()
+
 	p.lock.Lock()
 	for last := p.lastSeenBlock.Load(); last < onTopOf; last = p.lastSeenBlock.Load() {
 		select {

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -730,16 +730,23 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf uint64,
 	// Broadcasting on cancellation wakes it; every waiter rechecks its own condition anyway. The
 	// broadcast takes the lock so it cannot land between the check below and the wait, which is the
 	// window where a wakeup would be lost.
-	waitDone := make(chan struct{})
-	defer close(waitDone)
+	stopWatching, watcherDone := make(chan struct{}), make(chan struct{})
 	go func() {
+		defer close(watcherDone)
 		select {
 		case <-ctx.Done():
 			p.lock.Lock()
 			p.lastSeenCond.Broadcast()
 			p.lock.Unlock()
-		case <-waitDone:
+		case <-stopWatching:
 		}
+	}()
+	// Joined rather than merely told to stop: with the context already ended the watcher can pick
+	// either case, and one that picked cancellation would otherwise take the lock after this call
+	// had returned. Registered before the lock is taken, so it runs after the lock is released.
+	defer func() {
+		close(stopWatching)
+		<-watcherDone
 	}()
 
 	p.lock.Lock()

--- a/txnprovider/txpool/pool_best_lock_test.go
+++ b/txnprovider/txpool/pool_best_lock_test.go
@@ -17,13 +17,17 @@
 package txpool
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common/log/v3"
 	mdgas "github.com/erigontech/erigon/execution/protocol/mdgas"
 )
 
@@ -43,4 +47,60 @@ func TestBestReleasesTheLockWhenTheCallerGivesUpWaitingForABlock(t *testing.T) {
 	// updates that would have let this caller through, so nothing recovers on its own.
 	require.True(t, p.lock.TryLock(), "best returned holding the pool lock")
 	p.lock.Unlock()
+}
+
+// waitingBuffer records what the pool logged, so a test can tell when a caller has reached the
+// "Waiting for block" trace and is therefore about to park in the condition.
+type waitingBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *waitingBuffer) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *waitingBuffer) contains(s string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return strings.Contains(w.buf.String(), s)
+}
+
+func TestBestReturnsWhenItsCallerGoesAwayWhileWaitingForABlock(t *testing.T) {
+	logs := &waitingBuffer{}
+	logger := log.New()
+	logger.SetHandler(log.StreamHandler(logs, log.LogfmtFormat()))
+
+	lock := &sync.Mutex{}
+	p := &TxPool{
+		lock:         lock,
+		lastSeenCond: sync.NewCond(lock),
+		logger:       logger,
+		pending:      NewPendingSubPool(PendingSubPool, 1),
+		baseFee:      NewSubPool(BaseFeeSubPool, 1),
+		queued:       NewSubPool(QueuedSubPool, 1),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+
+	returned := make(chan error, 1)
+	go func() {
+		_, _, err := p.best(ctx, 1, &TxnsRlp{}, 1, mdgas.FullMdGas{}, mapset.NewSet[[32]byte](), 0)
+		returned <- err
+	}()
+
+	// Cancel only once it is parked, so this exercises the wait rather than the check before it.
+	require.Eventually(t, func() bool { return logs.contains("Waiting for block") }, 5*time.Second, time.Millisecond)
+	cancel()
+
+	// Nothing else wakes it: no block arrives and the pool is not shutting down. A wait that cannot
+	// observe its caller leaves the builder that made this request holding a read view until one of
+	// those happens, which on a stalled chain is never.
+	select {
+	case err := <-returned:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("best never returned; only a new block would have woken it")
+	}
 }


### PR DESCRIPTION
Second prerequisite for #23272, after #23333. Raised by @yperbasis reviewing that PR.

`TxPool.best` parks in `p.lastSeenCond.Wait()` until the block it was asked to build on top of arrives. `sync.Cond` has no notion of a context: the wait ends when a new block broadcasts the condition (`pool.go:361`) or when the node shuts down. Cancelling the caller does nothing.

So a caller that has given up stays parked, holding its read transaction and `SharedDomains`, until a block arrives. **While the chain is stalled that is never** — which is exactly when builders accumulate and when releasing them matters.

#23333 stopped a cancelled caller leaving the pool lock held. This is the other half: making the wait notice at all.

### The fix

Cancellation broadcasts the condition, so the parked caller wakes, sees its context, and returns. Waiters re-check their own condition on waking regardless, so an extra broadcast is harmless.

The broadcast takes the pool lock. That is load-bearing rather than incidental: without it the broadcast could land between the cancellation check and `Wait()`, and the wakeup would be lost — the caller would sleep on exactly as before. Holding the lock means the broadcast can only happen before the check, where the check sees it, or after `Wait()` has released the lock, where the broadcast reaches it.

The watcher goroutine is scoped to the call and exits with it.

### Test

`TestBestReturnsWhenItsCallerGoesAwayWhileWaitingForABlock` cancels only once the caller has reached the "Waiting for block" trace, so it exercises the wait rather than the check in front of it. Nothing else wakes it: no block arrives, nothing shuts down. Against the current code it fails with `best never returned; only a new block would have woken it`.

### Why separate

It is a `txnprovider/txpool` change, and #23272 is an `execution/` change that is large already. Same reasoning as #23333, which @yperbasis suggested splitting out for the same reason.

Note: `make lintci` reports `db/seg/decompress.go:199: field residencyOnce is unused`, which is darwin-only — that field's user is `residency_gate_linux.go`, so CI does not see it. `golangci-lint` is clean for `txnprovider/txpool/...`.
