### PR TITLE
execution: read block-end syscall logs once after Finalize

### DIFF
--- a/execution/exec/historical_trace_worker.go
+++ b/execution/exec/historical_trace_worker.go
@@ -490,17 +490,18 @@ func (p *historicalResultProcessor) processResults(consumer TraceConsumer, cfg *
 					defer ibs.Close()
 					ibs.SetTxContext(txTask.BlockNumber(), txTask.TxIndex)
 					syscall := func(contract accounts.Address, data []byte) ([]byte, error) {
-						ret, err := protocol.SysCallContract(contract, data, cfg.ChainConfig, ibs, txTask.Header, txTask.Engine, false /* constCall */, vm.Config{
+						return protocol.SysCallContract(contract, data, cfg.ChainConfig, ibs, txTask.Header, txTask.Engine, false /* constCall */, vm.Config{
 							Tracer: result.TracingHooks(),
 						})
-						result.Logs = append(result.Logs, ibs.GetRawLogs(txTask.TxIndex)...)
-						return ret, err
 					}
 
 					_, err := cfg.Engine.Finalize(cfg.ChainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Uncles, p.blockResult.Receipts, txTask.Withdrawals, chainReader, syscall, true /* skipReceiptsEval */, logger)
 					if err != nil {
 						result.Err = err
+						return
 					}
+
+					result.Logs = append(result.Logs, ibs.GetRawLogs(txTask.TxIndex)...)
 				}()
 			}
 

--- a/execution/exec/txtask_test.go
+++ b/execution/exec/txtask_test.go
@@ -18,16 +18,28 @@ package exec
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/hexutil"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/db/datadir"
+	"github.com/erigontech/erigon/db/kv"
+	"github.com/erigontech/erigon/db/kv/temporal/temporaltest"
+	"github.com/erigontech/erigon/db/state/execctx"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/protocol/rules/ethash"
+	"github.com/erigontech/erigon/execution/state"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/execution/vm"
 	"github.com/erigontech/erigon/execution/vm/evmtypes"
 )
 
