### PR TITLE
ci: stop the Linux dependency step from consuming the whole job budget

### DIFF
--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -209,12 +209,29 @@ runs:
       # mid-mirror-sync, or a 403 "no longer signed" on the azure-cli repo —
       # failing the whole job. Drop every source pointing at those CDNs before
       # updating (we never install from them); the Ubuntu archive retries on blips.
-      # Can't suppress "Reading database..." from apt-get install. Also it's very slow...
+      #
+      # apt waits indefinitely for an unreachable mirror or for a lock held by
+      # the image's own unattended-upgrades, and -qq hides that it is waiting,
+      # so the step can consume the entire job budget in silence. Skip apt when
+      # the toolchain already builds, and bound whatever is left.
       run: |
+        if command -v make >/dev/null 2>&1 &&
+           printf 'int main(void){return 0;}' | cc -x c -o /dev/null - 2>/dev/null; then
+          echo "C toolchain and make already usable; skipping apt"
+          exit 0
+        fi
         sudo grep -rlZE 'dl\.google\.com|packages\.microsoft\.com' \
           /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f || true
-        sudo apt-get update -qq -o Acquire::Retries=3 \
-          && sudo apt-get install -qq -y build-essential 2>/dev/null
+        apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15
+                  -o Acquire::https::Timeout=15 -o DPkg::Lock::Timeout=60)
+        if ! sudo timeout 300 apt-get update -q "${apt_opts[@]}"; then
+          echo "::error::apt-get update did not finish within 300s"
+          exit 1
+        fi
+        if ! sudo timeout 600 apt-get install -qq -y "${apt_opts[@]}" build-essential; then
+          echo "::error::apt-get install build-essential did not finish within 600s"
+          exit 1
+        fi
 
     - name: Ensure make on Windows
       if: ${{ runner.os == 'Windows' }}

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -208,14 +208,18 @@ runs:
       # apt repos (Google Chrome, Microsoft/azure-cli) whose
       # CDNs intermittently break `apt-get update` — a Packages.gz size mismatch
       # mid-mirror-sync, or a 403 "no longer signed" on the azure-cli repo —
-      # failing the whole job. Drop every source pointing at those CDNs before
-      # updating (we never install from them); the Ubuntu archive retries on blips.
+      # failing the whole job. Drop every source pointing at those CDNs (we never
+      # install from them); the Ubuntu archive retries on blips. That runs even
+      # when the install below is skipped, so anything else in the job that
+      # reaches for apt does not trip over them.
       #
       # apt waits indefinitely for an unreachable mirror or for a lock held by
       # the image's own unattended-upgrades, and -qq hides that it is waiting,
-      # so the step can consume the entire job budget in silence. Skip apt when
-      # those three are already on PATH, and bound whatever is left.
+      # so the step can consume the entire job budget in silence. Skip the
+      # install when the tools are already on PATH, and bound whatever is left.
       run: |
+        sudo grep -rlZE 'dl\.google\.com|packages\.microsoft\.com' \
+          /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f || true
         cc_bin=$(go env CC || true)
         cxx_bin=$(go env CXX || true)
         if command -v make >/dev/null 2>&1 &&
@@ -224,8 +228,6 @@ runs:
           echo "make, $cc_bin and $cxx_bin already present; skipping apt"
           exit 0
         fi
-        sudo grep -rlZE 'dl\.google\.com|packages\.microsoft\.com' \
-          /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f || true
         apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15
                   -o Acquire::https::Timeout=15 -o DPkg::Lock::Timeout=60)
         if ! sudo timeout --kill-after=10s 300 apt-get update -q "${apt_opts[@]}"; then

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -216,16 +216,16 @@ runs:
       # apt waits indefinitely for an unreachable mirror or for a lock held by
       # the image's own unattended-upgrades, and -qq hides that it is waiting,
       # so the step can consume the entire job budget in silence. Skip the
-      # install when the tools are already on PATH, and bound whatever is left.
+      # install when the toolchain already builds, and bound whatever is left.
       run: |
         sudo grep -rlZE 'dl\.google\.com|packages\.microsoft\.com' \
           /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f || true
         cc_bin=$(go env CC || true)
         cxx_bin=$(go env CXX || true)
         if command -v make >/dev/null 2>&1 &&
-           command -v "$cc_bin" >/dev/null 2>&1 &&
-           command -v "$cxx_bin" >/dev/null 2>&1; then
-          echo "make, $cc_bin and $cxx_bin already present; skipping apt"
+           printf 'int main(void){return 0;}\n' | "$cc_bin" -x c -o /dev/null - 2>/dev/null &&
+           printf 'int main(){return 0;}\n' | "$cxx_bin" -x c++ -o /dev/null - 2>/dev/null; then
+          echo "C and C++ toolchains and make already usable; skipping apt"
           exit 0
         fi
         apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -203,8 +203,9 @@ runs:
     - name: Install dependencies on Linux
       if: ${{ runner.os == 'Linux' }}
       shell: bash
