### PR TITLE
execution, cl: harden payload builder edge cases from review

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -46,6 +46,7 @@ import (
 	"github.com/erigontech/erigon/cl/gossip"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/network/subnets"
 	"github.com/erigontech/erigon/cl/pool"
@@ -63,7 +64,6 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
-	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
@@ -319,7 +319,7 @@ func pollAssembledPayload(
 		// Grab at least once, even past the deadline, so a late produce request still gets a payload.
 		payload, bundles, requestsBundle, blockValue, err := get()
 		switch {
-		case errors.Is(err, chainreader.ErrUnknownPayload):
+		case execution_client.IsUnknownPayloadError(err):
 			return nil, nil, nil, nil, false
 		case err != nil:
 			log.Error("BlockProduction: Failed to get payload", "err", err)

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -63,6 +63,7 @@ import (
 	"github.com/erigontech/erigon/db/kv"
 	"github.com/erigontech/erigon/db/version"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
+	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
@@ -317,9 +318,12 @@ func pollAssembledPayload(
 	for {
 		// Grab at least once, even past the deadline, so a late produce request still gets a payload.
 		payload, bundles, requestsBundle, blockValue, err := get()
-		if err != nil {
+		switch {
+		case errors.Is(err, chainreader.ErrUnknownPayload):
+			return nil, nil, nil, nil, false
+		case err != nil:
 			log.Error("BlockProduction: Failed to get payload", "err", err)
-		} else if payload != nil {
+		case payload != nil:
 			return payload, bundles, requestsBundle, blockValue, true
 		}
 		select {

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -294,8 +294,8 @@ func shouldRetryGetPayload(now, deadline time.Time) bool {
 	return now.Before(deadline)
 }
 
-// pollAssembledPayload waits out the build window, then polls get (which stops the EL builder) until
-// it returns a payload or the deadline passes; ok is false when no payload was produced in time.
+// pollAssembledPayload waits out the build window, then polls get until it returns a payload or the
+// request can no longer produce one. ok reports whether a payload was returned.
 func pollAssembledPayload(
 	ctx context.Context,
 	window blockBuilderWindow,
@@ -320,6 +320,7 @@ func pollAssembledPayload(
 		payload, bundles, requestsBundle, blockValue, err := get()
 		switch {
 		case execution_client.IsUnknownPayloadError(err):
+			log.Warn("BlockProduction: execution payload is unknown", "err", err)
 			return nil, nil, nil, nil, false
 		case err != nil:
 			log.Error("BlockProduction: Failed to get payload", "err", err)

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -42,6 +43,7 @@ import (
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
@@ -434,17 +436,27 @@ func TestPollAssembledPayloadRetriesOnError(t *testing.T) {
 }
 
 func TestPollAssembledPayloadStopsOnUnknownPayload(t *testing.T) {
-	now := time.Now()
-	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
-	calls := 0
-	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
-		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
-			calls++
-			return nil, nil, nil, nil, chainreader.ErrUnknownPayload
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"direct execution client", fmt.Errorf("get payload: %w", chainreader.ErrUnknownPayload)},
+		{"remote execution client", fmt.Errorf("get payload: %w", &engine_helpers.UnknownPayloadErr)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now()
+			window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
+			calls := 0
+			payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+				func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+					calls++
+					return nil, nil, nil, nil, tc.err
+				})
+			require.False(t, ok)
+			require.Nil(t, payload)
+			require.Equal(t, 1, calls)
 		})
-	require.False(t, ok)
-	require.Nil(t, payload)
-	require.Equal(t, 1, calls)
+	}
 }
 
 func TestPollAssembledPayloadStopsAtDeadline(t *testing.T) {

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -459,6 +459,25 @@ func TestPollAssembledPayloadStopsOnUnknownPayload(t *testing.T) {
 	}
 }
 
+func TestPollAssembledPayloadLogsUnknownPayload(t *testing.T) {
+	var output bytes.Buffer
+	root := log.Root()
+	previousHandler := root.GetHandler()
+	root.SetHandler(log.StreamHandler(&output, log.LogfmtFormat()))
+	t.Cleanup(func() { root.SetHandler(previousHandler) })
+
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
+	_, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			return nil, nil, nil, nil, &engine_helpers.UnknownPayloadErr
+		})
+
+	require.False(t, ok)
+	require.Contains(t, output.String(), "BlockProduction: execution payload is unknown")
+	require.Contains(t, output.String(), "lvl=warn")
+}
+
 func TestPollAssembledPayloadStopsAtDeadline(t *testing.T) {
 	now := time.Now()
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -463,7 +463,7 @@ func TestPollAssembledPayloadLogsUnknownPayload(t *testing.T) {
 	var output bytes.Buffer
 	root := log.Root()
 	previousHandler := root.GetHandler()
-	root.SetHandler(log.StreamHandler(&output, log.LogfmtFormat()))
+	root.SetHandler(log.SyncHandler(log.StreamHandler(&output, log.LogfmtFormat())))
 	t.Cleanup(func() { root.SetHandler(previousHandler) })
 
 	now := time.Now()

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -433,6 +433,20 @@ func TestPollAssembledPayloadRetriesOnError(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
+func TestPollAssembledPayloadStopsOnUnknownPayload(t *testing.T) {
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
+	calls := 0
+	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			return nil, nil, nil, nil, chainreader.ErrUnknownPayload
+		})
+	require.False(t, ok)
+	require.Nil(t, payload)
+	require.Equal(t, 1, calls)
+}
+
 func TestPollAssembledPayloadStopsAtDeadline(t *testing.T) {
 	now := time.Now()
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -25,6 +25,8 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -459,11 +461,30 @@ func TestPollAssembledPayloadStopsOnUnknownPayload(t *testing.T) {
 	}
 }
 
+// syncBuffer is a log sink safe to read while the process-wide root handler may still be written
+// to by goroutines leaked from other tests: Write and String share one lock.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 func TestPollAssembledPayloadLogsUnknownPayload(t *testing.T) {
-	var output bytes.Buffer
+	output := &syncBuffer{}
 	root := log.Root()
 	previousHandler := root.GetHandler()
-	root.SetHandler(log.SyncHandler(log.StreamHandler(&output, log.LogfmtFormat())))
+	root.SetHandler(log.StreamHandler(output, log.LogfmtFormat()))
 	t.Cleanup(func() { root.SetHandler(previousHandler) })
 
 	now := time.Now()
@@ -472,10 +493,19 @@ func TestPollAssembledPayloadLogsUnknownPayload(t *testing.T) {
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			return nil, nil, nil, nil, &engine_helpers.UnknownPayloadErr
 		})
-
 	require.False(t, ok)
-	require.Contains(t, output.String(), "BlockProduction: execution payload is unknown")
-	require.Contains(t, output.String(), "lvl=warn")
+
+	// The level is asserted within the record itself, so a stray warn line from another goroutine
+	// cannot satisfy it.
+	var record string
+	for line := range strings.SplitSeq(output.String(), "\n") {
+		if strings.Contains(line, "BlockProduction: execution payload is unknown") {
+			record = line
+			break
+		}
+	}
+	require.NotEmpty(t, record, "unknown-payload record not logged")
+	require.Contains(t, record, "lvl=warn")
 }
 
 func TestPollAssembledPayloadStopsAtDeadline(t *testing.T) {

--- a/cl/phase1/execution_client/errors.go
+++ b/cl/phase1/execution_client/errors.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execution_client
+
+import (
+	"errors"
+
+	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
+	"github.com/erigontech/erigon/execution/execmodule/chainreader"
+	"github.com/erigontech/erigon/rpc"
+)
+
+// IsUnknownPayloadError reports an unknown-payload result from local or remote execution clients.
+func IsUnknownPayloadError(err error) bool {
+	if errors.Is(err, chainreader.ErrUnknownPayload) {
+		return true
+	}
+	var rpcErr rpc.Error
+	return errors.As(err, &rpcErr) && rpcErr.ErrorCode() == engine_helpers.UnknownPayloadErr.Code
+}

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -18,6 +18,7 @@ package builder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -32,13 +33,22 @@ import (
 // that can block - opening a read view, waiting on a transaction provider - has to honour it.
 type BlockBuilderFunc func(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error)
 
+// ErrDiscarded reports that the payload was abandoned before the build completed.
+var ErrDiscarded = errors.New("block builder discarded")
+
+const (
+	blockBuilderRunning uint32 = iota
+	blockBuilderCompleted
+	blockBuilderDiscarded
+)
+
 // BlockBuilder wraps a goroutine that builds Proof-of-Stake payloads (PoS "mining").
 //
 // It answers to two different requests. Interrupting asks for the block it has so far, which is how
 // a payload is collected. Discarding says the payload is not wanted at all, and cancels the work.
 type BlockBuilder struct {
 	interrupt atomic.Bool
-	discarded atomic.Bool
+	state     atomic.Uint32
 	discard   context.CancelFunc
 	mu        sync.Mutex
 	done      chan struct{}
@@ -68,6 +78,7 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 			builder.mu.Lock()
 			builder.result = result
 			builder.err = err
+			builder.state.CompareAndSwap(blockBuilderRunning, blockBuilderCompleted)
 			builder.mu.Unlock()
 			close(builder.done)
 			discard()
@@ -102,6 +113,9 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 		graceCtx, cancelGrace := context.WithTimeout(ctx, stopGrace)
 		defer cancelGrace()
 		if _, err := builder.Stop(graceCtx); err != nil {
+			if errors.Is(err, ErrDiscarded) {
+				return
+			}
 			select {
 			case <-builder.done:
 				// The build ended within the grace with an error of its own, logged where it happened.
@@ -119,6 +133,9 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 
 func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, error) {
 	b.interrupt.Store(true)
+	if b.Discarded() {
+		return nil, ErrDiscarded
+	}
 
 	select {
 	case <-ctx.Done():
@@ -128,20 +145,23 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	// Keep a payload that completed as discard arrived.
+	if b.state.Load() == blockBuilderDiscarded && (b.result == nil || b.err != nil) {
+		return nil, ErrDiscarded
+	}
 	return b.result, b.err
 }
 
-// Discard marks the build unusable and cancels its context. It does not wait for the work to unwind.
+// Discard cancels the build without waiting for it to return.
 func (b *BlockBuilder) Discard() {
 	b.interrupt.Store(true)
-	b.discarded.Store(true)
+	b.state.CompareAndSwap(blockBuilderRunning, blockBuilderDiscarded)
 	b.discard()
 }
 
-// Discarded reports the payload was abandoned. The work may still be winding down, but nothing will
-// come of it, so a discarded builder reads as gone at once.
+// Discarded reports whether discard won before the build completed.
 func (b *BlockBuilder) Discarded() bool {
-	return b.discarded.Load()
+	return b.state.Load() == blockBuilderDiscarded
 }
 
 // Failed reports whether the builder has finished and ended in an error, which a caller looking to

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -112,20 +112,16 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 		log.Warn("Stopping block builder due to max build time exceeded")
 		graceCtx, cancelGrace := context.WithTimeout(ctx, stopGrace)
 		defer cancelGrace()
-		if _, err := builder.Stop(graceCtx); err != nil {
-			if errors.Is(err, ErrDiscarded) {
-				return
-			}
-			select {
-			case <-builder.done:
-				// The build ended within the grace with an error of its own, logged where it happened.
-			default:
-				builder.Discard()
-				log.Warn("Discarded unresponsive block builder due to max build time exceeded")
-			}
+		_, err := builder.Stop(graceCtx)
+		if err == nil {
+			log.Debug("Stopped block builder due to max build time exceeded")
 			return
 		}
-		log.Debug("Stopped block builder due to max build time exceeded")
+		if errors.Is(err, ErrDiscarded) || builder.finished() {
+			return
+		}
+		builder.Discard()
+		log.Warn("Discarded unresponsive block builder due to max build time exceeded")
 	}()
 
 	return builder
@@ -134,22 +130,38 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, error) {
 	b.interrupt.Store(true)
 	if b.Discarded() {
-		return nil, ErrDiscarded
+		return b.readResult()
 	}
 
 	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
 	case <-b.done:
+	case <-ctx.Done():
+		select {
+		case <-b.done:
+		default:
+			return nil, ctx.Err()
+		}
 	}
+	return b.readResult()
+}
 
+func (b *BlockBuilder) readResult() (*types.BlockWithReceipts, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	// Keep a payload that completed as discard arrived.
-	if b.state.Load() == blockBuilderDiscarded && (b.result == nil || b.err != nil) {
+
+	if b.Discarded() && (b.result == nil || b.err != nil) {
 		return nil, ErrDiscarded
 	}
 	return b.result, b.err
+}
+
+func (b *BlockBuilder) finished() bool {
+	select {
+	case <-b.done:
+		return true
+	default:
+		return false
+	}
 }
 
 // Discard cancels the build without waiting for it to return.
@@ -178,11 +190,9 @@ func (b *BlockBuilder) Failed() bool {
 }
 
 func (b *BlockBuilder) Block() *types.Block {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if b.result == nil {
+	result, err := b.readResult()
+	if err != nil || result == nil {
 		return nil
 	}
-	return b.result.Block
+	return result.Block
 }

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -106,7 +106,7 @@ func (b *BlockBuilder) Cancel() {
 	b.interrupt.Store(true)
 }
 
-// Failed reports whether the builder finished without producing anything. The error is latched, so
+// Failed reports whether the builder has finished and ended in an error. That error is latched, so
 // a caller that would otherwise reuse this builder has to treat it as absent. Being cancelled is
 // not failure: a stopped builder still holds the payload it was stopped for.
 func (b *BlockBuilder) Failed() bool {

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -72,7 +72,11 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 		t := time.Now()
 		result, err = build(buildCtx, param, &builder.interrupt)
 		if err != nil {
-			log.Warn("Failed to build a block", "err", err)
+			if buildCtx.Err() != nil {
+				log.Debug("Block builder discarded", "err", err)
+			} else {
+				log.Warn("Failed to build a block", "err", err)
+			}
 		} else {
 			block := result.Block
 			log.Info("Built block", "hash", block.Hash(), "height", block.NumberU64(), "txs", len(block.Transactions()), "executionRequests", len(result.Requests), "gasUsedPct", 100*float64(block.GasUsed())/float64(block.GasLimit()), "time", time.Since(t))

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -28,26 +28,27 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-// buildStopGrace is how long a builder asked to stop is given to hand its block over. It is sized
-// against how often the build loop looks at the interrupt flag, not against the slot: a build that
-// is cooperating answers within one of those polls, and one that is not never will.
+// buildStopGrace bounds how long a builder may ignore a stop request. Once acknowledged, its
+// packing tail and payload finalization are allowed to finish.
 const buildStopGrace = 500 * time.Millisecond
 
 // BlockBuilderFunc builds a payload. Its context ends when the payload is discarded, so anything
 // that can block - opening a read view, waiting on a transaction provider - has to honour it.
-type BlockBuilderFunc func(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error)
+// acknowledgeStop marks that the interrupt was observed or transaction packing has already ended.
+type BlockBuilderFunc func(ctx context.Context, param *Parameters, interrupt *atomic.Bool, acknowledgeStop func()) (*types.BlockWithReceipts, error)
 
 // BlockBuilder wraps a goroutine that builds Proof-of-Stake payloads (PoS "mining").
 //
 // It answers to two different requests. Interrupting asks for the block it has so far, which is how
 // a payload is collected. Discarding says the payload is not wanted at all, and cancels the work.
 type BlockBuilder struct {
-	interrupt atomic.Bool
-	discard   context.CancelFunc
-	mu        sync.Mutex
-	done      chan struct{}
-	result    *types.BlockWithReceipts
-	err       error
+	interrupt        atomic.Bool
+	discard          context.CancelFunc
+	mu               sync.Mutex
+	done             chan struct{}
+	result           *types.BlockWithReceipts
+	err              error
+	stopAcknowledged bool
 }
 
 func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Parameters, maxBuildTime time.Duration) *BlockBuilder {
@@ -75,7 +76,7 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 
 		log.Info("Building block...")
 		t := time.Now()
-		result, err = build(buildCtx, param, &builder.interrupt)
+		result, err = build(buildCtx, param, &builder.interrupt, builder.acknowledgeStop)
 		if err != nil {
 			if buildCtx.Err() != nil {
 				log.Debug("Block builder discarded", "err", err)
@@ -103,12 +104,33 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 		graceCtx, cancelGrace := context.WithTimeout(ctx, buildStopGrace)
 		defer cancelGrace()
 		if _, err := builder.Stop(graceCtx); err != nil {
-			builder.Discard()
+			if builder.discardIfUnresponsive() {
+				log.Debug("Discarded block builder due to max build time exceeded")
+			} else {
+				log.Debug("Block builder acknowledged stop after max build time exceeded")
+			}
+			return
 		}
 		log.Debug("Stopped block builder due to max build time exceeded")
 	}()
 
 	return builder
+}
+
+func (b *BlockBuilder) acknowledgeStop() {
+	b.mu.Lock()
+	b.stopAcknowledged = true
+	b.mu.Unlock()
+}
+
+func (b *BlockBuilder) discardIfUnresponsive() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.stopAcknowledged {
+		return false
+	}
+	b.discard()
+	return true
 }
 
 func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, error) {

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -28,6 +28,11 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
+// buildStopGrace is how long a builder asked to stop is given to hand its block over. It is sized
+// against how often the build loop looks at the interrupt flag, not against the slot: a build that
+// is cooperating answers within one of those polls, and one that is not never will.
+const buildStopGrace = 500 * time.Millisecond
+
 // BlockBuilderFunc builds a payload. Its context ends when the payload is discarded, so anything
 // that can block - opening a read view, waiting on a transaction provider - has to honour it.
 type BlockBuilderFunc func(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error)
@@ -88,13 +93,19 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 		defer timer.Stop()
 		select {
 		case <-timer.C:
-			log.Warn("Stopping block builder due to max build time exceeded")
-			_, _ = builder.Stop(context.Background())
-			log.Debug("Stopped block builder due to max build time exceeded")
-			return
 		case <-builder.done:
 			return
 		}
+		// Ask for the block it has, which is what the budget was for, but do not wait on it
+		// indefinitely: a build parked somewhere that never reads the flag would hold its read view
+		// until the builder count forced it out, which on a quiet node is a very long time.
+		log.Warn("Stopping block builder due to max build time exceeded")
+		graceCtx, cancelGrace := context.WithTimeout(ctx, buildStopGrace)
+		defer cancelGrace()
+		if _, err := builder.Stop(graceCtx); err != nil {
+			builder.Discard()
+		}
+		log.Debug("Stopped block builder due to max build time exceeded")
 	}()
 
 	return builder

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -97,8 +97,7 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 			return
 		}
 		// Ask for the block it has, which is what the budget was for. A build that has not answered
-		// by the end of the grace is parked in a wait that never reads the flag, and would hold its
-		// read view until the builder count forced it out, so it is discarded instead.
+		// by the end of the grace is treated as unresponsive and discarded.
 		log.Warn("Stopping block builder due to max build time exceeded")
 		graceCtx, cancelGrace := context.WithTimeout(ctx, stopGrace)
 		defer cancelGrace()
@@ -132,8 +131,7 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 	return b.result, b.err
 }
 
-// Discard abandons the build and releases what it holds: a read view or a transaction provider
-// blocked on the builder's context returns at once instead of waiting out its own deadline.
+// Discard marks the build unusable and cancels its context. It does not wait for the work to unwind.
 func (b *BlockBuilder) Discard() {
 	b.interrupt.Store(true)
 	b.discarded.Store(true)

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -28,30 +28,29 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-// buildStopGrace bounds how long a builder may ignore a stop request. Once acknowledged, its
-// packing tail and payload finalization are allowed to finish.
-const buildStopGrace = 500 * time.Millisecond
-
 // BlockBuilderFunc builds a payload. Its context ends when the payload is discarded, so anything
 // that can block - opening a read view, waiting on a transaction provider - has to honour it.
-// acknowledgeStop marks that the interrupt was observed or transaction packing has already ended.
-type BlockBuilderFunc func(ctx context.Context, param *Parameters, interrupt *atomic.Bool, acknowledgeStop func()) (*types.BlockWithReceipts, error)
+type BlockBuilderFunc func(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error)
 
 // BlockBuilder wraps a goroutine that builds Proof-of-Stake payloads (PoS "mining").
 //
 // It answers to two different requests. Interrupting asks for the block it has so far, which is how
 // a payload is collected. Discarding says the payload is not wanted at all, and cancels the work.
 type BlockBuilder struct {
-	interrupt        atomic.Bool
-	discard          context.CancelFunc
-	mu               sync.Mutex
-	done             chan struct{}
-	result           *types.BlockWithReceipts
-	err              error
-	stopAcknowledged bool
+	interrupt atomic.Bool
+	discarded atomic.Bool
+	discard   context.CancelFunc
+	mu        sync.Mutex
+	done      chan struct{}
+	result    *types.BlockWithReceipts
+	err       error
 }
 
-func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Parameters, maxBuildTime time.Duration) *BlockBuilder {
+// NewBlockBuilder starts a build. maxBuildTime is the budget after which the builder stops itself
+// and keeps the block it has; stopGrace is how long a stopped build may take to finish up - the
+// transaction in flight, the packing tail, payload finalization - before it is taken as stuck and
+// discarded.
+func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Parameters, maxBuildTime, stopGrace time.Duration) *BlockBuilder {
 	buildCtx, discard := context.WithCancel(ctx)
 	builder := &BlockBuilder{done: make(chan struct{}), discard: discard}
 
@@ -76,7 +75,7 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 
 		log.Info("Building block...")
 		t := time.Now()
-		result, err = build(buildCtx, param, &builder.interrupt, builder.acknowledgeStop)
+		result, err = build(buildCtx, param, &builder.interrupt)
 		if err != nil {
 			if buildCtx.Err() != nil {
 				log.Debug("Block builder discarded", "err", err)
@@ -97,17 +96,19 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 		case <-builder.done:
 			return
 		}
-		// Ask for the block it has, which is what the budget was for, but do not wait on it
-		// indefinitely: a build parked somewhere that never reads the flag would hold its read view
-		// until the builder count forced it out, which on a quiet node is a very long time.
+		// Ask for the block it has, which is what the budget was for. A build that has not answered
+		// by the end of the grace is parked in a wait that never reads the flag, and would hold its
+		// read view until the builder count forced it out, so it is discarded instead.
 		log.Warn("Stopping block builder due to max build time exceeded")
-		graceCtx, cancelGrace := context.WithTimeout(ctx, buildStopGrace)
+		graceCtx, cancelGrace := context.WithTimeout(ctx, stopGrace)
 		defer cancelGrace()
 		if _, err := builder.Stop(graceCtx); err != nil {
-			if builder.discardIfUnresponsive() {
-				log.Debug("Discarded block builder due to max build time exceeded")
-			} else {
-				log.Debug("Block builder acknowledged stop after max build time exceeded")
+			select {
+			case <-builder.done:
+				// The build ended within the grace with an error of its own, logged where it happened.
+			default:
+				builder.Discard()
+				log.Warn("Discarded unresponsive block builder due to max build time exceeded")
 			}
 			return
 		}
@@ -115,22 +116,6 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 	}()
 
 	return builder
-}
-
-func (b *BlockBuilder) acknowledgeStop() {
-	b.mu.Lock()
-	b.stopAcknowledged = true
-	b.mu.Unlock()
-}
-
-func (b *BlockBuilder) discardIfUnresponsive() bool {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.stopAcknowledged {
-		return false
-	}
-	b.discard()
-	return true
 }
 
 func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, error) {
@@ -147,13 +132,18 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 	return b.result, b.err
 }
 
-// Discard abandons the build and releases what it holds. A read view or a transaction provider
-// blocked on the builder's context returns at once instead of waiting out its own deadline, which
-// is the difference between an evicted builder freeing its resources now and freeing them a slot
-// from now.
+// Discard abandons the build and releases what it holds: a read view or a transaction provider
+// blocked on the builder's context returns at once instead of waiting out its own deadline.
 func (b *BlockBuilder) Discard() {
 	b.interrupt.Store(true)
+	b.discarded.Store(true)
 	b.discard()
+}
+
+// Discarded reports the payload was abandoned. The work may still be winding down, but nothing will
+// come of it, so a discarded builder reads as gone at once.
+func (b *BlockBuilder) Discarded() bool {
+	return b.discarded.Load()
 }
 
 // Failed reports whether the builder has finished and ended in an error, which a caller looking to

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -117,11 +117,16 @@ func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Paramet
 			log.Debug("Stopped block builder due to max build time exceeded")
 			return
 		}
-		if errors.Is(err, ErrDiscarded) || builder.finished() {
+		// Not unresponsive: someone else discarded it, it finished on its own, or the node is
+		// shutting down and cut the grace short.
+		if errors.Is(err, ErrDiscarded) || builder.Finished() || ctx.Err() != nil {
 			return
 		}
 		builder.Discard()
-		log.Warn("Discarded unresponsive block builder due to max build time exceeded")
+		// The swap can lose to a completion landing in between, and then nothing was discarded.
+		if builder.Discarded() {
+			log.Warn("Discarded unresponsive block builder due to max build time exceeded")
+		}
 	}()
 
 	return builder
@@ -136,9 +141,7 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 	select {
 	case <-b.done:
 	case <-ctx.Done():
-		select {
-		case <-b.done:
-		default:
+		if !b.Finished() {
 			return nil, ctx.Err()
 		}
 	}
@@ -149,13 +152,15 @@ func (b *BlockBuilder) readResult() (*types.BlockWithReceipts, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	// Keep a payload that completed as discard arrived: a replay must not lose a latched block.
 	if b.Discarded() && (b.result == nil || b.err != nil) {
 		return nil, ErrDiscarded
 	}
 	return b.result, b.err
 }
 
-func (b *BlockBuilder) finished() bool {
+// Finished reports whether the build goroutine has returned and latched its outcome.
+func (b *BlockBuilder) Finished() bool {
 	select {
 	case <-b.done:
 		return true
@@ -179,9 +184,7 @@ func (b *BlockBuilder) Discarded() bool {
 // Failed reports whether the builder has finished and ended in an error, which a caller looking to
 // reuse it has to read as absent because that error is latched.
 func (b *BlockBuilder) Failed() bool {
-	select {
-	case <-b.done:
-	default:
+	if !b.Finished() {
 		return false
 	}
 	b.mu.Lock()

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -28,19 +28,26 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-type BlockBuilderFunc func(param *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error)
+// BlockBuilderFunc builds a payload. Its context ends when the payload is discarded, so anything
+// that can block - opening a read view, waiting on a transaction provider - has to honour it.
+type BlockBuilderFunc func(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error)
 
-// BlockBuilder wraps a goroutine that builds Proof-of-Stake payloads (PoS "mining")
+// BlockBuilder wraps a goroutine that builds Proof-of-Stake payloads (PoS "mining").
+//
+// It answers to two different requests. Interrupting asks for the block it has so far, which is how
+// a payload is collected. Discarding says the payload is not wanted at all, and cancels the work.
 type BlockBuilder struct {
 	interrupt atomic.Bool
+	discard   context.CancelFunc
 	mu        sync.Mutex
 	done      chan struct{}
 	result    *types.BlockWithReceipts
 	err       error
 }
 
-func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime time.Duration) *BlockBuilder {
-	builder := &BlockBuilder{done: make(chan struct{})}
+func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Parameters, maxBuildTime time.Duration) *BlockBuilder {
+	buildCtx, discard := context.WithCancel(ctx)
+	builder := &BlockBuilder{done: make(chan struct{}), discard: discard}
 
 	go func() {
 		var result *types.BlockWithReceipts
@@ -58,11 +65,12 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime tim
 			builder.err = err
 			builder.mu.Unlock()
 			close(builder.done)
+			discard()
 		}()
 
 		log.Info("Building block...")
 		t := time.Now()
-		result, err = build(param, &builder.interrupt)
+		result, err = build(buildCtx, param, &builder.interrupt)
 		if err != nil {
 			log.Warn("Failed to build a block", "err", err)
 		} else {
@@ -89,7 +97,7 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime tim
 }
 
 func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, error) {
-	b.Cancel()
+	b.interrupt.Store(true)
 
 	select {
 	case <-ctx.Done():
@@ -102,13 +110,17 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 	return b.result, b.err
 }
 
-func (b *BlockBuilder) Cancel() {
+// Discard abandons the build and releases what it holds. A read view or a transaction provider
+// blocked on the builder's context returns at once instead of waiting out its own deadline, which
+// is the difference between an evicted builder freeing its resources now and freeing them a slot
+// from now.
+func (b *BlockBuilder) Discard() {
 	b.interrupt.Store(true)
+	b.discard()
 }
 
-// Failed reports whether the builder has finished and ended in an error. That error is latched, so
-// a caller that would otherwise reuse this builder has to treat it as absent. Being cancelled is
-// not failure: a stopped builder still holds the payload it was stopped for.
+// Failed reports whether the builder has finished and ended in an error, which a caller looking to
+// reuse it has to read as absent because that error is latched.
 func (b *BlockBuilder) Failed() bool {
 	select {
 	case <-b.done:

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -89,7 +89,7 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime tim
 }
 
 func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, error) {
-	b.interrupt.Store(true)
+	b.Cancel()
 
 	select {
 	case <-ctx.Done():
@@ -100,6 +100,24 @@ func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, erro
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.result, b.err
+}
+
+func (b *BlockBuilder) Cancel() {
+	b.interrupt.Store(true)
+}
+
+// Failed reports whether the builder finished without producing anything. The error is latched, so
+// a caller that would otherwise reuse this builder has to treat it as absent. Being cancelled is
+// not failure: a stopped builder still holds the payload it was stopped for.
+func (b *BlockBuilder) Failed() bool {
+	select {
+	case <-b.done:
+	default:
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.err != nil
 }
 
 func (b *BlockBuilder) Block() *types.Block {

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -147,9 +147,8 @@ func TestBlockBuilderKeepsAHealthyBuildThatIsSlowToObserveTheStop(t *testing.T) 
 func TestBlockBuilderReleasesABuildThatWedgesAfterObservingTheStop(t *testing.T) {
 	t.Parallel()
 
-	// Observing the stop earns the build its grace, not an unbounded stay: a wedge after the
-	// observation - in finalization, say - would otherwise pin the read view until the builder
-	// count forced it out.
+	// Observing the stop earns the build its grace, not an unbounded stay. Discard must still cancel
+	// context-aware work that blocks later in the build.
 	released := make(chan error, 1)
 	NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -82,3 +82,44 @@ func TestBlockBuilderStaysReusableOnceItFillsTheBlock(t *testing.T) {
 	// A builder that ran out of room holds a complete payload, so its id is still worth reusing.
 	require.Never(t, b.Failed, 50*time.Millisecond, 5*time.Millisecond)
 }
+
+func TestBlockBuilderReleasesABuildThatIgnoresTheDeadline(t *testing.T) {
+	t.Parallel()
+
+	// A build parked in something that never reads the interrupt flag - a transaction provider
+	// waiting on a block, say - would hold its read view until the builder count forced it out.
+	released := make(chan error, 1)
+	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		select {
+		case <-ctx.Done():
+			released <- ctx.Err()
+		case <-time.After(time.Minute):
+			released <- errors.New("build was never released")
+		}
+		return nil, errors.New("builder stopped")
+	}, &Parameters{}, time.Millisecond)
+
+	select {
+	case err := <-released:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("build outlived its budget without being released")
+	}
+	require.Eventually(t, b.Failed, 5*time.Second, time.Millisecond)
+}
+
+func TestBlockBuilderStillHandsOverAPayloadWhenItsBudgetRunsOut(t *testing.T) {
+	t.Parallel()
+
+	// Reaching the budget asks for the block it has, which is what the budget is for. Only a build
+	// that will not answer is discarded.
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	}, &Parameters{}, time.Millisecond)
+
+	require.Eventually(t, func() bool { return b.Block() != nil }, 5*time.Second, time.Millisecond)
+	require.False(t, b.Failed())
+}

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -33,10 +33,10 @@ func TestBlockBuilderRunningHasNotFailed(t *testing.T) {
 
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		<-release
 		return nil, errors.New("builder stopped")
-	}, &Parameters{}, time.Minute)
+	}, &Parameters{}, time.Minute, time.Minute)
 
 	require.Never(t, b.Failed, 50*time.Millisecond, 5*time.Millisecond)
 }
@@ -44,12 +44,12 @@ func TestBlockBuilderRunningHasNotFailed(t *testing.T) {
 func TestBlockBuilderStoppedForItsPayloadHasNotFailed(t *testing.T) {
 	t.Parallel()
 
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
 		}
 		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
-	}, &Parameters{}, time.Minute)
+	}, &Parameters{}, time.Minute, time.Minute)
 
 	_, err := b.Stop(t.Context())
 	require.NoError(t, err)
@@ -62,9 +62,9 @@ func TestBlockBuilderStoppedForItsPayloadHasNotFailed(t *testing.T) {
 func TestBlockBuilderHasFailedOnceItErrors(t *testing.T) {
 	t.Parallel()
 
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("build failed")
-	}, &Parameters{}, time.Minute)
+	}, &Parameters{}, time.Minute, time.Minute)
 
 	require.Eventually(t, b.Failed, time.Second, time.Millisecond)
 }
@@ -73,10 +73,10 @@ func TestBlockBuilderStaysReusableOnceItFillsTheBlock(t *testing.T) {
 	t.Parallel()
 
 	built := make(chan struct{})
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		defer close(built)
 		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
-	}, &Parameters{}, time.Minute)
+	}, &Parameters{}, time.Minute, time.Minute)
 
 	<-built
 	// A builder that ran out of room holds a complete payload, so its id is still worth reusing.
@@ -89,7 +89,7 @@ func TestBlockBuilderReleasesABuildThatIgnoresTheDeadline(t *testing.T) {
 	// A build parked in something that never reads the interrupt flag - a transaction provider
 	// waiting on a block, say - would hold its read view until the builder count forced it out.
 	released := make(chan error, 1)
-	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		select {
 		case <-ctx.Done():
 			released <- ctx.Err()
@@ -97,7 +97,7 @@ func TestBlockBuilderReleasesABuildThatIgnoresTheDeadline(t *testing.T) {
 			released <- errors.New("build was never released")
 		}
 		return nil, errors.New("builder stopped")
-	}, &Parameters{}, time.Millisecond)
+	}, &Parameters{}, time.Millisecond, 10*time.Millisecond)
 
 	select {
 	case err := <-released:
@@ -113,37 +113,61 @@ func TestBlockBuilderStillHandsOverAPayloadWhenItsBudgetRunsOut(t *testing.T) {
 
 	// Reaching the budget asks for the block it has, which is what the budget is for. Only a build
 	// that will not answer is discarded.
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
 		}
 		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
-	}, &Parameters{}, time.Millisecond)
+	}, &Parameters{}, time.Millisecond, time.Minute)
 
 	require.Eventually(t, func() bool { return b.Block() != nil }, 5*time.Second, time.Millisecond)
 	require.False(t, b.Failed())
 }
 
