### PR TITLE
builder, execmodule: identify abandoned builder waits

### DIFF
--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -18,6 +18,7 @@ package builder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -27,6 +28,11 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/types"
 )
+
+// ErrStopAbandoned reports that the caller stopped waiting before a build outcome was available.
+// It distinguishes that outcome from a build failure, which may wrap a context error of its own.
+// The builder still records its eventual outcome.
+var ErrStopAbandoned = errors.New("stopped waiting for the block builder")
 
 type BlockBuilderFunc func(param *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error)
 
@@ -98,7 +104,7 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 		select {
 		case <-b.done:
 		default:
-			return nil, ctx.Err()
+			return nil, fmt.Errorf("%w: %w", ErrStopAbandoned, ctx.Err())
 		}
 	}
 

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -92,9 +92,14 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 	b.interrupt.Store(true)
 
 	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
 	case <-b.done:
+	case <-ctx.Done():
+		// Completion may become ready while select chooses, so recheck before abandoning the result.
+		select {
+		case <-b.done:
+		default:
+			return nil, ctx.Err()
+		}
 	}
 
 	b.mu.Lock()

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -73,3 +73,15 @@ func TestBlockBuilderStopPrefersPayloadCompletedDuringSelection(t *testing.T) {
 		require.Same(t, want, result)
 	}
 }
+
+func TestBlockBuilderStopMarksAbandonedWait(t *testing.T) {
+	b := &BlockBuilder{done: make(chan struct{})}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	result, err := b.Stop(ctx)
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, ErrStopAbandoned)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/types"
+)
+
+func TestBlockBuilderStopPrefersFinishedPayload(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
+	b := &BlockBuilder{done: done, result: want}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	for range 100 {
+		result, err := b.Stop(ctx)
+		require.NoError(t, err)
+		require.Same(t, want, result)
+	}
+}
+
+type completeWhenCancellationIsChecked struct {
+	context.Context
+	cancelled chan struct{}
+	complete  func()
+	once      sync.Once
+}
+
+func (c *completeWhenCancellationIsChecked) Done() <-chan struct{} {
+	c.once.Do(c.complete)
+	return c.cancelled
+}
+
+func (c *completeWhenCancellationIsChecked) Err() error { return context.Canceled }
+
+func TestBlockBuilderStopPrefersPayloadCompletedDuringSelection(t *testing.T) {
+	for range 100 {
+		done := make(chan struct{})
+		cancelled := make(chan struct{})
+		close(cancelled)
+		want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
+		b := &BlockBuilder{done: done, result: want}
+		ctx := &completeWhenCancellationIsChecked{
+			Context:   t.Context(),
+			cancelled: cancelled,
+			complete:  func() { close(done) },
+		}
+
+		result, err := b.Stop(ctx)
+		require.NoError(t, err)
+		require.Same(t, want, result)
+	}
+}

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -18,6 +18,8 @@ package execmodule
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -129,6 +131,9 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 	}
 	blockWithReceipts, err := bldr.Stop(ctx)
 	if err != nil {
+		if errors.Is(err, builder.ErrStopAbandoned) {
+			return AssembledBlockResult{}, fmt.Errorf("%w: %w", ErrRequestAbandoned, err)
+		}
 		e.logger.Error("Failed to build PoS block", "err", err)
 		return AssembledBlockResult{}, err
 	}

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -796,6 +796,7 @@ func TestGetAssembledBlockHonorsCanceledContextWhenTxPoolIsBehindParent(t *testi
 		t.Fatal("GetAssembledBlock remained blocked after context cancellation while the txpool was behind the builder parent")
 	}
 	require.ErrorIs(t, requestErr, context.Canceled)
+	require.ErrorIs(t, requestErr, execmodule.ErrRequestAbandoned)
 }
 
 func TestAssembleBlockWithFreshlyAddedTxns(t *testing.T) {

--- a/execution/execmodule/interface.go
+++ b/execution/execmodule/interface.go
@@ -18,6 +18,7 @@ package execmodule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/holiman/uint256"
@@ -90,6 +91,10 @@ type AssembleBlockResult struct {
 	Busy      bool
 	PayloadID uint64
 }
+
+// ErrRequestAbandoned reports that an execution call ended because its caller stopped waiting,
+// rather than because the execution operation failed. Its error chain retains the reason.
+var ErrRequestAbandoned = errors.New("execution request abandoned")
 
 // AssembledBlockResult is the native return type for GetAssembledBlock.
 type AssembledBlockResult struct {


### PR DESCRIPTION
Stacked on #23289.

A caller abandoning `BlockBuilder.Stop` is not a builder failure. Matching `context.Canceled` or `context.DeadlineExceeded` is not precise because a genuine build failure may wrap either error.

This change gives caller abandonment its own builder sentinel and maps it to `execmodule.ErrRequestAbandoned`. The original cancellation reason remains in the error chain, and genuine builder failures keep their existing identity and logging.

The tests cover the builder marker and its propagation through `GetAssembledBlock`. Focused tests and race tests pass repeatedly.