### PR TITLE
engineapi, execmodule: preserve caller cancellation

### DIFF
--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -176,7 +176,7 @@ func (cc *ExecutionClientEngine) NewPayload(
 		payloadStatus, err = cc.engine.NewPayloadV5(ctx, request, versionedHashes, beaconParentRoot, executionRequestsList)
 	}
 	if err != nil {
-		return PayloadStatusNone, fmt.Errorf("engine NewPayload failed: %w", err)
+		return PayloadStatusNone, fmt.Errorf("engine NewPayload failed: %w", cc.markRequestAbandoned(ctx, err))
 	}
 	if payloadStatus == nil {
 		return PayloadStatusNone, errors.New("engine NewPayload returned nil status")

--- a/cl/phase1/execution_client/execution_client_engine_test.go
+++ b/cl/phase1/execution_client/execution_client_engine_test.go
@@ -108,6 +108,29 @@ func TestRemoteForkChoiceUpdateToleratesEngineTimeout(t *testing.T) {
 	require.Nil(t, payloadID)
 }
 
+type canceledNewPayloadEngine struct {
+	engineapi.EngineAPI
+}
+
+func (canceledNewPayloadEngine) NewPayloadV1(ctx context.Context, _ *engine_types.ExecutionPayload) (*engine_types.PayloadStatus, error) {
+	return nil, fmt.Errorf("remote NewPayload: %w", ctx.Err())
+}
+
+func TestRemoteNewPayloadMarksRequestCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	payload := cltypes.NewEth1Block(clparams.BellatrixVersion, &clparams.MainnetBeaconConfig)
+	payload.Extra = solid.NewExtraData()
+	payload.Transactions = &solid.TransactionsSSZ{}
+	payload.Withdrawals = solid.NewStaticListSSZ[*cltypes.Withdrawal](int(clparams.MainnetBeaconConfig.MaxWithdrawalsPerPayload), 44)
+
+	client := &ExecutionClientEngine{engine: canceledNewPayloadEngine{}}
+	_, err := client.NewPayload(ctx, payload, nil, nil, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+}
+
 type beaconCfgEngineStub struct {
 	engineapi.EngineAPI
 	cfg *clparams.BeaconChainConfig

--- a/execution/engineapi/engine_server.go
+++ b/execution/engineapi/engine_server.go
@@ -608,7 +608,7 @@ func (s *EngineServer) getQuickPayloadStatusIfPossible(ctx context.Context, bloc
 		if header != nil && isCanonical {
 			return &engine_types.PayloadStatus{Status: engine_types.ValidStatus, LatestValidHash: &blockHash}, nil
 		}
-		if shouldWait, _ := waitForResponse(50*time.Millisecond, func() (bool, error) {
+		if shouldWait, _ := waitForResponse(ctx, 50*time.Millisecond, func() (bool, error) {
 			if parent == nil {
 				parent = s.chainRW.GetHeaderByHash(ctx, parentHash)
 			}
@@ -618,7 +618,7 @@ func (s *EngineServer) getQuickPayloadStatusIfPossible(ctx context.Context, bloc
 			return &engine_types.PayloadStatus{Status: engine_types.SyncingStatus}, nil
 		}
 	} else {
-		if shouldWait, _ := waitForResponse(50*time.Millisecond, func() (bool, error) {
+		if shouldWait, _ := waitForResponse(ctx, 50*time.Millisecond, func() (bool, error) {
 			return header == nil && s.blockDownloader.Status() == engine_block_downloader.Syncing, nil
 		}); shouldWait {
 			s.logger.Debug(fmt.Sprintf("[%s] Downloading some other PoS stuff", prefix), "hash", blockHash)
@@ -632,7 +632,7 @@ func (s *EngineServer) getQuickPayloadStatusIfPossible(ctx context.Context, bloc
 			return &engine_types.PayloadStatus{Status: engine_types.ValidStatus, LatestValidHash: &blockHash}, nil
 		}
 	}
-	waitingForExecutionReady, err := waitForResponse(500*time.Millisecond, func() (bool, error) {
+	waitingForExecutionReady, err := waitForResponse(ctx, 500*time.Millisecond, func() (bool, error) {
 		isReady, err := s.chainRW.Ready(ctx)
 		return !isReady, err
 	})
@@ -669,7 +669,7 @@ func (s *EngineServer) getPayload(ctx context.Context, payloadId uint64, version
 	var assembled execmodule.AssembledBlockResult
 	var err error
 
-	execBusy, err := waitForResponse(time.Duration(s.config.SecondsPerSlot())*time.Second, func() (bool, error) {
+	execBusy, err := waitForResponse(ctx, time.Duration(s.config.SecondsPerSlot())*time.Second, func() (bool, error) {
 		assembled, err = s.executionService.GetAssembledBlock(ctx, payloadId)
 		if err != nil {
 			return false, err
@@ -849,7 +849,7 @@ func (s *EngineServer) forkchoiceUpdated(ctx context.Context, forkchoiceState *e
 	var assembled execmodule.AssembleBlockResult
 	// Wait for the execution service to be ready to assemble a block. Wait a full slot duration (12 seconds) to ensure that the execution service is not busy.
 	// Blocks are important and 0.5 seconds is not enough to wait for the execution service to be ready.
-	execBusy, err := waitForResponse(time.Duration(s.config.SecondsPerSlot())*time.Second, func() (bool, error) {
+	execBusy, err := waitForResponse(ctx, time.Duration(s.config.SecondsPerSlot())*time.Second, func() (bool, error) {
 		assembled, err = s.executionService.AssembleBlock(ctx, assembleParams)
 		if err != nil {
 			return false, err
@@ -976,7 +976,7 @@ func (e *EngineServer) HandleNewPayload(
 			// We try waiting until we finish downloading the PoS blocks if the distance from the head is enough,
 			// so that we will perform full validation.
 			var respondSyncing bool
-			if _, _ = waitForResponse(waitTime, func() (bool, error) {
+			if _, _ = waitForResponse(ctx, waitTime, func() (bool, error) {
 				status := e.blockDownloader.Status()
 				respondSyncing = status != engine_block_downloader.Synced
 				// no point in waiting if the downloader is no longer syncing (e.g. it's dropped the download request)
@@ -1304,7 +1304,7 @@ func (e *EngineServer) getBlobs(ctx context.Context, blobHashes []common.Hash, v
 	}
 }
 
-func waitForResponse(maxWait time.Duration, waitCondnF func() (bool, error)) (bool, error) {
+func waitForResponse(ctx context.Context, maxWait time.Duration, waitCondnF func() (bool, error)) (bool, error) {
 	shouldWait, err := waitCondnF()
 	if err != nil || !shouldWait {
 		return false, err
@@ -1312,7 +1312,9 @@ func waitForResponse(maxWait time.Duration, waitCondnF func() (bool, error)) (bo
 	checkInterval := 10 * time.Millisecond
 	maxChecks := int64(maxWait) / int64(checkInterval)
 	for range maxChecks {
-		time.Sleep(checkInterval)
+		if err := common.Sleep(ctx, checkInterval); err != nil {
+			return false, execmodule.RequestAbandonedError(err, nil)
+		}
 		shouldWait, err = waitCondnF()
 		if err != nil || !shouldWait {
 			return shouldWait, err

--- a/execution/engineapi/engine_server_test.go
+++ b/execution/engineapi/engine_server_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"math/big"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/jinzhu/copier"
@@ -38,6 +39,7 @@ import (
 	"github.com/erigontech/erigon/db/kv/kvcache"
 	"github.com/erigontech/erigon/db/rawdb"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/execmodule"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/tests/blockgen"
 	"github.com/erigontech/erigon/execution/types"
@@ -48,6 +50,24 @@ import (
 	"github.com/erigontech/erigon/rpc/rpccfg"
 	"github.com/erigontech/erigon/rpc/rpchelper"
 )
+
+func TestWaitForResponseStopsWhenContextIsCanceled(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		calls := 0
+
+		waiting, err := waitForResponse(ctx, time.Hour, func() (bool, error) {
+			calls++
+			cancel()
+			return true, nil
+		})
+
+		require.False(t, waiting)
+		require.ErrorIs(t, err, context.Canceled)
+		require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+		require.Equal(t, 1, calls)
+	})
+}
 
 // Do 1 step to start txPool
 func oneBlockSteps(m *execmoduletester.ExecModuleTester, require *require.Assertions, blocks int) {

--- a/execution/engineapi/testing_api.go
+++ b/execution/engineapi/testing_api.go
@@ -228,7 +228,7 @@ func (t *testingImpl) CommitBlockV1(
 		return common.Hash{}, err
 	}
 
-	status, validationErr, busy, err := t.lockedStatusPoll(deadline, func() (execmodule.ExecutionStatus, *string, error) {
+	status, validationErr, busy, err := t.lockedStatusPoll(ctx, deadline, func() (execmodule.ExecutionStatus, *string, error) {
 		s, v, _, err := t.server.chainRW.ValidateChain(ctx, blockHash, blockNumber)
 		return s, v, err
 	})
@@ -242,7 +242,7 @@ func (t *testingImpl) CommitBlockV1(
 		return common.Hash{}, commitStatusError("block validation failed", status, validationErr)
 	}
 
-	status, validationErr, busy, err = t.lockedStatusPoll(deadline, func() (execmodule.ExecutionStatus, *string, error) {
+	status, validationErr, busy, err = t.lockedStatusPoll(ctx, deadline, func() (execmodule.ExecutionStatus, *string, error) {
 		s, v, _, err := t.server.chainRW.UpdateForkChoice(ctx, blockHash, safeHash, finalizedHash)
 		return s, v, err
 	})
@@ -267,10 +267,10 @@ func (t *testingImpl) CommitBlockV1(
 
 // lockedStatusPoll runs call under the engine lock, retrying while the execution
 // service reports busy, until the deadline expires.
-func (t *testingImpl) lockedStatusPoll(deadline time.Time, call func() (execmodule.ExecutionStatus, *string, error)) (status execmodule.ExecutionStatus, validationErr *string, busy bool, err error) {
+func (t *testingImpl) lockedStatusPoll(ctx context.Context, deadline time.Time, call func() (execmodule.ExecutionStatus, *string, error)) (status execmodule.ExecutionStatus, validationErr *string, busy bool, err error) {
 	t.server.lock.Lock()
 	defer t.server.lock.Unlock()
-	busy, err = waitForResponse(time.Until(deadline), func() (bool, error) {
+	busy, err = waitForResponse(ctx, time.Until(deadline), func() (bool, error) {
 		var callErr error
 		status, validationErr, callErr = call()
 		if callErr != nil {
@@ -404,7 +404,7 @@ func (t *testingImpl) assembleTestingBlock(
 
 		var assembled execmodule.AssembleBlockResult
 		var err error
-		busy, err := waitForResponse(time.Until(deadline), func() (bool, error) {
+		busy, err := waitForResponse(ctx, time.Until(deadline), func() (bool, error) {
 			assembled, err = t.server.executionService.AssembleBlock(ctx, assembleParams)
 			if err != nil {
 				return false, err
@@ -427,7 +427,7 @@ func (t *testingImpl) assembleTestingBlock(
 		defer t.server.lock.Unlock()
 
 		var err error
-		busy, err := waitForResponse(time.Until(deadline), func() (bool, error) {
+		busy, err := waitForResponse(ctx, time.Until(deadline), func() (bool, error) {
 			assembled, err = t.server.executionService.GetAssembledBlock(ctx, payloadID)
 			if err != nil {
 				return false, err

--- a/execution/execmodule/chainreader/chain_reader.go
+++ b/execution/execmodule/chainreader/chain_reader.go
@@ -18,6 +18,7 @@ package chainreader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -44,6 +45,8 @@ type ChainReaderWriterEth1 struct {
 
 	fcuTimeout time.Duration
 }
+
+var errForkChoiceTimedOut = errors.New("fork choice update timed out")
 
 func NewChainReaderEth1(cfg *chain.Config, executionModule execmodule.ExecutionModule, fcuTimeout time.Duration) ChainReaderWriterEth1 {
 	return ChainReaderWriterEth1{
@@ -243,7 +246,7 @@ func (c ChainReaderWriterEth1) ValidateChain(ctx context.Context, hash common.Ha
 }
 
 func (c ChainReaderWriterEth1) UpdateForkChoice(ctx context.Context, headHash, safeHash, finalizeHash common.Hash, timeoutOverride ...uint64) (execmodule.ExecutionStatus, *string, common.Hash, error) {
-	// Apply timeout via context so the native UpdateForkChoice returns Busy on deadline exceeded.
+	// Only this configured timeout is translated to Busy; caller cancellation keeps its identity.
 	timeout := c.fcuTimeout
 	if len(timeoutOverride) > 0 {
 		timeout = time.Duration(timeoutOverride[0]) * time.Millisecond
@@ -251,11 +254,14 @@ func (c ChainReaderWriterEth1) UpdateForkChoice(ctx context.Context, headHash, s
 	callCtx := ctx
 	if timeout > 0 {
 		var cancel context.CancelFunc
-		callCtx, cancel = context.WithTimeout(ctx, timeout)
+		callCtx, cancel = context.WithTimeoutCause(ctx, timeout, errForkChoiceTimedOut)
 		defer cancel()
 	}
 	result, err := c.executionModule.UpdateForkChoice(callCtx, headHash, safeHash, finalizeHash)
 	if err != nil {
+		if errors.Is(err, execmodule.ErrRequestAbandoned) && errors.Is(context.Cause(callCtx), errForkChoiceTimedOut) {
+			return execmodule.ExecutionStatusBusy, nil, common.Hash{}, nil
+		}
 		return 0, nil, common.Hash{}, err
 	}
 	var validationError *string

--- a/execution/execmodule/chainreader/chain_reader_test.go
+++ b/execution/execmodule/chainreader/chain_reader_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package chainreader
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/execmodule"
+)
+
+type contextBoundExecutionModule struct {
+	execmodule.ExecutionModule
+}
+
+func (contextBoundExecutionModule) UpdateForkChoice(ctx context.Context, _, _, _ common.Hash) (execmodule.ForkChoiceResult, error) {
+	<-ctx.Done()
+	return execmodule.ForkChoiceResult{}, execmodule.RequestAbandonedError(ctx.Err(), nil)
+}
+
+func TestUpdateForkChoiceReportsConfiguredTimeoutAsBusy(t *testing.T) {
+	reader := NewChainReaderEth1(nil, contextBoundExecutionModule{}, time.Nanosecond)
+
+	status, _, _, err := reader.UpdateForkChoice(t.Context(), common.Hash{}, common.Hash{}, common.Hash{})
+
+	require.NoError(t, err)
+	require.Equal(t, execmodule.ExecutionStatusBusy, status)
+}
+
+func TestUpdateForkChoicePreservesCallerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	reader := NewChainReaderEth1(nil, contextBoundExecutionModule{}, time.Hour)
+
+	status, _, _, err := reader.UpdateForkChoice(ctx, common.Hash{}, common.Hash{}, common.Hash{})
+
+	require.Equal(t, execmodule.ExecutionStatus(0), status)
+	require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -130,16 +130,24 @@ func (e *ExecModule) UpdateForkChoice(ctx context.Context, headHash, safeHash, f
 		}
 	}()
 
+	result, err := waitForForkchoiceOutcome(ctx, outcomeCh)
+	if errors.Is(err, ErrRequestAbandoned) {
+		e.logger.Debug("forkChoiceUpdate cancelled")
+	}
+	return result, err
+}
+
+func waitForForkchoiceOutcome(ctx context.Context, outcomeCh <-chan forkchoiceOutcome) (ForkChoiceResult, error) {
 	select {
 	case outcome := <-outcomeCh:
 		return outcome.result, outcome.err
 	case <-ctx.Done():
-		if ctx.Err() == context.DeadlineExceeded {
-			e.logger.Debug("treating forkChoiceUpdated as asynchronous as it is taking too long")
-			return ForkChoiceResult{Status: ExecutionStatusBusy}, nil
+		select {
+		case outcome := <-outcomeCh:
+			return outcome.result, outcome.err
+		default:
 		}
-		e.logger.Debug("forkChoiceUpdate cancelled")
-		return ForkChoiceResult{}, fmt.Errorf("%w: %w", ErrRequestAbandoned, ctx.Err())
+		return ForkChoiceResult{}, RequestAbandonedError(ctx.Err(), nil)
 	}
 }
 

--- a/execution/execmodule/forkchoice_internal_test.go
+++ b/execution/execmodule/forkchoice_internal_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execmodule
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForForkchoiceOutcomePrefersReadyOutcome(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	want := ForkChoiceResult{Status: ExecutionStatusSuccess}
+
+	for range 100 {
+		outcomeCh := make(chan forkchoiceOutcome, 1)
+		outcomeCh <- forkchoiceOutcome{result: want}
+
+		result, err := waitForForkchoiceOutcome(ctx, outcomeCh)
+		require.NoError(t, err)
+		require.Equal(t, want, result)
+	}
+}
+
+func TestWaitForForkchoiceOutcomeReportsCallerDeadline(t *testing.T) {
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	result, err := waitForForkchoiceOutcome(ctx, make(chan forkchoiceOutcome))
+
+	require.Equal(t, ForkChoiceResult{}, result)
+	require.ErrorIs(t, err, ErrRequestAbandoned)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}


### PR DESCRIPTION
## Summary

- make in-process Engine API retry loops stop when their request context ends
- prefer a completed fork-choice outcome when completion and cancellation become ready together
- preserve caller cancellation and deadlines through `UpdateForkChoice`
- translate only the chain reader's own configured FCU timeout to an execution-busy status
- normalize cancellation from the remaining remote `NewPayload` call

## Why

The cancellation contract must also hold in local Engine API mode. Otherwise a canceled payload request can continue polling for up to a slot, and a completed fork-choice result can be discarded when cancellation wins a ready-channel race. Caller deadlines must not be reported as execution contention unless the execution wrapper's own timeout actually expired.

This is a draft follow-up to #23369 and is stacked on it.

## Testing

- full tests for `execution/engineapi`, `execution/execmodule`, `execution/execmodule/chainreader`, and `cl/phase1/execution_client`
- focused tests with `-count=10`
- focused tests with `-race -count=5`
- `make erigon integration`
- changed-code lint passed twice; the repository-wide macOS lint run reaches the existing `db/seg/decompress.go:199` Linux-only `residencyOnce` failure after its fast phase reports zero issues