### PR TITLE
exec: apply loop re-reads accounts the workers already read

### DIFF
--- a/execution/stagedsync/exec3.go
+++ b/execution/stagedsync/exec3.go
@@ -644,7 +644,8 @@ func (te *txExecutor) executeBlocks(ctx context.Context, startBlockNum uint64, m
 			}), te.cfg.engine, te.cfg.author, te.cfg.chainConfig)
 
 			var txTasks []exec.Task
-			// Per-block committed state cache for parallel workers' GetCommittedState.
+			// Per-block committed state cache, shared by the block's workers and
+			// (in parallel exec) its apply loop.
 			blockStateCache := state.NewBlockStateCache()
 
 			blockStartTxNum := inputTxNum

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1296,7 +1296,7 @@ func (pe *parallelExecutor) processRequest(ctx context.Context, execRequest *exe
 			executor, ok = pe.blockExecutors[blockNum]
 
 			if !ok {
-				executor = newBlockExec(blockNum, execRequest.blockHash, execRequest.gasPool, execRequest.accessList, execRequest.applyResults, execRequest.commitResults, execRequest.profile, execRequest.exhausted)
+				executor = newBlockExec(blockNum, execRequest.blockHash, execRequest.gasPool, execRequest.accessList, execRequest.applyResults, execRequest.commitResults, execRequest.profile, execRequest.exhausted, t.GetBlockStateCache())
 			}
 		}
 
@@ -2381,6 +2381,8 @@ type blockExecutor struct {
 
 	// blockStateCache provides a stable pre-block snapshot of account data
 	// for GetCommittedState reads, unaffected by intra-block ApplyStateWrites.
+	// Same instance the block's tasks carry, so the apply loop's readers hit
+	// what the workers already read instead of going back to the domain.
 	blockStateCache *state.BlockStateCache
 }
 
@@ -2439,7 +2441,10 @@ func (be *blockExecutor) sendResult(ctx context.Context, r applyResult, mustDeli
 	return nil
 }
 
