### PR TITLE
execmodule, execution_client: distinguish busy from caller timeout

### DIFF
--- a/cl/phase1/execution_client/execution_client_direct.go
+++ b/cl/phase1/execution_client/execution_client_direct.go
@@ -164,29 +164,27 @@ func retryAssembleBlock(ctx context.Context, attempts int, delay time.Duration, 
 	)
 	for attempt := range attempts {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return 0, ctxErr
+			return 0, execmodule.RequestAbandonedError(ctxErr, err)
 		}
 		if id, err = assemble(ctx); err == nil {
 			return id, nil
 		}
-		if !errors.Is(err, chainreader.ErrExecutionBusy) {
+		if errors.Is(err, execmodule.ErrRequestAbandoned) {
+			return 0, err
+		}
+		if !errors.Is(err, execmodule.ErrBusy) {
 			return 0, err
 		}
 		if attempt+1 == attempts {
 			break
 		}
-		timer := time.NewTimer(delay)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			return 0, ctx.Err()
-		case <-timer.C:
+		if sleepErr := common.Sleep(ctx, delay); sleepErr != nil {
+			return 0, execmodule.RequestAbandonedError(sleepErr, err)
 		}
+	}
+	// The last attempt can itself have used up the caller, and there is no wait left to notice it.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return 0, execmodule.RequestAbandonedError(ctxErr, err)
 	}
 	return 0, err
 }

