### PR TITLE
[r3.6] ci: stop the Linux dependency step from consuming the whole job budget

### DIFF
--- a/.github/actions/setup-erigon/action.yml
+++ b/.github/actions/setup-erigon/action.yml
@@ -242,18 +242,41 @@ runs:
     - name: Install dependencies on Linux
       if: ${{ runner.os == 'Linux' }}
       shell: bash
-      # erigon only needs build-essential (gcc/make). The hosted runner image
-      # ships third-party apt repos (Google Chrome, Microsoft/azure-cli) whose
+      # erigon needs make and a C and C++ compiler: cgo builds C++ sources from
+      # go-libutp and evmone_precompiles. The hosted runner image ships third-party
+      # apt repos (Google Chrome, Microsoft/azure-cli) whose
       # CDNs intermittently break `apt-get update` — a Packages.gz size mismatch
       # mid-mirror-sync, or a 403 "no longer signed" on the azure-cli repo —
-      # failing the whole job. Drop every source pointing at those CDNs before
-      # updating (we never install from them); the Ubuntu archive retries on blips.
-      # Can't suppress "Reading database..." from apt-get install. Also it's very slow...
+      # failing the whole job. Drop every source pointing at those CDNs (we never
+      # install from them); the Ubuntu archive retries on blips. That runs even
+      # when the install below is skipped, so anything else in the job that
+      # reaches for apt does not trip over them.
+      #
+      # apt waits indefinitely for an unreachable mirror or for a lock held by
+      # the image's own unattended-upgrades, and -qq hides that it is waiting,
+      # so the step can consume the entire job budget in silence. Skip the
+      # install when the toolchain already builds, and bound whatever is left.
       run: |
         sudo grep -rlZE 'dl\.google\.com|packages\.microsoft\.com' \
           /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -0 -r rm -f || true
-        sudo apt-get update -qq -o Acquire::Retries=3 \
-          && sudo apt-get install -qq -y build-essential 2>/dev/null
+        cc_bin=$(go env CC || true)
+        cxx_bin=$(go env CXX || true)
+        if command -v make >/dev/null 2>&1 &&
+           printf 'int main(void){return 0;}\n' | "$cc_bin" -x c -o /dev/null - 2>/dev/null &&
+           printf 'int main(){return 0;}\n' | "$cxx_bin" -x c++ -o /dev/null - 2>/dev/null; then
+          echo "C and C++ toolchains and make already usable; skipping apt"
+          exit 0
+        fi
+        apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15
+                  -o Acquire::https::Timeout=15 -o DPkg::Lock::Timeout=60)
+        if ! sudo timeout --kill-after=10s 300 apt-get update -q "${apt_opts[@]}"; then
+          echo "::error::apt-get update failed or did not finish within 300s"
+          exit 1
+        fi
+        if ! sudo timeout --kill-after=10s 600 apt-get install -qq -y "${apt_opts[@]}" build-essential; then
+          echo "::error::apt-get install build-essential failed or did not finish within 600s"
+          exit 1
+        fi
 
     - name: Ensure make on Windows
       if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
Cherry-pick of #23362 to release/3.6.

release/3.6 carries its own copy of `setup-erigon` and the same unbounded `apt-get`, so the 60-minute hang that evicted PRs from the merge queue on main is reachable here too. That is currently what stands between the approved backports on this branch and the queue.

## r3.6 notes

Straight cherry-pick, no adaptations. It touches only the "Install dependencies on Linux" step.

Worth stating explicitly, because `.github/` has diverged between the branches: this branch's `setup-erigon` still has the `submodules` input and its five gated steps, which main removed along with the `execution/tests/legacy-tests` submodule. Those are untouched here, and no workflow file is modified — the five workflows on this branch that pass `submodules: true` keep working.

## Verification

- YAML parses, `bash -n` clean on the extracted step.
- Ran the real step body with `sudo` stubbed: the CDN cleanup runs, then the toolchain check skips apt.
- Ran it again with `go` off `PATH`: it falls through to the bounded apt calls and exits 0, rather than failing on the command substitution.
