### PR TITLE
[r3.6] execution, cl/beacon: builder lifecycle and production reporting

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -46,6 +46,7 @@ import (
 	"github.com/erigontech/erigon/cl/gossip"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/network/subnets"
 	"github.com/erigontech/erigon/cl/pool"
@@ -288,8 +289,8 @@ func shouldRetryGetPayload(now, deadline time.Time) bool {
 	return now.Before(deadline)
 }
 
-// pollAssembledPayload waits out the build window, then polls get (which stops the EL builder) until
-// it returns a payload or the deadline passes; ok is false when no payload was produced in time.
+// pollAssembledPayload waits out the build window, then polls get until it returns a payload or the
+// request can no longer produce one. ok reports whether a payload was returned.
 func pollAssembledPayload(
 	ctx context.Context,
 	window blockBuilderWindow,
@@ -312,9 +313,13 @@ func pollAssembledPayload(
 	for {
 		// Grab at least once, even past the deadline, so a late produce request still gets a payload.
 		payload, bundles, requestsBundle, blockValue, err := get()
-		if err != nil {
+		switch {
+		case execution_client.IsUnknownPayloadError(err):
+			log.Warn("BlockProduction: execution payload is unknown", "err", err)
+			return nil, nil, nil, nil, false
+		case err != nil:
 			log.Error("BlockProduction: Failed to get payload", "err", err)
-		} else if payload != nil {
+		case payload != nil:
 			return payload, bundles, requestsBundle, blockValue, true
 		}
 		select {

--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -285,24 +285,61 @@ func (a *ApiHandler) expectedWithdrawals(
 	return cltypes.ConvertConsensusWithdrawalsToExecutionWithdrawals(consensusWithdrawals), nil
 }
 
+// feeRecipientForProposal resolves the fee recipient, warning once per proposer when there is none:
+// building with the zero address gives that block's fees away.
+func (a *ApiHandler) feeRecipientForProposal(proposerIndex, targetSlot uint64) common.Address {
+	feeRecipient, registered := a.validatorParams.GetFeeRecipient(proposerIndex)
+	if registered {
+		return feeRecipient
+	}
+	// Claimed in one step, so requests for the same slot arriving together do not each decide they
+	// are the first. Without somewhere to remember them, reporting every time beats reporting never.
+	firstTime := true
+	if a.unregisteredProposers != nil {
+		alreadyWarned, _ := a.unregisteredProposers.ContainsOrAdd(proposerIndex, struct{}{})
+		firstTime = !alreadyWarned
+	}
+	if firstTime {
+		log.Warn("BlockProduction: no fee recipient from prepare_beacon_proposer, using zero address",
+			"proposerIndex", proposerIndex, "slot", targetSlot)
+	}
+	return common.Address{}
+}
+
+// reportProductionFailure is the one place a failed production is recorded, so every exit through
+// produceBlock is covered exactly once. A caller that has already gone is not something anyone can
+// act on; an execution layer that stopped answering still is, and that arrives as a deadline.
+func reportProductionFailure(err error, targetSlot uint64) {
+	switch {
+	case err == nil:
+	case errors.Is(err, context.Canceled):
+		log.Debug("BlockProduction: abandoned by its caller", "err", err, "slot", targetSlot)
+	case execution_client.IsUnknownPayloadError(err):
+		log.Warn("BlockProduction: execution payload is unknown", "err", err, "slot", targetSlot)
+	default:
+		log.Error("BlockProduction: failed to produce block", "err", err, "slot", targetSlot)
+	}
+}
+
 func shouldRetryGetPayload(now, deadline time.Time) bool {
 	return now.Before(deadline)
 }
 
-// pollAssembledPayload waits out the build window, then polls get until it returns a payload or the
-// request can no longer produce one. ok reports whether a payload was returned.
+// pollAssembledPayload waits out the collection window and reports why no payload arrived rather
+// than logging it: the caller knows which slot it was for and is the one answering the validator
+// client. Contention that clears is invisible, and a caller that gave up produces no record at all.
 func pollAssembledPayload(
 	ctx context.Context,
 	window blockBuilderWindow,
 	retryTime time.Duration,
 	get func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error),
-) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, bool) {
+) (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 	if wait := time.Until(window.firstGetAt); wait > 0 {
 		buildTimer := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():
 			buildTimer.Stop()
-			return nil, nil, nil, nil, false
+			return nil, nil, nil, nil, ctx.Err()
 		case <-buildTimer.C:
 		}
 	}
@@ -310,31 +347,71 @@ func pollAssembledPayload(
 	defer deadlineTimer.Stop()
 	retryTicker := time.NewTicker(retryTime)
 	defer retryTicker.Stop()
+
+	var (
+		attempts int
+		failures int
+		firstErr error
+	)
 	for {
+		// Nothing is waiting for this payload any more, and starting another collection would stop
+		// the builder and could fail for reasons of its own - contention, most likely - which would
+		// then be reported against a slot nobody is waiting for.
+		if ctx.Err() != nil {
+			return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, firstErr)
+		}
 		// Grab at least once, even past the deadline, so a late produce request still gets a payload.
 		payload, bundles, requestsBundle, blockValue, err := get()
-		switch {
-		case execution_client.IsUnknownPayloadError(err):
-			log.Warn("BlockProduction: execution payload is unknown", "err", err)
-			return nil, nil, nil, nil, false
-		case err != nil:
-			log.Error("BlockProduction: Failed to get payload", "err", err)
-		case payload != nil:
-			return payload, bundles, requestsBundle, blockValue, true
+		attempts++
+		if execution_client.IsUnknownPayloadError(err) {
+			return nil, nil, nil, nil, err
+		}
+		if err != nil {
+			// The caller's own cancellation comes back through get. That is the slot ending, not
+			// the execution layer failing, and it is not worth reporting on a healthy node. A
+			// failure that happened before it still is.
+			if ctx.Err() == nil || !errors.Is(err, ctx.Err()) {
+				failures++
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		} else if payload != nil {
+			return payload, bundles, requestsBundle, blockValue, nil
 		}
 		select {
 		case <-ctx.Done():
-			return nil, nil, nil, nil, false
+			return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, firstErr)
 		case <-deadlineTimer.C:
-			return nil, nil, nil, nil, false
+			return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, firstErr)
 		case <-retryTicker.C:
 		}
 		// Re-check here, not before get(): the select may pick the ticker after
 		// deadlineTimer fired, and get() stops the builder, so it must not run past pollUntil.
 		if !shouldRetryGetPayload(time.Now(), window.pollUntil) {
-			return nil, nil, nil, nil, false
+			return nil, nil, nil, nil, terminalCause(ctx, attempts, failures, firstErr)
 		}
 	}
+}
+
+// terminalCause says why the window ended without a payload. A caller that went away with nothing
+// having failed took the slot with it, and there is nothing anyone can act on; anything that did
+// fail is worth reporting however the window ended, since giving up is often the consequence of it.
+func terminalCause(ctx context.Context, attempts, failures int, firstErr error) error {
+	if failures == 0 && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if firstErr != nil {
+		return fmt.Errorf("no payload after %s, %d failed: %w", attemptsMade(attempts), failures, firstErr)
+	}
+	return fmt.Errorf("no payload after %s", attemptsMade(attempts))
+}
+
+func attemptsMade(attempts int) string {
+	if attempts == 1 {
+		return "1 attempt"
+	}
+	return fmt.Sprintf("%d attempts", attempts)
 }
 
 func (a *ApiHandler) waitForHeadSlot(slot uint64) {
@@ -558,7 +635,7 @@ func (a *ApiHandler) GetEthV3ValidatorBlock(
 	log.Info("[Beacon API] Found BeaconState object for block production", "slot", targetSlot, "duration", time.Since(start))
 	block, err := a.produceBlock(ctx, builderBoostFactor, baseBlockSlot, baseBlockRoot, baseState, targetSlot, randaoReveal, graffiti)
 	if err != nil {
-		log.Warn("Failed to produce block", "err", err, "slot", targetSlot)
+		// produceBlock owns this record; repeating it here made one failure two.
 		return nil, err
 	}
 
@@ -674,7 +751,9 @@ func (a *ApiHandler) produceBlock(
 	targetSlot uint64,
 	randaoReveal common.Bytes96,
 	graffiti common.Hash,
-) (*cltypes.BlindOrExecutionBeaconBlock, error) {
+) (block *cltypes.BlindOrExecutionBeaconBlock, err error) {
+	defer func() { reportProductionFailure(err, targetSlot) }()
+
 	var wg sync.WaitGroup
 	// produce beacon body
 	var (
@@ -740,7 +819,6 @@ func (a *ApiHandler) produceBlock(
 
 	if localErr != nil {
 		// if we failed to locally produce the beacon body, we should not proceed with the block production
-		log.Error("Failed to produce beacon body", "err", localErr, "slot", targetSlot)
 		return nil, localErr
 	}
 	// prepare basic block
@@ -752,7 +830,7 @@ func (a *ApiHandler) produceBlock(
 	if err != nil {
 		return nil, err
 	}
-	block := &cltypes.BlindOrExecutionBeaconBlock{
+	block = &cltypes.BlindOrExecutionBeaconBlock{
 		Slot:          targetSlot,
 		ProposerIndex: proposerIndex,
 		ParentRoot:    baseBlockRoot,
@@ -1016,7 +1094,9 @@ func (a *ApiHandler) produceBeaconBody(
 
 	var executionPayload *cltypes.Eth1Block
 	var executionValue uint64
-	var executionErr error
+	// One collector per concurrent body step. Sharing one would be a write-write race whenever
+	// two steps fail together.
+	var executionErr, syncAggregateErr error
 	var executionRequestsRoot common.Hash
 	// [New in Gloas:EIP7732] saved for envelope construction.
 	// Always initialize for GLOAS so EncodeSSZ never sees nil sub-fields.
@@ -1033,10 +1113,10 @@ func (a *ApiHandler) produceBeaconBody(
 			log.Info("BlockProduction: ForkChoiceUpdate&GetPayload took", "duration", time.Since(start))
 		}()
 		retryTime := 10 * time.Millisecond
-		feeRecipient, _ := a.validatorParams.GetFeeRecipient(proposerIndex)
+		feeRecipient := a.feeRecipientForProposal(proposerIndex, targetSlot)
 		withdrawals, err := a.expectedWithdrawals(baseState, gloasWithdrawalsState, stateVersion, targetSlot)
 		if err != nil {
-			log.Error("BlockProduction: GetExpectedWithdrawals failed", "err", err)
+			executionErr = fmt.Errorf("produceBeaconBody: expected withdrawals: %w", err)
 			return
 		}
 		slotNumber := hexutil.Uint64(targetSlot)
@@ -1060,19 +1140,20 @@ func (a *ApiHandler) produceBeaconBody(
 			stateVersion,
 		)
 		if err != nil {
-			log.Error("BlockProduction: Failed to get payload id", "err", err)
+			executionErr = fmt.Errorf("produceBeaconBody: forkchoice update: %w", err)
 			return
 		}
 		if len(idBytes) == 0 {
-			log.Warn("BlockProduction: ForkchoiceUpdate returned no payload id (EL may be syncing)", "slot", targetSlot)
+			executionErr = errors.New("produceBeaconBody: forkchoice update returned no payload ID (EL may be syncing)")
 			return
 		}
 		slotStart := a.ethClock.GetSlotTime(targetSlot)
 		buildWindow := computeBlockBuilderWindow(builderStartedAt, slotStart, a.beaconChainCfg, stateVersion)
-		payload, bundles, requestsBundle, blockValue, ok := pollAssembledPayload(ctx, buildWindow, retryTime, func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+		payload, bundles, requestsBundle, blockValue, pollErr := pollAssembledPayload(ctx, buildWindow, retryTime, func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			return a.engine.GetAssembledBlock(ctx, idBytes, stateVersion)
 		})
-		if !ok {
+		if pollErr != nil {
+			executionErr = fmt.Errorf("produceBeaconBody: %w", pollErr)
 			return
 		}
 		// Determine block value
@@ -1085,28 +1166,28 @@ func (a *ApiHandler) produceBeaconBody(
 		if stateVersion.Before(clparams.FuluVersion) {
 			if len(bundles.Blobs) != len(bundles.Proofs) ||
 				len(bundles.Commitments) != len(bundles.Proofs) {
-				log.Error("BlockProduction: Invalid bundle")
+				executionErr = errors.New("produceBeaconBody: invalid blobs bundle")
 				return
 			}
 		} else {
 			if len(bundles.Blobs) != len(bundles.Commitments) ||
 				len(bundles.Proofs) != len(bundles.Blobs)*int(a.beaconChainCfg.NumberOfColumns) {
-				log.Error("BlockProduction: Invalid peerdas bundle")
+				executionErr = errors.New("produceBeaconBody: invalid peerdas bundle")
 				return
 			}
 		}
 
 		for i := range bundles.Blobs {
 			if len(bundles.Commitments[i]) != length.Bytes48 {
-				log.Error("BlockProduction: Invalid commitment length")
+				executionErr = errors.New("produceBeaconBody: invalid commitment length")
 				return
 			}
 			if stateVersion.Before(clparams.FuluVersion) && len(bundles.Proofs[i]) != length.Bytes48 {
-				log.Error("BlockProduction: Invalid proof length")
+				executionErr = errors.New("produceBeaconBody: invalid proof length")
 				return
 			}
 			if len(bundles.Blobs[i]) != cltypes.BYTES_PER_BLOB {
-				log.Error("BlockProduction: Invalid blob length")
+				executionErr = errors.New("produceBeaconBody: invalid blob length")
 				return
 			}
 
@@ -1173,7 +1254,7 @@ func (a *ApiHandler) produceBeaconBody(
 			// so the bid's ExecutionRequestsRoot matches the envelope's actual root.
 			root, err := gloasExecRequests.HashSSZ()
 			if err != nil {
-				log.Error("BlockProduction: GLOAS failed to compute ExecutionRequestsRoot", "err", err)
+				executionErr = fmt.Errorf("produceBeaconBody: execution requests root: %w", err)
 			} else {
 				executionRequestsRoot = common.Hash(root)
 			}
@@ -1221,10 +1302,12 @@ func (a *ApiHandler) produceBeaconBody(
 		defer func() {
 			log.Info("BlockProduction: GetSyncAggregate took", "duration", time.Since(start))
 		}()
-		beaconBody.SyncAggregate, err = a.syncMessagePool.GetSyncAggregate(targetSlot-1, blockRoot)
+		aggregate, err := a.syncMessagePool.GetSyncAggregate(targetSlot-1, blockRoot)
 		if err != nil {
-			log.Error("BlockProduction: Failed to get sync aggregate", "err", err)
+			syncAggregateErr = fmt.Errorf("produceBeaconBody: sync aggregate: %w", err)
+			return
 		}
+		beaconBody.SyncAggregate = aggregate
 	})
 	// Process operations all in parallel with each other.
 	wg.Go(func() {
@@ -1263,6 +1346,9 @@ func (a *ApiHandler) produceBeaconBody(
 	wg.Wait()
 	if executionErr != nil {
 		return nil, 0, executionErr
+	}
+	if syncAggregateErr != nil {
+		return nil, 0, syncAggregateErr
 	}
 	if executionPayload == nil {
 		return nil, 0, errors.New("failed to produce execution payload")

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -25,6 +25,8 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -38,7 +40,10 @@ import (
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/core/state/lru"
 	"github.com/erigontech/erigon/cl/phase1/execution_client"
+	sync_pool_mock "github.com/erigontech/erigon/cl/validator/sync_contribution_pool/mock_services"
+	"github.com/erigontech/erigon/cl/validator/validator_params"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
@@ -385,26 +390,28 @@ func TestShouldRetryGetPayloadStopsAtDeadline(t *testing.T) {
 }
 
 func TestPollAssembledPayloadReturnsReadyPayload(t *testing.T) {
+	ctx := t.Context()
 	now := time.Now()
 	window := blockBuilderWindow{firstGetAt: now.Add(-time.Millisecond), pollUntil: now.Add(time.Second)}
 	want := &cltypes.Eth1Block{}
 	calls := 0
-	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	payload, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			return want, nil, nil, nil, nil
 		})
-	require.True(t, ok)
+	require.NoError(t, err)
 	require.Same(t, want, payload)
 	require.Equal(t, 1, calls)
 }
 
 func TestPollAssembledPayloadRetriesWhileBusy(t *testing.T) {
+	ctx := t.Context()
 	now := time.Now()
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
 	want := &cltypes.Eth1Block{}
 	calls := 0
-	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	payload, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			if calls < 3 {
@@ -412,17 +419,18 @@ func TestPollAssembledPayloadRetriesWhileBusy(t *testing.T) {
 			}
 			return want, nil, nil, nil, nil
 		})
-	require.True(t, ok)
+	require.NoError(t, err)
 	require.Same(t, want, payload)
 	require.Equal(t, 3, calls)
 }
 
 func TestPollAssembledPayloadRetriesOnError(t *testing.T) {
+	ctx := t.Context()
 	now := time.Now()
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(time.Second)}
 	want := &cltypes.Eth1Block{}
 	calls := 0
-	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	payload, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			if calls == 1 {
@@ -430,7 +438,7 @@ func TestPollAssembledPayloadRetriesOnError(t *testing.T) {
 			}
 			return want, nil, nil, nil, nil
 		})
-	require.True(t, ok)
+	require.NoError(t, err)
 	require.Same(t, want, payload)
 	require.Equal(t, 2, calls)
 }
@@ -447,61 +455,56 @@ func TestPollAssembledPayloadStopsOnUnknownPayload(t *testing.T) {
 			now := time.Now()
 			window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
 			calls := 0
-			payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+			payload, _, _, _, err := pollAssembledPayload(context.Background(), window, time.Millisecond,
 				func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 					calls++
 					return nil, nil, nil, nil, tc.err
 				})
-			require.False(t, ok)
+			require.True(t, execution_client.IsUnknownPayloadError(err))
 			require.Nil(t, payload)
 			require.Equal(t, 1, calls)
 		})
 	}
 }
 
-func TestPollAssembledPayloadLogsUnknownPayload(t *testing.T) {
-	var output bytes.Buffer
-	root := log.Root()
-	previousHandler := root.GetHandler()
-	root.SetHandler(log.SyncHandler(log.StreamHandler(&output, log.LogfmtFormat())))
-	t.Cleanup(func() { root.SetHandler(previousHandler) })
+func TestProductionReportsUnknownPayloadOnce(t *testing.T) {
+	logs := captureProductionLogs(t)
 
-	now := time.Now()
-	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
-	_, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
-		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
-			return nil, nil, nil, nil, &engine_helpers.UnknownPayloadErr
-		})
+	err := produceBlockWithFailingCollection(t, t.Context(), &engine_helpers.UnknownPayloadErr)
+	require.Error(t, err)
 
-	require.False(t, ok)
-	require.Contains(t, output.String(), "BlockProduction: execution payload is unknown")
-	require.Contains(t, output.String(), "lvl=warn")
+	captured := logs()
+	require.Equal(t, 1, strings.Count(captured, "execution payload is unknown"), "records:\n"+captured)
+	require.Contains(t, captured, "lvl=warn")
+	require.NotContains(t, captured, "lvl=eror")
 }
 
 func TestPollAssembledPayloadStopsAtDeadline(t *testing.T) {
+	ctx := t.Context()
 	now := time.Now()
 	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
 	calls := 0
-	payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	payload, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			return nil, nil, nil, nil, nil
 		})
-	require.False(t, ok)
+	require.Error(t, err)
 	require.Nil(t, payload)
 	require.NotZero(t, calls)
 }
 
 func TestPollAssembledPayloadLateRequestGrabsOnce(t *testing.T) {
+	ctx := t.Context()
 	past := time.Now().Add(-time.Second)
 	window := blockBuilderWindow{firstGetAt: past, pollUntil: past}
 	calls := 0
-	_, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+	_, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			return nil, nil, nil, nil, nil
 		})
-	require.False(t, ok)
+	require.Error(t, err)
 	require.Equal(t, 1, calls)
 }
 
@@ -511,12 +514,12 @@ func TestPollAssembledPayloadReturnsOnContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	calls := 0
-	_, _, _, _, ok := pollAssembledPayload(ctx, window, time.Millisecond,
+	_, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
 		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
 			calls++
 			return nil, nil, nil, nil, nil
 		})
-	require.False(t, ok)
+	require.Error(t, err)
 	require.Zero(t, calls)
 }
 
@@ -873,4 +876,287 @@ func TestPayloadAttributesOmitFieldsTheChosenVersionCannotCarry(t *testing.T) {
 			require.Equal(t, common.Address{0xcc}, attrs.SuggestedFeeRecipient)
 		})
 	}
+}
+
+// syncedBuffer is a writer the log package can hand to several goroutines at once, which
+// StreamHandler requires and a bare bytes.Buffer does not provide.
+type syncedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncedBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncedBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// captureProductionLogs redirects the root logger for one test and returns everything written at
+// warning level or above. It deliberately does not filter by message: a record this package emits
+// under another name is exactly what a test asserting silence needs to see.
+func captureProductionLogs(t *testing.T) func() string {
+	t.Helper()
+	output := &syncedBuffer{}
+	previous := log.Root().GetHandler()
+	log.Root().SetHandler(log.StreamHandler(output, log.LogfmtFormat()))
+	t.Cleanup(func() { log.Root().SetHandler(previous) })
+	return func() string {
+		var loud []string
+		for line := range strings.SplitSeq(output.String(), "\n") {
+			if strings.Contains(line, "lvl=eror") || strings.Contains(line, "lvl=warn") {
+				loud = append(loud, line)
+			}
+		}
+		return strings.Join(loud, "\n")
+	}
+}
+
+func TestPollAssembledPayloadStaysQuietWhenAFailedPollRecovers(t *testing.T) {
+	ctx := t.Context()
+	logs := captureProductionLogs(t)
+	window := blockBuilderWindow{firstGetAt: time.Now(), pollUntil: time.Now().Add(time.Second)}
+
+	calls := 0
+	payload, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil, nil, nil, errors.New("execution module is busy")
+			}
+			return &cltypes.Eth1Block{}, &engine_types.BlobsBundle{}, nil, big.NewInt(1), nil
+		})
+
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	// Contention that clears is a healthy slot, so nothing may be reported at error level.
+	require.NotContains(t, logs(), "lvl=eror")
+}
+
+func TestPollAssembledPayloadReportsAWindowThatNeverProducedOnce(t *testing.T) {
+	ctx := t.Context()
+	logs := captureProductionLogs(t)
+	window := blockBuilderWindow{firstGetAt: time.Now(), pollUntil: time.Now().Add(50 * time.Millisecond)}
+
+	boom := errors.New("boom")
+	calls := 0
+	_, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			return nil, nil, nil, nil, boom
+		})
+
+	require.NotZero(t, calls)
+
+	// The reason goes to the caller, which knows the slot and owns the record, carrying the first
+	// failure - the one that says what went wrong - and how many there were.
+	require.ErrorIs(t, err, boom)
+	require.Contains(t, err.Error(), "attempt")
+	require.Empty(t, logs(), "the poll does not report; its caller does")
+}
+
+func TestPollAssembledPayloadStaysQuietWhenTheCallerGoesAway(t *testing.T) {
+	logs := captureProductionLogs(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	window := blockBuilderWindow{firstGetAt: time.Now(), pollUntil: time.Now().Add(time.Minute)}
+
+	_, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			cancel()
+			return nil, nil, nil, nil, context.Canceled
+		})
+
+	// A validator client that times out, or a node shutting down, takes the slot with it. Nothing
+	// failed that anyone can act on.
+	require.Error(t, err)
+	require.NotContains(t, logs(), "lvl=eror")
+}
+
+func TestPollAssembledPayloadStillReportsFailuresThatPrecededTheCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	window := blockBuilderWindow{firstGetAt: time.Now(), pollUntil: time.Now().Add(time.Minute)}
+
+	calls := 0
+	_, _, _, _, err := pollAssembledPayload(ctx, window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			if calls == 1 {
+				return nil, nil, nil, nil, errors.New("boom")
+			}
+			cancel()
+			return nil, nil, nil, nil, context.Canceled
+		})
+
+	// The client may well have given up because production was failing. Reporting only the
+	// cancellation would lose the only sign of it.
+	require.NotErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "boom")
+}
+
+func TestFeeRecipientWarnsOncePerProposer(t *testing.T) {
+	logs := captureProductionLogs(t)
+	warned, err := lru.New[uint64, struct{}]("unregisteredProposers", 8)
+	require.NoError(t, err)
+	params := validator_params.NewValidatorParams()
+	a := &ApiHandler{validatorParams: params, unregisteredProposers: warned}
+
+	registered := common.Address{0x11}
+	params.SetFeeRecipient(7, registered)
+	require.Equal(t, registered, a.feeRecipientForProposal(7, 1))
+	require.NotContains(t, logs(), "lvl=warn", "a registered proposer must stay quiet")
+
+	// Giving the fees away is worth saying, but only once: a chain whose validator never registers
+	// one would otherwise warn on every proposal.
+	require.Equal(t, common.Address{}, a.feeRecipientForProposal(9, 2))
+	require.Equal(t, common.Address{}, a.feeRecipientForProposal(9, 3))
+	require.Equal(t, 1, strings.Count(logs(), "lvl=warn"))
+
+	require.Equal(t, common.Address{}, a.feeRecipientForProposal(10, 4))
+	require.Equal(t, 2, strings.Count(logs(), "lvl=warn"), "a different proposer is worth saying again")
+
+	// Alternating proposers must not each reset the other: 9 has already been reported.
+	require.Equal(t, common.Address{}, a.feeRecipientForProposal(9, 5))
+	require.Equal(t, 2, strings.Count(logs(), "lvl=warn"))
+}
+
+func TestFeeRecipientWarnsOncePerProposerUnderConcurrentRequests(t *testing.T) {
+	logs := captureProductionLogs(t)
+	warned, err := lru.New[uint64, struct{}]("unregisteredProposers", 8)
+	require.NoError(t, err)
+	a := &ApiHandler{validatorParams: validator_params.NewValidatorParams(), unregisteredProposers: warned}
+
+	// Several block template requests for the same slot arrive together, and each would otherwise
+	// find the proposer absent and report it.
+	var wg sync.WaitGroup
+	for range 128 {
+		wg.Go(func() { a.feeRecipientForProposal(9, 2) })
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, strings.Count(logs(), "lvl=warn"))
+}
+
+func TestPollAssembledPayloadDoesNotCollectAfterTheCallerHasGone(t *testing.T) {
+	logs := captureProductionLogs(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	past := time.Now().Add(-time.Second)
+	window := blockBuilderWindow{firstGetAt: past, pollUntil: past}
+
+	calls := 0
+	_, _, _, _, err := pollAssembledPayload(ctx, window, time.Microsecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			calls++
+			// The execution module takes its semaphore before it looks at a context, so a request
+			// made after the caller has gone comes back as contention rather than cancellation.
+			return nil, nil, nil, nil, errors.New("execution module is busy")
+		})
+
+	require.Error(t, err)
+	require.Zero(t, calls, "collection must not be started for a caller that has gone")
+	require.NotContains(t, logs(), "lvl=eror")
+}
+
+// produceBlockWithFailingCollection drives a real production through to the payload collection and
+// makes that collection fail the given way, so the records the whole request emits are observable
+// rather than only those of the polling loop.
+func produceBlockWithFailingCollection(t *testing.T, ctx context.Context, collect error) error {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, _, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+
+	engine := execution_client.NewMockExecutionEngine(ctrl)
+	engine.EXPECT().ForkChoiceUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]byte{1, 2, 3, 4, 5, 6, 7, 8}, nil).AnyTimes()
+	engine.EXPECT().GetAssembledBlock(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil, nil, nil, collect).AnyTimes()
+	engine.EXPECT().SupportInsertion().Return(true).AnyTimes()
+	handler.engine = engine
+
+	_, err := handler.produceBlock(ctx, 1, postState.Slot(), common.Hash{0x41}, postState,
+		postState.Slot()+1, common.Bytes96{}, common.Hash{})
+	return err
+}
+
+func TestProductionReportsAFailedCollectionExactlyOnce(t *testing.T) {
+	ctx := t.Context()
+	logs := captureProductionLogs(t)
+
+	err := produceBlockWithFailingCollection(t, ctx, errors.New("boom"))
+	require.Error(t, err)
+
+	// One record for the whole request, and it carries the cause: the generic failure the caller
+	// used to see said only that production failed.
+	captured := logs()
+	require.Equal(t, 1, strings.Count(captured, "lvl=eror"), "records:\n"+captured)
+	require.Contains(t, captured, "boom")
+}
+
+func TestProductionReportsMissingPayloadIDExactlyOnce(t *testing.T) {
+	ctx := t.Context()
+	logs := captureProductionLogs(t)
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, _, _, validatorParams := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+	targetSlot := postState.Slot() + 1
+	proposerIndex, err := postState.GetBeaconProposerIndexForSlot(targetSlot)
+	require.NoError(t, err)
+	validatorParams.SetFeeRecipient(proposerIndex, common.Address{0x42})
+
+	engine := execution_client.NewMockExecutionEngine(ctrl)
+	engine.EXPECT().ForkChoiceUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+	engine.EXPECT().SupportInsertion().Return(true).AnyTimes()
+	handler.engine = engine
+
+	_, err = handler.produceBlock(ctx, 1, postState.Slot(), common.Hash{0x41}, postState,
+		targetSlot, common.Bytes96{}, common.Hash{})
+	require.ErrorContains(t, err, "forkchoice update returned no payload ID")
+
+	captured := logs()
+	require.Equal(t, 1, strings.Count(captured, "forkchoice update returned no payload ID"), "records:\n"+captured)
+	require.Equal(t, 1, strings.Count(captured, "lvl=eror"), "records:\n"+captured)
+	require.NotContains(t, captured, "lvl=warn", "records:\n"+captured)
+	require.NotContains(t, captured, "failed to produce execution payload")
+}
+
+func TestProductionCollectsTwoFailingBodyStepsWithoutRacing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	_, _, _, _, postState, handler, _, _, _, _ := setupTestingHandler(t, clparams.ElectraVersion, log.Root(), false)
+
+	engine := execution_client.NewMockExecutionEngine(ctrl)
+	engine.EXPECT().ForkChoiceUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]byte{1, 2, 3, 4, 5, 6, 7, 8}, nil).AnyTimes()
+	engine.EXPECT().GetAssembledBlock(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil, nil, nil, errors.New("boom")).AnyTimes()
+	engine.EXPECT().SupportInsertion().Return(true).AnyTimes()
+	handler.engine = engine
+
+	// The body steps run concurrently, so each needs somewhere of its own to put its failure.
+	syncPool := sync_pool_mock.NewMockSyncContributionPool(ctrl)
+	syncPool.EXPECT().GetSyncAggregate(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("no aggregate")).AnyTimes()
+	handler.syncMessagePool = syncPool
+
+	_, err := handler.produceBlock(t.Context(), 1, postState.Slot(), common.Hash{0x41}, postState,
+		postState.Slot()+1, common.Bytes96{}, common.Hash{})
+	require.Error(t, err)
+}
+
+func TestProductionSaysNothingWhenTheRequestWasAbandoned(t *testing.T) {
+	logs := captureProductionLogs(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := produceBlockWithFailingCollection(t, ctx, context.Canceled)
+	require.Error(t, err)
+
+	// A validator client that disconnects, or a node shutting down, is routine. Nothing about it is
+	// actionable, at any layer. The unregistered fee recipient this fixture also warns about is a
+	// separate matter and not what this measures.
+	require.NotContains(t, logs(), "lvl=eror", "records:\n"+logs())
 }

--- a/cl/beacon/handler/block_production_test.go
+++ b/cl/beacon/handler/block_production_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -42,6 +43,7 @@ import (
 	"github.com/erigontech/erigon/common/hexutil"
 	"github.com/erigontech/erigon/common/log/v3"
 	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
@@ -431,6 +433,49 @@ func TestPollAssembledPayloadRetriesOnError(t *testing.T) {
 	require.True(t, ok)
 	require.Same(t, want, payload)
 	require.Equal(t, 2, calls)
+}
+
+func TestPollAssembledPayloadStopsOnUnknownPayload(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"direct execution client", fmt.Errorf("get payload: %w", chainreader.ErrUnknownPayload)},
+		{"remote execution client", fmt.Errorf("get payload: %w", &engine_helpers.UnknownPayloadErr)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now()
+			window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
+			calls := 0
+			payload, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+				func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+					calls++
+					return nil, nil, nil, nil, tc.err
+				})
+			require.False(t, ok)
+			require.Nil(t, payload)
+			require.Equal(t, 1, calls)
+		})
+	}
+}
+
+func TestPollAssembledPayloadLogsUnknownPayload(t *testing.T) {
+	var output bytes.Buffer
+	root := log.Root()
+	previousHandler := root.GetHandler()
+	root.SetHandler(log.SyncHandler(log.StreamHandler(&output, log.LogfmtFormat())))
+	t.Cleanup(func() { root.SetHandler(previousHandler) })
+
+	now := time.Now()
+	window := blockBuilderWindow{firstGetAt: now, pollUntil: now.Add(50 * time.Millisecond)}
+	_, _, _, _, ok := pollAssembledPayload(context.Background(), window, time.Millisecond,
+		func() (*cltypes.Eth1Block, *engine_types.BlobsBundle, *typesproto.RequestsBundle, *big.Int, error) {
+			return nil, nil, nil, nil, &engine_helpers.UnknownPayloadErr
+		})
+
+	require.False(t, ok)
+	require.Contains(t, output.String(), "BlockProduction: execution payload is unknown")
+	require.Contains(t, output.String(), "lvl=warn")
 }
 
 func TestPollAssembledPayloadStopsAtDeadline(t *testing.T) {

--- a/cl/beacon/handler/handler.go
+++ b/cl/beacon/handler/handler.go
@@ -107,7 +107,10 @@ type ApiHandler struct {
 	logger    log.Logger
 
 	// Validator data structures
-	validatorParams                    *validator_params.ValidatorParams
+	validatorParams *validator_params.ValidatorParams
+	// unregisteredProposers remembers which proposers have already been warned about, so the
+	// warning is once per proposer rather than once per proposal.
+	unregisteredProposers              *lru.Cache[uint64, struct{}]
 	blobBundles                        *lru.Cache[common.Bytes48, BlobBundle] // Keep recent bundled blobs from the execution layer.
 	engine                             execution_client.ExecutionEngine
 	elClientVersion                    atomic.Pointer[engine_types.ClientVersionV1] // Cached execution client version for default graffiti.
@@ -199,6 +202,10 @@ func NewApiHandler(
 		blobSnapshots = caplinSnapshots
 	}
 
+	unregisteredProposers, err := lru.New[uint64, struct{}]("unregisteredProposers", 1024)
+	if err != nil {
+		panic(err)
+	}
 	slotWaitedForAttestationProduction, err := lru.New[uint64, struct{}]("slotWaitedForAttestationProduction", 1024)
 	if err != nil {
 		panic(err)
@@ -227,6 +234,7 @@ func NewApiHandler(
 		caplinStateSnapshots:               caplinStateSnapshots,
 		peerDas:                            peerDas,
 		slotWaitedForAttestationProduction: slotWaitedForAttestationProduction,
+		unregisteredProposers:              unregisteredProposers,
 		randaoMixesPool: sync.Pool{New: func() any {
 			return solid.NewHashVector(int(beaconChainConfig.EpochsPerHistoricalVector))
 		}},

--- a/cl/phase1/execution_client/errors.go
+++ b/cl/phase1/execution_client/errors.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package execution_client
+
+import (
+	"errors"
+
+	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
+	"github.com/erigontech/erigon/execution/execmodule/chainreader"
+	"github.com/erigontech/erigon/rpc"
+)
+
+// IsUnknownPayloadError reports an unknown-payload result from local or remote execution clients.
+func IsUnknownPayloadError(err error) bool {
+	if errors.Is(err, chainreader.ErrUnknownPayload) {
+		return true
+	}
+	var rpcErr rpc.Error
+	return errors.As(err, &rpcErr) && rpcErr.ErrorCode() == engine_helpers.UnknownPayloadErr.Code
+}

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -17,6 +17,7 @@
 package builder
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -32,18 +33,16 @@ type BlockBuilderFunc func(param *Parameters, interrupt *atomic.Bool) (*types.Bl
 // BlockBuilder wraps a goroutine that builds Proof-of-Stake payloads (PoS "mining")
 type BlockBuilder struct {
 	interrupt atomic.Bool
-	syncCond  *sync.Cond
+	mu        sync.Mutex
+	done      chan struct{}
 	result    *types.BlockWithReceipts
 	err       error
 }
 
 func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime time.Duration) *BlockBuilder {
-	builder := new(BlockBuilder)
-	builder.syncCond = sync.NewCond(new(sync.Mutex))
-	terminated := make(chan struct{})
+	builder := &BlockBuilder{done: make(chan struct{})}
 
 	go func() {
-		defer close(terminated)
 		var result *types.BlockWithReceipts
 		var err error
 
@@ -54,11 +53,11 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime tim
 				result = nil
 			}
 
-			builder.syncCond.L.Lock()
-			defer builder.syncCond.L.Unlock()
+			builder.mu.Lock()
 			builder.result = result
 			builder.err = err
-			builder.syncCond.Broadcast()
+			builder.mu.Unlock()
+			close(builder.done)
 		}()
 
 		log.Info("Building block...")
@@ -78,10 +77,10 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime tim
 		select {
 		case <-timer.C:
 			log.Warn("Stopping block builder due to max build time exceeded")
-			_, _ = builder.Stop()
+			_, _ = builder.Stop(context.Background())
 			log.Debug("Stopped block builder due to max build time exceeded")
 			return
-		case <-terminated:
+		case <-builder.done:
 			return
 		}
 	}()
@@ -89,21 +88,23 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime tim
 	return builder
 }
 
-func (b *BlockBuilder) Stop() (*types.BlockWithReceipts, error) {
+func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, error) {
 	b.interrupt.Store(true)
 
-	b.syncCond.L.Lock()
-	defer b.syncCond.L.Unlock()
-	for b.result == nil && b.err == nil {
-		b.syncCond.Wait()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-b.done:
 	}
 
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.result, b.err
 }
 
 func (b *BlockBuilder) Block() *types.Block {
-	b.syncCond.L.Lock()
-	defer b.syncCond.L.Unlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
 	if b.result == nil {
 		return nil

--- a/execution/builder/block_builder.go
+++ b/execution/builder/block_builder.go
@@ -18,6 +18,7 @@ package builder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -28,19 +29,40 @@ import (
 	"github.com/erigontech/erigon/execution/types"
 )
 
-type BlockBuilderFunc func(param *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error)
+// BlockBuilderFunc builds a payload. Its context ends when the payload is discarded, so anything
+// that can block - opening a read view, waiting on a transaction provider - has to honour it.
+type BlockBuilderFunc func(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error)
 
-// BlockBuilder wraps a goroutine that builds Proof-of-Stake payloads (PoS "mining")
+// ErrDiscarded reports that the payload was abandoned before the build completed.
+var ErrDiscarded = errors.New("block builder discarded")
+
+const (
+	blockBuilderRunning uint32 = iota
+	blockBuilderCompleted
+	blockBuilderDiscarded
+)
+
+// BlockBuilder wraps a goroutine that builds Proof-of-Stake payloads (PoS "mining").
+//
+// It answers to two different requests. Interrupting asks for the block it has so far, which is how
+// a payload is collected. Discarding says the payload is not wanted at all, and cancels the work.
 type BlockBuilder struct {
 	interrupt atomic.Bool
+	state     atomic.Uint32
+	discard   context.CancelFunc
 	mu        sync.Mutex
 	done      chan struct{}
 	result    *types.BlockWithReceipts
 	err       error
 }
 
-func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime time.Duration) *BlockBuilder {
-	builder := &BlockBuilder{done: make(chan struct{})}
+// NewBlockBuilder starts a build. maxBuildTime is the budget after which the builder stops itself
+// and keeps the block it has; stopGrace is how long a stopped build may take to finish up - the
+// transaction in flight, the packing tail, payload finalization - before it is taken as stuck and
+// discarded.
+func NewBlockBuilder(ctx context.Context, build BlockBuilderFunc, param *Parameters, maxBuildTime, stopGrace time.Duration) *BlockBuilder {
+	buildCtx, discard := context.WithCancel(ctx)
+	builder := &BlockBuilder{done: make(chan struct{}), discard: discard}
 
 	go func() {
 		var result *types.BlockWithReceipts
@@ -56,15 +78,21 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime tim
 			builder.mu.Lock()
 			builder.result = result
 			builder.err = err
+			builder.state.CompareAndSwap(blockBuilderRunning, blockBuilderCompleted)
 			builder.mu.Unlock()
 			close(builder.done)
+			discard()
 		}()
 
 		log.Info("Building block...")
 		t := time.Now()
-		result, err = build(param, &builder.interrupt)
+		result, err = build(buildCtx, param, &builder.interrupt)
 		if err != nil {
-			log.Warn("Failed to build a block", "err", err)
+			if buildCtx.Err() != nil {
+				log.Debug("Block builder discarded", "err", err)
+			} else {
+				log.Warn("Failed to build a block", "err", err)
+			}
 		} else {
 			block := result.Block
 			log.Info("Built block", "hash", block.Hash(), "height", block.NumberU64(), "txs", len(block.Transactions()), "executionRequests", len(result.Requests), "gas used %", 100*float64(block.GasUsed())/float64(block.GasLimit()), "time", time.Since(t))
@@ -76,13 +104,24 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime tim
 		defer timer.Stop()
 		select {
 		case <-timer.C:
-			log.Warn("Stopping block builder due to max build time exceeded")
-			_, _ = builder.Stop(context.Background())
-			log.Debug("Stopped block builder due to max build time exceeded")
-			return
 		case <-builder.done:
 			return
 		}
+		// Ask for the block it has, which is what the budget was for. A build that has not answered
+		// by the end of the grace is treated as unresponsive and discarded.
+		log.Warn("Stopping block builder due to max build time exceeded")
+		graceCtx, cancelGrace := context.WithTimeout(ctx, stopGrace)
+		defer cancelGrace()
+		_, err := builder.Stop(graceCtx)
+		if err == nil {
+			log.Debug("Stopped block builder due to max build time exceeded")
+			return
+		}
+		if errors.Is(err, ErrDiscarded) || builder.finished() {
+			return
+		}
+		builder.Discard()
+		log.Warn("Discarded unresponsive block builder due to max build time exceeded")
 	}()
 
 	return builder
@@ -90,24 +129,70 @@ func NewBlockBuilder(build BlockBuilderFunc, param *Parameters, maxBuildTime tim
 
 func (b *BlockBuilder) Stop(ctx context.Context) (*types.BlockWithReceipts, error) {
 	b.interrupt.Store(true)
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-b.done:
+	if b.Discarded() {
+		return b.readResult()
 	}
 
+	select {
+	case <-b.done:
+	case <-ctx.Done():
+		select {
+		case <-b.done:
+		default:
+			return nil, ctx.Err()
+		}
+	}
+	return b.readResult()
+}
+
+func (b *BlockBuilder) readResult() (*types.BlockWithReceipts, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if b.Discarded() && (b.result == nil || b.err != nil) {
+		return nil, ErrDiscarded
+	}
 	return b.result, b.err
 }
 
-func (b *BlockBuilder) Block() *types.Block {
+func (b *BlockBuilder) finished() bool {
+	select {
+	case <-b.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// Discard cancels the build without waiting for it to return.
+func (b *BlockBuilder) Discard() {
+	b.interrupt.Store(true)
+	b.state.CompareAndSwap(blockBuilderRunning, blockBuilderDiscarded)
+	b.discard()
+}
+
+// Discarded reports whether discard won before the build completed.
+func (b *BlockBuilder) Discarded() bool {
+	return b.state.Load() == blockBuilderDiscarded
+}
+
+// Failed reports whether the builder has finished and ended in an error, which a caller looking to
+// reuse it has to read as absent because that error is latched.
+func (b *BlockBuilder) Failed() bool {
+	select {
+	case <-b.done:
+	default:
+		return false
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	return b.err != nil
+}
 
-	if b.result == nil {
+func (b *BlockBuilder) Block() *types.Block {
+	result, err := b.readResult()
+	if err != nil || result == nil {
 		return nil
 	}
-	return b.result.Block
+	return result.Block
 }

--- a/execution/builder/block_builder_test.go
+++ b/execution/builder/block_builder_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/types"
+)
+
+func TestBlockBuilderRunningHasNotFailed(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-release
+		return nil, errors.New("builder stopped")
+	}, &Parameters{}, time.Minute, time.Minute)
+
+	require.Never(t, b.Failed, 50*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestBlockBuilderStoppedForItsPayloadHasNotFailed(t *testing.T) {
+	t.Parallel()
+
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	}, &Parameters{}, time.Minute, time.Minute)
+
+	_, err := b.Stop(t.Context())
+	require.NoError(t, err)
+
+	// Collecting the payload is what a proposal does. Reading that as failure would make a repeated
+	// request rebuild from scratch instead of being handed the block that was just built.
+	require.False(t, b.Failed())
+}
+
+func TestBlockBuilderHasFailedOnceItErrors(t *testing.T) {
+	t.Parallel()
+
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, errors.New("build failed")
+	}, &Parameters{}, time.Minute, time.Minute)
+
+	require.Eventually(t, b.Failed, time.Second, time.Millisecond)
+}
+
+func TestBlockBuilderStaysReusableOnceItFillsTheBlock(t *testing.T) {
+	t.Parallel()
+
+	built := make(chan struct{})
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		defer close(built)
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	}, &Parameters{}, time.Minute, time.Minute)
+
+	<-built
+	// A builder that ran out of room holds a complete payload, so its id is still worth reusing.
+	require.Never(t, b.Failed, 50*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestBlockBuilderReleasesABuildThatIgnoresTheDeadline(t *testing.T) {
+	t.Parallel()
+
+	// A build parked in something that never reads the interrupt flag - a transaction provider
+	// waiting on a block, say - would hold its read view until the builder count forced it out.
+	released := make(chan error, 1)
+	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		select {
+		case <-ctx.Done():
+			released <- ctx.Err()
+		case <-time.After(time.Minute):
+			released <- errors.New("build was never released")
+		}
+		return nil, errors.New("builder stopped")
+	}, &Parameters{}, time.Millisecond, 10*time.Millisecond)
+
+	select {
+	case err := <-released:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("build outlived its budget without being released")
+	}
+	require.Eventually(t, b.Failed, 5*time.Second, time.Millisecond)
+}
+
+func TestBlockBuilderStillHandsOverAPayloadWhenItsBudgetRunsOut(t *testing.T) {
+	t.Parallel()
+
+	// Reaching the budget asks for the block it has, which is what the budget is for. Only a build
+	// that will not answer is discarded.
+	b := NewBlockBuilder(t.Context(), func(_ context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	}, &Parameters{}, time.Millisecond, time.Minute)
+
+	require.Eventually(t, func() bool { return b.Block() != nil }, 5*time.Second, time.Millisecond)
+	require.False(t, b.Failed())
+}
+
+func TestBlockBuilderKeepsAHealthyBuildThatIsSlowToObserveTheStop(t *testing.T) {
+	t.Parallel()
+
+	// A single heavy transaction has no interrupt boundary, so a healthy build can be slow to
+	// answer the stop without being unresponsive. Discarding it destroys a payload a proposal may
+	// still collect.
+	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+			return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+		}
+	}, &Parameters{}, time.Millisecond, 5*time.Second)
+
+	result, err := b.Stop(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func TestBlockBuilderReleasesABuildThatWedgesAfterObservingTheStop(t *testing.T) {
+	t.Parallel()
+
+	// Observing the stop earns the build its grace, not an unbounded stay. Discard must still cancel
+	// context-aware work that blocks later in the build.
+	released := make(chan error, 1)
+	NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		select {
+		case <-ctx.Done():
+			released <- ctx.Err()
+		case <-time.After(time.Minute):
+			released <- errors.New("build was never released")
+		}
+		return nil, errors.New("builder stopped")
+	}, &Parameters{}, time.Millisecond, 50*time.Millisecond)
+
+	select {
+	case err := <-released:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("wedged build outlived its grace without being released")
+	}
+}
+
+func TestBlockBuilderReplaysPayloadCompletedAfterDiscard(t *testing.T) {
+	t.Parallel()
+
+	want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
+	b := NewBlockBuilder(t.Context(), func(ctx context.Context, _ *Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-ctx.Done()
+		return want, nil
+	}, &Parameters{}, time.Minute, time.Minute)
+
+	b.Discard()
+	select {
+	case <-b.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("discarded builder did not finish")
+	}
+
+	require.True(t, b.Discarded())
+	for range 2 {
+		got, err := b.Stop(t.Context())
+		require.NoError(t, err)
+		require.Same(t, want, got)
+	}
+}
+
+func TestBlockBuilderStopPrefersCompletedOutcomeOverCanceledCaller(t *testing.T) {
+	t.Parallel()
+
+	wantBlock := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
+	wantErr := errors.New("build failed")
+	tests := []struct {
+		name   string
+		result *types.BlockWithReceipts
+		err    error
+	}{
+		{name: "payload", result: wantBlock},
+		{name: "error", err: wantErr},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewBlockBuilder(t.Context(), func(context.Context, *Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+				return tc.result, tc.err
+			}, &Parameters{}, time.Minute, time.Minute)
+			select {
+			case <-b.done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("builder did not finish")
+			}
+
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			for range 100 {
+				got, err := b.Stop(ctx)
+				if tc.err != nil {
+					require.ErrorIs(t, err, tc.err)
+					continue
+				}
+				require.NoError(t, err)
+				require.Same(t, tc.result, got)
+			}
+		})
+	}
+}
+
+func TestBlockBuilderStopReturnsImmediatelyAfterDiscard(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	b := NewBlockBuilder(t.Context(), func(context.Context, *Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-release
+		return nil, errors.New("builder stopped")
+	}, &Parameters{}, time.Minute, time.Minute)
+	b.Discard()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := b.Stop(ctx)
+	require.ErrorIs(t, err, ErrDiscarded)
+}

