### PR TITLE
[r3.6] ci: bound apt setup in Kurtosis workflows

### DIFF
--- a/.github/actions/setup-kurtosis/action.yml
+++ b/.github/actions/setup-kurtosis/action.yml
@@ -1,0 +1,16 @@
+name: Setup Kurtosis
+description: Install a pinned Kurtosis CLI and start its engine
+
+inputs:
+  version:
+    description: Kurtosis CLI version to install
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Kurtosis CLI and start engine
+      shell: bash
+      env:
+        KURTOSIS_VERSION: ${{ inputs.version }}
+      run: bash "$GITHUB_ACTION_PATH/setup.sh"

--- a/.github/actions/setup-kurtosis/setup.sh
+++ b/.github/actions/setup-kurtosis/setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version=${KURTOSIS_VERSION:?KURTOSIS_VERSION is required}
+sources_dir=${KURTOSIS_APT_SOURCES_DIR:-/etc/apt/sources.list.d}
+
+# Kurtosis uses none of the hosted runner's failure-prone third-party apt sources.
+while IFS= read -r -d '' source; do
+  if sudo grep -qE 'dl\.google\.com|packages\.microsoft\.com' "$source"; then
+    sudo rm -f "$source"
+  fi
+done < <(sudo find "$sources_dir" -type f -print0 2>/dev/null)
+printf 'deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /\n' \
+  | sudo tee "$sources_dir/kurtosis.list" >/dev/null
+
+apt_opts=(-o Acquire::Retries=3 -o Acquire::http::Timeout=15
+          -o Acquire::https::Timeout=15 -o DPkg::Lock::Timeout=60)
+if ! sudo timeout --kill-after=10s 300 apt-get update -q "${apt_opts[@]}"; then
+  echo "::error::apt-get update failed or did not finish within 300s"
+  exit 1
+fi
+if ! sudo timeout --kill-after=10s 600 apt-get install -qq -y \
+  "${apt_opts[@]}" "kurtosis-cli=$version"; then
+  echo "::error::apt-get install Kurtosis failed or did not finish within 600s"
+  exit 1
+fi
+
+kurtosis analytics disable
+for n in 1 2 3; do
+  if kurtosis engine start; then
+    exit 0
+  fi
+  echo "kurtosis engine start failed (attempt $n of 3)"
+  kurtosis engine stop || true
+  sleep $((10 * n))
+done
+exit 1

--- a/.github/actions/setup-kurtosis/setup.test.sh
+++ b/.github/actions/setup-kurtosis/setup.test.sh
@@ -94,7 +94,11 @@ rejects "install ran after update failure" "apt-get install" "$calls"
 for workflow in test-kurtosis-assertoor.yml test-kurtosis-gloas.yml; do
   path="$repo/.github/workflows/$workflow"
   contains "$workflow does not use shared setup" "uses: ./.github/actions/setup-kurtosis" "$path"
+  contains "$workflow does not use the preinstalled Kurtosis action" \
+    "uses: erigontech/kurtosis-assertoor-github-action@v1.1.7" "$path"
   rejects "$workflow still installs with apt directly" "sudo apt-get" "$path"
+  rejects "$workflow uses an action that reinstalls Kurtosis" \
+    "uses: ethpandaops/kurtosis-assertoor-github-action@" "$path"
 done
 
 echo "setup-kurtosis tests passed"