--- a/cl/phase1/execution_client/execution_client_direct_test.go
+++ b/cl/phase1/execution_client/execution_client_direct_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/execution/execmodule/chainreader"
+	"github.com/erigontech/erigon/execution/execmodule"
 )
 
 func TestRetryAssembleBlockReturnsFirstSuccess(t *testing.T) {
@@ -32,7 +33,7 @@ func TestRetryAssembleBlockReturnsFirstSuccess(t *testing.T) {
 	id, err := retryAssembleBlock(t.Context(), 3, time.Millisecond, func(context.Context) (uint64, error) {
 		calls++
 		if calls < 3 {
-			return 0, chainreader.ErrExecutionBusy
+			return 0, execmodule.ErrBusy
 		}
 		return 7, nil
 	})
@@ -45,14 +46,26 @@ func TestRetryAssembleBlockReturnsFirstSuccess(t *testing.T) {
 func TestRetryAssembleBlockStopsOnRejection(t *testing.T) {
 	rejected := errors.New("withdrawals before shanghai")
 	calls := 0
-	_, err := retryAssembleBlock(t.Context(), 30, time.Hour, func(context.Context) (uint64, error) {
+	_, err := retryAssembleBlock(t.Context(), 30, time.Minute, func(context.Context) (uint64, error) {
 		calls++
 		return 0, rejected
 	})
 
-	// Only contention settles by waiting; a rejection answers the same way however often it is
-	// asked, so retrying it just burns the slot.
 	require.ErrorIs(t, err, rejected)
+	require.Equal(t, 1, calls)
+}
+
+func TestRetryAssembleBlockStopsOnAbandonedBusyAttempt(t *testing.T) {
+	abandonedBusy := errors.Join(execmodule.ErrRequestAbandoned, execmodule.ErrBusy)
+	calls := 0
+
+	_, err := retryAssembleBlock(t.Context(), 3, time.Millisecond, func(context.Context) (uint64, error) {
+		calls++
+		return 0, abandonedBusy
+	})
+
+	require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+	require.ErrorIs(t, err, execmodule.ErrBusy)
 	require.Equal(t, 1, calls)
 }
 
@@ -60,36 +73,41 @@ func TestRetryAssembleBlockGivesUpAfterAttempts(t *testing.T) {
 	calls := 0
 	_, err := retryAssembleBlock(t.Context(), 2, time.Millisecond, func(context.Context) (uint64, error) {
 		calls++
-		return 0, chainreader.ErrExecutionBusy
+		return 0, execmodule.ErrBusy
 	})
 
-	require.ErrorIs(t, err, chainreader.ErrExecutionBusy)
+	require.ErrorIs(t, err, execmodule.ErrBusy)
 	require.Equal(t, 2, calls)
 }
 
 func TestRetryAssembleBlockStopsWhenContextIsCanceled(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	calls := 0
-	_, err := retryAssembleBlock(ctx, 30, time.Hour, func(context.Context) (uint64, error) {
-		calls++
-		cancel()
-		return 0, chainreader.ErrExecutionBusy
-	})
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		calls := 0
+		_, err := retryAssembleBlock(ctx, 30, time.Minute, func(context.Context) (uint64, error) {
+			calls++
+			cancel()
+			return 0, execmodule.ErrBusy
+		})
 
-	require.ErrorIs(t, err, context.Canceled)
-	require.Equal(t, 1, calls)
+		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+		require.ErrorIs(t, err, execmodule.ErrBusy, "the contention that caused the wait must survive in the error")
+		require.Equal(t, 1, calls)
+	})
 }
 
 func TestRetryAssembleBlockDoesNotStartWithCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	calls := 0
-	_, err := retryAssembleBlock(ctx, 30, time.Hour, func(context.Context) (uint64, error) {
+	_, err := retryAssembleBlock(ctx, 30, time.Second, func(context.Context) (uint64, error) {
 		calls++
-		return 0, chainreader.ErrExecutionBusy
+		return 0, execmodule.ErrBusy
 	})
 
 	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
 	require.Zero(t, calls)
 }
 
@@ -98,4 +116,19 @@ func TestRetryAssembleBlockRejectsNoAttempts(t *testing.T) {
 		return 1, nil
 	})
 	require.EqualError(t, err, "assemble block requires at least one attempt")
+}
+
+func TestRetryAssembleBlockKeepsCancellationOnTheFinalAttempt(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	calls := 0
+	_, err := retryAssembleBlock(ctx, 1, time.Second, func(context.Context) (uint64, error) {
+		calls++
+		cancel()
+		return 0, execmodule.ErrBusy
+	})
+
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+	require.ErrorIs(t, err, execmodule.ErrBusy)
 }

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -19,7 +19,6 @@ package execmodule
 import (
 	"context"
 	"errors"
-	"fmt"
 	"reflect"
 	"time"
 
@@ -132,7 +131,7 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 	blockWithReceipts, err := bldr.Stop(ctx)
 	if err != nil {
 		if errors.Is(err, builder.ErrStopAbandoned) {
-			return AssembledBlockResult{}, fmt.Errorf("%w: %w", ErrRequestAbandoned, err)
+			return AssembledBlockResult{}, RequestAbandonedError(err, nil)
 		}
 		e.logger.Error("Failed to build PoS block", "err", err)
 		return AssembledBlockResult{}, err

--- a/execution/execmodule/chainreader/chain_reader.go
+++ b/execution/execmodule/chainreader/chain_reader.go
@@ -18,7 +18,6 @@ package chainreader
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -279,9 +278,10 @@ func (c ChainReaderWriterEth1) HasBlock(ctx context.Context, hash common.Hash) (
 	return c.executionModule.HasBlock(ctx, &hash, nil)
 }
 
-// ErrExecutionBusy reports that the execution module was already occupied, which settles on its
-// own, as opposed to a rejection that returns the same answer however many times it is asked.
-var ErrExecutionBusy = errors.New("execution module is busy")
+// ErrExecutionBusy aliases execmodule.ErrBusy.
+//
+// Deprecated: use execmodule.ErrBusy.
+var ErrExecutionBusy = execmodule.ErrBusy
 
 func (c ChainReaderWriterEth1) AssembleBlock(ctx context.Context, baseHash common.Hash, attributes *engine_types.PayloadAttributes) (id uint64, err error) {
 	params := &builder.Parameters{
@@ -299,7 +299,7 @@ func (c ChainReaderWriterEth1) AssembleBlock(ctx context.Context, baseHash commo
 		return 0, err
 	}
 	if result.Busy {
-		return 0, ErrExecutionBusy
+		return 0, execmodule.ErrBusy
 	}
 	return result.PayloadID, nil
 }
@@ -310,7 +310,7 @@ func (c ChainReaderWriterEth1) GetAssembledBlock(ctx context.Context, id uint64)
 		return nil, nil, nil, nil, err
 	}
 	if result.Busy {
-		return nil, nil, nil, nil, ErrExecutionBusy
+		return nil, nil, nil, nil, execmodule.ErrBusy
 	}
 	if result.Block == nil {
 		return nil, nil, nil, nil, nil

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -188,9 +188,11 @@ type ExecModule struct {
 	// pipeline Sync and all FCU state. Ops either TryAcquire and report Busy
 	// (retried by the CL) or block, and the background FCU commit/prune
 	// goroutines inherit the semaphore, releasing it only when their work is done.
-	semaphore        *semaphore.Weighted
-	forkValidator    *ForkValidator
-	pipelineExecutor *PipelineExecutor
+	semaphore *semaphore.Weighted
+	// setHeadAcquireTimeout bounds SetHead's semaphore wait. Zero uses defaultAcquireTimeout.
+	setHeadAcquireTimeout time.Duration
+	forkValidator         *ForkValidator
+	pipelineExecutor      *PipelineExecutor
 
 	logger log.Logger
 	// Block building

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -139,7 +139,7 @@ func (e *ExecModule) UpdateForkChoice(ctx context.Context, headHash, safeHash, f
 			return ForkChoiceResult{Status: ExecutionStatusBusy}, nil
 		}
 		e.logger.Debug("forkChoiceUpdate cancelled")
-		return ForkChoiceResult{}, ctx.Err()
+		return ForkChoiceResult{}, fmt.Errorf("%w: %w", ErrRequestAbandoned, ctx.Err())
 	}
 }
 

--- a/execution/execmodule/interface.go
+++ b/execution/execmodule/interface.go
@@ -92,13 +92,29 @@ type AssembleBlockResult struct {
 	PayloadID uint64
 }
 
+// ErrBusy reports that the execution module was already occupied. It settles on its own, unlike a
+// rejection, which returns the same answer however many times it is asked.
+//
+// It may be joined with ErrRequestAbandoned to retain contention as diagnostic context. Code that
+// retries ErrBusy must check ErrRequestAbandoned first because a joined error matches both.
+var ErrBusy = errors.New("execution module is busy")
+
 // ErrRequestAbandoned reports that an execution call ended because its caller stopped waiting,
 // rather than because the execution operation failed. Its error chain retains the reason.
 var ErrRequestAbandoned = errors.New("execution request abandoned")
 
+// RequestAbandonedError retains the cancellation cause and an optional final-attempt error.
+func RequestAbandonedError(cause, lastAttempt error) error {
+	if lastAttempt == nil {
+		return fmt.Errorf("%w: %w", ErrRequestAbandoned, cause)
+	}
+	return fmt.Errorf("%w: %w (last attempt: %w)", ErrRequestAbandoned, cause, lastAttempt)
+}
+
 // AssembledBlockResult is the native return type for GetAssembledBlock.
 type AssembledBlockResult struct {
-	// Busy is true when the builder has not finished yet.
+	// Busy is true when the module was already occupied, not when the builder is still working:
+	// a call that finds its builder waits for it to finish.
 	Busy bool
 	// Block holds the assembled block with receipts and requests.
 	// Nil when Busy is true or when no builder was found for the payload ID.
@@ -156,7 +172,9 @@ type ExecutionModule interface {
 	AssembleBlock(ctx context.Context, params *builder.Parameters) (AssembleBlockResult, error)
 
 	// GetAssembledBlock retrieves the block that was assembled under the
-	// given payloadID.  The result is Busy when the builder has not finished.
+	// given payloadID.  The result is Busy when the module was already occupied; otherwise the
+	// call waits for that payload's builder to finish. An unknown payloadID returns an empty
+	// result right away, not an error.
 	GetAssembledBlock(ctx context.Context, payloadID uint64) (AssembledBlockResult, error)
 
 	// --- Header / body queries --------------------------------------------

--- a/execution/execmodule/set_head.go
+++ b/execution/execmodule/set_head.go
@@ -18,6 +18,7 @@ package execmodule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -48,13 +49,26 @@ func getLatestBlockNumber(tx kv.Tx) (uint64, error) {
 	return blockNum, nil
 }
 
+const defaultAcquireTimeout = 5 * time.Second
+
+// errAcquireTimedOut distinguishes the module's semaphore timeout from cancellation of the caller's
+// context. It stays private so a caller-supplied cause cannot be mistaken for ErrBusy.
+var errAcquireTimedOut = errors.New("timed out waiting for the execution module")
+
 // SetHead rewinds the local chain to the specified block number by unwinding
 // all staged sync stages. This is the core implementation used by debug_setHead.
 func (e *ExecModule) SetHead(ctx context.Context, targetBlock uint64) error {
-	acquireCtx, acquireCancel := context.WithTimeout(ctx, 5*time.Second)
+	acquireTimeout := e.setHeadAcquireTimeout
+	if acquireTimeout == 0 {
+		acquireTimeout = defaultAcquireTimeout
+	}
+	acquireCtx, acquireCancel := context.WithTimeoutCause(ctx, acquireTimeout, errAcquireTimedOut)
 	defer acquireCancel()
 	if err := e.semaphore.Acquire(acquireCtx, 1); err != nil {
-		return fmt.Errorf("execution module is busy: %w", err)
+		if errors.Is(context.Cause(acquireCtx), errAcquireTimedOut) {
+			return fmt.Errorf("set head: %w", ErrBusy)
+		}
+		return fmt.Errorf("set head: %w", err)
 	}
 	defer e.semaphore.Release(1)
 

--- a/execution/execmodule/set_head_internal_test.go
+++ b/execution/execmodule/set_head_internal_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execmodule
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/stretchr/testify/require"
+)
+
+// occupiedModule returns a module whose semaphore is already taken, so SetHead cannot get past the
+// wait, with a wait short enough to run in a test.
+func occupiedModule(t *testing.T) *ExecModule {
+	t.Helper()
+	module := &ExecModule{semaphore: semaphore.NewWeighted(1), setHeadAcquireTimeout: time.Millisecond}
+	require.NoError(t, module.semaphore.Acquire(t.Context(), 1))
+	return module
+}
+
+func TestSetHeadReportsBusyWhenItsOwnWaitRunsOut(t *testing.T) {
+	err := occupiedModule(t).SetHead(t.Context(), 1)
+
+	// Reaching the wait's own deadline is what says the module was occupied.
+	require.ErrorIs(t, err, ErrBusy)
+}
+
+func TestSetHeadDoesNotReportBusyWhenTheCallerGivesUp(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := occupiedModule(t).SetHead(ctx, 1)
+
+	// Nothing is known about the module, so calling it busy would invite a retry with nothing to
+	// wait for.
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, ErrBusy)
+}
+
+func TestSetHeadDoesNotReportBusyForACallerCancelledWithThatCause(t *testing.T) {
+	// A caller may cancel with any cause it likes, including this package's own sentinel. That says
+	// nothing about the module, so the marker classified on has to be one no caller can supply.
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(ErrBusy)
+
+	err := occupiedModule(t).SetHead(ctx, 1)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, ErrBusy)
+}
+
+func TestSetHeadDoesNotReportBusyForACallerWithAShorterDeadline(t *testing.T) {
+	module := &ExecModule{semaphore: semaphore.NewWeighted(1), setHeadAcquireTimeout: time.Hour}
+	require.NoError(t, module.semaphore.Acquire(t.Context(), 1))
+
+	// The caller's own deadline expires long before this wait would, so what ran out is the
+	// caller's patience, not the module's. Classifying on the error's shape rather than on which
+	// deadline was reached reports the module as occupied on no evidence at all.
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+
+	err := module.SetHead(ctx, 1)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NotErrorIs(t, err, ErrBusy)
+}


### PR DESCRIPTION
Stacked on #23367.

Execution-module contention and caller cancellation were both represented by context deadline errors in several paths. That made retry and logging behavior depend on error shape instead of the reason the operation ended.

This change introduces `execmodule.ErrBusy` as the canonical transient-contention signal. `SetHead` uses a private timeout cause so only its own semaphore timeout becomes busy; caller cancellation and caller deadlines retain their identity. Block-assembly retry preserves both abandonment and the final busy attempt, and checks abandonment before retrying a joined busy error.

Tests cover retry exhaustion, cancellation before and during retries, the final-attempt boundary, and all `SetHead` timeout/cancellation cases. Focused tests and race tests pass.