--- a/execution/builder/builder.go
+++ b/execution/builder/builder.go
@@ -45,7 +45,6 @@ type SDProvider func() *execctx.SharedDomains
 // without staged-sync machinery. Its Build method satisfies BlockBuilderFunc and can
 // be passed directly to ExecModule.
 type Builder struct {
-	ctx                   context.Context
 	db                    kv.TemporalRoDB
 	pendingBlockCh        chan *types.Block
 	builderCfg            *buildercfg.BuilderConfig
@@ -64,7 +63,6 @@ type Builder struct {
 }
 
 func NewBuilder(
-	ctx context.Context,
 	db kv.TemporalRoDB,
 	builderCfg *buildercfg.BuilderConfig,
 	chainConfig *chain.Config,
@@ -81,7 +79,6 @@ func NewBuilder(
 	logger log.Logger,
 ) *Builder {
 	return &Builder{
-		ctx:                   ctx,
 		db:                    db,
 		pendingBlockCh:        make(chan *types.Block, 1),
 		builderCfg:            builderCfg,
@@ -107,7 +104,10 @@ func (b *Builder) PendingBlockCh() chan *types.Block {
 }
 
 // Build satisfies BlockBuilderFunc. Pass b.Build directly to ExecModule.
-func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *types.BlockWithReceipts, err error) {
+//
+// Build passes ctx through the read and execution paths and stops waiting for an asynchronous seal
+// result when the context ends, allowing its deferred read resources to close.
+func (b *Builder) Build(ctx context.Context, param *Parameters, interrupt *atomic.Bool) (result *types.BlockWithReceipts, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("%+v, trace: %s", rec, dbg.Stack())
@@ -124,7 +124,7 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 		BuiltBlock:      &exec.AssembledBlock{},
 	}
 
-	tx, err := b.db.BeginTemporalRo(b.ctx)
+	tx, err := b.db.BeginTemporalRo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 		}
 	}
 
-	sd, err := execctx.NewSharedDomains(b.ctx, compositeTx, b.logger, execctx.WithoutDeferredBranchUpdates(), execctx.WithoutSharedBranchCache())
+	sd, err := execctx.NewSharedDomains(ctx, compositeTx, b.logger, execctx.WithoutDeferredBranchUpdates(), execctx.WithoutSharedBranchCache())
 	if err != nil {
 		return nil, err
 	}
@@ -172,15 +172,30 @@ func (b *Builder) Build(param *Parameters, interrupt *atomic.Bool) (result *type
 	execCfg := StageBuilderExecCfg(state, b.notifier, b.chainConfig, b.engine, b.vmConfig, b.tmpdir, interrupt, param.PayloadId, txnProvider, b.blockReader)
 	finishCfg := StageBuilderFinishCfg(b.chainConfig, b.engine, state, b.sealCancel, b.blockReader, b.latestBlockBuiltStore)
 
-	if err := createBlock(b.ctx, sd, compositeTx, executionAt, createCfg, b.logger); err != nil {
+	if err := createBlock(ctx, sd, compositeTx, executionAt, createCfg, b.logger); err != nil {
 		return nil, err
 	}
-	if err := execBlock(b.ctx, sd, compositeTx, executionAt, execCfg, b.executeBlockCfg, b.logger); err != nil {
+	if err := execBlock(ctx, sd, compositeTx, executionAt, execCfg, b.executeBlockCfg, b.logger); err != nil {
 		return nil, err
 	}
-	if err := finishBlock(compositeTx, finishCfg, b.logger); err != nil {
+	if err := finishBlock(ctx, compositeTx, finishCfg, b.logger); err != nil {
 		return nil, err
 	}
 
-	return <-state.BuilderResultCh, nil
+	return waitForBuilderResult(ctx, state.BuilderResultCh)
+}
+
+func waitForBuilderResult(ctx context.Context, results <-chan *types.BlockWithReceipts) (*types.BlockWithReceipts, error) {
+	select {
+	case result := <-results:
+		return result, nil
+	case <-ctx.Done():
+		// Keep a payload that completed as cancellation arrived.
+		select {
+		case result := <-results:
+			return result, nil
+		default:
+			return nil, ctx.Err()
+		}
+	}
 }

--- a/execution/builder/builder_test.go
+++ b/execution/builder/builder_test.go
@@ -19,6 +19,7 @@ package builder
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -37,6 +38,17 @@ type errDB struct {
 	err             error
 }
 
+type finishOnDoneContext struct {
+	context.Context
+	finish func()
+	once   sync.Once
+}
+
+func (c *finishOnDoneContext) Done() <-chan struct{} {
+	c.once.Do(c.finish)
+	return c.Context.Done()
+}
+
 func (e *errDB) BeginTemporalRo(_ context.Context) (kv.TemporalTx, error) {
 	return nil, e.err
 }
@@ -48,14 +60,13 @@ func TestBuilder_Build_DBError(t *testing.T) {
 
 	want := errors.New("db open failed")
 	b := &Builder{
-		ctx:            context.Background(),
 		db:             &errDB{err: want},
 		builderCfg:     &buildercfg.BuilderConfig{},
 		pendingBlockCh: make(chan *types.Block, 1),
 		logger:         log.New(),
 	}
 
-	_, err := b.Build(&Parameters{}, &atomic.Bool{})
+	_, err := b.Build(t.Context(), &Parameters{}, &atomic.Bool{})
 	require.ErrorIs(t, err, want)
 }
 
@@ -68,4 +79,21 @@ func TestBuilder_PendingBlockCh(t *testing.T) {
 	ch := b.PendingBlockCh()
 	require.NotNil(t, ch)
 	require.Equal(t, ch, b.PendingBlockCh(), "must return the same channel on repeated calls")
+}
+
+func TestWaitForBuilderResultPrefersCompletedPayloadOverCancellation(t *testing.T) {
+	for range 50 {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		want := &types.BlockWithReceipts{}
+		results := make(chan *types.BlockWithReceipts, 1)
+		finishCtx := &finishOnDoneContext{
+			Context: ctx,
+			finish:  func() { results <- want },
+		}
+
+		got, err := waitForBuilderResult(finishCtx, results)
+		require.NoError(t, err)
+		require.Same(t, want, got)
+	}
 }

--- a/execution/builder/finish.go
+++ b/execution/builder/finish.go
@@ -17,6 +17,7 @@
 package builder
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/erigontech/erigon/common/dbg"
@@ -58,8 +59,11 @@ func StageBuilderFinishCfg(
 	}
 }
 
-func finishBlock(tx kv.TemporalTx, cfg BuilderFinishCfg, logger log.Logger) error {
+func finishBlock(ctx context.Context, tx kv.TemporalTx, cfg BuilderFinishCfg, logger log.Logger) error {
 	const logPrefix = "BuilderFinish"
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	current := cfg.builderState.BuiltBlock
 
 	// Short circuit when receiving duplicate result caused by resubmitting.
@@ -78,6 +82,9 @@ func finishBlock(tx kv.TemporalTx, cfg BuilderFinishCfg, logger log.Logger) erro
 	blockWithReceipts := &types.BlockWithReceipts{Block: block, Receipts: current.Receipts, Requests: current.Requests, BlockAccessList: current.BlockAccessList}
 	if dbg.LogHashMismatchReason() {
 		ethutils.LogReceipts(log.LvlInfo, "Block built", current.Receipts, current.Txns, cfg.chainConfig, current.Header, logger)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	*current = exec.AssembledBlock{} // hack to clean global data
 

--- a/execution/builder/finish_test.go
+++ b/execution/builder/finish_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/exec"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+type recordingSealEngine struct {
+	rules.Engine
+	called atomic.Bool
+}
+
+type cancelOnSecondCheckContext struct {
+	context.Context
+	cancel context.CancelFunc
+	checks atomic.Uint32
+}
+
+func (c *cancelOnSecondCheckContext) Err() error {
+	if c.checks.Add(1) == 2 {
+		c.cancel()
+	}
+	return c.Context.Err()
+}
+
+func (e *recordingSealEngine) Seal(rules.ChainHeaderReader, *types.BlockWithReceipts, chan<- *types.BlockWithReceipts, <-chan struct{}) error {
+	e.called.Store(true)
+	return nil
+}
+
+func TestFinishBlockDoesNotSealAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	engine := &recordingSealEngine{}
+	store := NewLatestBlockBuiltStore()
+	cfg := BuilderFinishCfg{
+		engine:                engine,
+		latestBlockBuiltStore: store,
+	}
+
+	err := finishBlock(ctx, nil, cfg, log.Root())
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, engine.called.Load())
+	require.Nil(t, store.BlockBuilt())
+}
+
+func TestFinishBlockDoesNotSealWhenCanceledDuringAssembly(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	testCtx := &cancelOnSecondCheckContext{Context: ctx, cancel: cancel}
+	engine := &recordingSealEngine{}
+	store := NewLatestBlockBuiltStore()
+	cfg := BuilderFinishCfg{
+		engine: engine,
+		builderState: BuilderState{
+			BuiltBlock: &exec.AssembledBlock{Header: &types.Header{}},
+		},
+		latestBlockBuiltStore: store,
+	}
+
+	err := finishBlock(testCtx, nil, cfg, log.Root())
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, engine.called.Load())
+	require.Nil(t, store.BlockBuilt())
+}

--- a/execution/builder/parameters.go
+++ b/execution/builder/parameters.go
@@ -17,6 +17,8 @@
 package builder
 
 import (
+	"bytes"
+
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/txnprovider"
@@ -39,4 +41,37 @@ type Parameters struct {
 	CustomTxnProvider txnprovider.TxnProvider
 	// ExtraData overrides the builder's configured extra data when non-nil.
 	ExtraData []byte
+}
+
+// Copy returns parameters that share nothing mutable with the receiver, except CustomTxnProvider:
+// a provider is a live object and stays shared by reference. Reference-typed fields added to
+// Parameters have to be handled here; TestParametersCopyCoversEveryField fails if one is not.
+func (p *Parameters) Copy() *Parameters {
+	if p == nil {
+		return nil
+	}
+	copied := *p
+	copied.ExtraData = bytes.Clone(p.ExtraData)
+	if p.Withdrawals != nil {
+		copied.Withdrawals = make([]*types.Withdrawal, len(p.Withdrawals))
+		for i, withdrawal := range p.Withdrawals {
+			if withdrawal != nil {
+				w := *withdrawal
+				copied.Withdrawals[i] = &w
+			}
+		}
+	}
+	if p.ParentBeaconBlockRoot != nil {
+		root := *p.ParentBeaconBlockRoot
+		copied.ParentBeaconBlockRoot = &root
+	}
+	if p.SlotNumber != nil {
+		slot := *p.SlotNumber
+		copied.SlotNumber = &slot
+	}
+	if p.TargetGasLimit != nil {
+		limit := *p.TargetGasLimit
+		copied.TargetGasLimit = &limit
+	}
+	return &copied
 }

--- a/execution/builder/parameters_test.go
+++ b/execution/builder/parameters_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/execution/types"
+)
+
+func TestParametersCopyKeepsNothingShared(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, (*Parameters)(nil).Copy())
+
+	// An empty slice is not the same request as an absent one, so the distinction has to survive.
+	empty := (&Parameters{Withdrawals: []*types.Withdrawal{}, ExtraData: []byte{}}).Copy()
+	require.NotNil(t, empty.Withdrawals)
+	require.NotNil(t, empty.ExtraData)
+
+	root := common.Hash{0x01}
+	slot := uint64(2)
+	gasLimit := uint64(3)
+	params := &Parameters{
+		Withdrawals:           []*types.Withdrawal{nil, {Index: 4}},
+		ParentBeaconBlockRoot: &root,
+		SlotNumber:            &slot,
+		TargetGasLimit:        &gasLimit,
+		ExtraData:             []byte{5},
+	}
+	copied := params.Copy()
+
+	params.Withdrawals[1].Index = 40
+	root[0] = 10
+	slot = 20
+	gasLimit = 30
+	params.ExtraData[0] = 50
+
+	require.Nil(t, copied.Withdrawals[0])
+	require.Equal(t, uint64(4), copied.Withdrawals[1].Index)
+	require.Equal(t, common.Hash{0x01}, *copied.ParentBeaconBlockRoot)
+	require.Equal(t, uint64(2), *copied.SlotNumber)
+	require.Equal(t, uint64(3), *copied.TargetGasLimit)
+	require.Equal(t, byte(5), copied.ExtraData[0])
+}
+
+func TestParametersCopyCoversEveryField(t *testing.T) {
+	t.Parallel()
+
+	// Copy has to be revisited whenever a reference-typed field is added, and nothing else will say
+	// so: a shallow copy of a new slice or pointer compiles and silently shares it.
+	require.Equal(t, 11, reflect.TypeFor[Parameters]().NumField(),
+		"Parameters gained or lost a field; check whether Copy has to copy it")
+}

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -18,6 +18,7 @@ package execmodule
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"time"
 
@@ -60,16 +61,112 @@ func buildDuration(payloadTimestamp uint64, now time.Time, secondsPerSlot uint64
 	return min(max(d, slot/4), 2*slot)
 }
 
-func (e *ExecModule) evictOldBuilders() {
-	ids := common.SortedKeys(e.builders)
+// stopGraceDuration returns how long a builder that reached its budget may take to finish up - the
+// transaction in flight, the packing tail, payload finalization - before it is taken as stuck and
+// discarded.
+func stopGraceDuration(secondsPerSlot uint64) time.Duration {
+	return time.Duration(secondsPerSlot) * time.Second / 2
+}
 
-	// remove old builders so that at most MaxBuilders - 1 remain
-	for i := 0; i <= len(e.builders)-engine_helpers.MaxBuilders; i++ {
-		delete(e.builders, ids[i])
+// sameBuildRequest reports whether a request is asking for the payload another one is already
+// building. A custom transaction provider is never treated as the same request: it is stateful and
+// hands its transactions over once, so a second request carrying one is not asking for what the
+// first is building, and comparing the provider itself would read fields the running build writes.
+func sameBuildRequest(previous, current *builder.Parameters) bool {
+	if previous == nil || current == nil {
+		return false
+	}
+	if previous.CustomTxnProvider != nil || current.CustomTxnProvider != nil {
+		return false
+	}
+	// The payload id is this module's to assign, so it is not part of the question, and comparing
+	// copies keeps the caller's parameters out of it.
+	withoutID := func(p *builder.Parameters) builder.Parameters {
+		stripped := *p
+		stripped.PayloadId = 0
+		return stripped
+	}
+	previousWithoutID, currentWithoutID := withoutID(previous), withoutID(current)
+	return reflect.DeepEqual(&previousWithoutID, &currentWithoutID)
+}
+
+// builderEntry keeps a builder with the immutable parameters it was created for, so the two cannot
+// drift apart and eviction can drop the timestamp index without scanning it.
+type builderEntry struct {
+	builder *builder.BlockBuilder
+	params  *builder.Parameters
+}
+
+// isIndexedFor reports whether the timestamp index still resolves to this entry, which is what has
+// to be cleaned up when the entry goes.
+func (e *ExecModule) isIndexedFor(id uint64, entry *builderEntry) bool {
+	return entry != nil && entry.params != nil && e.buildersByTimestamp[entry.params.Timestamp] == id
+}
+
+// isLiveProposalTarget reports whether an entry is what a proposal is still waiting on: the builder
+// its timestamp resolves to, for a slot that has not passed. Being indexed is not enough on its own,
+// because every slot has its own timestamp and successful entries stay indexed: protecting all of
+// them would mean never evicting anything.
+func (e *ExecModule) isLiveProposalTarget(id uint64, entry *builderEntry, now time.Time) bool {
+	if !e.isIndexedFor(id, entry) {
+		return false
+	}
+	// A builder that can no longer produce is not worth protecting, however live its slot.
+	if entry.builder == nil || entry.builder.Failed() || entry.builder.Discarded() {
+		return false
+	}
+	// Compared as seconds rather than times, so an implausible timestamp wraps into "not live"
+	// instead of overflowing into the past.
+	nowSeconds := uint64(max(now.Unix(), 0))
+	slotSeconds := e.config.SecondsPerSlot()
+	timestamp := entry.params.Timestamp
+	return timestamp+slotSeconds > nowSeconds && timestamp <= nowSeconds+2*slotSeconds
+}
+
+// dropBuilder removes and discards a builder.
+func (e *ExecModule) dropBuilder(id uint64, entry *builderEntry) {
+	if entry != nil {
+		if e.isIndexedFor(id, entry) {
+			delete(e.buildersByTimestamp, entry.params.Timestamp)
+		}
+		if entry.builder != nil {
+			entry.builder.Discard()
+		}
+	}
+	delete(e.builders, id)
+}
+
+// evictOldBuilders makes room for one builder by dropping the oldest entries, except those a live
+// proposal is still waiting on.
+func (e *ExecModule) evictOldBuilders() {
+	remaining := len(e.builders) - engine_helpers.MaxBuilders + 1
+	if remaining <= 0 {
+		return
+	}
+	now := time.Now()
+	for _, id := range common.SortedKeys(e.builders) {
+		if remaining <= 0 {
+			return
+		}
+		entry := e.builders[id]
+		if e.isLiveProposalTarget(id, entry, now) {
+			continue
+		}
+		e.dropBuilder(id, entry)
+		remaining--
 	}
 }
 
 func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Parameters) (AssembleBlockResult, error) {
+	// Cancellation is checked first so an expired request reports why it stopped instead of
+	// looking like contention, which callers retry. The module context check avoids starting work
+	// after shutdown has already been observed.
+	if err := ctx.Err(); err != nil {
+		return AssembleBlockResult{}, err
+	}
+	if err := e.backgroundCtx.Err(); err != nil {
+		return AssembleBlockResult{}, err
+	}
 	if !e.semaphore.TryAcquire(1) {
 		return AssembleBlockResult{Busy: true}, nil
 	}
@@ -79,23 +176,34 @@ func (e *ExecModule) AssembleBlock(ctx context.Context, params *builder.Paramete
 		return AssembleBlockResult{}, err
 	}
 
-	// First check if we're already building a block with the requested parameters
-	if e.lastParameters != nil {
-		params.PayloadId = e.lastParameters.PayloadId
-		if reflect.DeepEqual(e.lastParameters, params) {
-			e.logger.Info("[ForkChoiceUpdated] duplicate build request")
-			return AssembleBlockResult{PayloadID: e.lastParameters.PayloadId}, nil
+	// A stopped builder is still worth reusing: it holds the payload it was stopped for, which is
+	// exactly what a repeated request is asking for. Only one that cannot produce - failed, or
+	// discarded with its work still winding down - has to be passed over.
+	if previousID, ok := e.buildersByTimestamp[params.Timestamp]; ok {
+		if previous := e.builders[previousID]; previous != nil && previous.builder != nil &&
+			!previous.builder.Failed() && !previous.builder.Discarded() {
+			if sameBuildRequest(previous.params, params) {
+				e.logger.Info("[ForkChoiceUpdated] duplicate build request")
+				return AssembleBlockResult{PayloadID: previousID}, nil
+			}
 		}
 	}
-
-	// Initiate payload building
+	// A superseded builder keeps running to its own deadline. The timestamp index moves to the new
+	// one, so nothing reaches it by dedup, while an id already handed out goes on answering with a
+	// payload that is still growing.
 	e.evictOldBuilders()
 
 	e.nextPayloadId++
-	params.PayloadId = e.nextPayloadId
-	e.lastParameters = params
+	ownedParams := params.Copy()
+	ownedParams.PayloadId = e.nextPayloadId
 
-	e.builders[e.nextPayloadId] = builder.NewBlockBuilder(e.builderFunc, params, buildDuration(params.Timestamp, time.Now(), e.config.SecondsPerSlot()))
+	secondsPerSlot := e.config.SecondsPerSlot()
+	e.builders[e.nextPayloadId] = &builderEntry{
+		builder: builder.NewBlockBuilder(e.backgroundCtx, e.builderFunc, ownedParams,
+			buildDuration(params.Timestamp, time.Now(), secondsPerSlot), stopGraceDuration(secondsPerSlot)),
+		params: ownedParams,
+	}
+	e.buildersByTimestamp[params.Timestamp] = e.nextPayloadId
 	e.logger.Info("[ForkChoiceUpdated] BlockBuilder added", "payload", e.nextPayloadId)
 
 	return AssembleBlockResult{PayloadID: e.nextPayloadId}, nil
@@ -118,17 +226,33 @@ func blockValue(br *types.BlockWithReceipts, baseFee *uint256.Int) *uint256.Int 
 }
 
 func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (AssembledBlockResult, error) {
+	if err := ctx.Err(); err != nil {
+		return AssembledBlockResult{}, err
+	}
 	if !e.semaphore.TryAcquire(1) {
 		return AssembledBlockResult{Busy: true}, nil
 	}
 	defer e.semaphore.Release(1)
 
-	bldr, ok := e.builders[payloadID]
-	if !ok {
-		return AssembledBlockResult{}, nil
+	entry, ok := e.builders[payloadID]
+	if !ok || entry == nil || entry.builder == nil {
+		return AssembledBlockResult{Unknown: true}, nil
 	}
-	blockWithReceipts, err := bldr.Stop(ctx)
+	blockWithReceipts, err := entry.builder.Stop(ctx)
+	if errors.Is(err, builder.ErrDiscarded) {
+		e.dropBuilder(payloadID, entry)
+		return AssembledBlockResult{Unknown: true}, nil
+	}
 	if err != nil {
+		// Stop reports the caller's wait expiring and the build's own failure through the same
+		// error, and a build can fail with a context error of its own - a transaction provider
+		// giving up, say. Only the builder knows which happened, so ask it rather than guess from
+		// the error: a caller that gave up leaves a builder still worth collecting.
+		if !entry.builder.Failed() {
+			return AssembledBlockResult{}, err
+		}
+		// Keeping a failed entry would hand its latched error to every retry.
+		e.dropBuilder(payloadID, entry)
 		e.logger.Error("Failed to build PoS block", "err", err)
 		return AssembledBlockResult{}, err
 	}

--- a/execution/execmodule/block_building.go
+++ b/execution/execmodule/block_building.go
@@ -117,7 +117,7 @@ func blockValue(br *types.BlockWithReceipts, baseFee *uint256.Int) *uint256.Int 
 	return blockValue
 }
 
-func (e *ExecModule) GetAssembledBlock(_ context.Context, payloadID uint64) (AssembledBlockResult, error) {
+func (e *ExecModule) GetAssembledBlock(ctx context.Context, payloadID uint64) (AssembledBlockResult, error) {
 	if !e.semaphore.TryAcquire(1) {
 		return AssembledBlockResult{Busy: true}, nil
 	}
@@ -127,7 +127,7 @@ func (e *ExecModule) GetAssembledBlock(_ context.Context, payloadID uint64) (Ass
 	if !ok {
 		return AssembledBlockResult{}, nil
 	}
-	blockWithReceipts, err := bldr.Stop()
+	blockWithReceipts, err := bldr.Stop(ctx)
 	if err != nil {
 		e.logger.Error("Failed to build PoS block", "err", err)
 		return AssembledBlockResult{}, err

--- a/execution/execmodule/block_building_internal_test.go
+++ b/execution/execmodule/block_building_internal_test.go
@@ -17,12 +17,463 @@
 package execmodule
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"math"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+
 	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/common"
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/erigontech/erigon/execution/builder"
+	"github.com/erigontech/erigon/execution/chain"
+	"github.com/erigontech/erigon/execution/engineapi/engine_helpers"
+	"github.com/erigontech/erigon/execution/types"
+	"github.com/erigontech/erigon/txnprovider"
 )
+
+type doneObservedContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
+// newTestModule builds a module whose builders run builderFunc. Every test needs the same fields,
+// and getting the config or the context wrong changes the builder's own deadline silently.
+func newTestModule(t *testing.T, builderFunc builder.BlockBuilderFunc) *ExecModule {
+	t.Helper()
+	return &ExecModule{
+		logger:              log.Root(),
+		config:              &chain.Config{},
+		semaphore:           semaphore.NewWeighted(1),
+		builders:            map[uint64]*builderEntry{},
+		buildersByTimestamp: map[uint64]uint64{},
+		backgroundCtx:       t.Context(),
+		builderFunc:         builderFunc,
+	}
+}
+
+// newTestTimestamp is a slot that has not happened yet but is close enough to be one a proposal could
+// be waiting for. Far enough ahead that buildDuration gives a budget measured in slots, so the
+// max-build-time watchdog cannot fire mid-test, and near enough that the slot still counts as live.
+func newTestTimestamp() uint64 {
+	return uint64(time.Now().Add(10 * time.Second).Unix())
+}
+
+func TestAssembleBlockKeepsBuildersApartByTimestamp(t *testing.T) {
+	timestamp := newTestTimestamp()
+	type runningBuilder struct {
+		id        uint64
+		interrupt *atomic.Bool
+	}
+	started := make(chan runningBuilder, 4)
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- runningBuilder{id: params.PayloadId, interrupt: interrupt}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
+	t.Cleanup(func() {
+		for _, entry := range module.builders {
+			if entry != nil && entry.builder != nil {
+				_, _ = entry.builder.Stop(context.Background())
+			}
+		}
+	})
+
+	waitStarted := func() runningBuilder {
+		t.Helper()
+		select {
+		case running := <-started:
+			return running
+		case <-time.After(time.Second):
+			t.Fatal("builder did not start")
+			return runningBuilder{}
+		}
+	}
+	assemble := func(timestamp uint64, parent common.Hash) (uint64, runningBuilder) {
+		t.Helper()
+		result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: parent})
+		require.NoError(t, err)
+		require.False(t, result.Busy)
+		return result.PayloadID, waitStarted()
+	}
+
+	firstID, first := assemble(timestamp, common.Hash{0x01})
+	adjacentID, adjacent := assemble(timestamp+1, common.Hash{0x02})
+	require.NotEqual(t, firstID, adjacentID)
+
+	firstDuplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	require.Equal(t, firstID, firstDuplicate.PayloadID)
+
+	// Superseding moves only the timestamp index; the old builders keep running. The adjacent
+	// timestamp is a different proposal and is untouched throughout.
+	secondID, second := assemble(timestamp, common.Hash{0x03})
+	require.NotEqual(t, firstID, secondID)
+	require.Equal(t, secondID, module.buildersByTimestamp[timestamp])
+	require.Equal(t, adjacentID, module.buildersByTimestamp[timestamp+1])
+
+	thirdID, third := assemble(timestamp, common.Hash{0x04})
+	require.NotEqual(t, secondID, thirdID)
+	require.Equal(t, thirdID, module.buildersByTimestamp[timestamp])
+
+	duplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x04}})
+	require.NoError(t, err)
+	require.Equal(t, thirdID, duplicate.PayloadID)
+
+	for _, running := range []runningBuilder{first, second, third, adjacent} {
+		require.False(t, running.interrupt.Load(), "builder %d must still be packing", running.id)
+	}
+
+	// Eviction goes by age but skips what a timestamp still resolves to: first and second have been
+	// superseded, third and adjacent have not.
+	for id := thirdID + 1; len(module.builders) < engine_helpers.MaxBuilders; id++ {
+		module.builders[id] = nil
+	}
+	module.evictOldBuilders()
+
+	require.NotContains(t, module.builders, firstID)
+	require.Eventually(t, first.interrupt.Load, time.Second, time.Millisecond)
+	require.Contains(t, module.builders, adjacentID, "the current builder for a timestamp must survive eviction")
+	require.Contains(t, module.builders, thirdID)
+	require.False(t, adjacent.interrupt.Load())
+	require.False(t, third.interrupt.Load())
+	require.Equal(t, thirdID, module.buildersByTimestamp[timestamp])
+	require.Equal(t, adjacentID, module.buildersByTimestamp[timestamp+1])
+}
+
+func TestEvictionReleasesABuilderBlockedOnItsProvider(t *testing.T) {
+	timestamp := newTestTimestamp()
+	// A transaction provider can wait for most of a slot before returning, and the interrupt flag
+	// is not read until it does. Only cancelling the build reaches it.
+	entered := make(chan struct{}, 1)
+	released := make(chan error, 1)
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		entered <- struct{}{}
+		select {
+		case <-ctx.Done():
+			released <- ctx.Err()
+			return nil, ctx.Err()
+		case <-time.After(time.Minute):
+			released <- errors.New("provider was never released")
+			return nil, errors.New("provider was never released")
+		}
+	})
+
+	blocked, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	<-entered
+
+	// Superseded, so eviction is allowed to take it: what a timestamp still resolves to is exempt.
+	_, err = module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x02}})
+	require.NoError(t, err)
+	<-entered
+
+	entry := module.builders[blocked.PayloadID]
+	require.NotNil(t, entry)
+	for id := uint64(len(module.builders)) + 100; len(module.builders) < engine_helpers.MaxBuilders; id++ {
+		module.builders[id] = nil
+	}
+	module.evictOldBuilders()
+	require.NotContains(t, module.builders, blocked.PayloadID)
+
+	// Observing the goroutine finish is the point: an evicted builder that merely has its flag set
+	// keeps its read view open until whatever it is blocked on gives up on its own.
+	select {
+	case err := <-released:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("evicted builder was never released")
+	}
+	require.Eventually(t, func() bool { return entry.builder.Failed() }, 5*time.Second, time.Millisecond)
+}
+
+func TestSupersededBuilderKeepsPackingAndStaysRetrievable(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan *atomic.Bool, 4)
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- interrupt
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	})
+
+	first, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	firstInterrupt := <-started
+
+	second, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x02}})
+	require.NoError(t, err)
+	require.NotEqual(t, first.PayloadID, second.PayloadID)
+	secondInterrupt := <-started
+
+	// Superseding moves only the index; the old builder keeps running and its id stays retrievable.
+	require.Equal(t, second.PayloadID, module.buildersByTimestamp[timestamp])
+	require.False(t, firstInterrupt.Load())
+
+	assembled, err := module.GetAssembledBlock(t.Context(), first.PayloadID)
+	require.NoError(t, err)
+	require.NotNil(t, assembled.Block)
+
+	secondInterrupt.Store(true)
+}
+
+func TestCollectedPayloadIsHandedBackToARepeatedRequest(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan struct{}, 4)
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	})
+
+	params := func() *builder.Parameters {
+		return &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}}
+	}
+	first, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	<-started
+
+	assembled, err := module.GetAssembledBlock(t.Context(), first.PayloadID)
+	require.NoError(t, err)
+	require.NotNil(t, assembled.Block)
+
+	// Collecting stops the builder. A repeated request must still be handed that payload: rebuilding
+	// from scratch this late means the next grab takes a near-empty block.
+	repeat, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	require.Equal(t, first.PayloadID, repeat.PayloadID)
+	require.Empty(t, started, "a repeated request must not start a second builder")
+}
+
+func TestAssembleBlockDoesNotReuseFailedBuilder(t *testing.T) {
+	timestamp := newTestTimestamp()
+	var failNext atomic.Bool
+	failNext.Store(true)
+	started := make(chan struct{}, 4)
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		if failNext.Swap(false) {
+			return nil, errors.New("build failed")
+		}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
+
+	params := func() *builder.Parameters {
+		return &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}}
+	}
+	first, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	<-started
+	require.Eventually(t, module.builders[first.PayloadID].builder.Failed, time.Second, time.Millisecond)
+
+	// Identical parameters would normally dedup onto the same id, but a failed builder latches its
+	// error and has to be passed over.
+	second, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	require.NotEqual(t, first.PayloadID, second.PayloadID)
+	<-started
+
+	_, _ = module.builders[second.PayloadID].builder.Stop(context.Background())
+}
+
+func TestGetAssembledBlockDropsFailedBuilder(t *testing.T) {
+	timestamp := newTestTimestamp()
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, errors.New("build failed")
+	})
+
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+
+	_, err = module.GetAssembledBlock(t.Context(), result.PayloadID)
+	require.Error(t, err)
+
+	// The error is latched, so leaving the entry in place would keep serving it to every retry.
+	require.NotContains(t, module.builders, result.PayloadID)
+	require.NotContains(t, module.buildersByTimestamp, timestamp)
+}
+
+func TestGetAssembledBlockKeepsBuilderWhenTheCallerGivesUpMidStop(t *testing.T) {
+	timestamp := newTestTimestamp()
+	interrupted := make(chan struct{})
+	release := make(chan struct{})
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		close(interrupted)
+		<-release
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	})
+
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+
+	// Cancel while Stop is already waiting, which is the window a caller-side timeout actually
+	// lands in. Cancelling beforehand returns at the entry check and exercises none of this.
+	ctx, cancel := context.WithCancel(t.Context())
+	collected := make(chan error, 1)
+	go func() {
+		_, collectErr := module.GetAssembledBlock(ctx, result.PayloadID)
+		collected <- collectErr
+	}()
+	<-interrupted
+	cancel()
+	require.ErrorIs(t, <-collected, context.Canceled)
+
+	// The builder was not dropped, so the payload it goes on to produce is still reachable.
+	require.Contains(t, module.builders, result.PayloadID)
+	require.Equal(t, result.PayloadID, module.buildersByTimestamp[timestamp])
+
+	close(release)
+	assembled, err := module.GetAssembledBlock(t.Context(), result.PayloadID)
+	require.NoError(t, err)
+	require.NotNil(t, assembled.Block)
+}
+
+// mutableTxnProvider stands in for the stateful providers the testing namespace supplies: it hands
+// its transactions over once and clears them, from the build goroutine.
+type mutableTxnProvider struct {
+	txns []types.Transaction
+	done atomic.Bool
+}
+
+func (m *mutableTxnProvider) ProvideTxns(context.Context, ...txnprovider.ProvideOption) ([]types.Transaction, error) {
+	if !m.done.CompareAndSwap(false, true) {
+		return nil, nil
+	}
+	txns := m.txns
+	m.txns = nil
+	return txns, nil
+}
+
+func TestAssembleBlockNeverReusesABuilderWithACustomProvider(t *testing.T) {
+	started := make(chan struct{}, 4)
+	module := newTestModule(t, func(ctx context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		// Keep the provider busy for the whole test, which is when a comparison would read it.
+		for !interrupt.Load() && ctx.Err() == nil {
+			if params.CustomTxnProvider != nil {
+				_, _ = params.CustomTxnProvider.ProvideTxns(ctx)
+			}
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
+
+	timestamp := newTestTimestamp()
+	withProvider := func() *builder.Parameters {
+		return &builder.Parameters{
+			Timestamp:         timestamp,
+			ParentHash:        common.Hash{0x01},
+			CustomTxnProvider: &mutableTxnProvider{txns: []types.Transaction{}},
+		}
+	}
+	first, err := module.AssembleBlock(t.Context(), withProvider())
+	require.NoError(t, err)
+	<-started
+
+	// The provider is single-shot and mutates as it runs, so a second request carrying one is not
+	// asking for what the first is building, and its fields must never be compared.
+	second, err := module.AssembleBlock(t.Context(), withProvider())
+	require.NoError(t, err)
+	require.NotEqual(t, first.PayloadID, second.PayloadID)
+	<-started
+
+	for _, entry := range module.builders {
+		entry.builder.Discard()
+	}
+}
+
+func TestAssembleBlockOwnsParameters(t *testing.T) {
+	type observedParameters struct {
+		parentRoot common.Hash
+		extraData  byte
+	}
+	readParameters := make(chan struct{})
+	observed := make(chan observedParameters, 1)
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		<-readParameters
+		observed <- observedParameters{parentRoot: *params.ParentBeaconBlockRoot, extraData: params.ExtraData[0]}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
+	timestamp := newTestTimestamp()
+	root := common.Hash{0xaa}
+	params := &builder.Parameters{
+		Timestamp:             timestamp,
+		ParentHash:            common.Hash{0x01},
+		ParentBeaconBlockRoot: &root,
+		ExtraData:             []byte{0xbb},
+	}
+	result, err := module.AssembleBlock(t.Context(), params)
+	require.NoError(t, err)
+	require.False(t, result.Busy)
+	require.Zero(t, params.PayloadId, "the caller's parameters are not the module's to write to")
+
+	root[0] = 0xcc
+	params.ExtraData[0] = 0xdd
+	close(readParameters)
+	require.Equal(t, observedParameters{parentRoot: common.Hash{0xaa}, extraData: 0xbb}, <-observed)
+
+	duplicate, err := module.AssembleBlock(t.Context(), &builder.Parameters{
+		Timestamp:             timestamp,
+		ParentHash:            common.Hash{0x01},
+		ParentBeaconBlockRoot: &common.Hash{0xaa},
+		ExtraData:             []byte{0xbb},
+	})
+	require.NoError(t, err)
+	require.Equal(t, result.PayloadID, duplicate.PayloadID)
+	_, _ = module.builders[result.PayloadID].builder.Stop(context.Background())
+}
+
+func TestAssembleBlockCanceledContextDoesNotSupersedeBuilder(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan *atomic.Bool, 1)
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- interrupt
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	interrupt := <-started
+	t.Cleanup(func() {
+		_, _ = module.builders[result.PayloadID].builder.Stop(context.Background())
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = module.AssembleBlock(ctx, &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x02}})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, interrupt.Load())
+	require.Equal(t, result.PayloadID, module.buildersByTimestamp[timestamp])
+}
 
 func TestBuildDuration(t *testing.T) {
 	const ethereum, gnosis = uint64(12), uint64(5)
@@ -55,6 +506,13 @@ func TestBuildDuration(t *testing.T) {
 	}
 }
 
+func TestStopGraceDuration(t *testing.T) {
+	// The grace has to fit a heavy transaction plus the packing tail and finalization, while still
+	// bounding how long a stuck build can hold its read view past its budget.
+	require.Equal(t, 6*time.Second, stopGraceDuration(12))
+	require.Equal(t, 2500*time.Millisecond, stopGraceDuration(5))
+}
+
 func TestBuildDurationCapsAbsurdTimestamp(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	farFuture := uint64(now.Add(time.Hour).Unix())
@@ -69,4 +527,297 @@ func TestBuildDurationCapsOverflowingTimestamp(t *testing.T) {
 	// Beyond int64 seconds the conversion wraps into the past, which would collapse the budget to
 	// the floor instead of the cap.
 	require.Equal(t, 24*time.Second, buildDuration(math.MaxUint64, now, 12))
+}
+
+func TestGetAssembledBlockDropsABuildThatFailedWithAContextError(t *testing.T) {
+	timestamp := newTestTimestamp()
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		// A transaction provider that gives up reports its own context error, which is a failed
+		// build rather than a caller that stopped waiting.
+		return nil, fmt.Errorf("issue while waiting for parent block: %w", context.DeadlineExceeded)
+	})
+
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+
+	_, err = module.GetAssembledBlock(t.Context(), result.PayloadID)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// Keeping it would serve that latched error to every later retry of the same slot.
+	require.NotContains(t, module.builders, result.PayloadID)
+	require.NotContains(t, module.buildersByTimestamp, timestamp)
+}
+
+func TestGetAssembledBlockSaysWhenAPayloadIdIsUnknown(t *testing.T) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, errors.New("builder stopped")
+	})
+
+	// An id with no builder behind it can never produce anything. Reporting it as an ordinary empty
+	// result leaves a caller polling it for the rest of the slot.
+	assembled, err := module.GetAssembledBlock(t.Context(), 404)
+	require.NoError(t, err)
+	require.True(t, assembled.Unknown)
+	require.Nil(t, assembled.Block)
+}
+
+func TestEvictionSparesTheBuilderATimestampStillPointsAt(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan struct{}, 1)
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return nil, errors.New("builder stopped")
+	})
+
+	current, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	<-started
+
+	// It is the oldest by id, so eviction would take it first, and it is also what a proposal for
+	// that timestamp is waiting on. Age says nothing about that.
+	for id := current.PayloadID + 1; len(module.builders) < engine_helpers.MaxBuilders+1; id++ {
+		module.builders[id] = nil
+	}
+	module.evictOldBuilders()
+
+	require.Contains(t, module.builders, current.PayloadID)
+	require.Equal(t, current.PayloadID, module.buildersByTimestamp[timestamp])
+	require.False(t, module.builders[current.PayloadID].builder.Failed())
+
+	module.builders[current.PayloadID].builder.Discard()
+}
+
+func TestAssembleBlockDoesNotReuseADiscardedBuilder(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan struct{}, 2)
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		<-ctx.Done()
+		// The goroutine outliving the discard is the point: the builder must read as gone at once,
+		// not only once its work notices the cancellation.
+		time.Sleep(200 * time.Millisecond)
+		return nil, ctx.Err()
+	})
+
+	params := func() *builder.Parameters {
+		return &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}}
+	}
+	first, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	<-started
+
+	module.builders[first.PayloadID].builder.Discard()
+
+	second, err := module.AssembleBlock(t.Context(), params())
+	require.NoError(t, err)
+	require.NotEqual(t, first.PayloadID, second.PayloadID)
+	<-started
+	module.builders[second.PayloadID].builder.Discard()
+}
+
+func TestGetAssembledBlockReportsADiscardedBuilderAsUnknown(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan struct{}, 1)
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		<-ctx.Done()
+		time.Sleep(200 * time.Millisecond)
+		return nil, ctx.Err()
+	})
+
+	result, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	<-started
+	module.builders[result.PayloadID].builder.Discard()
+
+	assembled, err := module.GetAssembledBlock(t.Context(), result.PayloadID)
+	require.NoError(t, err)
+	require.True(t, assembled.Unknown)
+	require.NotContains(t, module.builders, result.PayloadID)
+	require.NotContains(t, module.buildersByTimestamp, timestamp)
+}
+
+func TestGetAssembledBlockReportsDiscardDuringStopAsUnknown(t *testing.T) {
+	timestamp := newTestTimestamp()
+	stopObserved := make(chan struct{})
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		close(stopObserved)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	assembled, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+
+	type response struct {
+		result AssembledBlockResult
+		err    error
+	}
+	collected := make(chan response, 1)
+	go func() {
+		result, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
+		collected <- response{result: result, err: err}
+	}()
+	select {
+	case <-stopObserved:
+	case <-time.After(5 * time.Second):
+		t.Fatal("builder did not observe the collection request")
+	}
+	module.builders[assembled.PayloadID].builder.Discard()
+
+	result := <-collected
+	require.NoError(t, result.err)
+	require.True(t, result.result.Unknown)
+	require.NotContains(t, module.builders, assembled.PayloadID)
+	require.NotContains(t, module.buildersByTimestamp, timestamp)
+}
+
+func TestGetAssembledBlockKeepsPayloadCompletedAsDiscardLands(t *testing.T) {
+	timestamp := newTestTimestamp()
+	finish := make(chan struct{})
+	want := &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}
+	module := newTestModule(t, func(_ context.Context, _ *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		<-finish
+		return want, nil
+	})
+
+	assembled, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+
+	type response struct {
+		result AssembledBlockResult
+		err    error
+	}
+	collected := make(chan response, 1)
+	stopObserved := make(chan struct{})
+	stopCtx := &doneObservedContext{Context: t.Context(), observed: stopObserved}
+	go func() {
+		result, err := module.GetAssembledBlock(stopCtx, assembled.PayloadID)
+		collected <- response{result: result, err: err}
+	}()
+	select {
+	case <-stopObserved:
+	case <-time.After(5 * time.Second):
+		t.Fatal("builder did not observe the collection request")
+	}
+	module.builders[assembled.PayloadID].builder.Discard()
+	close(finish)
+
+	select {
+	case result := <-collected:
+		require.NoError(t, result.err)
+		require.False(t, result.result.Unknown)
+		require.Same(t, want, result.result.Block)
+	case <-time.After(5 * time.Second):
+		t.Fatal("payload collection did not finish")
+	}
+
+	replayed, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
+	require.NoError(t, err)
+	require.False(t, replayed.Unknown)
+	require.Same(t, want, replayed.Block)
+}
+
+func TestGetAssembledBlockKeepsFailureCompletedBeforeDiscard(t *testing.T) {
+	timestamp := newTestTimestamp()
+	wantErr := errors.New("build failed")
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, wantErr
+	})
+
+	assembled, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	entry := module.builders[assembled.PayloadID]
+	require.Eventually(t, entry.builder.Failed, 5*time.Second, time.Millisecond)
+	entry.builder.Discard()
+
+	result, err := module.GetAssembledBlock(t.Context(), assembled.PayloadID)
+	require.ErrorIs(t, err, wantErr)
+	require.False(t, result.Unknown)
+	require.NotContains(t, module.builders, assembled.PayloadID)
+}
+
+func TestEvictionTakesAFailedCurrentBuilderBeforeALiveSupersededOne(t *testing.T) {
+	timestamp := newTestTimestamp()
+	started := make(chan struct{}, 4)
+	module := newTestModule(t, func(_ context.Context, params *builder.Parameters, interrupt *atomic.Bool) (*types.BlockWithReceipts, error) {
+		started <- struct{}{}
+		if params.ParentHash == (common.Hash{0xff}) {
+			return nil, errors.New("build failed")
+		}
+		for !interrupt.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		return &types.BlockWithReceipts{Block: types.NewBlock(&types.Header{}, nil, nil, nil, nil)}, nil
+	})
+	t.Cleanup(func() {
+		for _, entry := range module.builders {
+			if entry != nil && entry.builder != nil {
+				entry.builder.Discard()
+			}
+		}
+	})
+
+	failed, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp, ParentHash: common.Hash{0xff}})
+	require.NoError(t, err)
+	<-started
+	require.Eventually(t, module.builders[failed.PayloadID].builder.Failed, time.Second, time.Millisecond)
+
+	superseded, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp + 1, ParentHash: common.Hash{0x01}})
+	require.NoError(t, err)
+	<-started
+	_, err = module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: timestamp + 1, ParentHash: common.Hash{0x02}})
+	require.NoError(t, err)
+	<-started
+
+	for id := uint64(1000); len(module.builders) < engine_helpers.MaxBuilders; id++ {
+		module.builders[id] = nil
+	}
+	module.evictOldBuilders()
+
+	require.NotContains(t, module.builders, failed.PayloadID)
+	require.Contains(t, module.builders, superseded.PayloadID)
+}
+
+func TestAssembleBlockRefusesAfterShutdown(t *testing.T) {
+	module := newTestModule(t, func(ctx context.Context, _ *builder.Parameters, _ *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, ctx.Err()
+	})
+	shutdownCtx, cancel := context.WithCancel(t.Context())
+	module.backgroundCtx = shutdownCtx
+	cancel()
+
+	_, err := module.AssembleBlock(t.Context(), &builder.Parameters{Timestamp: newTestTimestamp(), ParentHash: common.Hash{0x01}})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, module.builders)
+}
+
+func TestEvictionKeepsTheBuilderCacheBounded(t *testing.T) {
+	module := newTestModule(t, func(context.Context, *builder.Parameters, *atomic.Bool) (*types.BlockWithReceipts, error) {
+		return nil, errors.New("builder stopped")
+	})
+
+	// Ordinary traffic is one builder per slot, so every entry is the one its own timestamp
+	// resolves to. If being indexed were enough to protect an entry, nothing would ever be evicted
+	// and both maps would grow for the life of the process.
+	past := uint64(time.Now().Add(-time.Hour).Unix())
+	for i := range uint64(engine_helpers.MaxBuilders + 8) {
+		_, err := module.AssembleBlock(t.Context(), &builder.Parameters{
+			Timestamp:  past + i,
+			ParentHash: common.Hash{byte(i), byte(i >> 8)},
+		})
+		require.NoError(t, err)
+	}
+
+	require.LessOrEqual(t, len(module.builders), engine_helpers.MaxBuilders)
+	require.LessOrEqual(t, len(module.buildersByTimestamp), engine_helpers.MaxBuilders)
 }