-func TestBlockBuilderLetsFinalizationOutliveStopGrace(t *testing.T) {
+func TestBlockBuilderKeepsAHealthyBuildThatIsSlowToObserveTheStop(t *testing.T) {
 	t.Parallel()
 
-	finalizing := make(chan struct{})
-	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, interrupt *atomic.Bool, acknowledgeStop func()) (*types.BlockWithReceipts, error) {
-		for !interrupt.Load() {
-			time.Sleep(time.Millisecond)
-		}
-		acknowledgeStop()
-		close(finalizing)
+	// A single heavy transaction has no interrupt boundary, so a healthy build can be slow to
+	// answer the stop without being unresponsive. Discarding it destroys a payload a proposal may
+	// still collect.
+	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		select {
-		case <-time.After(buildStopGrace + 100*time.Millisecond):
-			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
 		}
-	}, &Parameters{}, time.Millisecond)
+	}, &Parameters{}, time.Millisecond, 5*time.Second)
 
-	<-finalizing
 	result, err := b.Stop(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, result)
+}
+
+func TestBlockBuilderReleasesABuildThatWedgesAfterObservingTheStop(t *testing.T) {
+	t.Parallel()
+
+	// Observing the stop earns the build its grace, not an unbounded stay: a wedge after the
+	// observation - in finalization, say - would otherwise pin the read view until the builder
+	// count forced it out.
+	released := make(chan error, 1)
+	NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		select {
+		case <-ctx.Done():
+			released <- ctx.Err()
+		case <-time.After(time.Minute):
+			released <- errors.New("build was never released")
+		}
+		return nil, errors.New("builder stopped")
+	}, &Parameters{}, time.Millisecond, 50*time.Millisecond)
+
+	select {
+	case err := <-released:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("wedged build outlived its grace without being released")
+	}
 }

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/types"
+)
+
+func TestBlockBuilderRunningHasNotFailed(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	b := NewBlockBuilder(func(_ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-release
+		return nil, errors.New("builder stopped")
+	}, &Parameters{}, time.Minute)
+
+	require.Never(t, b.Failed, 50*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestBlockBuilderStoppedForItsPayloadHasNotFailed(t *testing.T) {
+	t.Parallel()
+
+	b := NewBlockBuilder(func(_ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	}, &Parameters{}, time.Minute)
+
+	_, err := b.Stop(t.Context())
+	require.NoError(t, err)
+
+	// Collecting the payload is what a proposal does. Reading that as failure would make a repeated
+	// request rebuild from scratch instead of being handed the block that was just built.
+	require.False(t, b.Failed())
+}
+
+func TestBlockBuilderHasFailedOnceItErrors(t *testing.T) {
+	t.Parallel()
+
+	b := NewBlockBuilder(func(_ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, errors.New("build failed")
+	}, &Parameters{}, time.Minute)
+
+	require.Eventually(t, b.Failed, time.Second, time.Millisecond)
+}
+
+func TestBlockBuilderStaysReusableOnceItFillsTheBlock(t *testing.T) {
+	t.Parallel()
+
+	built := make(chan struct{})
+	b := NewBlockBuilder(func(_ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		defer close(built)
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	}, &Parameters{}, time.Minute)
+
+	<-built
+	// A builder that ran out of room holds a complete payload, so its id is still worth reusing.
+	require.Never(t, b.Failed, 50*time.Millisecond, 5*time.Millisecond)
+}

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -250,3 +250,25 @@ func TestBlockBuilderStopReturnsImmediatelyAfterDiscard(t *testing.T) {
 	_, err := b.Stop(ctx)
 	require.ErrorIs(t, err, ErrDiscarded)
 }
+
+func TestBlockBuilderStopAfterAnExpiredWaitReturnsTheLatchedError(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	wantErr := errors.New("build failed")
+	b := NewBlockBuilder(t.Context(), func(context.Context, *Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-release
+		return nil, wantErr
+	}, &Parameters{}, time.Minute, time.Minute)
+
+	expired, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := b.Stop(expired)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// Once the build has finished, a later read reports its own outcome, not the earlier expiry.
+	close(release)
+	require.Eventually(t, b.Finished, 5*time.Second, time.Millisecond)
+	_, err = b.Stop(context.Background())
+	require.ErrorIs(t, err, wantErr)
+}

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -17,6 +17,7 @@
 package builder
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -32,7 +33,7 @@ func TestBlockBuilderRunningHasNotFailed(t *testing.T) {
 
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })
-	b := NewBlockBuilder(func(_ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		<-release
 		return nil, errors.New("builder stopped")
 	}, &Parameters{}, time.Minute)
@@ -43,7 +44,7 @@ func TestBlockBuilderRunningHasNotFailed(t *testing.T) {
 func TestBlockBuilderStoppedForItsPayloadHasNotFailed(t *testing.T) {
 	t.Parallel()
 
-	b := NewBlockBuilder(func(_ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
 		}
@@ -61,7 +62,7 @@ func TestBlockBuilderStoppedForItsPayloadHasNotFailed(t *testing.T) {
 func TestBlockBuilderHasFailedOnceItErrors(t *testing.T) {
 	t.Parallel()
 
-	b := NewBlockBuilder(func(_ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("build failed")
 	}, &Parameters{}, time.Minute)
 
@@ -72,7 +73,7 @@ func TestBlockBuilderStaysReusableOnceItFillsTheBlock(t *testing.T) {
 	t.Parallel()
 
 	built := make(chan struct{})
-	b := NewBlockBuilder(func(_ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		defer close(built)
 		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
 	}, &Parameters{}, time.Minute)

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -171,12 +171,13 @@ func TestBlockBuilderReleasesABuildThatWedgesAfterObservingTheStop(t *testing.T)
 	}
 }
 
-func TestBlockBuilderRemainsDiscardedWhenCanceledBuildReturnsPayload(t *testing.T) {
+func TestBlockBuilderReplaysPayloadCompletedAfterDiscard(t *testing.T) {
 	t.Parallel()
 
+	want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
 	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		<-ctx.Done()
-		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+		return want, nil
 	}, &Parameters{}, time.Minute, time.Minute)
 
 	b.Discard()
@@ -187,4 +188,65 @@ func TestBlockBuilderRemainsDiscardedWhenCanceledBuildReturnsPayload(t *testing.
 	}
 
 	require.True(t, b.Discarded())
+	for range 2 {
+		got, err := b.Stop(t.Context())
+		require.NoError(t, err)
+		require.Same(t, want, got)
+	}
+}
+
+func TestBlockBuilderStopPrefersCompletedOutcomeOverCanceledCaller(t *testing.T) {
+	t.Parallel()
+
+	wantBlock := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
+	wantErr := errors.New("build failed")
+	tests := []struct {
+		name   string
+		result *types.BlockWithReceipts
+		err    error
+	}{
+		{name: "payload", result: wantBlock},
+		{name: "error", err: wantErr},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewBlockBuilder(t.Context(), func(context.Context, *Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+				return tc.result, tc.err
+			}, &Parameters{}, time.Minute, time.Minute)
+			select {
+			case <-b.done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("builder did not finish")
+			}
+
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			for range 100 {
+				got, err := b.Stop(ctx)
+				if tc.err != nil {
+					require.ErrorIs(t, err, tc.err)
+					continue
+				}
+				require.NoError(t, err)
+				require.Same(t, tc.result, got)
+			}
+		})
+	}
+}
+
+func TestBlockBuilderStopReturnsImmediatelyAfterDiscard(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	b := NewBlockBuilder(t.Context(), func(context.Context, *Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-release
+		return nil, errors.New("builder stopped")
+	}, &Parameters{}, time.Minute, time.Minute)
+	b.Discard()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := b.Stop(ctx)
+	require.ErrorIs(t, err, ErrDiscarded)
 }

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -170,3 +170,21 @@ func TestBlockBuilderReleasesABuildThatWedgesAfterObservingTheStop(t *testing.T)
 		t.Fatal("wedged build outlived its grace without being released")
 	}
 }
+
+func TestBlockBuilderRemainsDiscardedWhenCanceledBuildReturnsPayload(t *testing.T) {
+	t.Parallel()
+
+	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-ctx.Done()
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	}, &Parameters{}, time.Minute, time.Minute)
+
+	b.Discard()
+	select {
+	case <-b.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("discarded builder did not finish")
+	}
+
+	require.True(t, b.Discarded())
+}

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -33,7 +33,7 @@ func TestBlockBuilderRunningHasNotFailed(t *testing.T) {
 
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		<-release
 		return nil, errors.New("builder stopped")
 	}, &Parameters{}, time.Minute)
@@ -44,7 +44,7 @@ func TestBlockBuilderRunningHasNotFailed(t *testing.T) {
 func TestBlockBuilderStoppedForItsPayloadHasNotFailed(t *testing.T) {
 	t.Parallel()
 
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
 		}
@@ -62,7 +62,7 @@ func TestBlockBuilderStoppedForItsPayloadHasNotFailed(t *testing.T) {
 func TestBlockBuilderHasFailedOnceItErrors(t *testing.T) {
 	t.Parallel()
 
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("build failed")
 	}, &Parameters{}, time.Minute)
 
@@ -73,7 +73,7 @@ func TestBlockBuilderStaysReusableOnceItFillsTheBlock(t *testing.T) {
 	t.Parallel()
 
 	built := make(chan struct{})
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		defer close(built)
 		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
 	}, &Parameters{}, time.Minute)
@@ -89,7 +89,7 @@ func TestBlockBuilderReleasesABuildThatIgnoresTheDeadline(t *testing.T) {
 	// A build parked in something that never reads the interrupt flag - a transaction provider
 	// waiting on a block, say - would hold its read view until the builder count forced it out.
 	released := make(chan error, 1)
-	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		select {
 		case <-ctx.Done():
 			released <- ctx.Err()
@@ -113,7 +113,7 @@ func TestBlockBuilderStillHandsOverAPayloadWhenItsBudgetRunsOut(t *testing.T) {
 
 	// Reaching the budget asks for the block it has, which is what the budget is for. Only a build
 	// that will not answer is discarded.
-	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
 		}
@@ -122,4 +122,28 @@ func TestBlockBuilderStillHandsOverAPayloadWhenItsBudgetRunsOut(t *testing.T) {
 
 	require.Eventually(t, func() bool { return b.Block() != nil }, 5*time.Second, time.Millisecond)
 	require.False(t, b.Failed())
+}
+
+func TestBlockBuilderLetsFinalizationOutliveStopGrace(t *testing.T) {
+	t.Parallel()
+
+	finalizing := make(chan struct{})
+	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, interrupt *atomic.Bool, acknowledgeStop func()) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		acknowledgeStop()
+		close(finalizing)
+		select {
+		case <-time.After(buildStopGrace + 100*time.Millisecond):
+			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}, &Parameters{}, time.Millisecond)
+
+	<-finalizing
+	result, err := b.Stop(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, result)
 }

