### PR TITLE
[r3.6] cl/antiquary: back off retirement steps that keep failing

### DIFF
--- a/cl/antiquary/antiquary.go
+++ b/cl/antiquary/antiquary.go
@@ -224,32 +224,46 @@ func (a *Antiquary) Loop() error {
 	if a.states {
 		go a.loopStates(a.ctx)
 	}
-	// Check for snapshots retirement every 3 minutes
+	return a.retirementLoop()
+}
+
+func (a *Antiquary) retirementLoop() error {
+	blocks := &retirementStep{
+		run:     a.antiquate,
+		onError: func(err error) { log.Warn("[Antiquary] Failed to antiquate", "err", err) },
+	}
+	blobs := &retirementStep{
+		run:     a.antiquateBlobs,
+		onError: func(err error) { log.Error("[Antiquary] Failed to antiquate blobs", "err", err) },
+	}
+
 	retirementTicker := time.NewTicker(12 * time.Second)
 	defer retirementTicker.Stop()
 	for {
 		select {
 		case <-retirementTicker.C:
-			if !a.backfilled.Load() {
-				continue
-			}
-
-			if err := a.antiquate(); err != nil {
-				log.Warn("[Antiquary] Failed to antiquate", "err", err)
-			}
-			if a.cfg.DenebForkEpoch == math.MaxUint64 {
-				continue
-			}
-			if !a.blobBackfilled.Load() {
-				continue
-			}
-			if err := a.antiquateBlobs(); err != nil {
-				log.Error("[Antiquary] Failed to antiquate blobs", "err", err)
-			}
+			a.retirementTick(blocks, blobs)
 		case <-a.ctx.Done():
 		}
 	}
 }
+
+func (a *Antiquary) retirementTick(blocks, blobs *retirementStep) {
+	if !a.backfilled.Load() {
+		return
+	}
+	blocks.attempt(a.shuttingDown)
+
+	if a.cfg.DenebForkEpoch == math.MaxUint64 {
+		return
+	}
+	if !a.blobBackfilled.Load() {
+		return
+	}
+	blobs.attempt(a.shuttingDown)
+}
+
+func (a *Antiquary) shuttingDown() bool { return a.ctx.Err() != nil }
 
 type readBeaconSnapshotHeaderFunc func(slot uint64, tx kv.Tx) (*cltypes.SignedBeaconBlockHeader, uint64, common.Hash, error)
 

--- a/cl/antiquary/retirement_backoff.go
+++ b/cl/antiquary/retirement_backoff.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package antiquary
+
+// maxRetirementSkipTicks caps the gap at roughly an hour of retirementLoop ticks.
+const maxRetirementSkipTicks = 300
+
+// retirementBackoff spaces out a retirement step that keeps failing. Not every
+// failure is transient: a data gap the step cannot get past fails identically on
+// every tick, and without a gap it would redo the same work and log the same error
+// for the life of the process.
+type retirementBackoff struct {
+	skipTicks int
+	remaining int
+}
+
+func (b *retirementBackoff) ready() bool {
+	if b.remaining > 0 {
+		b.remaining--
+		return false
+	}
+	return true
+}
+
+func (b *retirementBackoff) failed() {
+	b.skipTicks = min(max(b.skipTicks*2, 1), maxRetirementSkipTicks)
+	b.remaining = b.skipTicks
+}
+
+func (b *retirementBackoff) succeeded() {
+	b.skipTicks, b.remaining = 0, 0
+}
+
+// retirementStep pairs one retirement operation with its own backoff, so a step that
+// wedges on a data gap cannot slow down the other.
+type retirementStep struct {
+	run     func() error
+	onError func(error)
+	backoff retirementBackoff
+}
+
+func (s *retirementStep) attempt(shuttingDown func() bool) {
+	if !s.backoff.ready() {
+		return
+	}
+	err := s.run()
+	if err == nil {
+		s.backoff.succeeded()
+		return
+	}
+	// A cancelled context is a shutdown, not the step's failure.
+	if shuttingDown() {
+		return
+	}
+	s.backoff.failed()
+	s.onError(err)
+}