--- a/execution/execmodule/chainreader/chain_reader.go
+++ b/execution/execmodule/chainreader/chain_reader.go
@@ -297,6 +297,10 @@ func (c ChainReaderWriterEth1) HasBlock(ctx context.Context, hash common.Hash) (
 // own, as opposed to a rejection that returns the same answer however many times it is asked.
 var ErrExecutionBusy = errors.New("execution module is busy")
 
+// ErrUnknownPayload reports that no builder is held for a payload id, so nothing will ever arrive
+// for it. Without it a caller polling that id cannot tell it from a build still running.
+var ErrUnknownPayload = errors.New("unknown payload id")
+
 func (c ChainReaderWriterEth1) AssembleBlock(ctx context.Context, baseHash common.Hash, attributes *engine_types.PayloadAttributes) (id uint64, err error) {
 	params := &builder.Parameters{
 		ParentHash:            baseHash,
@@ -325,6 +329,9 @@ func (c ChainReaderWriterEth1) GetAssembledBlock(ctx context.Context, id uint64)
 	}
 	if result.Busy {
 		return nil, nil, nil, nil, ErrExecutionBusy
+	}
+	if result.Unknown {
+		return nil, nil, nil, nil, ErrUnknownPayload
 	}
 	if result.Block == nil {
 		return nil, nil, nil, nil, nil

--- a/execution/execmodule/chainreader/chain_reader_test.go
+++ b/execution/execmodule/chainreader/chain_reader_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package chainreader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/execution/execmodule"
+)
+
+// assembledBlockStub answers GetAssembledBlock with a fixed result and panics on anything else, so
+// a test can drive the one boundary it cares about.
+type assembledBlockStub struct {
+	execmodule.ExecutionModule
+	result execmodule.AssembledBlockResult
+}
+
+func (s assembledBlockStub) GetAssembledBlock(context.Context, uint64) (execmodule.AssembledBlockResult, error) {
+	return s.result, nil
+}
+
+func TestGetAssembledBlockDistinguishesAnUnknownIdFromAnEmptyOne(t *testing.T) {
+	unknown := ChainReaderWriterEth1{executionModule: assembledBlockStub{result: execmodule.AssembledBlockResult{Unknown: true}}}
+	_, _, _, _, err := unknown.GetAssembledBlock(t.Context(), 1)
+
+	// Nothing will ever arrive for an id with no builder behind it. Reporting that as an ordinary
+	// empty result leaves a caller polling it for the rest of the slot.
+	require.ErrorIs(t, err, ErrUnknownPayload)
+
+	busy := ChainReaderWriterEth1{executionModule: assembledBlockStub{result: execmodule.AssembledBlockResult{Busy: true}}}
+	_, _, _, _, err = busy.GetAssembledBlock(t.Context(), 1)
+	require.ErrorIs(t, err, ErrExecutionBusy)
+
+	// A builder that simply has nothing yet is neither: the caller should keep waiting.
+	building := ChainReaderWriterEth1{executionModule: assembledBlockStub{}}
+	block, _, _, _, err := building.GetAssembledBlock(t.Context(), 1)
+	require.NoError(t, err)
+	require.Nil(t, block)
+}

--- a/execution/execmodule/exec_module.go
+++ b/execution/execmodule/exec_module.go
@@ -178,7 +178,7 @@ func (c *CacheView) HasStorage(address common.Address) (bool, error) {
 }
 
 type ExecModule struct {
-	bacgroundCtx context.Context
+	backgroundCtx context.Context
 	// Snapshots + MDBX
 	blockReader dbservices.FullBlockReader
 
@@ -194,10 +194,10 @@ type ExecModule struct {
 
 	logger log.Logger
 	// Block building
-	nextPayloadId  uint64
-	lastParameters *builder.Parameters
-	builderFunc    builder.BlockBuilderFunc
-	builders       map[uint64]*builder.BlockBuilder
+	nextPayloadId       uint64
+	builderFunc         builder.BlockBuilderFunc
+	builders            map[uint64]*builderEntry
+	buildersByTimestamp map[uint64]uint64
 
 	// Changes accumulator
 	hook  *stageloop.Hook
@@ -268,7 +268,8 @@ func NewExecModule(
 		logger:                  logger,
 		forkValidator:           forkValidator,
 		pipelineExecutor:        pipelineExecutor,
-		builders:                make(map[uint64]*builder.BlockBuilder),
+		builders:                make(map[uint64]*builderEntry),
+		buildersByTimestamp:     make(map[uint64]uint64),
 		builderFunc:             builderFunc,
 		config:                  config,
 		semaphore:               semaphore.NewWeighted(1),
@@ -277,7 +278,7 @@ func NewExecModule(
 		engine:                  engine,
 		balRegenerator:          bal.NewRegenerator(blockReader, engine, logger),
 		syncCfg:                 syncCfg,
-		bacgroundCtx:            ctx,
+		backgroundCtx:           ctx,
 		fcuBackgroundPrune:      fcuBackgroundPrune,
 		fcuBackgroundCommit:     fcuBackgroundCommit,
 		onlySnapDownloadOnStart: onlySnapDownloadOnStart,
@@ -410,9 +411,16 @@ func (e *ExecModule) suspendReadAhead(ctx context.Context) (func(), error) {
 // Its caller must resume only after all reads of the staged state have ended.
 func (e *ExecModule) unwindToCommonCanonical(sd *execctx.SharedDomains, tx kv.TemporalRwTx, header *types.Header, ensureReadAheadSuspended func() error) error {
 	currentHeader := header
-	for isCanonical, err := e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash()); !isCanonical && err == nil; isCanonical, err = e.isCanonicalHash(e.bacgroundCtx, tx, currentHeader.Hash()) {
+	for {
+		isCanonical, err := e.isCanonicalHash(e.backgroundCtx, tx, currentHeader.Hash())
+		if err != nil {
+			return err
+		}
+		if isCanonical {
+			break
+		}
 		parentBlockHash, parentBlockNum := currentHeader.ParentHash, currentHeader.Number.Uint64()-1
-		currentHeader, err = e.getHeader(e.bacgroundCtx, tx, parentBlockHash, parentBlockNum)
+		currentHeader, err = e.getHeader(e.backgroundCtx, tx, parentBlockHash, parentBlockNum)
 		if err != nil {
 			return err
 		}

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -664,7 +664,10 @@ func syntheticSlotNumber(parent *types.Block) *uint64 {
 func TestGetAssembledBlockReportsUnknownPayload(t *testing.T) {
 	m := execmoduletester.New(t, execmoduletester.WithChainConfig(chain.AllProtocolChanges))
 
-	result, err := m.ExecModule.GetAssembledBlock(t.Context(), 404)
+	result, err := retryBusy(t.Context(), func() (execmodule.AssembledBlockResult, bool, error) {
+		result, err := m.ExecModule.GetAssembledBlock(t.Context(), 404)
+		return result, result.Busy, err
+	})
 	require.NoError(t, err)
 	require.True(t, result.Unknown)
 	require.Nil(t, result.Block)

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -53,6 +53,9 @@ import (
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 	"github.com/erigontech/erigon/execution/execmodule/execmoduletester"
 	"github.com/erigontech/erigon/execution/protocol/params"
+	"github.com/erigontech/erigon/execution/protocol/rules"
+	"github.com/erigontech/erigon/execution/protocol/rules/ethash"
+	"github.com/erigontech/erigon/execution/protocol/rules/merge"
 	"github.com/erigontech/erigon/execution/stagedsync"
 	"github.com/erigontech/erigon/execution/stagedsync/stages"
 	"github.com/erigontech/erigon/execution/state/contracts"
@@ -109,6 +112,67 @@ func (p *rewindingTxnProvider) ProvideTxns(ctx context.Context, opts ...txnprovi
 		return nil, p.err
 	}
 	return p.pool.ProvideTxns(ctx, opts...)
+}
+
+type observingTxnProvider struct {
+	txnprovider.TxnProvider
+	txnCounts chan int
+}
+
+type emptyTxnProvider struct{}
+
+func (emptyTxnProvider) ProvideTxns(context.Context, ...txnprovider.ProvideOption) ([]types.Transaction, error) {
+	return nil, nil
+}
+
+type delayedSealEngine struct {
+	rules.Engine
+	started chan struct{}
+	release chan struct{}
+}
+
+type doneObservedContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *doneObservedContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
+func (e *delayedSealEngine) Seal(_ rules.ChainHeaderReader, block *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, _ <-chan struct{}) error {
+	close(e.started)
+	go func() {
+		<-e.release
+		results <- block
+	}()
+	return nil
+}
+
+func (p *observingTxnProvider) ProvideTxns(ctx context.Context, opts ...txnprovider.ProvideOption) ([]types.Transaction, error) {
+	txns, err := p.TxnProvider.ProvideTxns(ctx, opts...)
+	if err == nil {
+		p.txnCounts <- len(txns)
+	}
+	return txns, err
+}
+
+func waitForProvidedTxnCount(t *testing.T, txnCounts <-chan int, want int) {
+	t.Helper()
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case got := <-txnCounts:
+			if got == want {
+				return
+			}
+		case <-timer.C:
+			t.Fatalf("transaction provider did not return %d transactions", want)
+		}
+	}
 }
 
 func txPoolHead(block *types.Block) *remoteproto.StateChangeBatch {
@@ -591,6 +655,21 @@ func addTwoTxnsToPool(ctx context.Context, startingNonce uint64, t *testing.T, m
 	}
 }
 
+func syntheticSlotNumber(parent *types.Block) *uint64 {
+	// Consensus assigns slots independently; synthetic tests reuse block numbers.
+	slotNumber := parent.NumberU64() + 1
+	return &slotNumber
+}
+
+func TestGetAssembledBlockReportsUnknownPayload(t *testing.T) {
+	m := execmoduletester.New(t, execmoduletester.WithChainConfig(chain.AllProtocolChanges))
+
+	result, err := m.ExecModule.GetAssembledBlock(t.Context(), 404)
+	require.NoError(t, err)
+	require.True(t, result.Unknown)
+	require.Nil(t, result.Block)
+}
+
 func TestAssembleBlock(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -628,6 +707,62 @@ func TestAssembleBlock(t *testing.T) {
 
 	err = insertValidateAndUfc1By1(ctx, exec, []*types.Block{block})
 	require.NoError(t, err)
+}
+
+func TestDiscardReleasesBuilderWaitingForSeal(t *testing.T) {
+	engine := &delayedSealEngine{
+		Engine:  merge.NewFaker(ethash.NewFaker()),
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	t.Cleanup(func() { close(engine.release) })
+	m := execmoduletester.New(t,
+		execmoduletester.WithChainConfig(chain.AllProtocolChanges),
+		execmoduletester.WithEngine(engine),
+	)
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 1, nil)
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(chainPack))
+
+	parent := chainPack.TopBlock
+	beaconRoot := randomHash()
+	payloadBuilder := builder.NewBlockBuilder(t.Context(), m.BlockBuilder.Build, &builder.Parameters{
+		ParentHash:            parent.Hash(),
+		Timestamp:             parent.Time() + 1,
+		PrevRandao:            parent.Header().MixDigest,
+		SuggestedFeeRecipient: common.Address{1},
+		Withdrawals:           make([]*types.Withdrawal, 0),
+		ParentBeaconBlockRoot: &beaconRoot,
+		SlotNumber:            syntheticSlotNumber(parent),
+		CustomTxnProvider:     emptyTxnProvider{},
+	}, time.Minute, time.Minute)
+
+	stopped := make(chan error, 1)
+	stopObserved := make(chan struct{})
+	stopCtx := &doneObservedContext{Context: context.Background(), observed: stopObserved}
+	go func() {
+		_, stopErr := payloadBuilder.Stop(stopCtx)
+		stopped <- stopErr
+	}()
+
+	select {
+	case <-engine.started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("builder did not reach sealing")
+	}
+	select {
+	case <-stopObserved:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stop did not begin waiting for the builder")
+	}
+	payloadBuilder.Discard()
+
+	select {
+	case err := <-stopped:
+		require.ErrorIs(t, err, builder.ErrDiscarded)
+	case <-time.After(5 * time.Second):
+		t.Fatal("discarded builder remained blocked waiting for a seal result")
+	}
 }
 
 func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {

--- a/execution/execmodule/exec_module_test.go
+++ b/execution/execmodule/exec_module_test.go
@@ -59,8 +59,10 @@ import (
 	"github.com/erigontech/erigon/execution/tests/blockgen"
 	"github.com/erigontech/erigon/execution/types"
 	"github.com/erigontech/erigon/execution/types/accounts"
+	"github.com/erigontech/erigon/node/gointerfaces/remoteproto"
 	"github.com/erigontech/erigon/node/gointerfaces/txpoolproto"
 	"github.com/erigontech/erigon/txnprovider"
+	txnpool "github.com/erigontech/erigon/txnprovider/txpool"
 )
 
 type blockingTxnProvider struct {
@@ -88,6 +90,35 @@ func (p *blockingTxnProvider) ProvideTxns(ctx context.Context, _ ...txnprovider.
 	}
 	p.emptyOnce.Do(func() { close(p.exhausted) })
 	return nil, nil
+}
+
+type rewindingTxnProvider struct {
+	pool  *txnpool.TxPool
+	head  *remoteproto.StateChangeBatch
+	ready chan struct{}
+	once  sync.Once
+	err   error
+}
+
+func (p *rewindingTxnProvider) ProvideTxns(ctx context.Context, opts ...txnprovider.ProvideOption) ([]types.Transaction, error) {
+	p.once.Do(func() {
+		p.err = p.pool.OnNewBlock(ctx, p.head, txnpool.TxnSlots{}, txnpool.TxnSlots{}, txnpool.TxnSlots{})
+		close(p.ready)
+	})
+	if p.err != nil {
+		return nil, p.err
+	}
+	return p.pool.ProvideTxns(ctx, opts...)
+}
+
+func txPoolHead(block *types.Block) *remoteproto.StateChangeBatch {
+	return &remoteproto.StateChangeBatch{
+		PendingBlockBaseFee: block.BaseFee().Uint64(),
+		BlockGasLimit:       block.GasLimit(),
+		ChangeBatch: []*remoteproto.StateChange{
+			{BlockHeight: block.NumberU64()},
+		},
+	}
 }
 
 func TestValidateChainWithLastTxNumOfBlockAtStepBoundary(t *testing.T) {
@@ -679,6 +710,65 @@ func TestAssembleBlockWithConcurrentSiblingCommit(t *testing.T) {
 	validation, err := validateChain(ctx, m.ExecModule, built.Header())
 	require.NoError(t, err)
 	require.Equal(t, execmodule.ExecutionStatusSuccess, validation.ValidationStatus)
+}
+
+func TestGetAssembledBlockHonorsCanceledContextWhenTxPoolIsBehindParent(t *testing.T) {
+	ctx := t.Context()
+	m := execmoduletester.New(t, execmoduletester.WithTxPool(), execmoduletester.WithChainConfig(chain.AllProtocolChanges))
+	chainPack, err := blockgen.GenerateChain(m.ChainConfig, m.Genesis, m.Engine, m.DB, 2, nil)
+	require.NoError(t, err)
+	require.NoError(t, m.InsertChain(chainPack))
+
+	parent := chainPack.TopBlock
+	provider := &rewindingTxnProvider{
+		pool:  m.TxPool,
+		head:  txPoolHead(chainPack.Blocks[len(chainPack.Blocks)-2]),
+		ready: make(chan struct{}),
+	}
+	parentBeaconBlockRoot := randomHash()
+	payloadID, err := assembleBlock(ctx, m.ExecModule, &builder.Parameters{
+		ParentHash:            parent.Hash(),
+		Timestamp:             parent.Time() + 1,
+		PrevRandao:            parent.Header().MixDigest,
+		SuggestedFeeRecipient: common.Address{1},
+		Withdrawals:           make([]*types.Withdrawal, 0),
+		ParentBeaconBlockRoot: &parentBeaconBlockRoot,
+		CustomTxnProvider:     provider,
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-provider.ready:
+	case <-time.After(10 * time.Second):
+		t.Fatal("builder did not reach transaction selection")
+	}
+
+	requestCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := m.ExecModule.GetAssembledBlock(requestCtx, payloadID)
+		resultCh <- err
+	}()
+
+	var requestErr error
+	blocked := false
+	select {
+	case requestErr = <-resultCh:
+	case <-time.After(time.Second):
+		blocked = true
+	}
+
+	require.NoError(t, m.TxPool.OnNewBlock(ctx, txPoolHead(parent), txnpool.TxnSlots{}, txnpool.TxnSlots{}, txnpool.TxnSlots{}))
+	if blocked {
+		select {
+		case <-resultCh:
+		case <-time.After(10 * time.Second):
+			t.Fatal("GetAssembledBlock did not return after restoring the txpool head")
+		}
+		t.Fatal("GetAssembledBlock remained blocked after context cancellation while the txpool was behind the builder parent")
+	}
+	require.ErrorIs(t, requestErr, context.Canceled)
 }
 
 func TestAssembleBlockWithFreshlyAddedTxns(t *testing.T) {

--- a/execution/execmodule/execmoduletester/exec_module_tester.go
+++ b/execution/execmodule/execmoduletester/exec_module_tester.go
@@ -122,6 +122,7 @@ type ExecModuleTester struct {
 	Address         common.Address
 	ForkValidator   *execmodule.ForkValidator
 	ExecModule      *execmodule.ExecModule
+	BlockBuilder    *builder.Builder
 	StateCache      *execmodule.Cache
 	retirementStart chan bool
 	retirementDone  chan struct{}
@@ -654,7 +655,6 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 
 	readAheader := exec.NewBlockReadAheader()
 	blkBuilder := builder.NewBuilder(
-		mock.Ctx,
 		mock.DB,
 		&cfg.Builder,
 		mock.ChainConfig,
@@ -686,6 +686,8 @@ func New(tb testing.TB, opts ...Option) *ExecModuleTester {
 		nil, /*sdProvider*/
 		logger,
 	)
+
+	mock.BlockBuilder = blkBuilder
 
 	blockRetire := freezeblocks.NewBlockRetire(mock.Ctx, 1, dirs, mock.BlockReader, blockWriter, mock.DB, nil, nil, mock.ChainConfig, &cfg, mock.Notifications.Events, nil, logger)
 	mock.blockRetire = blockRetire

--- a/execution/execmodule/forkchoice.go
+++ b/execution/execmodule/forkchoice.go
@@ -125,7 +125,7 @@ func (e *ExecModule) UpdateForkChoice(ctx context.Context, headHash, safeHash, f
 	// cleanup has run, so any follow-up op (AssembleBlock, next FCU) that acquires
 	// the semaphore observes fully-settled state.
 	go func() {
-		if err := e.updateForkChoice(e.bacgroundCtx, headHash, safeHash, finalizedHash, outcomeCh); err != nil {
+		if err := e.updateForkChoice(e.backgroundCtx, headHash, safeHash, finalizedHash, outcomeCh); err != nil {
 			e.logger.Debug("updateforkchoice failed", "err", err)
 		}
 	}()
@@ -840,7 +840,7 @@ func (e *ExecModule) dispatchNotificationsFromOverlay(sd *execctx.SharedDomains,
 
 	e.logger.Debug("[dispatchNotifications] dispatching", "finishBefore", finishProgressBefore, "finishAfter", finishProgressAfter)
 	if err := dispatcher.Dispatch(
-		e.bacgroundCtx,
+		e.backgroundCtx,
 		overlay,
 		stateVersion,
 		e.accum.Accumulator,
@@ -868,7 +868,7 @@ func (e *ExecModule) dispatchNotificationsFromOverlay(sd *execctx.SharedDomains,
 func (e *ExecModule) runForkchoiceFlushCommit(sd *execctx.SharedDomains, roTxToCloseBeforeCommit kv.TemporalTx, finishProgressBefore uint64, isSynced bool) ([]any, error) {
 	timings := make([]any, 0, 2)
 
-	rwTx, err := e.db.BeginTemporalRw(e.bacgroundCtx)
+	rwTx, err := e.db.BeginTemporalRw(e.backgroundCtx)
 	if err != nil {
 		return nil, fmt.Errorf("fcu flush+commit: begin rw: %w", err)
 	}
@@ -878,21 +878,21 @@ func (e *ExecModule) runForkchoiceFlushCommit(sd *execctx.SharedDomains, roTxToC
 		roTxToCloseBeforeCommit.Rollback()
 	}
 	flushStart := time.Now()
-	if err := sd.Commit(e.bacgroundCtx, rwTx); err != nil {
+	if err := sd.Commit(e.backgroundCtx, rwTx); err != nil {
 		return nil, err
 	}
 	timings = append(timings, "flush+commit", common.Round(time.Since(flushStart), 0))
 
 	// Update head and announce block range (notifications already dispatched).
 	if e.hook != nil {
-		if err := e.db.View(e.bacgroundCtx, func(tx kv.Tx) error {
+		if err := e.db.View(e.backgroundCtx, func(tx kv.Tx) error {
 			return e.hook.UpdateHead(tx, finishProgressBefore, isSynced)
 		}); err != nil {
 			return nil, err
 		}
 	}
 	// Force fsync so data is durable before the next slot.
-	if err := e.db.Update(e.bacgroundCtx, func(tx kv.RwTx) error {
+	if err := e.db.Update(e.backgroundCtx, func(tx kv.RwTx) error {
 		return kv.IncrementKey(tx, kv.DatabaseInfo, []byte("chaindata_force"))
 	}); err != nil {
 		return nil, err
@@ -920,13 +920,13 @@ func (e *ExecModule) runForkchoicePrune(initialCycle bool) ([]any, error) {
 			baseTimeout := time.Duration(e.config.SecondsPerSlot()*1000/3) * time.Millisecond
 			maxTimeout := time.Duration(e.config.SecondsPerSlot()*2000/3) * time.Millisecond
 			pruneTimeout := min(baseTimeout+time.Duration(agg.MaxPrunableStepsBacklog()/100)*200*time.Millisecond, maxTimeout)
-			if err := agg.CollateAndPrune(e.bacgroundCtx, e.db, func(tx kv.TemporalRwTx) error {
+			if err := agg.CollateAndPrune(e.backgroundCtx, e.db, func(tx kv.TemporalRwTx) error {
 				if e.codeStore != nil {
 					if err := e.codeStore.Evict(tx); err != nil {
 						return err
 					}
 				}
-				return e.pipelineExecutor.RunPrune(e.bacgroundCtx, tx, initialCycle, pruneTimeout)
+				return e.pipelineExecutor.RunPrune(e.backgroundCtx, tx, initialCycle, pruneTimeout)
 			}, e.logger); err != nil {
 				return nil, err
 			}

--- a/execution/execmodule/interface.go
+++ b/execution/execmodule/interface.go
@@ -93,10 +93,14 @@ type AssembleBlockResult struct {
 
 // AssembledBlockResult is the native return type for GetAssembledBlock.
 type AssembledBlockResult struct {
-	// Busy is true when the builder has not finished yet.
+	// Busy is true when the module was already occupied, not when the builder is still working:
+	// otherwise the call waits for the builder to finish.
 	Busy bool
+	// Unknown is true when no builder is held for the payload id, so nothing will ever arrive for
+	// it. A caller polling that id cannot otherwise tell it from a build still running.
+	Unknown bool
 	// Block holds the assembled block with receipts and requests.
-	// Nil when Busy is true or when no builder was found for the payload ID.
+	// Nil when Busy or Unknown is true, or when the builder produced nothing.
 	Block      *types.BlockWithReceipts
 	BlockValue *uint256.Int
 }
@@ -146,12 +150,12 @@ type ExecutionModule interface {
 
 	// --- Block building ---------------------------------------------------
 
-	// AssembleBlock initiates building a new block with the supplied
-	// parameters.  Returns the payload ID assigned to the build job.
+	// AssembleBlock initiates building a block. Busy reports that the execution module is occupied;
+	// otherwise PayloadID identifies the new build.
 	AssembleBlock(ctx context.Context, params *builder.Parameters) (AssembleBlockResult, error)
 
-	// GetAssembledBlock retrieves the block that was assembled under the
-	// given payloadID.  The result is Busy when the builder has not finished.
+	// GetAssembledBlock stops and waits for payloadID's builder. Busy reports that the execution
+	// module is occupied; Unknown reports that no builder is held for payloadID.
 	GetAssembledBlock(ctx context.Context, payloadID uint64) (AssembledBlockResult, error)
 
 	// --- Header / body queries --------------------------------------------

--- a/execution/protocol/rules/rules.go
+++ b/execution/protocol/rules/rules.go
@@ -184,6 +184,8 @@ type EngineWriter interface {
 	//
 	// Note, the method returns immediately and will send the result async. More
 	// than one result may also be returned depending on the consensus algorithm.
+	// Seal must not access chain after returning; the caller may release its backing resources
+	// immediately.
 	Seal(chain ChainHeaderReader, block *types.BlockWithReceipts, results chan<- *types.BlockWithReceipts, stop <-chan struct{}) error
 
 	// SealHash returns the hash of a block prior to it being sealed.

--- a/node/eth/backend.go
+++ b/node/eth/backend.go
@@ -824,7 +824,6 @@ func New(ctx context.Context, stack *node.Node, config *ethconfig.Config, logger
 	}
 
 	blkBuilder := builder.NewBuilder(
-		backend.sentryCtx,
 		backend.chainDB,
 		&config.Builder,
 		backend.chainConfig,


### PR DESCRIPTION
Cherry-picks of #23272 and #23274 to release/3.6, plus the prerequisite #22835.

## Why three commits

#23272 does not apply to this branch on its own. It assumes the `done`-channel `BlockBuilder` and `Stop(ctx)` that #22835 introduced, while release/3.6 still has the `sync.Cond` version — picking #23272 alone conflicts across six files and twelve hunks. With #22835 first, that drops to four files and four hunks, all small.

#22835 is worth having here on its own merits anyway: it is a `GetAssembledBlock` deadlock fix.

| commit | source |
| --- | --- |
| `07e266b0e8` | #22835 execution: fix GetAssembledBlock deadlock |
| `15aeafee70` | #23272 execution: key builders by payload timestamp and give them a lifecycle |
| `9aa81b6a79` | #23274 cl/beacon: report a failing payload poll once, and an unregistered fee recipient at all |

#23274 applies cleanly once #23272 is in, which is also the order they merged to main.

## r3.6 adaptations

**#22835** — one hunk. This branch already has the `maxBuildTime time.Duration` signature from #23103, which postdates #22835, so the resolution keeps that signature and takes the `done`-channel body.

**#23272** — four hunks:

- `exec_module.go`: took the restructured canonical-hash loop. The commit also renames the `bacgroundCtx` field to `backgroundCtx`; that rename is applied across this branch's twelve sites so the two files stay consistent.
- `exec_module_internal_test.go`: the hunk only touches a test that does not exist on this branch, so nothing to port.
- `exec_module_test.go`: took the added helper types, and adapted the two new tests. This branch's `ExecModuleTester` has no `GenerateChain` or `GetAssembledBlock` wrapper — those are part of a larger tester rewrite on main that has nothing to do with this change — so the tests use `blockgen.GenerateChain` directly, as the other tests in this file do, and assert on the module's `AssembledBlockResult.Unknown` rather than on the wrapper's translation to `ErrUnknownPayload`. The first test is renamed to `TestGetAssembledBlockReportsUnknownPayload` to match what it now checks.
- `exec_module_tester.go`: the three hunks that belong to this change — the `BlockBuilder` field, dropping the now-removed `ctx` argument to `builder.NewBuilder`, and the `Unknown` branch in `GetAssembledBlock`.

**#23274** — clean, no adaptations.

## Verification

- `go build ./...` clean; `go test -race` green across `execution/builder`, `execution/execmodule/...`, `cl/beacon/handler`, `cl/phase1/execution_client/...` and `txnprovider/txpool`.
- Both adapted tests were checked against the mutation they exist to catch: flipping `Unknown: true` to `false` fails `TestGetAssembledBlockReportsUnknownPayload`, and removing the `discard()` call from `BlockBuilder.Discard` fails `TestDiscardReleasesBuilderWaitingForSeal`.
- `make lintci` clean. It reported a spurious `typecheck` on one run out of five; the other four were `0 issues.` and both `go build ./...` and `go vet` are clean.