--- a/execution/builder/builder.go
+++ b/execution/builder/builder.go
@@ -189,13 +189,8 @@ func waitForBuilderResult(ctx context.Context, results <-chan *types.BlockWithRe
 	select {
 	case result := <-results:
 		return result, nil
-	default:
-	}
-
-	select {
-	case result := <-results:
-		return result, nil
 	case <-ctx.Done():
+		// Keep a payload that completed as cancellation arrived.
 		select {
 		case result := <-results:
 			return result, nil

--- a/execution/builder/builder.go
+++ b/execution/builder/builder.go
@@ -107,7 +107,7 @@ func (b *Builder) PendingBlockCh() chan *types.Block {
 //
 // Everything that can block runs under ctx, so discarding the payload releases the read view and
 // unblocks the transaction provider instead of leaving them to finish on their own.
-func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomic.Bool, acknowledgeStop func()) (result *types.BlockWithReceipts, err error) {
+func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (result *types.BlockWithReceipts, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("%+v, trace: %s", rec, dbg.Stack())
@@ -169,7 +169,7 @@ func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomi
 	if param.CustomTxnProvider != nil {
 		txnProvider = param.CustomTxnProvider
 	}
-	execCfg := StageBuilderExecCfg(state, b.notifier, b.chainConfig, b.engine, b.vmConfig, b.tmpdir, interrupt, acknowledgeStop, param.PayloadId, txnProvider, b.blockReader)
+	execCfg := StageBuilderExecCfg(state, b.notifier, b.chainConfig, b.engine, b.vmConfig, b.tmpdir, interrupt, param.PayloadId, txnProvider, b.blockReader)
 	finishCfg := StageBuilderFinishCfg(b.chainConfig, b.engine, state, b.sealCancel, b.blockReader, b.latestBlockBuiltStore)
 
 	if err := createBlock(ctx, sd, compositeTx, executionAt, createCfg, b.logger); err != nil {

--- a/execution/builder/builder.go
+++ b/execution/builder/builder.go
@@ -107,7 +107,7 @@ func (b *Builder) PendingBlockCh() chan *types.Block {
 //
 // Everything that can block runs under ctx, so discarding the payload releases the read view and
 // unblocks the transaction provider instead of leaving them to finish on their own.
-func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (result *types.BlockWithReceipts, err error) {
+func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomic.Bool, acknowledgeStop func()) (result *types.BlockWithReceipts, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("%+v, trace: %s", rec, dbg.Stack())
@@ -169,7 +169,7 @@ func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomi
 	if param.CustomTxnProvider != nil {
 		txnProvider = param.CustomTxnProvider
 	}
-	execCfg := StageBuilderExecCfg(state, b.notifier, b.chainConfig, b.engine, b.vmConfig, b.tmpdir, interrupt, param.PayloadId, txnProvider, b.blockReader)
+	execCfg := StageBuilderExecCfg(state, b.notifier, b.chainConfig, b.engine, b.vmConfig, b.tmpdir, interrupt, acknowledgeStop, param.PayloadId, txnProvider, b.blockReader)
 	finishCfg := StageBuilderFinishCfg(b.chainConfig, b.engine, state, b.sealCancel, b.blockReader, b.latestBlockBuiltStore)
 
 	if err := createBlock(ctx, sd, compositeTx, executionAt, createCfg, b.logger); err != nil {

--- a/execution/builder/builder.go
+++ b/execution/builder/builder.go
@@ -45,7 +45,6 @@ type SDProvider func() *execctx.SharedDomains
 // without staged-sync machinery. Its Build method satisfies BlockBuilderFunc and can
 // be passed directly to ExecModule.
 type Builder struct {
-	ctx                   context.Context
 	db                    kv.TemporalRoDB
 	pendingBlockCh        chan *types.Block
 	builderCfg            *buildercfg.BuilderConfig
@@ -64,7 +63,6 @@ type Builder struct {
 }
 
 func NewBuilder(
-	ctx context.Context,
 	db kv.TemporalRoDB,
 	builderCfg *buildercfg.BuilderConfig,
 	chainConfig *chain.Config,
@@ -81,7 +79,6 @@ func NewBuilder(
 	logger log.Logger,
 ) *Builder {
 	return &Builder{
-		ctx:                   ctx,
 		db:                    db,
 		pendingBlockCh:        make(chan *types.Block, 1),
 		builderCfg:            builderCfg,
@@ -107,7 +104,10 @@ func (b *Builder) PendingBlockCh() chan *types.Block {
 }
 
 // Build satisfies BlockBuilderFunc. Pass b.Build directly to ExecModule.
-func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *types.BlockWithReceipts, err error) {
+//
+// Everything that can block runs under ctx, so discarding the payload releases the read view and
+// unblocks the transaction provider instead of leaving them to finish on their own.
+func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (result *types.BlockWithReceipts, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("%+v, trace: %s", rec, dbg.Stack())
@@ -124,7 +124,7 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 		BuiltBlock:      &exec.AssembledBlock{},
 	}
 
-	tx, err := b.db.BeginTemporalRo(b.ctx)
+	tx, err := b.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 		}
 	}
 
-	sd, err := execctx.NewSharedDomains(b.ctx, compositeTx, b.logger, execctx.WithoutDeferredBranchUpdates(), execctx.WithoutSharedBranchCache())
+	sd, err := execctx.NewSharedDomains(ctx, compositeTx, b.logger, execctx.WithoutDeferredBranchUpdates(), execctx.WithoutSharedBranchCache())
 	if err != nil {
 		return nil, err
 	}
@@ -172,10 +172,10 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 	execCfg := StageBuilderExecCfg(state, b.notifier, b.chainConfig, b.engine, b.vmConfig, b.tmpdir, interrupt, param.PayloadId, txnProvider, b.blockReader)
 	finishCfg := StageBuilderFinishCfg(b.chainConfig, b.engine, state, b.sealCancel, b.blockReader, b.latestBlockBuiltStore)
 
-	if err := createBlock(b.ctx, sd, compositeTx, executionAt, createCfg, b.logger); err != nil {
+	if err := createBlock(ctx, sd, compositeTx, executionAt, createCfg, b.logger); err != nil {
 		return nil, err
 	}
-	if err := execBlock(b.ctx, sd, compositeTx, executionAt, execCfg, b.executeBlockCfg, b.logger); err != nil {
+	if err := execBlock(ctx, sd, compositeTx, executionAt, execCfg, b.executeBlockCfg, b.logger); err != nil {
 		return nil, err
 	}
 	if err := finishBlock(compositeTx, finishCfg, b.logger); err != nil {

--- a/execution/builder/builder.go
+++ b/execution/builder/builder.go
@@ -105,8 +105,8 @@ func (b *Builder) PendingBlockCh() chan *types.Block {
 
 // Build satisfies BlockBuilderFunc. Pass b.Build directly to ExecModule.
 //
-// Everything that can block runs under ctx, so discarding the payload releases the read view and
-// unblocks the transaction provider instead of leaving them to finish on their own.
+// Build passes ctx through the read and execution paths and stops waiting for an asynchronous seal
+// result when the context ends, allowing its deferred read resources to close.
 func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (result *types.BlockWithReceipts, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -178,9 +178,29 @@ func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomi
 	if err := execBlock(ctx, sd, compositeTx, executionAt, execCfg, b.executeBlockCfg, b.logger); err != nil {
 		return nil, err
 	}
-	if err := finishBlock(compositeTx, finishCfg, b.logger); err != nil {
+	if err := finishBlock(ctx, compositeTx, finishCfg, b.logger); err != nil {
 		return nil, err
 	}
 
-	return <-state.BuilderResultCh, nil
+	return waitForBuilderResult(ctx, state.BuilderResultCh)
+}
+
+func waitForBuilderResult(ctx context.Context, results <-chan *types.BlockWithReceipts) (*types.BlockWithReceipts, error) {
+	select {
+	case result := <-results:
+		return result, nil
+	default:
+	}
+
+	select {
+	case result := <-results:
+		return result, nil
+	case <-ctx.Done():
+		select {
+		case result := <-results:
+			return result, nil
+		default:
+			return nil, ctx.Err()
+		}
+	}
 }

--- a/execution/builder/builder_test.go
+++ b/execution/builder/builder_test.go
@@ -54,7 +54,7 @@ func TestBuilder_Build_DBError(t *testing.T) {
 		logger:         log.New(),
 	}
 
-	_, err := b.Build(t.Context(), &Parameters{}, &atomic.Bool{})
+	_, err := b.Build(t.Context(), &Parameters{}, &atomic.Bool{}, func() {})
 	require.ErrorIs(t, err, want)
 }
 

--- a/execution/builder/builder_test.go
+++ b/execution/builder/builder_test.go
@@ -54,7 +54,7 @@ func TestBuilder_Build_DBError(t *testing.T) {
 		logger:         log.New(),
 	}
 
-	_, err := b.Build(t.Context(), &Parameters{}, &atomic.Bool{}, func() {})
+	_, err := b.Build(t.Context(), &Parameters{}, &atomic.Bool{})
 	require.ErrorIs(t, err, want)
 }
 

--- a/execution/builder/builder_test.go
+++ b/execution/builder/builder_test.go
@@ -19,6 +19,7 @@ package builder
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -35,6 +36,17 @@ import (
 type errDB struct {
 	kv.TemporalRoDB // nil embed satisfies the interface; other methods must not be called
 	err             error
+}
+
+type finishOnDoneContext struct {
+	context.Context
+	finish func()
+	once   sync.Once
+}
+
+func (c *finishOnDoneContext) Done() <-chan struct{} {
+	c.once.Do(c.finish)
+	return c.Context.Done()
 }
 
 func (e *errDB) BeginTemporalRo(_ context.Context) (kv.TemporalTx, error) {
@@ -67,4 +79,21 @@ func TestBuilder_PendingBlockCh(t *testing.T) {
 	ch := b.PendingBlockCh()
 	require.NotNil(t, ch)
 	require.Equal(t, ch, b.PendingBlockCh(), "must return the same channel on repeated calls")
+}
+
+func TestWaitForBuilderResultPrefersCompletedPayloadOverCancellation(t *testing.T) {
+	for range 50 {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		want := &types.BlockWithReceipts{}
+		results := make(chan *types.BlockWithReceipts, 1)
+		finishCtx := &finishOnDoneContext{
+			Context: ctx,
+			finish:  func() { results <- want },
+		}
+
+		got, err := waitForBuilderResult(finishCtx, results)
+		require.NoError(t, err)
+		require.Same(t, want, got)
+	}
 }

--- a/execution/builder/builder_test.go
+++ b/execution/builder/builder_test.go
@@ -48,14 +48,13 @@ func TestBuilder_Build_DBError(t *testing.T) {
 
 	want := errors.New("db open failed")
 	b := &Builder{
-		ctx:            context.Background(),
 		db:             &errDB{err: want},
 		builderCfg:     &buildercfg.BuilderConfig{},
 		pendingBlockCh: make(chan *types.Block, 1),
 		logger:         log.New(),
 	}
 
-	_, err := b.Build(&Parameters{}, &atomic.Bool{})
+	_, err := b.Build(t.Context(), &Parameters{}, &atomic.Bool{})
 	require.ErrorIs(t, err, want)
 }
 

--- a/execution/builder/exec.go
+++ b/execution/builder/exec.go
@@ -48,16 +48,17 @@ import (
 )
 
 type BuilderExecCfg struct {
-	builderState BuilderState
-	notifier     stagedsync.ChainEventNotifier
-	chainConfig  *chain.Config
-	engine       rules.Engine
-	blockReader  dbservices.FullBlockReader
-	vmConfig     *vm.Config
-	tmpdir       string
-	interrupt    *atomic.Bool
-	payloadId    uint64
-	txnProvider  txnprovider.TxnProvider
+	builderState    BuilderState
+	notifier        stagedsync.ChainEventNotifier
+	chainConfig     *chain.Config
+	engine          rules.Engine
+	blockReader     dbservices.FullBlockReader
+	vmConfig        *vm.Config
+	tmpdir          string
+	interrupt       *atomic.Bool
+	acknowledgeStop func()
+	payloadId       uint64
+	txnProvider     txnprovider.TxnProvider
 }
 
 func StageBuilderExecCfg(
@@ -68,21 +69,23 @@ func StageBuilderExecCfg(
 	vmConfig *vm.Config,
 	tmpdir string,
 	interrupt *atomic.Bool,
+	acknowledgeStop func(),
 	payloadId uint64,
 	txnProvider txnprovider.TxnProvider,
 	blockReader dbservices.FullBlockReader,
 ) BuilderExecCfg {
 	return BuilderExecCfg{
-		builderState: builderState,
-		notifier:     notifier,
-		chainConfig:  chainConfig,
-		engine:       engine,
-		blockReader:  blockReader,
-		vmConfig:     vmConfig,
-		tmpdir:       tmpdir,
-		interrupt:    interrupt,
-		payloadId:    payloadId,
-		txnProvider:  txnProvider,
+		builderState:    builderState,
+		notifier:        notifier,
+		chainConfig:     chainConfig,
+		engine:          engine,
+		blockReader:     blockReader,
+		vmConfig:        vmConfig,
+		tmpdir:          tmpdir,
+		interrupt:       interrupt,
+		acknowledgeStop: acknowledgeStop,
+		payloadId:       payloadId,
+		txnProvider:     txnProvider,
 	}
 }
 
@@ -187,7 +190,7 @@ func execBlock(ctx context0.Context, sd *execctx.SharedDomains, tx kv.TemporalTx
 		}
 
 		if len(txns) > 0 {
-			logs, stop, err := ba.AddTransactions(ctx, getHeader, txns, coinbase, cfg.vmConfig, ibs, interrupt, logPrefix, logger)
+			logs, stop, err := ba.AddTransactions(ctx, getHeader, txns, coinbase, cfg.vmConfig, ibs, interrupt, cfg.acknowledgeStop, logPrefix, logger)
 			if err != nil {
 				return err
 			}
@@ -208,6 +211,7 @@ func execBlock(ctx context0.Context, sd *execctx.SharedDomains, tx kv.TemporalTx
 			}
 		}
 	}
+	cfg.acknowledgeStop()
 	logger.Info("Block txn filtration", append([]any{"block", current.Header.Number.Uint64()}, filtration.logArgs()...)...)
 
 	metrics.UpdateBlockProducerProductionDelay(current.ParentHeaderTime, current.Header.Number.Uint64(), logger)

--- a/execution/builder/exec.go
+++ b/execution/builder/exec.go
@@ -48,17 +48,16 @@ import (
 )
 
 type BuilderExecCfg struct {
-	builderState    BuilderState
-	notifier        stagedsync.ChainEventNotifier
-	chainConfig     *chain.Config
-	engine          rules.Engine
-	blockReader     dbservices.FullBlockReader
-	vmConfig        *vm.Config
-	tmpdir          string
-	interrupt       *atomic.Bool
-	acknowledgeStop func()
-	payloadId       uint64
-	txnProvider     txnprovider.TxnProvider
+	builderState BuilderState
+	notifier     stagedsync.ChainEventNotifier
+	chainConfig  *chain.Config
+	engine       rules.Engine
+	blockReader  dbservices.FullBlockReader
+	vmConfig     *vm.Config
+	tmpdir       string
+	interrupt    *atomic.Bool
+	payloadId    uint64
+	txnProvider  txnprovider.TxnProvider
 }
 
 func StageBuilderExecCfg(
@@ -69,23 +68,21 @@ func StageBuilderExecCfg(
 	vmConfig *vm.Config,
 	tmpdir string,
 	interrupt *atomic.Bool,
-	acknowledgeStop func(),
 	payloadId uint64,
 	txnProvider txnprovider.TxnProvider,
 	blockReader dbservices.FullBlockReader,
 ) BuilderExecCfg {
 	return BuilderExecCfg{
-		builderState:    builderState,
-		notifier:        notifier,
-		chainConfig:     chainConfig,
-		engine:          engine,
-		blockReader:     blockReader,
-		vmConfig:        vmConfig,
-		tmpdir:          tmpdir,
-		interrupt:       interrupt,
-		acknowledgeStop: acknowledgeStop,
-		payloadId:       payloadId,
-		txnProvider:     txnProvider,
+		builderState: builderState,
+		notifier:     notifier,
+		chainConfig:  chainConfig,
+		engine:       engine,
+		blockReader:  blockReader,
+		vmConfig:     vmConfig,
+		tmpdir:       tmpdir,
+		interrupt:    interrupt,
+		payloadId:    payloadId,
+		txnProvider:  txnProvider,
 	}
 }
 
@@ -190,7 +187,7 @@ func execBlock(ctx context0.Context, sd *execctx.SharedDomains, tx kv.TemporalTx
 		}
 
 		if len(txns) > 0 {
-			logs, stop, err := ba.AddTransactions(ctx, getHeader, txns, coinbase, cfg.vmConfig, ibs, interrupt, cfg.acknowledgeStop, logPrefix, logger)
+			logs, stop, err := ba.AddTransactions(ctx, getHeader, txns, coinbase, cfg.vmConfig, ibs, interrupt, logPrefix, logger)
 			if err != nil {
 				return err
 			}
@@ -211,7 +208,6 @@ func execBlock(ctx context0.Context, sd *execctx.SharedDomains, tx kv.TemporalTx
 			}
 		}
 	}
-	cfg.acknowledgeStop()
 	logger.Info("Block txn filtration", append([]any{"block", current.Header.Number.Uint64()}, filtration.logArgs()...)...)
 
 	metrics.UpdateBlockProducerProductionDelay(current.ParentHeaderTime, current.Header.Number.Uint64(), logger)

--- a/execution/builder/finish.go
+++ b/execution/builder/finish.go
@@ -61,9 +61,6 @@ func StageBuilderFinishCfg(
 
 func finishBlock(ctx context.Context, tx kv.TemporalTx, cfg BuilderFinishCfg, logger log.Logger) error {
 	const logPrefix = "BuilderFinish"
-	if err := ctx.Err(); err != nil {
-		return err
-	}
 	current := cfg.builderState.BuiltBlock
 
 	// Short circuit when receiving duplicate result caused by resubmitting.

--- a/execution/builder/finish.go
+++ b/execution/builder/finish.go
@@ -61,6 +61,9 @@ func StageBuilderFinishCfg(
 
 func finishBlock(ctx context.Context, tx kv.TemporalTx, cfg BuilderFinishCfg, logger log.Logger) error {
 	const logPrefix = "BuilderFinish"
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	current := cfg.builderState.BuiltBlock
 
 	// Short circuit when receiving duplicate result caused by resubmitting.

--- a/execution/builder/finish.go
+++ b/execution/builder/finish.go
@@ -17,6 +17,7 @@
 package builder
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/erigontech/erigon/common/dbg"
@@ -58,8 +59,11 @@ func StageBuilderFinishCfg(
 	}
 }
 
-func finishBlock(tx kv.TemporalTx, cfg BuilderFinishCfg, logger log.Logger) error {
+func finishBlock(ctx context.Context, tx kv.TemporalTx, cfg BuilderFinishCfg, logger log.Logger) error {
 	const logPrefix = "BuilderFinish"
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	current := cfg.builderState.BuiltBlock
 
 	// Short circuit when receiving duplicate result caused by resubmitting.
@@ -86,6 +90,9 @@ func finishBlock(tx kv.TemporalTx, cfg BuilderFinishCfg, logger log.Logger) erro
 	blockWithReceipts := &types.BlockWithReceipts{Block: block, Receipts: current.Receipts, Requests: current.Requests, BlockAccessList: current.BlockAccessList}
 	if dbg.LogHashMismatchReason() {
 		ethutils.LogReceipts(log.LvlInfo, "Block built", current.Receipts, current.Txns, cfg.chainConfig, current.Header, logger)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	*current = exec.AssembledBlock{} // hack to clean global data
 

--- a/execution/builder/finish_test.go
+++ b/execution/builder/finish_test.go
@@ -88,4 +88,7 @@ func TestFinishBlockDoesNotSealWhenCanceledDuringAssembly(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.False(t, engine.called.Load())
 	require.Nil(t, store.BlockBuilt())
+	// Exactly two checks means the cancellation fired at the mid-assembly check: an extra Err()
+	// call added upstream would silently turn this into a copy of the entry-check test.
+	require.Equal(t, uint32(2), testCtx.checks.Load())
 }

--- a/execution/builder/finish_test.go
+++ b/execution/builder/finish_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/exec"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+type recordingSealEngine struct {
+	rules.Engine
+	called atomic.Bool
+}
+
+func (e *recordingSealEngine) Seal(rules.ChainHeaderReader, *types.BlockWithReceipts, chan<- *types.BlockWithReceipts, <-chan struct{}) error {
+	e.called.Store(true)
+	return nil
+}
+
+func TestFinishBlockDoesNotSealAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	engine := &recordingSealEngine{}
+	store := NewLatestBlockBuiltStore()
+	cfg := BuilderFinishCfg{
+		engine: engine,
+		builderState: BuilderState{
+			BuiltBlock: &exec.AssembledBlock{Header: &types.Header{}},
+		},
+		latestBlockBuiltStore: store,
+	}
+
+	err := finishBlock(ctx, nil, cfg, log.Root())
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, engine.called.Load())
+	require.Nil(t, store.BlockBuilt())
+}

--- a/execution/builder/finish_test.go
+++ b/execution/builder/finish_test.go
@@ -34,6 +34,19 @@ type recordingSealEngine struct {
 	called atomic.Bool
 }
 
+type cancelOnSecondCheckContext struct {
+	context.Context
+	cancel context.CancelFunc
+	checks atomic.Uint32
+}
+
+func (c *cancelOnSecondCheckContext) Err() error {
+	if c.checks.Add(1) == 2 {
+		c.cancel()
+	}
+	return c.Context.Err()
+}
+
 func (e *recordingSealEngine) Seal(rules.ChainHeaderReader, *types.BlockWithReceipts, chan<- *types.BlockWithReceipts, <-chan struct{}) error {
 	e.called.Store(true)
 	return nil
@@ -45,6 +58,24 @@ func TestFinishBlockDoesNotSealAfterCancellation(t *testing.T) {
 	engine := &recordingSealEngine{}
 	store := NewLatestBlockBuiltStore()
 	cfg := BuilderFinishCfg{
+		engine:                engine,
+		latestBlockBuiltStore: store,
+	}
+
+	err := finishBlock(ctx, nil, cfg, log.Root())
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, engine.called.Load())
+	require.Nil(t, store.BlockBuilt())
+}
+
+func TestFinishBlockDoesNotSealWhenCanceledDuringAssembly(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	testCtx := &cancelOnSecondCheckContext{Context: ctx, cancel: cancel}
+	engine := &recordingSealEngine{}
+	store := NewLatestBlockBuiltStore()
+	cfg := BuilderFinishCfg{
 		engine: engine,
 		builderState: BuilderState{
 			BuiltBlock: &exec.AssembledBlock{Header: &types.Header{}},
@@ -52,7 +83,7 @@ func TestFinishBlockDoesNotSealAfterCancellation(t *testing.T) {
 		latestBlockBuiltStore: store,
 	}
 
-	err := finishBlock(ctx, nil, cfg, log.Root())
+	err := finishBlock(testCtx, nil, cfg, log.Root())
 
 	require.ErrorIs(t, err, context.Canceled)
 	require.False(t, engine.called.Load())

--- a/execution/builder/parameters.go
+++ b/execution/builder/parameters.go
@@ -43,8 +43,8 @@ type Parameters struct {
 	ExtraData []byte
 }
 
-// Copy returns parameters that no longer share anything mutable with the receiver, so a caller
-// cannot change what a builder was asked for after the fact. Reference-typed fields added to
+// Copy returns parameters that share nothing mutable with the receiver, except CustomTxnProvider:
+// a provider is a live object and stays shared by reference. Reference-typed fields added to
 // Parameters have to be handled here; TestParametersCopyCoversEveryField fails if one is not.
 func (p *Parameters) Copy() *Parameters {
 	if p == nil {

--- a/execution/builder/parameters.go
+++ b/execution/builder/parameters.go
@@ -17,6 +17,8 @@
 package builder
 
 import (
+	"bytes"
+
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/txnprovider"
@@ -39,4 +41,37 @@ type Parameters struct {
 	CustomTxnProvider txnprovider.TxnProvider
 	// ExtraData overrides the builder's configured extra data when non-nil.
 	ExtraData []byte
+}
+
+// Copy returns parameters that no longer share anything mutable with the receiver, so a caller
+// cannot change what a builder was asked for after the fact. Reference-typed fields added to
+// Parameters have to be handled here; TestParametersCopyCoversEveryField fails if one is not.
+func (p *Parameters) Copy() *Parameters {
+	if p == nil {
+		return nil
+	}
+	copied := *p
+	copied.ExtraData = bytes.Clone(p.ExtraData)
+	if p.Withdrawals != nil {
+		copied.Withdrawals = make([]*types.Withdrawal, len(p.Withdrawals))
+		for i, withdrawal := range p.Withdrawals {
+			if withdrawal != nil {
+				w := *withdrawal
+				copied.Withdrawals[i] = &w
+			}
+		}
+	}
+	if p.ParentBeaconBlockRoot != nil {
+		root := *p.ParentBeaconBlockRoot
+		copied.ParentBeaconBlockRoot = &root
+	}
+	if p.SlotNumber != nil {
+		slot := *p.SlotNumber
+		copied.SlotNumber = &slot
+	}
+	if p.TargetGasLimit != nil {
+		limit := *p.TargetGasLimit
+		copied.TargetGasLimit = &limit
+	}
+	return &copied
 }

--- a/execution/builder/parameters_test.go
+++ b/execution/builder/parameters_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+func TestParametersCopyKeepsNothingShared(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, (*Parameters)(nil).Copy())
+
+	// An empty slice is not the same request as an absent one, so the distinction has to survive.
+	empty := (&Parameters{Withdrawals: []*types.Withdrawal{}, ExtraData: []byte{}}).Copy()
+	require.NotNil(t, empty.Withdrawals)
+	require.NotNil(t, empty.ExtraData)
+
+	root := common.Hash{0x01}
+	slot := uint64(2)
+	gasLimit := uint64(3)
+	params := &Parameters{
+		Withdrawals:           []*types.Withdrawal{nil, {Index: 4}},
+		ParentBeaconBlockRoot: &root,
+		SlotNumber:            &slot,
+		TargetGasLimit:        &gasLimit,
+		ExtraData:             []byte{5},
+	}
+	copied := params.Copy()
+
+	params.Withdrawals[1].Index = 40
+	root[0] = 10
+	slot = 20
+	gasLimit = 30
+	params.ExtraData[0] = 50
+
+	require.Nil(t, copied.Withdrawals[0])
+	require.Equal(t, uint64(4), copied.Withdrawals[1].Index)
+	require.Equal(t, common.Hash{0x01}, *copied.ParentBeaconBlockRoot)
+	require.Equal(t, uint64(2), *copied.SlotNumber)
+	require.Equal(t, uint64(3), *copied.TargetGasLimit)
+	require.Equal(t, byte(5), copied.ExtraData[0])
+}
+
+func TestParametersCopyCoversEveryField(t *testing.T) {
+	t.Parallel()
+
+	// Copy has to be revisited whenever a reference-typed field is added, and nothing else will say
+	// so: a shallow copy of a new slice or pointer compiles and silently shares it.
+	require.Equal(t, 11, reflect.TypeFor[Parameters]().NumField(),
+		"Parameters gained or lost a field; check whether Copy has to copy it")
+}

--- a/execution/exec/block_assembler.go
+++ b/execution/exec/block_assembler.go
@@ -173,6 +173,7 @@ func (ba *BlockAssembler) AddTransactions(
 	vmConfig *vm.Config,
 	ibs *state.IntraBlockState,
 	interrupt *atomic.Bool,
+	acknowledgeStop func(),
 	logPrefix string,
 	logger log.Logger) (types.Logs, bool, error) {
 
@@ -317,6 +318,7 @@ LOOP:
 		}
 
 		if interrupt != nil && interrupt.Load() && stopped == nil {
+			acknowledgeStop()
 			logger.Debug("Transaction adding was requested to stop", "payload", ba.PayloadId)
 			// ensure we run for at least 500ms after the request to stop comes in from GetPayload
 			stopped = time.NewTicker(500 * time.Millisecond)

--- a/execution/exec/block_assembler.go
+++ b/execution/exec/block_assembler.go
@@ -173,7 +173,6 @@ func (ba *BlockAssembler) AddTransactions(
 	vmConfig *vm.Config,
 	ibs *state.IntraBlockState,
 	interrupt *atomic.Bool,
-	acknowledgeStop func(),
 	logPrefix string,
 	logger log.Logger) (types.Logs, bool, error) {
 
@@ -318,7 +317,6 @@ LOOP:
 		}
 
 		if interrupt != nil && interrupt.Load() && stopped == nil {
-			acknowledgeStop()
 			logger.Debug("Transaction adding was requested to stop", "payload", ba.PayloadId)
 			// ensure we run for at least 500ms after the request to stop comes in from GetPayload
 			stopped = time.NewTicker(500 * time.Millisecond)

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -89,16 +89,32 @@ type builderEntry struct {
 	params  *builder.Parameters
 }
 
-// isCurrentFor reports whether this entry is the one its timestamp resolves to, which is the one a
-// proposal for that timestamp is waiting on.
-func (e *ExecModule) isCurrentFor(id uint64, entry *builderEntry) bool {
+// isIndexedFor reports whether the timestamp index still resolves to this entry, which is what has
+// to be cleaned up when the entry goes.
+func (e *ExecModule) isIndexedFor(id uint64, entry *builderEntry) bool {
 	return entry != nil && entry.params != nil && e.buildersByTimestamp[entry.params.Timestamp] == id
+}
+
+// isLiveProposalTarget reports whether an entry is what a proposal is still waiting on: the builder
+// its timestamp resolves to, for a slot that has not passed. Being indexed is not enough on its own,
+// because every slot has its own timestamp and successful entries stay indexed: protecting all of
+// them would mean never evicting anything.
+func (e *ExecModule) isLiveProposalTarget(id uint64, entry *builderEntry, now time.Time) bool {
+	if !e.isIndexedFor(id, entry) {
+		return false
+	}
+	// Compared as seconds rather than times, so an implausible timestamp wraps into "not live"
+	// instead of overflowing into the past.
+	nowSeconds := uint64(max(now.Unix(), 0))
+	slotSeconds := e.config.SecondsPerSlot()
+	timestamp := entry.params.Timestamp
+	return timestamp+slotSeconds > nowSeconds && timestamp <= nowSeconds+2*slotSeconds
 }
 
 // dropBuilder removes a builder and releases whatever it is holding.
 func (e *ExecModule) dropBuilder(id uint64, entry *builderEntry) {
 	if entry != nil {
-		if e.isCurrentFor(id, entry) {
+		if e.isIndexedFor(id, entry) {
 			delete(e.buildersByTimestamp, entry.params.Timestamp)
 		}
 		if entry.builder != nil {
@@ -108,18 +124,21 @@ func (e *ExecModule) dropBuilder(id uint64, entry *builderEntry) {
 	delete(e.builders, id)
 }
 
-// evictOldBuilders drops the oldest builders so that at most MaxBuilders - 1 remain, skipping any
-// that a timestamp still resolves to: those are what a proposal is waiting on, and being old by id
-// says nothing about that. If every remaining builder is current the count is left above the bound,
-// which is the safer of the two ways to be wrong.
+// evictOldBuilders drops the oldest builders so that at most MaxBuilders - 1 remain, skipping only
+// those a proposal is still waiting on. Being old by id says nothing about that, and there are only
+// ever a couple of live targets, so the bound holds.
 func (e *ExecModule) evictOldBuilders() {
 	remaining := len(e.builders) - engine_helpers.MaxBuilders + 1
+	if remaining <= 0 {
+		return
+	}
+	now := time.Now()
 	for _, id := range common.SortedKeys(e.builders) {
 		if remaining <= 0 {
 			return
 		}
 		entry := e.builders[id]
-		if e.isCurrentFor(id, entry) {
+		if e.isLiveProposalTarget(id, entry, now) {
 			continue
 		}
 		e.dropBuilder(id, entry)

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -245,6 +245,10 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 		return AssembledBlockResult{Unknown: true}, nil
 	}
 	blockWithReceipts, err := entry.builder.Stop(ctx)
+	if entry.builder.Discarded() {
+		e.dropBuilder(payloadID, entry)
+		return AssembledBlockResult{Unknown: true}, nil
+	}
 	if err != nil {
 		// Stop reports the caller's wait expiring and the build's own failure through the same
 		// error, and a build can fail with a context error of its own - a transaction provider

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -17,6 +17,7 @@
 package execmodule
 
 import (
+	"bytes"
 	"context"
 	"reflect"
 	"time"
@@ -60,16 +61,75 @@ func buildDuration(payloadTimestamp uint64, now time.Time, secondsPerSlot uint64
 	return min(max(d, slot/4), 2*slot)
 }
 
+func cloneBuilderParameters(params *builder.Parameters) *builder.Parameters {
+	if params == nil {
+		return nil
+	}
+	cloned := *params
+	cloned.ExtraData = bytes.Clone(params.ExtraData)
+	if params.Withdrawals != nil {
+		cloned.Withdrawals = make([]*types.Withdrawal, len(params.Withdrawals))
+		for i, withdrawal := range params.Withdrawals {
+			if withdrawal != nil {
+				copy := *withdrawal
+				cloned.Withdrawals[i] = &copy
+			}
+		}
+	}
+	if params.ParentBeaconBlockRoot != nil {
+		copy := *params.ParentBeaconBlockRoot
+		cloned.ParentBeaconBlockRoot = &copy
+	}
+	if params.SlotNumber != nil {
+		copy := *params.SlotNumber
+		cloned.SlotNumber = &copy
+	}
+	if params.TargetGasLimit != nil {
+		copy := *params.TargetGasLimit
+		cloned.TargetGasLimit = &copy
+	}
+	return &cloned
+}
+
+// builderEntry keeps a builder with the parameters and timestamp it was created for, so the
+// three cannot drift apart and eviction can drop the timestamp index without scanning it.
+type builderEntry struct {
+	builder   *builder.BlockBuilder
+	params    *builder.Parameters
+	timestamp uint64
+}
+
+func (e *ExecModule) dropBuilder(id uint64, entry *builderEntry) {
+	if e.buildersByTimestamp[entry.timestamp] == id {
+		delete(e.buildersByTimestamp, entry.timestamp)
+	}
+	delete(e.builders, id)
+}
+
 func (e *ExecModule) evictOldBuilders() {
 	ids := common.SortedKeys(e.builders)
 
 	// remove old builders so that at most MaxBuilders - 1 remain
 	for i := 0; i <= len(e.builders)-engine_helpers.MaxBuilders; i++ {
-		delete(e.builders, ids[i])
+		id := ids[i]
+		if old := e.builders[id]; old != nil {
+			if old.builder != nil {
+				old.builder.Cancel()
+			}
+			if e.buildersByTimestamp[old.timestamp] == id {
+				delete(e.buildersByTimestamp, old.timestamp)
+			}
+		}
+		delete(e.builders, id)
 	}
 }
 
 func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Parameters) (AssembleBlockResult, error) {
+	// Cancellation is checked first so an expired request reports why it stopped instead of
+	// masquerading as contention, which callers retry.
+	if err := ctx.Err(); err != nil {
+		return AssembleBlockResult{}, err
+	}
 	if !e.semaphore.TryAcquire(1) {
 		return AssembleBlockResult{Busy: true}, nil
 	}
@@ -79,23 +139,35 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Paramete
 		return AssembleBlockResult{}, err
 	}
 
-	// First check if we're already building a block with the requested parameters
-	if e.lastParameters != nil {
-		params.PayloadId = e.lastParameters.PayloadId
-		if reflect.DeepEqual(e.lastParameters, params) {
-			e.logger.Info("[ForkChoiceUpdated] duplicate build request")
-			return AssembleBlockResult{PayloadID: e.lastParameters.PayloadId}, nil
+	// A stopped builder is still worth reusing: it holds the payload it was stopped for, which is
+	// exactly what a repeated request is asking for. Only a failed one has to be passed over.
+	if previousID, ok := e.buildersByTimestamp[params.Timestamp]; ok {
+		if previous := e.builders[previousID]; previous != nil && previous.builder != nil && !previous.builder.Failed() {
+			params.PayloadId = previousID
+			if reflect.DeepEqual(previous.params, params) {
+				e.logger.Info("[ForkChoiceUpdated] duplicate build request")
+				return AssembleBlockResult{PayloadID: previousID}, nil
+			}
 		}
 	}
-
-	// Initiate payload building
+	// A superseded builder keeps running to its own deadline. The timestamp index moves to the new
+	// one, so nothing reaches it by dedup, while an id already handed out goes on answering with a
+	// payload that is still growing.
 	e.evictOldBuilders()
 
 	e.nextPayloadId++
 	params.PayloadId = e.nextPayloadId
-	e.lastParameters = params
+	ownedParams := cloneBuilderParameters(params)
 
-	e.builders[e.nextPayloadId] = builder.NewBlockBuilder(e.builderFunc, params, buildDuration(params.Timestamp, time.Now(), e.config.SecondsPerSlot()))
+	if e.buildersByTimestamp == nil {
+		e.buildersByTimestamp = make(map[uint64]uint64)
+	}
+	e.builders[e.nextPayloadId] = &builderEntry{
+		builder:   builder.NewBlockBuilder(e.builderFunc, ownedParams, buildDuration(params.Timestamp, time.Now(), e.config.SecondsPerSlot())),
+		params:    ownedParams,
+		timestamp: params.Timestamp,
+	}
+	e.buildersByTimestamp[params.Timestamp] = e.nextPayloadId
 	e.logger.Info("[ForkChoiceUpdated] BlockBuilder added", "payload", e.nextPayloadId)
 
 	return AssembleBlockResult{PayloadID: e.nextPayloadId}, nil
@@ -118,17 +190,25 @@ func blockValue(br *types.BlockWithReceipts, baseFee *uint256.Int) *uint256.Int 
 }
 
 func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (AssembledBlockResult, error) {
+	if err := ctx.Err(); err != nil {
+		return AssembledBlockResult{}, err
+	}
 	if !e.semaphore.TryAcquire(1) {
 		return AssembledBlockResult{Busy: true}, nil
 	}
 	defer e.semaphore.Release(1)
 
-	bldr, ok := e.builders[payloadID]
-	if !ok {
+	entry, ok := e.builders[payloadID]
+	if !ok || entry == nil || entry.builder == nil {
 		return AssembledBlockResult{}, nil
 	}
-	blockWithReceipts, err := bldr.Stop(ctx)
+	blockWithReceipts, err := entry.builder.Stop(ctx)
 	if err != nil {
+		// Keeping a failed entry would hand the same latched error to every retry. A caller whose
+		// own context expired says nothing about the builder.
+		if ctx.Err() == nil {
+			e.dropBuilder(payloadID, entry)
+		}
 		e.logger.Error("Failed to build PoS block", "err", err)
 		return AssembledBlockResult{}, err
 	}

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -111,8 +111,10 @@ func (e *ExecModule) isLiveProposalTarget(id uint64, entry *builderEntry, now ti
 	if !e.isIndexedFor(id, entry) {
 		return false
 	}
-	// A builder that can no longer produce is not worth protecting, however live its slot.
-	if entry.builder == nil || entry.builder.Failed() || entry.builder.Discarded() {
+	// A builder that can no longer serve a payload is not worth protecting, however live its slot.
+	// A discarded one that already latched a completed payload still serves it to getPayload.
+	if entry.builder == nil || entry.builder.Failed() ||
+		(entry.builder.Discarded() && entry.builder.Block() == nil) {
 		return false
 	}
 	// Compared as seconds rather than times, so an implausible timestamp wraps into "not live"
@@ -239,15 +241,17 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 		return AssembledBlockResult{Unknown: true}, nil
 	}
 	blockWithReceipts, err := entry.builder.Stop(ctx)
+	if err != nil && entry.builder.Finished() {
+		// The build finished while Stop was returning the caller's expiry, so re-read its own
+		// latched outcome instead of reporting the caller's context error as the build's.
+		blockWithReceipts, err = entry.builder.Stop(context.Background())
+	}
 	if errors.Is(err, builder.ErrDiscarded) {
 		e.dropBuilder(payloadID, entry)
 		return AssembledBlockResult{Unknown: true}, nil
 	}
 	if err != nil {
-		// Stop reports the caller's wait expiring and the build's own failure through the same
-		// error, and a build can fail with a context error of its own - a transaction provider
-		// giving up, say. Only the builder knows which happened, so ask it rather than guess from
-		// the error: a caller that gave up leaves a builder still worth collecting.
+		// Still running, so the error is the caller's own expiry: the builder stays collectable.
 		if !entry.builder.Failed() {
 			return AssembledBlockResult{}, err
 		}

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -19,6 +19,7 @@ package execmodule
 import (
 	"bytes"
 	"context"
+	"errors"
 	"reflect"
 	"time"
 
@@ -114,7 +115,7 @@ func (e *ExecModule) evictOldBuilders() {
 		id := ids[i]
 		if old := e.builders[id]; old != nil {
 			if old.builder != nil {
-				old.builder.Cancel()
+				old.builder.Discard()
 			}
 			if e.buildersByTimestamp[old.timestamp] == id {
 				delete(e.buildersByTimestamp, old.timestamp)
@@ -163,7 +164,7 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Paramete
 		e.buildersByTimestamp = make(map[uint64]uint64)
 	}
 	e.builders[e.nextPayloadId] = &builderEntry{
-		builder:   builder.NewBlockBuilder(e.builderFunc, ownedParams, buildDuration(params.Timestamp, time.Now(), e.config.SecondsPerSlot())),
+		builder:   builder.NewBlockBuilder(e.bacgroundCtx, e.builderFunc, ownedParams, buildDuration(params.Timestamp, time.Now(), e.config.SecondsPerSlot())),
 		params:    ownedParams,
 		timestamp: params.Timestamp,
 	}
@@ -204,12 +205,13 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 	}
 	blockWithReceipts, err := entry.builder.Stop(ctx)
 	if err != nil {
-		// A caller that gave up says nothing about the builder, which keeps running and may still
-		// be collected. Only a builder that actually failed is reported and dropped, so its latched
-		// error stops being handed to every retry.
-		if ctx.Err() != nil {
+		// The caller gave up waiting; nothing about the build itself went wrong. Reading that from
+		// the returned error rather than the ambient context keeps the two from drifting apart
+		// between Stop returning and this check.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return AssembledBlockResult{}, err
 		}
+		// Keeping a failed entry would hand its latched error to every retry.
 		e.dropBuilder(payloadID, entry)
 		e.logger.Error("Failed to build PoS block", "err", err)
 		return AssembledBlockResult{}, err

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -17,7 +17,6 @@
 package execmodule
 
 import (
-	"bytes"
 	"context"
 	"reflect"
 	"time"
@@ -61,36 +60,6 @@ func buildDuration(payloadTimestamp uint64, now time.Time, secondsPerSlot uint64
 	return min(max(d, slot/4), 2*slot)
 }
 
-func cloneBuilderParameters(params *builder.Parameters) *builder.Parameters {
-	if params == nil {
-		return nil
-	}
-	cloned := *params
-	cloned.ExtraData = bytes.Clone(params.ExtraData)
-	if params.Withdrawals != nil {
-		cloned.Withdrawals = make([]*types.Withdrawal, len(params.Withdrawals))
-		for i, withdrawal := range params.Withdrawals {
-			if withdrawal != nil {
-				copy := *withdrawal
-				cloned.Withdrawals[i] = &copy
-			}
-		}
-	}
-	if params.ParentBeaconBlockRoot != nil {
-		copy := *params.ParentBeaconBlockRoot
-		cloned.ParentBeaconBlockRoot = &copy
-	}
-	if params.SlotNumber != nil {
-		copy := *params.SlotNumber
-		cloned.SlotNumber = &copy
-	}
-	if params.TargetGasLimit != nil {
-		copy := *params.TargetGasLimit
-		cloned.TargetGasLimit = &copy
-	}
-	return &cloned
-}
-
 // sameBuildRequest reports whether a request is asking for the payload another one is already
 // building. A custom transaction provider is never treated as the same request: it is stateful and
 // hands its transactions over once, so a second request carrying one is not asking for what the
@@ -102,39 +71,59 @@ func sameBuildRequest(previous, current *builder.Parameters) bool {
 	if previous.CustomTxnProvider != nil || current.CustomTxnProvider != nil {
 		return false
 	}
-	return reflect.DeepEqual(previous, current)
+	// The payload id is this module's to assign, so it is not part of the question, and comparing
+	// copies keeps the caller's parameters out of it.
+	withoutID := func(p *builder.Parameters) builder.Parameters {
+		stripped := *p
+		stripped.PayloadId = 0
+		return stripped
+	}
+	previousWithoutID, currentWithoutID := withoutID(previous), withoutID(current)
+	return reflect.DeepEqual(&previousWithoutID, &currentWithoutID)
 }
 
-// builderEntry keeps a builder with the parameters and timestamp it was created for, so the
-// three cannot drift apart and eviction can drop the timestamp index without scanning it.
+// builderEntry keeps a builder with the immutable parameters it was created for, so the two cannot
+// drift apart and eviction can drop the timestamp index without scanning it.
 type builderEntry struct {
-	builder   *builder.BlockBuilder
-	params    *builder.Parameters
-	timestamp uint64
+	builder *builder.BlockBuilder
+	params  *builder.Parameters
 }
 
+// isCurrentFor reports whether this entry is the one its timestamp resolves to, which is the one a
+// proposal for that timestamp is waiting on.
+func (e *ExecModule) isCurrentFor(id uint64, entry *builderEntry) bool {
+	return entry != nil && entry.params != nil && e.buildersByTimestamp[entry.params.Timestamp] == id
+}
+
+// dropBuilder removes a builder and releases whatever it is holding.
 func (e *ExecModule) dropBuilder(id uint64, entry *builderEntry) {
-	if e.buildersByTimestamp[entry.timestamp] == id {
-		delete(e.buildersByTimestamp, entry.timestamp)
+	if entry != nil {
+		if e.isCurrentFor(id, entry) {
+			delete(e.buildersByTimestamp, entry.params.Timestamp)
+		}
+		if entry.builder != nil {
+			entry.builder.Discard()
+		}
 	}
 	delete(e.builders, id)
 }
 
+// evictOldBuilders drops the oldest builders so that at most MaxBuilders - 1 remain, skipping any
+// that a timestamp still resolves to: those are what a proposal is waiting on, and being old by id
+// says nothing about that. If every remaining builder is current the count is left above the bound,
+// which is the safer of the two ways to be wrong.
 func (e *ExecModule) evictOldBuilders() {
-	ids := common.SortedKeys(e.builders)
-
-	// remove old builders so that at most MaxBuilders - 1 remain
-	for i := 0; i <= len(e.builders)-engine_helpers.MaxBuilders; i++ {
-		id := ids[i]
-		if old := e.builders[id]; old != nil {
-			if old.builder != nil {
-				old.builder.Discard()
-			}
-			if e.buildersByTimestamp[old.timestamp] == id {
-				delete(e.buildersByTimestamp, old.timestamp)
-			}
+	remaining := len(e.builders) - engine_helpers.MaxBuilders + 1
+	for _, id := range common.SortedKeys(e.builders) {
+		if remaining <= 0 {
+			return
 		}
-		delete(e.builders, id)
+		entry := e.builders[id]
+		if e.isCurrentFor(id, entry) {
+			continue
+		}
+		e.dropBuilder(id, entry)
+		remaining--
 	}
 }
 
@@ -157,7 +146,6 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Paramete
 	// exactly what a repeated request is asking for. Only a failed one has to be passed over.
 	if previousID, ok := e.buildersByTimestamp[params.Timestamp]; ok {
 		if previous := e.builders[previousID]; previous != nil && previous.builder != nil && !previous.builder.Failed() {
-			params.PayloadId = previousID
 			if sameBuildRequest(previous.params, params) {
 				e.logger.Info("[ForkChoiceUpdated] duplicate build request")
 				return AssembleBlockResult{PayloadID: previousID}, nil
@@ -171,15 +159,11 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Paramete
 
 	e.nextPayloadId++
 	params.PayloadId = e.nextPayloadId
-	ownedParams := cloneBuilderParameters(params)
+	ownedParams := params.Copy()
 
-	if e.buildersByTimestamp == nil {
-		e.buildersByTimestamp = make(map[uint64]uint64)
-	}
 	e.builders[e.nextPayloadId] = &builderEntry{
-		builder:   builder.NewBlockBuilder(e.bacgroundCtx, e.builderFunc, ownedParams, buildDuration(params.Timestamp, time.Now(), e.config.SecondsPerSlot())),
-		params:    ownedParams,
-		timestamp: params.Timestamp,
+		builder: builder.NewBlockBuilder(e.bacgroundCtx, e.builderFunc, ownedParams, buildDuration(params.Timestamp, time.Now(), e.config.SecondsPerSlot())),
+		params:  ownedParams,
 	}
 	e.buildersByTimestamp[params.Timestamp] = e.nextPayloadId
 	e.logger.Info("[ForkChoiceUpdated] BlockBuilder added", "payload", e.nextPayloadId)
@@ -214,7 +198,7 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 
 	entry, ok := e.builders[payloadID]
 	if !ok || entry == nil || entry.builder == nil {
-		return AssembledBlockResult{}, nil
+		return AssembledBlockResult{Unknown: true}, nil
 	}
 	blockWithReceipts, err := entry.builder.Stop(ctx)
 	if err != nil {

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -122,7 +122,7 @@ func (e *ExecModule) isLiveProposalTarget(id uint64, entry *builderEntry, now ti
 	return timestamp+slotSeconds > nowSeconds && timestamp <= nowSeconds+2*slotSeconds
 }
 
-// dropBuilder removes a builder and releases whatever it is holding.
+// dropBuilder removes and discards a builder.
 func (e *ExecModule) dropBuilder(id uint64, entry *builderEntry) {
 	if entry != nil {
 		if e.isIndexedFor(id, entry) {
@@ -135,9 +135,8 @@ func (e *ExecModule) dropBuilder(id uint64, entry *builderEntry) {
 	delete(e.builders, id)
 }
 
-// evictOldBuilders drops the oldest builders so that at most MaxBuilders - 1 remain, skipping only
-// those a proposal is still waiting on. Being old by id says nothing about that, and there are only
-// ever a couple of live targets, so the bound holds.
+// evictOldBuilders makes room for one builder by dropping the oldest entries, except those a live
+// proposal is still waiting on.
 func (e *ExecModule) evictOldBuilders() {
 	remaining := len(e.builders) - engine_helpers.MaxBuilders + 1
 	if remaining <= 0 {
@@ -159,8 +158,8 @@ func (e *ExecModule) evictOldBuilders() {
 
 func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Parameters) (AssembleBlockResult, error) {
 	// Cancellation is checked first so an expired request reports why it stopped instead of
-	// looking like contention, which callers retry. The module's own context is checked too: a
-	// builder born after shutdown can only fail, yet its id would be handed out.
+	// looking like contention, which callers retry. The module context check avoids starting work
+	// after shutdown has already been observed.
 	if err := ctx.Err(); err != nil {
 		return AssembleBlockResult{}, err
 	}

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -60,6 +60,13 @@ func buildDuration(payloadTimestamp uint64, now time.Time, secondsPerSlot uint64
 	return min(max(d, slot/4), 2*slot)
 }
 
+// stopGraceDuration returns how long a builder that reached its budget may take to finish up - the
+// transaction in flight, the packing tail, payload finalization - before it is taken as stuck and
+// discarded.
+func stopGraceDuration(secondsPerSlot uint64) time.Duration {
+	return time.Duration(secondsPerSlot) * time.Second / 2
+}
+
 // sameBuildRequest reports whether a request is asking for the payload another one is already
 // building. A custom transaction provider is never treated as the same request: it is stateful and
 // hands its transactions over once, so a second request carrying one is not asking for what the
@@ -101,6 +108,10 @@ func (e *ExecModule) isIndexedFor(id uint64, entry *builderEntry) bool {
 // them would mean never evicting anything.
 func (e *ExecModule) isLiveProposalTarget(id uint64, entry *builderEntry, now time.Time) bool {
 	if !e.isIndexedFor(id, entry) {
+		return false
+	}
+	// A builder that can no longer produce is not worth protecting, however live its slot.
+	if entry.builder == nil || entry.builder.Failed() || entry.builder.Discarded() {
 		return false
 	}
 	// Compared as seconds rather than times, so an implausible timestamp wraps into "not live"
@@ -148,8 +159,12 @@ func (e *ExecModule) evictOldBuilders() {
 
 func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Parameters) (AssembleBlockResult, error) {
 	// Cancellation is checked first so an expired request reports why it stopped instead of
-	// masquerading as contention, which callers retry.
+	// looking like contention, which callers retry. The module's own context is checked too: a
+	// builder born after shutdown can only fail, yet its id would be handed out.
 	if err := ctx.Err(); err != nil {
+		return AssembleBlockResult{}, err
+	}
+	if err := e.backgroundCtx.Err(); err != nil {
 		return AssembleBlockResult{}, err
 	}
 	if !e.semaphore.TryAcquire(1) {
@@ -162,9 +177,11 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Paramete
 	}
 
 	// A stopped builder is still worth reusing: it holds the payload it was stopped for, which is
-	// exactly what a repeated request is asking for. Only a failed one has to be passed over.
+	// exactly what a repeated request is asking for. Only one that cannot produce - failed, or
+	// discarded with its work still winding down - has to be passed over.
 	if previousID, ok := e.buildersByTimestamp[params.Timestamp]; ok {
-		if previous := e.builders[previousID]; previous != nil && previous.builder != nil && !previous.builder.Failed() {
+		if previous := e.builders[previousID]; previous != nil && previous.builder != nil &&
+			!previous.builder.Failed() && !previous.builder.Discarded() {
 			if sameBuildRequest(previous.params, params) {
 				e.logger.Info("[ForkChoiceUpdated] duplicate build request")
 				return AssembleBlockResult{PayloadID: previousID}, nil
@@ -177,12 +194,14 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Paramete
 	e.evictOldBuilders()
 
 	e.nextPayloadId++
-	params.PayloadId = e.nextPayloadId
 	ownedParams := params.Copy()
+	ownedParams.PayloadId = e.nextPayloadId
 
+	secondsPerSlot := e.config.SecondsPerSlot()
 	e.builders[e.nextPayloadId] = &builderEntry{
-		builder: builder.NewBlockBuilder(e.bacgroundCtx, e.builderFunc, ownedParams, buildDuration(params.Timestamp, time.Now(), e.config.SecondsPerSlot())),
-		params:  ownedParams,
+		builder: builder.NewBlockBuilder(e.backgroundCtx, e.builderFunc, ownedParams,
+			buildDuration(params.Timestamp, time.Now(), secondsPerSlot), stopGraceDuration(secondsPerSlot)),
+		params: ownedParams,
 	}
 	e.buildersByTimestamp[params.Timestamp] = e.nextPayloadId
 	e.logger.Info("[ForkChoiceUpdated] BlockBuilder added", "payload", e.nextPayloadId)
@@ -217,6 +236,12 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 
 	entry, ok := e.builders[payloadID]
 	if !ok || entry == nil || entry.builder == nil {
+		return AssembledBlockResult{Unknown: true}, nil
+	}
+	// Nothing comes of a discarded build, and waiting for its goroutine to notice would hold the
+	// caller for as long as whatever the build is blocked on.
+	if entry.builder.Discarded() {
+		e.dropBuilder(payloadID, entry)
 		return AssembledBlockResult{Unknown: true}, nil
 	}
 	blockWithReceipts, err := entry.builder.Stop(ctx)

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -204,11 +204,13 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 	}
 	blockWithReceipts, err := entry.builder.Stop(ctx)
 	if err != nil {
-		// Keeping a failed entry would hand the same latched error to every retry. A caller whose
-		// own context expired says nothing about the builder.
-		if ctx.Err() == nil {
-			e.dropBuilder(payloadID, entry)
+		// A caller that gave up says nothing about the builder, which keeps running and may still
+		// be collected. Only a builder that actually failed is reported and dropped, so its latched
+		// error stops being handed to every retry.
+		if ctx.Err() != nil {
+			return AssembledBlockResult{}, err
 		}
+		e.dropBuilder(payloadID, entry)
 		e.logger.Error("Failed to build PoS block", "err", err)
 		return AssembledBlockResult{}, err
 	}

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -18,6 +18,7 @@ package execmodule
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"time"
 
@@ -237,14 +238,8 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 	if !ok || entry == nil || entry.builder == nil {
 		return AssembledBlockResult{Unknown: true}, nil
 	}
-	// Nothing comes of a discarded build, and waiting for its goroutine to notice would hold the
-	// caller for as long as whatever the build is blocked on.
-	if entry.builder.Discarded() {
-		e.dropBuilder(payloadID, entry)
-		return AssembledBlockResult{Unknown: true}, nil
-	}
 	blockWithReceipts, err := entry.builder.Stop(ctx)
-	if entry.builder.Discarded() {
+	if errors.Is(err, builder.ErrDiscarded) {
 		e.dropBuilder(payloadID, entry)
 		return AssembledBlockResult{Unknown: true}, nil
 	}

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -92,6 +92,20 @@ func cloneBuilderParameters(params *builder.Parameters) *builder.Parameters {
 	return &cloned
 }
 
+// sameBuildRequest reports whether a request is asking for the payload another one is already
+// building. A custom transaction provider is never treated as the same request: it is stateful and
+// hands its transactions over once, so a second request carrying one is not asking for what the
+// first is building, and comparing the provider itself would read fields the running build writes.
+func sameBuildRequest(previous, current *builder.Parameters) bool {
+	if previous == nil || current == nil {
+		return false
+	}
+	if previous.CustomTxnProvider != nil || current.CustomTxnProvider != nil {
+		return false
+	}
+	return reflect.DeepEqual(previous, current)
+}
+
 // builderEntry keeps a builder with the parameters and timestamp it was created for, so the
 // three cannot drift apart and eviction can drop the timestamp index without scanning it.
 type builderEntry struct {
@@ -145,7 +159,7 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Paramete
 	if previousID, ok := e.buildersByTimestamp[params.Timestamp]; ok {
 		if previous := e.builders[previousID]; previous != nil && previous.builder != nil && !previous.builder.Failed() {
 			params.PayloadId = previousID
-			if reflect.DeepEqual(previous.params, params) {
+			if sameBuildRequest(previous.params, params) {
 				e.logger.Info("[ForkChoiceUpdated] duplicate build request")
 				return AssembleBlockResult{PayloadID: previousID}, nil
 			}

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -19,7 +19,6 @@ package execmodule
 import (
 	"bytes"
 	"context"
-	"errors"
 	"reflect"
 	"time"
 
@@ -219,10 +218,11 @@ func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (A
 	}
 	blockWithReceipts, err := entry.builder.Stop(ctx)
 	if err != nil {
-		// The caller gave up waiting; nothing about the build itself went wrong. Reading that from
-		// the returned error rather than the ambient context keeps the two from drifting apart
-		// between Stop returning and this check.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		// Stop reports the caller's wait expiring and the build's own failure through the same
+		// error, and a build can fail with a context error of its own - a transaction provider
+		// giving up, say. Only the builder knows which happened, so ask it rather than guess from
+		// the error: a caller that gave up leaves a builder still worth collecting.
+		if !entry.builder.Failed() {
 			return AssembledBlockResult{}, err
 		}
 		// Keeping a failed entry would hand its latched error to every retry.

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -53,11 +53,11 @@ func newTestModule(t *testing.T, builderFunc builder.BlockBuilderFunc) *ExecModu
 	}
 }
 
-// testTimestamp is far enough ahead that buildDuration gives a builder a budget measured in slots.
-// A timestamp in the past takes the floor instead, which is seconds, and the max-build-time
-// watchdog then fires in the middle of a test.
+// testTimestamp is a slot that has not happened yet but is close enough to be one a proposal could
+// be waiting for. Far enough ahead that buildDuration gives a budget measured in slots, so the
+// max-build-time watchdog cannot fire mid-test, and near enough that the slot still counts as live.
 func testTimestamp(offset uint64) uint64 {
-	return uint64(time.Now().Add(time.Hour).Unix()) + offset
+	return uint64(time.Now().Add(10*time.Second).Unix()) + offset
 }
 
 func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
@@ -558,4 +558,25 @@ func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
 	require.False(t, module.builders[current.PayloadID].builder.Failed())
 
 	module.builders[current.PayloadID].builder.Discard()
+}
+
+func TestEvictionKeepsTheBuilderCacheBounded(t *testing.T) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, errors.New("builder stopped")
+	})
+
+	// Ordinary traffic is one builder per slot, so every entry is the one its own timestamp
+	// resolves to. If being indexed were enough to protect an entry, nothing would ever be evicted
+	// and both maps would grow for the life of the process.
+	past := uint64(time.Now().Add(-time.Hour).Unix())
+	for i := range uint64(engine_helpers.MaxBuilders + 8) {
+		_, err := module.AssembleBlock(t.Context(), &builder.Parameters{
+			Timestamp:  past + i,
+			ParentHash: common.Hash{byte(i), byte(i >> 8)},
+		})
+		require.NoError(t, err)
+	}
+
+	require.LessOrEqual(t, len(module.builders), engine_helpers.MaxBuilders)
+	require.LessOrEqual(t, len(module.buildersByTimestamp), engine_helpers.MaxBuilders)
 }

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -628,6 +628,40 @@ func TestGetAssembledBlockReportsADiscardedBuilderAsUnknown(t *testing.T) {
 	require.NotContains(t, module.buildersByTimestamp, timestamp)
 }
 
+func TestGetAssembledBlockReportsDiscardDuringStopAsUnknown(t *testing.T) {
+	timestamp := newTestTimestamp()
+	stopObserved := make(chan struct{})
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		close(stopObserved)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	assembled, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+
+	type response struct {
+		result AssembledBlockResult
+		err    error
+	}
+	collected := make(chan response, 1)
+	go func() {
+		result, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
+		collected <- response{result: result, err: err}
+	}()
+	<-stopObserved
+	module.builders[assembled.PayloadID].builder.Discard()
+
+	result := <-collected
+	require.NoError(t, result.err)
+	require.True(t, result.result.Unknown)
+	require.NotContains(t, module.builders, assembled.PayloadID)
+	require.NotContains(t, module.buildersByTimestamp, timestamp)
+}
+
 func TestEvictionTakesAFailedCurrentBuilderBeforeALiveSupersededOne(t *testing.T) {
 	timestamp := newTestTimestamp()
 	started := make(chan struct{}, 4)

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/erigontech/erigon/execution/chain"
 	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
 	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/txnprovider"
 )
 
 func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
@@ -352,6 +353,66 @@ func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) 
 	assembled, err := module.GetAssembledBlock(t.Context(), result.PayloadID)
 	require.NoError(t, err)
 	require.NotNil(t, assembled.Block)
+}
+
+// mutableTxnProvider stands in for the stateful providers the testing namespace supplies: it hands
+// its transactions over once and clears them, from the build goroutine.
+type mutableTxnProvider struct {
+	txns []types.Transaction
+	done atomic.Bool
+}
+
+func (m *mutableTxnProvider) ProvideTxns(context.Context, ...txnprovider.ProvideOption) ([]types.Transaction, error) {
+	if !m.done.CompareAndSwap(false, true) {
+		return nil, nil
+	}
+	txns := m.txns
+	m.txns = nil
+	return txns, nil
+}
+
+func TestAssembleBlockNeverReusesABuilderWithACustomProvider(t *testing.T) {
+	started := make(chan struct{}, 4)
+	module := &ExecModule{
+		logger:       log.Root(),
+		config:       &chain.Config{},
+		semaphore:    semaphore.NewWeighted(1),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(ctx context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+			started <- struct{}{}
+			// Keep the provider busy for the whole test, which is when a comparison would read it.
+			for !interrupt.Load() && ctx.Err() == nil {
+				if params.CustomTxnProvider != nil {
+					_, _ = params.CustomTxnProvider.ProvideTxns(ctx)
+				}
+				time.Sleep(time.Millisecond)
+			}
+			return nil, errors.New("builder stopped")
+		},
+	}
+
+	withProvider := func() *builder.Parameters {
+		return &builder.Parameters{
+			Timestamp:         100,
+			ParentHash:        common.Hash{0x01},
+			CustomTxnProvider: &mutableTxnProvider{txns: []types.Transaction{}},
+		}
+	}
+	first, err := module.AssembleBlock(t.Context(), withProvider())
+	require.NoError(t, err)
+	<-started
+
+	// The provider is single-shot and mutates as it runs, so a second request carrying one is not
+	// asking for what the first is building, and its fields must never be compared.
+	second, err := module.AssembleBlock(t.Context(), withProvider())
+	require.NoError(t, err)
+	require.NotEqual(t, first.PayloadID, second.PayloadID)
+	<-started
+
+	for _, entry := range module.builders {
+		entry.builder.Discard()
+	}
 }
 
 func TestAssembleBlockOwnsParameters(t *testing.T) {

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -254,6 +254,39 @@ func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
 	require.NotContains(t, module.buildersByTimestamp, uint64(100))
 }
 
+func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUp(t *testing.T) {
+	started := make(chan struct{}, 1)
+	module := &ExecModule{
+		logger:    log.Root(),
+		config:    &chain.Config{},
+		semaphore: semaphore.NewWeighted(1),
+		builders:  map[uint64]*builderEntry{},
+		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+			started <- struct{}{}
+			for !interrupt.Load() {
+				time.Sleep(time.Millisecond)
+			}
+			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+		},
+	}
+
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	<-started
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = module.GetAssembledBlock(ctx, result.PayloadID)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// The caller gave up; the builder did not. Dropping it here would lose a payload that is still
+	// on its way, and reporting it as a build failure would misattribute the timeout.
+	require.Contains(t, module.builders, result.PayloadID)
+	require.Equal(t, result.PayloadID, module.buildersByTimestamp[100])
+
+	_, _ = module.builders[result.PayloadID].builder.Stop(context.Background())
+}
+
 func TestAssembleBlockOwnsParameters(t *testing.T) {
 	type observedParameters struct {
 		parentRoot common.Hash

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -652,7 +652,11 @@ func TestGetAssembledBlockReportsDiscardDuringStopAsUnknown(t *testing.T) {
 		result, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
 		collected <- response{result: result, err: err}
 	}()
-	<-stopObserved
+	select {
+	case <-stopObserved:
+	case <-time.After(5 * time.Second):
+		t.Fatal("builder did not observe the collection request")
+	}
 	module.builders[assembled.PayloadID].builder.Discard()
 
 	result := <-collected
@@ -660,6 +664,69 @@ func TestGetAssembledBlockReportsDiscardDuringStopAsUnknown(t *testing.T) {
 	require.True(t, result.result.Unknown)
 	require.NotContains(t, module.builders, assembled.PayloadID)
 	require.NotContains(t, module.buildersByTimestamp, timestamp)
+}
+
+func TestGetAssembledBlockKeepsPayloadCompletedAsDiscardLands(t *testing.T) {
+	timestamp := newTestTimestamp()
+	stopObserved := make(chan struct{})
+	finish := make(chan struct{})
+	want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		close(stopObserved)
+		<-finish
+		return want, nil
+	})
+
+	assembled, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+
+	type response struct {
+		result AssembledBlockResult
+		err    error
+	}
+	collected := make(chan response, 1)
+	go func() {
+		result, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
+		collected <- response{result: result, err: err}
+	}()
+	select {
+	case <-stopObserved:
+	case <-time.After(5 * time.Second):
+		t.Fatal("builder did not observe the collection request")
+	}
+	module.builders[assembled.PayloadID].builder.Discard()
+	close(finish)
+
+	select {
+	case result := <-collected:
+		require.NoError(t, result.err)
+		require.False(t, result.result.Unknown)
+		require.Same(t, want, result.result.Block)
+	case <-time.After(5 * time.Second):
+		t.Fatal("payload collection did not finish")
+	}
+}
+
+func TestGetAssembledBlockKeepsFailureCompletedBeforeDiscard(t *testing.T) {
+	timestamp := newTestTimestamp()
+	wantErr := errors.New("build failed")
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, wantErr
+	})
+
+	assembled, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	entry := module.builders[assembled.PayloadID]
+	require.Eventually(t, entry.builder.Failed, 5*time.Second, time.Millisecond)
+	entry.builder.Discard()
+
+	result, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
+	require.ErrorIs(t, err, wantErr)
+	require.False(t, result.Unknown)
+	require.NotContains(t, module.builders, assembled.PayloadID)
 }
 
 func TestEvictionTakesAFailedCurrentBuilderBeforeALiveSupersededOne(t *testing.T) {

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -43,11 +43,12 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 	}
 	started := make(chan runningBuilder, 4)
 	module := &ExecModule{
-		semaphore: semaphore.NewWeighted(1),
-		config:    &chain.Config{},
-		logger:    log.Root(),
-		builders:  map[uint64]*builderEntry{},
-		builderFunc: func(params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		semaphore:    semaphore.NewWeighted(1),
+		config:       &chain.Config{},
+		logger:       log.Root(),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 			started <- runningBuilder{id: params.PayloadId, interrupt: interrupt}
 			for !interrupt.Load() {
 				time.Sleep(time.Millisecond)
@@ -109,6 +110,10 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 	}
 
 	// Eviction is where a builder is actually stopped, and it takes the timestamp index with it.
+	// Removing entries puts them beyond the registered cleanup, so release them here instead of
+	// leaving two goroutines running until their watchdogs fire.
+	module.builders[firstID].builder.Discard()
+	module.builders[secondID].builder.Discard()
 	delete(module.builders, firstID)
 	delete(module.builders, secondID)
 	for id := thirdID + 1; len(module.builders) < engine_helpers.MaxBuilders; id++ {
@@ -121,14 +126,62 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 	require.False(t, third.interrupt.Load(), "the current builder for a timestamp must survive eviction")
 }
 
+func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
+	// A transaction provider can wait for most of a slot before returning, and the interrupt flag
+	// is not read until it does. Only cancelling the build reaches it.
+	entered := make(chan struct{}, 1)
+	released := make(chan error, 1)
+	module := &ExecModule{
+		logger:       log.Root(),
+		config:       &chain.Config{},
+		semaphore:    semaphore.NewWeighted(1),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+			entered <- struct{}{}
+			select {
+			case <-ctx.Done():
+				released <- ctx.Err()
+				return nil, ctx.Err()
+			case <-time.After(time.Minute):
+				released <- errors.New("provider was never released")
+				return nil, errors.New("provider was never released")
+			}
+		},
+	}
+
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	<-entered
+
+	entry := module.builders[result.PayloadID]
+	require.NotNil(t, entry)
+	for id := result.PayloadID + 1; len(module.builders) < engine_helpers.MaxBuilders; id++ {
+		module.builders[id] = nil
+	}
+	module.evictOldBuilders()
+	require.NotContains(t, module.builders, result.PayloadID)
+
+	// Observing the goroutine finish is the point: an evicted builder that merely has its flag set
+	// keeps its read view open until whatever it is blocked on gives up on its own.
+	select {
+	case err := <-released:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("evicted builder was never released")
+	}
+	require.Eventually(t, func() bool { return entry.builder.Failed() }, 5*time.Second, time.Millisecond)
+}
+
 func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 	started := make(chan *atomic.Bool, 4)
 	module := &ExecModule{
-		logger:    log.Root(),
-		config:    &chain.Config{},
-		semaphore: semaphore.NewWeighted(1),
-		builders:  map[uint64]*builderEntry{},
-		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		logger:       log.Root(),
+		config:       &chain.Config{},
+		semaphore:    semaphore.NewWeighted(1),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 			started <- interrupt
 			for !interrupt.Load() {
 				time.Sleep(time.Millisecond)
@@ -161,11 +214,12 @@ func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 func TestCollectedPayloadIsHandedBackToARepeatedRequest(t *testing.T) {
 	started := make(chan struct{}, 4)
 	module := &ExecModule{
-		logger:    log.Root(),
-		config:    &chain.Config{},
-		semaphore: semaphore.NewWeighted(1),
-		builders:  map[uint64]*builderEntry{},
-		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		logger:       log.Root(),
+		config:       &chain.Config{},
+		semaphore:    semaphore.NewWeighted(1),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 			started <- struct{}{}
 			for !interrupt.Load() {
 				time.Sleep(time.Millisecond)
@@ -198,11 +252,12 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 	failNext.Store(true)
 	started := make(chan struct{}, 4)
 	module := &ExecModule{
-		logger:    log.Root(),
-		config:    &chain.Config{},
-		semaphore: semaphore.NewWeighted(1),
-		builders:  map[uint64]*builderEntry{},
-		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		logger:       log.Root(),
+		config:       &chain.Config{},
+		semaphore:    semaphore.NewWeighted(1),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 			started <- struct{}{}
 			if failNext.Swap(false) {
 				return nil, errors.New("build failed")
@@ -234,11 +289,12 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 
 func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
 	module := &ExecModule{
-		logger:    log.Root(),
-		config:    &chain.Config{},
-		semaphore: semaphore.NewWeighted(1),
-		builders:  map[uint64]*builderEntry{},
-		builderFunc: func(_ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		logger:       log.Root(),
+		config:       &chain.Config{},
+		semaphore:    semaphore.NewWeighted(1),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(_ context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 			return nil, errors.New("build failed")
 		},
 	}
@@ -254,37 +310,48 @@ func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
 	require.NotContains(t, module.buildersByTimestamp, uint64(100))
 }
 
-func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUp(t *testing.T) {
-	started := make(chan struct{}, 1)
+func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) {
+	interrupted := make(chan struct{})
+	release := make(chan struct{})
 	module := &ExecModule{
-		logger:    log.Root(),
-		config:    &chain.Config{},
-		semaphore: semaphore.NewWeighted(1),
-		builders:  map[uint64]*builderEntry{},
-		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			started <- struct{}{}
+		logger:       log.Root(),
+		config:       &chain.Config{},
+		semaphore:    semaphore.NewWeighted(1),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 			for !interrupt.Load() {
 				time.Sleep(time.Millisecond)
 			}
+			close(interrupted)
+			<-release
 			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
 		},
 	}
 
 	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
-	<-started
 
+	// Cancel while Stop is already waiting, which is the window a caller-side timeout actually
+	// lands in. Cancelling beforehand returns at the entry check and exercises none of this.
 	ctx, cancel := context.WithCancel(t.Context())
+	collected := make(chan error, 1)
+	go func() {
+		_, collectErr := module.GetAssembledBlock(ctx, result.PayloadID)
+		collected <- collectErr
+	}()
+	<-interrupted
 	cancel()
-	_, err = module.GetAssembledBlock(ctx, result.PayloadID)
-	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, <-collected, context.Canceled)
 
-	// The caller gave up; the builder did not. Dropping it here would lose a payload that is still
-	// on its way, and reporting it as a build failure would misattribute the timeout.
+	// The builder was not dropped, so the payload it goes on to produce is still reachable.
 	require.Contains(t, module.builders, result.PayloadID)
 	require.Equal(t, result.PayloadID, module.buildersByTimestamp[100])
 
-	_, _ = module.builders[result.PayloadID].builder.Stop(context.Background())
+	close(release)
+	assembled, err := module.GetAssembledBlock(t.Context(), result.PayloadID)
+	require.NoError(t, err)
+	require.NotNil(t, assembled.Block)
 }
 
 func TestAssembleBlockOwnsParameters(t *testing.T) {
@@ -295,11 +362,12 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 	readParameters := make(chan struct{})
 	observed := make(chan observedParameters, 1)
 	module := &ExecModule{
-		semaphore: semaphore.NewWeighted(1),
-		config:    &chain.Config{},
-		logger:    log.Root(),
-		builders:  map[uint64]*builderEntry{},
-		builderFunc: func(params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		semaphore:    semaphore.NewWeighted(1),
+		config:       &chain.Config{},
+		logger:       log.Root(),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 			<-readParameters
 			observed <- observedParameters{parentRoot: *params.ParentBeaconBlockRoot, extraData: params.ExtraData[0]}
 			for !interrupt.Load() {
@@ -338,11 +406,12 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
 	started := make(chan *atomic.Bool, 1)
 	module := &ExecModule{
-		semaphore: semaphore.NewWeighted(1),
-		config:    &chain.Config{},
-		logger:    log.Root(),
-		builders:  map[uint64]*builderEntry{},
-		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		semaphore:    semaphore.NewWeighted(1),
+		config:       &chain.Config{},
+		logger:       log.Root(),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 			started <- interrupt
 			for !interrupt.Load() {
 				time.Sleep(time.Millisecond)

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -17,12 +17,352 @@
 package execmodule
 
 import (
+	"context"
+	"errors"
 	"math"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+
 	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/builder"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
+	"github.com/erigontech/erigon/execution/types"
 )
+
+func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
+	type runningBuilder struct {
+		id        uint64
+		interrupt *atomic.Bool
+	}
+	started := make(chan runningBuilder, 4)
+	module := &ExecModule{
+		semaphore: semaphore.NewWeighted(1),
+		config:    &chain.Config{},
+		logger:    log.Root(),
+		builders:  map[uint64]*builderEntry{},
+		builderFunc: func(params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+			started <- runningBuilder{id: params.PayloadId, interrupt: interrupt}
+			for !interrupt.Load() {
+				time.Sleep(time.Millisecond)
+			}
+			return nil, errors.New("builder stopped")
+		},
+	}
+	t.Cleanup(func() {
+		for _, entry := range module.builders {
+			if entry != nil && entry.builder != nil {
+				_, _ = entry.builder.Stop(context.Background())
+			}
+		}
+	})
+
+	waitStarted := func() runningBuilder {
+		t.Helper()
+		select {
+		case running := <-started:
+			return running
+		case <-time.After(time.Second):
+			t.Fatal("builder did not start")
+			return runningBuilder{}
+		}
+	}
+	assemble := func(timestamp uint64, parent common.Hash) (uint64, runningBuilder) {
+		t.Helper()
+		result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: parent})
+		require.NoError(t, err)
+		require.False(t, result.Busy)
+		return result.PayloadID, waitStarted()
+	}
+
+	firstID, first := assemble(100, common.Hash{0x01})
+	adjacentID, adjacent := assemble(101, common.Hash{0x02})
+	require.NotEqual(t, firstID, adjacentID)
+
+	firstDuplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	require.Equal(t, firstID, firstDuplicate.PayloadID)
+
+	// Superseding hands the timestamp to a new builder and leaves the old ones running, so only the
+	// index moves. Timestamp 101 is a different proposal and is untouched throughout.
+	secondID, second := assemble(100, common.Hash{0x03})
+	require.NotEqual(t, firstID, secondID)
+	require.Equal(t, secondID, module.buildersByTimestamp[100])
+	require.Equal(t, adjacentID, module.buildersByTimestamp[101])
+
+	thirdID, third := assemble(100, common.Hash{0x04})
+	require.NotEqual(t, secondID, thirdID)
+	require.Equal(t, thirdID, module.buildersByTimestamp[100])
+
+	duplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x04}})
+	require.NoError(t, err)
+	require.Equal(t, thirdID, duplicate.PayloadID)
+
+	for _, running := range []runningBuilder{first, second, third, adjacent} {
+		require.False(t, running.interrupt.Load(), "builder %d must still be packing", running.id)
+	}
+
+	// Eviction is where a builder is actually stopped, and it takes the timestamp index with it.
+	delete(module.builders, firstID)
+	delete(module.builders, secondID)
+	for id := thirdID + 1; len(module.builders) < engine_helpers.MaxBuilders; id++ {
+		module.builders[id] = nil
+	}
+	module.evictOldBuilders()
+	require.Eventually(t, adjacent.interrupt.Load, time.Second, time.Millisecond)
+	require.NotContains(t, module.builders, adjacentID)
+	require.NotContains(t, module.buildersByTimestamp, uint64(101))
+	require.False(t, third.interrupt.Load(), "the current builder for a timestamp must survive eviction")
+}
+
+func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
+	started := make(chan *atomic.Bool, 4)
+	module := &ExecModule{
+		logger:    log.Root(),
+		config:    &chain.Config{},
+		semaphore: semaphore.NewWeighted(1),
+		builders:  map[uint64]*builderEntry{},
+		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+			started <- interrupt
+			for !interrupt.Load() {
+				time.Sleep(time.Millisecond)
+			}
+			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+		},
+	}
+
+	first, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	firstInterrupt := <-started
+
+	second, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x02}})
+	require.NoError(t, err)
+	require.NotEqual(t, first.PayloadID, second.PayloadID)
+	secondInterrupt := <-started
+
+	// The timestamp index moves to the new builder, so nothing reaches the old one by dedup. It is
+	// left running: freezing it would answer an id already handed out with a near-empty payload.
+	require.Equal(t, second.PayloadID, module.buildersByTimestamp[100])
+	require.False(t, firstInterrupt.Load())
+
+	assembled, err := module.GetAssembledBlock(t.Context(), first.PayloadID)
+	require.NoError(t, err)
+	require.NotNil(t, assembled.Block)
+
+	secondInterrupt.Store(true)
+}
+
+func TestCollectedPayloadIsHandedBackToARepeatedRequest(t *testing.T) {
+	started := make(chan struct{}, 4)
+	module := &ExecModule{
+		logger:    log.Root(),
+		config:    &chain.Config{},
+		semaphore: semaphore.NewWeighted(1),
+		builders:  map[uint64]*builderEntry{},
+		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+			started <- struct{}{}
+			for !interrupt.Load() {
+				time.Sleep(time.Millisecond)
+			}
+			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+		},
+	}
+
+	params := func() *builder.Parameters {
+		return &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}}
+	}
+	first, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	<-started
+
+	assembled, err := module.GetAssembledBlock(t.Context(), first.PayloadID)
+	require.NoError(t, err)
+	require.NotNil(t, assembled.Block)
+
+	// Collecting stops the builder. A repeated request must still be handed that payload: rebuilding
+	// from scratch this late means the next grab takes a near-empty block.
+	repeat, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	require.Equal(t, first.PayloadID, repeat.PayloadID)
+	require.Empty(t, started, "a repeated request must not start a second builder")
+}
+
+func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
+	var failNext atomic.Bool
+	failNext.Store(true)
+	started := make(chan struct{}, 4)
+	module := &ExecModule{
+		logger:    log.Root(),
+		config:    &chain.Config{},
+		semaphore: semaphore.NewWeighted(1),
+		builders:  map[uint64]*builderEntry{},
+		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+			started <- struct{}{}
+			if failNext.Swap(false) {
+				return nil, errors.New("build failed")
+			}
+			for !interrupt.Load() {
+				time.Sleep(time.Millisecond)
+			}
+			return nil, errors.New("builder stopped")
+		},
+	}
+
+	params := func() *builder.Parameters {
+		return &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}}
+	}
+	first, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	<-started
+	require.Eventually(t, module.builders[first.PayloadID].builder.Failed, time.Second, time.Millisecond)
+
+	// Identical parameters would normally dedup onto the same id. A builder that already died
+	// latches its error, so reusing it would spend the slot on a payload that can never arrive.
+	second, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	require.NotEqual(t, first.PayloadID, second.PayloadID)
+	<-started
+
+	_, _ = module.builders[second.PayloadID].builder.Stop(context.Background())
+}
+
+func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
+	module := &ExecModule{
+		logger:    log.Root(),
+		config:    &chain.Config{},
+		semaphore: semaphore.NewWeighted(1),
+		builders:  map[uint64]*builderEntry{},
+		builderFunc: func(_ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+			return nil, errors.New("build failed")
+		},
+	}
+
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+
+	_, err = module.GetAssembledBlock(t.Context(), result.PayloadID)
+	require.Error(t, err)
+
+	// The error is latched, so leaving the entry in place would keep serving it to every retry.
+	require.NotContains(t, module.builders, result.PayloadID)
+	require.NotContains(t, module.buildersByTimestamp, uint64(100))
+}
+
+func TestAssembleBlockOwnsParameters(t *testing.T) {
+	type observedParameters struct {
+		parentRoot common.Hash
+		extraData  byte
+	}
+	readParameters := make(chan struct{})
+	observed := make(chan observedParameters, 1)
+	module := &ExecModule{
+		semaphore: semaphore.NewWeighted(1),
+		config:    &chain.Config{},
+		logger:    log.Root(),
+		builders:  map[uint64]*builderEntry{},
+		builderFunc: func(params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+			<-readParameters
+			observed <- observedParameters{parentRoot: *params.ParentBeaconBlockRoot, extraData: params.ExtraData[0]}
+			for !interrupt.Load() {
+				time.Sleep(time.Millisecond)
+			}
+			return nil, errors.New("builder stopped")
+		},
+	}
+	root := common.Hash{0xaa}
+	params := &builder.Parameters{
+		Timestamp:             100,
+		ParentHash:            common.Hash{0x01},
+		ParentBeaconBlockRoot: &root,
+		ExtraData:             []byte{0xbb},
+	}
+	result, err := module.AssembleBlock(t.Context(), params)
+	require.NoError(t, err)
+	require.False(t, result.Busy)
+
+	root[0] = 0xcc
+	params.ExtraData[0] = 0xdd
+	close(readParameters)
+	require.Equal(t, observedParameters{parentRoot: common.Hash{0xaa}, extraData: 0xbb}, <-observed)
+
+	duplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{
+		Timestamp:             100,
+		ParentHash:            common.Hash{0x01},
+		ParentBeaconBlockRoot: &common.Hash{0xaa},
+		ExtraData:             []byte{0xbb},
+	})
+	require.NoError(t, err)
+	require.Equal(t, result.PayloadID, duplicate.PayloadID)
+	_, _ = module.builders[result.PayloadID].builder.Stop(context.Background())
+}
+
+func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
+	started := make(chan *atomic.Bool, 1)
+	module := &ExecModule{
+		semaphore: semaphore.NewWeighted(1),
+		config:    &chain.Config{},
+		logger:    log.Root(),
+		builders:  map[uint64]*builderEntry{},
+		builderFunc: func(_ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+			started <- interrupt
+			for !interrupt.Load() {
+				time.Sleep(time.Millisecond)
+			}
+			return nil, errors.New("builder stopped")
+		},
+	}
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	interrupt := <-started
+	t.Cleanup(func() {
+		_, _ = module.builders[result.PayloadID].builder.Stop(context.Background())
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = module.AssembleBlock(ctx, &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x02}})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, interrupt.Load())
+	require.Equal(t, result.PayloadID, module.buildersByTimestamp[100])
+}
+
+func TestCloneBuilderParametersPreservesRepresentations(t *testing.T) {
+	require.Nil(t, cloneBuilderParameters(nil))
+
+	empty := cloneBuilderParameters(&builder.Parameters{Withdrawals: []*types.Withdrawal{}, ExtraData: []byte{}})
+	require.NotNil(t, empty.Withdrawals)
+	require.NotNil(t, empty.ExtraData)
+
+	root := common.Hash{0x01}
+	slot := uint64(2)
+	gasLimit := uint64(3)
+	params := &builder.Parameters{
+		Withdrawals:           []*types.Withdrawal{nil, {Index: 4}},
+		ParentBeaconBlockRoot: &root,
+		SlotNumber:            &slot,
+		TargetGasLimit:        &gasLimit,
+		ExtraData:             []byte{5},
+	}
+	cloned := cloneBuilderParameters(params)
+	params.Withdrawals[1].Index = 40
+	root[0] = 10
+	slot = 20
+	gasLimit = 30
+	params.ExtraData[0] = 50
+
+	require.Nil(t, cloned.Withdrawals[0])
+	require.Equal(t, uint64(4), cloned.Withdrawals[1].Index)
+	require.Equal(t, common.Hash{0x01}, *cloned.ParentBeaconBlockRoot)
+	require.Equal(t, uint64(2), *cloned.SlotNumber)
+	require.Equal(t, uint64(3), *cloned.TargetGasLimit)
+	require.Equal(t, byte(5), cloned.ExtraData[0])
+}
 
 func TestBuildDuration(t *testing.T) {
 	const ethereum, gnosis = uint64(12), uint64(5)

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -38,26 +38,41 @@ import (
 	"github.com/erigontech/erigon/txnprovider"
 )
 
+// newTestModule builds a module whose builders run builderFunc. Every test needs the same fields,
+// and getting the config or the context wrong changes the builder's own deadline silently.
+func newTestModule(t *testing.T, builderFunc builder.BlockBuilderFunc) *ExecModule {
+	t.Helper()
+	return &ExecModule{
+		logger:              log.Root(),
+		config:              &chain.Config{},
+		semaphore:           semaphore.NewWeighted(1),
+		builders:            map[uint64]*builderEntry{},
+		buildersByTimestamp: map[uint64]uint64{},
+		bacgroundCtx:        t.Context(),
+		builderFunc:         builderFunc,
+	}
+}
+
+// testTimestamp is far enough ahead that buildDuration gives a builder a budget measured in slots.
+// A timestamp in the past takes the floor instead, which is seconds, and the max-build-time
+// watchdog then fires in the middle of a test.
+func testTimestamp(offset uint64) uint64 {
+	return uint64(time.Now().Add(time.Hour).Unix()) + offset
+}
+
 func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 	type runningBuilder struct {
 		id        uint64
 		interrupt *atomic.Bool
 	}
 	started := make(chan runningBuilder, 4)
-	module := &ExecModule{
-		semaphore:    semaphore.NewWeighted(1),
-		config:       &chain.Config{},
-		logger:       log.Root(),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			started <- runningBuilder{id: params.PayloadId, interrupt: interrupt}
-			for !interrupt.Load() {
-				time.Sleep(time.Millisecond)
-			}
-			return nil, errors.New("builder stopped")
-		},
-	}
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- runningBuilder{id: params.PayloadId, interrupt: interrupt}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
 	t.Cleanup(func() {
 		for _, entry := range module.builders {
 			if entry != nil && entry.builder != nil {
@@ -84,26 +99,26 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 		return result.PayloadID, waitStarted()
 	}
 
-	firstID, first := assemble(100, common.Hash{0x01})
-	adjacentID, adjacent := assemble(101, common.Hash{0x02})
+	firstID, first := assemble(testTimestamp(0), common.Hash{0x01})
+	adjacentID, adjacent := assemble(testTimestamp(1), common.Hash{0x02})
 	require.NotEqual(t, firstID, adjacentID)
 
-	firstDuplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	firstDuplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 	require.Equal(t, firstID, firstDuplicate.PayloadID)
 
 	// Superseding hands the timestamp to a new builder and leaves the old ones running, so only the
 	// index moves. Timestamp 101 is a different proposal and is untouched throughout.
-	secondID, second := assemble(100, common.Hash{0x03})
+	secondID, second := assemble(testTimestamp(0), common.Hash{0x03})
 	require.NotEqual(t, firstID, secondID)
-	require.Equal(t, secondID, module.buildersByTimestamp[100])
-	require.Equal(t, adjacentID, module.buildersByTimestamp[101])
+	require.Equal(t, secondID, module.buildersByTimestamp[testTimestamp(0)])
+	require.Equal(t, adjacentID, module.buildersByTimestamp[testTimestamp(1)])
 
-	thirdID, third := assemble(100, common.Hash{0x04})
+	thirdID, third := assemble(testTimestamp(0), common.Hash{0x04})
 	require.NotEqual(t, secondID, thirdID)
-	require.Equal(t, thirdID, module.buildersByTimestamp[100])
+	require.Equal(t, thirdID, module.buildersByTimestamp[testTimestamp(0)])
 
-	duplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x04}})
+	duplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x04}})
 	require.NoError(t, err)
 	require.Equal(t, thirdID, duplicate.PayloadID)
 
@@ -111,21 +126,22 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 		require.False(t, running.interrupt.Load(), "builder %d must still be packing", running.id)
 	}
 
-	// Eviction is where a builder is actually stopped, and it takes the timestamp index with it.
-	// Removing entries puts them beyond the registered cleanup, so release them here instead of
-	// leaving two goroutines running until their watchdogs fire.
-	module.builders[firstID].builder.Discard()
-	module.builders[secondID].builder.Discard()
-	delete(module.builders, firstID)
-	delete(module.builders, secondID)
+	// Eviction is where a builder is actually stopped, and it goes by age. What a timestamp still
+	// resolves to is exempt whatever its age, because that is what a proposal for that timestamp is
+	// waiting on: first and second have been superseded, third and adjacent have not.
 	for id := thirdID + 1; len(module.builders) < engine_helpers.MaxBuilders; id++ {
 		module.builders[id] = nil
 	}
 	module.evictOldBuilders()
-	require.Eventually(t, adjacent.interrupt.Load, time.Second, time.Millisecond)
-	require.NotContains(t, module.builders, adjacentID)
-	require.NotContains(t, module.buildersByTimestamp, uint64(101))
-	require.False(t, third.interrupt.Load(), "the current builder for a timestamp must survive eviction")
+
+	require.NotContains(t, module.builders, firstID)
+	require.Eventually(t, first.interrupt.Load, time.Second, time.Millisecond)
+	require.Contains(t, module.builders, adjacentID, "the current builder for a timestamp must survive eviction")
+	require.Contains(t, module.builders, thirdID)
+	require.False(t, adjacent.interrupt.Load())
+	require.False(t, third.interrupt.Load())
+	require.Equal(t, thirdID, module.buildersByTimestamp[testTimestamp(0)])
+	require.Equal(t, adjacentID, module.buildersByTimestamp[testTimestamp(1)])
 }
 
 func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
@@ -133,36 +149,34 @@ func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
 	// is not read until it does. Only cancelling the build reaches it.
 	entered := make(chan struct{}, 1)
 	released := make(chan error, 1)
-	module := &ExecModule{
-		logger:       log.Root(),
-		config:       &chain.Config{},
-		semaphore:    semaphore.NewWeighted(1),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			entered <- struct{}{}
-			select {
-			case <-ctx.Done():
-				released <- ctx.Err()
-				return nil, ctx.Err()
-			case <-time.After(time.Minute):
-				released <- errors.New("provider was never released")
-				return nil, errors.New("provider was never released")
-			}
-		},
-	}
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		entered <- struct{}{}
+		select {
+		case <-ctx.Done():
+			released <- ctx.Err()
+			return nil, ctx.Err()
+		case <-time.After(time.Minute):
+			released <- errors.New("provider was never released")
+			return nil, errors.New("provider was never released")
+		}
+	})
 
-	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	blocked, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 	<-entered
 
-	entry := module.builders[result.PayloadID]
+	// Superseded, so eviction is allowed to take it: what a timestamp still resolves to is exempt.
+	_, err = module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x02}})
+	require.NoError(t, err)
+	<-entered
+
+	entry := module.builders[blocked.PayloadID]
 	require.NotNil(t, entry)
-	for id := result.PayloadID + 1; len(module.builders) < engine_helpers.MaxBuilders; id++ {
+	for id := uint64(len(module.builders)) + 100; len(module.builders) < engine_helpers.MaxBuilders; id++ {
 		module.builders[id] = nil
 	}
 	module.evictOldBuilders()
-	require.NotContains(t, module.builders, result.PayloadID)
+	require.NotContains(t, module.builders, blocked.PayloadID)
 
 	// Observing the goroutine finish is the point: an evicted builder that merely has its flag set
 	// keeps its read view open until whatever it is blocked on gives up on its own.
@@ -177,33 +191,26 @@ func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
 
 func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 	started := make(chan *atomic.Bool, 4)
-	module := &ExecModule{
-		logger:       log.Root(),
-		config:       &chain.Config{},
-		semaphore:    semaphore.NewWeighted(1),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			started <- interrupt
-			for !interrupt.Load() {
-				time.Sleep(time.Millisecond)
-			}
-			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
-		},
-	}
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- interrupt
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	})
 
-	first, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	first, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 	firstInterrupt := <-started
 
-	second, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x02}})
+	second, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x02}})
 	require.NoError(t, err)
 	require.NotEqual(t, first.PayloadID, second.PayloadID)
 	secondInterrupt := <-started
 
 	// The timestamp index moves to the new builder, so nothing reaches the old one by dedup. It is
 	// left running: freezing it would answer an id already handed out with a near-empty payload.
-	require.Equal(t, second.PayloadID, module.buildersByTimestamp[100])
+	require.Equal(t, second.PayloadID, module.buildersByTimestamp[testTimestamp(0)])
 	require.False(t, firstInterrupt.Load())
 
 	assembled, err := module.GetAssembledBlock(t.Context(), first.PayloadID)
@@ -215,23 +222,16 @@ func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 
 func TestCollectedPayloadIsHandedBackToARepeatedRequest(t *testing.T) {
 	started := make(chan struct{}, 4)
-	module := &ExecModule{
-		logger:       log.Root(),
-		config:       &chain.Config{},
-		semaphore:    semaphore.NewWeighted(1),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			started <- struct{}{}
-			for !interrupt.Load() {
-				time.Sleep(time.Millisecond)
-			}
-			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
-		},
-	}
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	})
 
 	params := func() *builder.Parameters {
-		return &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}}
+		return &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}}
 	}
 	first, err := module.AssembleBlock(t.Context(), params())
 	require.NoError(t, err)
@@ -253,26 +253,19 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 	var failNext atomic.Bool
 	failNext.Store(true)
 	started := make(chan struct{}, 4)
-	module := &ExecModule{
-		logger:       log.Root(),
-		config:       &chain.Config{},
-		semaphore:    semaphore.NewWeighted(1),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			started <- struct{}{}
-			if failNext.Swap(false) {
-				return nil, errors.New("build failed")
-			}
-			for !interrupt.Load() {
-				time.Sleep(time.Millisecond)
-			}
-			return nil, errors.New("builder stopped")
-		},
-	}
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		if failNext.Swap(false) {
+			return nil, errors.New("build failed")
+		}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
 
 	params := func() *builder.Parameters {
-		return &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}}
+		return &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}}
 	}
 	first, err := module.AssembleBlock(t.Context(), params())
 	require.NoError(t, err)
@@ -290,18 +283,11 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 }
 
 func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
-	module := &ExecModule{
-		logger:       log.Root(),
-		config:       &chain.Config{},
-		semaphore:    semaphore.NewWeighted(1),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(_ context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
-			return nil, errors.New("build failed")
-		},
-	}
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, errors.New("build failed")
+	})
 
-	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 
 	_, err = module.GetAssembledBlock(t.Context(), result.PayloadID)
@@ -309,29 +295,22 @@ func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
 
 	// The error is latched, so leaving the entry in place would keep serving it to every retry.
 	require.NotContains(t, module.builders, result.PayloadID)
-	require.NotContains(t, module.buildersByTimestamp, uint64(100))
+	require.NotContains(t, module.buildersByTimestamp, testTimestamp(0))
 }
 
 func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) {
 	interrupted := make(chan struct{})
 	release := make(chan struct{})
-	module := &ExecModule{
-		logger:       log.Root(),
-		config:       &chain.Config{},
-		semaphore:    semaphore.NewWeighted(1),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			for !interrupt.Load() {
-				time.Sleep(time.Millisecond)
-			}
-			close(interrupted)
-			<-release
-			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
-		},
-	}
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		close(interrupted)
+		<-release
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	})
 
-	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 
 	// Cancel while Stop is already waiting, which is the window a caller-side timeout actually
@@ -348,7 +327,7 @@ func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) 
 
 	// The builder was not dropped, so the payload it goes on to produce is still reachable.
 	require.Contains(t, module.builders, result.PayloadID)
-	require.Equal(t, result.PayloadID, module.buildersByTimestamp[100])
+	require.Equal(t, result.PayloadID, module.buildersByTimestamp[testTimestamp(0)])
 
 	close(release)
 	assembled, err := module.GetAssembledBlock(t.Context(), result.PayloadID)
@@ -374,24 +353,17 @@ func (m *mutableTxnProvider) ProvideTxns(context.Context, ...txnprovider.Provide
 
 func TestAssembleBlockNeverReusesABuilderWithACustomProvider(t *testing.T) {
 	started := make(chan struct{}, 4)
-	module := &ExecModule{
-		logger:       log.Root(),
-		config:       &chain.Config{},
-		semaphore:    semaphore.NewWeighted(1),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(ctx context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			started <- struct{}{}
-			// Keep the provider busy for the whole test, which is when a comparison would read it.
-			for !interrupt.Load() && ctx.Err() == nil {
-				if params.CustomTxnProvider != nil {
-					_, _ = params.CustomTxnProvider.ProvideTxns(ctx)
-				}
-				time.Sleep(time.Millisecond)
+	module := newTestModule(t, func(ctx context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		// Keep the provider busy for the whole test, which is when a comparison would read it.
+		for !interrupt.Load() && ctx.Err() == nil {
+			if params.CustomTxnProvider != nil {
+				_, _ = params.CustomTxnProvider.ProvideTxns(ctx)
 			}
-			return nil, errors.New("builder stopped")
-		},
-	}
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
 
 	withProvider := func() *builder.Parameters {
 		return &builder.Parameters{
@@ -423,21 +395,14 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 	}
 	readParameters := make(chan struct{})
 	observed := make(chan observedParameters, 1)
-	module := &ExecModule{
-		semaphore:    semaphore.NewWeighted(1),
-		config:       &chain.Config{},
-		logger:       log.Root(),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			<-readParameters
-			observed <- observedParameters{parentRoot: *params.ParentBeaconBlockRoot, extraData: params.ExtraData[0]}
-			for !interrupt.Load() {
-				time.Sleep(time.Millisecond)
-			}
-			return nil, errors.New("builder stopped")
-		},
-	}
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-readParameters
+		observed <- observedParameters{parentRoot: *params.ParentBeaconBlockRoot, extraData: params.ExtraData[0]}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
 	root := common.Hash{0xaa}
 	params := &builder.Parameters{
 		Timestamp:             100,
@@ -467,21 +432,14 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 
 func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
 	started := make(chan *atomic.Bool, 1)
-	module := &ExecModule{
-		semaphore:    semaphore.NewWeighted(1),
-		config:       &chain.Config{},
-		logger:       log.Root(),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
-			started <- interrupt
-			for !interrupt.Load() {
-				time.Sleep(time.Millisecond)
-			}
-			return nil, errors.New("builder stopped")
-		},
-	}
-	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- interrupt
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 	interrupt := <-started
 	t.Cleanup(func() {
@@ -490,42 +448,10 @@ func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	_, err = module.AssembleBlock(ctx, &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x02}})
+	_, err = module.AssembleBlock(ctx, &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x02}})
 	require.ErrorIs(t, err, context.Canceled)
 	require.False(t, interrupt.Load())
-	require.Equal(t, result.PayloadID, module.buildersByTimestamp[100])
-}
-
-func TestCloneBuilderParametersPreservesRepresentations(t *testing.T) {
-	require.Nil(t, cloneBuilderParameters(nil))
-
-	empty := cloneBuilderParameters(&builder.Parameters{Withdrawals: []*types.Withdrawal{}, ExtraData: []byte{}})
-	require.NotNil(t, empty.Withdrawals)
-	require.NotNil(t, empty.ExtraData)
-
-	root := common.Hash{0x01}
-	slot := uint64(2)
-	gasLimit := uint64(3)
-	params := &builder.Parameters{
-		Withdrawals:           []*types.Withdrawal{nil, {Index: 4}},
-		ParentBeaconBlockRoot: &root,
-		SlotNumber:            &slot,
-		TargetGasLimit:        &gasLimit,
-		ExtraData:             []byte{5},
-	}
-	cloned := cloneBuilderParameters(params)
-	params.Withdrawals[1].Index = 40
-	root[0] = 10
-	slot = 20
-	gasLimit = 30
-	params.ExtraData[0] = 50
-
-	require.Nil(t, cloned.Withdrawals[0])
-	require.Equal(t, uint64(4), cloned.Withdrawals[1].Index)
-	require.Equal(t, common.Hash{0x01}, *cloned.ParentBeaconBlockRoot)
-	require.Equal(t, uint64(2), *cloned.SlotNumber)
-	require.Equal(t, uint64(3), *cloned.TargetGasLimit)
-	require.Equal(t, byte(5), cloned.ExtraData[0])
+	require.Equal(t, result.PayloadID, module.buildersByTimestamp[testTimestamp(0)])
 }
 
 func TestBuildDuration(t *testing.T) {
@@ -576,20 +502,13 @@ func TestBuildDurationCapsOverflowingTimestamp(t *testing.T) {
 }
 
 func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
-	module := &ExecModule{
-		logger:       log.Root(),
-		config:       &chain.Config{},
-		semaphore:    semaphore.NewWeighted(1),
-		builders:     map[uint64]*builderEntry{},
-		bacgroundCtx: t.Context(),
-		builderFunc: func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
-			// A transaction provider that gives up reports its own context error, which is a failed
-			// build rather than a caller that stopped waiting.
-			return nil, fmt.Errorf("issue while waiting for parent block: %w", context.DeadlineExceeded)
-		},
-	}
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		// A transaction provider that gives up reports its own context error, which is a failed
+		// build rather than a caller that stopped waiting.
+		return nil, fmt.Errorf("issue while waiting for parent block: %w", context.DeadlineExceeded)
+	})
 
-	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 
 	_, err = module.GetAssembledBlock(t.Context(), result.PayloadID)
@@ -597,5 +516,46 @@ func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
 
 	// Keeping it would serve that latched error to every later retry of the same slot.
 	require.NotContains(t, module.builders, result.PayloadID)
-	require.NotContains(t, module.buildersByTimestamp, uint64(100))
+	require.NotContains(t, module.buildersByTimestamp, testTimestamp(0))
+}
+
+func TestGetAssembledBlockSaysWhenAPayloadIdIsUnknown(t *testing.T) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, errors.New("builder stopped")
+	})
+
+	// An id with no builder behind it can never produce anything. Reporting it as an ordinary empty
+	// result leaves a caller polling it for the rest of the slot.
+	assembled, err := module.GetAssembledBlock(t.Context(), 404)
+	require.NoError(t, err)
+	require.True(t, assembled.Unknown)
+	require.Nil(t, assembled.Block)
+}
+
+func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
+	started := make(chan struct{}, 1)
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
+
+	current, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	<-started
+
+	// It is the oldest by id, so eviction would take it first, and it is also what a proposal for
+	// that timestamp is waiting on. Age says nothing about that.
+	for id := current.PayloadID + 1; len(module.builders) < engine_helpers.MaxBuilders+1; id++ {
+		module.builders[id] = nil
+	}
+	module.evictOldBuilders()
+
+	require.Contains(t, module.builders, current.PayloadID)
+	require.Equal(t, current.PayloadID, module.buildersByTimestamp[testTimestamp(0)])
+	require.False(t, module.builders[current.PayloadID].builder.Failed())
+
+	module.builders[current.PayloadID].builder.Discard()
 }

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -48,7 +48,7 @@ func newTestModule(t *testing.T, builderFunc builder.BlockBuilderFunc) *ExecModu
 		semaphore:           semaphore.NewWeighted(1),
 		builders:            map[uint64]*builderEntry{},
 		buildersByTimestamp: map[uint64]uint64{},
-		bacgroundCtx:        t.Context(),
+		backgroundCtx:       t.Context(),
 		builderFunc:         builderFunc,
 	}
 }
@@ -67,7 +67,7 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 		interrupt *atomic.Bool
 	}
 	started := make(chan runningBuilder, 4)
-	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- runningBuilder{id: params.PayloadId, interrupt: interrupt}
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -108,8 +108,8 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, firstID, firstDuplicate.PayloadID)
 
-	// Superseding hands the timestamp to a new builder and leaves the old ones running, so only the
-	// index moves. The adjacent timestamp is a different proposal and is untouched throughout.
+	// Superseding moves only the timestamp index; the old builders keep running. The adjacent
+	// timestamp is a different proposal and is untouched throughout.
 	secondID, second := assemble(timestamp, common.Hash{0x03})
 	require.NotEqual(t, firstID, secondID)
 	require.Equal(t, secondID, module.buildersByTimestamp[timestamp])
@@ -127,9 +127,8 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 		require.False(t, running.interrupt.Load(), "builder %d must still be packing", running.id)
 	}
 
-	// Eviction is where a builder is actually stopped, and it goes by age. What a timestamp still
-	// resolves to is exempt whatever its age, because that is what a proposal for that timestamp is
-	// waiting on: first and second have been superseded, third and adjacent have not.
+	// Eviction goes by age but skips what a timestamp still resolves to: first and second have been
+	// superseded, third and adjacent have not.
 	for id := thirdID + 1; len(module.builders) < engine_helpers.MaxBuilders; id++ {
 		module.builders[id] = nil
 	}
@@ -151,7 +150,7 @@ func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
 	// is not read until it does. Only cancelling the build reaches it.
 	entered := make(chan struct{}, 1)
 	released := make(chan error, 1)
-	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		entered <- struct{}{}
 		select {
 		case <-ctx.Done():
@@ -194,7 +193,7 @@ func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
 func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 	timestamp := newTestTimestamp()
 	started := make(chan *atomic.Bool, 4)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- interrupt
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -211,8 +210,7 @@ func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 	require.NotEqual(t, first.PayloadID, second.PayloadID)
 	secondInterrupt := <-started
 
-	// The timestamp index moves to the new builder, so nothing reaches the old one by dedup. It is
-	// left running: freezing it would answer an id already handed out with a near-empty payload.
+	// Superseding moves only the index; the old builder keeps running and its id stays retrievable.
 	require.Equal(t, second.PayloadID, module.buildersByTimestamp[timestamp])
 	require.False(t, firstInterrupt.Load())
 
@@ -226,7 +224,7 @@ func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 func TestCollectedPayloadIsHandedBackToARepeatedRequest(t *testing.T) {
 	timestamp := newTestTimestamp()
 	started := make(chan struct{}, 4)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -258,7 +256,7 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 	var failNext atomic.Bool
 	failNext.Store(true)
 	started := make(chan struct{}, 4)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
 		if failNext.Swap(false) {
 			return nil, errors.New("build failed")
@@ -277,8 +275,8 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 	<-started
 	require.Eventually(t, module.builders[first.PayloadID].builder.Failed, time.Second, time.Millisecond)
 
-	// Identical parameters would normally dedup onto the same id. A builder that already died
-	// latches its error, so reusing it would spend the slot on a payload that can never arrive.
+	// Identical parameters would normally dedup onto the same id, but a failed builder latches its
+	// error and has to be passed over.
 	second, err := module.AssembleBlock(t.Context(), params())
 	require.NoError(t, err)
 	require.NotEqual(t, first.PayloadID, second.PayloadID)
@@ -289,7 +287,7 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 
 func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
 	timestamp := newTestTimestamp()
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("build failed")
 	})
 
@@ -308,7 +306,7 @@ func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) 
 	timestamp := newTestTimestamp()
 	interrupted := make(chan struct{})
 	release := make(chan struct{})
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
 		}
