### PR TITLE
cl: classify abandoned block production requests

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -63,6 +63,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
@@ -75,7 +76,10 @@ const (
 	BlockPublishingValidationConsensusAndEquivocation BlockPublishingValidation = "consensus_and_equivocation"
 )
 
-var errBuilderNotEnabled = errors.New("builder is not enabled")
+var (
+	errBuilderNotEnabled           = errors.New("builder is not enabled")
+	errExecutionPayloadUnavailable = errors.New("execution payload unavailable")
+)
 
 const (
 	caplinClientCode = "CN"
@@ -293,21 +297,37 @@ func shouldRetryGetPayload(now, deadline time.Time) bool {
 	return now.Before(deadline)
 }
 
-// pollAssembledPayload waits out the build window, then polls get (which stops the EL builder) until
-// it returns a payload or the deadline passes; ok is false when no payload was produced in time.
+func isRequestAbandoned(err error) bool {
+	return errors.Is(err, execmodule.ErrRequestAbandoned)
+}
+
+type assembledPayload struct {
+	payload        *cltypes.Eth1Block
+	blobs          *engine_types.BlobsBundle
+	requestsBundle *typesproto.RequestsBundle
+	blockValue     *big.Int
+}
+
+func payloadPollingError(lastBusy error) error {
+	if lastBusy == nil {
+		return nil
+	}
+	return fmt.Errorf("failed to produce execution payload: %w", lastBusy)
+}
+
+// pollAssembledPayload waits for the build window, then polls until it receives a payload, the
+// request ends, or the polling deadline passes. A nil result and nil error mean that no payload
+// became available before the deadline.
 func pollAssembledPayload(
 	ctx context.Context,
 	window blockBuilderWindow,
 	retryTime time.Duration,
 	get func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error),
-) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, bool) {
+) (*assembledPayload, error) {
+	var lastBusy error
 	if wait := time.Until(window.firstGetAt); wait > 0 {
-		buildTimer := time.NewTimer(wait)
-		select {
-		case <-ctx.Done():
-			buildTimer.Stop()
-			return nil, nil, nil, nil, false
-		case <-buildTimer.C:
+		if err := common.Sleep(ctx, wait); err != nil {
+			return nil, execmodule.RequestAbandonedError(err, nil)
 		}
 	}
 	deadlineTimer := time.NewTimer(time.Until(window.pollUntil))
@@ -317,23 +337,67 @@ func pollAssembledPayload(
 	for {
 		// Grab at least once, even past the deadline, so a late produce request still gets a payload.
 		payload, bundles, requestsBundle, blockValue, err := get()
+		lastBusy = nil
 		if err != nil {
-			log.Error("BlockProduction: Failed to get payload", "err", err)
+			switch {
+			case isRequestAbandoned(err):
+				return nil, err
+			case errors.Is(err, execmodule.ErrBusy):
+				lastBusy = err
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return nil, execmodule.RequestAbandonedError(ctxErr, lastBusy)
+				}
+			default:
+				log.Error("BlockProduction: Failed to get payload", "err", err)
+				if ctx.Err() != nil {
+					return nil, err
+				}
+			}
 		} else if payload != nil {
-			return payload, bundles, requestsBundle, blockValue, true
+			return &assembledPayload{
+				payload:        payload,
+				blobs:          bundles,
+				requestsBundle: requestsBundle,
+				blockValue:     blockValue,
+			}, nil
 		}
 		select {
 		case <-ctx.Done():
-			return nil, nil, nil, nil, false
+			return nil, execmodule.RequestAbandonedError(ctx.Err(), lastBusy)
 		case <-deadlineTimer.C:
-			return nil, nil, nil, nil, false
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, execmodule.RequestAbandonedError(ctxErr, lastBusy)
+			}
+			return nil, payloadPollingError(lastBusy)
 		case <-retryTicker.C:
 		}
 		// Re-check here, not before get(): the select may pick the ticker after
 		// deadlineTimer fired, and get() stops the builder, so it must not run past pollUntil.
 		if !shouldRetryGetPayload(time.Now(), window.pollUntil) {
-			return nil, nil, nil, nil, false
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, execmodule.RequestAbandonedError(ctxErr, lastBusy)
+			}
+			return nil, payloadPollingError(lastBusy)
 		}
+	}
+}
+
+// logBlockProductionFailure logs only terminal outcomes. Request abandonment is expected and stays
+// at Debug level; a joined ErrBusy preserves the contention that prevented the final attempt.
+func logBlockProductionFailure(err error, slot uint64) {
+	switch {
+	case isRequestAbandoned(err):
+		if errors.Is(err, execmodule.ErrBusy) {
+			log.Debug("Block production request ended while execution module was busy", "err", err, "slot", slot)
+		} else {
+			log.Debug("Block production request abandoned", "err", err, "slot", slot)
+		}
+	case errors.Is(err, errExecutionPayloadUnavailable):
+		log.Warn("Execution payload unavailable during block production", "err", err, "slot", slot)
+	case errors.Is(err, execmodule.ErrBusy):
+		log.Warn("Execution module stayed busy during block production", "err", err, "slot", slot)
+	default:
+		log.Error("Failed to produce block", "err", err, "slot", slot)
 	}
 }
 
