### PR TITLE
[r3.5] txnprovider/txpool: release the pool lock and wake a caller that gives up waiting

### DIFF
--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -714,6 +714,8 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf uint64,
 	for last := p.lastSeenBlock.Load(); last < onTopOf; last = p.lastSeenBlock.Load() {
 		select {
 		case <-ctx.Done():
+			// Leaving with the lock held would stop every later pool operation, not just this one.
+			p.lock.Unlock()
 			return false, 0, ctx.Err()
 		default:
 			// continue

--- a/txnprovider/txpool/pool.go
+++ b/txnprovider/txpool/pool.go
@@ -710,6 +710,30 @@ func (p *TxPool) best(ctx context.Context, n int, txns *TxnsRlp, onTopOf uint64,
 	availableGas mdgas.FullMdGas,
 	yielded mapset.Set[[32]byte], availableRlpSpace int) (bool, int, error) {
 
+	// sync.Cond has no notion of a context, so a caller that goes away while parked below would
+	// sleep until the next block broadcast the condition, or forever while the chain is stalled.
+	// Broadcasting on cancellation wakes it; every waiter rechecks its own condition anyway. The
+	// broadcast takes the lock so it cannot land between the check below and the wait, which is the
+	// window where a wakeup would be lost.
+	stopWatching, watcherDone := make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(watcherDone)
+		select {
+		case <-ctx.Done():
+			p.lock.Lock()
+			p.lastSeenCond.Broadcast()
+			p.lock.Unlock()
+		case <-stopWatching:
+		}
+	}()
+	// Joined rather than merely told to stop: with the context already ended the watcher can pick
+	// either case, and one that picked cancellation would otherwise take the lock after this call
+	// had returned. Registered before the lock is taken, so it runs after the lock is released.
+	defer func() {
+		close(stopWatching)
+		<-watcherDone
+	}()
+
 	p.lock.Lock()
 	for last := p.lastSeenBlock.Load(); last < onTopOf; last = p.lastSeenBlock.Load() {
 		select {

--- a/txnprovider/txpool/pool_best_lock_test.go
+++ b/txnprovider/txpool/pool_best_lock_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package txpool
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/require"
+
+	mdgas "github.com/erigontech/erigon/execution/protocol/mdgas"
+)
+
+func TestBestReleasesTheLockWhenTheCallerGivesUpWaitingForABlock(t *testing.T) {
+	lock := &sync.Mutex{}
+	p := &TxPool{lock: lock, lastSeenCond: sync.NewCond(lock)}
+
+	// The requested block has not been seen, so the wait loop is entered, and the caller is already
+	// gone by the time it checks.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := p.best(ctx, 1, &TxnsRlp{}, 1, mdgas.FullMdGas{}, mapset.NewSet[[32]byte](), 0)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// Returning with the lock still held blocks every later pool operation, including the block
+	// updates that would have let this caller through, so nothing recovers on its own.
+	require.True(t, p.lock.TryLock(), "best returned holding the pool lock")
+	p.lock.Unlock()
+}

--- a/txnprovider/txpool/pool_best_lock_test.go
+++ b/txnprovider/txpool/pool_best_lock_test.go
@@ -17,13 +17,17 @@
 package txpool
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/erigontech/erigon/common/log/v3"
 	mdgas "github.com/erigontech/erigon/execution/protocol/mdgas"
 )
 
@@ -43,4 +47,60 @@ func TestBestReleasesTheLockWhenTheCallerGivesUpWaitingForABlock(t *testing.T) {
 	// updates that would have let this caller through, so nothing recovers on its own.
 	require.True(t, p.lock.TryLock(), "best returned holding the pool lock")
 	p.lock.Unlock()
+}
+
+// waitingBuffer records what the pool logged, so a test can tell when a caller has reached the
+// "Waiting for block" trace and is therefore about to park in the condition.
+type waitingBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *waitingBuffer) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *waitingBuffer) contains(s string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return strings.Contains(w.buf.String(), s)
+}
+
+func TestBestReturnsWhenItsCallerGoesAwayWhileWaitingForABlock(t *testing.T) {
+	logs := &waitingBuffer{}
+	logger := log.New()
+	logger.SetHandler(log.StreamHandler(logs, log.LogfmtFormat()))
+
+	lock := &sync.Mutex{}
+	p := &TxPool{
+		lock:         lock,
+		lastSeenCond: sync.NewCond(lock),
+		logger:       logger,
+		pending:      NewPendingSubPool(PendingSubPool, 1),
+		baseFee:      NewSubPool(BaseFeeSubPool, 1),
+		queued:       NewSubPool(QueuedSubPool, 1),
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+
+	returned := make(chan error, 1)
+	go func() {
+		_, _, err := p.best(ctx, 1, &TxnsRlp{}, 1, mdgas.FullMdGas{}, mapset.NewSet[[32]byte](), 0)
+		returned <- err
+	}()
+
+	// Cancel only once it is parked, so this exercises the wait rather than the check before it.
+	require.Eventually(t, func() bool { return logs.contains("Waiting for block") }, 5*time.Second, time.Millisecond)
+	cancel()
+
+	// Nothing else wakes it: no block arrives and the pool is not shutting down. A wait that cannot
+	// observe its caller leaves the builder that made this request holding a read view until one of
+	// those happens, which on a stalled chain is never.
+	select {
+	case err := <-returned:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("best never returned; only a new block would have woken it")
+	}
 }


### PR DESCRIPTION
Cherry-pick of #23333 and #23343 to release/3.5. Companion to #23360, which does the same for release/3.6.

Both fix the same wait loop in `TxPool.best`, and they ship together because #23343 does not apply without #23333: the test file it touches is created by #23333.

The first is the one worth having on a release branch on its own merits. `best` returned `ctx.Err()` from inside the wait loop while still holding `p.lock`, so a caller that gave up leaked the pool lock and every later pool operation blocked behind it. Verified present on this branch before the pick.

The second makes a caller parked in `sync.Cond.Wait` observable to cancellation at all: without it, a caller that goes away sleeps until the next block, or forever while the chain is stalled.

## r3.5 notes

Straight cherry-picks, no adaptations — both applied unchanged despite this branch being further from main. `BlockBuilder.Stop()` takes no context here, so nothing depends on #22835 or #23289.

Known follow-up, tracked in #23355 and not specific to this backport: the watcher join means a cancelled caller's return now waits for `p.lock`. Not reachable on this branch, for the same reason it is not reachable on main — no in-tree give-up path cancels the context `best` receives.

## Verification

- `go test ./txnprovider/txpool/ -run TestBest -race -count=200` green.
- Each fix mutation-checked on this branch: dropping the unlock deadlocks the package (`test timed out`); dropping the watcher join fails `TestBestReleasesTheLockWhenTheCallerGivesUpWaitingForABlock`.
- `make lintci` clean, 0 issues.