@@ -360,7 +358,7 @@ func (m *mutableTxnProvider) ProvideTxns(context.Context, ...txnprovider.Provide
 
 func TestAssembleBlockNeverReusesABuilderWithACustomProvider(t *testing.T) {
 	started := make(chan struct{}, 4)
-	module := newTestModule(t, func(ctx context.Context, params *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(ctx context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
 		// Keep the provider busy for the whole test, which is when a comparison would read it.
 		for !interrupt.Load() && ctx.Err() == nil {
@@ -372,9 +370,10 @@ func TestAssembleBlockNeverReusesABuilderWithACustomProvider(t *testing.T) {
 		return nil, errors.New("builder stopped")
 	})
 
+	timestamp := newTestTimestamp()
 	withProvider := func() *builder.Parameters {
 		return &builder.Parameters{
-			Timestamp:         100,
+			Timestamp:         timestamp,
 			ParentHash:        common.Hash{0x01},
 			CustomTxnProvider: &mutableTxnProvider{txns: []types.Transaction{}},
 		}
@@ -402,7 +401,7 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 	}
 	readParameters := make(chan struct{})
 	observed := make(chan observedParameters, 1)
-	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		<-readParameters
 		observed <- observedParameters{parentRoot: *params.ParentBeaconBlockRoot, extraData: params.ExtraData[0]}
 		for !interrupt.Load() {
@@ -410,9 +409,10 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 		}
 		return nil, errors.New("builder stopped")
 	})
+	timestamp := newTestTimestamp()
 	root := common.Hash{0xaa}
 	params := &builder.Parameters{
-		Timestamp:             100,
+		Timestamp:             timestamp,
 		ParentHash:            common.Hash{0x01},
 		ParentBeaconBlockRoot: &root,
 		ExtraData:             []byte{0xbb},
@@ -420,6 +420,7 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 	result, err := module.AssembleBlock(t.Context(), params)
 	require.NoError(t, err)
 	require.False(t, result.Busy)
+	require.Zero(t, params.PayloadId, "the caller's parameters are not the module's to write to")
 
 	root[0] = 0xcc
 	params.ExtraData[0] = 0xdd
@@ -427,7 +428,7 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 	require.Equal(t, observedParameters{parentRoot: common.Hash{0xaa}, extraData: 0xbb}, <-observed)
 
 	duplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{
-		Timestamp:             100,
+		Timestamp:             timestamp,
 		ParentHash:            common.Hash{0x01},
 		ParentBeaconBlockRoot: &common.Hash{0xaa},
 		ExtraData:             []byte{0xbb},
@@ -440,7 +441,7 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
 	timestamp := newTestTimestamp()
 	started := make(chan *atomic.Bool, 1)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- interrupt
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -493,6 +494,13 @@ func TestBuildDuration(t *testing.T) {
 	}
 }
 
+func TestStopGraceDuration(t *testing.T) {
+	// The grace has to fit a heavy transaction plus the packing tail and finalization, while still
+	// bounding how long a stuck build can hold its read view past its budget.
+	require.Equal(t, 6*time.Second, stopGraceDuration(12))
+	require.Equal(t, 2500*time.Millisecond, stopGraceDuration(5))
+}
+
 func TestBuildDurationCapsAbsurdTimestamp(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	farFuture := uint64(now.Add(time.Hour).Unix())
@@ -511,7 +519,7 @@ func TestBuildDurationCapsOverflowingTimestamp(t *testing.T) {
 
 func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
 	timestamp := newTestTimestamp()
-	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool, func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
 		// A transaction provider that gives up reports its own context error, which is a failed
 		// build rather than a caller that stopped waiting.
 		return nil, fmt.Errorf("issue while waiting for parent block: %w", context.DeadlineExceeded)
@@ -529,7 +537,7 @@ func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
 }
 
 func TestGetAssembledBlockSaysWhenAPayloadIdIsUnknown(t *testing.T) {
-	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool, func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("builder stopped")
 	})
 
@@ -544,7 +552,7 @@ func TestGetAssembledBlockSaysWhenAPayloadIdIsUnknown(t *testing.T) {
 func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
 	timestamp := newTestTimestamp()
 	started := make(chan struct{}, 1)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -570,8 +578,113 @@ func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
 	module.builders[current.PayloadID].builder.Discard()
 }
 
+func TestAssembleBlockDoesNotReuseADiscardedBuilder(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan struct{}, 2)
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		<-ctx.Done()
+		// The goroutine outliving the discard is the point: the builder must read as gone at once,
+		// not only once its work notices the cancellation.
+		time.Sleep(200 * time.Millisecond)
+		return nil, ctx.Err()
+	})
+
+	params := func() *builder.Parameters {
+		return &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}}
+	}
+	first, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	<-started
+
+	module.builders[first.PayloadID].builder.Discard()
+
+	second, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	require.NotEqual(t, first.PayloadID, second.PayloadID)
+	<-started
+	module.builders[second.PayloadID].builder.Discard()
+}
+
+func TestGetAssembledBlockReportsADiscardedBuilderAsUnknown(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan struct{}, 1)
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		<-ctx.Done()
+		time.Sleep(200 * time.Millisecond)
+		return nil, ctx.Err()
+	})
+
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	<-started
+	module.builders[result.PayloadID].builder.Discard()
+
+	assembled, err := module.GetAssembledBlock(t.Context(), result.PayloadID)
+	require.NoError(t, err)
+	require.True(t, assembled.Unknown)
+	require.NotContains(t, module.builders, result.PayloadID)
+	require.NotContains(t, module.buildersByTimestamp, timestamp)
+}
+
+func TestEvictionTakesAFailedCurrentBuilderBeforeALiveSupersededOne(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan struct{}, 4)
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		if params.ParentHash == (common.Hash{0xff}) {
+			return nil, errors.New("build failed")
+		}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	})
+	t.Cleanup(func() {
+		for _, entry := range module.builders {
+			if entry != nil && entry.builder != nil {
+				entry.builder.Discard()
+			}
+		}
+	})
+
+	failed, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0xff}})
+	require.NoError(t, err)
+	<-started
+	require.Eventually(t, module.builders[failed.PayloadID].builder.Failed, time.Second, time.Millisecond)
+
+	superseded, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp + 1, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	<-started
+	_, err = module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp + 1, ParentHash: common.Hash{0x02}})
+	require.NoError(t, err)
+	<-started
+
+	for id := uint64(1000); len(module.builders) < engine_helpers.MaxBuilders; id++ {
+		module.builders[id] = nil
+	}
+	module.evictOldBuilders()
+
+	require.NotContains(t, module.builders, failed.PayloadID)
+	require.Contains(t, module.builders, superseded.PayloadID)
+}
+
+func TestAssembleBlockRefusesAfterShutdown(t *testing.T) {
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, ctx.Err()
+	})
+	shutdownCtx, cancel := context.WithCancel(t.Context())
+	module.backgroundCtx = shutdownCtx
+	cancel()
+
+	_, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: newTestTimestamp(), ParentHash: common.Hash{0x01}})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, module.builders)
+}
+
 func TestEvictionKeepsTheBuilderCacheBounded(t *testing.T) {
-	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool, func()) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("builder stopped")
 	})
 

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -37,6 +38,17 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/txnprovider"
 )