@@ -153,4 +165,112 @@ func TestCreateReceiptTxIndex(t *testing.T) {
 	require.Equal(t, uint32(firstLogIndex), receipt.FirstLogIndexWithinBlock)
 	require.Len(t, receipt.Logs, 1)
 	require.Equal(t, hexutil.Uint(firstLogIndex), receipt.Logs[0].Index)
+}
+
+// logEmittingFinalizeEngine drives a fixed number of block-end system calls at
+// one contract, each of which emits a log. failAt (1-based) makes Finalize fail
+// right after that call.
+type logEmittingFinalizeEngine struct {
+	rules.Engine
+	contract accounts.Address
+	calls    int
+	failAt   int
+}
+
+func (e *logEmittingFinalizeEngine) Finalize(config *chain.Config, header *types.Header, ibs *state.IntraBlockState,
+	uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal, chainReader rules.ChainReader,
+	syscall rules.SystemCall, skipReceiptsEval bool, logger log.Logger,
+) (types.FlatRequests, error) {
+	for i := 1; i <= e.calls; i++ {
+		if _, err := syscall(e.contract, nil); err != nil {
+			return nil, err
+		}
+		if i == e.failAt {
+			return nil, fmt.Errorf("finalize syscall %d failed", i)
+		}
+	}
+	return nil, nil
+}
+
+// TestHistoricalBlockEndLogs pins the block-end log run of the historical
+// tracer: the finalize system calls share one IntraBlockState and one txIndex,
+// so the state holds their cumulative logs, and collecting per call counted the
+// earlier ones again — k(k+1)/2 logs for k calls. A failed finalize attaches no
+// logs at all, matching the serial and parallel paths.
+func TestHistoricalBlockEndLogs(t *testing.T) {
+	const syscalls = 3
+
+	code := []byte{byte(vm.PUSH1), 0, byte(vm.PUSH1), 0, byte(vm.LOG0), byte(vm.STOP)}
+	contract := common.HexToAddress("0x00000000000000000000000000000000000c0de0")
+
+	for _, tc := range []struct {
+		name     string
+		failAt   int
+		wantLogs int
+	}{
+		{name: "each syscall counted once", wantLogs: syscalls},
+		{name: "failed syscall attaches nothing", failAt: 2, wantLogs: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := log.New()
+			db := temporaltest.NewTestDBWithStepSize(t, datadir.New(t.TempDir()), 16)
+			require.NoError(t, db.UpdateTemporal(t.Context(), func(rwTx kv.TemporalRwTx) error {
+				domains, err := execctx.NewSharedDomains(t.Context(), rwTx, logger)
+				if err != nil {
+					return err
+				}
+				defer domains.Close()
+				acc := accounts.NewAccount()
+				acc.CodeHash = accounts.InternCodeHash(crypto.Keccak256Hash(code))
+				putter := domains.AsPutDel(rwTx)
+				if err := putter.DomainPut(kv.CodeDomain, contract[:], code, 0, nil); err != nil {
+					return err
+				}
+				if err := putter.DomainPut(kv.AccountsDomain, contract[:], accounts.SerialiseV3(&acc), 0, nil); err != nil {
+					return err
+				}
+				return domains.Flush(t.Context(), rwTx)
+			}))
+
+			roTx, err := db.BeginTemporalRo(t.Context())
+			require.NoError(t, err)
+			defer roTx.Rollback()
+
+			engine := &logEmittingFinalizeEngine{
+				Engine:   ethash.NewFaker(),
+				contract: accounts.InternAddress(contract),
+				calls:    syscalls,
+				failAt:   tc.failAt,
+			}
+			txTask := &TxTask{
+				TxNum:   1,
+				TxIndex: 0,
+				Header: &types.Header{
+					Number:   *uint256.NewInt(1),
+					GasLimit: 10_000_000,
+				},
+				Config: chain.TestChainBerlinConfig,
+				Engine: engine,
+			}
+			result := &TxResult{Task: txTask}
+
+			rws := NewResultsQueue(1, 1)
+			_, err = rws.Drain(t.Context(), result)
+			require.NoError(t, err)
+
+			p := &historicalResultProcessor{}
+			cfg := &ExecArgs{ChainConfig: chain.TestChainBerlinConfig, Engine: engine}
+			consumer := TraceConsumerFunc(func(*BlockResult, *TxResult, kv.TemporalTx) error { return nil })
+
+			_, _, err = p.processResults(consumer, cfg, rws, txTask.TxNum, roTx, false, logger)
+			require.NoError(t, err)
+
+			if tc.failAt > 0 {
+				require.Error(t, result.Err)
+			} else {
+				require.NoError(t, result.Err)
+			}
+			require.Len(t, result.Logs, tc.wantLogs)
+		})
+	}
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -3160,12 +3160,7 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 				syscallIBS := ibs
 
 				syscall := func(contract accounts.Address, data []byte) ([]byte, error) {
-					ret, err := protocol.SysCallContract(contract, data, pe.cfg.chainConfig, syscallIBS, tt.Header, pe.cfg.engine, false, *pe.cfg.vmConfig)
-					if err != nil {
-						return nil, err
-					}
-					lastResult.Logs = append(lastResult.Logs, syscallIBS.GetRawLogs(tt.TxIndex)...)
-					return ret, err
+					return protocol.SysCallContract(contract, data, pe.cfg.chainConfig, syscallIBS, tt.Header, pe.cfg.engine, false, *pe.cfg.vmConfig)
 				}
 
 				chainReader := consensuschain.NewReader(pe.cfg.chainConfig, applyTx, pe.cfg.blockReader, pe.logger)