-func newBlockExec(blockNum uint64, blockHash common.Hash, gasPool *protocol.GasPool, accessList types.BlockAccessList, applyResults chan applyResult, commitResults chan applyResult, profile bool, exhausted *ErrLoopExhausted) *blockExecutor {
+func newBlockExec(blockNum uint64, blockHash common.Hash, gasPool *protocol.GasPool, accessList types.BlockAccessList, applyResults chan applyResult, commitResults chan applyResult, profile bool, exhausted *ErrLoopExhausted, blockStateCache *state.BlockStateCache) *blockExecutor {
+	if blockStateCache == nil {
+		blockStateCache = state.NewBlockStateCache()
+	}
 	return &blockExecutor{
 		blockNum:         blockNum,
 		blockHash:        blockHash,
@@ -2456,7 +2461,7 @@ func newBlockExec(blockNum uint64, blockHash common.Hash, gasPool *protocol.GasP
 		applyResults:     applyResults,
 		commitResults:    commitResults,
 		gasPool:          gasPool,
-		blockStateCache:  state.NewBlockStateCache(),
+		blockStateCache:  blockStateCache,
 		exhausted:        exhausted,
 	}
 }

--- a/execution/stagedsync/exec3_parallel.go
+++ b/execution/stagedsync/exec3_parallel.go
@@ -1296,7 +1296,7 @@ func (pe *parallelExecutor) processRequest(ctx context.Context, execRequest *exe
 			executor, ok = pe.blockExecutors[blockNum]
 
 			if !ok {
-				executor = newBlockExec(blockNum, execRequest.blockHash, execRequest.gasPool, execRequest.accessList, execRequest.applyResults, execRequest.commitResults, execRequest.profile, execRequest.exhausted, t.GetBlockStateCache())
+				executor = newBlockExec(blockNum, execRequest.blockHash, execRequest.gasPool, execRequest.accessList, execRequest.applyResults, execRequest.commitResults, execRequest.profile, execRequest.exhausted, blockStateCacheOf(t))
 			}
 		}
 
@@ -2439,6 +2439,22 @@ func (be *blockExecutor) sendResult(ctx context.Context, r applyResult, mustDeli
 		}
 	}
 	return nil
+}
+
+// blockStateCacheOf returns the per-block state cache the block's tasks carry,
+// so the apply loop reads the entries the workers already filled.
+//
+// A block that straddles lastFrozenTxNum keeps its own cache: its historic
+// tasks are applied through HistoryReaderV3, whose block-cache tier falls back
+// to the committed (pre-block latest) view, so entries filled by the block's
+// non-historic workers would answer reads that must resolve as of an earlier
+// txNum. Tasks turn historic in txNum order, so the block's first task decides
+// it for the whole block.
+func blockStateCacheOf(t exec.Task) *state.BlockStateCache {
+	if t.IsHistoric() {
+		return nil
+	}
+	return t.GetBlockStateCache()
 }
 
 func newBlockExec(blockNum uint64, blockHash common.Hash, gasPool *protocol.GasPool, accessList types.BlockAccessList, applyResults chan applyResult, commitResults chan applyResult, profile bool, exhausted *ErrLoopExhausted, blockStateCache *state.BlockStateCache) *blockExecutor {

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1846,4 +1846,9 @@ func TestBlockExecUsesTaskStateCache(t *testing.T) {
 	require.Same(t, second, pe.blockExecutors[8].blockStateCache)
 
 	require.NotNil(t, newBlockExec(0, common.Hash{}, nil, nil, nil, nil, false, nil, nil).blockStateCache)
+
+	// A block straddling lastFrozenTxNum applies its historic tasks through
+	// HistoryReaderV3, which resolves reads as of a txNum the workers' entries
+	// are ahead of — such a block keeps a private cache.
+	require.Nil(t, blockStateCacheOf(&exec.TxTask{BlockStateCache: first, HistoryExecution: true}))
 }

--- a/execution/stagedsync/exec3_parallel_test.go
+++ b/execution/stagedsync/exec3_parallel_test.go
@@ -1435,7 +1435,7 @@ func TestParallelResumeBoundaryOffsets(t *testing.T) {
 
 	gasPool := new(protocol.GasPool).AddGas(10_000_000)
 
-	be := newBlockExec(0, common.Hash{}, gasPool, nil, make(chan applyResult, 1), nil, false, nil)
+	be := newBlockExec(0, common.Hash{}, gasPool, nil, make(chan applyResult, 1), nil, false, nil, nil)
 	eTask := &execTask{
 		Task:  txTask,
 		index: 0,
@@ -1518,7 +1518,7 @@ func TestParallelResumeReconstructsPriorReceipts(t *testing.T) {
 
 	gasPool := new(protocol.GasPool).AddGas(10_000_000)
 
-	be := newBlockExec(1, common.Hash{}, gasPool, nil, make(chan applyResult, 4), nil, false, nil)
+	be := newBlockExec(1, common.Hash{}, gasPool, nil, make(chan applyResult, 4), nil, false, nil, nil)
 	eTask := &execTask{
 		Task:  txTask,
 		index: 0,
@@ -1591,7 +1591,7 @@ func TestParallelResumeReconstructionFailureIsNonFatal(t *testing.T) {
 
 	gasPool := new(protocol.GasPool).AddGas(10_000_000)
 
-	be := newBlockExec(1, common.Hash{}, gasPool, nil, make(chan applyResult, 4), nil, false, nil)
+	be := newBlockExec(1, common.Hash{}, gasPool, nil, make(chan applyResult, 4), nil, false, nil, nil)
 	eTask := &execTask{
 		Task:  txTask,
 		index: 0,
@@ -1666,7 +1666,7 @@ func TestParallelFinalizeMissingPrevReceiptErrors(t *testing.T) {
 
 	gasPool := new(protocol.GasPool).AddGas(10_000_000)
 
-	be := newBlockExec(0, common.Hash{}, gasPool, nil, make(chan applyResult, 1), nil, false, nil)
+	be := newBlockExec(0, common.Hash{}, gasPool, nil, make(chan applyResult, 1), nil, false, nil, nil)
 	be.tasks = []*execTask{eTask0, eTask1}
 	be.results = []*execResult{nil, nil}
 	// tx 0 was "finalized" without a receipt — the invariant nextResult
@@ -1826,4 +1826,24 @@ func BenchmarkDispatchPendingCompaction(b *testing.B) {
 			}
 		})
 	}
+}
+
+// The apply loop's readers (fee calc, finalize syscalls, WriteSet.Normalize)
+// must use the per-block state cache the block's workers fill — a private one
+// starts empty on every block, so each address costs a domain read. One
+// request can carry several blocks, each with its own cache.
+func TestBlockExecUsesTaskStateCache(t *testing.T) {
+	first, second := state.NewBlockStateCache(), state.NewBlockStateCache()
+	tasks := []exec.Task{
+		&exec.TxTask{Header: &types.Header{Number: *uint256.NewInt(7)}, BlockStateCache: first},
+		&exec.TxTask{Header: &types.Header{Number: *uint256.NewInt(8)}, BlockStateCache: second},
+	}
+
+	// A busy map keeps processRequest from scheduling the blocks for execution.
+	pe := &parallelExecutor{blockExecutors: map[uint64]*blockExecutor{0: {}}}
+	require.NoError(t, pe.processRequest(context.Background(), &execRequest{tasks: tasks}))
+	require.Same(t, first, pe.blockExecutors[7].blockStateCache)
+	require.Same(t, second, pe.blockExecutors[8].blockStateCache)
+
+	require.NotNil(t, newBlockExec(0, common.Hash{}, nil, nil, nil, nil, false, nil, nil).blockStateCache)
 }


### PR DESCRIPTION
Cherry-pick of #23356 to release/3.6.

## r3.6-specific adaptations

`newBlockExec` takes `blockNum`/`blockHash` here instead of a `*types.Block`, and
`processRequest` creates the executor inside the task loop — one request can
carry tasks for several blocks. So the cache comes from the task that creates
the executor, not from the request, and the `blockStateCacheOf` helper main uses
is not needed.