+
+type doneObservedContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
 
 // newTestModule builds a module whose builders run builderFunc. Every test needs the same fields,
 // and getting the config or the context wrong changes the builder's own deadline silently.
@@ -668,14 +680,12 @@ func TestGetAssembledBlockReportsDiscardDuringStopAsUnknown(t *testing.T) {
 
 func TestGetAssembledBlockKeepsPayloadCompletedAsDiscardLands(t *testing.T) {
 	timestamp := newTestTimestamp()
-	stopObserved := make(chan struct{})
 	finish := make(chan struct{})
 	want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
 	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
 		}
-		close(stopObserved)
 		<-finish
 		return want, nil
 	})
@@ -688,8 +698,10 @@ func TestGetAssembledBlockKeepsPayloadCompletedAsDiscardLands(t *testing.T) {
 		err    error
 	}
 	collected := make(chan response, 1)
+	stopObserved := make(chan struct{})
+	stopCtx := &doneObservedContext{Context: t.Context(), observed: stopObserved}
 	go func() {
-		result, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
+		result, err := module.GetAssembledBlock(stopCtx, assembled.PayloadID)
 		collected <- response{result: result, err: err}
 	}()
 	select {
@@ -708,6 +720,11 @@ func TestGetAssembledBlockKeepsPayloadCompletedAsDiscardLands(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("payload collection did not finish")
 	}
+
+	replayed, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
+	require.NoError(t, err)
+	require.False(t, replayed.Unknown)
+	require.Same(t, want, replayed.Block)
 }
 
 func TestGetAssembledBlockKeepsFailureCompletedBeforeDiscard(t *testing.T) {

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -67,7 +67,7 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 		interrupt *atomic.Bool
 	}
 	started := make(chan runningBuilder, 4)
