### PR TITLE
[r3.6] execution/commitment: tolerate preload metric counter rounding

### DIFF
--- a/execution/commitment/adaptive_pin_test.go
+++ b/execution/commitment/adaptive_pin_test.go
@@ -18,6 +18,7 @@ package commitment
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -136,7 +137,11 @@ func TestRecordPreload_RecordsElapsedAndBytes(t *testing.T) {
 			if got := mxPreloadBytesTotal.GetValue() - bytesBefore; got != tc.wantBytes {
 				t.Errorf("commitment_trunk_preload_bytes_total advanced by %v, want %v", got, tc.wantBytes)
 			}
-			if got := mxPreloadDurationSecondsTotal.GetValue() - secondsBefore; got < elapsed.Seconds() {
+			// Differencing a growing accumulator loses up to half an ULP of its
+			// magnitude, so a constant slack stops covering it as the total rises.
+			secondsAfter := mxPreloadDurationSecondsTotal.GetValue()
+			slack := math.Nextafter(secondsAfter, math.Inf(1)) - secondsAfter
+			if got := secondsAfter - secondsBefore; got+slack < elapsed.Seconds() {
 				t.Errorf("commitment_trunk_preload_duration_seconds_total advanced by %v, want >= %v", got, elapsed.Seconds())
 			}
 		})


### PR DESCRIPTION
Backports the test-only floating-point tolerance from #23189 to release/3.6.

The duration metric is a cumulative `float64` counter. Subtracting two snapshots can lose one ULP, so Windows CI observed `0.049999999999999996` for a `0.05` increment. That failed the first full-suite pass; the automatic cold-cache retry then pushed the job past its 60-minute limit.

## r3.6-specific adaptations

- Includes only the test fix from #23189; its unrelated commitment-cache optimization is omitted.

## Verification

- Red: `ERIGON_EXEC3_PARALLEL=true go test ./execution/commitment -run TestRecordPreload_RecordsElapsedAndBytes -count=10000` reproduced the rounding failure on release/3.6.
- Green: the same 10,000-iteration command passed after the fix.
- `ERIGON_EXEC3_PARALLEL=true go test ./execution/commitment`
- `make lint` clean on repeated runs.
- `make erigon integration`

Failure observed in https://github.com/erigontech/erigon/actions/runs/32131386270/job/95693128992.
