### PR TITLE
node/logging: keep the file-logging banner on the console

### DIFF
--- a/node/logging/logging.go
+++ b/node/logging/logging.go
@@ -279,9 +279,9 @@ func initSeparatedLogging(
 	}
 	userLog := log.StreamHandler(lumberjack, dirFormat)
 
-	mux := log.MultiHandler(consoleHandler, log.LvlFilterHandler(dirLevel, userLog))
-	logger.SetHandler(mux)
+	// Emit before attaching the file handler: this banner is for the console, in the file it is noise.
 	logger.Info("logging to file system", "logDir", dirPath, "filePrefix", filePrefix, "logLevel", dirLevel, "json", dirJson)
+	logger.SetHandler(log.MultiHandler(consoleHandler, log.LvlFilterHandler(dirLevel, userLog)))
 }
 
 // GetLogLevel parses a log level given as a name ("info") or a numeric string ("3").

--- a/node/logging/logging_test.go
+++ b/node/logging/logging_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package logging
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+)
+
+func TestSetupBannerGoesToConsoleOnly(t *testing.T) {
+	var console bytes.Buffer
+	stderrHandler := log.StderrHandler
+	log.StderrHandler = log.StreamHandler(&console, log.TerminalFormatNoColor())
+	t.Cleanup(func() { log.StderrHandler = stderrHandler })
+
+	dirPath := t.TempDir()
+	logger := log.New()
+	initSeparatedLogging(logger, "test", dirPath, log.LvlInfo, log.LvlInfo, false, false)
+	logger.Info("first line of the app")
+
+	content, err := os.ReadFile(filepath.Join(dirPath, "test.log"))
+	require.NoError(t, err)
+	require.Contains(t, string(content), "first line of the app")
+	require.NotContains(t, string(content), "logging to file system")
+	require.Contains(t, console.String(), "logging to file system")
+}


### PR DESCRIPTION
One-shot commands (`erigon seg reset`, `seg rm-state`, ...) attach the file handler, write `logging to file system`, then print their result to stdout or return an error to the CLI. So the banner is often the only line they add to `<datadir>/logs/erigon.log`:

```
[INFO] [08-16|04:52:08.237] logging to file system  logDir=/erigon-data/mainnet36_archive/logs filePrefix=erigon logLevel=dbug json=false
[INFO] [08-17|11:34:53.471] logging to file system  logDir=/erigon-data/mainnet36_archive/logs filePrefix=erigon logLevel=dbug json=false
[INFO] [08-18|02:58:21.093] logging to file system  logDir=/erigon-data/mainnet36_archive/logs filePrefix=erigon logLevel=dbug json=false
[INFO] [08-18|02:58:55.162] logging to file system  logDir=/erigon-data/mainnet36_archive/logs filePrefix=erigon logLevel=dbug json=false
```

Fix: emit the banner while the logger still has only the console handler, so it stays on the console and out of the file. A node run still marks its start in the file with `Startup command` / `Build info` / `Starting Erigon on ...`. Console output is unchanged.