-	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		started <- runningBuilder{id: params.PayloadId, interrupt: interrupt}
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -151,7 +151,7 @@ func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
 	// is not read until it does. Only cancelling the build reaches it.
 	entered := make(chan struct{}, 1)
 	released := make(chan error, 1)
-	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		entered <- struct{}{}
 		select {
 		case <-ctx.Done():
@@ -194,7 +194,7 @@ func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
 func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 	timestamp := newTestTimestamp()
 	started := make(chan *atomic.Bool, 4)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		started <- interrupt
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -226,7 +226,7 @@ func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 func TestCollectedPayloadIsHandedBackToARepeatedRequest(t *testing.T) {
 	timestamp := newTestTimestamp()
 	started := make(chan struct{}, 4)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -258,7 +258,7 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 	var failNext atomic.Bool
 	failNext.Store(true)
 	started := make(chan struct{}, 4)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
 		if failNext.Swap(false) {
 			return nil, errors.New("build failed")
@@ -289,7 +289,7 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 
 func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
 	timestamp := newTestTimestamp()
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, _ *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("build failed")
 	})
 
@@ -308,7 +308,7 @@ func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) 
 	timestamp := newTestTimestamp()
 	interrupted := make(chan struct{})
 	release := make(chan struct{})
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
 		}