@@ -3174,6 +3169,8 @@ func (be *blockExecutor) nextResult(ctx context.Context, pe *parallelExecutor, r
 					tt.Withdrawals, chainReader, syscall, false, pe.logger); err != nil {
 					return be.invalidBlockResult(fmt.Errorf("%w: can't finalize block %d: %w", rules.ErrInvalidBlock, be.number(), err)), nil
 				}
+
+				lastResult.Logs = append(lastResult.Logs, syscallIBS.GetRawLogs(tt.TxIndex)...)
 
 				be.blockIO.RecordReads(finalVersion, ibs.VersionedReads())
 

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/crypto"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/db/datadir"
 	"github.com/erigontech/erigon/db/kv"
@@ -1915,4 +1916,86 @@ func BenchmarkDispatchPendingCompaction(b *testing.B) {
 			}
 		})
 	}
+}
+
+// logEmittingSyscallEngine drives a fixed number of block-end system calls at
+// one contract, each of which emits a log.
+type logEmittingSyscallEngine struct {
+	rules.Engine
+	contract accounts.Address
+	calls    int
+}
+
+func (e *logEmittingSyscallEngine) Finalize(config *chain.Config, header *types.Header, ibs *state.IntraBlockState,
+	uncles []*types.Header, receipts types.Receipts, withdrawals []*types.Withdrawal, chain rules.ChainReader,
+	syscall rules.SystemCall, skipReceiptsEval bool, logger log.Logger,
+) (types.FlatRequests, error) {
+	for range e.calls {
+		if _, err := syscall(e.contract, nil); err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+// seedLogEmittingContract deploys `LOG0` bytecode at addr so that every system
+// call to it appends exactly one log to the caller's IntraBlockState.
+func seedLogEmittingContract(t *testing.T, db kv.TemporalRwDB, addr common.Address) {
+	code := []byte{byte(vm.PUSH1), 0, byte(vm.PUSH1), 0, byte(vm.LOG0), byte(vm.STOP)}
+	seedResumeTestDB(t, db, func(putter kv.TemporalPutDel) error {
+		acc := accounts.NewAccount()
+		acc.CodeHash = accounts.InternCodeHash(crypto.Keccak256Hash(code))
+		if err := putter.DomainPut(kv.CodeDomain, addr[:], code, 0, nil); err != nil {
+			return err
+		}
+		return putter.DomainPut(kv.AccountsDomain, addr[:], accounts.SerialiseV3(&acc), 0, nil)
+	})
+}
+
+// TestParallelBlockEndLogsCountEachSyscallOnce pins the block-end log run: the
+// finalize system calls share one IntraBlockState and one txIndex, so the state
+// holds their cumulative logs, and collecting per call counted the earlier ones
+// again — k(k+1)/2 logs for k calls.
+func TestParallelBlockEndLogsCountEachSyscallOnce(t *testing.T) {
+	const syscalls = 3
+
+	db := newResumeTestDB(t)
+	config := chain.TestChainBerlinConfig
+	contract := common.HexToAddress("0x00000000000000000000000000000000000c0de0")
+	seedLogEmittingContract(t, db, contract)
+
+	txTask := &exec.TxTask{
+		Header: &types.Header{
+			Number:   *uint256.NewInt(1),
+			GasLimit: 10_000_000,
+		},
+		TxNum:   1,
+		TxIndex: 0,
+		Config:  config,
+	}
+
+	pe, roTx := newResumeTestExec(t, db, config)
+	pe.cfg.engine = &logEmittingSyscallEngine{Engine: ethash.NewFaker(), contract: accounts.InternAddress(contract), calls: syscalls}
+	pe.cfg.vmConfig = &vm.Config{}
+
+	be := newBlockExec(newParallelTestBlock(1), new(protocol.GasPool).AddGas(10_000_000), nil, make(chan applyResult, 4), nil, false, nil)
+	eTask := &execTask{Task: txTask, index: 0}
+	be.tasks = []*execTask{eTask}
+	be.results = []*execResult{nil}
+	be.execTasks.setInProgress(0)
+
+	txResult := &exec.TxResult{
+		Task: &taskVersion{
+			execTask: eTask,
+			version:  state.Version{BlockNum: 1, TxIndex: 0, Incarnation: 1, TxNum: 1},
+		},
+		ExecutionResult: evmtypes.ExecutionResult{ReceiptGasUsed: 21000},
+	}
+
+	res, err := be.nextResult(context.Background(), pe, txResult, roTx)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NoError(t, res.Err)
+
+	assert.Len(t, txResult.Logs, syscalls)
 }

--- a/execution/stagedsync/exec3_serial.go
+++ b/execution/stagedsync/exec3_serial.go
@@ -376,12 +376,7 @@ func (se *serialExecutor) executeBlock(ctx context.Context, block *types.Block, 
 				defer ibs.Close()
 				ibs.SetTxContext(txTask.BlockNumber(), txTask.TxIndex)
 				syscall := func(contract accounts.Address, data []byte) ([]byte, error) {
-					ret, err := protocol.SysCallContract(contract, data, se.cfg.chainConfig, ibs, txTask.Header, se.cfg.engine, false /* constCall */, *se.cfg.vmConfig)
-					if err != nil {
-						return nil, err
-					}
-					result.Logs = append(result.Logs, ibs.GetRawLogs(txTask.TxIndex)...)
-					return ret, err
+					return protocol.SysCallContract(contract, data, se.cfg.chainConfig, ibs, txTask.Header, se.cfg.engine, false /* constCall */, *se.cfg.vmConfig)
 				}
 
 				chainReader := consensuschain.NewReader(se.cfg.chainConfig, se.applyTx, se.cfg.blockReader, se.logger)
@@ -413,6 +408,8 @@ func (se *serialExecutor) executeBlock(ctx context.Context, block *types.Block, 
 				if err != nil {
 					return fmt.Errorf("%w, txnIdx=%d, %w", rules.ErrInvalidBlock, txTask.TxIndex, err)
 				}
+
+				result.Logs = append(result.Logs, ibs.GetRawLogs(txTask.TxIndex)...)
 
 				if priorComplete && !isInitialCycle {
 					se.cfg.notifications.RecentReceipts.Add(finalizeReceipts, txTask.Txs, txTask.Header)


### PR DESCRIPTION
Fixes #23255.

The block-finalize syscall closure appended `ibs.GetRawLogs(txIndex)` after every call. All finalize syscalls share one `ibs` and one txIndex, so `GetRawLogs` returns the cumulative run of the block-end tx — each call re-appended the earlier calls' logs, giving k(k+1)/2 entries for k syscalls.

Read the run once, after `engine.Finalize` returns. Same change in the three places that had the pattern: `exec3_serial.go`, `exec3_parallel.go`, `historical_trace_worker.go`. The historical one also read the logs before checking the `Finalize` error, so it attached a partial run after a failed syscall; it now collects them only on success, like the other two.

Visible on Gnosis post-Pectra: the AuRa block-reward syscall runs first and emits `MintedNative`, so in the post-Pectra sequence of four finalize syscalls (reward, system withdrawals, EIP-7002, EIP-7251) that log is collected 4× — one original plus three duplicates — and 6× once Amsterdam adds the two builder-request calls. Also visible on Polygon sprint-start blocks with two or more log-emitting state-sync events, where `stage_custom_trace` derives the block-end log-index metadata from `len(result.Logs)` and the bor receipts generator serves shifted `log.Index` values from it. Mainnet is unaffected: its finalize syscalls emit no logs.

`TestParallelBlockEndLogsCountEachSyscallOnce` drives three log-emitting syscalls through the parallel block-end path: 6 logs before, 3 after. `TestHistoricalBlockEndLogs` does the same for the historical tracer and covers its error path: with the second syscall failing, 3 logs before, 0 after.
