### PR TITLE
[r3.6] cl/phase1: report forkchoice timeouts and missing payload IDs

### DIFF
--- a/cl/beacon/handler/block_production.go
+++ b/cl/beacon/handler/block_production.go
@@ -46,6 +46,7 @@ import (
 	"github.com/erigontech/erigon/cl/gossip"
 	"github.com/erigontech/erigon/cl/persistence/beacon_indicies"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/phase1/forkchoice"
 	"github.com/erigontech/erigon/cl/phase1/network/subnets"
 	"github.com/erigontech/erigon/cl/pool"
@@ -2108,7 +2109,12 @@ func (a *ApiHandler) storeBlockAndBlobs(
 	safeHash := a.forkchoiceStore.GetFinalizedExecutionHash(a.forkchoiceStore.JustifiedCheckpoint().Root)
 	headVersion := a.beaconChainCfg.GetCurrentStateVersion(headSlot / a.beaconChainCfg.SlotsPerEpoch)
 	if _, err := a.engine.ForkChoiceUpdate(ctx, finalizedHash, safeHash, a.forkchoiceStore.GetEth1Hash(headRoot), nil, headVersion); err != nil {
-		return err
+		// Storing the block does not depend on the execution layer acknowledging the head in time,
+		// and the next head sends another update.
+		if !errors.Is(err, execution_client.ErrForkChoiceUpdateTimeout) {
+			return err
+		}
+		log.Debug("BlockProduction: forkchoice update timed out while storing block", "root", headRoot)
 	}
 
 	if err := a.indiciesDB.View(ctx, func(tx kv.Tx) error {

--- a/cl/phase1/execution_client/execution_client_engine.go
+++ b/cl/phase1/execution_client/execution_client_engine.go
@@ -244,14 +244,20 @@ func (cc *ExecutionClientEngine) ForkChoiceUpdate(
 		resp, err = cc.engine.ForkchoiceUpdatedV4(ctx, forkChoiceState, attributes)
 	}
 	if err != nil {
-		if err.Error() == errContextExceeded {
-			return nil, nil
+		if isDeadlineExceeded(err) {
+			return nil, fmt.Errorf("%w: %w", ErrForkChoiceUpdateTimeout, err)
 		}
 		return nil, fmt.Errorf("engine ForkchoiceUpdated failed: %w", err)
 	}
 
 	if resp.PayloadId == nil {
-		return []byte{}, checkPayloadStatus(resp.PayloadStatus)
+		if err := checkPayloadStatus(resp.PayloadStatus); err != nil {
+			return nil, err
+		}
+		if attributes != nil {
+			return nil, ErrForkChoiceUpdateNoPayloadID
+		}
+		return []byte{}, nil
 	}
 	return *resp.PayloadId, checkPayloadStatus(resp.PayloadStatus)
 }

--- a/cl/phase1/execution_client/execution_client_engine_test.go
+++ b/cl/phase1/execution_client/execution_client_engine_test.go
@@ -17,17 +17,105 @@
 package execution_client
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/erigontech/erigon/common"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
 	"github.com/erigontech/erigon/cl/cltypes/solid"
 	"github.com/erigontech/erigon/execution/engineapi"
+	"github.com/erigontech/erigon/execution/engineapi/engine_types"
 	"github.com/erigontech/erigon/execution/execmodule/chainreader"
 )
+
+type fcuEngineStub struct {
+	engineapi.EngineAPI
+	response *engine_types.ForkChoiceUpdatedResponse
+	err      error
+}
+
+func (s *fcuEngineStub) ForkchoiceUpdatedV3(context.Context, *engine_types.ForkChoiceState, *engine_types.PayloadAttributes) (*engine_types.ForkChoiceUpdatedResponse, error) {
+	return s.response, s.err
+}
+
+// A forkchoice update that ran out of time has not been refused: the execution layer may still
+// apply it, and no payload id came back. Reporting that as success left every caller to infer a
+// timeout from an empty id, which reads identically to an execution layer that is syncing.
+func TestForkChoiceUpdateReportsATimeoutRatherThanAnEmptySuccess(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"wrapped context deadline", fmt.Errorf("wrapped: %w", context.DeadlineExceeded)},
+		{"grpc deadline", status.Error(codes.DeadlineExceeded, "context deadline exceeded")},
+		{"legacy grpc string", errors.New("rpc error: code = DeadlineExceeded desc = context deadline exceeded")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := clparams.MainnetBeaconConfig
+			cc := &ExecutionClientEngine{engine: &fcuEngineStub{err: tc.err}, beaconCfg: &cfg}
+
+			id, err := cc.ForkChoiceUpdate(t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, nil, clparams.DenebVersion)
+
+			require.Nil(t, id)
+			require.ErrorIs(t, err, ErrForkChoiceUpdateTimeout)
+		})
+	}
+}
+
+// A failure that is not a timeout keeps reporting as an ordinary failure, so a caller that retries
+// only on timeouts does not retry a rejection forever.
+func TestForkChoiceUpdateDoesNotCallEveryFailureATimeout(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cc := &ExecutionClientEngine{engine: &fcuEngineStub{err: errors.New("boom")}, beaconCfg: &cfg}
+
+	_, err := cc.ForkChoiceUpdate(t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, nil, clparams.DenebVersion)
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrForkChoiceUpdateTimeout)
+}
+
+func TestForkChoiceUpdateRejectsMissingPayloadIDForPayloadBuild(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cc := &ExecutionClientEngine{
+		engine: &fcuEngineStub{response: &engine_types.ForkChoiceUpdatedResponse{
+			PayloadStatus: &engine_types.PayloadStatus{Status: engine_types.SyncingStatus},
+		}},
+		beaconCfg: &cfg,
+	}
+
+	id, err := cc.ForkChoiceUpdate(
+		t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, &engine_types.PayloadAttributes{}, clparams.DenebVersion,
+	)
+
+	require.ErrorIs(t, err, ErrForkChoiceUpdateNoPayloadID)
+	require.Nil(t, id)
+}
+
+func TestForkChoiceUpdateAllowsMissingPayloadIDWithoutPayloadBuild(t *testing.T) {
+	cfg := clparams.MainnetBeaconConfig
+	cc := &ExecutionClientEngine{
+		engine: &fcuEngineStub{response: &engine_types.ForkChoiceUpdatedResponse{
+			PayloadStatus: &engine_types.PayloadStatus{Status: engine_types.SyncingStatus},
+		}},
+		beaconCfg: &cfg,
+	}
+
+	id, err := cc.ForkChoiceUpdate(
+		t.Context(), common.Hash{}, common.Hash{}, common.Hash{}, nil, clparams.DenebVersion,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, id)
+}
 
 type beaconCfgEngineStub struct {
 	engineapi.EngineAPI

--- a/cl/phase1/execution_client/interface.go
+++ b/cl/phase1/execution_client/interface.go
@@ -18,7 +18,11 @@ package execution_client
 
 import (
 	"context"
+	"errors"
 	"math/big"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/erigontech/erigon/cl/clparams"
 	"github.com/erigontech/erigon/cl/cltypes"
@@ -29,7 +33,30 @@ import (
 	"github.com/erigontech/erigon/node/gointerfaces/typesproto"
 )
 
-var errContextExceeded = "rpc error: code = DeadlineExceeded desc = context deadline exceeded"
+// ErrForkChoiceUpdateTimeout reports that the execution layer did not answer a forkchoice update
+// in time. The update is not refused by it - the execution layer may still apply it - and no
+// payload id came back, so a caller that needed one has to treat this as a failure rather than as
+// an empty success.
+var ErrForkChoiceUpdateTimeout = errors.New("forkchoice update timed out")
+
+// ErrForkChoiceUpdateNoPayloadID reports that an attribute-bearing update did not start a payload build.
+var ErrForkChoiceUpdateNoPayloadID = errors.New("forkchoice update returned no payload ID")
+
+// legacyGrpcDeadlineMessage is what a deadline used to be recognised by. Kept as a last resort for
+// a transport that reports one without a status code or a wrapped context error.
+const legacyGrpcDeadlineMessage = "rpc error: code = DeadlineExceeded desc = context deadline exceeded"
+
+// isDeadlineExceeded reports whether err is the execution layer running out of time, by the
+// context, by the gRPC status, or by the message a transport that carries neither would produce.
+func isDeadlineExceeded(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if status.Code(err) == codes.DeadlineExceeded {
+		return true
+	}
+	return err.Error() == legacyGrpcDeadlineMessage
+}
 
 // ExecutionEngine is used only for syncing up very close to chain tip and to stay in sync.
 // It pretty much mimics engine API.

--- a/cl/phase1/stages/forkchoice.go
+++ b/cl/phase1/stages/forkchoice.go
@@ -20,6 +20,7 @@ import (
 	"github.com/erigontech/erigon/cl/phase1/core/caches"
 	"github.com/erigontech/erigon/cl/phase1/core/state"
 	"github.com/erigontech/erigon/cl/phase1/core/state/shuffling"
+	"github.com/erigontech/erigon/cl/phase1/execution_client"
 	"github.com/erigontech/erigon/cl/utils"
 	"github.com/erigontech/erigon/common"
 	"github.com/erigontech/erigon/common/dbg"
@@ -77,8 +78,15 @@ func computeAndNotifyServicesOfNewForkChoice(ctx context.Context, logger log.Log
 			cfg.forkChoice.GetFinalizedExecutionHash(justifiedCheckpoint.Root),
 			cfg.forkChoice.GetEth1Hash(headRoot), nil, headVersion,
 		); err != nil {
-			err = fmt.Errorf("failed to run forkchoice: %w", err)
-			return
+			// A forkchoice update that ran out of time is not a rejection, and sync has no payload
+			// to lose by carrying on: the next head will send another one.
+			if errors.Is(err, execution_client.ErrForkChoiceUpdateTimeout) {
+				logger.Debug("[Caplin] forkchoice update timed out", "head", headRoot)
+				err = nil
+			} else {
+				err = fmt.Errorf("failed to run forkchoice: %w", err)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick of #23397 to release/3.6.

Both halves matter on this branch, and both are on every forkchoice path here today, not only the one payload preparation will add:

- A deadline was mapped to `(nil, nil)`, so a caller saw success with no payload id. `produceBeaconBody` reads an empty id as the execution layer syncing, which is how a slow one gets reported, and the caller that needs an id cannot tell the two apart.
- An attribute-bearing update that returns `payloadId: null` — `SYNCING` after the execution module's own forkchoice timeout — was likewise an empty success rather than a failure.

Recognition of a deadline no longer depends on gRPC phrasing its message one exact way: a wrapped context error and the status code are both accepted, with the old string kept as a last resort.

## r3.6 adaptations

Three small ones, no behaviour differences:

- `cl/phase1/stages/forkchoice.go`: the import hunk wanted `execution_client` and `phase1/forkchoice`. Only the first belongs to this change — the second comes from something not on this branch, and adding it would leave an unused import.
- `cl/beacon/handler/block_production.go` needed the `execution_client` import added; this branch did not have it.
- `execution_client_engine_test.go`: the three-way merge dropped the `engine_types` import, restored.

The call sites keep the behaviour they had. `stages/forkchoice.go` and `storeBlockAndBlobs` tolerated a timeout because they were never told about one; they still tolerate it, now by matching the sentinel. Block production treats it as a failure, which is the case it was misreporting.

## Verification

- `go test -race` green across `cl/phase1/execution_client/...`, `cl/phase1/stages` and `cl/beacon/handler`.
- Both halves mutation-checked on this branch: restoring `return nil, nil` on a deadline fails `TestForkChoiceUpdateReportsATimeoutRatherThanAnEmptySuccess`, and dropping the missing-id sentinel fails `TestForkChoiceUpdateRejectsMissingPayloadIDForPayloadBuild`.
- `make lintci` clean, 0 issues.