@@ -360,7 +360,7 @@ func (m *mutableTxnProvider) ProvideTxns(context.Context, ...txnprovider.Provide
 
 func TestAssembleBlockNeverReusesABuilderWithACustomProvider(t *testing.T) {
 	started := make(chan struct{}, 4)
-	module := newTestModule(t, func(ctx context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(ctx context.Context, params *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
 		// Keep the provider busy for the whole test, which is when a comparison would read it.
 		for !interrupt.Load() && ctx.Err() == nil {
@@ -402,7 +402,7 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 	}
 	readParameters := make(chan struct{})
 	observed := make(chan observedParameters, 1)
-	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		<-readParameters
 		observed <- observedParameters{parentRoot: *params.ParentBeaconBlockRoot, extraData: params.ExtraData[0]}
 		for !interrupt.Load() {
@@ -440,7 +440,7 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
 	timestamp := newTestTimestamp()
 	started := make(chan *atomic.Bool, 1)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		started <- interrupt
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -511,7 +511,7 @@ func TestBuildDurationCapsOverflowingTimestamp(t *testing.T) {
 
 func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
 	timestamp := newTestTimestamp()
-	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool, func()) (*types.BlockWithReceipts, error) {
 		// A transaction provider that gives up reports its own context error, which is a failed
 		// build rather than a caller that stopped waiting.
 		return nil, fmt.Errorf("issue while waiting for parent block: %w", context.DeadlineExceeded)
@@ -529,7 +529,7 @@ func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
 }
 
 func TestGetAssembledBlockSaysWhenAPayloadIdIsUnknown(t *testing.T) {
-	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool, func()) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("builder stopped")
 	})
 
@@ -544,7 +544,7 @@ func TestGetAssembledBlockSaysWhenAPayloadIdIsUnknown(t *testing.T) {
 func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
 	timestamp := newTestTimestamp()
 	started := make(chan struct{}, 1)
-	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool, _ func()) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
 		for !interrupt.Load() {
 			time.Sleep(time.Millisecond)
@@ -571,7 +571,7 @@ func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
 }
 
 func TestEvictionKeepsTheBuilderCacheBounded(t *testing.T) {
-	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool, func()) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("builder stopped")
 	})
 

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -53,14 +53,15 @@ func newTestModule(t *testing.T, builderFunc builder.BlockBuilderFunc) *ExecModu
 	}
 }
 
-// testTimestamp is a slot that has not happened yet but is close enough to be one a proposal could
+// newTestTimestamp is a slot that has not happened yet but is close enough to be one a proposal could
 // be waiting for. Far enough ahead that buildDuration gives a budget measured in slots, so the
 // max-build-time watchdog cannot fire mid-test, and near enough that the slot still counts as live.
-func testTimestamp(offset uint64) uint64 {
-	return uint64(time.Now().Add(10*time.Second).Unix()) + offset
+func newTestTimestamp() uint64 {
+	return uint64(time.Now().Add(10 * time.Second).Unix())
 }
 
 func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
+	timestamp := newTestTimestamp()
 	type runningBuilder struct {
 		id        uint64
 		interrupt *atomic.Bool
@@ -99,26 +100,26 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 		return result.PayloadID, waitStarted()
 	}
 
-	firstID, first := assemble(testTimestamp(0), common.Hash{0x01})
-	adjacentID, adjacent := assemble(testTimestamp(1), common.Hash{0x02})
+	firstID, first := assemble(timestamp, common.Hash{0x01})
+	adjacentID, adjacent := assemble(timestamp+1, common.Hash{0x02})
 	require.NotEqual(t, firstID, adjacentID)
 
-	firstDuplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
+	firstDuplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 	require.Equal(t, firstID, firstDuplicate.PayloadID)
 
 	// Superseding hands the timestamp to a new builder and leaves the old ones running, so only the
-	// index moves. Timestamp 101 is a different proposal and is untouched throughout.
-	secondID, second := assemble(testTimestamp(0), common.Hash{0x03})
+	// index moves. The adjacent timestamp is a different proposal and is untouched throughout.
+	secondID, second := assemble(timestamp, common.Hash{0x03})
 	require.NotEqual(t, firstID, secondID)
-	require.Equal(t, secondID, module.buildersByTimestamp[testTimestamp(0)])
-	require.Equal(t, adjacentID, module.buildersByTimestamp[testTimestamp(1)])
+	require.Equal(t, secondID, module.buildersByTimestamp[timestamp])
+	require.Equal(t, adjacentID, module.buildersByTimestamp[timestamp+1])
 
-	thirdID, third := assemble(testTimestamp(0), common.Hash{0x04})
+	thirdID, third := assemble(timestamp, common.Hash{0x04})
 	require.NotEqual(t, secondID, thirdID)
-	require.Equal(t, thirdID, module.buildersByTimestamp[testTimestamp(0)])
+	require.Equal(t, thirdID, module.buildersByTimestamp[timestamp])
 
-	duplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x04}})
+	duplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x04}})
 	require.NoError(t, err)
 	require.Equal(t, thirdID, duplicate.PayloadID)
 
@@ -140,11 +141,12 @@ func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
 	require.Contains(t, module.builders, thirdID)
 	require.False(t, adjacent.interrupt.Load())
 	require.False(t, third.interrupt.Load())
-	require.Equal(t, thirdID, module.buildersByTimestamp[testTimestamp(0)])
-	require.Equal(t, adjacentID, module.buildersByTimestamp[testTimestamp(1)])
+	require.Equal(t, thirdID, module.buildersByTimestamp[timestamp])
+	require.Equal(t, adjacentID, module.buildersByTimestamp[timestamp+1])
 }
 
 func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
+	timestamp := newTestTimestamp()
 	// A transaction provider can wait for most of a slot before returning, and the interrupt flag
 	// is not read until it does. Only cancelling the build reaches it.
 	entered := make(chan struct{}, 1)
@@ -161,12 +163,12 @@ func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
 		}
 	})
 
-	blocked, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
+	blocked, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 	<-entered
 
 	// Superseded, so eviction is allowed to take it: what a timestamp still resolves to is exempt.
-	_, err = module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x02}})
+	_, err = module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x02}})
 	require.NoError(t, err)
 	<-entered
 
@@ -190,6 +192,7 @@ func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
 }
 
 func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
+	timestamp := newTestTimestamp()
 	started := make(chan *atomic.Bool, 4)
 	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- interrupt
@@ -199,18 +202,18 @@ func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
 	})
 
-	first, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
+	first, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 	firstInterrupt := <-started
 
-	second, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x02}})
+	second, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x02}})
 	require.NoError(t, err)
 	require.NotEqual(t, first.PayloadID, second.PayloadID)
 	secondInterrupt := <-started
 
 	// The timestamp index moves to the new builder, so nothing reaches the old one by dedup. It is
 	// left running: freezing it would answer an id already handed out with a near-empty payload.
-	require.Equal(t, second.PayloadID, module.buildersByTimestamp[testTimestamp(0)])
+	require.Equal(t, second.PayloadID, module.buildersByTimestamp[timestamp])
 	require.False(t, firstInterrupt.Load())
 
 	assembled, err := module.GetAssembledBlock(t.Context(), first.PayloadID)
@@ -221,6 +224,7 @@ func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
 }
 
 func TestCollectedPayloadIsHandedBackToARepeatedRequest(t *testing.T) {
+	timestamp := newTestTimestamp()
 	started := make(chan struct{}, 4)
 	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
@@ -231,7 +235,7 @@ func TestCollectedPayloadIsHandedBackToARepeatedRequest(t *testing.T) {
 	})
 
 	params := func() *builder.Parameters {
-		return &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}}
+		return &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}}
 	}
 	first, err := module.AssembleBlock(t.Context(), params())
 	require.NoError(t, err)
@@ -250,6 +254,7 @@ func TestCollectedPayloadIsHandedBackToARepeatedRequest(t *testing.T) {
 }
 
 func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
+	timestamp := newTestTimestamp()
 	var failNext atomic.Bool
 	failNext.Store(true)
 	started := make(chan struct{}, 4)
@@ -265,7 +270,7 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 	})
 
 	params := func() *builder.Parameters {
-		return &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}}
+		return &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}}
 	}
 	first, err := module.AssembleBlock(t.Context(), params())
 	require.NoError(t, err)
@@ -283,11 +288,12 @@ func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
 }
 
 func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
+	timestamp := newTestTimestamp()
 	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
 		return nil, errors.New("build failed")
 	})
 
-	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 
 	_, err = module.GetAssembledBlock(t.Context(), result.PayloadID)
@@ -295,10 +301,11 @@ func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
 
 	// The error is latched, so leaving the entry in place would keep serving it to every retry.
 	require.NotContains(t, module.builders, result.PayloadID)
-	require.NotContains(t, module.buildersByTimestamp, testTimestamp(0))
+	require.NotContains(t, module.buildersByTimestamp, timestamp)
 }
 
 func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) {
+	timestamp := newTestTimestamp()
 	interrupted := make(chan struct{})
 	release := make(chan struct{})
 	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
@@ -310,7 +317,7 @@ func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) 
 		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
 	})
 
-	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 
 	// Cancel while Stop is already waiting, which is the window a caller-side timeout actually
@@ -327,7 +334,7 @@ func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) 
 
 	// The builder was not dropped, so the payload it goes on to produce is still reachable.
 	require.Contains(t, module.builders, result.PayloadID)
-	require.Equal(t, result.PayloadID, module.buildersByTimestamp[testTimestamp(0)])
+	require.Equal(t, result.PayloadID, module.buildersByTimestamp[timestamp])
 
 	close(release)
 	assembled, err := module.GetAssembledBlock(t.Context(), result.PayloadID)
@@ -431,6 +438,7 @@ func TestAssembleBlockOwnsParameters(t *testing.T) {
 }
 
 func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
+	timestamp := newTestTimestamp()
 	started := make(chan *atomic.Bool, 1)
 	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- interrupt
@@ -439,7 +447,7 @@ func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
 		}
 		return nil, errors.New("builder stopped")
 	})
-	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 	interrupt := <-started
 	t.Cleanup(func() {
@@ -448,10 +456,10 @@ func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	_, err = module.AssembleBlock(ctx, &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x02}})
+	_, err = module.AssembleBlock(ctx, &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x02}})
 	require.ErrorIs(t, err, context.Canceled)
 	require.False(t, interrupt.Load())
-	require.Equal(t, result.PayloadID, module.buildersByTimestamp[testTimestamp(0)])
+	require.Equal(t, result.PayloadID, module.buildersByTimestamp[timestamp])
 }
 
 func TestBuildDuration(t *testing.T) {
@@ -502,13 +510,14 @@ func TestBuildDurationCapsOverflowingTimestamp(t *testing.T) {
 }
 
 func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
+	timestamp := newTestTimestamp()
 	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
 		// A transaction provider that gives up reports its own context error, which is a failed
 		// build rather than a caller that stopped waiting.
 		return nil, fmt.Errorf("issue while waiting for parent block: %w", context.DeadlineExceeded)
 	})
 
-	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 
 	_, err = module.GetAssembledBlock(t.Context(), result.PayloadID)
@@ -516,7 +525,7 @@ func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
 
 	// Keeping it would serve that latched error to every later retry of the same slot.
 	require.NotContains(t, module.builders, result.PayloadID)
-	require.NotContains(t, module.buildersByTimestamp, testTimestamp(0))
+	require.NotContains(t, module.buildersByTimestamp, timestamp)
 }
 
 func TestGetAssembledBlockSaysWhenAPayloadIdIsUnknown(t *testing.T) {
@@ -533,6 +542,7 @@ func TestGetAssembledBlockSaysWhenAPayloadIdIsUnknown(t *testing.T) {
 }
 
 func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
+	timestamp := newTestTimestamp()
 	started := make(chan struct{}, 1)
 	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		started <- struct{}{}
@@ -542,7 +552,7 @@ func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
 		return nil, errors.New("builder stopped")
 	})
 
-	current, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: testTimestamp(0), ParentHash: common.Hash{0x01}})
+	current, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
 	require.NoError(t, err)
 	<-started
 
@@ -554,7 +564,7 @@ func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
 	module.evictOldBuilders()
 
 	require.Contains(t, module.builders, current.PayloadID)
-	require.Equal(t, current.PayloadID, module.buildersByTimestamp[testTimestamp(0)])
+	require.Equal(t, current.PayloadID, module.buildersByTimestamp[timestamp])
 	require.False(t, module.builders[current.PayloadID].builder.Failed())
 
 	module.builders[current.PayloadID].builder.Discard()

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -19,6 +19,7 @@ package execmodule
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"sync/atomic"
 	"testing"
@@ -572,4 +573,29 @@ func TestBuildDurationCapsOverflowingTimestamp(t *testing.T) {
 	// Beyond int64 seconds the conversion wraps into the past, which would collapse the budget to
 	// the floor instead of the cap.
 	require.Equal(t, 24*time.Second, buildDuration(math.MaxUint64, now, 12))
+}
+
+func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
+	module := &ExecModule{
+		logger:       log.Root(),
+		config:       &chain.Config{},
+		semaphore:    semaphore.NewWeighted(1),
+		builders:     map[uint64]*builderEntry{},
+		bacgroundCtx: t.Context(),
+		builderFunc: func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+			// A transaction provider that gives up reports its own context error, which is a failed
+			// build rather than a caller that stopped waiting.
+			return nil, fmt.Errorf("issue while waiting for parent block: %w", context.DeadlineExceeded)
+		},
+	}
+
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: 100, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+
+	_, err = module.GetAssembledBlock(t.Context(), result.PayloadID)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// Keeping it would serve that latched error to every later retry of the same slot.
+	require.NotContains(t, module.builders, result.PayloadID)
+	require.NotContains(t, module.buildersByTimestamp, uint64(100))
 }

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -39,17 +39,6 @@ import (
 	"github.com/erigontech/erigon/txnprovider"
 )
 