--- a/.github/actions/setup-kurtosis/setup.test.sh
+++ b/.github/actions/setup-kurtosis/setup.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here=$(cd "$(dirname -- "$0")" && pwd)
+repo=$(cd "$here/../../.." && pwd)
+script="$here/setup.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mock_bin="$tmp/bin"
+calls="$tmp/calls"
+sources="$tmp/sources"
+mkdir -p "$mock_bin" "$sources"
+
+cat >"$mock_bin/mock-command" <<'EOF'
+#!/usr/bin/env bash
+case "${0##*/}" in
+  sudo)
+    exec "$@"
+    ;;
+  timeout)
+    printf 'timeout %s\n' "$*" >>"$SETUP_KURTOSIS_CALLS"
+    [ "$1" = "--kill-after=10s" ] || exit 98
+    shift 2
+    exec "$@"
+    ;;
+  apt-get)
+    printf 'apt-get %s\n' "$*" >>"$SETUP_KURTOSIS_CALLS"
+    case "$1" in
+      update) exit "${MOCK_APT_UPDATE_EXIT:-0}" ;;
+      install) exit "${MOCK_APT_INSTALL_EXIT:-0}" ;;
+      *) exit 97 ;;
+    esac
+    ;;
+  kurtosis)
+    printf 'kurtosis %s\n' "$*" >>"$SETUP_KURTOSIS_CALLS"
+    exit 0
+    ;;
+esac
+EOF
+for command in sudo timeout apt-get kurtosis; do
+  cp "$mock_bin/mock-command" "$mock_bin/$command"
+done
+chmod +x "$mock_bin"/*
+
+fail() {
+  printf 'FAIL - %s\n' "$1"
+  exit 1
+}
+
+contains() {
+  grep -Fq -- "$2" "$3" || fail "$1"
+}
+
+rejects() {
+  if grep -Fq -- "$2" "$3"; then fail "$1"; fi
+}
+
+reset_case() {
+  : >"$calls"
+  rm -rf "$sources"
+  mkdir -p "$sources"
+  printf 'deb https://packages.microsoft.com/example stable main\n' >"$sources/microsoft.list"
+  printf 'deb http://archive.ubuntu.com/ubuntu noble main\n' >"$sources/ubuntu.list"
+}
+
+run_setup() {
+  env PATH="$mock_bin:$PATH" \
+    SETUP_KURTOSIS_CALLS="$calls" \
+    KURTOSIS_VERSION=1.15.2 \
+    KURTOSIS_APT_SOURCES_DIR="$sources" \
+    "$@" bash "$script"
+}
+
+reset_case
+run_setup || fail "successful setup"
+contains "update has no hard deadline" "timeout --kill-after=10s 300 apt-get update" "$calls"
+contains "install has no hard deadline" "timeout --kill-after=10s 600 apt-get install" "$calls"
+contains "apt has no network bound" "Acquire::https::Timeout=15" "$calls"
+contains "apt has no lock bound" "DPkg::Lock::Timeout=60" "$calls"
+contains "version is not pinned" "kurtosis-cli=1.15.2" "$calls"
+contains "engine did not start" "kurtosis engine start" "$calls"
+[ ! -e "$sources/microsoft.list" ] || fail "broken third-party source remains"
+[ -e "$sources/ubuntu.list" ] || fail "Ubuntu source was removed"
+
+reset_case
+if update_out=$(run_setup MOCK_APT_UPDATE_EXIT=1 2>&1); then
+  fail "update failure did not stop setup"
+fi
+grep -Fq "apt-get update failed or did not finish within 300s" <<<"$update_out" \
+  || fail "update failure was not diagnosed"
+rejects "install ran after update failure" "apt-get install" "$calls"
+
+for workflow in test-kurtosis-assertoor.yml test-kurtosis-gloas.yml; do
+  path="$repo/.github/workflows/$workflow"
+  contains "$workflow does not use shared setup" "uses: ./.github/actions/setup-kurtosis" "$path"
+  rejects "$workflow still installs with apt directly" "sudo apt-get" "$path"
+done
+
+echo "setup-kurtosis tests passed"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,9 @@ jobs:
           find . -name '*.sh' -not -path './.git/*' -not -path '*/node_modules/*' -print0 \
             | xargs -0 shellcheck --severity=warning
 
+      - name: Test Kurtosis setup
+        run: make test-kurtosis-setup
+
       - uses: ./.github/actions/setup-erigon
         id: erigon
         with:

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -485,21 +485,9 @@ jobs:
           docker save "${ETH2_VAL_TOOLS_IMAGE}" -o /tmp/docker-cache/eth2-val-tools.tar
 
       - name: Install Kurtosis CLI and start engine
-        # The engine otherwise bootstraps inside `kurtosis run`, mid-action,
-        # where a registry blip fails the whole test step. Start it here from
-        # the pre-loaded images, with cheap retries.
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt-get update
-          sudo apt-get install -y kurtosis-cli=${KURTOSIS_VERSION}
-          kurtosis analytics disable
-          for n in 1 2 3; do
-            if kurtosis engine start; then exit 0; fi
-            echo "kurtosis engine start failed (attempt $n of 3)"
-            kurtosis engine stop || true
-            sleep $((10 * n))
-          done
-          exit 1
+        uses: ./.github/actions/setup-kurtosis
+        with:
+          version: ${{ env.KURTOSIS_VERSION }}
 
       - name: Download erigon image artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/test-kurtosis-assertoor.yml
+++ b/.github/workflows/test-kurtosis-assertoor.yml
@@ -520,9 +520,8 @@ jobs:
         # failures so the next investigation or retry can start sooner
         # instead of burning runner hours on a dead chain.
         timeout-minutes: ${{ matrix.test_timeout_minutes }}
-        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        uses: erigontech/kurtosis-assertoor-github-action@v1.1.7
         with:
-            kurtosis_version: "${{ env.KURTOSIS_VERSION }}"
             enclave_name: "kurtosis-${{ matrix.suite }}-${{ matrix.exec_mode }}-${{ github.run_id }}"
             ethereum_package_url: "${{ matrix.ethereum_package_url || 'github.com/ethpandaops/ethereum-package' }}"
             ethereum_package_args: "${{ matrix.package_args }}"

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -344,21 +344,9 @@ jobs:
           path: /tmp/docker-cache
           key: docker-cl-${{ env.ASSERTOOR_IMAGE }}-kurtosis-${{ env.KURTOSIS_VERSION }}-${{ env.KURTOSIS_VECTOR_IMAGE }}-${{ env.KURTOSIS_FLUENTBIT_IMAGE }}-${{ env.KURTOSIS_CURL_JQ_IMAGE }}-${{ env.KURTOSIS_TRAEFIK_IMAGE }}-${{ env.KURTOSIS_ALPINE_IMAGE }}-${{ env.GENESIS_GENERATOR_IMAGE }}-${{ env.ETH2_VAL_TOOLS_IMAGE }}
       - name: Install Kurtosis CLI and start engine
-        # The engine otherwise bootstraps inside `kurtosis run`, mid-action,
-        # where a registry blip fails the whole test step. Start it here from
-        # the pre-loaded images, with cheap retries.
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt-get update
-          sudo apt-get install -y kurtosis-cli=${KURTOSIS_VERSION}
-          kurtosis analytics disable
-          for n in 1 2 3; do
-            if kurtosis engine start; then exit 0; fi
-            echo "kurtosis engine start failed (attempt $n of 3)"
-            kurtosis engine stop || true
-            sleep $((10 * n))
-          done
-          exit 1
+        uses: ./.github/actions/setup-kurtosis
+        with:
+          version: ${{ env.KURTOSIS_VERSION }}
 
       - name: Build erigon Docker image (with BuildKit layer cache)
         id: build_erigon_image

--- a/.github/workflows/test-kurtosis-gloas.yml
+++ b/.github/workflows/test-kurtosis-gloas.yml
@@ -377,9 +377,8 @@ jobs:
 
       - name: Run ${{ matrix.suite }} Kurtosis + assertoor tests
         timeout-minutes: ${{ matrix.test_timeout_minutes }}
-        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        uses: erigontech/kurtosis-assertoor-github-action@v1.1.7
         with:
-            kurtosis_version: "${{ env.KURTOSIS_VERSION }}"
             enclave_name: "kurtosis-${{ matrix.suite }}-${{ github.run_id }}"
             ethereum_package_url: "github.com/ethpandaops/ethereum-package"
             ethereum_package_args: "${{ matrix.package_args }}"

--- a/Makefile
+++ b/Makefile
@@ -463,6 +463,10 @@ check-kurtosis:
 		exit 1; \
 	fi; \
 
+## test-kurtosis-setup:             test the bounded Kurtosis CI setup
+test-kurtosis-setup:
+	@bash .github/actions/setup-kurtosis/setup.test.sh
+
 kurtosis-pectra-assertoor:	check-kurtosis
 	@$(call run-kurtosis-assertoor,".github/workflows/kurtosis/pectra.io")
 


### PR DESCRIPTION
Cherry-pick of #23400 to release/3.6.

## r3.6-specific adaptations

- Keep the release/3.6 exec_mode matrix name while applying the action changes.

TDD is not applicable to this mechanical backport; it includes the original regression test.