### PR TITLE
execution/exec: stop losing the real error on the historical block-end path

### DIFF
--- a/execution/exec/historical_trace_worker.go
+++ b/execution/exec/historical_trace_worker.go
@@ -454,7 +454,7 @@ func (p *historicalResultProcessor) processResults(consumer TraceConsumer, cfg *
 		hooks := result.TracingHooks()
 		if result.Err != nil {
 			if hooks != nil && hooks.OnTxEnd != nil {
-				hooks.OnTxEnd(nil, err)
+				hooks.OnTxEnd(nil, result.Err)
 			}
 			return outputTxNum, false, fmt.Errorf("bn=%d, tn=%d: %w", result.BlockNumber(), result.Version().TxNum, result.Err)
 		}
@@ -473,7 +473,7 @@ func (p *historicalResultProcessor) processResults(consumer TraceConsumer, cfg *
 		}
 
 		if err != nil {
-			return outputTxNum, false, fmt.Errorf("bn=%d, tn=%d: %w", result.BlockNumber(), result.Version().TxNum, result.Err)
+			return outputTxNum, false, fmt.Errorf("bn=%d, tn=%d: %w", result.BlockNumber(), result.Version().TxNum, err)
 		}
 
 		if receipt != nil {
@@ -490,9 +490,7 @@ func (p *historicalResultProcessor) processResults(consumer TraceConsumer, cfg *
 					defer ibs.Close()
 					ibs.SetTxContext(txTask.BlockNumber(), txTask.TxIndex)
 					syscall := func(contract accounts.Address, data []byte) ([]byte, error) {
-						return protocol.SysCallContract(contract, data, cfg.ChainConfig, ibs, txTask.Header, txTask.Engine, false /* constCall */, vm.Config{
-							Tracer: result.TracingHooks(),
-						})
+						return protocol.SysCallContract(contract, data, cfg.ChainConfig, ibs, txTask.Header, txTask.Engine, false /* constCall */, vm.Config{})
 					}
 
 					_, err := cfg.Engine.Finalize(cfg.ChainConfig, types.CopyHeader(txTask.Header), ibs, txTask.Uncles, p.blockResult.Receipts, txTask.Withdrawals, chainReader, syscall, true /* skipReceiptsEval */, logger)


### PR DESCRIPTION
Follow-up to the review on #23347 (https://github.com/erigontech/erigon/pull/23347#pullrequestreview-4960880488). All three are in `historicalResultProcessor.processResults`, in the error path that PR already changed; it was in the merge queue by then, so they land here instead.

- `hooks.OnTxEnd(nil, err)` passed the named return, still nil at that point, so a tracer was told a failed tx succeeded. Passes `result.Err`.
- The `CreateNextReceipt` failure return `%w`-wrapped `result.Err`, which the branch above guarantees is nil there, so it rendered `%!w(<nil>)` and threw away the receipt error. Wraps `err`.
- The `vm.Config` built for the syscall closure carried only a `Tracer`, and `SysCallContractWithBlockContext` sets `vmConfig.Tracer = nil` before `vm.NewEVM`. Dropped, so the code stops reading as if block-end syscalls were traced here.

Not included, from the same review: swapping the closure's nil `txTask.Engine` for `cfg.Engine`. That one is not inert on bor — `NewEVMBlockContext` takes `transferFunc`/`postApplyMessageFunc` from a non-nil engine, and Bor returns `BorTransfer`, which appends a transfer log to the state. Top-level syscalls avoid it via the `syscall && value.IsZero()` touch branch in `evm.Call`, but calls the system contract makes itself do not, so it changes the block-end log set on Polygon and wants bor verification of its own.

No behaviour change on any chain: the tracer and error values were already nil or discarded at these sites.
