### PR TITLE
docs(site): make the docs test script portable, drop the shell glob

### DIFF
--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -102,6 +102,8 @@ jobs:
       # Release selection (src/releases.js) orders by semantic version because
       # the GitHub API orders by publish date; the unit tests pin that so a
       # back-port cannot silently regress the version in the install snippets.
+      # Bare `node --test` discovers test files itself — a glob would not
+      # survive npm running scripts through cmd.exe on Windows.
       - run: npm test
         if: steps.guard.outputs.present == 'true'
         working-directory: docs/site

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -13,7 +13,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "test": "node --test src/*.test.js",
+    "test": "node --test",
     "check:tsconfig": "node scripts/check-tsconfig-drift.mjs"
   },
   "dependencies": {

--- a/docs/site/src/releases.js
+++ b/docs/site/src/releases.js
@@ -1,7 +1,7 @@
 // Release selection for docusaurus.config.ts.
 //
 // Lives in its own module so the ordering rules below can be exercised without
-// booting Docusaurus: `node --test src/releases.test.js`.
+// booting Docusaurus: `npm test` from docs/site.
 
 // Releases carry a pre-release suffix without reliably setting the API's
 // `prerelease` flag, so tag shape is the load-bearing check. Semver identifiers

--- a/docs/site/src/releases.test.js
+++ b/docs/site/src/releases.test.js
@@ -1,4 +1,4 @@
-// node --test src/releases.test.js
+// npm test (from docs/site)
 //
 // Every case here is a list ordered the way the GitHub API returns it — by
 // publish date, newest first — so a selector that trusts that order fails.


### PR DESCRIPTION
Follow-up to #23284, as @yperbasis asked there.

`node --test src/*.test.js` relies on the shell expanding the glob. npm runs scripts through `cmd.exe` on Windows, which does not, and Node 20 — what CI pins (`docs-site-build.yml:83`) — has no test-path glob support of its own, so the literal pattern reaches Node as a path and fails to resolve.

Bare `node --test` discovers test files itself. Preferred over naming the file explicitly because a second test file then needs no change here, and a list nobody remembers to extend is a silently untested file — the failure this step exists to prevent.

For the record, a third option does **not** work: `node --test src/` makes Node treat the directory as a module to run rather than a tree to search (`Cannot find module .../docs/site/src`).

Verified locally: bare `node --test` finds all 8 tests in ~130 ms. The same fix is already on the `release/3.6` sibling (#23283, `97a136c8c2`), so the two branches do not diverge on this line.