-      # erigon only needs build-essential (gcc/make). The hosted runner image
-      # ships third-party apt repos (Google Chrome, Microsoft/azure-cli) whose
+      # erigon needs make and a C and C++ compiler: cgo builds C++ sources from
+      # go-libutp and evmone_precompiles. The hosted runner image ships third-party
+      # apt repos (Google Chrome, Microsoft/azure-cli) whose
       # CDNs intermittently break `apt-get update` — a Packages.gz size mismatch
       # mid-mirror-sync, or a 403 "no longer signed" on the azure-cli repo —
       # failing the whole job. Drop every source pointing at those CDNs before
@@ -213,11 +214,14 @@ runs:
       # apt waits indefinitely for an unreachable mirror or for a lock held by
       # the image's own unattended-upgrades, and -qq hides that it is waiting,
       # so the step can consume the entire job budget in silence. Skip apt when
-      # the toolchain already builds, and bound whatever is left.
+      # those three are already on PATH, and bound whatever is left.
       run: |
+        cc_bin=$(go env CC)
+        cxx_bin=$(go env CXX)
         if command -v make >/dev/null 2>&1 &&
-           printf 'int main(void){return 0;}' | cc -x c -o /dev/null - 2>/dev/null; then
-          echo "C toolchain and make already usable; skipping apt"
+           command -v "$cc_bin" >/dev/null 2>&1 &&
+           command -v "$cxx_bin" >/dev/null 2>&1; then
+          echo "make, $cc_bin and $cxx_bin already present; skipping apt"
           exit 0
         fi
         sudo grep -rlZE 'dl\.google\.com|packages\.microsoft\.com' \

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -216,8 +216,8 @@ runs:
       # so the step can consume the entire job budget in silence. Skip apt when
       # those three are already on PATH, and bound whatever is left.
       run: |
-        cc_bin=$(go env CC)
-        cxx_bin=$(go env CXX)
+        cc_bin=$(go env CC || true)
+        cxx_bin=$(go env CXX || true)
         if command -v make >/dev/null 2>&1 &&
            command -v "$cc_bin" >/dev/null 2>&1 &&
            command -v "$cxx_bin" >/dev/null 2>&1; then

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -224,8 +224,8 @@ runs:
           /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f || true
         apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15
                   -o Acquire::https::Timeout=15 -o DPkg::Lock::Timeout=60)
-        if ! sudo timeout 300 apt-get update -q "${apt_opts[@]}"; then
-          echo "::error::apt-get update did not finish within 300s"
+        if ! sudo timeout --kill-after=10s 300 apt-get update -q "${apt_opts[@]}"; then
+          echo "::error::apt-get update failed or did not finish within 300s"
           exit 1
         fi
         if ! sudo timeout 600 apt-get install -qq -y "${apt_opts[@]}" build-essential; then

--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -228,8 +228,8 @@ runs:
           echo "::error::apt-get update failed or did not finish within 300s"
           exit 1
         fi
-        if ! sudo timeout 600 apt-get install -qq -y "${apt_opts[@]}" build-essential; then
-          echo "::error::apt-get install build-essential did not finish within 600s"
+        if ! sudo timeout --kill-after=10s 600 apt-get install -qq -y "${apt_opts[@]}" build-essential; then
+          echo "::error::apt-get install build-essential failed or did not finish within 600s"
           exit 1
         fi
 


### PR DESCRIPTION
## What happened

Five CI Gate runs were cancelled at the 60-minute cap in about two hours today, on `pull_request` and `merge_group` alike. In each, every Linux job died inside `setup-erigon` having done no work of its own:

```
caplin / tests (ubuntu-24.04)        3608s  cancelled  Run ./.github/actions/setup-erigon
lint / lint                          3594s  cancelled  Run ./.github/actions/setup-erigon
eest-spec-blocktests-legacy-...      3608s  cancelled  Run ./.github/actions/setup-erigon
```

Inside that action it is "Install dependencies on Linux", 58m32s in the run that prompted this, ending in `Error: The operation was canceled`.

## Why

`apt-get` waits indefinitely — for an unreachable mirror, or for the dpkg lock while the image's own `unattended-upgrades` holds it. `-qq` suppresses the "Waiting for cache lock" line, so the step looks hung rather than blocked, and nothing bounds it. The job's entire budget goes to a step that has produced no output.

This is not specific to any PR. It took out unrelated runs all morning; the one that prompted this was #23274 failing the merge queue.

## What changed

Two things, both in that step:

- **Skip apt when it is not needed.** The hosted image usually already has a working toolchain, and erigon only needs a C compiler and make. The probe compiles and links a trivial program rather than looking for `gcc` on `PATH`, so a compiler that cannot link is not mistaken for a working one.
- **Bound what is left.** A wall-clock `timeout` on each apt call, `Acquire::*::Timeout` for the network, and `DPkg::Lock::Timeout` for the lock. A repeat now fails in minutes with `::error::` naming the call that hung, instead of silently eating the run.

The CDN-source removal and the reasoning behind it are unchanged.

## Verification

YAML parses; `bash -n` clean. The guard was exercised in all three states: toolchain present and working (skips), `cc` absent (falls through to apt), and `cc` present but failing to link (falls through) — the last is the case a `command -v gcc` check would have got wrong.