-type doneObservedContext struct {
-	context.Context
-	observed chan struct{}
-	once     sync.Once
-}
-
-func (c *doneObservedContext) Done() <-chan struct{} {
-	c.once.Do(func() { close(c.observed) })
-	return c.Context.Done()
-}
-
 // newTestModule builds a module whose builders run builderFunc. Every test needs the same fields,
 // and getting the config or the context wrong changes the builder's own deadline silently.
 func newTestModule(t *testing.T, builderFunc builder.BlockBuilderFunc) *ExecModule {
@@ -681,6 +670,9 @@ func TestGetAssembledBlockReportsDiscardDuringStopAsUnknown(t *testing.T) {
 func TestGetAssembledBlockKeepsPayloadCompletedAsDiscardLands(t *testing.T) {
 	timestamp := newTestTimestamp()
 	finish := make(chan struct{})
+	var finishOnce sync.Once
+	closeFinish := func() { finishOnce.Do(func() { close(finish) }) }
+	t.Cleanup(closeFinish)
 	want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
 	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
 		for !interrupt.Load() {
@@ -698,8 +690,7 @@ func TestGetAssembledBlockKeepsPayloadCompletedAsDiscardLands(t *testing.T) {
 		err    error
 	}
 	collected := make(chan response, 1)
-	stopObserved := make(chan struct{})
-	stopCtx := &doneObservedContext{Context: t.Context(), observed: stopObserved}
+	stopCtx, stopObserved := NewDoneObservedContext(t.Context())
 	go func() {
 		result, err := module.GetAssembledBlock(stopCtx, assembled.PayloadID)
 		collected <- response{result: result, err: err}
@@ -710,7 +701,7 @@ func TestGetAssembledBlockKeepsPayloadCompletedAsDiscardLands(t *testing.T) {
 		t.Fatal("builder did not observe the collection request")
 	}
 	module.builders[assembled.PayloadID].builder.Discard()
-	close(finish)
+	closeFinish()
 
 	select {
 	case result := <-collected:
@@ -744,6 +735,36 @@ func TestGetAssembledBlockKeepsFailureCompletedBeforeDiscard(t *testing.T) {
 	require.ErrorIs(t, err, wantErr)
 	require.False(t, result.Unknown)
 	require.NotContains(t, module.builders, assembled.PayloadID)
+}
+
+func TestEvictionSparesADiscardedBuilderWithALatchedPayload(t *testing.T) {
+	timestamp := newTestTimestamp()
+	release := make(chan struct{})
+	want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-release
+		return want, nil
+	})
+
+	assembled, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	entry := module.builders[assembled.PayloadID]
+	entry.builder.Discard()
+	close(release)
+	require.Eventually(t, func() bool { return entry.builder.Block() != nil }, 5*time.Second, time.Millisecond)
+
+	// The latched payload is still served to getPayload, so evicting this entry while its slot is
+	// live would flip a payload the CL can already collect into Unknown between two polls.
+	for id := assembled.PayloadID + 1; len(module.builders) < engine_helpers.MaxBuilders; id++ {
+		module.builders[id] = nil
+	}
+	module.evictOldBuilders()
+
+	require.Contains(t, module.builders, assembled.PayloadID)
+	replayed, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
+	require.NoError(t, err)
+	require.False(t, replayed.Unknown)
+	require.Same(t, want, replayed.Block)
 }
 
 func TestEvictionTakesAFailedCurrentBuilderBeforeALiveSupersededOne(t *testing.T) {

--- a/execution/execmodule/chainreader/chain_reader.go
+++ b/execution/execmodule/chainreader/chain_reader.go
@@ -283,6 +283,10 @@ func (c ChainReaderWriterEth1) HasBlock(ctx context.Context, hash common.Hash) (
 // own, as opposed to a rejection that returns the same answer however many times it is asked.
 var ErrExecutionBusy = errors.New("execution module is busy")
 
+// ErrUnknownPayload reports that no builder is held for a payload id, so nothing will ever arrive
+// for it. Without it a caller polling that id cannot tell it from a build still running.
+var ErrUnknownPayload = errors.New("unknown payload id")
+
 func (c ChainReaderWriterEth1) AssembleBlock(ctx context.Context, baseHash common.Hash, attributes *engine_types.PayloadAttributes) (id uint64, err error) {
 	params := &builder.Parameters{
 		ParentHash:            baseHash,

--- a/execution/execmodule/chainreader/chain_reader.go
+++ b/execution/execmodule/chainreader/chain_reader.go
@@ -316,6 +316,9 @@ func (c ChainReaderWriterEth1) GetAssembledBlock(ctx context.Context, id uint64)
 	if result.Busy {
 		return nil, nil, nil, nil, ErrExecutionBusy
 	}
+	if result.Unknown {
+		return nil, nil, nil, nil, ErrUnknownPayload
+	}
 	if result.Block == nil {
 		return nil, nil, nil, nil, nil
 	}

--- a/execution/execmodule/chainreader/chain_reader_test.go
+++ b/execution/execmodule/chainreader/chain_reader_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package chainreader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/execmodule"
+)
+
+// assembledBlockStub answers GetAssembledBlock with a fixed result and panics on anything else, so
+// a test can drive the one boundary it cares about.
+type assembledBlockStub struct {
+	execmodule.ExecutionModule
+	result execmodule.AssembledBlockResult
+}
+
+func (s assembledBlockStub) GetAssembledBlock(context.Context, uint64) (execmodule.AssembledBlockResult, error) {
+	return s.result, nil
+}
+
+func TestGetAssembledBlockDistinguishesAnUnknownIdFromAnEmptyOne(t *testing.T) {
+	unknown := ChainReaderWriterEth1{executionModule: assembledBlockStub{result: execmodule.AssembledBlockResult{Unknown: true}}}
+	_, _, _, _, err := unknown.GetAssembledBlock(t.Context(), 1)
+
+	// Nothing will ever arrive for an id with no builder behind it. Reporting that as an ordinary
+	// empty result leaves a caller polling it for the rest of the slot.
+	require.ErrorIs(t, err, ErrUnknownPayload)
+
+	busy := ChainReaderWriterEth1{executionModule: assembledBlockStub{result: execmodule.AssembledBlockResult{Busy: true}}}
+	_, _, _, _, err = busy.GetAssembledBlock(t.Context(), 1)
+	require.ErrorIs(t, err, ErrExecutionBusy)
+
+	// A builder that simply has nothing yet is neither: the caller should keep waiting.
+	building := ChainReaderWriterEth1{executionModule: assembledBlockStub{}}
+	block, _, _, _, err := building.GetAssembledBlock(t.Context(), 1)
+	require.NoError(t, err)
+	require.Nil(t, block)
+}

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -178,7 +178,7 @@ func (c *CacheView) HasStorage(address common.Address) (bool, error) {
 }
 
 type ExecModule struct {
-	bacgroundCtx context.Context
+	backgroundCtx context.Context
 	// Snapshots + MDBX
 	blockReader dbservices.FullBlockReader
 
@@ -276,7 +276,7 @@ func NewExecModule(
 		engine:                  engine,
 		balRegenerator:          bal.NewRegenerator(blockReader, engine, logger),
 		syncCfg:                 syncCfg,
-		bacgroundCtx:            ctx,
+		backgroundCtx:           ctx,
 		fcuBackgroundPrune:      fcuBackgroundPrune,
 		onlySnapDownloadOnStart: onlySnapDownloadOnStart,
 		stateCache:              domainCache,
@@ -409,7 +409,7 @@ func (e *ExecModule) suspendReadAhead(ctx context.Context) (func(), error) {
 func (e *ExecModule) unwindToCommonCanonical(sd *execctx.SharedDomains, tx kv.TemporalRwTx, header *types.Header, ensureReadAheadSuspended func() error) error {
 	currentHeader := header
 	for {
-		isCanonical, err := e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash())
+		isCanonical, err := e.isCanonicalHash(e.backgroundCtx, tx, currentHeader.Hash())
 		if err != nil {
 			return err
 		}
@@ -417,7 +417,7 @@ func (e *ExecModule) unwindToCommonCanonical(sd *execctx.SharedDomains, tx kv.Te
 			break
 		}
 		parentBlockHash, parentBlockNum := currentHeader.ParentHash, currentHeader.Number.Uint64()-1
-		currentHeader, err = e.getHeader(e.bacgroundCtx, tx, parentBlockHash, parentBlockNum)
+		currentHeader, err = e.getHeader(e.backgroundCtx, tx, parentBlockHash, parentBlockNum)
 		if err != nil {
 			return err
 		}

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -194,10 +194,10 @@ type ExecModule struct {
 
 	logger log.Logger
 	// Block building
-	nextPayloadId  uint64
-	lastParameters *builder.Parameters
-	builderFunc    builder.BlockBuilderFunc
-	builders       map[uint64]*builder.BlockBuilder
+	nextPayloadId       uint64
+	builderFunc         builder.BlockBuilderFunc
+	builders            map[uint64]*builderEntry
+	buildersByTimestamp map[uint64]uint64
 
 	// Changes accumulator
 	hook  *stageloop.Hook
@@ -266,7 +266,7 @@ func NewExecModule(
 		logger:                  logger,
 		forkValidator:           forkValidator,
 		pipelineExecutor:        pipelineExecutor,
-		builders:                make(map[uint64]*builder.BlockBuilder),
+		builders:                make(map[uint64]*builderEntry),
 		builderFunc:             builderFunc,
 		config:                  config,
 		semaphore:               semaphore.NewWeighted(1),

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -267,6 +267,7 @@ func NewExecModule(
 		forkValidator:           forkValidator,
 		pipelineExecutor:        pipelineExecutor,
 		builders:                make(map[uint64]*builderEntry),
+		buildersByTimestamp:     make(map[uint64]uint64),
 		builderFunc:             builderFunc,
 		config:                  config,
 		semaphore:               semaphore.NewWeighted(1),

--- a/execution/execmodule/exec_module_internal_test.go
+++ b/execution/execmodule/exec_module_internal_test.go
@@ -98,8 +98,8 @@ func TestNewDomainStateCacheRespectsUseStateCache(t *testing.T) {
 func TestUnwindToCommonCanonicalReturnsCanonicalityError(t *testing.T) {
 	expectedErr := errors.New("canonicality read failed")
 	e := &ExecModule{
-		bacgroundCtx: t.Context(),
-		blockReader:  headerNumberErrorReader{err: expectedErr},
+		backgroundCtx: t.Context(),
+		blockReader:   headerNumberErrorReader{err: expectedErr},
 	}
 	header := &types.Header{Number: *uint256.NewInt(0)}
 

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -129,6 +129,17 @@ type delayedSealEngine struct {
 	release chan struct{}
 }
 
+type doneObservedContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
 func (e *delayedSealEngine) Seal(_ rules.ChainHeaderReader, block *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, _ <-chan struct{}) error {
 	close(e.started)
 	go func() {
@@ -640,6 +651,14 @@ func addTwoTxnsToPool(ctx context.Context, startingNonce uint64, t *testing.T, m
 	}
 }
 
+func TestExecModuleTesterReportsUnknownPayload(t *testing.T) {
+	m := execmoduletester.New(t, execmoduletester.WithChainConfig(chain.AllProtocolChanges))
+
+	block, err := m.GetAssembledBlock(t.Context(), 404)
+	require.ErrorIs(t, err, chainreader.ErrUnknownPayload)
+	require.Nil(t, block)
+}
+
 func TestAssembleBlock(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -685,6 +704,7 @@ func TestDiscardReleasesBuilderWaitingForSeal(t *testing.T) {
 		started: make(chan struct{}),
 		release: make(chan struct{}),
 	}
+	t.Cleanup(func() { close(engine.release) })
 	m := execmoduletester.New(t,
 		execmoduletester.WithChainConfig(chain.AllProtocolChanges),
 		execmoduletester.WithEngine(engine),
@@ -707,26 +727,29 @@ func TestDiscardReleasesBuilderWaitingForSeal(t *testing.T) {
 	}, time.Minute, time.Minute)
 
 	stopped := make(chan error, 1)
+	stopObserved := make(chan struct{})
+	stopCtx := &doneObservedContext{Context: context.Background(), observed: stopObserved}
 	go func() {
-		_, stopErr := payloadBuilder.Stop(context.Background())
+		_, stopErr := payloadBuilder.Stop(stopCtx)
 		stopped <- stopErr
 	}()
 
 	select {
 	case <-engine.started:
 	case <-time.After(10 * time.Second):
-		close(engine.release)
 		t.Fatal("builder did not reach sealing")
+	}
+	select {
+	case <-stopObserved:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stop did not begin waiting for the builder")
 	}
 	payloadBuilder.Discard()
 
 	select {
 	case err := <-stopped:
-		close(engine.release)
-		require.ErrorIs(t, err, context.Canceled)
-	case <-time.After(time.Second):
-		close(engine.release)
-		<-stopped
+		require.ErrorIs(t, err, builder.ErrDiscarded)
+	case <-time.After(5 * time.Second):
 		t.Fatal("discarded builder remained blocked waiting for a seal result")
 	}
 }

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -129,17 +129,6 @@ type delayedSealEngine struct {
 	release chan struct{}
 }
 
-type doneObservedContext struct {
-	context.Context
-	observed chan struct{}
-	once     sync.Once
-}
-
-func (c *doneObservedContext) Done() <-chan struct{} {
-	c.once.Do(func() { close(c.observed) })
-	return c.Context.Done()
-}
-
 func (e *delayedSealEngine) Seal(_ rules.ChainHeaderReader, block *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, _ <-chan struct{}) error {
 	close(e.started)
 	go func() {
@@ -727,8 +716,7 @@ func TestDiscardReleasesBuilderWaitingForSeal(t *testing.T) {
 	}, time.Minute, time.Minute)
 
 	stopped := make(chan error, 1)
-	stopObserved := make(chan struct{})
-	stopCtx := &doneObservedContext{Context: context.Background(), observed: stopObserved}
+	stopCtx, stopObserved := execmodule.NewDoneObservedContext(context.Background())
 	go func() {
 		_, stopErr := payloadBuilder.Stop(stopCtx)
 		stopped <- stopErr

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -51,6 +51,9 @@ import (
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/protocol/rules/ethash"
+	"github.com/erigontech/erigon/execution/protocol/rules/merge"
 	"github.com/erigontech/erigon/execution/stagedsync"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/execution/state/contracts"
@@ -112,6 +115,27 @@ func (p *rewindingTxnProvider) ProvideTxns(ctx context.Context, opts ...txnprovi
 type observingTxnProvider struct {
 	txnprovider.TxnProvider
 	txnCounts chan int
+}
+
+type emptyTxnProvider struct{}
+
+func (emptyTxnProvider) ProvideTxns(context.Context, ...txnprovider.ProvideOption) ([]types.Transaction, error) {
+	return nil, nil
+}
+
+type delayedSealEngine struct {
+	rules.Engine
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *delayedSealEngine) Seal(_ rules.ChainHeaderReader, block *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, _ <-chan struct{}) error {
+	close(e.started)
+	go func() {
+		<-e.release
+		results <- block
+	}()
+	return nil
 }
 
 func (p *observingTxnProvider) ProvideTxns(ctx context.Context, opts ...txnprovider.ProvideOption) ([]types.Transaction, error) {
@@ -653,6 +677,58 @@ func TestAssembleBlock(t *testing.T) {
 
 	err = m.InsertValidateAndUfc1By1(ctx, []*types.Block{block})
 	require.NoError(t, err)
+}
+
+func TestDiscardReleasesBuilderWaitingForSeal(t *testing.T) {
+	engine := &delayedSealEngine{
+		Engine:  merge.NewFaker(ethash.NewFaker()),
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m := execmoduletester.New(t,
+		execmoduletester.WithChainConfig(chain.AllProtocolChanges),
+		execmoduletester.WithEngine(engine),
+	)
+	chainPack, err := m.GenerateChain(1, nil)
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(chainPack))
+
+	parent := chainPack.TopBlock
+	beaconRoot := randomHash()
+	payloadBuilder := builder.NewBlockBuilder(t.Context(), m.BlockBuilder.Build, &builder.Parameters{
+		ParentHash:            parent.Hash(),
+		Timestamp:             parent.Time() + 1,
+		PrevRandao:            parent.Header().MixDigest,
+		SuggestedFeeRecipient: common.Address{1},
+		Withdrawals:           make([]*types.Withdrawal, 0),
+		ParentBeaconBlockRoot: &beaconRoot,
+		SlotNumber:            syntheticSlotNumber(parent),
+		CustomTxnProvider:     emptyTxnProvider{},
+	}, time.Minute, time.Minute)
+
+	stopped := make(chan error, 1)
+	go func() {
+		_, stopErr := payloadBuilder.Stop(context.Background())
+		stopped <- stopErr
+	}()
+
+	select {
+	case <-engine.started:
+	case <-time.After(10 * time.Second):
+		close(engine.release)
+		t.Fatal("builder did not reach sealing")
+	}
+	payloadBuilder.Discard()
+
+	select {
+	case err := <-stopped:
+		close(engine.release)
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		close(engine.release)
+		<-stopped
+		t.Fatal("discarded builder remained blocked waiting for a seal result")
+	}
 }
 
 func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -682,7 +682,6 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 
 	readAheader := exec.NewBlockReadAheader()
 	blkBuilder := builder.NewBuilder(
-		mock.Ctx,
 		mock.DB,
 		&cfg.Builder,
 		mock.ChainConfig,

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -960,6 +960,9 @@ func (emt *ExecModuleTester) GetAssembledBlock(ctx context.Context, payloadID ui
 		if err != nil {
 			return nil, false, err
 		}
+		if result.Unknown {
+			return nil, false, chainreader.ErrUnknownPayload
+		}
 		if result.Block == nil {
 			return nil, result.Busy, nil
 		}

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -128,6 +128,7 @@ type ExecModuleTester struct {
 	Address         common.Address
 	ForkValidator   *execmodule.ForkValidator
 	ExecModule      *execmodule.ExecModule
+	BlockBuilder    *builder.Builder
 	StateCache      *execmodule.Cache
 	retirementStart chan bool
 	retirementDone  chan struct{}
@@ -713,6 +714,7 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 		nil, /*sdProvider*/
 		logger,
 	)
+	mock.BlockBuilder = blkBuilder
 
 	blockRetire := freezeblocks.NewBlockRetire(mock.Ctx, 1, dirs, mock.BlockReader, blockWriter, mock.DB, nil, nil, mock.ChainConfig, &cfg, mock.Notifications.Events, nil, logger)
 	mock.blockRetire = blockRetire

--- a/execution/execmodule/export_test.go
+++ b/execution/execmodule/export_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execmodule
+
+import (
+	"context"
+	"sync"
+)
+
+// doneObservedContext signals on observed the first time Done is asked for, which lets a test order
+// an action strictly after a select has committed to waiting on the context.
+type doneObservedContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
+// NewDoneObservedContext is exported so the external execmodule_test package shares the helper
+// instead of keeping its own copy.
+func NewDoneObservedContext(parent context.Context) (context.Context, <-chan struct{}) {
+	observed := make(chan struct{})
+	return &doneObservedContext{Context: parent, observed: observed}, observed
+}

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -125,7 +125,7 @@ func (e *ExecModule) UpdateForkChoice(ctx context.Context, headHash, safeHash, f
 	// cleanup has run, so any follow-up op (AssembleBlock, next FCU) that acquires
 	// the semaphore observes fully-settled state.
 	go func() {
-		if err := e.updateForkChoice(e.bacgroundCtx, headHash, safeHash, finalizedHash, outcomeCh); err != nil {
+		if err := e.updateForkChoice(e.backgroundCtx, headHash, safeHash, finalizedHash, outcomeCh); err != nil {
 			e.logger.Debug("updateforkchoice failed", "err", err)
 		}
 	}()
@@ -799,7 +799,7 @@ func (e *ExecModule) dispatchNotificationsFromOverlay(sd *execctx.SharedDomains,
 
 	e.logger.Debug("[dispatchNotifications] dispatching", "finishBefore", finishProgressBefore, "finishAfter", finishProgressAfter)
 	if err := dispatcher.Dispatch(
-		e.bacgroundCtx,
+		e.backgroundCtx,
 		overlay,
 		stateVersion,
 		e.accum.Accumulator,
@@ -827,7 +827,7 @@ func (e *ExecModule) dispatchNotificationsFromOverlay(sd *execctx.SharedDomains,
 func (e *ExecModule) runForkchoiceFlushCommit(sd *execctx.SharedDomains, roTxToCloseBeforeCommit kv.TemporalTx, finishProgressBefore uint64, isSynced bool) ([]any, error) {
 	timings := make([]any, 0, 2)
 
-	rwTx, err := e.db.BeginTemporalRw(e.bacgroundCtx)
+	rwTx, err := e.db.BeginTemporalRw(e.backgroundCtx)
 	if err != nil {
 		return nil, fmt.Errorf("fcu flush+commit: begin rw: %w", err)
 	}
@@ -837,21 +837,21 @@ func (e *ExecModule) runForkchoiceFlushCommit(sd *execctx.SharedDomains, roTxToC
 		roTxToCloseBeforeCommit.Rollback()
 	}
 	flushStart := time.Now()
-	if err := sd.Commit(e.bacgroundCtx, rwTx); err != nil {
+	if err := sd.Commit(e.backgroundCtx, rwTx); err != nil {
 		return nil, err
 	}
 	timings = append(timings, "flush+commit", common.Round(time.Since(flushStart), 0))
 
 	// Update head and announce block range (notifications already dispatched).
 	if e.hook != nil {
-		if err := e.db.View(e.bacgroundCtx, func(tx kv.Tx) error {
+		if err := e.db.View(e.backgroundCtx, func(tx kv.Tx) error {
 			return e.hook.UpdateHead(tx, finishProgressBefore, isSynced)
 		}); err != nil {
 			return nil, err
 		}
 	}
 	// Force fsync so data is durable before the next slot.
-	if err := e.db.Update(e.bacgroundCtx, func(tx kv.RwTx) error {
+	if err := e.db.Update(e.backgroundCtx, func(tx kv.RwTx) error {
 		return kv.IncrementKey(tx, kv.DatabaseInfo, []byte("chaindata_force"))
 	}); err != nil {
 		return nil, err
@@ -879,13 +879,13 @@ func (e *ExecModule) runForkchoicePrune(initialCycle bool) ([]any, error) {
 			baseTimeout := time.Duration(e.config.SecondsPerSlot()*1000/3) * time.Millisecond
 			maxTimeout := time.Duration(e.config.SecondsPerSlot()*2000/3) * time.Millisecond
 			pruneTimeout := min(baseTimeout+time.Duration(agg.MaxPrunableStepsBacklog()/100)*200*time.Millisecond, maxTimeout)
-			if err := agg.CollateAndPrune(e.bacgroundCtx, e.db, func(tx kv.TemporalRwTx) error {
+			if err := agg.CollateAndPrune(e.backgroundCtx, e.db, func(tx kv.TemporalRwTx) error {
 				if e.codeStore != nil {
 					if err := e.codeStore.Evict(tx); err != nil {
 						return err
 					}
 				}
-				return e.pipelineExecutor.RunPrune(e.bacgroundCtx, tx, initialCycle, pruneTimeout)
+				return e.pipelineExecutor.RunPrune(e.backgroundCtx, tx, initialCycle, pruneTimeout)
 			}, e.logger); err != nil {
 				return nil, err
 			}

--- a/execution/execmodule/interface.go
+++ b/execution/execmodule/interface.go
@@ -93,10 +93,14 @@ type AssembleBlockResult struct {
 
 // AssembledBlockResult is the native return type for GetAssembledBlock.
 type AssembledBlockResult struct {
-	// Busy is true when the builder has not finished yet.
+	// Busy is true when the module was already occupied, not when the builder is still working:
+	// otherwise the call waits for the builder to finish.
 	Busy bool
+	// Unknown is true when no builder is held for the payload id, so nothing will ever arrive for
+	// it. A caller polling that id cannot otherwise tell it from a build still running.
+	Unknown bool
 	// Block holds the assembled block with receipts and requests.
-	// Nil when Busy is true or when no builder was found for the payload ID.
+	// Nil when Busy or Unknown is true, or when the builder produced nothing.
 	Block      *types.BlockWithReceipts
 	BlockValue *uint256.Int
 }

--- a/execution/execmodule/interface.go
+++ b/execution/execmodule/interface.go
@@ -154,8 +154,8 @@ type ExecutionModule interface {
 	// parameters.  Returns the payload ID assigned to the build job.
 	AssembleBlock(ctx context.Context, params *builder.Parameters) (AssembleBlockResult, error)
 
-	// GetAssembledBlock retrieves the block that was assembled under the
-	// given payloadID.  The result is Busy when the builder has not finished.
+	// GetAssembledBlock stops and waits for payloadID's builder. Busy reports that the execution
+	// module is occupied; Unknown reports that no builder is held for payloadID.
 	GetAssembledBlock(ctx context.Context, payloadID uint64) (AssembledBlockResult, error)
 
 	// --- Header / body queries --------------------------------------------

--- a/execution/execmodule/interface.go
+++ b/execution/execmodule/interface.go
@@ -150,8 +150,8 @@ type ExecutionModule interface {
 
 	// --- Block building ---------------------------------------------------
 
-	// AssembleBlock initiates building a new block with the supplied
-	// parameters.  Returns the payload ID assigned to the build job.
+	// AssembleBlock initiates building a block. Busy reports that the execution module is occupied;
+	// otherwise PayloadID identifies the new build.
 	AssembleBlock(ctx context.Context, params *builder.Parameters) (AssembleBlockResult, error)
 
 	// GetAssembledBlock stops and waits for payloadID's builder. Busy reports that the execution

--- a/execution/execmodule/interface.go
+++ b/execution/execmodule/interface.go
@@ -154,8 +154,9 @@ type ExecutionModule interface {
 	// otherwise PayloadID identifies the new build.
 	AssembleBlock(ctx context.Context, params *builder.Parameters) (AssembleBlockResult, error)
 
-	// GetAssembledBlock stops and waits for payloadID's builder. Busy reports that the execution
-	// module is occupied; Unknown reports that no builder is held for payloadID.
+	// GetAssembledBlock stops payloadID's builder and waits for its payload; a discarded builder
+	// is answered at once. Busy reports that the execution module is occupied; Unknown reports
+	// that no builder is held for payloadID.
 	GetAssembledBlock(ctx context.Context, payloadID uint64) (AssembledBlockResult, error)
 
 	// --- Header / body queries --------------------------------------------

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -184,6 +184,8 @@ type EngineWriter interface {
 	//
 	// Note, the method returns immediately and will send the result async. More
 	// than one result may also be returned depending on the consensus algorithm.
+	// Seal must not access chain after returning; the caller may release its backing resources
+	// immediately.
 	Seal(chain ChainHeaderReader, block *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error
 
 	// SealHash returns the hash of a block prior to it being sealed.

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -807,7 +807,6 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	}
 
 	blkBuilder := builder.NewBuilder(
-		backend.sentryCtx,
 		backend.chainDB,
 		&config.Builder,
 		backend.chainConfig,


### PR DESCRIPTION
Stacked on #23272 (base branch `feature/lystopad/builder-lifecycle`); addresses the round-5 review findings on that PR.

### Behavior

- **Eviction spares a discarded builder that latched a payload.** `readResult` serves such a payload to getPayload replays, but eviction still read `Discarded()` as cannot-produce, so under builder-count pressure a payload the consensus layer had already collected could flip to Unknown between two polls. `isLiveProposalTarget` now keeps an entry whose latched payload is still servable. Red-first test: `TestEvictionSparesADiscardedBuilderWithALatchedPayload`. Request dedup deliberately keeps declining discarded builders: a fresh request is better served by a fresh build, while a handed-out id must keep answering.
- **`GetAssembledBlock` re-reads the builder's own outcome when the build finished as the caller's wait expired.** Before, that window classified and logged the caller's context error as the build's failure ("Failed to build PoS block err=context canceled"); a payload completed in the window is now delivered instead of erroring. The window is a scheduler race between `Stop` returning and the `Failed()` check, and admits no deterministic red test without an injection seam; the primitive the re-read relies on is pinned by `TestBlockBuilderStopAfterAnExpiredWaitReturnsTheLatchedError`, and the module change is covered by analysis plus the existing suite under `-race`.
- **Watchdog logs tell the truth in race windows.** No "Discarded unresponsive…" warn when the node is shutting down mid-grace or when the discard lost to a completion that landed in between; `Finished` is exported and reused by `Stop`, `Failed`, and the watchdog instead of three hand-rolled done-checks.

### Test hygiene

- The unknown-payload log test reads the process-wide root handler through a locked sink (`Write` and `String` share one mutex) and asserts `lvl=warn` inside the matched record, so a stray line from a leaked goroutine can neither race the read nor satisfy the level pin.
- `TestGetAssembledBlockKeepsPayloadCompletedAsDiscardLands` releases its builder on every exit path (once-guarded `t.Cleanup`), so a `t.Fatal` no longer leaks the goroutine into the rest of the package binary.
- `doneObservedContext` has one shared definition (`export_test.go`), replacing the two per-package copies.
- The mid-assembly cancellation test asserts its exactly-two-`Err()`-calls coupling, so an extra upstream check can no longer silently degrade it into a copy of the entry-check test.
- The keep-payload invariant comment is restored in `readResult`, and the `GetAssembledBlock` interface doc mentions the discarded fast path answering at once.

### Verification

All touched packages green under `-race` (`-count=3` full, `-count=10` on the new/changed tests). `make lint` clean except the pre-existing `db/seg/decompress.go` `residencyOnce` unused-field report, confirmed present on the base branch with this change stashed (also noted in #23333).
