### PR TITLE
db/snapshotsync, db/snaptype: caplin overlap-removal guards and review follow-ups

### DIFF
--- a/db/snapshotsync/caplin_state_lifecycle_test.go
+++ b/db/snapshotsync/caplin_state_lifecycle_test.go
@@ -258,3 +258,22 @@ func TestCaplinStateNilSnapshotsRemoveOverlapsIsNoop(t *testing.T) {
 	var s *CaplinStateSnapshots
 	require.NoError(t, s.RemoveOverlaps(nil))
 }
+
+// A dump that skips a hole and continues still creates the later files, and they must be
+// announced to the seeder even though the visible set is truncated at the gap.
+func TestCaplinStateSegFileNamesIncludesSegmentsPastAGap(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.BlockRoot
+
+	nearSeg, _ := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 50_000, logger)
+	farSeg, _ := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 100_000, 150_000, logger)
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+
+	require.Equal(t, uint64(49_999), s.BlocksAvailable(), "visible set must still stop at the gap")
+
+	paths := s.SegFileNames(0, 150_000)
+	require.Contains(t, paths, nearSeg)
+	require.Contains(t, paths, farSeg, "the segment past the gap must still be seedable")
+}

--- a/db/snapshotsync/caplin_state_overlap_test.go
+++ b/db/snapshotsync/caplin_state_overlap_test.go
@@ -40,7 +40,12 @@ import (
 
 func writeCaplinStateFixture(t *testing.T, dir, table string, from, to uint64, logger log.Logger) (segPath, idxPath string) {
 	t.Helper()
-	segName := strings.ReplaceAll(snaptype.BeaconBlocks.FileName(version.ZeroVersion, from, to), "beaconblocks", table)
+	return writeCaplinStateFixtureVersion(t, dir, table, from, to, version.ZeroVersion, logger)
+}
+
+func writeCaplinStateFixtureVersion(t *testing.T, dir, table string, from, to uint64, v version.Version, logger log.Logger) (segPath, idxPath string) {
+	t.Helper()
+	segName := strings.ReplaceAll(snaptype.BeaconBlocks.FileName(v, from, to), "beaconblocks", table)
 	segPath = filepath.Join(dir, segName)
 
 	compressCfg := seg.DefaultCfg
@@ -258,4 +263,41 @@ func TestCaplinStateRemoveOverlapsWithSeveralTables(t *testing.T) {
 	for _, table := range tables {
 		require.Equal(t, []Range{{from: 0, to: 150_000}}, s.coveredRangesForType(table))
 	}
+}
+
+// An indexed subset must survive when its only covering superset has no index: the visible
+// set requires IsIndexed, so removing the subset would make the range unreadable.
+func TestCaplinStateRemoveOverlapsKeepsSubsetWithoutIndexedSuperset(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	subSeg, subIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 50_000, logger)
+	supSeg, supIdx := writeCaplinStateFixture(t, dirs.SnapCaplin, table, 0, 100_000, logger)
+	require.NoError(t, dir2.RemoveFile(supIdx))
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.NoError(t, s.RemoveOverlaps(nil))
+
+	require.FileExists(t, subSeg, "the indexed subset is the only readable copy of [0,50k)")
+	require.FileExists(t, subIdx)
+	require.FileExists(t, supSeg)
+	require.Equal(t, []Range{{from: 0, to: 50_000}}, s.coveredRangesForType(table))
+}
+
+// The visible set serves the newest of two equal-range versions, so overlap removal must
+// delete the older one — deleting the newer would unlink the file readers are pointed at.
+func TestCaplinStateRemoveOverlapsKeepsNewestEqualRangeVersion(t *testing.T) {
+	logger := log.New()
+	dirs := datadir.New(t.TempDir())
+	table := kv.PendingDepositsDump
+
+	oldSeg, _ := writeCaplinStateFixtureVersion(t, dirs.SnapCaplin, table, 0, 50_000, version.V1_0, logger)
+	newSeg, _ := writeCaplinStateFixtureVersion(t, dirs.SnapCaplin, table, 0, 50_000, version.V1_1, logger)
+
+	s := openTestCaplinStateSnapshots(t, dirs, table, logger)
+	require.NoError(t, s.RemoveOverlaps(nil))
+
+	require.FileExists(t, newSeg, "the newest version is what View() serves")
+	require.NoFileExists(t, oldSeg)
 }

--- a/db/snapshotsync/caplin_state_snapshots.go
+++ b/db/snapshotsync/caplin_state_snapshots.go
@@ -169,7 +169,7 @@ func NewCaplinStateSnapshots(cfg ethconfig.BlocksFreezing, beaconCfg *clparams.B
 	typeEnums := make(map[string]snaptype.Enum, len(snapshotTypes.KeyValueGetters))
 	for name := range snapshotTypes.KeyValueGetters {
 		enum, ok := snaptype.ParseEnum(name)
-		if !ok || enum < snaptype.MinCaplinEnum+2 || enum >= snaptype.MinBorEnum {
+		if !ok || enum < snaptype.MinCaplinStateEnum || enum >= snaptype.MinBorEnum {
 			panic(fmt.Sprintf("caplin state snapshot type %q is not registered", name))
 		}
 		typ := enum.Type()
@@ -184,27 +184,33 @@ func NewCaplinStateSnapshots(cfg ethconfig.BlocksFreezing, beaconCfg *clparams.B
 	}
 	slices.SortFunc(types, func(a, b snaptype.Type) int { return cmp.Compare(a.Enum(), b.Enum()) })
 
-	return &CaplinStateSnapshots{
+	sn := &CaplinStateSnapshots{
 		BaseRoSnapshots: NewBaseRoSnapshots(cfg, dirs.SnapCaplin, types, types[0], false, logger),
 		snapshotTypes:   snapshotTypes,
 		tmpdir:          dirs.Tmp,
 		typeEnums:       typeEnums,
 	}
+	sn.keepUnindexedlyCovered = true
+	return sn
 }
 
+// SegFileNames walks dirty rather than visible segments: its caller announces freshly
+// dumped files to the seeder, and the visible set is truncated at the first gap, which a
+// partially-filled dump legitimately produces. Visible-backed, everything after a hole is
+// created and then never seeded.
 func (s *CaplinStateSnapshots) SegFileNames(from, to uint64) []string {
-	view := s.View()
-	defer view.Close()
-
 	var res []string
 
 	for _, typ := range s.Types() {
-		for _, seg := range view.view.Segments(typ) {
+		s.WalkDirtySegments(typ.Enum(), func(seg *DirtySegment) bool {
 			if seg.from >= to || seg.to <= from {
-				continue
+				return true
 			}
-			res = append(res, filepath.Join(s.Dir(), seg.src.FileName()))
-		}
+			if name := seg.FileName(); name != "" {
+				res = append(res, filepath.Join(s.Dir(), name))
+			}
+			return true
+		})
 	}
 	return res
 }
@@ -213,9 +219,16 @@ func (s *CaplinStateSnapshots) BlocksAvailable() uint64 {
 	return min(s.SegmentsMax(), s.IndicesMax())
 }
 
-// RemoveOverlaps re-declares the base guard, as CaplinSnapshots.Close already does:
-// `seg retire` holds a nil *CaplinStateSnapshots on any chain without a beacon config,
-// and reaching the embedded pointer to run a promoted method dereferences that nil.
+// Close and RemoveOverlaps re-declare the nil guard rather than inheriting it: the base is
+// embedded by pointer, so reaching it to run a promoted method dereferences a nil receiver
+// before the base's own check. `seg retire` holds a nil on any chain without a beacon config.
+func (s *CaplinStateSnapshots) Close() {
+	if s == nil {
+		return
+	}
+	s.BaseRoSnapshots.Close()
+}
+
 func (s *CaplinStateSnapshots) RemoveOverlaps(onDelete func(l []string) error) error {
 	if s == nil {
 		return nil
@@ -469,7 +482,7 @@ func simpleIdx(ctx context.Context, sn snaptype.FileInfo, salt uint32, tmpDir st
 
 func caplinStateFileName(snapName string, fromSlot, toSlot uint64) (string, error) {
 	enum, ok := snaptype.ParseEnum(snapName)
-	if !ok || enum < snaptype.MinCaplinEnum+2 || enum >= snaptype.MinBorEnum {
+	if !ok || enum < snaptype.MinCaplinStateEnum || enum >= snaptype.MinBorEnum {
 		return "", fmt.Errorf("unknown caplin state snapshot type %q", snapName)
 	}
 	typ := enum.Type()

--- a/db/snapshotsync/caplinsnapschema/caplin_snap_schema.go
+++ b/db/snapshotsync/caplinsnapschema/caplin_snap_schema.go
@@ -26,7 +26,7 @@ func NewCaplinSchema(dirs datadir.Dirs, stepSize uint64, stateTypes snapshotsync
 	statemp := make(map[string]state.SnapNameSchema)
 	for table := range stateTypes.KeyValueGetters {
 		enum, ok := snaptype.ParseEnum(table)
-		if !ok || enum < snaptype.MinCaplinEnum+2 || enum >= snaptype.MinBorEnum {
+		if !ok || enum < snaptype.MinCaplinStateEnum || enum >= snaptype.MinBorEnum {
 			panic(fmt.Sprintf("Caplin schema: unknown state table %s", table))
 		}
 		snapt := enum.Type()

--- a/db/snapshotsync/snapshots.go
+++ b/db/snapshotsync/snapshots.go
@@ -517,6 +517,9 @@ type BaseRoSnapshots struct {
 	ready     ready
 	operators map[snaptype.Enum]*retireOperators
 	alignMin  bool // do we want to align all visible segments to the minimum available
+	// keepUnindexedlyCovered opts RemoveOverlaps into refusing to unlink a subset whose only
+	// covering superset has no index. EL/bor rely on the plain behaviour; caplin state does not.
+	keepUnindexedlyCovered bool
 
 	// (type, from, to) of files a producer is currently building — a merge
 	// output, a dump, or a missed-index rebuild. The data file can be on disk
@@ -1459,12 +1462,107 @@ func ClassifyOpenErr(err error, optimistic bool) (stop bool, failErr error) {
 	return false, err
 }
 
+// supersededEqualRangeVersions splits out older duplicates of an identical [from,to).
+// buildVisibleSegments serves the newest of such a pair, so findOverlaps must not delete it:
+// FilterExt sorts equal ranges by ascending version, which would otherwise mark the newer
+// file as the overlapped one and leave the reader pointing at a file that is about to go.
+func supersededEqualRangeVersions(list []snaptype.FileInfo) (kept, superseded []snaptype.FileInfo) {
+	type rangeKey struct {
+		grouping string
+		from, to uint64
+	}
+	newest := make(map[rangeKey]int, len(list))
+	drop := make(map[string]struct{})
+	for i := range list {
+		k := rangeKey{list[i].GetGrouping(), list[i].From, list[i].To}
+		j, seen := newest[k]
+		if !seen {
+			newest[k] = i
+			continue
+		}
+		if list[j].Version.Less(list[i].Version) {
+			drop[list[j].Path] = struct{}{}
+			newest[k] = i
+		} else {
+			drop[list[i].Path] = struct{}{}
+		}
+	}
+	if len(drop) == 0 {
+		return list, nil
+	}
+	kept = make([]snaptype.FileInfo, 0, len(list)-len(drop))
+	superseded = make([]snaptype.FileInfo, 0, len(drop))
+	for i := range list {
+		if _, ok := drop[list[i].Path]; ok {
+			superseded = append(superseded, list[i])
+			continue
+		}
+		kept = append(kept, list[i])
+	}
+	return kept, superseded
+}
+
+// keepUnindexedlyCovered moves back any removal whose covering superset has no index on
+// disk. buildVisibleSegments requires IsIndexed, so unlinking an indexed subset for an
+// unindexed superset leaves the range unreadable until someone rebuilds indexes.
+func keepUnindexedlyCovered(dirPath string, keep, remove []snaptype.FileInfo) ([]snaptype.FileInfo, []snaptype.FileInfo) {
+	if len(remove) == 0 {
+		return keep, remove
+	}
+	indexed := make([]snaptype.FileInfo, 0, len(keep))
+	for i := range keep {
+		if isIndexedOnDisk(dirPath, keep[i]) {
+			indexed = append(indexed, keep[i])
+		}
+	}
+	stillRemove := make([]snaptype.FileInfo, 0, len(remove))
+	for i := range remove {
+		if remove[i].From == remove[i].To || hasIndexedKeeper(indexed, &remove[i]) {
+			stillRemove = append(stillRemove, remove[i])
+			continue
+		}
+		keep = append(keep, remove[i])
+	}
+	return keep, stillRemove
+}
+
+func hasIndexedKeeper(indexed []snaptype.FileInfo, rm *snaptype.FileInfo) bool {
+	for i := range indexed {
+		k := &indexed[i]
+		if k.GetGrouping() != rm.GetGrouping() || k.Path == rm.Path {
+			continue
+		}
+		if k.From <= rm.From && k.To >= rm.To {
+			return true
+		}
+	}
+	return false
+}
+
+func isIndexedOnDisk(dirPath string, f snaptype.FileInfo) bool {
+	if f.Type == nil {
+		return false
+	}
+	for _, name := range f.Type.IdxFileNames(f.From, f.To) {
+		ok, err := dir.FileExist(filepath.Join(dirPath, name))
+		if err != nil || !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *BaseRoSnapshots) RemoveOverlaps(onDelete func(l []string) error) error {
 	list, err := snaptype.Segments(s.dir)
 	if err != nil {
 		return err
 	}
+	list, superseded := supersededEqualRangeVersions(list)
 	keepSegments, segmentsToRemove := findOverlaps(list)
+	segmentsToRemove = append(segmentsToRemove, superseded...)
+	if s.keepUnindexedlyCovered {
+		keepSegments, segmentsToRemove = keepUnindexedlyCovered(s.dir, keepSegments, segmentsToRemove)
+	}
 
 	keepNames := make([]string, 0, len(keepSegments))
 	for i := range keepSegments {

--- a/db/snaptype/caplin_state_types.go
+++ b/db/snaptype/caplin_state_types.go
@@ -17,7 +17,6 @@
 package snaptype
 
 import (
-	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/version"
 )
@@ -102,32 +101,3 @@ var (
 		LatestExecutionPayloadBidTable,
 	}
 )
-
-var caplinStateIntroducedIn = map[Enum]clparams.StateVersion{
-	InactivityScores.Enum():                  clparams.AltairVersion,
-	NextSyncCommittee.Enum():                 clparams.AltairVersion,
-	CurrentSyncCommittee.Enum():              clparams.AltairVersion,
-	PendingConsolidations.Enum():             clparams.ElectraVersion,
-	PendingPartialWithdrawals.Enum():         clparams.ElectraVersion,
-	PendingDeposits.Enum():                   clparams.ElectraVersion,
-	PendingConsolidationsDump.Enum():         clparams.ElectraVersion,
-	PendingPartialWithdrawalsDump.Enum():     clparams.ElectraVersion,
-	PendingDepositsDump.Enum():               clparams.ElectraVersion,
-	Builders.Enum():                          clparams.GloasVersion,
-	BuildersDump.Enum():                      clparams.GloasVersion,
-	BuilderPendingWithdrawals.Enum():         clparams.GloasVersion,
-	BuilderPendingWithdrawalsDump.Enum():     clparams.GloasVersion,
-	PayloadExpectedWithdrawals.Enum():        clparams.GloasVersion,
-	PayloadExpectedWithdrawalsDump.Enum():    clparams.GloasVersion,
-	ExecutionPayloadAvailabilityTable.Enum(): clparams.GloasVersion,
-	BuilderPendingPaymentsTable.Enum():       clparams.GloasVersion,
-	PtcWindowTable.Enum():                    clparams.GloasVersion,
-	LatestExecutionPayloadBidTable.Enum():    clparams.GloasVersion,
-}
-
-func CaplinStateIntroducedIn(enum Enum) clparams.StateVersion {
-	if version, ok := caplinStateIntroducedIn[enum]; ok {
-		return version
-	}
-	return clparams.Phase0Version
-}

--- a/db/snaptype/caplin_state_types_test.go
+++ b/db/snaptype/caplin_state_types_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/snapshotsync"
 	"github.com/erigontech/erigon/db/snaptype"
@@ -29,46 +28,45 @@ import (
 )
 
 type caplinStateTypeExpectation struct {
-	typ        snaptype.Type
-	name       string
-	introduced clparams.StateVersion
+	typ  snaptype.Type
+	name string
 }
 
 func caplinStateTypeExpectations() []caplinStateTypeExpectation {
 	return []caplinStateTypeExpectation{
-		{snaptype.ValidatorEffectiveBalance, kv.ValidatorEffectiveBalance, clparams.Phase0Version},
-		{snaptype.ValidatorSlashings, kv.ValidatorSlashings, clparams.Phase0Version},
-		{snaptype.ValidatorBalance, kv.ValidatorBalance, clparams.Phase0Version},
-		{snaptype.StateEvents, kv.StateEvents, clparams.Phase0Version},
-		{snaptype.ActiveValidatorIndicies, kv.ActiveValidatorIndicies, clparams.Phase0Version},
-		{snaptype.StateRoot, kv.StateRoot, clparams.Phase0Version},
-		{snaptype.BlockRoot, kv.BlockRoot, clparams.Phase0Version},
-		{snaptype.SlotData, kv.SlotData, clparams.Phase0Version},
-		{snaptype.EpochData, kv.EpochData, clparams.Phase0Version},
-		{snaptype.InactivityScores, kv.InactivityScores, clparams.AltairVersion},
-		{snaptype.NextSyncCommittee, kv.NextSyncCommittee, clparams.AltairVersion},
-		{snaptype.CurrentSyncCommittee, kv.CurrentSyncCommittee, clparams.AltairVersion},
-		{snaptype.Eth1DataVotes, kv.Eth1DataVotes, clparams.Phase0Version},
-		{snaptype.IntraRandaoMixes, kv.IntraRandaoMixes, clparams.Phase0Version},
-		{snaptype.RandaoMixes, kv.RandaoMixes, clparams.Phase0Version},
-		{snaptype.BalancesDump, kv.BalancesDump, clparams.Phase0Version},
-		{snaptype.EffectiveBalancesDump, kv.EffectiveBalancesDump, clparams.Phase0Version},
-		{snaptype.PendingConsolidations, kv.PendingConsolidations, clparams.ElectraVersion},
-		{snaptype.PendingPartialWithdrawals, kv.PendingPartialWithdrawals, clparams.ElectraVersion},
-		{snaptype.PendingDeposits, kv.PendingDeposits, clparams.ElectraVersion},
-		{snaptype.PendingConsolidationsDump, kv.PendingConsolidationsDump, clparams.ElectraVersion},
-		{snaptype.PendingPartialWithdrawalsDump, kv.PendingPartialWithdrawalsDump, clparams.ElectraVersion},
-		{snaptype.PendingDepositsDump, kv.PendingDepositsDump, clparams.ElectraVersion},
-		{snaptype.Builders, kv.Builders, clparams.GloasVersion},
-		{snaptype.BuildersDump, kv.BuildersDump, clparams.GloasVersion},
-		{snaptype.BuilderPendingWithdrawals, kv.BuilderPendingWithdrawals, clparams.GloasVersion},
-		{snaptype.BuilderPendingWithdrawalsDump, kv.BuilderPendingWithdrawalsDump, clparams.GloasVersion},
-		{snaptype.PayloadExpectedWithdrawals, kv.PayloadExpectedWithdrawals, clparams.GloasVersion},
-		{snaptype.PayloadExpectedWithdrawalsDump, kv.PayloadExpectedWithdrawalsDump, clparams.GloasVersion},
-		{snaptype.ExecutionPayloadAvailabilityTable, kv.ExecutionPayloadAvailabilityTable, clparams.GloasVersion},
-		{snaptype.BuilderPendingPaymentsTable, kv.BuilderPendingPaymentsTable, clparams.GloasVersion},
-		{snaptype.PtcWindowTable, kv.PtcWindowTable, clparams.GloasVersion},
-		{snaptype.LatestExecutionPayloadBidTable, kv.LatestExecutionPayloadBidTable, clparams.GloasVersion},
+		{snaptype.ValidatorEffectiveBalance, kv.ValidatorEffectiveBalance},
+		{snaptype.ValidatorSlashings, kv.ValidatorSlashings},
+		{snaptype.ValidatorBalance, kv.ValidatorBalance},
+		{snaptype.StateEvents, kv.StateEvents},
+		{snaptype.ActiveValidatorIndicies, kv.ActiveValidatorIndicies},
+		{snaptype.StateRoot, kv.StateRoot},
+		{snaptype.BlockRoot, kv.BlockRoot},
+		{snaptype.SlotData, kv.SlotData},
+		{snaptype.EpochData, kv.EpochData},
+		{snaptype.InactivityScores, kv.InactivityScores},
+		{snaptype.NextSyncCommittee, kv.NextSyncCommittee},
+		{snaptype.CurrentSyncCommittee, kv.CurrentSyncCommittee},
+		{snaptype.Eth1DataVotes, kv.Eth1DataVotes},
+		{snaptype.IntraRandaoMixes, kv.IntraRandaoMixes},
+		{snaptype.RandaoMixes, kv.RandaoMixes},
+		{snaptype.BalancesDump, kv.BalancesDump},
+		{snaptype.EffectiveBalancesDump, kv.EffectiveBalancesDump},
+		{snaptype.PendingConsolidations, kv.PendingConsolidations},
+		{snaptype.PendingPartialWithdrawals, kv.PendingPartialWithdrawals},
+		{snaptype.PendingDeposits, kv.PendingDeposits},
+		{snaptype.PendingConsolidationsDump, kv.PendingConsolidationsDump},
+		{snaptype.PendingPartialWithdrawalsDump, kv.PendingPartialWithdrawalsDump},
+		{snaptype.PendingDepositsDump, kv.PendingDepositsDump},
+		{snaptype.Builders, kv.Builders},
+		{snaptype.BuildersDump, kv.BuildersDump},
+		{snaptype.BuilderPendingWithdrawals, kv.BuilderPendingWithdrawals},
+		{snaptype.BuilderPendingWithdrawalsDump, kv.BuilderPendingWithdrawalsDump},
+		{snaptype.PayloadExpectedWithdrawals, kv.PayloadExpectedWithdrawals},
+		{snaptype.PayloadExpectedWithdrawalsDump, kv.PayloadExpectedWithdrawalsDump},
+		{snaptype.ExecutionPayloadAvailabilityTable, kv.ExecutionPayloadAvailabilityTable},
+		{snaptype.BuilderPendingPaymentsTable, kv.BuilderPendingPaymentsTable},
+		{snaptype.PtcWindowTable, kv.PtcWindowTable},
+		{snaptype.LatestExecutionPayloadBidTable, kv.LatestExecutionPayloadBidTable},
 	}
 }
 
@@ -85,7 +83,6 @@ func TestCaplinStateSnapshotTypes(t *testing.T) {
 		require.Equal(t, snaptype.MinCaplinEnum+2+snaptype.Enum(i), typ.Enum())
 		require.Equal(t, expected.name, typ.Name())
 		require.Equal(t, version.V1_1_standart, typ.Versions())
-		require.Equal(t, expected.introduced, snaptype.CaplinStateIntroducedIn(typ.Enum()))
 
 		indexes := typ.Indexes()
 		require.Len(t, indexes, 1)
@@ -120,8 +117,4 @@ func TestCaplinStateSnapshotTypeRange(t *testing.T) {
 
 func TestCaplinSnapshotTypesRemainBlockTypes(t *testing.T) {
 	require.Len(t, snaptype.CaplinSnapshotTypes, 2)
-}
-
-func TestCaplinStateIntroducedInDefaultsToGenesis(t *testing.T) {
-	require.Equal(t, clparams.Phase0Version, snaptype.CaplinStateIntroducedIn(snaptype.Unknown))
 }

--- a/db/snaptype/type.go
+++ b/db/snaptype/type.go
@@ -416,6 +416,10 @@ const MinCoreEnum = 1
 const MinBorEnum = 50
 const MinCaplinEnum = 10
 
+// MinCaplinStateEnum is the first beacon-state type; BeaconBlocks and BlobSidecars occupy
+// the two slots below it, so a new caplin block type must go here, not at a free tail slot.
+const MinCaplinStateEnum = MinCaplinEnum + 2
+
 const MaxEnum = 54
 
 var CaplinEnums = struct {


### PR DESCRIPTION
Follow-up to the review on #23352, which merged out of the queue before these landed. Six findings, all verified against the code before fixing; each fix is pinned by a test that goes red when the fix is reverted.

## Changes

- `RemoveOverlaps` no longer unlinks an indexed subset whose only covering superset has no index on disk. The visible set requires `IsIndexed`, so that deletion left the range unreadable until an index rebuild. Opt-in per collection — EL and bor keep the plain behaviour, which `TestRemoveOverlaps` pins. Restores the invariant `TestCaplinStateRemoveOverlapsKeepsSubsetWithoutIndexedSuperset` used to cover.
- Equal-range version duplicates now resolve the same way on both sides. `buildVisibleSegments` keeps the newer version while `findOverlaps` kept the older, so overlap removal unlinked the exact file `View()` was serving. Older duplicates are split out before `findOverlaps` runs.
- `CaplinStateSnapshots.Close` re-declares the nil guard. The base is embedded by pointer, so reaching it to run a promoted method dereferences a nil receiver before the base's own check — `RemoveOverlaps` was already re-declared for this reason.
- `SegFileNames` walks dirty rather than visible segments. Its one caller announces freshly dumped files to the seeder, and the visible set truncates at the first gap, which a partially-filled dump legitimately produces — so every file after a hole was created and never seeded.
- `MinCaplinStateEnum` replaces `MinCaplinEnum+2` in the three places that test for "is a caplin state type". As written, a new caplin *block* type at a free tail slot would have passed all three.
- Drop `caplinStateIntroducedIn` and its getter: no caller outside its own test, and it was the only `cl/` import in `db/snaptype`.

On the two findings that needed no code change: the `.tmp` cleanup the base now applies to `snapshots/caplin` matches existing expectation rather than creating a hazard — `TestDeleteStateSnapshots` already asserts `.tmp` files under `dirs.SnapCaplin` should be removed (issue #18789), and nothing in the caplin dump path writes `.tmp` there; it uses `dirs.Tmp`.
