### PR TITLE
p2p: decode eth/68 Status TD as uint256 instead of big.Int

### DIFF
--- a/p2p/protocols/eth/protocol.go
+++ b/p2p/protocols/eth/protocol.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"math/big"
 
 	"github.com/holiman/uint256"
 
@@ -155,10 +154,15 @@ type Packet interface {
 }
 
 // StatusPacket is the network packet for the status message for eth/64 and later.
+//
+// TD is a *uint256.Int rather than a *big.Int: total difficulty fits in 256
+// bits and the wire encoding is identical, while execution/rlp can decode a
+// uint256.Int but not a big.Int (a *big.Int field falls through to the struct
+// decoder and fails with "expected input list for big.Int").
 type StatusPacket struct {
 	ProtocolVersion uint32
 	NetworkID       uint64
-	TD              *big.Int
+	TD              *uint256.Int
 	Head            common.Hash
 	Genesis         common.Hash
 	ForkID          forkid.ID

--- a/p2p/sentry/eth_handshake.go
+++ b/p2p/sentry/eth_handshake.go
@@ -164,7 +164,7 @@ func encodeStatusPacket(status *sentryproto.StatusData, version uint) eth.Status
 	return eth.StatusPacket{
 		ProtocolVersion: uint32(version),
 		NetworkID:       status.NetworkId,
-		TD:              ourTD.ToBig(),
+		TD:              ourTD,
 		Head:            gointerfaces.ConvertH256ToHash(status.BestHash),
 		Genesis:         genesisHash,
 		ForkID:          forkid.NewIDFromForks(status.ForkData.HeightForks, status.ForkData.TimeForks, genesisHash, status.MaxBlockHeight, status.MaxBlockTime),

--- a/p2p/sentry/eth_handshake_test.go
+++ b/p2p/sentry/eth_handshake_test.go
@@ -17,7 +17,6 @@
 package sentry
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -39,7 +38,7 @@ func TestCheckPeerStatusCompatibility(t *testing.T) {
 	goodReply := eth.StatusPacket{
 		ProtocolVersion: uint32(version),
 		NetworkID:       networkID,
-		TD:              big.NewInt(0),
+		TD:              new(uint256.Int),
 		Head:            common.Hash{},
 		Genesis:         chainspec.Mainnet.GenesisHash,
 		ForkID:          forkid.NewIDFromForks(heightForks, timeForks, chainspec.Mainnet.GenesisHash, 0, 0),

--- a/p2p/sentry/sentry_grpc_server_test.go
+++ b/p2p/sentry/sentry_grpc_server_test.go
@@ -295,7 +295,7 @@ func TestHandShake69_ETH69ToETH68(t *testing.T) {
 	sentry2EthStatus := &eth.StatusPacket{
 		ProtocolVersion: direct.ETH68,
 		NetworkID:       sentry2Status.NetworkId,
-		TD:              gointerfaces.ConvertH256ToUint256Int(sentry2Status.TotalDifficulty).ToBig(),
+		TD:              gointerfaces.ConvertH256ToUint256Int(sentry2Status.TotalDifficulty),
 		Head:            gointerfaces.ConvertH256ToHash(sentry2Status.BestHash),
 		Genesis:         gointerfaces.ConvertH256ToHash(sentry2Status.ForkData.Genesis),
 		ForkID:          forkid.NewIDFromForks(sentry2Status.ForkData.HeightForks, sentry2Status.ForkData.TimeForks, gointerfaces.ConvertH256ToHash(sentry2Status.ForkData.Genesis), sentry2Status.MaxBlockHeight, sentry2Status.MaxBlockTime),


### PR DESCRIPTION
`execution/rlp` has a decoder for `uint256.Int` but not for `big.Int`: a `*big.Int` struct field falls through to the struct decoder and fails to decode a scalar with `rlp: expected input list for big.Int`.

`StatusPacket.TD` was `*big.Int`, so decoding an eth/68 peer's `Status` message errors out on the TD field. This went unnoticed because the default protocol set (eth/69+) uses `StatusPacket69`, which has no TD field.

Total difficulty fits in 256 bits and the wire encoding is identical, so this switches `StatusPacket.TD` to `*uint256.Int` (which `execution/rlp` decodes correctly) and updates the encoder + tests accordingly.