### PR TITLE
execution_client: reject payloads without blob bundles

### DIFF
--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -376,6 +376,9 @@ func (cc *ExecutionClientEngine) getAssembledBlockFromResponse(resp *engine_type
 	if resp.ExecutionPayload == nil {
 		return nil, nil, nil, nil, errors.New("GetPayload returned nil execution payload")
 	}
+	if resp.BlobsBundle == nil {
+		return nil, nil, nil, nil, errors.New("GetPayload returned nil blobs bundle")
+	}
 	if cc.beaconCfg == nil {
 		return nil, nil, nil, nil, errors.New("beaconCfg not set — call SetBeaconChainConfig before GetAssembledBlock")
 	}

--- a/cl/phase1/execution_client/execution_client_engine_test.go
+++ b/cl/phase1/execution_client/execution_client_engine_test.go
@@ -131,6 +131,19 @@ func TestRemoteNewPayloadMarksRequestCancellation(t *testing.T) {
 	require.ErrorIs(t, err, execmodule.ErrRequestAbandoned)
 }
 
+func TestGetAssembledBlockRejectsMissingBlobsBundle(t *testing.T) {
+	client := &ExecutionClientEngine{beaconCfg: &clparams.MainnetBeaconConfig}
+	resp := &engine_types.GetPayloadResponse{ExecutionPayload: &engine_types.ExecutionPayload{}}
+
+	payload, blobs, requests, value, err := client.getAssembledBlockFromResponse(resp, clparams.DenebVersion)
+
+	require.Nil(t, payload)
+	require.Nil(t, blobs)
+	require.Nil(t, requests)
+	require.Nil(t, value)
+	require.EqualError(t, err, "GetPayload returned nil blobs bundle")
+}
+
 type beaconCfgEngineStub struct {
 	engineapi.EngineAPI
 	cfg *clparams.BeaconChainConfig


### PR DESCRIPTION
## Summary

Reject a remote `engine_getPayload` response when it contains an execution payload but omits `blobsBundle`. Validation happens at the response-conversion boundary, before block production can dereference the missing bundle.

## Why

The Engine API response is external input. A malformed response with no blob bundle currently reaches block production as `blobs == nil`, where bundle validation dereferences it and can terminate the process. Returning a normal error keeps the failure contained to the request.

This is an independent draft follow-up to #23370 and is stacked on it.

## Testing

- regression test confirmed Red before the guard and Green after it
- focused test with `-count=10`
- focused test with `-race -count=5`
- full `cl/phase1/execution_client` package tests
- `make erigon integration`
- changed-code lint passed twice; the repository-wide macOS lint run reaches the existing `db/seg/decompress.go:199` Linux-only `residencyOnce` failure after its fast phase reports zero issues