--- a/cl/antiquary/retirement_backoff_test.go
+++ b/cl/antiquary/retirement_backoff_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package antiquary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ticksUntilReady counts how many ticks are refused before the step runs again.
+func ticksUntilReady(t *testing.T, b *retirementBackoff) int {
+	t.Helper()
+	for skipped := 0; skipped <= maxRetirementSkipTicks*2; skipped++ {
+		if b.ready() {
+			return skipped
+		}
+	}
+	t.Fatal("backoff never became ready")
+	return 0
+}
+
+func TestRetirementBackoffRunsUntilSomethingFails(t *testing.T) {
+	var b retirementBackoff
+	for range 5 {
+		require.True(t, b.ready(), "an unfailed step must run on every tick")
+	}
+}
+
+func TestRetirementBackoffSpacesOutRepeatedFailures(t *testing.T) {
+	var b retirementBackoff
+
+	b.failed()
+	require.Equal(t, 1, ticksUntilReady(t, &b))
+
+	b.failed()
+	require.Equal(t, 2, ticksUntilReady(t, &b))
+
+	b.failed()
+	require.Equal(t, 4, ticksUntilReady(t, &b))
+}
+
+func TestRetirementBackoffCapsTheGap(t *testing.T) {
+	var b retirementBackoff
+	for range 64 {
+		b.failed()
+		ticksUntilReady(t, &b)
+	}
+
+	b.failed()
+	require.Equal(t, maxRetirementSkipTicks, ticksUntilReady(t, &b))
+}
+
+func TestRetirementBackoffResetsOnSuccess(t *testing.T) {
+	var b retirementBackoff
+	for range 4 {
+		b.failed()
+		ticksUntilReady(t, &b)
+	}
+
+	b.succeeded()
+	require.True(t, b.ready())
+	require.True(t, b.ready())
+}

--- a/cl/antiquary/retirement_loop_test.go
+++ b/cl/antiquary/retirement_loop_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 The Erigon Authors
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package antiquary
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/erigontech/erigon/cl/clparams"
+)
+
+// tickHarness drives retirementTick without a ticker: each step counts its calls and
+// returns whatever the test tells it to.
+type tickHarness struct {
+	a            *Antiquary
+	blocks       *retirementStep
+	blobs        *retirementStep
+	blocksRuns   int
+	blobsRuns    int
+	blocksFails  bool
+	blobsFails   bool
+	cancel       context.CancelFunc
+	denebEnabled bool
+}
+
+func newTickHarness(t *testing.T) *tickHarness {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	h := &tickHarness{cancel: cancel, denebEnabled: true}
+	backfilled, blobBackfilled := &atomic.Bool{}, &atomic.Bool{}
+	backfilled.Store(true)
+	blobBackfilled.Store(true)
+
+	h.a = &Antiquary{
+		ctx:            ctx,
+		backfilled:     backfilled,
+		blobBackfilled: blobBackfilled,
+		cfg:            &clparams.BeaconChainConfig{DenebForkEpoch: 0},
+	}
+	h.blocks = &retirementStep{
+		run: func() error {
+			h.blocksRuns++
+			if h.blocksFails {
+				return errors.New("blocks failed")
+			}
+			return nil
+		},
+		onError: func(error) {},
+	}
+	h.blobs = &retirementStep{
+		run: func() error {
+			h.blobsRuns++
+			if h.blobsFails {
+				return errors.New("blobs failed")
+			}
+			return nil
+		},
+		onError: func(error) {},
+	}
+	return h
+}
+
+func (h *tickHarness) tick(n int) {
+	for range n {
+		h.a.retirementTick(h.blocks, h.blobs)
+	}
+}
+
+// ticksUntilBlobsRun ticks until the blobs step runs again and reports how many ticks
+// its backoff refused first, so a test can assert the exact width of the gap.
+func (h *tickHarness) ticksUntilBlobsRun(t *testing.T) int {
+	t.Helper()
+	before := h.blobsRuns
+	for skipped := 0; skipped <= maxRetirementSkipTicks*2; skipped++ {
+		h.tick(1)
+		if h.blobsRuns > before {
+			return skipped
+		}
+	}
+	t.Fatal("blobs step never ran again")
+	return 0
+}
+
+// A step that keeps failing must not drag its sibling down with it.
+func TestRetirementTickBacksOffEachStepIndependently(t *testing.T) {
+	h := newTickHarness(t)
+	h.blocksFails = true
+
+	h.tick(6)
+
+	require.Equal(t, 6, h.blobsRuns, "a succeeding step must run on every tick")
+	require.Less(t, h.blocksRuns, 6, "a failing step must be skipped on some ticks")
+	require.Positive(t, h.blocksRuns)
+}
+
+func TestRetirementTickBacksOffBlobsIndependently(t *testing.T) {
+	h := newTickHarness(t)
+	h.blobsFails = true
+
+	h.tick(6)
+
+	require.Equal(t, 6, h.blocksRuns)
+	require.Less(t, h.blobsRuns, 6)
+	require.Positive(t, h.blobsRuns)
+}
+
+// Success on one step must not clear the other's accumulated backoff.
+func TestRetirementTickSuccessResetsOnlyItsOwnStep(t *testing.T) {
+	h := newTickHarness(t)
+	h.blobsFails = true
+	h.tick(8)
+	blobsAfterFailures := h.blobsRuns
+
+	h.blocksFails = false
+	h.tick(2)
+
+	require.Equal(t, blobsAfterFailures, h.blobsRuns,
+		"blocks succeeding must not reset the blobs backoff")
+}
+
+func TestRetirementTickRecoversAfterSuccess(t *testing.T) {
+	h := newTickHarness(t)
+	h.blobsFails = true
+	h.tick(8)
+
+	h.blobsFails = false
+	// Enough ticks for the accumulated gap to elapse, then it must run every tick.
+	h.tick(8)
+	before := h.blobsRuns
+	h.tick(3)
+
+	require.Equal(t, before+3, h.blobsRuns)
+}
+
+// A success must clear the accumulated gap, not merely let the current one elapse:
+// the next failure has to restart at the minimum width.
+func TestRetirementTickSuccessClearsAccumulatedGap(t *testing.T) {
+	h := newTickHarness(t)
+
+	h.blobsFails = true
+	for range 4 {
+		h.ticksUntilBlobsRun(t)
+	}
+	require.Greater(t, h.ticksUntilBlobsRun(t), 1, "repeated failures must widen the gap")
+
+	h.blobsFails = false
+	h.ticksUntilBlobsRun(t)
+
+	h.blobsFails = true
+	h.ticksUntilBlobsRun(t)
+	require.Equal(t, 1, h.ticksUntilBlobsRun(t),
+		"after a success the next failure must restart at the minimum gap")
+}
+
+func TestRetirementTickSkipsBlobsBeforeDeneb(t *testing.T) {
+	h := newTickHarness(t)
+	h.a.cfg = &clparams.BeaconChainConfig{DenebForkEpoch: math.MaxUint64}
+
+	h.tick(3)
+
+	require.Equal(t, 3, h.blocksRuns)
+	require.Zero(t, h.blobsRuns, "blobs must not be antiquated before Deneb")
+}
+
+func TestRetirementTickWaitsForBackfill(t *testing.T) {
+	h := newTickHarness(t)
+	h.a.backfilled.Store(false)
+	h.tick(3)
+	require.Zero(t, h.blocksRuns)
+	require.Zero(t, h.blobsRuns)
+
+	h.a.backfilled.Store(true)
+	h.a.blobBackfilled.Store(false)
+	h.tick(3)
+	require.Equal(t, 3, h.blocksRuns)
+	require.Zero(t, h.blobsRuns)
+}
+
+// A failure during shutdown is not the step's fault, so it must not be counted.
+func TestRetirementTickDoesNotBackOffOnShutdown(t *testing.T) {
+	h := newTickHarness(t)
+	h.blocksFails = true
+	h.blobsFails = true
+	h.cancel()
+
+	h.tick(4)
+
+	require.Equal(t, 4, h.blocksRuns)
+	require.Equal(t, 4, h.blobsRuns)
+}