@@ -559,7 +623,7 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 	log.Info("[Beacon API] Found BeaconState object for block production", "slot", targetSlot, "duration", time.Since(start))
 	block, err := a.produceBlock(ctx, builderBoostFactor, baseBlockSlot, baseBlockRoot, baseState, targetSlot, randaoReveal, graffiti)
 	if err != nil {
-		log.Warn("Failed to produce block", "err", err, "slot", targetSlot)
+		logBlockProductionFailure(err, targetSlot)
 		return nil, err
 	}
 
@@ -742,8 +806,6 @@ func (a *ApiHandler) produceBlock(
 	wg.Wait()
 
 	if localErr != nil {
-		// if we failed to locally produce the beacon body, we should not proceed with the block production
-		log.Error("Failed to produce beacon body", "err", localErr, "slot", targetSlot)
 		return nil, localErr
 	}
 	// prepare basic block
@@ -1040,7 +1102,7 @@ func (a *ApiHandler) produceBeaconBody(
 		feeRecipient, _ := a.validatorParams.GetFeeRecipient(proposerIndex)
 		withdrawals, err := a.expectedWithdrawals(baseState, gloasWithdrawalsState, stateVersion, targetSlot)
 		if err != nil {
-			log.Error("BlockProduction: GetExpectedWithdrawals failed", "err", err)
+			executionErr = fmt.Errorf("BlockProduction: GetExpectedWithdrawals failed: %w", err)
 			return
 		}
 		slotNumber := hexutil.Uint64(targetSlot)
@@ -1064,21 +1126,30 @@ func (a *ApiHandler) produceBeaconBody(
 			stateVersion,
 		)
 		if err != nil {
-			log.Error("BlockProduction: Failed to get payload id", "err", err)
+			executionErr = err
 			return
 		}
 		if len(idBytes) == 0 {
-			log.Warn("BlockProduction: ForkchoiceUpdate returned no payload id (EL may be syncing)", "slot", targetSlot)
+			executionErr = fmt.Errorf("%w: fork choice update returned no payload ID (EL may be syncing)", errExecutionPayloadUnavailable)
 			return
 		}
 		slotStart := a.ethClock.GetSlotTime(targetSlot)
 		buildWindow := computeBlockBuilderWindow(builderStartedAt, slotStart, a.beaconChainCfg, stateVersion)
-		payload, bundles, requestsBundle, blockValue, ok := pollAssembledPayload(ctx, buildWindow, retryTime, func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+		assembled, err := pollAssembledPayload(ctx, buildWindow, retryTime, func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			return a.engine.GetAssembledBlock(ctx, idBytes, stateVersion)
 		})
-		if !ok {
+		if err != nil {
+			executionErr = err
 			return
 		}
+		if assembled == nil {
+			executionErr = fmt.Errorf("%w before polling deadline", errExecutionPayloadUnavailable)
+			return
+		}
+		payload := assembled.payload
+		bundles := assembled.blobs
+		requestsBundle := assembled.requestsBundle
+		blockValue := assembled.blockValue
 		// Determine block value
 		if blockValue == nil {
 			executionValue = 0

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -21,12 +21,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -43,6 +47,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/protocol/params"
@@ -387,13 +392,13 @@ func TestPollAssembledPayloadReturnsReadyPayload(t *testing.T) {
 	window := blockBuilderWindow{firstGetAt: now.Add(-time.Millisecond), pollUntil: now.Add(time.Second)}
 	want := &cltypes.Eth1Block{}
 	calls := 0
-	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	result, err := pollAssembledPayload(context.Background(), window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			return want, nil, nil, nil, nil
 		})
-	require.True(t, ok)
-	require.Same(t, want, payload)
+	require.NoError(t, err)
+	require.Same(t, want, result.payload)
 	require.Equal(t, 1, calls)
 }
 
@@ -402,7 +407,7 @@ func TestPollAssembledPayloadRetriesWhileBusy(t *testing.T) {
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
 	want := &cltypes.Eth1Block{}
 	calls := 0
-	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	result, err := pollAssembledPayload(context.Background(), window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			if calls < 3 {
@@ -410,8 +415,8 @@ func TestPollAssembledPayloadRetriesWhileBusy(t *testing.T) {
 			}
 			return want, nil, nil, nil, nil
 		})
-	require.True(t, ok)
-	require.Same(t, want, payload)
+	require.NoError(t, err)
+	require.Same(t, want, result.payload)
 	require.Equal(t, 3, calls)
 }
 
@@ -420,7 +425,7 @@ func TestPollAssembledPayloadRetriesOnError(t *testing.T) {
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
 	want := &cltypes.Eth1Block{}
 	calls := 0
-	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	result, err := pollAssembledPayload(context.Background(), window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			if calls == 1 {
@@ -428,8 +433,8 @@ func TestPollAssembledPayloadRetriesOnError(t *testing.T) {
 			}
 			return want, nil, nil, nil, nil
 		})
-	require.True(t, ok)
-	require.Same(t, want, payload)
+	require.NoError(t, err)
+	require.Same(t, want, result.payload)
 	require.Equal(t, 2, calls)
 }
 
@@ -437,13 +442,13 @@ func TestPollAssembledPayloadStopsAtDeadline(t *testing.T) {
 	now := time.Now()
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
 	calls := 0
-	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	result, err := pollAssembledPayload(context.Background(), window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			return nil, nil, nil, nil, nil
 		})
-	require.False(t, ok)
-	require.Nil(t, payload)
+	require.NoError(t, err)
+	require.Nil(t, result)
 	require.NotZero(t, calls)
 }
 
@@ -451,12 +456,13 @@ func TestPollAssembledPayloadLateRequestGrabsOnce(t *testing.T) {
 	past := time.Now().Add(-time.Second)
 	window := blockBuilderWindow{firstGetAt: past, pollUntil: past}
 	calls := 0
-	_, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	result, err := pollAssembledPayload(context.Background(), window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			return nil, nil, nil, nil, nil
 		})
-	require.False(t, ok)
+	require.NoError(t, err)
+	require.Nil(t, result)
 	require.Equal(t, 1, calls)
 }
 
@@ -466,13 +472,265 @@ func TestPollAssembledPayloadReturnsOnContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	calls := 0
-	_, _, _, _, ok := pollAssembledPayload(ctx, window, time.Millisecond,
+	result, err := pollAssembledPayload(ctx, window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			return nil, nil, nil, nil, nil
 		})
-	require.False(t, ok)
+	require.Nil(t, result)
+	require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+	require.ErrorIs(t, err, context.Canceled)
 	require.Zero(t, calls)
+}
+
+func TestPollAssembledPayloadPrefersCancellationOverExpiredPollingWindow(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	past := time.Now().Add(-time.Second)
+	window := blockBuilderWindow{firstGetAt: past, pollUntil: past}
+
+	for range 100 {
+		result, err := pollAssembledPayload(ctx, window, time.Hour,
+			func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+				return nil, nil, nil, nil, nil
+			})
+
+		require.Nil(t, result)
+		require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+		require.ErrorIs(t, err, context.Canceled)
+	}
+}
+
+type getPayloadErrorLogCounter struct{ errors int }
+
+func (h *getPayloadErrorLogCounter) Log(r *log.Record) error {
+	if r.Lvl <= log.LvlError && r.Msg == "BlockProduction: Failed to get payload" {
+		h.errors++
+	}
+	return nil
+}
+
+func (h *getPayloadErrorLogCounter) Enabled(context.Context, log.Lvl) bool { return true }
+
+func captureGetPayloadErrors(t *testing.T) *getPayloadErrorLogCounter {
+	t.Helper()
+	rec := &getPayloadErrorLogCounter{}
+	prevHandler := log.Root().GetHandler()
+	log.Root().SetHandler(rec)
+	t.Cleanup(func() { log.Root().SetHandler(prevHandler) })
+	return rec
+}
+
+func TestPollAssembledPayloadDoesNotReportCancellationAsError(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now.Add(-time.Millisecond), pollUntil: now.Add(time.Hour)}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	rec := captureGetPayloadErrors(t)
+
+	calls := 0
+	result, err := pollAssembledPayload(ctx, window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil, nil, nil, errors.New("EL hiccup")
+			}
+			cancel()
+			return nil, nil, nil, nil, fmt.Errorf("%w: %w", execmodule.ErrRequestAbandoned, ctx.Err())
+		})
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 2, calls, "polling must stop once the request is cancelled")
+	require.Equal(t, 1, rec.errors, "only the failure before the cancellation is a node fault")
+}
+
+func TestPollAssembledPayloadReportsFailureAfterCancellation(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now.Add(-time.Millisecond), pollUntil: now.Add(time.Hour)}
+	ctx, cancel := context.WithCancel(context.Background())
+	failure := fmt.Errorf("EL disconnected: %w", context.Canceled)
+
+	rec := captureGetPayloadErrors(t)
+
+	calls := 0
+	result, err := pollAssembledPayload(ctx, window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			cancel()
+			return nil, nil, nil, nil, failure
+		})
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, failure)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, execmodule.ErrRequestAbandoned)
+	require.Equal(t, 1, calls)
+	require.Equal(t, 1, rec.errors, "an EL failure with its own context error must remain visible")
+}
+
+func TestPollAssembledPayloadDoesNotReportBusyAsError(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now.Add(-time.Millisecond), pollUntil: now.Add(5 * time.Millisecond)}
+	rec := captureGetPayloadErrors(t)
+
+	result, err := pollAssembledPayload(context.Background(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			return nil, nil, nil, nil, execmodule.ErrBusy
+		})
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, execmodule.ErrBusy)
+	require.Zero(t, rec.errors)
+}
+
+func TestPollAssembledPayloadDoesNotReportStaleBusy(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		now := time.Now()
+		window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
+
+		calls := 0
+		result, err := pollAssembledPayload(t.Context(), window, time.Millisecond,
+			func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+				calls++
+				if calls == 1 {
+					return nil, nil, nil, nil, execmodule.ErrBusy
+				}
+				return nil, nil, nil, nil, nil
+			})
+
+		require.Nil(t, result)
+		require.NoError(t, err)
+		require.Greater(t, calls, 1)
+	})
+}
+
+type abandonedBlockProductionEngine struct {
+	execution_client.ExecutionEngine
+}
+
+func (abandonedBlockProductionEngine) ForkChoiceUpdate(
+	context.Context,
+	common.Hash,
+	common.Hash,
+	common.Hash,
+	*engine_types.PayloadAttributes,
+	clparams.StateVersion,
+) ([]byte, error) {
+	return nil, execmodule.RequestAbandonedError(context.Canceled, execmodule.ErrBusy)
+}
+
+type blockProductionFailureLogCounter struct {
+	mu                     sync.Mutex
+	failures               int
+	busyDiagnostics        int
+	abandonmentDiagnostics int
+	unavailableWarnings    int
+}
+
+func (h *blockProductionFailureLogCounter) Log(r *log.Record) error {
+	if r.Msg == "Block production request ended while execution module was busy" {
+		h.mu.Lock()
+		h.busyDiagnostics++
+		h.mu.Unlock()
+	}
+	if r.Msg == "Block production request abandoned" {
+		h.mu.Lock()
+		h.abandonmentDiagnostics++
+		h.mu.Unlock()
+	}
+	if r.Lvl == log.LvlWarn && r.Msg == "Execution payload unavailable during block production" {
+		h.mu.Lock()
+		h.unavailableWarnings++
+		h.mu.Unlock()
+	}
+	if r.Lvl > log.LvlWarn {
+		return nil
+	}
+	switch r.Msg {
+	case "BlockProduction: Failed to get payload id", "Failed to produce beacon body", "Failed to produce block":
+		h.mu.Lock()
+		h.failures++
+		h.mu.Unlock()
+	}
+	return nil
+}
+
+func (h *blockProductionFailureLogCounter) Enabled(context.Context, log.Lvl) bool { return true }
+
+func (h *blockProductionFailureLogCounter) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.failures
+}
+
+func (h *blockProductionFailureLogCounter) busyDiagnosticCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.busyDiagnostics
+}
+
+func (h *blockProductionFailureLogCounter) abandonmentDiagnosticCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.abandonmentDiagnostics
+}
+
+func (h *blockProductionFailureLogCounter) unavailableWarningCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.unavailableWarnings
+}
+
+func TestLogBlockProductionFailureWarnsWhenPayloadIsUnavailable(t *testing.T) {
+	rec := &blockProductionFailureLogCounter{}
+	previousHandler := log.Root().GetHandler()
+	log.Root().SetHandler(rec)
+	t.Cleanup(func() { log.Root().SetHandler(previousHandler) })
+
+	logBlockProductionFailure(errExecutionPayloadUnavailable, 1)
+
+	require.Zero(t, rec.count())
+	require.Equal(t, 1, rec.unavailableWarningCount())
+}
+
+func TestLogBlockProductionFailureRecordsRequestAbandonmentAtDebug(t *testing.T) {
+	rec := &blockProductionFailureLogCounter{}
+	previousHandler := log.Root().GetHandler()
+	log.Root().SetHandler(rec)
+	t.Cleanup(func() { log.Root().SetHandler(previousHandler) })
+
+	logBlockProductionFailure(execmodule.RequestAbandonedError(context.Canceled, nil), 1)
+
+	require.Zero(t, rec.count())
+	require.Equal(t, 1, rec.abandonmentDiagnosticCount())
+}
+
+func TestBlockProductionDoesNotReportRequestAbandonmentAsFailure(t *testing.T) {
+	_, blocks, _, _, _, h, _, _, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), true)
+	h.engine = abandonedBlockProductionEngine{}
+
+	rec := &blockProductionFailureLogCounter{}
+	previousHandler := log.Root().GetHandler()
+	log.Root().SetHandler(rec)
+	t.Cleanup(func() { log.Root().SetHandler(previousHandler) })
+
+	targetSlot := blocks[len(blocks)-1].Block.Slot + 1
+	url := fmt.Sprintf("/?randao_reveal=%s&skip_randao_verification&graffiti=0x00", hexutil.Encode(make([]byte, 96)))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("slot", fmt.Sprint(targetSlot))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+
+	response, err := h.GetEthV3ValidatorBlock(httptest.NewRecorder(), req)
+
+	require.Nil(t, response)
+	require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, execmodule.ErrBusy)
+	require.Zero(t, rec.count())
+	require.Equal(t, 1, rec.busyDiagnosticCount())
 }
 
 func TestSetupHeaderResponseForBlockProductionGloasPayloadIncluded(t *testing.T) {

--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -34,6 +34,7 @@ import (
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/engineapi"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/gointerfaces"
@@ -45,7 +46,23 @@ import (
 
 var ErrNotSupported = errors.New("operation not supported in engine API mode")
 
-const DefaultRPCHTTPTimeout = 30 * time.Second
+const (
+	DefaultRPCHTTPTimeout          = 30 * time.Second
+	remoteForkChoiceTimeoutMessage = "rpc error: code = DeadlineExceeded desc = context deadline exceeded"
+)
+
+func markRemoteRequestAbandoned(ctx context.Context, err error) error {
+	if err == nil || errors.Is(err, execmodule.ErrRequestAbandoned) {
+		return err
+	}
+	ctxErr := ctx.Err()
+	// HTTP transport errors retain context identity, while JSON-RPC application errors do not.
+	// Requiring both signals keeps an engine-side timeout classified as an engine error.
+	if ctxErr != nil && errors.Is(err, ctxErr) {
+		return execmodule.RequestAbandonedError(err, nil)
+	}
+	return err
+}
 
 func checkPayloadStatus(payloadStatus *engine_types.PayloadStatus) error {
 	if payloadStatus == nil {
@@ -104,6 +121,13 @@ func NewExecutionClientEngineRPC(jwtSecret []byte, addr string, port int, beacon
 
 func (cc *ExecutionClientEngine) isLocal() bool {
 	return cc.chainRW != nil
+}
+
+func (cc *ExecutionClientEngine) markRequestAbandoned(ctx context.Context, err error) error {
+	if cc.isLocal() {
+		return err
+	}
+	return markRemoteRequestAbandoned(ctx, err)
 }
 
 func (cc *ExecutionClientEngine) SetBeaconChainConfig(beaconCfg *clparams.BeaconChainConfig) {
@@ -193,10 +217,12 @@ func (cc *ExecutionClientEngine) ForkChoiceUpdate(
 		resp, err = cc.engine.ForkchoiceUpdatedV4(ctx, forkChoiceState, attributes, nil)
 	}
 	if err != nil {
-		if err.Error() == errContextExceeded {
+		// A remote EL exposes its internal FCU timeout as an application error. It means the update
+		// continues asynchronously, not that the caller abandoned the request.
+		if err.Error() == remoteForkChoiceTimeoutMessage {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("engine ForkchoiceUpdated failed: %w", err)
+		return nil, fmt.Errorf("engine ForkchoiceUpdated failed: %w", cc.markRequestAbandoned(ctx, err))
 	}
 
 	if resp.PayloadId == nil {
@@ -337,28 +363,11 @@ func (cc *ExecutionClientEngine) GetAssembledBlock(ctx context.Context, id []byt
 }
 
 func (cc *ExecutionClientEngine) getAssembledBlockV3(ctx context.Context, id []byte, version clparams.StateVersion) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
-	if cc.beaconCfg == nil {
-		return nil, nil, nil, nil, errors.New("beaconCfg not set — call SetBeaconChainConfig before GetAssembledBlock")
-	}
 	resp, err := cc.engine.GetPayloadV3(ctx, hexutil.Bytes(id))
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("engine GetPayloadV3 failed: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("engine GetPayloadV3 failed: %w", cc.markRequestAbandoned(ctx, err))
 	}
-	if resp.ExecutionPayload == nil {
-		return nil, nil, nil, nil, errors.New("GetPayloadV3 returned nil execution payload")
-	}
-
-	block, err := executionPayloadToEth1Block(resp.ExecutionPayload, version, cc.beaconCfg)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
-	var blockValue *big.Int
-	if resp.BlockValue != nil {
-		blockValue = resp.BlockValue.ToInt()
-	}
-
-	return block, resp.BlobsBundle, nil, blockValue, nil
+	return cc.getAssembledBlockFromResponse(resp, version)
 }
 
 // getAssembledBlockFromResponse converts an Engine response into Caplin's
@@ -397,7 +406,7 @@ func (cc *ExecutionClientEngine) getAssembledBlockFromResponse(resp *engine_type
 func (cc *ExecutionClientEngine) getAssembledBlockV4(ctx context.Context, id []byte, version clparams.StateVersion) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 	resp, err := cc.engine.GetPayloadV4(ctx, hexutil.Bytes(id))
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("engine GetPayloadV4 failed: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("engine GetPayloadV4 failed: %w", cc.markRequestAbandoned(ctx, err))
 	}
 	return cc.getAssembledBlockFromResponse(resp, version)
 }
@@ -405,7 +414,7 @@ func (cc *ExecutionClientEngine) getAssembledBlockV4(ctx context.Context, id []b
 func (cc *ExecutionClientEngine) getAssembledBlockV5(ctx context.Context, id []byte, version clparams.StateVersion) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 	resp, err := cc.engine.GetPayloadV5(ctx, hexutil.Bytes(id))
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("engine GetPayloadV5 failed: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("engine GetPayloadV5 failed: %w", cc.markRequestAbandoned(ctx, err))
 	}
 	return cc.getAssembledBlockFromResponse(resp, version)
 }
@@ -413,7 +422,7 @@ func (cc *ExecutionClientEngine) getAssembledBlockV5(ctx context.Context, id []b
 func (cc *ExecutionClientEngine) getAssembledBlockV6(ctx context.Context, id []byte, version clparams.StateVersion) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 	resp, err := cc.engine.GetPayloadV6(ctx, hexutil.Bytes(id))
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("engine GetPayloadV6 failed: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("engine GetPayloadV6 failed: %w", cc.markRequestAbandoned(ctx, err))
 	}
 	return cc.getAssembledBlockFromResponse(resp, version)
 }

--- a/cl/phase1/execution_client/execution_client_engine_test.go
+++ b/cl/phase1/execution_client/execution_client_engine_test.go
@@ -17,7 +17,10 @@
 package execution_client
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,10 +28,85 @@ import (
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
+	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/engineapi"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 )
+
+func TestMarkRemoteRequestAbandoned(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		err        error
+		abandoned  bool
+		contextErr error
+	}{
+		{
+			name:       "matching request cancellation",
+			ctx:        canceledCtx,
+			err:        fmt.Errorf("rpc call: %w", context.Canceled),
+			abandoned:  true,
+			contextErr: context.Canceled,
+		},
+		{
+			name:      "unrelated remote failure after cancellation",
+			ctx:       canceledCtx,
+			err:       errors.New("remote builder failed"),
+			abandoned: false,
+		},
+		{
+			name:      "unrelated context error while request is active",
+			ctx:       t.Context(),
+			err:       fmt.Errorf("remote builder failed: %w", context.Canceled),
+			abandoned: false,
+		},
+		{
+			name:      "remote engine deadline string while request is active",
+			ctx:       t.Context(),
+			err:       errors.New(remoteForkChoiceTimeoutMessage),
+			abandoned: false,
+		},
+		{
+			name:      "remote engine deadline string racing caller cancellation",
+			ctx:       canceledCtx,
+			err:       errors.New(remoteForkChoiceTimeoutMessage),
+			abandoned: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := markRemoteRequestAbandoned(test.ctx, test.err)
+			require.Equal(t, test.abandoned, errors.Is(err, execmodule.ErrRequestAbandoned))
+			require.ErrorIs(t, err, test.err)
+			if test.contextErr != nil {
+				require.ErrorIs(t, err, test.contextErr)
+			}
+		})
+	}
+}
+
+type timedOutForkChoiceEngine struct {
+	engineapi.EngineAPI
+}
+
+func (timedOutForkChoiceEngine) ForkchoiceUpdatedV1(context.Context, *engine_types.ForkChoiceState, *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error) {
+	return nil, errors.New(remoteForkChoiceTimeoutMessage)
+}
+
+func TestRemoteForkChoiceUpdateToleratesEngineTimeout(t *testing.T) {
+	client := &ExecutionClientEngine{engine: timedOutForkChoiceEngine{}}
+
+	payloadID, err := client.ForkChoiceUpdate(t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, nil, clparams.BellatrixVersion)
+
+	require.NoError(t, err)
+	require.Nil(t, payloadID)
+}
 
 type beaconCfgEngineStub struct {
 	engineapi.EngineAPI

--- a/cl/phase1/execution_client/interface.go
+++ b/cl/phase1/execution_client/interface.go
@@ -29,8 +29,6 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
 
-var errContextExceeded = "rpc error: code = DeadlineExceeded desc = context deadline exceeded"
-
 // ExecutionEngine is used only for syncing up very close to chain tip and to stay in sync.
 // It pretty much mimics engine API.
 


### PR DESCRIPTION
## Summary

- propagate typed request-abandonment and execution-busy outcomes through payload polling
- classify block-production outcomes once at the terminal log site
- log caller abandonment at Debug, unavailable or busy payloads at Warn, and genuine failures at Error
- normalize remote Engine API cancellation only when the request context and transport error agree
- preserve the remote FCU timeout behavior, where the update continues asynchronously

## Why

Validator clients can cancel block-production requests while the execution layer is still building or while Caplin is polling for the payload. Those expected request endings must remain distinguishable from execution-layer failures. The same distinction must hold for both direct and remote Engine API configurations.

This is a draft follow-up to #23368 and is stacked on it.

## Testing

- `go test ./cl/phase1/execution_client`
- changed block-production tests with `-count=10`
- changed block-production and execution-client tests with `-race -count=5`
- `make erigon integration`
- changed-code lint passed twice; the repository-wide macOS lint run reaches the existing `db/seg/decompress.go:199` Linux-only `residencyOnce` failure after its fast phase reports zero issues