### PR TITLE
cl/phase1: report forkchoice timeouts and missing payload IDs

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -2216,7 +2216,12 @@ func (a *ApiHandler) storeBlockAndBlobs(
 	safeHash := a.forkchoiceStore.GetFinalizedExecutionHash(a.forkchoiceStore.JustifiedCheckpoint().Root)
 	headVersion := a.beaconChainCfg.GetCurrentStateVersion(headSlot / a.beaconChainCfg.SlotsPerEpoch)
 	if _, err := a.engine.ForkChoiceUpdate(ctx, finalizedHash, safeHash, a.forkchoiceStore.GetEth1Hash(headRoot), nil, headVersion); err != nil {
-		return err
+		// Storing the block does not depend on the execution layer acknowledging the head in time,
+		// and the next head sends another update.
+		if !errors.Is(err, execution_client.ErrForkChoiceUpdateTimeout) {
+			return err
+		}
+		log.Debug("BlockProduction: forkchoice update timed out while storing block", "root", headRoot)
 	}
 
 	if err := a.indiciesDB.View(ctx, func(tx kv.Tx) error {

--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -193,8 +193,8 @@ func (cc *ExecutionClientEngine) ForkChoiceUpdate(
 		resp, err = cc.engine.ForkchoiceUpdatedV4(ctx, forkChoiceState, attributes, nil)
 	}
 	if err != nil {
-		if err.Error() == errContextExceeded {
-			return nil, nil
+		if isDeadlineExceeded(err) {
+			return nil, fmt.Errorf("%w: %w", ErrForkChoiceUpdateTimeout, err)
 		}
 		return nil, fmt.Errorf("engine ForkchoiceUpdated failed: %w", err)
 	}

--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -200,7 +200,13 @@ func (cc *ExecutionClientEngine) ForkChoiceUpdate(
 	}
 
 	if resp.PayloadId == nil {
-		return []byte{}, checkPayloadStatus(resp.PayloadStatus)
+		if err := checkPayloadStatus(resp.PayloadStatus); err != nil {
+			return nil, err
+		}
+		if attributes != nil {
+			return nil, ErrForkChoiceUpdateNoPayloadID
+		}
+		return []byte{}, nil
 	}
 	return *resp.PayloadId, checkPayloadStatus(resp.PayloadStatus)
 }

--- a/cl/phase1/execution_client/execution_client_engine_test.go
+++ b/cl/phase1/execution_client/execution_client_engine_test.go
@@ -99,6 +99,23 @@ func TestForkChoiceUpdateRejectsMissingPayloadIDForPayloadBuild(t *testing.T) {
 	require.Nil(t, id)
 }
 
+func TestForkChoiceUpdateAllowsMissingPayloadIDWithoutPayloadBuild(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cc := &ExecutionClientEngine{
+		engine: &fcuEngineStub{response: &engine_types.ForkChoiceUpdatedResponse{
+			PayloadStatus: &engine_types.PayloadStatus{Status: engine_types.SyncingStatus},
+		}},
+		beaconCfg: &cfg,
+	}
+
+	id, err := cc.ForkChoiceUpdate(
+		t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, nil, clparams.DenebVersion,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, id)
+}
+
 type beaconCfgEngineStub struct {
 	engineapi.EngineAPI
 	cfg *clparams.BeaconChainConfig

--- a/cl/phase1/execution_client/execution_client_engine_test.go
+++ b/cl/phase1/execution_client/execution_client_engine_test.go
@@ -36,13 +36,14 @@ import (
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 )
 
-type fcuErrorEngineStub struct {
+type fcuEngineStub struct {
 	engineapi.EngineAPI
-	err error
+	response *engine_types.ForkChoiceUpdatedResponse
+	err      error
 }
 
-func (s *fcuErrorEngineStub) ForkchoiceUpdatedV3(context.Context, *engine_types.ForkChoiceState, *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error) {
-	return nil, s.err
+func (s *fcuEngineStub) ForkchoiceUpdatedV3(context.Context, *engine_types.ForkChoiceState, *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error) {
+	return s.response, s.err
 }
 
 // A forkchoice update that ran out of time has not been refused: the execution layer may still
@@ -59,7 +60,7 @@ func TestForkChoiceUpdateReportsATimeoutRatherThanAnEmptySuccess(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := clparams.MainnetBeaconConfig
-			cc := &ExecutionClientEngine{engine: &fcuErrorEngineStub{err: tc.err}, beaconCfg: &cfg}
+			cc := &ExecutionClientEngine{engine: &fcuEngineStub{err: tc.err}, beaconCfg: &cfg}
 
 			id, err := cc.ForkChoiceUpdate(t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, nil, clparams.DenebVersion)
 
@@ -73,12 +74,29 @@ func TestForkChoiceUpdateReportsATimeoutRatherThanAnEmptySuccess(t *testing.T) {
 // only on timeouts does not retry a rejection forever.
 func TestForkChoiceUpdateDoesNotCallEveryFailureATimeout(t *testing.T) {
 	cfg := clparams.MainnetBeaconConfig
-	cc := &ExecutionClientEngine{engine: &fcuErrorEngineStub{err: errors.New("boom")}, beaconCfg: &cfg}
+	cc := &ExecutionClientEngine{engine: &fcuEngineStub{err: errors.New("boom")}, beaconCfg: &cfg}
 
 	_, err := cc.ForkChoiceUpdate(t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, nil, clparams.DenebVersion)
 
 	require.Error(t, err)
 	require.NotErrorIs(t, err, ErrForkChoiceUpdateTimeout)
+}
+
+func TestForkChoiceUpdateRejectsMissingPayloadIDForPayloadBuild(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cc := &ExecutionClientEngine{
+		engine: &fcuEngineStub{response: &engine_types.ForkChoiceUpdatedResponse{
+			PayloadStatus: &engine_types.PayloadStatus{Status: engine_types.SyncingStatus},
+		}},
+		beaconCfg: &cfg,
+	}
+
+	id, err := cc.ForkChoiceUpdate(
+		t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, &engine_types.PayloadAttributes{}, clparams.DenebVersion,
+	)
+
+	require.ErrorIs(t, err, ErrForkChoiceUpdateNoPayloadID)
+	require.Nil(t, id)
 }
 
 type beaconCfgEngineStub struct {

--- a/cl/phase1/execution_client/execution_client_engine_test.go
+++ b/cl/phase1/execution_client/execution_client_engine_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,7 +55,7 @@ func TestForkChoiceUpdateReportsATimeoutRatherThanAnEmptySuccess(t *testing.T) {
 		name string
 		err  error
 	}{
-		{"context deadline", context.DeadlineExceeded},
+		{"wrapped context deadline", fmt.Errorf("wrapped: %w", context.DeadlineExceeded)},
 		{"grpc deadline", status.Error(codes.DeadlineExceeded, "context deadline exceeded")},
 		{"legacy grpc string", errors.New("rpc error: code = DeadlineExceeded desc = context deadline exceeded")},
 	} {

--- a/cl/phase1/execution_client/execution_client_engine_test.go
+++ b/cl/phase1/execution_client/execution_client_engine_test.go
@@ -17,10 +17,16 @@
 package execution_client
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/erigontech/erigon/common"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -29,6 +35,51 @@ import (
 	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 )
+
+type fcuErrorEngineStub struct {
+	engineapi.EngineAPI
+	err error
+}
+
+func (s *fcuErrorEngineStub) ForkchoiceUpdatedV3(context.Context, *engine_types.ForkChoiceState, *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error) {
+	return nil, s.err
+}
+
+// A forkchoice update that ran out of time has not been refused: the execution layer may still
+// apply it, and no payload id came back. Reporting that as success left every caller to infer a
+// timeout from an empty id, which reads identically to an execution layer that is syncing.
+func TestForkChoiceUpdateReportsATimeoutRatherThanAnEmptySuccess(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"context deadline", context.DeadlineExceeded},
+		{"grpc deadline", status.Error(codes.DeadlineExceeded, "context deadline exceeded")},
+		{"legacy grpc string", errors.New("rpc error: code = DeadlineExceeded desc = context deadline exceeded")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := clparams.MainnetBeaconConfig
+			cc := &ExecutionClientEngine{engine: &fcuErrorEngineStub{err: tc.err}, beaconCfg: &cfg}
+
+			id, err := cc.ForkChoiceUpdate(t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, nil, clparams.DenebVersion)
+
+			require.Nil(t, id)
+			require.ErrorIs(t, err, ErrForkChoiceUpdateTimeout)
+		})
+	}
+}
+
+// A failure that is not a timeout keeps reporting as an ordinary failure, so a caller that retries
+// only on timeouts does not retry a rejection forever.
+func TestForkChoiceUpdateDoesNotCallEveryFailureATimeout(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cc := &ExecutionClientEngine{engine: &fcuErrorEngineStub{err: errors.New("boom")}, beaconCfg: &cfg}
+
+	_, err := cc.ForkChoiceUpdate(t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, nil, clparams.DenebVersion)
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrForkChoiceUpdateTimeout)
+}
 
 type beaconCfgEngineStub struct {
 	engineapi.EngineAPI

--- a/cl/phase1/execution_client/interface.go
+++ b/cl/phase1/execution_client/interface.go
@@ -39,6 +39,9 @@ import (
 // an empty success.
 var ErrForkChoiceUpdateTimeout = errors.New("forkchoice update timed out")
 
+// ErrForkChoiceUpdateNoPayloadID reports that an attribute-bearing update did not start a payload build.
+var ErrForkChoiceUpdateNoPayloadID = errors.New("forkchoice update returned no payload ID")
+
 // legacyGrpcDeadlineMessage is what a deadline used to be recognised by. Kept as a last resort for
 // a transport that reports one without a status code or a wrapped context error.
 const legacyGrpcDeadlineMessage = "rpc error: code = DeadlineExceeded desc = context deadline exceeded"

--- a/cl/phase1/execution_client/interface.go
+++ b/cl/phase1/execution_client/interface.go
@@ -18,7 +18,11 @@ package execution_client
 
 import (
 	"context"
+	"errors"
 	"math/big"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -29,7 +33,27 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
 
-var errContextExceeded = "rpc error: code = DeadlineExceeded desc = context deadline exceeded"
+// ErrForkChoiceUpdateTimeout reports that the execution layer did not answer a forkchoice update
+// in time. The update is not refused by it - the execution layer may still apply it - and no
+// payload id came back, so a caller that needed one has to treat this as a failure rather than as
+// an empty success.
+var ErrForkChoiceUpdateTimeout = errors.New("forkchoice update timed out")
+
+// legacyGrpcDeadlineMessage is what a deadline used to be recognised by. Kept as a last resort for
+// a transport that reports one without a status code or a wrapped context error.
+const legacyGrpcDeadlineMessage = "rpc error: code = DeadlineExceeded desc = context deadline exceeded"
+
+// isDeadlineExceeded reports whether err is the execution layer running out of time, by the
+// context, by the gRPC status, or by the message a transport that carries neither would produce.
+func isDeadlineExceeded(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if status.Code(err) == codes.DeadlineExceeded {
+		return true
+	}
+	return err.Error() == legacyGrpcDeadlineMessage
+}
 
 // ExecutionEngine is used only for syncing up very close to chain tip and to stay in sync.
 // It pretty much mimics engine API.

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -21,6 +21,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/core/caches"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/cl/phase1/core/state/shuffling"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
@@ -80,8 +81,15 @@ func computeAndNotifyServicesOfNewForkChoice(ctx context.Context, logger log.Log
 			cfg.forkChoice.GetFinalizedExecutionHash(justifiedCheckpoint.Root),
 			cfg.forkChoice.GetEth1Hash(headRoot), nil, headVersion,
 		); err != nil {
-			err = fmt.Errorf("failed to run forkchoice: %w", err)
-			return
+			// A forkchoice update that ran out of time is not a rejection, and sync has no payload
+			// to lose by carrying on: the next head will send another one.
+			if errors.Is(err, execution_client.ErrForkChoiceUpdateTimeout) {
+				logger.Debug("[Caplin] forkchoice update timed out", "head", headRoot)
+				err = nil
+			} else {
+				err = fmt.Errorf("failed to run forkchoice: %w", err)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
First of two, extracted from #23105. It addresses the third blocking concern in domiwei's review and a defect in every Engine API forkchoice path today, not only the one #23105 adds.

## Problem

`ExecutionClientEngine.ForkChoiceUpdate` had two ways to report a failed payload request as an empty success.

First, a returned deadline error was mapped to `(nil, nil)`:

```go
if err.Error() == errContextExceeded {
    return nil, nil
}
```

Second, Erigon's configured internal FCU timeout does not reach this client as an error. The execution module returns `ExecutionStatusBusy`, the Engine API maps that to `SYNCING` with a null payload id, and the client returned `([]byte{}, nil)` because `SYNCING` is not a payload-status error.

For an update carrying payload attributes, a missing id means no payload build started. A caller treating `err == nil` as success skips the retry it would otherwise make, so a slow or busy execution layer can cost a proposal. Block production also reported the empty id as "execution layer may be syncing", hiding an actual returned deadline.

A head-only update is different: without payload attributes, a null payload id is expected.

Deadline recognition was also a string comparison against one exact gRPC message. Any rewording, or a transport that phrases it differently, silently stopped matching.

## Change

`ErrForkChoiceUpdateTimeout` wraps a returned deadline cause. It is recognised through a wrapped `context.DeadlineExceeded`, the gRPC status code, or the old message as a last resort for a transport carrying neither.

`ErrForkChoiceUpdateNoPayloadID` reports an attribute-bearing response with no payload id. Payload-status validation runs first, so a supplied validation error keeps priority. Head-only updates keep their existing empty-id success.

The missing-id result is not called a timeout. Engine API `SYNCING` can also represent execution contention, a missing segment, or a head that is too far away. The separate sentinel states what is known and lets each caller decide whether to retry or fail.

Call sites keep the behaviour they need:

- `stages/forkchoice.go` and `storeBlockAndBlobs` still tolerate returned timeouts because they do not need a payload id.
- `block_collector` already warns on any error.
- Block production treats a timeout or an attribute-bearing response without an id as a failure because it cannot build the block without that id.

## Verification

Regression coverage checks wrapped context deadlines, gRPC deadline status, the legacy message, unrelated errors, and a `SYNCING` response with a null payload id.

- `make test-short`
- `make erigon integration`
- `make check-generated`
- affected-package tests
- `make lint`