### PR DESCRIPTION
Cherry-pick of #23252 to release/3.6.

Worth having here on its own merits: the failure it addresses was reported on a release branch, not on main. A Gnosis archive node running `release/3.5` retried the same missing blob sidecar **328 times in 65 minutes** at a flat 12s period, each attempt re-reading ~3900 beacon block bodies.

The part that OOM-killed that node is already fixed here — the `seg.Compressor` worker leak, backported as #23235. What remains on this branch is the retry storm itself: the CPU burn, the log spam, and blob pruning blocked for as long as the deterministic failure lasts. The 12s period also coincides with slot cadence, so on a validating node it is background load landing on every slot boundary.

## r3.6 adaptations

Two conflicts, both the same shape: main had already split `Loop` into `Loop` plus a `retirementLoop` method, while this branch still has the retirement ticker inline. Resolved by taking the extracted form, so the result matches main.

One difference deliberately **not** brought across: main's `retirementLoop` returns `nil` on `a.ctx.Done()`, this branch does not. That line came from #22944, not from #23252, so importing it here would smuggle in an unrelated change.

It is worth knowing that it is missing, though. As it stands on this branch, a cancelled context leaves `select` with a permanently ready `a.ctx.Done()` case and no return, so the loop spins rather than exiting on shutdown. That predates this PR and applies equally to release/3.5. Happy to fix it separately if you want it.

## Verification

- `go test ./cl/antiquary/... -race` green; the 12 backported tests all came across.
- Mutation-checked on this branch: making `ready()` always true fails four tests, and dropping the reset in `succeeded()` fails `TestRetirementTickSuccessClearsAccumulatedGap`.
- `make lintci` clean, 0 issues.
